### PR TITLE
Add functions atElevation and minusElevation

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1154,11 +1154,15 @@
 			<title>Restricciones</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="tgeo_atGeometry"><varname>atGeometry</varname>, <varname>minusGeometry</varname></link>: Restringir a (al complemento de) una geometría, un lapso Z y/o un período</para>
+					<para><link linkend="tgeo_atGeometry"><varname>atGeometry</varname>, <varname>minusGeometry</varname></link>: Restringir a (al complemento de) una geometría</para>
 				</listitem>
 
 				<listitem>
 					<para><link linkend="tgeo_atStbox"><varname>atStbox</varname>, <varname>minuStbox</varname></link>: Restringir a (al complemento de) un <varname>stbox</varname></para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tgeo_atElevation"><varname>atElevation</varname>, <varname>minuElevation</varname></link>: Restringir a (al complemento de) un rango de altitud</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/es/temporal_spatial_p2.xml
+++ b/doc/es/temporal_spatial_p2.xml
@@ -16,9 +16,9 @@
 			<listitem xml:id="tgeo_atGeometry">
 				<indexterm significance="normal"><primary><varname>atGeometry</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusGeometry</varname></primary></indexterm>
-				<para>Restringir a (al complemento de) una geometría, un lapso Z y/o un período &Z_support;</para>
-				<para><varname>atGeometry(tgeom,geometry[,zspan]) → tgeom</varname></para>
-				<para><varname>minusGeometry(tgeom,geometry[,zspan]) → tgeom</varname></para>
+				<para>Restringir a (al complemento de) una geometría &Z_support;</para>
+				<para><varname>atGeometry(tgeom,geometry) → tgeom</varname></para>
+				<para><varname>minusGeometry(tgeom,geometry]) → tgeom</varname></para>
 				<para>La geometría debe ser 2D y el cálculo con respecto a ella se realiza en 2D. El resultado conserva la dimensión Z del punto temporal, si existe.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(atGeometry(tgeompoint '[Point(0 0)@2001-01-01, Point(3 3)@2001-01-04)',
@@ -28,8 +28,8 @@ SELECT astext(atGeometry(tgeompoint '[Point(0 0 0)@2001-01-01, Point(4 4 4)@2001
   geometry 'Polygon((1 1,1 2,2 2,2 1,1 1))'));
 -- {[POINT Z (1 1 1)@2001-01-02, POINT Z (2 2 2)@2001-01-03]}
 SELECT asText(atGeometry(tgeompoint '[Point(1 1 1)@2001-01-01, Point(3 1 1)@2001-01-03,
-  Point(3 1 3)@2001-01-05]', 'Polygon((2 0,2 2,2 4,4 0,2 0))', '[0,2]'));
--- {[POINT Z (2 1 1)@2001-01-02, POINT Z (3 1 1)@2001-01-03, POINT Z (3 1 2)@2001-01-04]}
+  Point(3 1 3)@2001-01-05]', 'Polygon((2 0,2 2,2 4,4 0,2 0))'));
+-- {[POINT Z (2 1 1)@2001-01-02, POINT Z (3 1 1)@2001-01-03, POINT Z (3 1 3)@2001-01-05]}
 SELECT asText(atGeometry(tgeometry 'Linestring(1 1,10 1)@2001-01-01', 
   'Polygon((0 0,0 5,5 5,5 0,0 0))'));
 -- LINESTRING(1 1,5 1)@2001-01-01
@@ -44,9 +44,8 @@ SELECT astext(minusGeometry(tgeompoint '[Point(0 0 0)@2001-01-01,
 /* {[POINT Z (0 0 0)@2001-01-01, POINT Z (1 1 1)@2001-01-02),
    (POINT Z (2 2 2)@2001-01-03, POINT Z (4 4 4)@2001-01-05]} */
 SELECT asText(minusGeometry(tgeompoint '[Point(1 1 1)@2001-01-01, Point(3 1 1)@2001-01-03,
-  Point(3 1 3)@2001-01-05]', 'Polygon((2 0,2 2,2 4,4 0,2 0))', '[0,2]'));
-/* {[POINT Z (1 1 1)@2001-01-01, POINT Z (2 1 1)@2001-01-02),
-    (POINT Z (3 1 2)@2001-01-04, POINT Z (3 1 3)@2001-01-05]} */
+  Point(3 1 3)@2001-01-05]', 'Polygon((2 0,2 2,2 4,4 0,2 0))'));
+-- {[POINT Z (1 1 1)@2001-01-01, POINT Z (2 1 1)@2001-01-02)}
 SELECT asText(minusGeometry(tgeometry 'Linestring(1 1,10 1)@2001-01-01', 
   'Polygon((0 0,0 5,5 5,5 0,0 0))'));
 -- LINESTRING(5 1,10 1)@2001-01-01
@@ -88,6 +87,25 @@ SELECT asText(minusStbox(tgeometry '[Point(1 1)@2001-01-01,
    LINESTRING(1 1,2 2)@2001-01-04),[MULTILINESTRING((1 1,2 2),(3 3,4 4))@2001-01-09]} */
 </programlisting>
 			</listitem>
+
+			<listitem xml:id="tgeo_atElevation">
+				<indexterm significance="normal"><primary><varname>atElevation</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>minusElevation</varname></primary></indexterm>
+				<para>Restringir a (al complemento de) un rango de altitud &Z_support;</para>
+				<para><varname>atElevation(tgeom,zspan) → tgeom</varname></para>
+				<para><varname>minusElevation(tgeom,zspan) → tgeom</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT astext(atElevation(tgeompoint '[Point(1 1 1)@2001-01-01,
+  Point(4 4 4)@2001-01-04, Point(1 1 1)@2001-01-07]', floatspan '[2,3]'));
+/* {[POINT Z (2 2 2)@2001-01-02, POINT Z (3 3 3)@2001-01-03],
+  [POINT Z (3 3 3)@2001-01-05, POINT Z (2 2 2)@2001-01-06]} */
+SELECT astext(minusElevation(tgeompoint '[Point(1 1 1)@2001-01-01,
+  Point(4 4 4)@2001-01-04, Point(1 1 1)@2001-01-07]', floatspan '[2,3]'));
+/* {[POINT Z (2 2 2)@2001-01-02, POINT Z (3 3 3)@2001-01-03],
+  [POINT Z (3 3 3)@2001-01-05, POINT Z (2 2 2)@2001-01-06]} */
+</programlisting>
+			</listitem>
+
 		</itemizedlist>
 	</sect1>
 

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1152,11 +1152,15 @@
 			<title>Restrictions</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="tgeo_atGeometry"><varname>atGeometry</varname>, <varname>minusGeometry</varname></link>: Restrict to (the complement of) a geometry, a span in Z and/or a period</para>
+					<para><link linkend="tgeo_atGeometry"><varname>atGeometry</varname>, <varname>minusGeometry</varname></link>: Restrict to (the complement of) a geometry</para>
 				</listitem>
 
 				<listitem>
 					<para><link linkend="tgeo_atStbox"><varname>atStbox</varname>, <varname>minuStbox</varname></link>: Restrict to (the complement of) an <varname>stbox</varname></para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tgeo_atElevation"><varname>atElevation</varname>, <varname>minuElevation</varname></link>: Restrict to (the complement of) an elevation span</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/temporal_spatial_p2.xml
+++ b/doc/temporal_spatial_p2.xml
@@ -16,9 +16,9 @@
 			<listitem xml:id="tgeo_atGeometry">
 				<indexterm significance="normal"><primary><varname>atGeometry</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusGeometry</varname></primary></indexterm>
-				<para>Restrict to (the complement of) a geometry, a Z span, and/or a period &Z_support;</para>
-				<para><varname>atGeometry(tgeom,geometry[,zspan]) → tgeom</varname></para>
-				<para><varname>minusGeometry(tgeom,geometry[,zspan]) → tgeom</varname></para>
+				<para>Restrict to (the complement of) a geometry &Z_support;</para>
+				<para><varname>atGeometry(tgeom,geometry) → tgeom</varname></para>
+				<para><varname>minusGeometry(tgeom,geometry) → tgeom</varname></para>
 				<para>The geometry must be in 2D and the computation with respect to it is done in 2D. The result preserves the Z dimension of the temporal point, if it exists.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(atGeometry(tgeompoint '[Point(0 0)@2001-01-01, Point(3 3)@2001-01-04)',
@@ -28,8 +28,8 @@ SELECT astext(atGeometry(tgeompoint '[Point(0 0 0)@2001-01-01, Point(4 4 4)@2001
   geometry 'Polygon((1 1,1 2,2 2,2 1,1 1))'));
 -- {[POINT Z (1 1 1)@2001-01-02, POINT Z (2 2 2)@2001-01-03]}
 SELECT asText(atGeometry(tgeompoint '[Point(1 1 1)@2001-01-01, Point(3 1 1)@2001-01-03,
-  Point(3 1 3)@2001-01-05]', 'Polygon((2 0,2 2,2 4,4 0,2 0))', '[0,2]'));
--- {[POINT Z (2 1 1)@2001-01-02, POINT Z (3 1 1)@2001-01-03, POINT Z (3 1 2)@2001-01-04]}
+  Point(3 1 3)@2001-01-05]', 'Polygon((2 0,2 2,2 4,4 0,2 0))'));
+-- {[POINT Z (2 1 1)@2001-01-02, POINT Z (3 1 1)@2001-01-03, POINT Z (3 1 3)@2001-01-05]}
 SELECT asText(atGeometry(tgeometry 'Linestring(1 1,10 1)@2001-01-01', 
   'Polygon((0 0,0 5,5 5,5 0,0 0))'));
 -- LINESTRING(1 1,5 1)@2001-01-01
@@ -44,9 +44,8 @@ SELECT astext(minusGeometry(tgeompoint '[Point(0 0 0)@2001-01-01,
 /* {[POINT Z (0 0 0)@2001-01-01, POINT Z (1 1 1)@2001-01-02),
    (POINT Z (2 2 2)@2001-01-03, POINT Z (4 4 4)@2001-01-05]} */
 SELECT asText(minusGeometry(tgeompoint '[Point(1 1 1)@2001-01-01, Point(3 1 1)@2001-01-03,
-  Point(3 1 3)@2001-01-05]', 'Polygon((2 0,2 2,2 4,4 0,2 0))', '[0,2]'));
-/* {[POINT Z (1 1 1)@2001-01-01, POINT Z (2 1 1)@2001-01-02),
-    (POINT Z (3 1 2)@2001-01-04, POINT Z (3 1 3)@2001-01-05]} */
+  Point(3 1 3)@2001-01-05]', 'Polygon((2 0,2 2,2 4,4 0,2 0))'));
+-- {[POINT Z (1 1 1)@2001-01-01, POINT Z (2 1 1)@2001-01-02)}
 SELECT asText(minusGeometry(tgeometry 'Linestring(1 1,10 1)@2001-01-01', 
   'Polygon((0 0,0 5,5 5,5 0,0 0))'));
 -- LINESTRING(5 1,10 1)@2001-01-01
@@ -86,6 +85,24 @@ SELECT asText(minusStbox(tgeometry '[Point(1 1)@2001-01-01,
   Linestring(1 1,4 4)@2001-01-09]', stbox 'STBOX X((2,2),(3,3))'));
 /* {[POINT(1 1)@2001-01-01, LINESTRING(1 1,2 2)@2001-01-03, 
    LINESTRING(1 1,2 2)@2001-01-04),[MULTILINESTRING((1 1,2 2),(3 3,4 4))@2001-01-09]} */
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="tgeo_atElevation">
+				<indexterm significance="normal"><primary><varname>atElevation</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>minusElevation</varname></primary></indexterm>
+				<para>Restrict to (the complement of) an elevation span &Z_support;</para>
+				<para><varname>atElevation(tgeom,zspan) → tgeom</varname></para>
+				<para><varname>minusElevation(tgeom,zspan) → tgeom</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT astext(atElevation(tgeompoint '[Point(1 1 1)@2001-01-01,
+  Point(4 4 4)@2001-01-04, Point(1 1 1)@2001-01-07]', floatspan '[2,3]'));
+/* {[POINT Z (2 2 2)@2001-01-02, POINT Z (3 3 3)@2001-01-03],
+  [POINT Z (3 3 3)@2001-01-05, POINT Z (2 2 2)@2001-01-06]} */
+SELECT astext(minusElevation(tgeompoint '[Point(1 1 1)@2001-01-01,
+  Point(4 4 4)@2001-01-04, Point(1 1 1)@2001-01-07]', floatspan '[2,3]'));
+/* {[POINT Z (2 2 2)@2001-01-02, POINT Z (3 3 3)@2001-01-03],
+  [POINT Z (3 3 3)@2001-01-05, POINT Z (2 2 2)@2001-01-06]} */
 </programlisting>
 			</listitem>
 		</itemizedlist>

--- a/meos/include/meos_geo.h
+++ b/meos/include/meos_geo.h
@@ -696,9 +696,11 @@ extern Temporal *tgeo_at_value(const Temporal *temp, GSERIALIZED *gs);
 extern Temporal *tgeo_minus_geom(const Temporal *temp, const GSERIALIZED *gs);
 extern Temporal *tgeo_minus_stbox(const Temporal *temp, const STBox *box, bool border_inc);
 extern Temporal *tgeo_minus_value(const Temporal *temp, GSERIALIZED *gs);
-extern Temporal *tpoint_at_geom(const Temporal *temp, const GSERIALIZED *gs, const Span *zspan);
+extern Temporal *tpoint_at_elevation(const Temporal *temp, const Span *s);
+extern Temporal *tpoint_at_geom(const Temporal *temp, const GSERIALIZED *gs);
 extern Temporal *tpoint_at_value(const Temporal *temp, GSERIALIZED *gs);
-extern Temporal *tpoint_minus_geom(const Temporal *temp, const GSERIALIZED *gs, const Span *zspan);
+extern Temporal *tpoint_minus_elevation(const Temporal *temp, const Span *s);
+extern Temporal *tpoint_minus_geom(const Temporal *temp, const GSERIALIZED *gs);
 extern Temporal *tpoint_minus_value(const Temporal *temp, GSERIALIZED *gs);
 
 /* Ever and always comparisons */

--- a/meos/include/meos_internal_geo.h
+++ b/meos/include/meos_internal_geo.h
@@ -206,13 +206,14 @@ extern void tspatialseqset_set_stbox(const TSequenceSet *ss, STBox *box);
 
 /* Restriction functions */
 
-extern Temporal *tgeo_restrict_geom(const Temporal *temp, const GSERIALIZED *gs, const Span *zspan, bool atfunc);
+extern Temporal *tgeo_restrict_elevation(const Temporal *temp, const Span *s, bool atfunc);
+extern Temporal *tgeo_restrict_geom(const Temporal *temp, const GSERIALIZED *gs, bool atfunc);
 extern Temporal *tgeo_restrict_stbox(const Temporal *temp, const STBox *box, bool border_inc, bool atfunc);
-extern TInstant *tgeoinst_restrict_geom(const TInstant *inst, const GSERIALIZED *gs, const Span *zspan, bool atfunc);
+extern TInstant *tgeoinst_restrict_geom(const TInstant *inst, const GSERIALIZED *gs, bool atfunc);
 extern TInstant *tgeoinst_restrict_stbox(const TInstant *inst, const STBox *box, bool border_inc, bool atfunc);
-extern Temporal *tgeoseq_restrict_geom(const TSequence *seq, const GSERIALIZED *gs, const Span *zspan, bool atfunc);
+extern Temporal *tgeoseq_restrict_geom(const TSequence *seq, const GSERIALIZED *gs, bool atfunc);
 extern Temporal *tgeoseq_restrict_stbox(const TSequence *seq, const STBox *box, bool border_inc, bool atfunc);
-extern TSequenceSet *tgeoseqset_restrict_geom(const TSequenceSet *ss, const GSERIALIZED *gs, const Span *zspan, bool atfunc);
+extern TSequenceSet *tgeoseqset_restrict_geom(const TSequenceSet *ss, const GSERIALIZED *gs, bool atfunc);
 extern TSequenceSet *tgeoseqset_restrict_stbox(const TSequenceSet *ss, const STBox *box, bool border_inc, bool atfunc);
 
 /*****************************************************************************/

--- a/meos/include/meos_pose.h
+++ b/meos/include/meos_pose.h
@@ -239,10 +239,10 @@ extern Pose **tpose_values(const Temporal *temp, int *count);
  * Restriction functions
  *****************************************************************************/
 
-extern Temporal *tpose_at_geom(const Temporal *temp, const GSERIALIZED *gs, const Span *zspan);
+extern Temporal *tpose_at_geom(const Temporal *temp, const GSERIALIZED *gs);
 extern Temporal *tpose_at_stbox(const Temporal *temp, const STBox *box, bool border_inc);
 extern Temporal *tpose_at_pose(const Temporal *temp, const Pose *pose);
-extern Temporal *tpose_minus_geom(const Temporal *temp, const GSERIALIZED *gs, const Span *zspan);
+extern Temporal *tpose_minus_geom(const Temporal *temp, const GSERIALIZED *gs);
 extern Temporal *tpose_minus_pose(const Temporal *temp, const Pose *pose);
 extern Temporal *tpose_minus_stbox(const Temporal *temp, const STBox *box, bool border_inc);
 

--- a/meos/include/meos_rgeo.h
+++ b/meos/include/meos_rgeo.h
@@ -140,12 +140,14 @@ extern Temporal *trgeo_restrict_tstzset(const Temporal *temp, const Set *s, bool
 extern Temporal *trgeo_restrict_tstzspan(const Temporal *temp, const Span *s, bool atfunc);
 extern Temporal *trgeo_restrict_tstzspanset(const Temporal *temp, const SpanSet *ss, bool atfunc);
 
-// extern Temporal *trgeo_at_geom(const Temporal *temp, const GSERIALIZED *gs, const Span *zspan);
-// extern Temporal *trgeo_at_geo(const Temporal *temp, const GSERIALIZED *gs, const Span *zspan);
+// extern Temporal *trgeo_at_geom(const Temporal *temp, const GSERIALIZED *gs);
+// extern Temporal *trgeo_at_geo(const Temporal *temp, const GSERIALIZED *gs);
 // extern Temporal *trgeo_at_stbox(const Temporal *temp, const STBox *box, bool border_inc);
-// extern Temporal *trgeo_minus_geom(const Temporal *temp, const GSERIALIZED *gs, const Span *zspan);
-// extern Temporal *trgeo_minus_geo(const Temporal *temp, const GSERIALIZED *gs, const Span *zspan);
+// extern Temporal *trgeo_at_elevation(const Temporal *temp, const Span *s);
+// extern Temporal *trgeo_minus_geom(const Temporal *temp, const GSERIALIZED *gs);
+// extern Temporal *trgeo_minus_geo(const Temporal *temp, const GSERIALIZED *gs);
 // extern Temporal *trgeo_minus_stbox(const Temporal *temp, const STBox *box, bool border_inc);
+// extern Temporal *trgeo_minus_elevation(const Temporal *temp, const Span *s);
 
 /*****************************************************************************
  * Distance functions

--- a/meos/include/pose/tpose_spatialfuncs.h
+++ b/meos/include/pose/tpose_spatialfuncs.h
@@ -46,9 +46,11 @@ extern GSERIALIZED *tpose_trajectory(const Temporal *temp);
 /* Restriction functions */
 
 extern Temporal *tpose_restrict_geom(const Temporal *temp,
-  const GSERIALIZED *gs, const Span *zspan, bool atfunc);
+  const GSERIALIZED *gs, bool atfunc);
 extern Temporal *tpose_restrict_stbox(const Temporal *temp, const STBox *box,
   bool border_inc, bool atfunc);
+extern Temporal *tpose_restrict_elevation(const Temporal *temp, const Span *s,
+  bool atfunc);
 
 /*****************************************************************************/
 

--- a/meos/src/cbuffer/tcbuffer.c
+++ b/meos/src/cbuffer/tcbuffer.c
@@ -1085,7 +1085,7 @@ tcbuffer_restrict_geom(const Temporal *temp, const GSERIALIZED *gs, bool
 
   Temporal *tpoint = tcbuffer_to_tgeompoint(temp);
   Temporal *tfloat = tcbuffer_to_tfloat(temp);
-  Temporal *tpoint_rest = tgeo_restrict_geom(tpoint, gs, NULL, atfunc);
+  Temporal *tpoint_rest = tgeo_restrict_geom(tpoint, gs, atfunc);
   Temporal *result = NULL;
   if (tpoint_rest)
   {

--- a/meos/src/geo/tgeo_restrict.c
+++ b/meos/src/geo/tgeo_restrict.c
@@ -500,7 +500,7 @@ liangBarskyClip(const GSERIALIZED *point1, const GSERIALIZED *point2,
 /**
  * @brief Return a temporal point instant restricted to (the complement of) a
  * spatiotemporal box (iterator function)
- * @pre The box has only X dimension and the arguments have the same SRID.
+ * @pre The box has only spatial dimension and the arguments have the same SRID.
  * @note This function restricts only to the spatial dimension, the restriction
  * to the time dimension is made in function #tgeo_restrict_stbox
  */
@@ -511,7 +511,7 @@ tpointinst_restrict_stbox_iter(const TInstant *inst, const STBox *box,
   assert(! MEOS_FLAGS_GET_T(box->flags));
   bool hasz = MEOS_FLAGS_GET_Z(inst->flags) && MEOS_FLAGS_GET_Z(box->flags);
 
-  /* Restrict to the XY(Z) dimension */
+  /* Restrict to the spatial dimension */
   Datum value = tinstant_value_p(inst);
   /* Get the input point */
   double x, y, z = 0.0;
@@ -547,7 +547,7 @@ tpointinst_restrict_stbox_iter(const TInstant *inst, const STBox *box,
  * @param[in] box Spatiotemporal box
  * @param[in] border_inc True when the box contains the upper border
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
- * @pre The box has only X dimension and the arguments have the same SRID.
+ * @pre The box has only spatial dimension and the arguments have the same SRID.
  * @note This function restricts only to the spatial dimension, the restriction
  * to the time dimension is made in function #tgeo_restrict_stbox
  */
@@ -586,7 +586,7 @@ tgeoinst_restrict_stbox_iter(const TInstant *inst, const STBox *box,
  * @param[in] box Spatiotemporal box
  * @param[in] border_inc True when the box contains the upper border
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
- * @pre The box has only X dimension and the arguments have the same SRID.
+ * @pre The box has only spatial dimension and the arguments have the same SRID.
  * @note This function restricts only to the spatial dimension, the restriction
  * to the time dimension is made in function #tgeo_restrict_stbox
  * @csqlfn #Tgeo_at_stbox(), #Tgeo_minus_stbox()
@@ -610,7 +610,7 @@ tgeoinst_restrict_stbox(const TInstant *inst, const STBox *box,
  * @param[in] box Spatiotemporal box
  * @param[in] border_inc True when the box contains the upper border
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
- * @pre The box has only X dimension, the arguments have the same SRID, and
+ * @pre The box has only spatial dimension, the arguments have the same SRID, and
  * the sequence is not instantaneous.
  * @note The function only restricts to the spatial dimension, the restriction
  * to the time dimension is made in function #tgeo_restrict_stbox.
@@ -651,7 +651,7 @@ tgeoseq_disc_restrict_stbox(const TSequence *seq, const STBox *box,
  * @param[in] box Spatiotemporal box
  * @param[in] border_inc True when the box contains the upper border
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
- * @pre The box has only X dimension, the arguments have the same SRID, and
+ * @pre The box has only spatial dimension, the arguments have the same SRID, and
  * the sequence is not instantaneous.
  * @note This function restricts only to the spatial dimension, the restriction
  * to the time dimension is made in function #tgeo_restrict_stbox
@@ -730,8 +730,8 @@ tgeoseq_step_restrict_stbox(const TSequence *seq, const STBox *box,
  * @param[in] seq Temporal point sequence
  * @param[in] box Bounding box
  * @param[in] border_inc True when the box contains the upper border
- * @pre The box has only X dimension, the arguments have the same SRID, and
- * the sequence is not instantaneous.
+ * @pre The box has only spatial dimension, the arguments have the same SRID,
+ * and the sequence is not instantaneous.
  * @note The function only restricts to the spatial dimension, the restriction
  * to the time dimension is made in function #tgeo_restrict_stbox.
  */
@@ -954,7 +954,7 @@ tpointseq_linear_at_stbox_xyz(const TSequence *seq, const STBox *box,
  * @param[in] box Spatiotemporal box
  * @param[in] border_inc True when the box contains the upper border
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
- * @pre The box has only X dimension, the arguments have the same SRID, and
+ * @pre The box has only spatial dimension, the arguments have the same SRID, and
  * the sequence is not instantaneous.
  * @note The function only restricts to the spatial dimension, the restriction
  * to the time dimension is made in function #tgeo_restrict_stbox.
@@ -992,7 +992,7 @@ tpointseq_linear_restrict_stbox(const TSequence *seq, const STBox *box,
  * @param[in] box Spatiotemporal box
  * @param[in] border_inc True when the box contains the upper border
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
- * @pre The box has only X dimension and the arguments have the same SRID.
+ * @pre The box has only spatial dimension and the arguments have the same SRID.
  * @note The function only restricts to the spatial dimension, the restriction
  * to the time dimension is made in function #tgeo_restrict_stbox.
  * @csqlfn #Tgeo_at_stbox(), #Tgeo_minus_stbox()
@@ -1044,7 +1044,7 @@ tgeoseq_restrict_stbox(const TSequence *seq, const STBox *box,
  * @param[in] box Spatiotemporal box
  * @param[in] border_inc True when the box contains the upper border
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
- * @pre The box has only X dimension and the arguments have the same SRID.
+ * @pre The box has only spatial dimension and the arguments have the same SRID.
  * @note The function only restricts to the spatial dimension, the restriction
  * to the time dimension is made in function #tgeo_restrict_stbox.
  * @csqlfn #Tgeo_at_stbox(), #Tgeo_minus_stbox()
@@ -1388,7 +1388,7 @@ tpoint_at_stbox_segm(const Temporal *temp, const STBox *box, bool border_inc)
 }
 
 /*****************************************************************************
- * Restriction functions for geometry and possible a Z span and a time period
+ * Restriction functions for geometry
  * N.B. In the current PostGIS version there is no true ST_Intersection
  * function for geography, it is implemented as ST_DWithin with tolerance 0
  *****************************************************************************/
@@ -1401,25 +1401,16 @@ tpoint_at_stbox_segm(const Temporal *temp, const STBox *box, bool border_inc)
  */
 TInstant *
 tpointinst_restrict_geom_iter(const TInstant *inst, const GSERIALIZED *gs,
-  const Span *zspan, bool atfunc)
+  bool atfunc)
 {
-  /* Restrict to the Z dimension */
-  Datum value = tinstant_value_p(inst);
-  if (zspan)
-  {
-    const POINT3DZ *p = DATUM_POINT3DZ_P(value);
-    if (! contains_span_value(zspan, Float8GetDatum(p->z)))
-      /* For temporal point types we return the instants of the input value */
-      return atfunc ? NULL : (TInstant *) inst;
-  }
-
   /* Restrict to the XY dimension */
+  Datum value = tinstant_value_p(inst);
   if (! geom_intersects2d(DatumGetGserializedP(value), gs))
       /* For temporal point types we return the instants of the input value */
       return atfunc ? NULL : (TInstant *) inst;
 
-  /* Point intersects the geometry and the Z/T spans */
-      return atfunc ? (TInstant *) inst : NULL;
+  /* The point intersects the geometry */
+  return atfunc ? (TInstant *) inst : NULL;
 }
 
 /**
@@ -1427,23 +1418,20 @@ tpointinst_restrict_geom_iter(const TInstant *inst, const GSERIALIZED *gs,
  * geometry (iterator function)
  * @param[in] inst Temporal geo instant
  * @param[in] gs Geometry
- * @param[in] zspan Span of values to restrict the Z dimension
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
  * @pre The arguments have the same SRID. This is verified in
  * #tgeo_restrict_geom
  */
 TInstant *
 tgeoinst_restrict_geom_iter(const TInstant *inst, const GSERIALIZED *gs,
-  const Span *zspan, bool atfunc)
+  bool atfunc)
 {
   assert(inst); assert(gs); assert(tgeo_type_all(inst->temptype));
   assert(! gserialized_is_empty(gs));
   /* Execute the specialized function for temporal points */
   if (tpoint_type(inst->temptype))
-    return tpointinst_restrict_geom_iter(inst, gs, zspan, atfunc);
+    return tpointinst_restrict_geom_iter(inst, gs, atfunc);
 
-  /* Z span is not allowed for general geometries */
-  assert(! zspan);
   /* Get the geometry of the instant */
   const GSERIALIZED *gs1 = DatumGetGserializedP(tinstant_value_p(inst));
   /* Restrict to the spatial dimension */
@@ -1463,18 +1451,16 @@ tgeoinst_restrict_geom_iter(const TInstant *inst, const GSERIALIZED *gs,
  * @ingroup meos_internal_geo_restrict
  * @brief Return a temporal geo instant restricted to (the complement of) a
  * geometry
- * and possibly a Z span and a timestamptz span
  * @param[in] inst Temporal geo
  * @param[in] gs Geometry
- * @param[in] zspan Span of values to restrict the Z dimension
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
  */
 TInstant *
 tgeoinst_restrict_geom(const TInstant *inst, const GSERIALIZED *gs,
-  const Span *zspan, bool atfunc)
+  bool atfunc)
 {
   assert(inst); assert(gs); assert(tgeo_type_all(inst->temptype));
-  TInstant *res = tgeoinst_restrict_geom_iter(inst, gs, zspan, atfunc);
+  TInstant *res = tgeoinst_restrict_geom_iter(inst, gs, atfunc);
   if (! res)
     return NULL;
   return tpoint_type(inst->temptype) ? tinstant_copy(res) : res;
@@ -1482,16 +1468,15 @@ tgeoinst_restrict_geom(const TInstant *inst, const GSERIALIZED *gs,
 
 /**
  * @brief Return a temporal geo discrete sequence restricted to
- * (the complement of) a geometry and possibly a Z span and a timestamptz span
+ * (the complement of) a geometry
  * @param[in] seq Temporal geo
  * @param[in] gs Geometry
- * @param[in] zspan Span of values to restrict the Z dimension
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
  * @pre Instantaneous sequences have been managed in the calling function
  */
 TSequence *
 tgeoseq_disc_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
-  const Span *zspan, bool atfunc)
+  bool atfunc)
 {
   assert(seq); assert(gs); assert(tgeo_type_all(seq->temptype));
   assert(MEOS_FLAGS_GET_INTERP(seq->flags) == DISCRETE);
@@ -1501,8 +1486,8 @@ tgeoseq_disc_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
   int ninsts = 0;
   for (int i = 0; i < seq->count; i++)
   {
-    TInstant *res = tgeoinst_restrict_geom_iter(TSEQUENCE_INST_N(seq, i), 
-      gs, zspan, atfunc);
+    TInstant *res = tgeoinst_restrict_geom_iter(TSEQUENCE_INST_N(seq, i), gs,
+      atfunc);
     if (res)
       instants[ninsts++] = res;
   }
@@ -1520,10 +1505,9 @@ tgeoseq_disc_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
 
 /**
  * @brief Return a temporal geo sequence with step interpolation
- * restricted to a geometry and possibly a Z span and a timestamptz span
+ * restricted to a geometry
  * @param[in] seq Temporal geo
  * @param[in] gs Geometry
- * @param[in] zspan Span of values to restrict the Z dimension
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
  * @pre Instantaneous sequences have been managed in the calling function
  * @note The function computes the "at" restriction on all dimensions. Then,
@@ -1532,7 +1516,7 @@ tgeoseq_disc_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
  */
 TSequenceSet *
 tgeoseq_step_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
-   const Span *zspan, bool atfunc)
+   bool atfunc)
 {
   assert(seq); assert(gs); assert(tgeo_type_all(seq->temptype));
   assert(MEOS_FLAGS_GET_INTERP(seq->flags) == STEP);
@@ -1547,7 +1531,7 @@ tgeoseq_step_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
   for (int i = 0; i < seq->count; i++)
   {
     const TInstant *inst = TSEQUENCE_INST_N(seq, i);
-    TInstant *res = tgeoinst_restrict_geom_iter(inst, gs, zspan, REST_AT);
+    TInstant *res = tgeoinst_restrict_geom_iter(inst, gs, REST_AT);
     if (res)
       instants[ninsts++] = res;
     else
@@ -1853,8 +1837,7 @@ tpointseq_linear_at_geom(const TSequence *seq, const GSERIALIZED *gs)
 
 /**
  * @brief Return a temporal point sequence with linear interpolation
- * restricted to (the complement of) a geometry and possibly a Z span and a
- * timestamptz span
+ * restricted to (the complement of) a geometry
  * @details The function first filters the temporal point wrt the time
  * dimension to reduce the number of instants before computing the restriction
  * to the geometry, which is an expensive operation. Notice that we need to
@@ -1862,7 +1845,6 @@ tpointseq_linear_at_geom(const TSequence *seq, const GSERIALIZED *gs)
  * the temporal point may change from a sequence to a sequence set.
  * @param[in] seq Temporal point
  * @param[in] gs Geometry
- * @param[in] zspan Span of values to restrict the Z dimension
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
  * @note The function computes the "at" restriction on all dimensions. Then,
  * for the "minus" restriction, it computes the complement of the "at"
@@ -1871,47 +1853,14 @@ tpointseq_linear_at_geom(const TSequence *seq, const GSERIALIZED *gs)
  */
 TSequenceSet *
 tpointseq_linear_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
-  const Span *zspan, bool atfunc)
+  bool atfunc)
 {
   VALIDATE_TPOINT(seq, NULL); VALIDATE_NOT_NULL(gs, NULL); 
   assert(MEOS_FLAGS_LINEAR_INTERP(seq->flags));
   assert(seq->count > 1);
 
   /* Compute atGeometry for the sequence */
-  TSequenceSet *at_xy = tpointseq_linear_at_geom(seq, gs);
-
-  /* Restrict to the Z dimension */
-  TSequenceSet *result_at = NULL;
-  if (at_xy)
-  {
-    if (zspan)
-    {
-      /* Bounding box test for the Z dimension */
-      STBox box1;
-      tspatialseqset_set_stbox(at_xy, &box1);
-      Span zspan1;
-      span_set(Float8GetDatum(box1.zmin), Float8GetDatum(box1.zmax), true, true,
-        T_FLOAT8, T_FLOATSPAN, &zspan1);
-      if (overlaps_span_span(&zspan1, zspan))
-      {
-        /* Get the Z coordinate values as a temporal float */
-        Temporal *tfloat_z = tpoint_get_coord((Temporal *) at_xy, 2);
-        /* Restrict to the zspan */
-        Temporal *tfloat_zspan = tnumber_restrict_span(tfloat_z, zspan, REST_AT);
-        pfree(tfloat_z);
-        if (tfloat_zspan)
-        {
-          SpanSet *ss = temporal_time(tfloat_zspan);
-          result_at = tsequenceset_restrict_tstzspanset(at_xy, ss, REST_AT);
-          pfree(tfloat_zspan);
-          pfree(ss);
-        }
-      }
-      pfree(at_xy);
-    }
-    else
-      result_at = at_xy;
-  }
+  TSequenceSet *result_at = tpointseq_linear_at_geom(seq, gs);
 
   /* If "at" restriction, return */
   if (atfunc)
@@ -1930,15 +1879,14 @@ tpointseq_linear_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
 /**
  * @ingroup meos_internal_geo_restrict
  * @brief Return a temporal geo sequence restricted to (the complement of) a
- * geometry and possibly a Z span and a timestamptz span
+ * geometry
  * @param[in] seq Temporal geo
  * @param[in] gs Geometry
- * @param[in] zspan Span of values to restrict the Z dimension
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
  */
 Temporal *
 tgeoseq_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
-  const Span *zspan, bool atfunc)
+  bool atfunc)
 {
   assert(seq); assert(gs); assert(tgeo_type_all(seq->temptype));
   interpType interp = MEOS_FLAGS_GET_INTERP(seq->flags);
@@ -1947,7 +1895,7 @@ tgeoseq_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
   if (seq->count == 1)
   {
     TInstant *res = tgeoinst_restrict_geom_iter(TSEQUENCE_INST_N(seq, 0), gs,
-      zspan, atfunc);
+      atfunc);
     if (! res)
       return NULL;
     if (tpoint_type(seq->temptype))
@@ -1964,28 +1912,27 @@ tgeoseq_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
 
   /* General case */
   if (interp == DISCRETE)
-    return (Temporal *) tgeoseq_disc_restrict_geom((TSequence *) seq,
-      gs, zspan, atfunc);
+    return (Temporal *) tgeoseq_disc_restrict_geom((TSequence *) seq, gs,
+      atfunc);
   else if (interp == STEP)
-    return (Temporal *) tgeoseq_step_restrict_geom((TSequence *) seq,
-      gs, zspan, atfunc);
+    return (Temporal *) tgeoseq_step_restrict_geom((TSequence *) seq, gs,
+      atfunc);
   else /* interp == LINEAR */
-    return (Temporal *) tpointseq_linear_restrict_geom((TSequence *) seq,
-      gs, zspan, atfunc);
+    return (Temporal *) tpointseq_linear_restrict_geom((TSequence *) seq, gs,
+      atfunc);
 }
 
 /**
  * @ingroup meos_internal_geo_restrict
  * @brief Return a temporal geo sequence set restricted to (the complement
- * of) a geometry and possibly a Z span and a timestamptz span
+ * of) a geometry
  * @param[in] ss Temporal geo
  * @param[in] gs Geometry
- * @param[in] zspan Span of values to restrict the Z dimension
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
  */
 TSequenceSet *
 tgeoseqset_restrict_geom(const TSequenceSet *ss, const GSERIALIZED *gs,
-  const Span *zspan, bool atfunc)
+  bool atfunc)
 {
   assert(ss); assert(gs); assert(tgeo_type_all(ss->temptype));
 
@@ -1993,7 +1940,7 @@ tgeoseqset_restrict_geom(const TSequenceSet *ss, const GSERIALIZED *gs,
   if (ss->count == 1)
     /* We can safely cast since the composing sequences are continuous */
     return (TSequenceSet *) tgeoseq_restrict_geom(TSEQUENCESET_SEQ_N(ss, 0), 
-      gs, zspan, atfunc);
+      gs, atfunc);
 
   /* General case */
   STBox box2;
@@ -2014,8 +1961,7 @@ tgeoseqset_restrict_geom(const TSequenceSet *ss, const GSERIALIZED *gs,
     else
     {
       /* We can safely cast since the composing sequences are continuous */
-      seqsets[i] = (TSequenceSet *) tgeoseq_restrict_geom(seq, gs, zspan,
-        atfunc);
+      seqsets[i] = (TSequenceSet *) tgeoseq_restrict_geom(seq, gs, atfunc);
       if (seqsets[i])
         totalseqs += seqsets[i]->count;
     }
@@ -2031,22 +1977,19 @@ tgeoseqset_restrict_geom(const TSequenceSet *ss, const GSERIALIZED *gs,
 /**
  * @ingroup meos_internal_geo_restrict
  * @brief Return a temporal geo restricted to (the complement of) a geometry
- * and possibly a Z span
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry
- * @param[in] zspan Span of values to restrict the Z dimension, may be `NULL`
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
  */
 Temporal *
 tgeo_restrict_geom(const Temporal *temp, const GSERIALIZED *gs,
-  const Span *zspan, bool atfunc)
+  bool atfunc)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TGEO(temp, NULL); VALIDATE_NOT_NULL(gs, NULL); 
   /* Ensure the validity of the arguments */
   if (! ensure_same_srid(tspatial_srid(temp), gserialized_get_srid(gs)) ||
       ! ensure_has_not_Z_geo(gs) ||
-      (zspan && ! ensure_has_Z(temp->temptype, temp->flags)) ||
       /* Generic 3D geometries cannot be restricted to a geometry */
       (tgeo_type(temp->temptype) &&
        ! ensure_has_not_Z(temp->temptype, temp->flags)))
@@ -2061,12 +2004,6 @@ tgeo_restrict_geom(const Temporal *temp, const GSERIALIZED *gs,
   tspatial_set_stbox(temp, &box1);
   /* Non-empty geometries have a bounding box */
   geo_set_stbox(gs, &box2);
-  if (zspan)
-  {
-    box2.zmin = DatumGetFloat8(zspan->lower);
-    box2.zmax = DatumGetFloat8(zspan->upper);
-    MEOS_FLAGS_SET_Z(box2.flags, true);
-  }
   if (! overlaps_stbox_stbox(&box1, &box2))
     return atfunc ? NULL : temporal_copy(temp);
 
@@ -2088,16 +2025,15 @@ tgeo_restrict_geom(const Temporal *temp, const GSERIALIZED *gs,
   switch (temp1->subtype)
   {
     case TINSTANT:
-      return (Temporal *) tgeoinst_restrict_geom((TInstant *) temp1,
-        gs, zspan, atfunc);
+      return (Temporal *) tgeoinst_restrict_geom((TInstant *) temp1, gs,
+        atfunc);
       break;
     case TSEQUENCE:
-      result = tgeoseq_restrict_geom((TSequence *) temp1,
-        gs, zspan, atfunc);
+      result = tgeoseq_restrict_geom((TSequence *) temp1, gs, atfunc);
       break;
     default: /* TSEQUENCESET */
       result = (Temporal *) tgeoseqset_restrict_geom((TSequenceSet *) temp1,
-         gs, zspan, atfunc);
+         gs, atfunc);
   }
   if (interp == LINEAR && atfunc)
     pfree(temp1);
@@ -2112,15 +2048,14 @@ tgeo_restrict_geom(const Temporal *temp, const GSERIALIZED *gs,
  * @brief Return a temporal point restricted to a geometry
  * @param[in] temp Temporal point
  * @param[in] gs Geometry
- * @param[in] zspan Span of values to restrict the Z dimension
  * @csqlfn #Tgeo_at_geom()
  * @note This function has a last parameter for the Z dimension which is not
  * available for temporal geometries
  */
 inline Temporal *
-tpoint_at_geom(const Temporal *temp, const GSERIALIZED *gs, const Span *zspan)
+tpoint_at_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
-  return tgeo_restrict_geom(temp, gs, zspan, REST_AT);
+  return tgeo_restrict_geom(temp, gs, REST_AT);
 }
 
 /**
@@ -2133,7 +2068,7 @@ tpoint_at_geom(const Temporal *temp, const GSERIALIZED *gs, const Span *zspan)
 inline Temporal *
 tgeo_at_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
-  return tgeo_restrict_geom(temp, gs, NULL, REST_AT);
+  return tgeo_restrict_geom(temp, gs, REST_AT);
 }
 
 /**
@@ -2141,16 +2076,14 @@ tgeo_at_geom(const Temporal *temp, const GSERIALIZED *gs)
  * @brief Return a temporal point restricted to the complement of a geometry
  * @param[in] temp Temporal point
  * @param[in] gs Geometry
- * @param[in] zspan Span of values to restrict the Z dimension
  * @csqlfn #Tgeo_minus_geom()
  * @note This function has a last parameter for the Z dimension which is not
  * available for temporal geometries
  */
 inline Temporal *
-tpoint_minus_geom(const Temporal *temp, const GSERIALIZED *gs,
-  const Span *zspan)
+tpoint_minus_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
-  return tgeo_restrict_geom(temp, gs, zspan, REST_MINUS);
+  return tgeo_restrict_geom(temp, gs, REST_MINUS);
 }
 
 /**
@@ -2163,7 +2096,110 @@ tpoint_minus_geom(const Temporal *temp, const GSERIALIZED *gs,
 inline Temporal *
 tgeo_minus_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
-  return tgeo_restrict_geom(temp, gs, NULL, REST_MINUS);
+  return tgeo_restrict_geom(temp, gs, REST_MINUS);
+}
+#endif /* MEOS */
+
+/*****************************************************************************/
+
+/**
+ * @ingroup meos_internal_geo_restrict
+ * @brief Return a temporal geo restricted to (the complement of) an elevation
+ * span
+ * @param[in] temp Temporal geo
+ * @param[in] s Elevation span
+ * @param[in] atfunc True if the restriction is `at`, false for `minus`
+ */
+Temporal *
+tgeo_restrict_elevation(const Temporal *temp, const Span *s, bool atfunc)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TGEO(temp, NULL); VALIDATE_NOT_NULL(s, NULL); 
+  /* Ensure the validity of the arguments */
+  if (! ensure_has_Z(temp->temptype, temp->flags))
+    return NULL;
+
+  /* Bounding box test */
+  STBox box;
+  tspatial_set_stbox(temp, &box);
+  /* Non-empty geometries have a bounding box */
+  Span s1;
+  span_set(Float8GetDatum(box.zmin), Float8GetDatum(box.zmax), true, true,
+    T_FLOAT8, T_FLOATSPAN, &s1);
+  if (! overlaps_span_span(&s1, s))
+    return atfunc ? NULL : temporal_copy(temp);
+
+  /* Get the Z coordinate as a temporal float, project the temporal float to
+     the span, and project the temporal geometry */
+  Temporal *temp1 = tpoint_get_coord(temp, 2);
+  Temporal *temp2 = tnumber_restrict_span(temp1, s, atfunc);
+  Temporal *result = NULL;
+  if (temp2)
+  {
+    SpanSet *ss = temporal_time(temp2);
+    result = temporal_restrict_tstzspanset(temp, ss, REST_AT);
+    pfree(ss); pfree(temp2);
+  }
+  /* Clean out and return */
+  pfree(temp1);
+  return result;
+}
+
+/*****************************************************************************/
+
+#if MEOS
+/**
+ * @ingroup meos_geo_restrict
+ * @brief Return a temporal point restricted to an elevation span
+ * @param[in] temp Temporal point
+ * @param[in] s Elevation span
+ * @csqlfn #Tgeo_at_elevation()
+ */
+inline Temporal *
+tpoint_at_elevation(const Temporal *temp, const Span *s)
+{
+  return tgeo_restrict_elevation(temp, s, REST_AT);
+}
+
+/**
+ * @ingroup meos_geo_restrict
+ * @brief Return a temporal geo restricted to an elevation span
+ * @param[in] temp Temporal geo
+ * @param[in] s Elevation span
+ * @csqlfn #Tgeo_at_elevation()
+ */
+inline Temporal *
+tgeo_at_elevation(const Temporal *temp, const Span *s)
+{
+  return tgeo_restrict_elevation(temp, s, REST_AT);
+}
+
+/**
+ * @ingroup meos_geo_restrict
+ * @brief Return a temporal point restricted to the complement of a geometry
+ * @param[in] temp Temporal point
+ * @param[in] s Elevation span
+ * @csqlfn #Tgeo_minus_elevation()
+ * @note This function has a last parameter for the Z dimension which is not
+ * available for temporal geometries
+ */
+inline Temporal *
+tpoint_minus_elevation(const Temporal *temp, const Span *s)
+{
+  return tgeo_restrict_elevation(temp, s, REST_MINUS);
+}
+
+/**
+ * @ingroup meos_geo_restrict
+ * @brief Return a temporal geo restricted to the complement of a geometry
+ * @param[in] temp Temporal geo
+ * @param[in] s Elevation span
+ * @csqlfn #Tgeo_minus_elevation()
+ */
+inline Temporal *
+tgeo_minus_elevation(const Temporal *temp, const Span *s)
+{
+  return tgeo_restrict_elevation(temp, s, REST_MINUS);
 }
 #endif /* MEOS */
 

--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -1263,7 +1263,7 @@ ea_touches_tpoint_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
   bool result = false;
   if (gsbound && ! gserialized_is_empty(gsbound))
   {
-    Temporal *temp1 = tgeo_restrict_geom(temp, gsbound, NULL, REST_MINUS);
+    Temporal *temp1 = tgeo_restrict_geom(temp, gsbound, REST_MINUS);
     result = (temp1 == NULL);
     if (temp1)
       pfree(temp1);

--- a/meos/src/npoint/tnpoint_spatialfuncs.c
+++ b/meos/src/npoint/tnpoint_spatialfuncs.c
@@ -488,7 +488,7 @@ tnpoint_restrict_geom(const Temporal *temp, const GSERIALIZED *gs, bool atfunc)
     return atfunc ? NULL : temporal_copy(temp);
 
   Temporal *tpoint = tnpoint_to_tgeompoint(temp);
-  Temporal *res = tgeo_restrict_geom(tpoint, gs, NULL, atfunc);
+  Temporal *res = tgeo_restrict_geom(tpoint, gs, atfunc);
   Temporal *result = NULL;
   if (res)
   {

--- a/meos/src/pose/tpose_spatialfuncs.c
+++ b/meos/src/pose/tpose_spatialfuncs.c
@@ -75,11 +75,9 @@ tpose_trajectory(const Temporal *temp)
 /**
  * @ingroup meos_internal_pose_restrict
  * @brief Return a temporal pose restricted to (the complement of) a geometry
- * @note `zspan` may be `NULL`
  */
 Temporal *
-tpose_restrict_geom(const Temporal *temp, const GSERIALIZED *gs,
-  const Span *zspan, bool atfunc)
+tpose_restrict_geom(const Temporal *temp, const GSERIALIZED *gs, bool atfunc)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tpose_geo(temp, gs) || ! ensure_has_not_Z_geo(gs))
@@ -90,7 +88,7 @@ tpose_restrict_geom(const Temporal *temp, const GSERIALIZED *gs,
     return atfunc ? NULL : temporal_copy(temp);
 
   Temporal *tpoint = tpose_to_tpoint(temp);
-  Temporal *res = tgeo_restrict_geom(tpoint, gs, zspan, atfunc);
+  Temporal *res = tgeo_restrict_geom(tpoint, gs, atfunc);
   Temporal *result = NULL;
   if (res)
   {
@@ -109,14 +107,12 @@ tpose_restrict_geom(const Temporal *temp, const GSERIALIZED *gs,
  * @brief Return a temporal pose restricted to a geometry
  * @param[in] temp Temporal pose
  * @param[in] gs Geometry
- * @param[in] zspan Span of values to restrict the Z dimension
  * @csqlfn #Tpose_at_geom()
  */
 inline Temporal *
-tpose_at_geom(const Temporal *temp, const GSERIALIZED *gs,
-  const Span *zspan)
+tpose_at_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
-  return tpose_restrict_geom(temp, gs, zspan, REST_AT);
+  return tpose_restrict_geom(temp, gs, REST_AT);
 }
 
 /**
@@ -124,14 +120,12 @@ tpose_at_geom(const Temporal *temp, const GSERIALIZED *gs,
  * @brief Return a temporal point restricted to (the complement of) a geometry
  * @param[in] temp Temporal pose
  * @param[in] gs Geometry
- * @param[in] zspan Span of values to restrict the Z dimension
  * @csqlfn #Tpose_minus_geom()
  */
 inline Temporal *
-tpose_minus_geom(const Temporal *temp, const GSERIALIZED *gs,
-  const Span *zspan)
+tpose_minus_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
-  return tpose_restrict_geom(temp, gs, zspan, REST_MINUS);
+  return tpose_restrict_geom(temp, gs, REST_MINUS);
 }
 #endif /* MEOS */
 

--- a/meos/src/temporal/temporal_aggfuncs.c
+++ b/meos/src/temporal/temporal_aggfuncs.c
@@ -543,6 +543,7 @@ tsequence_tagg_iter(const TSequence *seq1, const TSequence *seq2,
   TSequence *syncseq1, *syncseq2;
   synchronize_tsequence_tsequence(seq1, seq2, &syncseq1, &syncseq2, crossings);
   TInstant **instants = palloc(sizeof(TInstant *) * syncseq1->count);
+  // meosType basetype = temptype_basetype(seq1->temptype);
   for (int i = 0; i < syncseq1->count; i++)
   {
     const TInstant *inst1 = TSEQUENCE_INST_N(syncseq1, i);
@@ -551,6 +552,7 @@ tsequence_tagg_iter(const TSequence *seq1, const TSequence *seq2,
     {
       Datum value = func(tinstant_value_p(inst1), tinstant_value_p(inst2));
       instants[i] = tinstant_make(value, seq1->temptype, inst1->t);
+      // DATUM_FREE(value, basetype); // TODO
     }
     else
     {

--- a/meos/src/temporal/type_parser.c
+++ b/meos/src/temporal/type_parser.c
@@ -534,7 +534,10 @@ set_parse(const char **str, meosType settype)
       spatial_set_srid(values[i], basetype, set_srid);
   }
   result = set_make(values, array->count, basetype, ORDER);
-  pfree(values);
+  if (meostype_length(basetype) < 0)
+    pfree_array((void **) values, array->count);
+  else
+    pfree(values);
 
 error:
   meos_array_destroy(array);

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -1852,8 +1852,16 @@ int main(void)
     free(tgeompt_result);
   free(char_result);
 
-  /* Temporal *tpoint_at_geom(const Temporal *temp, const GSERIALIZED *gs, const Span *zspan); */
-  tgeompt_result = tpoint_at_geom(tgeompt3d1, geom1, fspan1);
+  /* Temporal *tpoint_at_elevation(const Temporal *temp, const Span *s); */
+  tgeompt_result = tpoint_at_elevation(tgeompt3d1, fspan1);
+  char_result = tgeompt_result ? tspatial_as_ewkt(tgeompt_result, 6) : text_out(text_null);
+  printf("tpoint_at_geom(%s, %s): %s\n", tgeompt3d1_out, fspan1_out, char_result);
+  if (tgeompt_result)
+    free(tgeompt_result);
+  free(char_result);
+
+  /* Temporal *tpoint_at_geom(const Temporal *temp, const GSERIALIZED *gs); */
+  tgeompt_result = tpoint_at_geom(tgeompt3d1, geom1);
   char_result = tgeompt_result ? tspatial_as_ewkt(tgeompt_result, 6) : text_out(text_null);
   printf("tpoint_at_geom(%s, %s, %s): %s\n", tgeompt3d1_out, geom1_out, fspan1_out, char_result);
   if (tgeompt_result)
@@ -1868,14 +1876,22 @@ int main(void)
     free(tgeompt_result);
   free(char_result);
 
-  /* Temporal *tpoint_minus_geom(const Temporal *temp, const GSERIALIZED *gs, const Span *zspan); */
-  tgeompt_result = tpoint_minus_geom(tgeompt3d1, geom1, fspan1);
+  /* Temporal *tpoint_minus_geom(const Temporal *temp, const GSERIALIZED *gs); */
+  tgeompt_result = tpoint_minus_geom(tgeompt3d1, geom1);
   char_result = tgeompt_result ? tspatial_as_ewkt(tgeompt_result, 6) : text_out(text_null);
-  printf("tpoint_minus_geom(%s, %s, %s): %s\n", tgeompt3d1_out, geom1_out, fspan1_out, char_result);
+  printf("tpoint_minus_geom(%s, %s): %s\n", tgeompt3d1_out, geom1_out, char_result);
   if (tgeompt_result)
     free(tgeompt_result);
   free(char_result);
 
+  /* Temporal *tpoint_minus_elevation(const Temporal *temp, const Span *s); */
+  tgeompt_result = tpoint_minus_elevation(tgeompt3d1, fspan1);
+  char_result = tgeompt_result ? tspatial_as_ewkt(tgeompt_result, 6) : text_out(text_null);
+  printf("tpoint_minus_geom(%s, %s): %s\n", tgeompt3d1_out, fspan1_out, char_result);
+  if (tgeompt_result)
+    free(tgeompt_result);
+  free(char_result);
+  
   /* Temporal *tpoint_minus_value(const Temporal *temp, GSERIALIZED *gs); */
   tgeompt_result = tpoint_minus_value(tgeompt1, geom1);
   char_result = tgeompt_result ? tspatial_as_ewkt(tgeompt_result, 6) : text_out(text_null);

--- a/mobilitydb/sql/geo/056_tpoint_spatialfuncs.in.sql
+++ b/mobilitydb/sql/geo/056_tpoint_spatialfuncs.in.sql
@@ -318,16 +318,7 @@ CREATE FUNCTION atGeometry(tgeompoint, geometry)
   RETURNS tgeompoint
   AS 'MODULE_PATHNAME', 'Tgeo_at_geom'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION atGeometry(tgeompoint, geometry, floatspan)
-  RETURNS tgeompoint
-  AS 'MODULE_PATHNAME', 'Tgeo_at_geom'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
 CREATE FUNCTION minusGeometry(tgeompoint, geometry)
-  RETURNS tgeompoint
-  AS 'MODULE_PATHNAME', 'Tgeo_minus_geom'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION minusGeometry(tgeompoint, geometry, floatspan)
   RETURNS tgeompoint
   AS 'MODULE_PATHNAME', 'Tgeo_minus_geom'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -349,5 +340,15 @@ CREATE FUNCTION minusStbox(tgeogpoint, stbox, borderInc bool DEFAULT TRUE)
   RETURNS tgeogpoint
   AS 'MODULE_PATHNAME', 'Tgeo_minus_stbox'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION atElevation(tgeompoint, floatspan)
+  RETURNS tgeompoint
+  AS 'MODULE_PATHNAME', 'Tgeo_at_elevation'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION minusElevation(tgeompoint, floatspan)
+  RETURNS tgeompoint
+  AS 'MODULE_PATHNAME', 'Tgeo_minus_elevation'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 
 /*****************************************************************************/

--- a/mobilitydb/src/geo/tgeo_spatialfuncs.c
+++ b/mobilitydb/src/geo/tgeo_spatialfuncs.c
@@ -713,16 +713,9 @@ Tpoint_make_simple(PG_FUNCTION_ARGS)
 static Datum
 Tgeo_restrict_geom(FunctionCallInfo fcinfo, bool atfunc)
 {
-  /*
-  CREATE FUNCTION at/minusGeometry(tgeometry, geometry)
-  CREATE FUNCTION at/minusGeometry(tgeometry, geometry, floatspan)
-  */
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(1);
-  Span *zspan = NULL;
-  if (PG_NARGS() == 3)
-    zspan = PG_GETARG_SPAN_P(2);
-  Temporal *result = tgeo_restrict_geom(temp, gs, zspan, atfunc);
+  Temporal *result = tgeo_restrict_geom(temp, gs, atfunc);
   PG_FREE_IF_COPY(temp, 0);
   PG_FREE_IF_COPY(gs, 1);
   if (! result)
@@ -802,6 +795,52 @@ inline Datum
 Tgeo_minus_stbox(PG_FUNCTION_ARGS)
 {
   return Tgeo_restrict_stbox(fcinfo, REST_MINUS);
+}
+
+/*****************************************************************************
+ * Restriction functions
+ *****************************************************************************/
+
+/**
+ * @brief Return a temporal geo restricted to (the complement of) an elevation
+ * span
+ */
+static Datum
+Tgeo_restrict_elevation(FunctionCallInfo fcinfo, bool atfunc)
+{
+  Temporal *temp = PG_GETARG_TEMPORAL_P(0);
+  Span *s = PG_GETARG_SPAN_P(1);
+  Temporal *result = tgeo_restrict_elevation(temp, s, atfunc);
+  PG_FREE_IF_COPY(temp, 0);
+  if (! result)
+    PG_RETURN_NULL();
+  PG_RETURN_TEMPORAL_P(result);
+}
+
+PGDLLEXPORT Datum Tgeo_at_elevation(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tgeo_at_elevation);
+/**
+ * @ingroup mobilitydb_geo_restrict
+ * @brief Return a temporal geo restricted to an elevation span
+ * @sqlfn atGeometry()
+ */
+inline Datum
+Tgeo_at_elevation(PG_FUNCTION_ARGS)
+{
+  return Tgeo_restrict_elevation(fcinfo, REST_AT);
+}
+
+PGDLLEXPORT Datum Tgeo_minus_elevation(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tgeo_minus_elevation);
+/**
+ * @ingroup mobilitydb_geo_restrict
+ * @brief Return a temporal geo restricted to the complement an elevation span
+ * @sqlfn minusGeometry()
+ */
+inline Datum
+Tgeo_minus_elevation(PG_FUNCTION_ARGS)
+{
+  return Tgeo_restrict_elevation(fcinfo, REST_MINUS);
 }
 
 /*****************************************************************************/

--- a/mobilitydb/src/pose/tpose_spatialfuncs.c
+++ b/mobilitydb/src/pose/tpose_spatialfuncs.c
@@ -79,7 +79,7 @@ Tpose_restrict_geom(FunctionCallInfo fcinfo, bool atfunc)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(1);
-  Temporal *result = tpose_restrict_geom(temp, gs, NULL, atfunc);
+  Temporal *result = tpose_restrict_geom(temp, gs, atfunc);
   PG_FREE_IF_COPY(temp, 0);
   PG_FREE_IF_COPY(gs, 1);
   if (! result)

--- a/mobilitydb/test/geo/expected/056_tpoint_spatialfuncs.test.out
+++ b/mobilitydb/test/geo/expected/056_tpoint_spatialfuncs.test.out
@@ -3265,18 +3265,6 @@ SELECT asText(atGeometry(tgeompoint '[Point(1 1 1)@2000-01-01, Point(1 1 1)@2000
  
 (1 row)
 
-SELECT asText(atGeometry(tgeompoint 'Point(1 1 1)@2000-01-01', geometry 'Linestring(0 0, 2 2)', floatspan '[0, 2]'));
-                    astext                    
-----------------------------------------------
- POINT Z (1 1 1)@Sat Jan 01 00:00:00 2000 PST
-(1 row)
-
-select asText(atGeometry(tgeompoint 'Interp=Step;[Point(1 1 1)@2000-01-01, Point(1 1 3)@2000-01-02]', geometry 'Point(1 1)', floatspan '[1, 2]'));
-                                                   astext                                                   
-------------------------------------------------------------------------------------------------------------
- Interp=Step;{[POINT Z (1 1 1)@Sat Jan 01 00:00:00 2000 PST, POINT Z (1 1 1)@Sun Jan 02 00:00:00 2000 PST)}
-(1 row)
-
 SELECT asText(atGeometry(tgeompoint '[Point(1 1)@2000-01-01]', geometry 'Linestring(0 0,1 1)'));
                    astext                    
 ---------------------------------------------
@@ -3503,10 +3491,10 @@ SELECT minusGeometry(tgeompoint 'Point(1 1)@2000-01-01', geometry 'SRID=5676;Lin
 ERROR:  Operation on mixed SRID
 SELECT minusGeometry(tgeompoint 'Point(1 1)@2000-01-01', geometry 'Linestring(1 1 1,2 2 2)');
 ERROR:  The geometry cannot have Z dimension
-WITH temp(trip, geo, zspan) AS (
+WITH temp(trip, geo) AS (
   SELECT tgeompoint '[Point(1 1 1)@2000-01-01, Point(3 1 1)@2000-01-03,
-    Point(3 1 3)@2000-01-05]', geometry 'Polygon((2 0,2 2,4 2,4 0,2 0))', floatspan '[0,2]' )
-SELECT trip = merge(atGeometry(trip, geo, zspan), minusGeometry(trip, geo, zspan))
+    Point(3 1 3)@2000-01-05]', geometry 'Polygon((2 0,2 2,4 2,4 0,2 0))' )
+SELECT trip = merge(atGeometry(trip, geo), minusGeometry(trip, geo))
 FROM temp;
  ?column? 
 ----------

--- a/mobilitydb/test/geo/expected/056_tpoint_spatialfuncs_tbl.test.out
+++ b/mobilitydb/test/geo/expected/056_tpoint_spatialfuncs_tbl.test.out
@@ -642,3 +642,9 @@ SELECT COUNT(*) FROM tbl_tgeogpoint3d t1, tbl_geodstbox3d t2 WHERE temp != merge
      1
 (1 row)
 
+SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_floatspan t2 WHERE temp != merge(atElevation(temp, f), minusElevation(temp, f));
+ count 
+-------
+     0
+(1 row)
+

--- a/mobilitydb/test/geo/queries/056_tpoint_spatialfuncs.test.sql
+++ b/mobilitydb/test/geo/queries/056_tpoint_spatialfuncs.test.sql
@@ -892,10 +892,6 @@ SELECT asText(atGeometry(tgeompoint 'Interp=Step;{[Point(1 1 1)@2000-01-01, Poin
 
 SELECT asText(atGeometry(tgeompoint '[Point(1 1 1)@2000-01-01, Point(1 1 1)@2000-01-02]', geometry 'Linestring(0 0,0 2,2 2)'));
 
---3D Zspan
-SELECT asText(atGeometry(tgeompoint 'Point(1 1 1)@2000-01-01', geometry 'Linestring(0 0, 2 2)', floatspan '[0, 2]'));
-select asText(atGeometry(tgeompoint 'Interp=Step;[Point(1 1 1)@2000-01-01, Point(1 1 3)@2000-01-02]', geometry 'Point(1 1)', floatspan '[1, 2]'));
-
 SELECT asText(atGeometry(tgeompoint '[Point(1 1)@2000-01-01]', geometry 'Linestring(0 0,1 1)'));
 SELECT asText(atGeometry(tgeompoint '[Point(1 1)@2000-01-01, Point(3 3)@2000-01-02]','Point(2 2)'));
 SELECT asText(atGeometry(tgeompoint '[Point(0 1)@2000-01-01,Point(5 1)@2000-01-05]', geometry 'Linestring(0 0,2 2,3 1,4 1,5 0)'));
@@ -950,10 +946,10 @@ SELECT minusGeometry(tgeompoint 'Point(1 1)@2000-01-01', geometry 'Linestring(1 
 --------------------------------------------------------
 
 -- Equivalences
-WITH temp(trip, geo, zspan) AS (
+WITH temp(trip, geo) AS (
   SELECT tgeompoint '[Point(1 1 1)@2000-01-01, Point(3 1 1)@2000-01-03,
-    Point(3 1 3)@2000-01-05]', geometry 'Polygon((2 0,2 2,4 2,4 0,2 0))', floatspan '[0,2]' )
-SELECT trip = merge(atGeometry(trip, geo, zspan), minusGeometry(trip, geo, zspan))
+    Point(3 1 3)@2000-01-05]', geometry 'Polygon((2 0,2 2,4 2,4 0,2 0))' )
+SELECT trip = merge(atGeometry(trip, geo), minusGeometry(trip, geo))
 FROM temp;
 
 --------------------------------------------------------

--- a/mobilitydb/test/geo/queries/056_tpoint_spatialfuncs_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/056_tpoint_spatialfuncs_tbl.test.sql
@@ -188,4 +188,7 @@ SELECT COUNT(*) FROM tbl_tgeompoint3d t1, tbl_stbox3d t2 WHERE temp != merge(atS
 -- TODO THE FOLLOWING FUNCTION RETURNS 1, WE NEED TO DEBUG TO UNDERSTAND WHY
 SELECT COUNT(*) FROM tbl_tgeogpoint3d t1, tbl_geodstbox3d t2 WHERE temp != merge(atStbox(temp, b), minusStbox(temp, b));
 
+SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_floatspan t2 WHERE temp != merge(atElevation(temp, f), minusElevation(temp, f));
+
+
 -------------------------------------------------------------------------------


### PR DESCRIPTION
The functions `atGeometry` and `minusGeometry` provide the possibility to restrict the resulting 3D temporal point to an elevation span. This PR extracts this functionality outside these functions into the new functions `atElevation` and `minusElevation` so that it can be used for restricting 3D temporal points indepedently of  `atGeometry` and `minusGeometry`.