### PR TITLE
Add rtree_insert_temporal and rtree_search_temporal convenience functions

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -285,7 +285,9 @@ extern RTree *rtree_create_tbox();
 extern RTree *rtree_create_stbox();
 extern void rtree_free(RTree *rtree);
 extern void rtree_insert(RTree *rtree, void *box, int id);
+extern void rtree_insert_temporal(RTree *rtree, const Temporal *temp, int id);
 extern int *rtree_search(const RTree *rtree, RTreeSearchOp op, const void *query, int *count);
+extern int *rtree_search_temporal(const RTree *rtree, RTreeSearchOp op, const Temporal *temp, int *count);
 
 /*****************************************************************************
  * Error codes

--- a/meos/include/meos_geo.h
+++ b/meos/include/meos_geo.h
@@ -602,13 +602,6 @@ extern bool stbox_le(const STBox *box1, const STBox *box2);
 extern bool stbox_lt(const STBox *box1, const STBox *box2);
 extern bool stbox_ne(const STBox *box1, const STBox *box2);
 
-/* RTree functions */
-
-// extern RTree *rtree_create_stbox();
-// extern void rtree_free(RTree *rtree);
-// extern void rtree_insert(RTree *rtree, STBox *box, int64 id);
-// extern int *rtree_search(const RTree *rtree,const STBox *query, int *count);
-
 /*****************************************************************************
  * Functions for temporal geometries/geographies
  *****************************************************************************/

--- a/meos/src/temporal/temporal_rtree.c
+++ b/meos/src/temporal/temporal_rtree.c
@@ -944,6 +944,82 @@ rtree_search(const RTree *rtree, RTreeSearchOp op, const void *query,
 }
 
 /**
+ * @brief Return true if the RTree's bounding box type is compatible with the
+ * temporal type, report an error otherwise
+ * @param[in] rtree Pointer to the RTree structure
+ * @param[in] temp Temporal value
+ */
+static bool
+ensure_rtree_temporal_compatible(const RTree *rtree, const Temporal *temp)
+{
+  meosType temptype = temp->temptype;
+  bool compatible =
+    (talpha_type(temptype) && rtree->bboxtype == T_TSTZSPAN) ||
+    (tnumber_type(temptype) && rtree->bboxtype == T_TBOX) ||
+    (tspatial_type(temptype) && rtree->bboxtype == T_STBOX);
+  if (! compatible)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_TYPE,
+      "RTree bounding box type (%s) is not compatible with temporal type (%s)",
+      meostype_name(rtree->bboxtype), meostype_name(temptype));
+    return false;
+  }
+  return true;
+}
+
+/**
+ * @ingroup meos_temporal_box_index
+ * @brief Insert a temporal value into the RTree index
+ * @details The bounding box is automatically extracted from the temporal value.
+ * The temporal type must be compatible with the RTree's bounding box type:
+ * temporal alphas (tbool, ttext) require a span-based RTree, temporal numbers
+ * (tint, tfloat) require a TBox-based RTree, and spatiotemporal types
+ * (tgeompoint, tgeogpoint) require an STBox-based RTree.
+ * @param[in] rtree The RTree previously initialized
+ * @param[in] temp The temporal value to be inserted
+ * @param[in] id The id of the temporal value being inserted
+ */
+void
+rtree_insert_temporal(RTree *rtree, const Temporal *temp, int id)
+{
+  if (! ensure_rtree_temporal_compatible(rtree, temp))
+    return;
+  /* Use a stack buffer large enough for any MEOS bounding box type */
+  char buf[sizeof(STBox)];
+  memset(buf, 0, sizeof(buf));
+  temporal_set_bbox(temp, buf);
+  rtree_insert(rtree, buf, id);
+  return;
+}
+
+/**
+ * @ingroup meos_temporal_box_index
+ * @brief Search an RTree using a temporal value's bounding box
+ * @details The bounding box is automatically extracted from the temporal value
+ * and used as the search query.
+ * @param[in] rtree The RTree to query
+ * @param[in] op The search operation
+ * @param[in] temp The temporal value whose bounding box serves as query
+ * @param[out] count The number of hits the RTree found
+ * @return Array of ids that have a hit.
+ */
+int *
+rtree_search_temporal(const RTree *rtree, RTreeSearchOp op,
+  const Temporal *temp, int *count)
+{
+  if (! ensure_rtree_temporal_compatible(rtree, temp))
+  {
+    *count = 0;
+    return NULL;
+  }
+  /* Use a stack buffer large enough for any MEOS bounding box type */
+  char buf[sizeof(STBox)];
+  memset(buf, 0, sizeof(buf));
+  temporal_set_bbox(temp, buf);
+  return rtree_search(rtree, op, buf, count);
+}
+
+/**
  * @brief Frees the memory allocated for an RTree node
  * @details The function recursively frees the memory of an RTree node.
  * If the node is a branch node, it first recursively frees all child nodes.


### PR DESCRIPTION
Add functions that automatically extract the bounding box from a Temporal value, so users don't need to manually call tnumber_to_tbox or tspatial_to_stbox before inserting or searching.

A type compatibility check (ensure_rtree_temporal_compatible) validates that the temporal type matches the RTree's bounding box type at runtime:
- talpha (tbool, ttext) requires a tstzspan-based RTree
- tnumber (tint, tfloat) requires a TBox-based RTree
- tspatial (tgeompoint, tgeogpoint) requires an STBox-based RTree

Also remove commented-out R-tree declarations from meos_geo.h since the real API lives in meos.h.