### PR TITLE
Add upgrade file from 1.2.0 to 1.2.1

### DIFF
--- a/mobilitydb/CMakeLists.txt
+++ b/mobilitydb/CMakeLists.txt
@@ -201,6 +201,9 @@ add_custom_target(control ALL DEPENDS ${CMAKE_BINARY_DIR}/mobilitydb.control)
 install(
   FILES "${CMAKE_BINARY_DIR}/mobilitydb.control" "${CMAKE_BINARY_DIR}/${MOBILITYDB_EXTENSION_FILE}"
   DESTINATION "${POSTGRESQL_SHARE_DIR}/extension")
+install(
+  FILES "${CMAKE_SOURCE_DIR}/mobilitydb/sql/mobilitydb--1.2.0--1.2.1.sql"
+  DESTINATION "${POSTGRESQL_SHARE_DIR}/extension")
 install(TARGETS ${MOBILITYDB_LIB_NAME} DESTINATION "${POSTGRESQL_DYNLIB_DIR}")
 
 #-----------------------------------------------------------------------------

--- a/mobilitydb/sql/mobilitydb--1.2.0--1.2.1.sql
+++ b/mobilitydb/sql/mobilitydb--1.2.0--1.2.1.sql
@@ -1,0 +1,85 @@
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "ALTER EXTENSION mobilitydb UPDATE TO '1.2.1'" to load this file. \quit
+
+-- Fully drop all operators and rebuild them
+-- with the correct commutators defined
+
+DROP OPERATOR #< (text, ttext);
+DROP OPERATOR #< (ttext, text);
+DROP OPERATOR #< (ttext, ttext);
+
+DROP OPERATOR #> (text, ttext);
+DROP OPERATOR #> (ttext, text);
+DROP OPERATOR #> (ttext, ttext);
+
+DROP OPERATOR #<= (text, ttext);
+DROP OPERATOR #<= (ttext, text);
+DROP OPERATOR #<= (ttext, ttext);
+
+DROP OPERATOR #>= (text, ttext);
+DROP OPERATOR #>= (ttext, text);
+DROP OPERATOR #>= (ttext, ttext);
+
+CREATE OPERATOR #< (
+  PROCEDURE = temporal_tlt,
+  LEFTARG = text, RIGHTARG = ttext,
+  COMMUTATOR = #>
+);
+CREATE OPERATOR #< (
+  PROCEDURE = temporal_tlt,
+  LEFTARG = ttext, RIGHTARG = text,
+  COMMUTATOR = #>
+);
+CREATE OPERATOR #< (
+  PROCEDURE = temporal_tlt,
+  LEFTARG = ttext, RIGHTARG = ttext,
+  COMMUTATOR = #>
+);
+
+CREATE OPERATOR #> (
+  PROCEDURE = temporal_tgt,
+  LEFTARG = text, RIGHTARG = ttext,
+  COMMUTATOR = #<
+);
+CREATE OPERATOR #> (
+  PROCEDURE = temporal_tgt,
+  LEFTARG = ttext, RIGHTARG = text,
+  COMMUTATOR = #<
+);
+CREATE OPERATOR #> (
+  PROCEDURE = temporal_tgt,
+  LEFTARG = ttext, RIGHTARG = ttext,
+  COMMUTATOR = #<
+);
+
+CREATE OPERATOR #<= (
+  PROCEDURE = temporal_tle,
+  LEFTARG = text, RIGHTARG = ttext,
+  COMMUTATOR = #>=
+);
+CREATE OPERATOR #<= (
+  PROCEDURE = temporal_tle,
+  LEFTARG = ttext, RIGHTARG = text,
+  COMMUTATOR = #>=
+);
+CREATE OPERATOR #<= (
+  PROCEDURE = temporal_tle,
+  LEFTARG = ttext, RIGHTARG = ttext,
+  COMMUTATOR = #>=
+);
+
+CREATE OPERATOR #>= (
+  PROCEDURE = temporal_tge,
+  LEFTARG = text, RIGHTARG = ttext,
+  COMMUTATOR = #<=
+);
+CREATE OPERATOR #>= (
+  PROCEDURE = temporal_tge,
+  LEFTARG = ttext, RIGHTARG = text,
+  COMMUTATOR = #<=
+);
+CREATE OPERATOR #>= (
+  PROCEDURE = temporal_tge,
+  LEFTARG = ttext, RIGHTARG = ttext,
+  COMMUTATOR = #<=
+);


### PR DESCRIPTION
The only SQL change between 1.2.0 and 1.2.1 are the commutator fixes from 5e410dc86. This commit adds an upgrade file that can be used to go from 1.2.0 to 1.2.1 by dropping and recreating the needed operators. This file gets installed together with the rest of the files during `make install`. To upgrade, run the following command after having build and installed 1.2.1:

```
ALTER EXTENSION mobilitydb UPDATE TO "1.2.1";
```