### PR TITLE
Fix inverted geodetic flag in geoset_make

### DIFF
--- a/meos/src/geo/geoset_meos.c
+++ b/meos/src/geo/geoset_meos.c
@@ -113,7 +113,7 @@ geoset_make(GSERIALIZED **values, int count)
   for (int i = 0; i < count; ++i)
     datums[i] = PointerGetDatum(values[i]);
   meosType geotype = FLAGS_GET_GEODETIC(values[0]->gflags) ?
-    T_GEOMETRY : T_GEOGRAPHY;
+    T_GEOGRAPHY : T_GEOMETRY;
   return set_make_free(datums, count, geotype, ORDER);
 }
 


### PR DESCRIPTION
### Bug fix: `geoset_make` inverted geodetic flag

`geoset_make` in `geoset_meos.c` had an inverted ternary for determining the set type.

`FLAGS_GET_GEODETIC` is truthy when the geodetic flag is set, so the true branch must map to `T_GEOGRAPHY`. The inverted logic caused non-geodetic geometries to always produce a `geogset`, triggering a "mixed temporal and set types" error when passed to `temporal_at_values` with a `tgeompoint`. The other two identical patterns in the same file already had the correct order, consistent with a copy-paste mistake.
