### PR TITLE
Polygon clip

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,17 +1,23 @@
 ---
+# Codacy's cppcheck wrapper runs the tool without the build's -I include
+# paths, so every project/system header fires a 'missingInclude[System]'
+# warning - on this codebase ~200 of them drown the real findings.
+# MobilityDB runs its own cppcheck in .github/workflows/cppcheck.yml
+# instead: it feeds cppcheck the real compile_commands.json (so include
+# resolution works) and publishes SARIF to GitHub Code Scanning (inline
+# PR annotations, Security tab). Turn Codacy's copy off.
 engines:
   cppcheck:
-    language: c
-    exclude_paths:
-      - "postgis/**"
-      - "postgres/**"
+    enabled: false
   duplication:
     exclude_paths:
       - "postgis/**"
       - "postgres/**"
+      - "pgtypes/**"
     config:
       languages:
         - "c"
 exclude_paths:
   - "postgis/**"
   - "postgres/**"
+  - "pgtypes/**"

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -8,7 +8,12 @@
 # PR annotations, Security tab). Turn Codacy's copy off.
 engines:
   cppcheck:
+    # Belt-and-braces: `enabled: false` is the documented kill switch
+    # but Codacy has been observed to still surface cppcheck issues on
+    # PR analyses, so we additionally tell cppcheck to scan no paths.
     enabled: false
+    exclude_paths:
+      - "**"
   duplication:
     exclude_paths:
       - "postgis/**"
@@ -21,3 +26,5 @@ exclude_paths:
   - "postgis/**"
   - "postgres/**"
   - "pgtypes/**"
+  - "meos/test/**"
+  - "meos/examples/**"

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,185 @@
+name: Cppcheck
+
+# Runs cppcheck with the build's real -I include paths (via
+# compile_commands.json) and publishes the findings to GitHub's Code
+# Scanning UI as inline PR annotations. This replaces Codacy's cppcheck,
+# which can't be given the build's include paths and therefore drowns
+# the finding list with `missingInclude` / `missingIncludeSystem`
+# warnings on every #include of a project header.
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/cppcheck.yml'
+      - 'cmake/**'
+      - 'CMakeLists.txt'
+      - 'meos/src/**'
+      - 'meos/include/**'
+      - 'mobilitydb/src/**'
+      - 'mobilitydb/pg_include/**'
+  pull_request:
+    paths:
+      - '.github/workflows/cppcheck.yml'
+      - 'cmake/**'
+      - 'CMakeLists.txt'
+      - 'meos/src/**'
+      - 'meos/include/**'
+      - 'mobilitydb/src/**'
+      - 'mobilitydb/pg_include/**'
+
+# SARIF upload needs write access to Code Scanning alerts.
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+
+jobs:
+  cppcheck:
+    name: Cppcheck (with project include paths)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies and cppcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cppcheck \
+            libgeos-dev \
+            libproj-dev \
+            libjson-c-dev \
+            libgsl-dev
+          cppcheck --version
+
+      - name: Configure (generate compile_commands.json)
+        run: |
+          mkdir build
+          cd build
+          cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DMEOS=on ..
+
+      - name: Run cppcheck (XML output - universally supported)
+        # --project uses the same -I paths CMake records for the real
+        # build, which is what makes the missingInclude noise vanish.
+        # XML is preferred over --output-format=sarif because SARIF
+        # support in cppcheck only landed in 2.13+; we convert XML to
+        # SARIF ourselves in the next step so the job works regardless
+        # of the runner's cppcheck version.
+        run: |
+          set -x
+          cppcheck --version
+          cppcheck \
+            --project=build/compile_commands.json \
+            --enable=warning,style,performance,portability \
+            --inline-suppr \
+            --suppress='*:*/postgres/*' \
+            --suppress='*:*/postgis/*' \
+            --suppress='*:*/pgtypes/*' \
+            --suppress='missingIncludeSystem' \
+            --suppress='unmatchedSuppression' \
+            --xml --xml-version=2 \
+            -j "$(nproc)" \
+            2> cppcheck.xml || true
+          echo "--- cppcheck.xml (first 40 lines) ---"
+          head -40 cppcheck.xml || true
+          test -s cppcheck.xml
+
+      - name: Convert cppcheck XML to SARIF
+        run: |
+          python3 <<'PYEOF' > cppcheck.sarif
+          import sys, json, xml.etree.ElementTree as ET
+
+          # Map cppcheck severities to SARIF level (note: cppcheck
+          # uses "error"/"warning"/"style"/"performance"/"portability"
+          # /"information"; SARIF has "error"/"warning"/"note"/"none").
+          SEV = {
+              "error":       "error",
+              "warning":     "warning",
+              "portability": "warning",
+              "performance": "warning",
+              "style":       "note",
+              "information": "note",
+          }
+
+          root = ET.parse("cppcheck.xml").getroot()
+          results = []
+          rules   = {}
+
+          # <errors><error id=... severity=... msg=...><location .../></error>
+          for err in root.iter("error"):
+              rid   = err.get("id") or "cppcheck"
+              sev   = SEV.get(err.get("severity") or "", "warning")
+              msg   = err.get("msg") or err.get("verbose") or rid
+              rules[rid] = {
+                  "id":   rid,
+                  "name": rid,
+                  "shortDescription": {"text": err.get("msg") or rid},
+                  "defaultConfiguration": {"level": sev},
+              }
+              for loc in err.findall("location"):
+                  # SARIF requires startLine/startColumn >= 1. cppcheck
+                  # sometimes emits 0 (no-column-info sentinel); clamp.
+                  start_line = max(1, int(loc.get("line") or 1))
+                  start_col  = max(1, int(loc.get("column") or 1))
+                  results.append({
+                      "ruleId":  rid,
+                      "level":   sev,
+                      "message": {"text": msg},
+                      "locations": [{
+                          "physicalLocation": {
+                              "artifactLocation": {
+                                  "uri": loc.get("file") or "unknown",
+                              },
+                              "region": {
+                                  "startLine":   start_line,
+                                  "startColumn": start_col,
+                              },
+                          },
+                      }],
+                  })
+
+          sarif = {
+              "version": "2.1.0",
+              "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+              "runs": [{
+                  "tool": {
+                      "driver": {
+                          "name":    "Cppcheck",
+                          "version": "reported by cppcheck --version",
+                          "informationUri": "https://cppcheck.sourceforge.io/",
+                          "rules":   list(rules.values()),
+                      },
+                  },
+                  "results": results,
+              }],
+          }
+          json.dump(sarif, sys.stdout, indent=2)
+          PYEOF
+          echo "--- cppcheck.sarif (summary) ---"
+          python3 -c "
+          import json
+          d = json.load(open('cppcheck.sarif'))
+          res = d['runs'][0]['results']
+          print(f'SARIF runs: {len(d[\"runs\"])}, results: {len(res)}')
+          counts = {}
+          for r in res:
+              counts[r['level']] = counts.get(r['level'], 0) + 1
+          for k, v in sorted(counts.items()):
+              print(f'  {k}: {v}')
+          "
+
+      - name: Upload SARIF to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: cppcheck.sarif
+          category: cppcheck
+
+      - name: Attach SARIF as workflow artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cppcheck-sarif
+          path: cppcheck.sarif
+          retention-days: 30

--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1154,11 +1154,15 @@
 			<title>Restricciones</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="tgeo_atGeometry"><varname>atGeometry</varname>, <varname>minusGeometry</varname></link>: Restringir a (al complemento de) una geometría, un lapso Z y/o un período</para>
+					<para><link linkend="tgeo_atGeometry"><varname>atGeometry</varname>, <varname>minusGeometry</varname></link>: Restringir a (al complemento de) una geometría</para>
 				</listitem>
 
 				<listitem>
 					<para><link linkend="tgeo_atStbox"><varname>atStbox</varname>, <varname>minuStbox</varname></link>: Restringir a (al complemento de) un <varname>stbox</varname></para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tgeo_atElevation"><varname>atElevation</varname>, <varname>minuElevation</varname></link>: Restringir a (al complemento de) un rango de altitud</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/es/temporal_spatial_p2.xml
+++ b/doc/es/temporal_spatial_p2.xml
@@ -16,9 +16,9 @@
 			<listitem xml:id="tgeo_atGeometry">
 				<indexterm significance="normal"><primary><varname>atGeometry</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusGeometry</varname></primary></indexterm>
-				<para>Restringir a (al complemento de) una geometría, un lapso Z y/o un período &Z_support;</para>
-				<para><varname>atGeometry(tgeom,geometry[,zspan]) → tgeom</varname></para>
-				<para><varname>minusGeometry(tgeom,geometry[,zspan]) → tgeom</varname></para>
+				<para>Restringir a (al complemento de) una geometría &Z_support;</para>
+				<para><varname>atGeometry(tgeom,geometry) → tgeom</varname></para>
+				<para><varname>minusGeometry(tgeom,geometry]) → tgeom</varname></para>
 				<para>La geometría debe ser 2D y el cálculo con respecto a ella se realiza en 2D. El resultado conserva la dimensión Z del punto temporal, si existe.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(atGeometry(tgeompoint '[Point(0 0)@2001-01-01, Point(3 3)@2001-01-04)',
@@ -28,8 +28,8 @@ SELECT astext(atGeometry(tgeompoint '[Point(0 0 0)@2001-01-01, Point(4 4 4)@2001
   geometry 'Polygon((1 1,1 2,2 2,2 1,1 1))'));
 -- {[POINT Z (1 1 1)@2001-01-02, POINT Z (2 2 2)@2001-01-03]}
 SELECT asText(atGeometry(tgeompoint '[Point(1 1 1)@2001-01-01, Point(3 1 1)@2001-01-03,
-  Point(3 1 3)@2001-01-05]', 'Polygon((2 0,2 2,2 4,4 0,2 0))', '[0,2]'));
--- {[POINT Z (2 1 1)@2001-01-02, POINT Z (3 1 1)@2001-01-03, POINT Z (3 1 2)@2001-01-04]}
+  Point(3 1 3)@2001-01-05]', 'Polygon((2 0,2 2,2 4,4 0,2 0))'));
+-- {[POINT Z (2 1 1)@2001-01-02, POINT Z (3 1 1)@2001-01-03, POINT Z (3 1 3)@2001-01-05]}
 SELECT asText(atGeometry(tgeometry 'Linestring(1 1,10 1)@2001-01-01', 
   'Polygon((0 0,0 5,5 5,5 0,0 0))'));
 -- LINESTRING(1 1,5 1)@2001-01-01
@@ -44,9 +44,8 @@ SELECT astext(minusGeometry(tgeompoint '[Point(0 0 0)@2001-01-01,
 /* {[POINT Z (0 0 0)@2001-01-01, POINT Z (1 1 1)@2001-01-02),
    (POINT Z (2 2 2)@2001-01-03, POINT Z (4 4 4)@2001-01-05]} */
 SELECT asText(minusGeometry(tgeompoint '[Point(1 1 1)@2001-01-01, Point(3 1 1)@2001-01-03,
-  Point(3 1 3)@2001-01-05]', 'Polygon((2 0,2 2,2 4,4 0,2 0))', '[0,2]'));
-/* {[POINT Z (1 1 1)@2001-01-01, POINT Z (2 1 1)@2001-01-02),
-    (POINT Z (3 1 2)@2001-01-04, POINT Z (3 1 3)@2001-01-05]} */
+  Point(3 1 3)@2001-01-05]', 'Polygon((2 0,2 2,2 4,4 0,2 0))'));
+-- {[POINT Z (1 1 1)@2001-01-01, POINT Z (2 1 1)@2001-01-02)}
 SELECT asText(minusGeometry(tgeometry 'Linestring(1 1,10 1)@2001-01-01', 
   'Polygon((0 0,0 5,5 5,5 0,0 0))'));
 -- LINESTRING(5 1,10 1)@2001-01-01
@@ -88,6 +87,25 @@ SELECT asText(minusStbox(tgeometry '[Point(1 1)@2001-01-01,
    LINESTRING(1 1,2 2)@2001-01-04),[MULTILINESTRING((1 1,2 2),(3 3,4 4))@2001-01-09]} */
 </programlisting>
 			</listitem>
+
+			<listitem xml:id="tgeo_atElevation">
+				<indexterm significance="normal"><primary><varname>atElevation</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>minusElevation</varname></primary></indexterm>
+				<para>Restringir a (al complemento de) un rango de altitud &Z_support;</para>
+				<para><varname>atElevation(tgeom,zspan) → tgeom</varname></para>
+				<para><varname>minusElevation(tgeom,zspan) → tgeom</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT astext(atElevation(tgeompoint '[Point(1 1 1)@2001-01-01,
+  Point(4 4 4)@2001-01-04, Point(1 1 1)@2001-01-07]', floatspan '[2,3]'));
+/* {[POINT Z (2 2 2)@2001-01-02, POINT Z (3 3 3)@2001-01-03],
+  [POINT Z (3 3 3)@2001-01-05, POINT Z (2 2 2)@2001-01-06]} */
+SELECT astext(minusElevation(tgeompoint '[Point(1 1 1)@2001-01-01,
+  Point(4 4 4)@2001-01-04, Point(1 1 1)@2001-01-07]', floatspan '[2,3]'));
+/* {[POINT Z (2 2 2)@2001-01-02, POINT Z (3 3 3)@2001-01-03],
+  [POINT Z (3 3 3)@2001-01-05, POINT Z (2 2 2)@2001-01-06]} */
+</programlisting>
+			</listitem>
+
 		</itemizedlist>
 	</sect1>
 

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1152,11 +1152,15 @@
 			<title>Restrictions</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="tgeo_atGeometry"><varname>atGeometry</varname>, <varname>minusGeometry</varname></link>: Restrict to (the complement of) a geometry, a span in Z and/or a period</para>
+					<para><link linkend="tgeo_atGeometry"><varname>atGeometry</varname>, <varname>minusGeometry</varname></link>: Restrict to (the complement of) a geometry</para>
 				</listitem>
 
 				<listitem>
 					<para><link linkend="tgeo_atStbox"><varname>atStbox</varname>, <varname>minuStbox</varname></link>: Restrict to (the complement of) an <varname>stbox</varname></para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tgeo_atElevation"><varname>atElevation</varname>, <varname>minuElevation</varname></link>: Restrict to (the complement of) an elevation span</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/temporal_spatial_p2.xml
+++ b/doc/temporal_spatial_p2.xml
@@ -16,9 +16,9 @@
 			<listitem xml:id="tgeo_atGeometry">
 				<indexterm significance="normal"><primary><varname>atGeometry</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusGeometry</varname></primary></indexterm>
-				<para>Restrict to (the complement of) a geometry, a Z span, and/or a period &Z_support;</para>
-				<para><varname>atGeometry(tgeom,geometry[,zspan]) → tgeom</varname></para>
-				<para><varname>minusGeometry(tgeom,geometry[,zspan]) → tgeom</varname></para>
+				<para>Restrict to (the complement of) a geometry &Z_support;</para>
+				<para><varname>atGeometry(tgeom,geometry) → tgeom</varname></para>
+				<para><varname>minusGeometry(tgeom,geometry) → tgeom</varname></para>
 				<para>The geometry must be in 2D and the computation with respect to it is done in 2D. The result preserves the Z dimension of the temporal point, if it exists.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(atGeometry(tgeompoint '[Point(0 0)@2001-01-01, Point(3 3)@2001-01-04)',
@@ -28,8 +28,8 @@ SELECT astext(atGeometry(tgeompoint '[Point(0 0 0)@2001-01-01, Point(4 4 4)@2001
   geometry 'Polygon((1 1,1 2,2 2,2 1,1 1))'));
 -- {[POINT Z (1 1 1)@2001-01-02, POINT Z (2 2 2)@2001-01-03]}
 SELECT asText(atGeometry(tgeompoint '[Point(1 1 1)@2001-01-01, Point(3 1 1)@2001-01-03,
-  Point(3 1 3)@2001-01-05]', 'Polygon((2 0,2 2,2 4,4 0,2 0))', '[0,2]'));
--- {[POINT Z (2 1 1)@2001-01-02, POINT Z (3 1 1)@2001-01-03, POINT Z (3 1 2)@2001-01-04]}
+  Point(3 1 3)@2001-01-05]', 'Polygon((2 0,2 2,2 4,4 0,2 0))'));
+-- {[POINT Z (2 1 1)@2001-01-02, POINT Z (3 1 1)@2001-01-03, POINT Z (3 1 3)@2001-01-05]}
 SELECT asText(atGeometry(tgeometry 'Linestring(1 1,10 1)@2001-01-01', 
   'Polygon((0 0,0 5,5 5,5 0,0 0))'));
 -- LINESTRING(1 1,5 1)@2001-01-01
@@ -44,9 +44,8 @@ SELECT astext(minusGeometry(tgeompoint '[Point(0 0 0)@2001-01-01,
 /* {[POINT Z (0 0 0)@2001-01-01, POINT Z (1 1 1)@2001-01-02),
    (POINT Z (2 2 2)@2001-01-03, POINT Z (4 4 4)@2001-01-05]} */
 SELECT asText(minusGeometry(tgeompoint '[Point(1 1 1)@2001-01-01, Point(3 1 1)@2001-01-03,
-  Point(3 1 3)@2001-01-05]', 'Polygon((2 0,2 2,2 4,4 0,2 0))', '[0,2]'));
-/* {[POINT Z (1 1 1)@2001-01-01, POINT Z (2 1 1)@2001-01-02),
-    (POINT Z (3 1 2)@2001-01-04, POINT Z (3 1 3)@2001-01-05]} */
+  Point(3 1 3)@2001-01-05]', 'Polygon((2 0,2 2,2 4,4 0,2 0))'));
+-- {[POINT Z (1 1 1)@2001-01-01, POINT Z (2 1 1)@2001-01-02)}
 SELECT asText(minusGeometry(tgeometry 'Linestring(1 1,10 1)@2001-01-01', 
   'Polygon((0 0,0 5,5 5,5 0,0 0))'));
 -- LINESTRING(5 1,10 1)@2001-01-01
@@ -86,6 +85,24 @@ SELECT asText(minusStbox(tgeometry '[Point(1 1)@2001-01-01,
   Linestring(1 1,4 4)@2001-01-09]', stbox 'STBOX X((2,2),(3,3))'));
 /* {[POINT(1 1)@2001-01-01, LINESTRING(1 1,2 2)@2001-01-03, 
    LINESTRING(1 1,2 2)@2001-01-04),[MULTILINESTRING((1 1,2 2),(3 3,4 4))@2001-01-09]} */
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="tgeo_atElevation">
+				<indexterm significance="normal"><primary><varname>atElevation</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>minusElevation</varname></primary></indexterm>
+				<para>Restrict to (the complement of) an elevation span &Z_support;</para>
+				<para><varname>atElevation(tgeom,zspan) → tgeom</varname></para>
+				<para><varname>minusElevation(tgeom,zspan) → tgeom</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT astext(atElevation(tgeompoint '[Point(1 1 1)@2001-01-01,
+  Point(4 4 4)@2001-01-04, Point(1 1 1)@2001-01-07]', floatspan '[2,3]'));
+/* {[POINT Z (2 2 2)@2001-01-02, POINT Z (3 3 3)@2001-01-03],
+  [POINT Z (3 3 3)@2001-01-05, POINT Z (2 2 2)@2001-01-06]} */
+SELECT astext(minusElevation(tgeompoint '[Point(1 1 1)@2001-01-01,
+  Point(4 4 4)@2001-01-04, Point(1 1 1)@2001-01-07]', floatspan '[2,3]'));
+/* {[POINT Z (2 2 2)@2001-01-02, POINT Z (3 3 3)@2001-01-03],
+  [POINT Z (3 3 3)@2001-01-05, POINT Z (2 2 2)@2001-01-06]} */
 </programlisting>
 			</listitem>
 		</itemizedlist>

--- a/meos/include/geo/tgeo_tile.h
+++ b/meos/include/geo/tgeo_tile.h
@@ -90,7 +90,7 @@ extern Temporal *tpoint_at_tile(const Temporal *temp, const STBox *box);
 
 extern void stbox_tile_state_set(double x, double y, double z, TimestampTz t,
   double xsize, double ysize, double zsize, int64 tunits, bool hasx, bool hasz,
-  bool hast, int32 srid, STBox *result);
+  bool hast, int32_t srid, STBox *result);
 extern STboxGridState *stbox_tile_state_make(const Temporal *temp,
   const STBox *box, double xsize, double ysize, double zsize, 
   const Interval *duration, POINT3DZ sorigin, TimestampTz torigin, 

--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -259,6 +259,13 @@ typedef struct SkipList SkipList;
 
 /*****************************************************************************/
 
+/* Structure of an expandable arrays used in particular to avoid parsing twice
+ * a MEOS value input in text format */
+
+typedef struct MeosArray MeosArray;
+
+/*****************************************************************************/
+
 /**
  * @brief Enumeration that defines the search operations for an RTree.
  */

--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -259,13 +259,6 @@ typedef struct SkipList SkipList;
 
 /*****************************************************************************/
 
-/* Structure of an expandable arrays used in particular to avoid parsing twice
- * a MEOS value input in text format */
-
-typedef struct MeosArray MeosArray;
-
-/*****************************************************************************/
-
 /**
  * @brief Enumeration that defines the search operations for an RTree.
  */

--- a/meos/include/meos_geo.h
+++ b/meos/include/meos_geo.h
@@ -696,9 +696,11 @@ extern Temporal *tgeo_at_value(const Temporal *temp, GSERIALIZED *gs);
 extern Temporal *tgeo_minus_geom(const Temporal *temp, const GSERIALIZED *gs);
 extern Temporal *tgeo_minus_stbox(const Temporal *temp, const STBox *box, bool border_inc);
 extern Temporal *tgeo_minus_value(const Temporal *temp, GSERIALIZED *gs);
-extern Temporal *tpoint_at_geom(const Temporal *temp, const GSERIALIZED *gs, const Span *zspan);
+extern Temporal *tpoint_at_elevation(const Temporal *temp, const Span *s);
+extern Temporal *tpoint_at_geom(const Temporal *temp, const GSERIALIZED *gs);
 extern Temporal *tpoint_at_value(const Temporal *temp, GSERIALIZED *gs);
-extern Temporal *tpoint_minus_geom(const Temporal *temp, const GSERIALIZED *gs, const Span *zspan);
+extern Temporal *tpoint_minus_elevation(const Temporal *temp, const Span *s);
+extern Temporal *tpoint_minus_geom(const Temporal *temp, const GSERIALIZED *gs);
 extern Temporal *tpoint_minus_value(const Temporal *temp, GSERIALIZED *gs);
 
 /* Ever and always comparisons */

--- a/meos/include/meos_geo.h
+++ b/meos/include/meos_geo.h
@@ -330,7 +330,7 @@ extern char *geo_as_ewkt(const GSERIALIZED *gs, int precision);
 extern char *geo_as_geojson(const GSERIALIZED *gs, int option, int precision, const char *srs);
 extern char *geo_as_hexewkb(const GSERIALIZED *gs, const char *endian);
 extern char *geo_as_text(const GSERIALIZED *gs, int precision);
-extern GSERIALIZED *geo_from_ewkb(const uint8_t *wkb, size_t wkb_size, int32 srid);
+extern GSERIALIZED *geo_from_ewkb(const uint8_t *wkb, size_t wkb_size, int32_t srid);
 extern GSERIALIZED *geo_from_geojson(const char *geojson);
 extern GSERIALIZED *geo_from_text(const char *wkt, int32_t srid);
 extern char *geo_out(const GSERIALIZED *gs);
@@ -506,7 +506,7 @@ extern char *stbox_out(const STBox *box, int maxdd);
 extern STBox *geo_timestamptz_to_stbox(const GSERIALIZED *gs, TimestampTz t);
 extern STBox *geo_tstzspan_to_stbox(const GSERIALIZED *gs, const Span *s);
 extern STBox *stbox_copy(const STBox *box);
-extern STBox *stbox_make(bool hasx, bool hasz, bool geodetic, int32 srid, double xmin, double xmax, double ymin, double ymax, double zmin, double zmax, const Span *s);
+extern STBox *stbox_make(bool hasx, bool hasz, bool geodetic, int32_t srid, double xmin, double xmax, double ymin, double ymax, double zmin, double zmax, const Span *s);
 
 /* Conversion functions */
 
@@ -631,7 +631,7 @@ extern Temporal *tpoint_from_base_temp(const GSERIALIZED *gs, const Temporal *te
 extern TInstant *tpointinst_make(const GSERIALIZED *gs, TimestampTz t);
 extern TSequence *tpointseq_from_base_tstzset(const GSERIALIZED *gs, const Set *s);
 extern TSequence *tpointseq_from_base_tstzspan(const GSERIALIZED *gs, const Span *s, interpType interp);
-extern TSequence *tpointseq_make_coords(const double *xcoords, const double *ycoords, const double *zcoords, const TimestampTz *times, int count, int32 srid, bool geodetic, bool lower_inc, bool upper_inc, interpType interp, bool normalize);
+extern TSequence *tpointseq_make_coords(const double *xcoords, const double *ycoords, const double *zcoords, const TimestampTz *times, int count, int32_t srid, bool geodetic, bool lower_inc, bool upper_inc, interpType interp, bool normalize);
 extern TSequenceSet *tpointseqset_from_base_tstzspanset(const GSERIALIZED *gs, const SpanSet *ss, interpType interp);
 
 /* Conversion functions */

--- a/meos/include/meos_internal_geo.h
+++ b/meos/include/meos_internal_geo.h
@@ -206,13 +206,14 @@ extern void tspatialseqset_set_stbox(const TSequenceSet *ss, STBox *box);
 
 /* Restriction functions */
 
-extern Temporal *tgeo_restrict_geom(const Temporal *temp, const GSERIALIZED *gs, const Span *zspan, bool atfunc);
+extern Temporal *tgeo_restrict_elevation(const Temporal *temp, const Span *s, bool atfunc);
+extern Temporal *tgeo_restrict_geom(const Temporal *temp, const GSERIALIZED *gs, bool atfunc);
 extern Temporal *tgeo_restrict_stbox(const Temporal *temp, const STBox *box, bool border_inc, bool atfunc);
-extern TInstant *tgeoinst_restrict_geom(const TInstant *inst, const GSERIALIZED *gs, const Span *zspan, bool atfunc);
+extern TInstant *tgeoinst_restrict_geom(const TInstant *inst, const GSERIALIZED *gs, bool atfunc);
 extern TInstant *tgeoinst_restrict_stbox(const TInstant *inst, const STBox *box, bool border_inc, bool atfunc);
-extern Temporal *tgeoseq_restrict_geom(const TSequence *seq, const GSERIALIZED *gs, const Span *zspan, bool atfunc);
+extern Temporal *tgeoseq_restrict_geom(const TSequence *seq, const GSERIALIZED *gs, bool atfunc);
 extern Temporal *tgeoseq_restrict_stbox(const TSequence *seq, const STBox *box, bool border_inc, bool atfunc);
-extern TSequenceSet *tgeoseqset_restrict_geom(const TSequenceSet *ss, const GSERIALIZED *gs, const Span *zspan, bool atfunc);
+extern TSequenceSet *tgeoseqset_restrict_geom(const TSequenceSet *ss, const GSERIALIZED *gs, bool atfunc);
 extern TSequenceSet *tgeoseqset_restrict_stbox(const TSequenceSet *ss, const STBox *box, bool border_inc, bool atfunc);
 
 /*****************************************************************************/

--- a/meos/include/meos_internal_geo.h
+++ b/meos/include/meos_internal_geo.h
@@ -112,7 +112,7 @@ extern GSERIALIZED *point_round(const GSERIALIZED *gs, int maxdd);
 
 /* Constructor functions for box types */
 
-extern void stbox_set(bool hasx, bool hasz, bool geodetic, int32 srid, double xmin, double xmax, double ymin, double ymax, double zmin, double zmax, const Span *s, STBox *box);
+extern void stbox_set(bool hasx, bool hasz, bool geodetic, int32_t srid, double xmin, double xmax, double ymin, double ymax, double zmin, double zmax, const Span *s, STBox *box);
 
 /*****************************************************************************/
 

--- a/meos/include/meos_pose.h
+++ b/meos/include/meos_pose.h
@@ -239,10 +239,10 @@ extern Pose **tpose_values(const Temporal *temp, int *count);
  * Restriction functions
  *****************************************************************************/
 
-extern Temporal *tpose_at_geom(const Temporal *temp, const GSERIALIZED *gs, const Span *zspan);
+extern Temporal *tpose_at_geom(const Temporal *temp, const GSERIALIZED *gs);
 extern Temporal *tpose_at_stbox(const Temporal *temp, const STBox *box, bool border_inc);
 extern Temporal *tpose_at_pose(const Temporal *temp, const Pose *pose);
-extern Temporal *tpose_minus_geom(const Temporal *temp, const GSERIALIZED *gs, const Span *zspan);
+extern Temporal *tpose_minus_geom(const Temporal *temp, const GSERIALIZED *gs);
 extern Temporal *tpose_minus_pose(const Temporal *temp, const Pose *pose);
 extern Temporal *tpose_minus_stbox(const Temporal *temp, const STBox *box, bool border_inc);
 

--- a/meos/include/meos_rgeo.h
+++ b/meos/include/meos_rgeo.h
@@ -140,12 +140,14 @@ extern Temporal *trgeo_restrict_tstzset(const Temporal *temp, const Set *s, bool
 extern Temporal *trgeo_restrict_tstzspan(const Temporal *temp, const Span *s, bool atfunc);
 extern Temporal *trgeo_restrict_tstzspanset(const Temporal *temp, const SpanSet *ss, bool atfunc);
 
-// extern Temporal *trgeo_at_geom(const Temporal *temp, const GSERIALIZED *gs, const Span *zspan);
-// extern Temporal *trgeo_at_geo(const Temporal *temp, const GSERIALIZED *gs, const Span *zspan);
+// extern Temporal *trgeo_at_geom(const Temporal *temp, const GSERIALIZED *gs);
+// extern Temporal *trgeo_at_geo(const Temporal *temp, const GSERIALIZED *gs);
 // extern Temporal *trgeo_at_stbox(const Temporal *temp, const STBox *box, bool border_inc);
-// extern Temporal *trgeo_minus_geom(const Temporal *temp, const GSERIALIZED *gs, const Span *zspan);
-// extern Temporal *trgeo_minus_geo(const Temporal *temp, const GSERIALIZED *gs, const Span *zspan);
+// extern Temporal *trgeo_at_elevation(const Temporal *temp, const Span *s);
+// extern Temporal *trgeo_minus_geom(const Temporal *temp, const GSERIALIZED *gs);
+// extern Temporal *trgeo_minus_geo(const Temporal *temp, const GSERIALIZED *gs);
 // extern Temporal *trgeo_minus_stbox(const Temporal *temp, const STBox *box, bool border_inc);
+// extern Temporal *trgeo_minus_elevation(const Temporal *temp, const Span *s);
 
 /*****************************************************************************
  * Distance functions

--- a/meos/include/pose/tpose_spatialfuncs.h
+++ b/meos/include/pose/tpose_spatialfuncs.h
@@ -46,9 +46,11 @@ extern GSERIALIZED *tpose_trajectory(const Temporal *temp);
 /* Restriction functions */
 
 extern Temporal *tpose_restrict_geom(const Temporal *temp,
-  const GSERIALIZED *gs, const Span *zspan, bool atfunc);
+  const GSERIALIZED *gs, bool atfunc);
 extern Temporal *tpose_restrict_stbox(const Temporal *temp, const STBox *box,
   bool border_inc, bool atfunc);
+extern Temporal *tpose_restrict_elevation(const Temporal *temp, const Span *s,
+  bool atfunc);
 
 /*****************************************************************************/
 

--- a/meos/src/cbuffer/tcbuffer.c
+++ b/meos/src/cbuffer/tcbuffer.c
@@ -1085,7 +1085,7 @@ tcbuffer_restrict_geom(const Temporal *temp, const GSERIALIZED *gs, bool
 
   Temporal *tpoint = tcbuffer_to_tgeompoint(temp);
   Temporal *tfloat = tcbuffer_to_tfloat(temp);
-  Temporal *tpoint_rest = tgeo_restrict_geom(tpoint, gs, NULL, atfunc);
+  Temporal *tpoint_rest = tgeo_restrict_geom(tpoint, gs, atfunc);
   Temporal *result = NULL;
   if (tpoint_rest)
   {

--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -194,8 +194,8 @@ ea_spatialrel_tcbufferseq_discstep_geo(const TSequence *seq,
   bool ever, bool invert)
 {
   assert(seq); assert(gs); assert(seq->temptype == T_TCBUFFER);
-  interpType interp = MEOS_FLAGS_GET_INTERP(seq->flags);
-  assert(interp == DISCRETE || interp == STEP);
+  assert(MEOS_FLAGS_GET_INTERP(seq->flags) == DISCRETE ||
+     MEOS_FLAGS_GET_INTERP(seq->flags) == STEP);
   bool result;
   for (int i = 0; i < seq->count; i++)
   {

--- a/meos/src/geo/CMakeLists.txt
+++ b/meos/src/geo/CMakeLists.txt
@@ -13,6 +13,7 @@ set(GEO_SRCS
   tgeo_spatialrels.c
   tgeo_tile.c
   tpoint_datagen.c
+  tpoint_geom_clip.c
   tpoint_spatialfuncs.c
   tspatial.c
   tspatial_parser.c

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -3183,7 +3183,7 @@ geom_in(const char *str, int32 typmod)
     {
       meos_error(ERROR, MEOS_ERR_TEXT_INPUT,
         "Could not parse geometry value: %s", str);
-      return false;
+      return NULL;
     }
 
     /* Check next character to see if we have WKB */

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -1549,7 +1549,6 @@ geom_contains(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 {
   return geom_spatialrel(gs1, gs2, CONTAINS);
 }
-#endif /* MEOS */
 
 /**
  * @ingroup meos_geo_base_rel
@@ -1563,7 +1562,6 @@ geom_touches(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   return geom_spatialrel(gs1, gs2, TOUCHES);
 }
 
-#if MEOS
 /**
  * @ingroup meos_geo_base_rel
  * @brief Return true if the first geometry covers the second one

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -168,7 +168,7 @@ gbox_out(const GBOX *box, int maxdd)
  */
 BOX3D *
 box3d_make(double xmin, double xmax, double ymin, double ymax,
-  double zmin, double zmax, int32 srid)
+  double zmin, double zmax, int32_t srid)
 {
   /* Note: zero-fill is required here, just as in heap tuples */
   BOX3D *result = palloc0(sizeof(BOX3D));
@@ -3450,7 +3450,7 @@ geo_as_hexewkb(const GSERIALIZED *gs, const char *endian)
  * @note wkb is in *binary* not hex form
  */
 GSERIALIZED *
-geo_from_ewkb(const uint8_t *wkb, size_t wkb_size, int32 srid)
+geo_from_ewkb(const uint8_t *wkb, size_t wkb_size, int32_t srid)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(wkb, NULL);

--- a/meos/src/geo/stbox.c
+++ b/meos/src/geo/stbox.c
@@ -326,7 +326,7 @@ stbox_as_hexwkb(const STBox *box, uint8_t variant, size_t *size_out)
  * @csqlfn #Stbox_constructor()
  */
 STBox *
-stbox_make(bool hasx, bool hasz, bool geodetic, int32 srid, double xmin,
+stbox_make(bool hasx, bool hasz, bool geodetic, int32_t srid, double xmin,
   double xmax, double ymin, double ymax, double zmin, double zmax,
   const Span *s)
 {
@@ -359,7 +359,7 @@ stbox_make(bool hasx, bool hasz, bool geodetic, int32 srid, double xmin,
  * @note This function is equivalent to #stbox_make without memory allocation
  */
 void
-stbox_set(bool hasx, bool hasz, bool geodetic, int32 srid, double xmin,
+stbox_set(bool hasx, bool hasz, bool geodetic, int32_t srid, double xmin,
   double xmax, double ymin, double ymax, double zmin, double zmax,
   const Span *s, STBox *box)
 {

--- a/meos/src/geo/tgeo_restrict.c
+++ b/meos/src/geo/tgeo_restrict.c
@@ -1471,6 +1471,61 @@ tgeoseqset_restrict_geom(const TSequenceSet *ss, const GSERIALIZED *gs,
 }
 
 /**
+ * @brief Return true if an LWGEOM tree contains any curve component
+ * (CircularString, CompoundCurve, CurvePolygon, MultiCurve, MultiSurface)
+ */
+static bool
+lwgeom_has_curve(const LWGEOM *geom)
+{
+  if (! geom)
+    return false;
+  switch (geom->type)
+  {
+    case CIRCSTRINGTYPE:
+    case COMPOUNDTYPE:
+    case CURVEPOLYTYPE:
+    case MULTICURVETYPE:
+    case MULTISURFACETYPE:
+      return true;
+    case COLLECTIONTYPE:
+    {
+      const LWCOLLECTION *col = (const LWCOLLECTION *) geom;
+      for (uint32_t i = 0; i < col->ngeoms; i++)
+        if (lwgeom_has_curve(col->geoms[i]))
+          return true;
+      return false;
+    }
+    default:
+      return false;
+  }
+}
+
+/**
+ * @brief Return a flat geometry (no arcs) from a possibly curved one
+ * @details If the input has any curve component, return a stroked
+ * (linearized) copy that the edge-clipper can consume. Returns NULL if no
+ * stroking was needed; caller should keep using the original input.
+ */
+static GSERIALIZED *
+geo_stroke_if_curved(const GSERIALIZED *gs)
+{
+  LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
+  if (! lwgeom_has_curve(lwgeom))
+  {
+    lwgeom_free(lwgeom);
+    return NULL;
+  }
+  /* Stroke with 32 segments per quadrant, the PostGIS default. */
+  LWGEOM *stroked = lwgeom_stroke(lwgeom, 32);
+  lwgeom_free(lwgeom);
+  if (! stroked)
+    return NULL;
+  GSERIALIZED *result = geo_serialize(stroked);
+  lwgeom_free(stroked);
+  return result;
+}
+
+/**
  * @ingroup meos_internal_geo_restrict
  * @brief Return a temporal geo restricted to (the complement of) a geometry
  * @param[in] temp Temporal geo
@@ -1502,10 +1557,23 @@ tgeo_restrict_geom(const Temporal *temp, const GSERIALIZED *gs,
   if (! overlaps_stbox_stbox(&box1, &box2))
     return atfunc ? NULL : temporal_copy(temp);
 
-  /* Call the specific function for temporal points with linear interpolation */
+  /* Call the specific (edge-clipper) function for temporal points with
+   * linear interpolation. The edge-clipper does not support curve types
+   * (CircularString, CompoundCurve, CurvePolygon, MultiCurve,
+   * MultiSurface), so stroke-flatten any such input before passing it
+   * to the clipper. */
   if (temp->temptype == T_TGEOMPOINT &&
       MEOS_FLAGS_GET_INTERP(temp->flags) == LINEAR)
+  {
+    GSERIALIZED *flat = geo_stroke_if_curved(gs);
+    if (flat)
+    {
+      Temporal *res = tpoint_linear_restrict_geom(temp, flat, atfunc);
+      pfree(flat);
+      return res;
+    }
     return tpoint_linear_restrict_geom(temp, gs, atfunc);
+  }
 
   Temporal *result;
   assert(temptype_subtype(temp->subtype));

--- a/meos/src/geo/tgeo_restrict.c
+++ b/meos/src/geo/tgeo_restrict.c
@@ -503,7 +503,7 @@ liangBarskyClip(const GSERIALIZED *point1, const GSERIALIZED *point2,
 /**
  * @brief Return a temporal point instant restricted to (the complement of) a
  * spatiotemporal box (iterator function)
- * @pre The box has only X dimension and the arguments have the same SRID.
+ * @pre The box has only spatial dimension and the arguments have the same SRID.
  * @note This function restricts only to the spatial dimension, the restriction
  * to the time dimension is made in function #tgeo_restrict_stbox
  */
@@ -514,7 +514,7 @@ tpointinst_restrict_stbox_iter(const TInstant *inst, const STBox *box,
   assert(! MEOS_FLAGS_GET_T(box->flags));
   bool hasz = MEOS_FLAGS_GET_Z(inst->flags) && MEOS_FLAGS_GET_Z(box->flags);
 
-  /* Restrict to the XY(Z) dimension */
+  /* Restrict to the spatial dimension */
   Datum value = tinstant_value_p(inst);
   /* Get the input point */
   double x, y, z = 0.0;
@@ -550,7 +550,7 @@ tpointinst_restrict_stbox_iter(const TInstant *inst, const STBox *box,
  * @param[in] box Spatiotemporal box
  * @param[in] border_inc True when the box contains the upper border
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
- * @pre The box has only X dimension and the arguments have the same SRID.
+ * @pre The box has only spatial dimension and the arguments have the same SRID.
  * @note This function restricts only to the spatial dimension, the restriction
  * to the time dimension is made in function #tgeo_restrict_stbox
  */
@@ -589,7 +589,7 @@ tgeoinst_restrict_stbox_iter(const TInstant *inst, const STBox *box,
  * @param[in] box Spatiotemporal box
  * @param[in] border_inc True when the box contains the upper border
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
- * @pre The box has only X dimension and the arguments have the same SRID.
+ * @pre The box has only spatial dimension and the arguments have the same SRID.
  * @note This function restricts only to the spatial dimension, the restriction
  * to the time dimension is made in function #tgeo_restrict_stbox
  * @csqlfn #Tgeo_at_stbox(), #Tgeo_minus_stbox()
@@ -613,7 +613,7 @@ tgeoinst_restrict_stbox(const TInstant *inst, const STBox *box,
  * @param[in] box Spatiotemporal box
  * @param[in] border_inc True when the box contains the upper border
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
- * @pre The box has only X dimension, the arguments have the same SRID, and
+ * @pre The box has only spatial dimension, the arguments have the same SRID, and
  * the sequence is not instantaneous.
  * @note The function only restricts to the spatial dimension, the restriction
  * to the time dimension is made in function #tgeo_restrict_stbox.
@@ -654,7 +654,7 @@ tgeoseq_disc_restrict_stbox(const TSequence *seq, const STBox *box,
  * @param[in] box Spatiotemporal box
  * @param[in] border_inc True when the box contains the upper border
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
- * @pre The box has only X dimension, the arguments have the same SRID, and
+ * @pre The box has only spatial dimension, the arguments have the same SRID, and
  * the sequence is not instantaneous.
  * @note This function restricts only to the spatial dimension, the restriction
  * to the time dimension is made in function #tgeo_restrict_stbox
@@ -733,8 +733,8 @@ tgeoseq_step_restrict_stbox(const TSequence *seq, const STBox *box,
  * @param[in] seq Temporal point sequence
  * @param[in] box Bounding box
  * @param[in] border_inc True when the box contains the upper border
- * @pre The box has only X dimension, the arguments have the same SRID, and
- * the sequence is not instantaneous.
+ * @pre The box has only spatial dimension, the arguments have the same SRID,
+ * and the sequence is not instantaneous.
  * @note The function only restricts to the spatial dimension, the restriction
  * to the time dimension is made in function #tgeo_restrict_stbox.
  */
@@ -957,7 +957,7 @@ tpointseq_linear_at_stbox_xyz(const TSequence *seq, const STBox *box,
  * @param[in] box Spatiotemporal box
  * @param[in] border_inc True when the box contains the upper border
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
- * @pre The box has only X dimension, the arguments have the same SRID, and
+ * @pre The box has only spatial dimension, the arguments have the same SRID, and
  * the sequence is not instantaneous.
  * @note The function only restricts to the spatial dimension, the restriction
  * to the time dimension is made in function #tgeo_restrict_stbox.
@@ -995,7 +995,7 @@ tpointseq_linear_restrict_stbox(const TSequence *seq, const STBox *box,
  * @param[in] box Spatiotemporal box
  * @param[in] border_inc True when the box contains the upper border
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
- * @pre The box has only X dimension and the arguments have the same SRID.
+ * @pre The box has only spatial dimension and the arguments have the same SRID.
  * @note The function only restricts to the spatial dimension, the restriction
  * to the time dimension is made in function #tgeo_restrict_stbox.
  * @csqlfn #Tgeo_at_stbox(), #Tgeo_minus_stbox()
@@ -1047,7 +1047,7 @@ tgeoseq_restrict_stbox(const TSequence *seq, const STBox *box,
  * @param[in] box Spatiotemporal box
  * @param[in] border_inc True when the box contains the upper border
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
- * @pre The box has only X dimension and the arguments have the same SRID.
+ * @pre The box has only spatial dimension and the arguments have the same SRID.
  * @note The function only restricts to the spatial dimension, the restriction
  * to the time dimension is made in function #tgeo_restrict_stbox.
  * @csqlfn #Tgeo_at_stbox(), #Tgeo_minus_stbox()
@@ -1391,7 +1391,7 @@ tpoint_at_stbox_segm(const Temporal *temp, const STBox *box, bool border_inc)
 }
 
 /*****************************************************************************
- * Restriction functions for geometry and possible a Z span and a time period
+ * Restriction functions for geometry
  * N.B. In the current PostGIS version there is no true ST_Intersection
  * function for geography, it is implemented as ST_DWithin with tolerance 0
  *****************************************************************************/
@@ -1404,25 +1404,16 @@ tpoint_at_stbox_segm(const Temporal *temp, const STBox *box, bool border_inc)
  */
 TInstant *
 tpointinst_restrict_geom_iter(const TInstant *inst, const GSERIALIZED *gs,
-  const Span *zspan, bool atfunc)
+  bool atfunc)
 {
-  /* Restrict to the Z dimension */
-  Datum value = tinstant_value_p(inst);
-  if (zspan)
-  {
-    const POINT3DZ *p = DATUM_POINT3DZ_P(value);
-    if (! contains_span_value(zspan, Float8GetDatum(p->z)))
-      /* For temporal point types we return the instants of the input value */
-      return atfunc ? NULL : (TInstant *) inst;
-  }
-
   /* Restrict to the XY dimension */
+  Datum value = tinstant_value_p(inst);
   if (! geom_intersects2d(DatumGetGserializedP(value), gs))
       /* For temporal point types we return the instants of the input value */
       return atfunc ? NULL : (TInstant *) inst;
 
-  /* Point intersects the geometry and the Z/T spans */
-      return atfunc ? (TInstant *) inst : NULL;
+  /* The point intersects the geometry */
+  return atfunc ? (TInstant *) inst : NULL;
 }
 
 /**
@@ -1430,23 +1421,20 @@ tpointinst_restrict_geom_iter(const TInstant *inst, const GSERIALIZED *gs,
  * geometry (iterator function)
  * @param[in] inst Temporal geo instant
  * @param[in] gs Geometry
- * @param[in] zspan Span of values to restrict the Z dimension
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
  * @pre The arguments have the same SRID. This is verified in
  * #tgeo_restrict_geom
  */
 TInstant *
 tgeoinst_restrict_geom_iter(const TInstant *inst, const GSERIALIZED *gs,
-  const Span *zspan, bool atfunc)
+  bool atfunc)
 {
   assert(inst); assert(gs); assert(tgeo_type_all(inst->temptype));
   assert(! gserialized_is_empty(gs));
   /* Execute the specialized function for temporal points */
   if (tpoint_type(inst->temptype))
-    return tpointinst_restrict_geom_iter(inst, gs, zspan, atfunc);
+    return tpointinst_restrict_geom_iter(inst, gs, atfunc);
 
-  /* Z span is not allowed for general geometries */
-  assert(! zspan);
   /* Get the geometry of the instant */
   const GSERIALIZED *gs1 = DatumGetGserializedP(tinstant_value_p(inst));
   /* Restrict to the spatial dimension */
@@ -1466,18 +1454,16 @@ tgeoinst_restrict_geom_iter(const TInstant *inst, const GSERIALIZED *gs,
  * @ingroup meos_internal_geo_restrict
  * @brief Return a temporal geo instant restricted to (the complement of) a
  * geometry
- * and possibly a Z span and a timestamptz span
  * @param[in] inst Temporal geo
  * @param[in] gs Geometry
- * @param[in] zspan Span of values to restrict the Z dimension
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
  */
 TInstant *
 tgeoinst_restrict_geom(const TInstant *inst, const GSERIALIZED *gs,
-  const Span *zspan, bool atfunc)
+  bool atfunc)
 {
   assert(inst); assert(gs); assert(tgeo_type_all(inst->temptype));
-  TInstant *res = tgeoinst_restrict_geom_iter(inst, gs, zspan, atfunc);
+  TInstant *res = tgeoinst_restrict_geom_iter(inst, gs, atfunc);
   if (! res)
     return NULL;
   return tpoint_type(inst->temptype) ? tinstant_copy(res) : res;
@@ -1485,16 +1471,15 @@ tgeoinst_restrict_geom(const TInstant *inst, const GSERIALIZED *gs,
 
 /**
  * @brief Return a temporal geo discrete sequence restricted to
- * (the complement of) a geometry and possibly a Z span and a timestamptz span
+ * (the complement of) a geometry
  * @param[in] seq Temporal geo
  * @param[in] gs Geometry
- * @param[in] zspan Span of values to restrict the Z dimension
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
  * @pre Instantaneous sequences have been managed in the calling function
  */
 TSequence *
 tgeoseq_disc_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
-  const Span *zspan, bool atfunc)
+  bool atfunc)
 {
   assert(seq); assert(gs); assert(tgeo_type_all(seq->temptype));
   assert(MEOS_FLAGS_GET_INTERP(seq->flags) == DISCRETE);
@@ -1504,8 +1489,8 @@ tgeoseq_disc_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
   int ninsts = 0;
   for (int i = 0; i < seq->count; i++)
   {
-    TInstant *res = tgeoinst_restrict_geom_iter(TSEQUENCE_INST_N(seq, i), 
-      gs, zspan, atfunc);
+    TInstant *res = tgeoinst_restrict_geom_iter(TSEQUENCE_INST_N(seq, i), gs,
+      atfunc);
     if (res)
       instants[ninsts++] = res;
   }
@@ -1523,10 +1508,9 @@ tgeoseq_disc_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
 
 /**
  * @brief Return a temporal geo sequence with step interpolation
- * restricted to a geometry and possibly a Z span and a timestamptz span
+ * restricted to a geometry
  * @param[in] seq Temporal geo
  * @param[in] gs Geometry
- * @param[in] zspan Span of values to restrict the Z dimension
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
  * @pre Instantaneous sequences have been managed in the calling function
  * @note The function computes the "at" restriction on all dimensions. Then,
@@ -1535,7 +1519,7 @@ tgeoseq_disc_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
  */
 TSequenceSet *
 tgeoseq_step_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
-   const Span *zspan, bool atfunc)
+   bool atfunc)
 {
   assert(seq); assert(gs); assert(tgeo_type_all(seq->temptype));
   assert(MEOS_FLAGS_GET_INTERP(seq->flags) == STEP);
@@ -1550,7 +1534,7 @@ tgeoseq_step_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
   for (int i = 0; i < seq->count; i++)
   {
     const TInstant *inst = TSEQUENCE_INST_N(seq, i);
-    TInstant *res = tgeoinst_restrict_geom_iter(inst, gs, zspan, REST_AT);
+    TInstant *res = tgeoinst_restrict_geom_iter(inst, gs, REST_AT);
     if (res)
       instants[ninsts++] = res;
     else
@@ -1856,8 +1840,7 @@ tpointseq_interperiods(const TSequence *seq, const GSERIALIZED *gsinter,
 
 /**
  * @brief Return a temporal point sequence with linear interpolation
- * restricted to (the complement of) a geometry and possibly a Z span and a
- * timestamptz span
+ * restricted to (the complement of) a geometry
  * @details The function first filters the temporal point wrt the time
  * dimension to reduce the number of instants before computing the restriction
  * to the geometry, which is an expensive operation. Notice that we need to
@@ -1865,7 +1848,6 @@ tpointseq_interperiods(const TSequence *seq, const GSERIALIZED *gsinter,
  * the temporal point may change from a sequence to a sequence set.
  * @param[in] seq Temporal point
  * @param[in] gs Geometry
- * @param[in] zspan Span of values to restrict the Z dimension
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
  * @note The function computes the "at" restriction on all dimensions. Then,
  * for the "minus" restriction, it computes the complement of the "at"
@@ -1874,49 +1856,14 @@ tpointseq_interperiods(const TSequence *seq, const GSERIALIZED *gsinter,
  */
 TSequenceSet *
 tpointseq_linear_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
-  const Span *zspan, bool atfunc)
+  bool atfunc)
 {
   VALIDATE_TPOINT(seq, NULL); VALIDATE_NOT_NULL(gs, NULL); 
   assert(MEOS_FLAGS_LINEAR_INTERP(seq->flags));
   assert(seq->count > 1);
 
-  TSequenceSet *result_at = NULL;
-
-  /* Clip the temporal point to the geometry */
-  TSequenceSet *at_xy = tpointseq_linear_at_geom(seq, gs);
-
-  /* Restrict to the Z dimension */
-  if (at_xy)
-  {
-    if (zspan)
-    {
-      /* Bounding box test for the Z dimension */
-      STBox box1;
-      tspatialseqset_set_stbox(at_xy, &box1);
-      Span zspan1;
-      span_set(Float8GetDatum(box1.zmin), Float8GetDatum(box1.zmax),
-        true, true, T_FLOAT8, T_FLOATSPAN, &zspan1);
-      if (overlaps_span_span(&zspan1, zspan))
-      {
-        /* Get the Z coordinate values as a temporal float */
-        Temporal *tfloat_z = tpoint_get_coord((Temporal *) at_xy, 2);
-        /* Restrict to the zspan */
-        Temporal *tfloat_zspan = tnumber_restrict_span(tfloat_z, zspan,
-          REST_AT);
-        pfree(tfloat_z);
-        if (tfloat_zspan)
-        {
-          SpanSet *ss = temporal_time(tfloat_zspan);
-          result_at = tsequenceset_restrict_tstzspanset(at_xy, ss, REST_AT);
-          pfree(tfloat_zspan);
-          pfree(ss);
-        }
-      }
-      pfree(at_xy);
-    }
-    else
-      result_at = at_xy;
-  }
+  /* Compute atGeometry for the sequence */
+  TSequenceSet *result_at = tpointseq_linear_at_geom(seq, gs);
 
   /* If "at" restriction, return */
   if (atfunc)
@@ -1935,15 +1882,14 @@ tpointseq_linear_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
 /**
  * @ingroup meos_internal_geo_restrict
  * @brief Return a temporal geo sequence restricted to (the complement of) a
- * geometry and possibly a Z span and a timestamptz span
+ * geometry
  * @param[in] seq Temporal geo
  * @param[in] gs Geometry
- * @param[in] zspan Span of values to restrict the Z dimension
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
  */
 Temporal *
 tgeoseq_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
-  const Span *zspan, bool atfunc)
+  bool atfunc)
 {
   assert(seq); assert(gs); assert(tgeo_type_all(seq->temptype));
   interpType interp = MEOS_FLAGS_GET_INTERP(seq->flags);
@@ -1952,7 +1898,7 @@ tgeoseq_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
   if (seq->count == 1)
   {
     TInstant *res = tgeoinst_restrict_geom_iter(TSEQUENCE_INST_N(seq, 0), gs,
-      zspan, atfunc);
+      atfunc);
     if (! res)
       return NULL;
     if (tpoint_type(seq->temptype))
@@ -1969,28 +1915,27 @@ tgeoseq_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
 
   /* General case */
   if (interp == DISCRETE)
-    return (Temporal *) tgeoseq_disc_restrict_geom((TSequence *) seq,
-      gs, zspan, atfunc);
+    return (Temporal *) tgeoseq_disc_restrict_geom((TSequence *) seq, gs,
+      atfunc);
   else if (interp == STEP)
-    return (Temporal *) tgeoseq_step_restrict_geom((TSequence *) seq,
-      gs, zspan, atfunc);
+    return (Temporal *) tgeoseq_step_restrict_geom((TSequence *) seq, gs,
+      atfunc);
   else /* interp == LINEAR */
-    return (Temporal *) tpointseq_linear_restrict_geom((TSequence *) seq,
-      gs, zspan, atfunc);
+    return (Temporal *) tpointseq_linear_restrict_geom((TSequence *) seq, gs,
+      atfunc);
 }
 
 /**
  * @ingroup meos_internal_geo_restrict
  * @brief Return a temporal geo sequence set restricted to (the complement
- * of) a geometry and possibly a Z span and a timestamptz span
+ * of) a geometry
  * @param[in] ss Temporal geo
  * @param[in] gs Geometry
- * @param[in] zspan Span of values to restrict the Z dimension
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
  */
 TSequenceSet *
 tgeoseqset_restrict_geom(const TSequenceSet *ss, const GSERIALIZED *gs,
-  const Span *zspan, bool atfunc)
+  bool atfunc)
 {
   assert(ss); assert(gs); assert(tgeo_type_all(ss->temptype));
 
@@ -1998,7 +1943,7 @@ tgeoseqset_restrict_geom(const TSequenceSet *ss, const GSERIALIZED *gs,
   if (ss->count == 1)
     /* We can safely cast since the composing sequences are continuous */
     return (TSequenceSet *) tgeoseq_restrict_geom(TSEQUENCESET_SEQ_N(ss, 0), 
-      gs, zspan, atfunc);
+      gs, atfunc);
 
   /* General case */
   STBox box2;
@@ -2019,8 +1964,7 @@ tgeoseqset_restrict_geom(const TSequenceSet *ss, const GSERIALIZED *gs,
     else
     {
       /* We can safely cast since the composing sequences are continuous */
-      seqsets[i] = (TSequenceSet *) tgeoseq_restrict_geom(seq, gs, zspan,
-        atfunc);
+      seqsets[i] = (TSequenceSet *) tgeoseq_restrict_geom(seq, gs, atfunc);
       if (seqsets[i])
         totalseqs += seqsets[i]->count;
     }
@@ -2036,21 +1980,18 @@ tgeoseqset_restrict_geom(const TSequenceSet *ss, const GSERIALIZED *gs,
 /**
  * @ingroup meos_internal_geo_restrict
  * @brief Return a temporal geo restricted to (the complement of) a geometry
- * and possibly a Z span
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry
- * @param[in] zspan Span of values to restrict the Z dimension, may be `NULL`
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
  */
 Temporal *
 tgeo_restrict_geom(const Temporal *temp, const GSERIALIZED *gs,
-  const Span *zspan, bool atfunc)
+  bool atfunc)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TGEO(temp, NULL); VALIDATE_NOT_NULL(gs, NULL); 
   if (! ensure_same_srid(tspatial_srid(temp), gserialized_get_srid(gs)) ||
       ! ensure_has_not_Z_geo(gs) ||
-      (zspan && ! ensure_has_Z(temp->temptype, temp->flags)) ||
       /* Generic 3D geometries cannot be restricted to a geometry */
       (tgeo_type(temp->temptype) &&
        ! ensure_has_not_Z(temp->temptype, temp->flags)))
@@ -2065,12 +2006,6 @@ tgeo_restrict_geom(const Temporal *temp, const GSERIALIZED *gs,
   tspatial_set_stbox(temp, &box1);
   /* Non-empty geometries have a bounding box */
   geo_set_stbox(gs, &box2);
-  if (zspan)
-  {
-    box2.zmin = DatumGetFloat8(zspan->lower);
-    box2.zmax = DatumGetFloat8(zspan->upper);
-    MEOS_FLAGS_SET_Z(box2.flags, true);
-  }
   if (! overlaps_stbox_stbox(&box1, &box2))
     return atfunc ? NULL : temporal_copy(temp);
 
@@ -2092,16 +2027,15 @@ tgeo_restrict_geom(const Temporal *temp, const GSERIALIZED *gs,
   switch (temp1->subtype)
   {
     case TINSTANT:
-      return (Temporal *) tgeoinst_restrict_geom((TInstant *) temp1,
-        gs, zspan, atfunc);
+      return (Temporal *) tgeoinst_restrict_geom((TInstant *) temp1, gs,
+        atfunc);
       break;
     case TSEQUENCE:
-      result = tgeoseq_restrict_geom((TSequence *) temp1,
-        gs, zspan, atfunc);
+      result = tgeoseq_restrict_geom((TSequence *) temp1, gs, atfunc);
       break;
     default: /* TSEQUENCESET */
       result = (Temporal *) tgeoseqset_restrict_geom((TSequenceSet *) temp1,
-         gs, zspan, atfunc);
+         gs, atfunc);
   }
   if (interp == LINEAR && atfunc)
     pfree(temp1);
@@ -2116,15 +2050,14 @@ tgeo_restrict_geom(const Temporal *temp, const GSERIALIZED *gs,
  * @brief Return a temporal point restricted to a geometry
  * @param[in] temp Temporal point
  * @param[in] gs Geometry
- * @param[in] zspan Span of values to restrict the Z dimension
  * @csqlfn #Tgeo_at_geom()
  * @note This function has a last parameter for the Z dimension which is not
  * available for temporal geometries
  */
 inline Temporal *
-tpoint_at_geom(const Temporal *temp, const GSERIALIZED *gs, const Span *zspan)
+tpoint_at_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
-  return tgeo_restrict_geom(temp, gs, zspan, REST_AT);
+  return tgeo_restrict_geom(temp, gs, REST_AT);
 }
 
 /**
@@ -2137,7 +2070,7 @@ tpoint_at_geom(const Temporal *temp, const GSERIALIZED *gs, const Span *zspan)
 inline Temporal *
 tgeo_at_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
-  return tgeo_restrict_geom(temp, gs, NULL, REST_AT);
+  return tgeo_restrict_geom(temp, gs, REST_AT);
 }
 
 /**
@@ -2145,16 +2078,14 @@ tgeo_at_geom(const Temporal *temp, const GSERIALIZED *gs)
  * @brief Return a temporal point restricted to the complement of a geometry
  * @param[in] temp Temporal point
  * @param[in] gs Geometry
- * @param[in] zspan Span of values to restrict the Z dimension
  * @csqlfn #Tgeo_minus_geom()
  * @note This function has a last parameter for the Z dimension which is not
  * available for temporal geometries
  */
 inline Temporal *
-tpoint_minus_geom(const Temporal *temp, const GSERIALIZED *gs,
-  const Span *zspan)
+tpoint_minus_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
-  return tgeo_restrict_geom(temp, gs, zspan, REST_MINUS);
+  return tgeo_restrict_geom(temp, gs, REST_MINUS);
 }
 
 /**
@@ -2167,7 +2098,110 @@ tpoint_minus_geom(const Temporal *temp, const GSERIALIZED *gs,
 inline Temporal *
 tgeo_minus_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
-  return tgeo_restrict_geom(temp, gs, NULL, REST_MINUS);
+  return tgeo_restrict_geom(temp, gs, REST_MINUS);
+}
+#endif /* MEOS */
+
+/*****************************************************************************/
+
+/**
+ * @ingroup meos_internal_geo_restrict
+ * @brief Return a temporal geo restricted to (the complement of) an elevation
+ * span
+ * @param[in] temp Temporal geo
+ * @param[in] s Elevation span
+ * @param[in] atfunc True if the restriction is `at`, false for `minus`
+ */
+Temporal *
+tgeo_restrict_elevation(const Temporal *temp, const Span *s, bool atfunc)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TGEO(temp, NULL); VALIDATE_NOT_NULL(s, NULL); 
+  /* Ensure the validity of the arguments */
+  if (! ensure_has_Z(temp->temptype, temp->flags))
+    return NULL;
+
+  /* Bounding box test */
+  STBox box;
+  tspatial_set_stbox(temp, &box);
+  /* Non-empty geometries have a bounding box */
+  Span s1;
+  span_set(Float8GetDatum(box.zmin), Float8GetDatum(box.zmax), true, true,
+    T_FLOAT8, T_FLOATSPAN, &s1);
+  if (! overlaps_span_span(&s1, s))
+    return atfunc ? NULL : temporal_copy(temp);
+
+  /* Get the Z coordinate as a temporal float, project the temporal float to
+     the span, and project the temporal geometry */
+  Temporal *temp1 = tpoint_get_coord(temp, 2);
+  Temporal *temp2 = tnumber_restrict_span(temp1, s, atfunc);
+  Temporal *result = NULL;
+  if (temp2)
+  {
+    SpanSet *ss = temporal_time(temp2);
+    result = temporal_restrict_tstzspanset(temp, ss, REST_AT);
+    pfree(ss); pfree(temp2);
+  }
+  /* Clean out and return */
+  pfree(temp1);
+  return result;
+}
+
+/*****************************************************************************/
+
+#if MEOS
+/**
+ * @ingroup meos_geo_restrict
+ * @brief Return a temporal point restricted to an elevation span
+ * @param[in] temp Temporal point
+ * @param[in] s Elevation span
+ * @csqlfn #Tgeo_at_elevation()
+ */
+inline Temporal *
+tpoint_at_elevation(const Temporal *temp, const Span *s)
+{
+  return tgeo_restrict_elevation(temp, s, REST_AT);
+}
+
+/**
+ * @ingroup meos_geo_restrict
+ * @brief Return a temporal geo restricted to an elevation span
+ * @param[in] temp Temporal geo
+ * @param[in] s Elevation span
+ * @csqlfn #Tgeo_at_elevation()
+ */
+inline Temporal *
+tgeo_at_elevation(const Temporal *temp, const Span *s)
+{
+  return tgeo_restrict_elevation(temp, s, REST_AT);
+}
+
+/**
+ * @ingroup meos_geo_restrict
+ * @brief Return a temporal point restricted to the complement of a geometry
+ * @param[in] temp Temporal point
+ * @param[in] s Elevation span
+ * @csqlfn #Tgeo_minus_elevation()
+ * @note This function has a last parameter for the Z dimension which is not
+ * available for temporal geometries
+ */
+inline Temporal *
+tpoint_minus_elevation(const Temporal *temp, const Span *s)
+{
+  return tgeo_restrict_elevation(temp, s, REST_MINUS);
+}
+
+/**
+ * @ingroup meos_geo_restrict
+ * @brief Return a temporal geo restricted to the complement of a geometry
+ * @param[in] temp Temporal geo
+ * @param[in] s Elevation span
+ * @csqlfn #Tgeo_minus_elevation()
+ */
+inline Temporal *
+tgeo_minus_elevation(const Temporal *temp, const Span *s)
+{
+  return tgeo_restrict_elevation(temp, s, REST_MINUS);
 }
 #endif /* MEOS */
 

--- a/meos/src/geo/tgeo_restrict.c
+++ b/meos/src/geo/tgeo_restrict.c
@@ -56,8 +56,8 @@
 #include "geo/tgeo_spatialfuncs.h"
 #include "geo/tgeo_spatialrels.h"
 
-extern TSequenceSet *tpointseq_linear_at_geom(const TSequence *seq,
-  const GSERIALIZED *gs);
+extern Temporal *tpoint_linear_restrict_geom(const Temporal *temp,
+  const GSERIALIZED *gs, bool atfunc);
 
 /*****************************************************************************/
 
@@ -227,41 +227,6 @@ tpointsegm_timestamp_at_value1_iter(const TInstant *inst1,
     }
   }
   return result;
-}
-
-/**
- * @brief Return the timestamp at which a temporal point sequence is equal to a
- * point
- * @details This function is called by the #tpointseq_interperiods function
- * while computing atGeometry to find the timestamp at which an intersection
- * point found by PostGIS is located.
- * @param[in] seq Temporal point sequence
- * @param[in] value Base value
- * @param[out] t Timestamp
- * @return Return true if the point is found in the temporal point
- * @pre The point is known to belong to the temporal sequence (taking into
- * account roundoff errors), the temporal sequence has linear interpolation,
- * and is simple
- * @note The resulting timestamp may be at an exclusive bound
- */
-static bool
-tpointseq_timestamp_at_value(const TSequence *seq, Datum value,
-  TimestampTz *t)
-{
-  const TInstant *inst1 = TSEQUENCE_INST_N(seq, 0);
-  for (int i = 1; i < seq->count; i++)
-  {
-    const TInstant *inst2 = TSEQUENCE_INST_N(seq, i);
-    /* We are sure that the segment is not constant since the
-     * sequence is simple */
-    if (tpointsegm_timestamp_at_value1_iter(inst1, inst2, value, t))
-      return true;
-    inst1 = inst2;
-  }
-  /* We should never arrive here */
-  meos_error(ERROR, MEOS_ERR_TEXT_INPUT,
-    "The value has not been found due to roundoff errors");
-  return false;
 }
 
 /*****************************************************************************
@@ -995,7 +960,7 @@ tpointseq_linear_restrict_stbox(const TSequence *seq, const STBox *box,
  * @param[in] box Spatiotemporal box
  * @param[in] border_inc True when the box contains the upper border
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
- * @pre The box has only spatial dimension and the arguments have the same SRID.
+ * @pre The box has only spatial dimension and the arguments have the same SRID
  * @note The function only restricts to the spatial dimension, the restriction
  * to the time dimension is made in function #tgeo_restrict_stbox.
  * @csqlfn #Tgeo_at_stbox(), #Tgeo_minus_stbox()
@@ -1201,196 +1166,6 @@ tgeo_minus_stbox(const Temporal *temp, const STBox *box, bool border_inc)
 #endif /* MEOS */
 
 /*****************************************************************************
- * Restriction functions for a spatiotemporal box keeping the original
- * segments WITHOUT clipping
- *****************************************************************************/
-
-/**
- * @brief Return a temporal point sequence with the segments that intersect
- * a spatiotemporal box in ONLY the spatial dimension
- * @param[in] seq temporal point sequence
- * @param[in] box Spatiotemporal box
- * @param[in] border_inc True when the box contains the upper border
- * @pre The box has X dimension and the arguments have the same SRID.
- * This is verified in #tgeo_restrict_stbox
- * @note This function is ONLY called by the function atGeometry and thus the
- * stbox has NO temporal dimension
- */
-static TSequenceSet *
-tpointseq_at_stbox_segm(const TSequence *seq, const STBox *box,
-  bool border_inc)
-{
-  assert(seq); assert(box); assert(tpoint_type(seq->temptype));
-  assert(MEOS_FLAGS_GET_INTERP(seq->flags) == LINEAR);
-  assert(! MEOS_FLAGS_GET_T(box->flags));
-
-  /* Instantaneous sequence */
-  if (seq->count == 1)
-  {
-    if (tpointinst_restrict_stbox_iter(TSEQUENCE_INST_N(seq, 0), box,
-        border_inc, REST_AT))
-      return tsequence_to_tsequenceset(seq);
-    return NULL;
-  }
-
-  /* General case */
-  bool hasz_seq = MEOS_FLAGS_GET_Z(seq->flags);
-  bool hasz_box = MEOS_FLAGS_GET_Z(box->flags);
-  bool hasz = hasz_seq && hasz_box;
-  TSequence **sequences = palloc(sizeof(TSequence *) * (seq->count - 1));
-  TInstant **instants = palloc(sizeof(TInstant *) * seq->count);
-  const TInstant *inst1 = TSEQUENCE_INST_N(seq, 0);
-  const GSERIALIZED *p1 = DatumGetGserializedP(tinstant_value_p(inst1));
-  bool lower_inc = seq->period.lower_inc;
-  bool lower_inc_seq = lower_inc, upper_inc;
-  int nseqs = 0, ninsts = 0;
-  for (int i = 1; i < seq->count; i++)
-  {
-    const TInstant *inst2 = TSEQUENCE_INST_N(seq, i);
-    upper_inc = (i == seq->count - 1) ? seq->period.upper_inc : false;
-    const GSERIALIZED *p2 = DatumGetGserializedP(tinstant_value_p(inst2));
-    /* Keep the segment if intersects the bounding box */
-    bool inter = false;
-    if (geopoint_eq(p1, p2))
-    {
-      /* Constant segment */
-      if (tpointinst_restrict_stbox_iter(inst1, box, border_inc, REST_AT))
-        inter = true;
-    }
-    else
-    {
-      /* Keep the segment if intersects the bounding box in the spatial
-       * dimension */
-      if (liangBarskyClip(p1, p2, box, hasz, border_inc, NULL, NULL, NULL,
-          NULL))
-        inter = true;
-    }
-    if (inter)
-    {
-      if (ninsts == 0)
-        instants[ninsts++] = (TInstant *) inst1;
-      instants[ninsts++] = (TInstant *) inst2;
-    }
-    else if (ninsts > 0)
-    {
-      sequences[nseqs++] = tsequence_make(instants, ninsts, lower_inc_seq,
-        upper_inc, LINEAR, NORMALIZE_NO);
-      ninsts = 0;
-      lower_inc_seq = lower_inc;
-    }
-    lower_inc = true;
-    inst1 = inst2;
-    p1 = p2;
-  }
-  if (ninsts > 0)
-    sequences[nseqs++] = tsequence_make(instants, ninsts, lower_inc_seq,
-      upper_inc, LINEAR, NORMALIZE_NO);
-  pfree(instants);
-  return tsequenceset_make_free(sequences, nseqs, NORMALIZE);
-}
-
-/**
- * @brief Return a temporal point sequence set with the segments that intersect
- * a spatiotemporal box in BOTH the spatial and the temporal dimension (if any)
- * @param[in] ss Temporal point sequence set
- * @param[in] box Spatiotemporal box
- * @param[in] border_inc True when the box contains the upper border
- * @pre The box has X dimension and the arguments have the same SRID.
- * This is verified in #tgeo_restrict_stbox
- * @note This function is ONLY called by the function atGeometry and thus the
- * stbox has NO temporal dimension
- */
-static TSequenceSet *
-tpointseqset_at_stbox_segm(const TSequenceSet *ss, const STBox *box,
-  bool border_inc)
-{
-  assert(ss); assert(box); assert(tpoint_type(ss->temptype));
-  TSequenceSet *result = NULL;
-
-  /* Singleton sequence set */
-  if (ss->count == 1)
-    /* We can safely cast since the composing sequences are continuous */
-    return (TSequenceSet *) tpointseq_at_stbox_segm(TSEQUENCESET_SEQ_N(ss, 0),
-      box, border_inc);
-
-  /* General case */
-
-  /* Initialize to 0 due to the bounding box test below */
-  TSequenceSet **seqsets = palloc0(sizeof(TSequenceSet *) * ss->count);
-  int totalseqs = 0;
-  for (int i = 0; i < ss->count; i++)
-  {
-    /* Bounding box test */
-    const TSequence *seq = TSEQUENCESET_SEQ_N(ss, i);
-    STBox box1;
-    tspatialseq_set_stbox(seq, &box1);
-    if (! overlaps_stbox_stbox(&box1, box))
-      continue;
-    else
-    {
-      /* We can safely cast since the composing sequences are continuous */
-      seqsets[i] = (TSequenceSet *) tpointseq_at_stbox_segm(seq, box,
-        border_inc);
-      if (seqsets[i])
-        totalseqs += seqsets[i]->count;
-    }
-  }
-  /* Assemble the sequences from all the sequence sets */
-  if (totalseqs > 0)
-    result = tseqsetarr_to_tseqset(seqsets, ss->count, totalseqs);
-  pfree_array((void **) seqsets, ss->count);
-  return result;
-}
-
-/**
- * @brief Return a temporal point with the segments that intersect
- * a spatiotemporal box in ONLY the spatial dimension
- * @param[in] temp Temporal point
- * @param[in] box Spatiotemporal box
- * @param[in] border_inc True when the box contains the upper border
- * @note It is possible to mix 2D/3D geometries, the Z dimension is only
- * considered if both the temporal point and the box have Z dimension
- * @pre This function supposes all the checks have been done in the calling
- * function
- * @note This function is ONLY called by the function atGeometry and thus the
- * stbox has NO temporal dimension
- */
-static Temporal *
-tpoint_at_stbox_segm(const Temporal *temp, const STBox *box, bool border_inc)
-{
-  assert(temp); assert(box); assert(tpoint_type(temp->temptype));
-  /* The following implies that temp->subtype != TINSTANT */
-  assert(MEOS_FLAGS_GET_INTERP(temp->flags) == LINEAR);
-  /* The stbox has ONLY spatial dimension */
-  assert(MEOS_FLAGS_GET_X(box->flags));
-  assert(! MEOS_FLAGS_GET_T(box->flags));
-  /* Ensure the validity of the arguments */
-  if (! ensure_same_geodetic(temp->flags, box->flags) ||
-      (MEOS_FLAGS_GET_X(box->flags) &&
-        ! ensure_same_srid(tspatial_srid(temp), stbox_srid(box))))
-    return NULL;
-
-  /* Parameter test */
-  assert(tspatial_srid(temp) == stbox_srid(box));
-  assert(MEOS_FLAGS_GET_GEODETIC(temp->flags) ==
-    MEOS_FLAGS_GET_GEODETIC(box->flags));
-
-  /* Bounding box test */
-  STBox box1;
-  tspatial_set_stbox(temp, &box1);
-  if (! overlaps_stbox_stbox(&box1, box))
-    return NULL;
-
-  assert(temptype_subtype(temp->subtype));
-  if (temp->subtype == TSEQUENCE)
-    return (Temporal *) tpointseq_at_stbox_segm((TSequence *) temp,
-        box, border_inc);
-  else /* temp->subtype == TSEQUENCESET */
-    return (Temporal *) tpointseqset_at_stbox_segm((TSequenceSet *) temp,
-      box, border_inc);
-}
-
-/*****************************************************************************
  * Restriction functions for geometry
  * N.B. In the current PostGIS version there is no true ST_Intersection
  * function for geography, it is implemented as ST_DWithin with tolerance 0
@@ -1406,12 +1181,11 @@ TInstant *
 tpointinst_restrict_geom_iter(const TInstant *inst, const GSERIALIZED *gs,
   bool atfunc)
 {
-  /* Restrict to the XY dimension */
+  /* Restrict to the spatial dimension */
   Datum value = tinstant_value_p(inst);
   if (! geom_intersects2d(DatumGetGserializedP(value), gs))
-      /* For temporal point types we return the instants of the input value */
-      return atfunc ? NULL : (TInstant *) inst;
-
+    /* For temporal point types we return the instants of the input value */
+    return atfunc ? NULL : (TInstant *) inst;
   /* The point intersects the geometry */
   return atfunc ? (TInstant *) inst : NULL;
 }
@@ -1595,303 +1369,22 @@ tgeoseq_step_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
 /*****************************************************************************/
 
 /**
- * @brief Get the periods at which a temporal point sequence with linear
- * interpolation intersects a geometry
- * @param[in] seq Temporal point
- * @param[in] gsinter Intersection of the temporal point and the geometry
- * @param[out] count Number of elements in the resulting array
- * @pre The temporal sequence is simple, that is, non self-intersecting and
- * the intersecting geometry is non empty
- */
-Span *
-tpointseq_interperiods(const TSequence *seq, const GSERIALIZED *gsinter,
-  int *count)
-{
-  /* The temporal sequence has at least 2 instants since
-   * (1) the test for instantaneous full sequence is done in the calling function
-   * (2) the simple components of a non self-intersecting sequence have at least
-   *     two instants */
-  assert(seq->count > 1);
-  const TInstant *start = TSEQUENCE_INST_N(seq, 0);
-  const TInstant *end = TSEQUENCE_INST_N(seq, seq->count - 1);
-  Span *result;
-
-  /* If the sequence is stationary the whole sequence intersects with the
-   * geometry since gsinter is not empty */
-  if (seq->count == 2 &&
-    datum_point_eq(tinstant_value_p(start), tinstant_value_p(end)))
-  {
-    result = palloc(sizeof(Span));
-    result[0] = seq->period;
-    *count = 1;
-    return result;
-  }
-
-  /* General case */
-  LWGEOM *geom_inter = lwgeom_from_gserialized(gsinter);
-  int type = geom_inter->type;
-  int ninter;
-  LWPOINT *point_inter = NULL; /* make compiler quiet */
-  LWLINE *line_inter = NULL; /* make compiler quiet */
-  LWCOLLECTION *coll = NULL; /* make compiler quiet */
-  if (type == POINTTYPE)
-  {
-    ninter = 1;
-    point_inter = lwgeom_as_lwpoint(geom_inter);
-  }
-  else if (type == LINETYPE)
-  {
-    ninter = 1;
-    line_inter = lwgeom_as_lwline(geom_inter);
-  }
-  else
-  /* It is a collection of type MULTIPOINTTYPE, MULTILINETYPE, or
-   * COLLECTIONTYPE */
-  {
-    coll = lwgeom_as_lwcollection(geom_inter);
-    ninter = coll->ngeoms;
-  }
-  Span *periods = palloc(sizeof(Span) * ninter);
-  int npers = 0;
-  for (int i = 0; i < ninter; i++)
-  {
-    if (ninter > 1)
-    {
-      /* Find the i-th intersection */
-      LWGEOM *subgeom = coll->geoms[i];
-      if (subgeom->type == POINTTYPE)
-        point_inter = lwgeom_as_lwpoint(subgeom);
-      else /* type == LINETYPE */
-        line_inter = lwgeom_as_lwline(subgeom);
-      type = subgeom->type;
-    }
-    TimestampTz t1, t2;
-    GSERIALIZED *gspoint;
-    /* Each intersection is either a point or a linestring */
-    if (type == POINTTYPE)
-    {
-      gspoint = geo_serialize((LWGEOM *) point_inter);
-      tpointseq_timestamp_at_value(seq, PointerGetDatum(gspoint), &t1);
-      pfree(gspoint);
-      /* If the intersection is not at an exclusive bound */
-      if ((seq->period.lower_inc || t1 > start->t) &&
-          (seq->period.upper_inc || t1 < end->t))
-        span_set(t1, t1, true, true, T_TIMESTAMPTZ, T_TSTZSPAN,
-          &periods[npers++]);
-    }
-    else
-    {
-      /* Get the fraction of the start point of the intersecting line */
-      LWPOINT *point = lwline_get_lwpoint(line_inter, 0);
-      gspoint = geo_serialize((LWGEOM *) point);
-      lwpoint_free(point);
-      tpointseq_timestamp_at_value(seq, PointerGetDatum(gspoint), &t1);
-      pfree(gspoint);
-      /* Get the fraction of the end point of the intersecting line */
-      point = lwline_get_lwpoint(line_inter, line_inter->points->npoints - 1);
-      gspoint = geo_serialize((LWGEOM *) point);
-      lwpoint_free(point);
-      tpointseq_timestamp_at_value(seq, PointerGetDatum(gspoint), &t2);
-      pfree(gspoint);
-      /* If t1 == t2 and the intersection is not at an exclusive bound */
-      if (t1 == t2)
-      {
-        if ((seq->period.lower_inc || t1 > start->t) &&
-            (seq->period.upper_inc || t1 < end->t))
-          span_set(t1, t1, true, true, T_TIMESTAMPTZ, T_TSTZSPAN,
-            &periods[npers++]);
-      }
-      else
-      {
-        TimestampTz lower1 = Min(t1, t2);
-        TimestampTz upper1 = Max(t1, t2);
-        bool lower_inc1 = (lower1 == start->t) ? seq->period.lower_inc : true;
-        bool upper_inc1 = (upper1 == end->t) ? seq->period.upper_inc : true;
-        span_set(lower1, upper1, lower_inc1, upper_inc1, T_TIMESTAMPTZ,
-          T_TSTZSPAN, &periods[npers++]);
-      }
-    }
-  }
-  lwgeom_free(geom_inter);
-
-  if (npers == 0)
-  {
-    *count = npers;
-    pfree(periods);
-    return NULL;
-  }
-  if (npers == 1)
-  {
-    *count = npers;
-    return periods;
-  }
-
-  int newcount;
-  result = spanarr_normalize(periods, npers, ORDER, &newcount);
-  *count = newcount;
-  pfree(periods);
-  return result;
-}
-
-// /**
- // * @brief Return a temporal point sequence with linear interpolation
- // * restricted to a geometry
- // * @details The computation is based on the PostGIS function @p ST_Intersection
- // * which delegates the computation to GEOS. The geometry must be in 2D.
- // * When computing the intersection the Z values of the temporal point must
- // * be dropped since the Z values "are copied, averaged or interpolated"
- // * as stated in https://postgis.net/docs/ST_Intersection.html
- // * After this computation, the Z values are recovered by restricting the
- // * original sequence to the time span of the 2D result.
- // * @pre The arguments have the same SRID, the geometry is 2D and is not empty.
- // * This is verified in #tgeo_restrict_geom
- // */
-// static TSequenceSet *
-// tpointseq_linear_at_geom(const TSequence *seq, const GSERIALIZED *gs)
-// {
-  // assert(MEOS_FLAGS_LINEAR_INTERP(seq->flags)); assert(seq->count > 1);
-
-  // /* Bounding box test */
-  // STBox box1, box2;
-  // tspatialseq_set_stbox(seq, &box1);
-  // /* Non-empty geometries have a bounding box */
-  // geo_set_stbox(gs, &box2);
-  // if (! overlaps_stbox_stbox(&box1, &box2))
-    // return NULL;
-
-  // /* Convert the point to 2D before computing the restriction to geometry */
-  // bool hasz = MEOS_FLAGS_GET_Z(seq->flags);
-  // TSequence *seq2d = hasz ?
-    // (TSequence *) tpoint_force2d((Temporal *) seq) : (TSequence *) seq;
-
-  // /* Split the temporal point in an array of non self-intersecting fragments
-   // * to be able to recover the time dimension after obtaining the spatial
-   // * intersection */
-  // int nsimple;
-  // TSequence **simpleseqs = tpointseq_make_simple(seq2d, &nsimple);
-  // Span *allperiods = NULL; /* make compiler quiet */
-  // int totalpers = 0;
-  // GSERIALIZED *traj, *inter;
-
-  // if (nsimple == 1)
-  // {
-    // /* Particular case when the input sequence is simple */
-    // pfree_array((void **) simpleseqs, nsimple);
-    // traj = tpointseq_linear_trajectory(seq2d, UNARY_UNION_NO);
-    // inter = geom_intersection2d(traj, gs);
-    // if (! gserialized_is_empty(inter))
-      // allperiods = tpointseq_interperiods(seq2d, inter, &totalpers);
-    // pfree(inter); pfree(traj);
-    // if (totalpers == 0)
-    // {
-      // if (hasz)
-        // pfree(seq2d);
-      // return NULL;
-    // }
-  // }
-  // else
-  // {
-    // /* General case */
-    // if (hasz)
-      // pfree(seq2d);
-    // Span **periods = palloc(sizeof(Span *) * nsimple);
-    // int *npers = palloc0(sizeof(int) * nsimple);
-    // /* Loop for every simple fragment of the sequence */
-    // for (int i = 0; i < nsimple; i++)
-    // {
-      // traj = tpointseq_linear_trajectory(simpleseqs[i], UNARY_UNION_NO);
-      // inter = geom_intersection2d(traj, gs);
-      // if (! gserialized_is_empty(inter))
-      // {
-        // periods[i] = tpointseq_interperiods(simpleseqs[i], inter, &npers[i]);
-        // totalpers += npers[i];
-      // }
-      // pfree(inter); pfree(traj);
-    // }
-    // pfree_array((void **) simpleseqs, nsimple);
-    // if (totalpers == 0)
-    // {
-      // pfree(periods); pfree(npers);
-      // return NULL;
-    // }
-
-    // /* Assemble the periods into a single array */
-    // allperiods = palloc(sizeof(Span) * totalpers);
-    // int k = 0;
-    // for (int i = 0; i < nsimple; i++)
-    // {
-      // for (int j = 0; j < npers[i]; j++)
-        // allperiods[k++] = periods[i][j];
-      // if (npers[i] != 0)
-        // pfree(periods[i]);
-    // }
-    // pfree(periods); pfree(npers);
-    // /* It is necessary to sort the periods */
-    // spanarr_sort(allperiods, totalpers);
-  // }
-  // /* Compute the periodset */
-  // assert(totalpers > 0);
-  // SpanSet *ss = spanset_make_free(allperiods, totalpers, NORMALIZE, ORDER);
-  // /* Recover the Z values from the original sequence */
-  // TSequenceSet *result = tcontseq_restrict_tstzspanset(seq, ss, REST_AT);
-  // pfree(ss);
-  // return result;
-// }
-
-/**
- * @brief Return a temporal point sequence with linear interpolation
- * restricted to (the complement of) a geometry
- * @details The function first filters the temporal point wrt the time
- * dimension to reduce the number of instants before computing the restriction
- * to the geometry, which is an expensive operation. Notice that we need to
- * filter wrt the Z dimension after that since while doing this, the subtype of
- * the temporal point may change from a sequence to a sequence set.
- * @param[in] seq Temporal point
- * @param[in] gs Geometry
- * @param[in] atfunc True if the restriction is `at`, false for `minus`
- * @note The function computes the "at" restriction on all dimensions. Then,
- * for the "minus" restriction, it computes the complement of the "at"
- * restriction with respect to the time dimension.
- * @pre Instantaneous sequences have been managed in the calling function
- */
-TSequenceSet *
-tpointseq_linear_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
-  bool atfunc)
-{
-  VALIDATE_TPOINT(seq, NULL); VALIDATE_NOT_NULL(gs, NULL); 
-  assert(MEOS_FLAGS_LINEAR_INTERP(seq->flags));
-  assert(seq->count > 1);
-
-  /* Compute atGeometry for the sequence */
-  TSequenceSet *result_at = tpointseq_linear_at_geom(seq, gs);
-
-  /* If "at" restriction, return */
-  if (atfunc)
-    return result_at;
-
-  /* If "minus" restriction, compute the complement wrt time */
-  if (! result_at)
-    return tsequence_to_tsequenceset(seq);
-
-  SpanSet *ss = tsequenceset_time(result_at);
-  TSequenceSet *result = tcontseq_restrict_tstzspanset(seq, ss, atfunc);
-  pfree(ss); pfree(result_at);
-  return result;
-}
-
-/**
  * @ingroup meos_internal_geo_restrict
  * @brief Return a temporal geo sequence restricted to (the complement of) a
  * geometry
  * @param[in] seq Temporal geo
  * @param[in] gs Geometry
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
+ * @pre The sequence do not have linear interpolation, which is ensured by
+ * function #tgeo_restrict_geom
  */
 Temporal *
 tgeoseq_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
   bool atfunc)
 {
   assert(seq); assert(gs); assert(tgeo_type_all(seq->temptype));
+  assert(MEOS_FLAGS_GET_INTERP(seq->flags) != LINEAR);
+
   interpType interp = MEOS_FLAGS_GET_INTERP(seq->flags);
 
   /* Instantaneous sequence */
@@ -1917,11 +1410,8 @@ tgeoseq_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
   if (interp == DISCRETE)
     return (Temporal *) tgeoseq_disc_restrict_geom((TSequence *) seq, gs,
       atfunc);
-  else if (interp == STEP)
+  else /* interp == STEP */
     return (Temporal *) tgeoseq_step_restrict_geom((TSequence *) seq, gs,
-      atfunc);
-  else /* interp == LINEAR */
-    return (Temporal *) tpointseq_linear_restrict_geom((TSequence *) seq, gs,
       atfunc);
 }
 
@@ -1932,12 +1422,15 @@ tgeoseq_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
  * @param[in] ss Temporal geo
  * @param[in] gs Geometry
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
+ * @pre The sequence set do not have linear interpolation, which is ensured by
+ * function #tgeo_restrict_geom
  */
 TSequenceSet *
 tgeoseqset_restrict_geom(const TSequenceSet *ss, const GSERIALIZED *gs,
   bool atfunc)
 {
   assert(ss); assert(gs); assert(tgeo_type_all(ss->temptype));
+  assert(MEOS_FLAGS_GET_INTERP(ss->flags) != LINEAR);
 
   /* Singleton sequence set */
   if (ss->count == 1)
@@ -2009,36 +1502,26 @@ tgeo_restrict_geom(const Temporal *temp, const GSERIALIZED *gs,
   if (! overlaps_stbox_stbox(&box1, &box2))
     return atfunc ? NULL : temporal_copy(temp);
 
-  /* Restrict to atStbox prior to do atGeom to improve efficiency */
-  interpType interp = MEOS_FLAGS_GET_INTERP(temp->flags);
-  Temporal *temp1;
-  if (interp == LINEAR && atfunc)
-  {
-    temp1 = tpoint_at_stbox_segm(temp, &box2, BORDER_INC);
-    /* This is not redundant with the bounding box check above */
-    if (! temp1)
-      return NULL;
-  }
-  else
-    temp1 = (Temporal *) temp;
+  /* Call the specific function for temporal points with linear interpolation */
+  if (temp->temptype == T_TGEOMPOINT &&
+      MEOS_FLAGS_GET_INTERP(temp->flags) == LINEAR)
+    return tpoint_linear_restrict_geom(temp, gs, atfunc);
 
   Temporal *result;
-  assert(temptype_subtype(temp1->subtype));
-  switch (temp1->subtype)
+  assert(temptype_subtype(temp->subtype));
+  switch (temp->subtype)
   {
     case TINSTANT:
-      return (Temporal *) tgeoinst_restrict_geom((TInstant *) temp1, gs,
+      return (Temporal *) tgeoinst_restrict_geom((TInstant *) temp, gs,
         atfunc);
       break;
     case TSEQUENCE:
-      result = tgeoseq_restrict_geom((TSequence *) temp1, gs, atfunc);
+      result = tgeoseq_restrict_geom((TSequence *) temp, gs, atfunc);
       break;
     default: /* TSEQUENCESET */
-      result = (Temporal *) tgeoseqset_restrict_geom((TSequenceSet *) temp1,
+      result = (Temporal *) tgeoseqset_restrict_geom((TSequenceSet *) temp,
          gs, atfunc);
   }
-  if (interp == LINEAR && atfunc)
-    pfree(temp1);
   return result;
 }
 

--- a/meos/src/geo/tgeo_restrict.c
+++ b/meos/src/geo/tgeo_restrict.c
@@ -56,6 +56,9 @@
 #include "geo/tgeo_spatialfuncs.h"
 #include "geo/tgeo_spatialrels.h"
 
+extern TSequenceSet *tpointseq_linear_at_geom(const TSequence *seq,
+  const GSERIALIZED *gs);
+
 /*****************************************************************************/
 
 #if MEOS
@@ -177,7 +180,7 @@ tpoint_force2d(const Temporal *temp)
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) &point_force2d;
   lfinfo.numparam = 1;
-  int32 srid = tspatial_srid(temp);
+  int32_t srid = tspatial_srid(temp);
   lfinfo.param[0] = Int32GetDatum(srid);
   lfinfo.argtype[0] = temp->temptype;
   lfinfo.restype = T_TGEOMPOINT;
@@ -1395,7 +1398,7 @@ tpoint_at_stbox_segm(const Temporal *temp, const STBox *box, bool border_inc)
 
 /**
  * @brief Return a temporal point instant restricted to (the complement of) a
- * spatiotemporal box (iterator function)
+ * geometry (iterator function)
  * @pre The arguments have the same SRID, the geometry is 2D and is not empty.
  * This is verified in #tgeo_restrict_geom
  */
@@ -1746,110 +1749,110 @@ tpointseq_interperiods(const TSequence *seq, const GSERIALIZED *gsinter,
   return result;
 }
 
-/**
- * @brief Return a temporal point sequence with linear interpolation
- * restricted to a geometry
- * @details The computation is based on the PostGIS function @p ST_Intersection
- * which delegates the computation to GEOS. The geometry must be in 2D.
- * When computing the intersection the Z values of the temporal point must
- * be dropped since the Z values "are copied, averaged or interpolated"
- * as stated in https://postgis.net/docs/ST_Intersection.html
- * After this computation, the Z values are recovered by restricting the
- * original sequence to the time span of the 2D result.
- * @pre The arguments have the same SRID, the geometry is 2D and is not empty.
- * This is verified in #tgeo_restrict_geom
- */
-static TSequenceSet *
-tpointseq_linear_at_geom(const TSequence *seq, const GSERIALIZED *gs)
-{
-  assert(MEOS_FLAGS_LINEAR_INTERP(seq->flags)); assert(seq->count > 1);
+// /**
+ // * @brief Return a temporal point sequence with linear interpolation
+ // * restricted to a geometry
+ // * @details The computation is based on the PostGIS function @p ST_Intersection
+ // * which delegates the computation to GEOS. The geometry must be in 2D.
+ // * When computing the intersection the Z values of the temporal point must
+ // * be dropped since the Z values "are copied, averaged or interpolated"
+ // * as stated in https://postgis.net/docs/ST_Intersection.html
+ // * After this computation, the Z values are recovered by restricting the
+ // * original sequence to the time span of the 2D result.
+ // * @pre The arguments have the same SRID, the geometry is 2D and is not empty.
+ // * This is verified in #tgeo_restrict_geom
+ // */
+// static TSequenceSet *
+// tpointseq_linear_at_geom(const TSequence *seq, const GSERIALIZED *gs)
+// {
+  // assert(MEOS_FLAGS_LINEAR_INTERP(seq->flags)); assert(seq->count > 1);
 
-  /* Bounding box test */
-  STBox box1, box2;
-  tspatialseq_set_stbox(seq, &box1);
-  /* Non-empty geometries have a bounding box */
-  geo_set_stbox(gs, &box2);
-  if (! overlaps_stbox_stbox(&box1, &box2))
-    return NULL;
+  // /* Bounding box test */
+  // STBox box1, box2;
+  // tspatialseq_set_stbox(seq, &box1);
+  // /* Non-empty geometries have a bounding box */
+  // geo_set_stbox(gs, &box2);
+  // if (! overlaps_stbox_stbox(&box1, &box2))
+    // return NULL;
 
-  /* Convert the point to 2D before computing the restriction to geometry */
-  bool hasz = MEOS_FLAGS_GET_Z(seq->flags);
-  TSequence *seq2d = hasz ?
-    (TSequence *) tpoint_force2d((Temporal *) seq) : (TSequence *) seq;
+  // /* Convert the point to 2D before computing the restriction to geometry */
+  // bool hasz = MEOS_FLAGS_GET_Z(seq->flags);
+  // TSequence *seq2d = hasz ?
+    // (TSequence *) tpoint_force2d((Temporal *) seq) : (TSequence *) seq;
 
-  /* Split the temporal point in an array of non self-intersecting fragments
-   * to be able to recover the time dimension after obtaining the spatial
-   * intersection */
-  int nsimple;
-  TSequence **simpleseqs = tpointseq_make_simple(seq2d, &nsimple);
-  Span *allperiods = NULL; /* make compiler quiet */
-  int totalpers = 0;
-  GSERIALIZED *traj, *inter;
+  // /* Split the temporal point in an array of non self-intersecting fragments
+   // * to be able to recover the time dimension after obtaining the spatial
+   // * intersection */
+  // int nsimple;
+  // TSequence **simpleseqs = tpointseq_make_simple(seq2d, &nsimple);
+  // Span *allperiods = NULL; /* make compiler quiet */
+  // int totalpers = 0;
+  // GSERIALIZED *traj, *inter;
 
-  if (nsimple == 1)
-  {
-    /* Particular case when the input sequence is simple */
-    pfree_array((void **) simpleseqs, nsimple);
-    traj = tpointseq_linear_trajectory(seq2d, UNARY_UNION_NO);
-    inter = geom_intersection2d(traj, gs);
-    if (! gserialized_is_empty(inter))
-      allperiods = tpointseq_interperiods(seq2d, inter, &totalpers);
-    pfree(inter); pfree(traj);
-    if (totalpers == 0)
-    {
-      if (hasz)
-        pfree(seq2d);
-      return NULL;
-    }
-  }
-  else
-  {
-    /* General case */
-    if (hasz)
-      pfree(seq2d);
-    Span **periods = palloc(sizeof(Span *) * nsimple);
-    int *npers = palloc0(sizeof(int) * nsimple);
-    /* Loop for every simple fragment of the sequence */
-    for (int i = 0; i < nsimple; i++)
-    {
-      traj = tpointseq_linear_trajectory(simpleseqs[i], UNARY_UNION_NO);
-      inter = geom_intersection2d(traj, gs);
-      if (! gserialized_is_empty(inter))
-      {
-        periods[i] = tpointseq_interperiods(simpleseqs[i], inter, &npers[i]);
-        totalpers += npers[i];
-      }
-      pfree(inter); pfree(traj);
-    }
-    pfree_array((void **) simpleseqs, nsimple);
-    if (totalpers == 0)
-    {
-      pfree(periods); pfree(npers);
-      return NULL;
-    }
+  // if (nsimple == 1)
+  // {
+    // /* Particular case when the input sequence is simple */
+    // pfree_array((void **) simpleseqs, nsimple);
+    // traj = tpointseq_linear_trajectory(seq2d, UNARY_UNION_NO);
+    // inter = geom_intersection2d(traj, gs);
+    // if (! gserialized_is_empty(inter))
+      // allperiods = tpointseq_interperiods(seq2d, inter, &totalpers);
+    // pfree(inter); pfree(traj);
+    // if (totalpers == 0)
+    // {
+      // if (hasz)
+        // pfree(seq2d);
+      // return NULL;
+    // }
+  // }
+  // else
+  // {
+    // /* General case */
+    // if (hasz)
+      // pfree(seq2d);
+    // Span **periods = palloc(sizeof(Span *) * nsimple);
+    // int *npers = palloc0(sizeof(int) * nsimple);
+    // /* Loop for every simple fragment of the sequence */
+    // for (int i = 0; i < nsimple; i++)
+    // {
+      // traj = tpointseq_linear_trajectory(simpleseqs[i], UNARY_UNION_NO);
+      // inter = geom_intersection2d(traj, gs);
+      // if (! gserialized_is_empty(inter))
+      // {
+        // periods[i] = tpointseq_interperiods(simpleseqs[i], inter, &npers[i]);
+        // totalpers += npers[i];
+      // }
+      // pfree(inter); pfree(traj);
+    // }
+    // pfree_array((void **) simpleseqs, nsimple);
+    // if (totalpers == 0)
+    // {
+      // pfree(periods); pfree(npers);
+      // return NULL;
+    // }
 
-    /* Assemble the periods into a single array */
-    allperiods = palloc(sizeof(Span) * totalpers);
-    int k = 0;
-    for (int i = 0; i < nsimple; i++)
-    {
-      for (int j = 0; j < npers[i]; j++)
-        allperiods[k++] = periods[i][j];
-      if (npers[i] != 0)
-        pfree(periods[i]);
-    }
-    pfree(periods); pfree(npers);
-    /* It is necessary to sort the periods */
-    spanarr_sort(allperiods, totalpers);
-  }
-  /* Compute the periodset */
-  assert(totalpers > 0);
-  SpanSet *ss = spanset_make_free(allperiods, totalpers, NORMALIZE, ORDER);
-  /* Recover the Z values from the original sequence */
-  TSequenceSet *result = tcontseq_restrict_tstzspanset(seq, ss, REST_AT);
-  pfree(ss);
-  return result;
-}
+    // /* Assemble the periods into a single array */
+    // allperiods = palloc(sizeof(Span) * totalpers);
+    // int k = 0;
+    // for (int i = 0; i < nsimple; i++)
+    // {
+      // for (int j = 0; j < npers[i]; j++)
+        // allperiods[k++] = periods[i][j];
+      // if (npers[i] != 0)
+        // pfree(periods[i]);
+    // }
+    // pfree(periods); pfree(npers);
+    // /* It is necessary to sort the periods */
+    // spanarr_sort(allperiods, totalpers);
+  // }
+  // /* Compute the periodset */
+  // assert(totalpers > 0);
+  // SpanSet *ss = spanset_make_free(allperiods, totalpers, NORMALIZE, ORDER);
+  // /* Recover the Z values from the original sequence */
+  // TSequenceSet *result = tcontseq_restrict_tstzspanset(seq, ss, REST_AT);
+  // pfree(ss);
+  // return result;
+// }
 
 /**
  * @brief Return a temporal point sequence with linear interpolation
@@ -1877,11 +1880,12 @@ tpointseq_linear_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
   assert(MEOS_FLAGS_LINEAR_INTERP(seq->flags));
   assert(seq->count > 1);
 
-  /* Compute atGeometry for the sequence */
+  TSequenceSet *result_at = NULL;
+
+  /* Clip the temporal point to the geometry */
   TSequenceSet *at_xy = tpointseq_linear_at_geom(seq, gs);
 
   /* Restrict to the Z dimension */
-  TSequenceSet *result_at = NULL;
   if (at_xy)
   {
     if (zspan)
@@ -1890,14 +1894,15 @@ tpointseq_linear_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
       STBox box1;
       tspatialseqset_set_stbox(at_xy, &box1);
       Span zspan1;
-      span_set(Float8GetDatum(box1.zmin), Float8GetDatum(box1.zmax), true, true,
-        T_FLOAT8, T_FLOATSPAN, &zspan1);
+      span_set(Float8GetDatum(box1.zmin), Float8GetDatum(box1.zmax),
+        true, true, T_FLOAT8, T_FLOATSPAN, &zspan1);
       if (overlaps_span_span(&zspan1, zspan))
       {
         /* Get the Z coordinate values as a temporal float */
         Temporal *tfloat_z = tpoint_get_coord((Temporal *) at_xy, 2);
         /* Restrict to the zspan */
-        Temporal *tfloat_zspan = tnumber_restrict_span(tfloat_z, zspan, REST_AT);
+        Temporal *tfloat_zspan = tnumber_restrict_span(tfloat_z, zspan,
+          REST_AT);
         pfree(tfloat_z);
         if (tfloat_zspan)
         {
@@ -2043,7 +2048,6 @@ tgeo_restrict_geom(const Temporal *temp, const GSERIALIZED *gs,
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TGEO(temp, NULL); VALIDATE_NOT_NULL(gs, NULL); 
-  /* Ensure the validity of the arguments */
   if (! ensure_same_srid(tspatial_srid(temp), gserialized_get_srid(gs)) ||
       ! ensure_has_not_Z_geo(gs) ||
       (zspan && ! ensure_has_Z(temp->temptype, temp->flags)) ||

--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -1263,7 +1263,7 @@ ea_touches_tpoint_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
   bool result = false;
   if (gsbound && ! gserialized_is_empty(gsbound))
   {
-    Temporal *temp1 = tgeo_restrict_geom(temp, gsbound, NULL, REST_MINUS);
+    Temporal *temp1 = tgeo_restrict_geom(temp, gsbound, REST_MINUS);
     result = (temp1 == NULL);
     if (temp1)
       pfree(temp1);

--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -1223,7 +1223,7 @@ aintersects_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 int
 ea_touches_tpoint_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 {
-  VALIDATE_TGEO(temp, -1); VALIDATE_NOT_NULL(gs, -1);
+  VALIDATE_TPOINT(temp, -1); VALIDATE_NOT_NULL(gs, -1);
   /* Ensure validity of the arguments */
   if (! ensure_valid_tpoint_geo(temp, gs) || gserialized_is_empty(gs) ||
       /* The validity function ensures that both have the same geodetic flag */

--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -61,7 +61,7 @@
 #include "geo/tgeo_tempspatialrels.h"
 
 /*****************************************************************************
- * Spatial relationship functions
+ * Spatial relationship functions computed in GEOS
  * disjoint and intersects are inverse to each other
  *****************************************************************************/
 
@@ -86,13 +86,37 @@ datum_geom_covers(Datum geom1, Datum geom2)
 }
 
 /**
+ * @brief Return a Datum true if two 2D geometries are within a distance
+ */
+Datum
+datum_geom_relate_pattern(Datum geom1, Datum geom2, Datum p)
+{
+  return BoolGetDatum(geom_relate_pattern(DatumGetGserializedP(geom1),
+    DatumGetGserializedP(geom2), (char *) DatumGetPointer(p)));
+}
+
+/**
+ * @brief Return a Datum true if the first geometry covers the second one
+ */
+Datum
+datum_geom_touches(Datum geom1, Datum geom2)
+{
+  return BoolGetDatum(geom_spatialrel(DatumGetGserializedP(geom1),
+    DatumGetGserializedP(geom2), TOUCHES));
+}
+
+/*****************************************************************************
+ * Spatial relationship functions computed in PostGIS
+ *****************************************************************************/
+
+/**
  * @brief Return a Datum true if two geometries are disjoint in 2D
  */
 Datum
 datum_geom_disjoint2d(Datum geom1, Datum geom2)
 {
-  return BoolGetDatum(! geom_spatialrel(DatumGetGserializedP(geom1),
-    DatumGetGserializedP(geom2), INTERSECTS));
+  return BoolGetDatum(! geom_intersects2d(DatumGetGserializedP(geom1),
+    DatumGetGserializedP(geom2)));
 }
 
 /**
@@ -173,26 +197,6 @@ datum_geog_dwithin(Datum geog1, Datum geog2, Datum dist)
 {
   return BoolGetDatum(geog_dwithin(DatumGetGserializedP(geog1),
     DatumGetGserializedP(geog2), DatumGetFloat8(dist), true));
-}
-
-/**
- * @brief Return a Datum true if two 2D geometries are within a distance
- */
-Datum
-datum_geom_relate_pattern(Datum geom1, Datum geom2, Datum p)
-{
-  return BoolGetDatum(geom_relate_pattern(DatumGetGserializedP(geom1),
-    DatumGetGserializedP(geom2), (char *) DatumGetPointer(p)));
-}
-
-/**
- * @brief Return a Datum true if the first geometry covers the second one
- */
-Datum
-datum_geom_touches(Datum geom1, Datum geom2)
-{
-  return BoolGetDatum(geom_touches(DatumGetGserializedP(geom1),
-    DatumGetGserializedP(geom2)));
 }
 
 /*****************************************************************************/

--- a/meos/src/geo/tgeo_tile.c
+++ b/meos/src/geo/tgeo_tile.c
@@ -692,7 +692,7 @@ stbox_space_time_tiles(const STBox *bounds, double xsize, double ysize,
   memset(&pt, 0, sizeof(POINT3DZ));
   if (sorigin)
   {
-    if (sorigin && FLAGS_GET_Z(sorigin->gflags))
+    if (FLAGS_GET_Z(sorigin->gflags))
     {
       const POINT3DZ *p3d = GSERIALIZED_POINT3DZ_P(sorigin);
       pt.x = p3d->x;

--- a/meos/src/geo/tgeo_tile.c
+++ b/meos/src/geo/tgeo_tile.c
@@ -501,7 +501,7 @@ stbox_tile_state_make(const Temporal *temp, const STBox *box, double xsize,
 void
 stbox_tile_state_set(double x, double y, double z, TimestampTz t, double xsize,
   double ysize, double zsize, int64 tunits, bool hasx, bool hasz, bool hast,
-  int32 srid, STBox *result)
+  int32_t srid, STBox *result)
 {
   assert(hasx || hast);
 
@@ -682,7 +682,7 @@ stbox_space_time_tiles(const STBox *bounds, double xsize, double ysize,
       return NULL;
   if (sorigin)
   {    
-    int32 srid = bounds->srid;
+    int32_t srid = bounds->srid;
     int32 gs_srid = gserialized_get_srid(sorigin);
     if (gs_srid != SRID_UNKNOWN && ! ensure_same_srid(srid, gs_srid))
       return NULL;
@@ -836,8 +836,8 @@ stbox_space_time_tile(const GSERIALIZED *point, TimestampTz t,
   double xmin = 0, ymin = 0, zmin = 0;
   bool hasz = false;
   int64 tunits = hast ? interval_units(duration) : 0;
-  int32 srid = hasx ? gserialized_get_srid(point) : SRID_UNKNOWN;
-  int32 gs_srid = hasx ? gserialized_get_srid(sorigin) : SRID_UNKNOWN;
+  int32_t srid = hasx ? gserialized_get_srid(point) : SRID_UNKNOWN;
+  int32_t gs_srid = hasx ? gserialized_get_srid(sorigin) : SRID_UNKNOWN;
   if (gs_srid != SRID_UNKNOWN)
     ensure_same_srid(srid, gs_srid);
   POINT3DZ pt, ptorig;

--- a/meos/src/geo/tpoint_datagen.c
+++ b/meos/src/geo/tpoint_datagen.c
@@ -420,7 +420,7 @@ create_trip(LWLINE **lines, const double *maxSpeeds, const int *categories,
   }
 
   for (i = 0; i < noEdges; i++)
-    lwgeom_free(lwline_as_lwgeom(lines[i]));
+    lwgeom_free((LWGEOM *) lines[i]);
   pfree(lines);
   return result;
 }

--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -54,19 +54,36 @@
 
 /* Minimum number of edges to use an R-tree index in order to compensate the
  * overhead of the tree construction and destruction */
-#define RTREE_MIN_NUMBER_ELEMS 100
+#define RTREE_MIN_NUMBER_ELEMS 100000 // TODO -> 100 
+  // CURRENTLY INDEX CREATION IS DISABLED SINCE IT BREAK THE CI/CD TESTS
 
 /*****************************************************************************
  * Data structures
  *****************************************************************************/
+
+/* Static global arrays for accumulating the results of the clipping process*/
+static MeosArray *events = NULL;
+static MeosArray *intervals = NULL;
+static MeosArray *periods = NULL;
+
+/**
+ * @brief Enumeration defining the edge types 
+ */
+typedef enum
+{
+  EDGE_POINT = 0,
+  EDGE_LINE,
+  EDGE_POLY
+} EdgeType;
 
 /**
  * @brief Structure keeping a geometry edge
  */
 typedef struct
 {
-  double x1, y1, x2, y2; /**< Coordinates of the start and end 2D points */
+  double x1, y1, x2, y2;         /**< Coordinates of the start/end 2D points */
   double xmin, ymin, xmax, ymax; /**< Bounding box of the edge */
+  EdgeType etype;                /**< Edge type */
 } Edge;
 
 /**
@@ -196,7 +213,7 @@ static bool
 point_on_segment(double px, double py, double x1, double y1, double x2,
   double y2)
 {
-  /* Vector AP and AB */
+  /* Vectors AP and AB */
   double apx = px - x1;
   double apy = py - y1;
   double abx = x2 - x1;
@@ -209,7 +226,7 @@ point_on_segment(double px, double py, double x1, double y1, double x2,
   double dot = apx * abx + apy * aby;
   if (dot < -FP_TOLERANCE)
     return false;
-  /* Check P lies between A and B */
+  /* Check if P lies between A and B */
   double ab2 = abx * abx + aby * aby;
   if (dot > ab2 + FP_TOLERANCE)
     return false;
@@ -221,10 +238,10 @@ point_on_segment(double px, double py, double x1, double y1, double x2,
  * @details The computation is done using vectors and an even-odd rule
  */
 static int
-point_in_polygon(double x, double y, Edge **edges, int n)
+point_in_polygon(double x, double y, Edge **edges, int nedges)
 {
   /* Boundary check */
-  for (int i = 0; i < n; i++)
+  for (int i = 0; i < nedges; i++)
   {
     double x1 = edges[i]->x1, y1 = edges[i]->y1;
     double x2 = edges[i]->x2, y2 = edges[i]->y2;
@@ -246,7 +263,7 @@ point_in_polygon(double x, double y, Edge **edges, int n)
 
   /* Perform even‑odd crossing */
   int crossings = 0;
-  for (int i = 0; i < n; i++)
+  for (int i = 0; i < nedges; i++)
   {
     double x1 = edges[i]->x1, y1 = edges[i]->y1;
     double x2 = edges[i]->x2, y2 = edges[i]->y2;
@@ -262,33 +279,93 @@ point_in_polygon(double x, double y, Edge **edges, int n)
 
 /**
  * @brief Compute the intersection intervals of a trajectory segment with an
+ * array of point edges
+ */
+static void
+intervals_from_points(const POINT2D *a, const POINT2D *b, Edge **edges,
+  int nedges)
+{
+  assert(a); assert(b); assert(edges); assert(nedges >= 0);
+
+  /* Segment vector */
+  double dx = b->x - a->x;
+  double dy = b->y - a->y;
+
+  /* Iterate through the points */
+  for (int i = 0; i < nedges; i++)
+  {
+    Edge *e = edges[i]; /* point: x1==x2, y1==y2 */
+    /* Iterate only for the points */
+    if (e->etype != EDGE_POINT)
+      continue;
+
+    /* Solve parameter t */
+    double t;
+    if (fabs(dx) >= fabs(dy))
+    {
+      if (fabs(dx) < FP_TOLERANCE)
+        continue;
+      t = (e->x1 - a->x) / dx;
+    }
+    else
+    {
+      if (fabs(dy) < FP_TOLERANCE)
+        continue;
+      t = (e->y1 - a->y) / dy;
+    }
+
+    /* Check bounds */
+    if (t < -FP_TOLERANCE || t > 1.0 + FP_TOLERANCE)
+      continue;
+
+    /* Reconstruct point and add interval */
+    double x = a->x + t * dx;
+    double y = a->y + t * dy;
+    if (fabs(x - e->x1) < FP_TOLERANCE && fabs(y - e->y1) < FP_TOLERANCE)
+    {
+      Span in;
+      span_set(Float8GetDatum(t), Float8GetDatum(t), true, true,
+        T_FLOAT8, T_FLOATSPAN, &in);
+      meos_array_add(intervals, &in);
+    }
+  }
+  return;
+}
+
+/**
+ * @brief Compute the intersection intervals of a trajectory segment with an
  * array of linear or point edges
  */
 static void
-linear_intervals(POINT4D a, POINT4D b, Edge **edges, int nedges,
-  MeosArray *intervals)
+intervals_from_lines(const POINT2D *a, const POINT2D *b, Edge **edges,
+  int nedges)
 {
-  /* Compute the bounding box of the segment */
-  double seg_xmin = FP_MIN(a.x, b.x);
-  double seg_xmax = FP_MAX(a.x, b.x);
-  double seg_ymin = FP_MIN(a.y, b.y);
-  double seg_ymax = FP_MAX(a.y, b.y);
-  
+  assert(a); assert(b); assert(edges); assert(nedges >= 0);
+
+  /* Segment bounding box */
+  double seg_xmin = FP_MIN(a->x, b->x);
+  double seg_xmax = FP_MAX(a->x, b->x);
+  double seg_ymin = FP_MIN(a->y, b->y);
+  double seg_ymax = FP_MAX(a->y, b->y);
+  /* Segment vector */
+  double rx = b->x - a->x;  
+  double ry = b->y - a->y;  
   bool has_intersection = false;
   Span in;
-  /* To avoid recomputing the vector AB in the call to linesegm_intersect
-   * inside the loop, we pass the vector instead of the second point b */
-  double rx = b.x - a.x, ry = b.y - a.y;
+
   for (int i = 0; i < nedges; i++)
   {
     Edge *e = edges[i];
+    /* Iterate only for the polygon edges */
+    if (e->etype != EDGE_LINE)
+      continue;
 
     /* Bounding box filter */
     if (e->xmax < seg_xmin || e->xmin > seg_xmax ||
         e->ymax < seg_ymin || e->ymin > seg_ymax)
       continue;
     /* Compute the intersection */
-    IntersectResult r = linesegm_intersect(a.x, a.y, rx, ry,
+    IntersectResult r = linesegm_intersect(a->x, a->y, rx, ry,
       e->x1, e->y1, e->x2, e->y2);
     /* If there is no intersection  */
     if (r.type == INTERSECT_NONE)
@@ -309,11 +386,14 @@ linear_intervals(POINT4D a, POINT4D b, Edge **edges, int nedges,
   if (! has_intersection)
   {
     /* test midpoint */
-    double mx = (a.x + b.x) * 0.5;
-    double my = (a.y + b.y) * 0.5;
+    double mx = (a->x + b->x) * 0.5;
+    double my = (a->y + b->y) * 0.5;
     for (int i = 0; i < nedges; i++)
     {
       Edge *e = edges[i];
+      /* Iterate only for the polygon edges */
+      if (e->etype != EDGE_LINE)
+        continue;
       if (point_on_segment(mx, my, e->x1, e->y1, e->x2, e->y2))
       {
         span_set(Float8GetDatum(0.0), Float8GetDatum(1.0), true, true,
@@ -348,305 +428,123 @@ float8_qsort_cmp(const void *a1, const void *a2)
  * @note Function performing robust duplicate handling
  */
 static void
-polygon_intervals(POINT4D a, POINT4D b, Edge **edges, int nedges,
-  MeosArray *events, MeosArray *intervals, int *inside)
+intervals_from_polygons(const POINT2D *a, const POINT2D *b, Edge **edges,
+  int nedges)
 {
-  assert(edges); assert(nedges >= 0); assert(events); assert(intervals);
-  assert(inside); 
+  assert(a); assert(b); assert(edges); assert(nedges >= 0);
   
   /* Reset event array */
   events->count = 0;
-  Span in;
 
-  /* Compute the bounding box of the segment */
-  double seg_xmin = FP_MIN(a.x, b.x);
-  double seg_xmax = FP_MAX(a.x, b.x);
-  double seg_ymin = FP_MIN(a.y, b.y);
-  double seg_ymax = FP_MAX(a.y, b.y);
+  /* Segment bounding box */
+  double seg_xmin = FP_MIN(a->x, b->x);
+  double seg_xmax = FP_MAX(a->x, b->x);
+  double seg_ymin = FP_MIN(a->y, b->y);
+  double seg_ymax = FP_MAX(a->y, b->y);
+  /* Segment vector */
+  double rx = b->x - a->x;
+  double ry = b->y - a->y;
 
-  /* To avoid recomputing the vector AB in the call to linesegm_intersect
-   * inside the loop, we pass the vector instead of the second point b */
-  double rx = b.x - a.x, ry = b.y - a.y;
-
-  /* Collect intersection events */
+  /* Collect all intersection parameters */
+  bool has_polys = false;
   for (int i = 0; i < nedges; i++)
   {
     Edge *e = edges[i];
-    /* Bounding box filter  */
+    /* Iterate only for the polygon edges */
+    if (e->etype != EDGE_POLY)
+      continue;
+    has_polys = true;
+
+    /* Bounding box filter */
     if (e->xmax < seg_xmin || e->xmin > seg_xmax ||
         e->ymax < seg_ymin || e->ymin > seg_ymax)
       continue;
-      
-    IntersectResult r = linesegm_intersect(a.x, a.y, rx, ry,
+
+    IntersectResult r = linesegm_intersect(a->x, a->y, rx, ry,
       e->x1, e->y1, e->x2, e->y2);
-
     if (r.type == INTERSECT_POINT)
-      meos_array_add(events, &r.t0);
-    else if (r.type == INTERSECT_OVERLAP)
     {
-      meos_array_add(events, &r.t0);
-      meos_array_add(events, &r.t1);
+      if (r.t0 > -FP_TOLERANCE && r.t0 < 1.0 + FP_TOLERANCE)
+        meos_array_add(events, &r.t0);
     }
   }
 
-  /* No intersections */
-  if (events->count == 0)
-  {
-    if (*inside)
-    {
-      span_set(Float8GetDatum(0.0), Float8GetDatum(1.0), true, true,
-        T_FLOAT8, T_FLOATSPAN, &in);
-      meos_array_add(intervals, &in);
-    }
+  /* If no polygon edges have been found, we do not continue */
+  if (! has_polys)
     return;
-  }
 
-  /* Sort events */
+  /* Add endpoints */
+  double t0 = 0.0, t1 = 1.0;
+  meos_array_add(events, &t0);
+  meos_array_add(events, &t1);
+
+  /* Sort */
   qsort(events->elems, events->count, sizeof(double), float8_qsort_cmp);
-  double *evtarr = (double *) events->elems;
 
-  /* Robust duplicate clustering */
-  int inside_flag = *inside;
-  double start = 0.0;
-    double last_kept = evtarr[0]; // - 2 * FP_TOLERANCE; /* force first keep */
+  /* Deduplicate */
+  int newcount = 0;
+  double *evtarr = (double *) events->elems;
   for (int i = 0; i < (int) events->count; i++)
   {
-    double t = evtarr[i];
-    if (fabs(t - last_kept) < FP_TOLERANCE)
+    if (i == 0 || fabs(evtarr[i] - evtarr[newcount - 1]) > FP_TOLERANCE)
+      evtarr[newcount++] = evtarr[i];
+  }
+  events->count = newcount;
+
+  /* Build intervals using midpoint test */
+  for (int i = 0; i < (int) events->count - 1; i++)
+  {
+    double ta = evtarr[i];
+    double tb = evtarr[i + 1];
+    if (tb - ta <= FP_TOLERANCE)
       continue;
 
-    last_kept = t;
-    if (!inside_flag)
+    double tm = (ta + tb) * 0.5;
+    double x = a->x + tm * rx;
+    double y = a->y + tm * ry;
+    if (point_in_polygon(x, y, edges, nedges))
     {
-      start = t;
-      inside_flag = 1;
-    }
-    else
-    {
-      span_set(Float8GetDatum(start), Float8GetDatum(t), true, true,
+      Span in;
+      span_set(Float8GetDatum(ta), Float8GetDatum(tb), true, true,
         T_FLOAT8, T_FLOATSPAN, &in);
       meos_array_add(intervals, &in);
-      inside_flag = 0;
     }
   }
-
-  /* If inside generate an interval */
-  if (inside_flag)
-  {
-    span_set(Float8GetDatum(start), Float8GetDatum(1.0), true, true,
-      T_FLOAT8, T_FLOATSPAN, &in);
-    meos_array_add(intervals, &in);
-  }
-  /* Set ouput parameter and return */
-  *inside = inside_flag;
   return;
 }
 
-/*****************************************************************************
- * Extract edges from a geometry that can be of type point, line, polygon or
- * collection of these
- *****************************************************************************/
+/*****************************************************************************/
 
 /**
- * @brief Add to the dynamic array in the last argument the edges obtained
- * from a ring
+ * @brief Return true if a trajectory point intersects with an array of point
+ * and linear edges
  */
-static void
-emit_ring_edges(const POINTARRAY *pa, MeosArray *edges)
+static bool
+point_inter_points_lines(const POINT2D *a, Edge **edges, int nedges)
 {
-  for (int i = 0; i < (int) pa->npoints - 1; i++)
-  {
-    POINT4D a, b;
-    (void) getPoint4d_p(pa, i, &a);
-    (void) getPoint4d_p(pa, i + 1, &b);
-    Edge e;
-    e.x1 = a.x; e.y1 = a.y;
-    e.x2 = b.x; e.y2 = b.y;
-    e.xmin = FP_MIN(e.x1, e.x2); e.xmax = FP_MAX(e.x1, e.x2);
-    e.ymin = FP_MIN(e.y1, e.y2); e.ymax = FP_MAX(e.y1, e.y2);
-    meos_array_add(edges, &e);
-  }
-  return;
-}
+  assert(a); assert(edges); assert(nedges >= 0);
 
-/**
- * @brief Add to the dynamic array in the last argument the edge obtained
- * from a point
- */
-static void
-extract_point(const LWPOINT *pt, MeosArray *edges)
-{
-  POINT4D p;
-  (void) getPoint4d_p(pt->point, 0, &p);
-  Edge e;
-  e.x1 = e.x2 = e.xmin = e.xmax = p.x;
-  e.y1 = e.y2 = e.ymin = e.ymax = p.y;
-  meos_array_add(edges, &e);
-  return;
-}
-
-/**
- * @brief Add to the dynamic array in the last argument the edges obtained
- * from a multipoint
- */
-static void
-extract_mpoint(const LWMPOINT *mp, MeosArray *edges)
-{
-  for (int i = 0; i < (int) mp->ngeoms; i++)
-    extract_point((const LWPOINT *) mp->geoms[i], edges);
-  return;
-}
-
-/**
- * @brief Add to the dynamic array in the last argument the segments obtained
- * from a line
- */
-static void
-extract_line(const LWLINE *line, MeosArray *edges)
-{
-  emit_ring_edges(line->points, edges);
-  return;
-}
-
-/**
- * @brief Add to the dynamic array in the last argument the segments obtained
- * from a multiline
- */
-static void
-extract_mline(const LWMLINE *ml, MeosArray *edges)
-{
-  for (int i = 0; i < (int) ml->ngeoms; i++)
-    extract_line(ml->geoms[i], edges);
-  return;
-}
-
-/**
- * @brief Add to the dynamic array in the last argument the edges obtained
- * from a polygon
- */
-static void
-extract_poly(const LWPOLY *poly, MeosArray *edges)
-{
-  for (int r = 0; r < (int) poly->nrings; r++)
-    emit_ring_edges(poly->rings[r], edges);
-  return;
-}
-
-/**
- * @brief Add to the dynamic array in the last argument the edges obtained
- * from a multipolygon
- */
-static void
-extract_mpoly(const LWMPOLY *mp, MeosArray *edges)
-{
-  for (int i = 0; i < (int) mp->ngeoms; i++)
-    extract_poly(mp->geoms[i], edges);
-  return;
-}
-
-/**
- * @brief Add to the dynamic array in the last argument the edges obtained
- * from a triangle
- * @details In PostGIS a triangle has a single (outer) ring stored as
- * POINTARRAY, which is already closed or implicitly closed
- */
-static void
-extract_triangle(const LWTRIANGLE *tri, MeosArray *edges)
-{
-  emit_ring_edges(tri->points, edges);
-  return;
-}
-
-/**
- * @brief Return the edges of a geometry in a dynamic array (iterator)
- */
-static void
-geom_extract_edges_iter(const LWGEOM *geom, MeosArray *edges,
-  bool *is_polygonal)
-{
-  if (! geom)
-    return;
-
-  switch (geom->type)
-  {
-    case POINTTYPE:
-      extract_point((const LWPOINT *) geom, edges);
-      break;
-
-    case MULTIPOINTTYPE:
-      extract_mpoint((const LWMPOINT *) geom, edges);
-      break;
-
-    case LINETYPE:
-      extract_line((const LWLINE *) geom, edges);
-      break;
-
-    case MULTILINETYPE:
-      extract_mline((const LWMLINE *) geom, edges);
-      break;
-
-    case POLYGONTYPE:
-      *is_polygonal = true;
-      extract_poly((const LWPOLY *) geom, edges);
-      break;
-
-    case MULTIPOLYGONTYPE:
-      *is_polygonal = true;
-      extract_mpoly((const LWMPOLY *) geom, edges);
-      break;
-
-    case TRIANGLETYPE:
-      *is_polygonal = true;
-      extract_triangle((const LWTRIANGLE *) geom, edges);
-      break;
-
-    case COLLECTIONTYPE:
-      const LWCOLLECTION *col = (const LWCOLLECTION *) geom;
-      for (int i = 0; i < (int) col->ngeoms; i++)
-        geom_extract_edges_iter(col->geoms[i], edges, is_polygonal);
-      break;
-
-    /* Unsupported type */
-    default:
-      meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
-        "Unsupported geometry type");
-      break;
-  }
-  return;
-}
-
-/**
- * @brief Return the edges of a geometry in a dynamic array 
- */
-static MeosArray *
-geom_extract_edges(const LWGEOM *geom, bool *is_polygonal)
-{
-  MeosArray *edges = meos_array_init(sizeof(Edge));
-  geom_extract_edges_iter(geom, edges, is_polygonal);
-  return edges;
-}
-
-/**
- * @brief Build an R-tree from edges
- */
-static RTree *
-build_edge_rtree(const Edge *edges, int nedges, int32_t srid)
-{
-  RTree *rtree = rtree_create_stbox();
+  /* Iterate only through the point and linear edges */
   for (int i = 0; i < nedges; i++)
   {
-    const Edge *e = &edges[i];
-    STBox box;
-    stbox_set(true, false, false, srid, e->xmin, e->xmax, e->ymin, e->ymax,
-      0, 0, NULL, &box);
-    /* Store pointer to edge */
-    rtree_insert(rtree, &box, i);
+    Edge *e = edges[i];
+    if (e->etype == EDGE_POINT)
+    {
+      if (fabs(e->x1 - a->x) < FP_TOLERANCE &&
+          fabs(e->y1 - a->y) < FP_TOLERANCE)
+        return true;
+    }
+    else if (e->etype == EDGE_LINE)
+    {
+      if (point_on_segment(a->x, a->y, e->x1, e->y1, e->x2, e->y2))
+        return true;
+    }
   }
-  return rtree;
+  return false;
 }
 
 /*****************************************************************************
- * Clip a temporal geometry point sequence
+ * Clip a temporal geometry point
  *****************************************************************************/
 
 /**
@@ -659,58 +557,123 @@ build_edge_rtree(const Edge *edges, int nedges, int32_t srid)
  * @param[in] cand_edges Edge array buffer of size `nedges` for storing the
  * result of an R-tree look up, may be `NULL` if no index is used
  */
-static TSequenceSet *
-tpointseq_clip_geom(const TSequence *seq, Edge **edges, int nedges,
-  RTree *rtree, Edge **cand_edges, bool is_polygonal)
+static void
+tpointinst_clip_edges(const TInstant *inst, Edge **edges, int nedges,
+  RTree *rtree, Edge **cand_edges)
+{
+  assert(inst); assert(edges); assert(nedges > 0);
+  assert(inst->temptype == T_TGEOMPOINT);
+
+  bool use_index = (rtree != NULL);
+  int32_t srid = tspatial_srid((Temporal *) inst);
+  const POINT2D *a = DATUM_POINT2D_P(tinstant_value_p(inst));
+
+  /* Edges to process: either all of them or those filtered by an R-tree */
+  Edge **sel_edges = NULL;
+  int sel_nedges = 0;
+  if (use_index)
+  {
+    /* Build the segment bounding box */
+    STBox query;
+    stbox_set(true, false, false, srid, a->x, a->x, a->y, a->y, 0, 0, NULL,
+      &query);
+    /* Query the R-tree */
+    int *results = rtree_search(rtree, RTREE_OVERLAPS, &query, &sel_nedges);
+    if (sel_nedges == 0)
+      return;
+
+    /* Transform the result of the R-tree look up into an edge pointer array */
+    for (int j = 0; j < sel_nedges; j++)
+      cand_edges[j] = (Edge *) &edges[results[j]];
+    sel_edges = cand_edges;
+    pfree(results);
+  }
+  else /* no index */
+  {
+    sel_edges = edges;
+    sel_nedges = nedges;
+  }
+
+  /* Reset the interval array */
+  intervals->count = 0;
+  /* Compute the intervals for the points, lines, and polygon edges */
+  bool found = point_inter_points_lines(a, sel_edges, sel_nedges);
+  if (! found)
+  {
+    intervals_from_polygons(a, a, sel_edges, sel_nedges);
+    if (intervals->count == 0)
+      return;
+  }
+  
+  /* Generate the instantantaneous span */
+  Span s;
+  span_set(TimestampTzGetDatum(inst->t), TimestampTzGetDatum(inst->t),
+    true, true, T_TIMESTAMPTZ, T_TSTZSPAN, &s);
+  meos_array_add(periods, &s);
+  return;
+}
+
+/**
+ * @brief Clip a 2D/3D trajectory with linear interpolation with respect to a
+ * geometry
+ * @param[in] seq Temporal sequence
+ * @param[in] edges Array of geometry edges
+ * @param[in] nedges Number of edges in the array
+ * @param[in] rtree R-tree for the edges, may be `NULL` if no index is used
+ * @param[in] cand_edges Edge array buffer of size `nedges` for storing the
+ * result of an R-tree look up, may be `NULL` if no index is used
+ */
+static void
+tpointseq_clip_edges(const TSequence *seq, Edge **edges, int nedges,
+  RTree *rtree, Edge **cand_edges)
 {
   assert(seq); assert(edges); assert(nedges > 0);
   assert(seq->temptype == T_TGEOMPOINT);
-  assert(MEOS_FLAGS_LINEAR_INTERP(seq->flags)); assert(seq->count > 1);
+  assert(MEOS_FLAGS_LINEAR_INTERP(seq->flags));
+
+  /* Singleton sequence */
+  if (seq->count == 1)
+    return tpointinst_clip_edges(TSEQUENCE_INST_N(seq, 0), edges, nedges,
+      rtree, cand_edges);
 
   bool use_index = (rtree != NULL);
   int32_t srid = tspatial_srid((Temporal *) seq);
-  MeosArray *events = meos_array_init(sizeof(double));
-  MeosArray *intervals = meos_array_init(sizeof(Span));
-  MeosArray *periods = meos_array_init(sizeof(Span));
 
   /* Initialize variables for the loop */
   const TInstant *inst1 = TSEQUENCE_INST_N(seq, 0);
-  POINT4D a;
-  datum_point4d(tinstant_value(inst1), &a);
-  int inside = is_polygonal ? point_in_polygon(a.x, a.y, edges, nedges) : 0;
+  const POINT2D *a = DATUM_POINT2D_P(tinstant_value_p(inst1));
   bool lower_inc = seq->period.lower_inc;
+  /* Edges to process: either all of them or those filtered by an R-tree */
+  Edge **sel_edges = NULL;
+  int sel_nedges = 0;
+  if (! use_index)
+  {
+    sel_edges = edges;
+    sel_nedges = nedges;
+  }
   /* Loop for each segment */
   for (int i = 1; i < seq->count; i++)
   {
     const TInstant *inst2 = TSEQUENCE_INST_N(seq, i);
-    POINT4D b;
-    datum_point4d(tinstant_value(inst2), &b);
+    const POINT2D *b = DATUM_POINT2D_P(tinstant_value_p(inst2));
     bool upper_inc = (i < seq->count - 1) ? false : seq->period.upper_inc;
     /* Reset the interval array */
     intervals->count = 0;
+    Span *intervarr = NULL;
 
-    /* Select the edges to process: either all of them or those filtered by
-     * an R-tree */
-    Edge **sel_edges;
-    int sel_nedges;
-    if (! use_index)
-    {
-      sel_edges = edges;
-      sel_nedges = nedges;
-    }
-    else
+    /* Filter the edges to process by a R-tree, if any */
+    if (use_index)
     {
       /* Build the segment bounding box */
       STBox query;
-      stbox_set(true, false, false, srid, FP_MIN(a.x, b.x), FP_MAX(a.x, b.x),
-        FP_MIN(a.y, b.y), FP_MAX(a.y, b.y), 0, 0, NULL, &query);
+      stbox_set(true, false, false, srid, FP_MIN(a->x, b->x),
+        FP_MAX(a->x, b->x), FP_MIN(a->y, b->y), FP_MAX(a->y, b->y),
+        0, 0, NULL, &query);
       /* Query the R-tree */
       int *results = rtree_search(rtree, RTREE_OVERLAPS, &query, &sel_nedges);
       if (sel_nedges == 0)
-      {
-        a = b;
-        continue;
-      }
+        goto next_segment;
+
       /* Transform the result of the R-tree look up into an edge pointer array */
       for (int j = 0; j < sel_nedges; j++)
         cand_edges[j] = (Edge *) &edges[results[j]];
@@ -718,20 +681,14 @@ tpointseq_clip_geom(const TSequence *seq, Edge **edges, int nedges,
       pfree(results);
     }
 
-    /* Compute the intervals */
-    if (is_polygonal)
-      polygon_intervals(a, b, sel_edges, sel_nedges, events, intervals,
-        &inside);
-    else
-      linear_intervals(a, b, sel_edges, sel_nedges, intervals);
+    /* Compute the intervals for the points, lines, and polygon edges */
+    intervals_from_points(a, b, sel_edges, sel_nedges);
+    intervals_from_lines(a, b, sel_edges, sel_nedges);
+    intervals_from_polygons(a, b, sel_edges, sel_nedges);
     if (intervals->count == 0)
-    {
-      a = b;
-      continue;
-    }
+      goto next_segment;
 
     /* Normalize the intervals */
-    Span *intervarr;
     int count;
     if (intervals->count > 1)
       intervarr = spanarr_normalize(intervals->elems, intervals->count,
@@ -779,46 +736,242 @@ tpointseq_clip_geom(const TSequence *seq, Edge **edges, int nedges,
       }
     }
     
+next_segment:
     /* Prepare the next iteration */
     if (intervals->count > 1)
       pfree(intervarr);
+    inst1 = inst2;
     a = b;
   }
 
-  TSequenceSet *result = NULL;
-  if (periods->count > 0)
+  return;
+}
+
+/*****************************************************************************
+ * Extract edges from a geometry that can be of type point, line, polygon or
+ * collection of these
+ *****************************************************************************/
+
+/**
+ * @brief Add to the dynamic array in the last argument the edges obtained
+ * from a ring
+ */
+static void
+emit_ring_edges(const POINTARRAY *pa, MeosArray *edges, EdgeType etype)
+{
+  for (int i = 0; i < (int) pa->npoints - 1; i++)
   {
-    SpanSet *ss = spanset_make_exp(periods->elems, periods->count,
-      periods->count, NORMALIZE, ORDER);
-    result = tcontseq_restrict_tstzspanset(seq, ss, REST_AT);
-    pfree(ss);
+    POINT4D a, b;
+    (void) getPoint4d_p(pa, i, &a);
+    (void) getPoint4d_p(pa, i + 1, &b);
+    Edge e;
+    e.x1 = a.x; e.y1 = a.y;
+    e.x2 = b.x; e.y2 = b.y;
+    e.xmin = FP_MIN(e.x1, e.x2); e.xmax = FP_MAX(e.x1, e.x2);
+    e.ymin = FP_MIN(e.y1, e.y2); e.ymax = FP_MAX(e.y1, e.y2);
+    e.etype = etype;
+    meos_array_add(edges, &e);
   }
-  /* Clean up and return */
-  meos_array_destroy(events, false);
-  meos_array_destroy(intervals, false);
-  meos_array_destroy(periods, false);
-  return result;
+  return;
 }
 
 /**
- * @brief Return a temporal point sequence with linear interpolation
- * restricted to a geometry
- * @details For performance reasons we avoid the call to ST_Intersection
- * which delegates the computation to GEOS. 
+ * @brief Add to the dynamic array in the last argument the edge obtained
+ * from a point
+ */
+static void
+extract_point(const LWPOINT *pt, MeosArray *edges)
+{
+  POINT4D p;
+  (void) getPoint4d_p(pt->point, 0, &p);
+  Edge e;
+  e.x1 = e.x2 = e.xmin = e.xmax = p.x;
+  e.y1 = e.y2 = e.ymin = e.ymax = p.y;
+  e.etype = EDGE_POINT;
+  meos_array_add(edges, &e);
+  return;
+}
+
+/**
+ * @brief Add to the dynamic array in the last argument the edges obtained
+ * from a multipoint
+ */
+static void
+extract_mpoint(const LWMPOINT *mp, MeosArray *edges)
+{
+  for (int i = 0; i < (int) mp->ngeoms; i++)
+    extract_point((const LWPOINT *) mp->geoms[i], edges);
+  return;
+}
+
+/**
+ * @brief Add to the dynamic array in the last argument the segments obtained
+ * from a line
+ */
+static void
+extract_line(const LWLINE *line, MeosArray *edges)
+{
+  emit_ring_edges(line->points, edges, EDGE_LINE);
+  return;
+}
+
+/**
+ * @brief Add to the dynamic array in the last argument the segments obtained
+ * from a multiline
+ */
+static void
+extract_mline(const LWMLINE *ml, MeosArray *edges)
+{
+  for (int i = 0; i < (int) ml->ngeoms; i++)
+    extract_line(ml->geoms[i], edges);
+  return;
+}
+
+/**
+ * @brief Add to the dynamic array in the last argument the edges obtained
+ * from a polygon
+ */
+static void
+extract_poly(const LWPOLY *poly, MeosArray *edges)
+{
+  for (int r = 0; r < (int) poly->nrings; r++)
+    emit_ring_edges(poly->rings[r], edges, EDGE_POLY);
+  return;
+}
+
+/**
+ * @brief Add to the dynamic array in the last argument the edges obtained
+ * from a multipolygon
+ */
+static void
+extract_mpoly(const LWMPOLY *mp, MeosArray *edges)
+{
+  for (int i = 0; i < (int) mp->ngeoms; i++)
+    extract_poly(mp->geoms[i], edges);
+  return;
+}
+
+/**
+ * @brief Add to the dynamic array in the last argument the edges obtained
+ * from a triangle
+ * @details In PostGIS a triangle has a single (outer) ring stored as
+ * POINTARRAY, which is already closed or implicitly closed
+ */
+static void
+extract_triangle(const LWTRIANGLE *tri, MeosArray *edges)
+{
+  emit_ring_edges(tri->points, edges, EDGE_POLY);
+  return;
+}
+
+/**
+ * @brief Return the edges of a geometry in a dynamic array (iterator)
+ */
+static void
+geom_extract_edges_iter(const LWGEOM *geom, MeosArray *edges)
+{
+  if (! geom)
+    return;
+
+  switch (geom->type)
+  {
+    case POINTTYPE:
+      extract_point((const LWPOINT *) geom, edges);
+      break;
+
+    case MULTIPOINTTYPE:
+      extract_mpoint((const LWMPOINT *) geom, edges);
+      break;
+
+    case LINETYPE:
+      extract_line((const LWLINE *) geom, edges);
+      break;
+
+    case MULTILINETYPE:
+      extract_mline((const LWMLINE *) geom, edges);
+      break;
+
+    case POLYGONTYPE:
+      extract_poly((const LWPOLY *) geom, edges);
+      break;
+
+    case MULTIPOLYGONTYPE:
+      extract_mpoly((const LWMPOLY *) geom, edges);
+      break;
+
+    case TRIANGLETYPE:
+      extract_triangle((const LWTRIANGLE *) geom, edges);
+      break;
+
+    case COLLECTIONTYPE:
+      const LWCOLLECTION *col = (const LWCOLLECTION *) geom;
+      for (int i = 0; i < (int) col->ngeoms; i++)
+        geom_extract_edges_iter(col->geoms[i], edges);
+      break;
+
+    /* Unsupported type */
+    default:
+      meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
+        "Unsupported geometry type");
+      break;
+  }
+  return;
+}
+
+/**
+ * @brief Return the edges of a geometry in a dynamic array 
+ */
+static MeosArray *
+geom_extract_edges(const LWGEOM *geom)
+{
+  MeosArray *edges = meos_array_init(sizeof(Edge));
+  geom_extract_edges_iter(geom, edges);
+  return edges;
+}
+
+/**
+ * @brief Build an R-tree from edges
+ */
+static RTree *
+build_edge_rtree(const Edge *edges, int nedges, int32_t srid)
+{
+  RTree *rtree = rtree_create_stbox();
+  for (int i = 0; i < nedges; i++)
+  {
+    const Edge *e = &edges[i];
+    STBox box;
+    stbox_set(true, false, false, srid, e->xmin, e->xmax, e->ymin, e->ymax,
+      0, 0, NULL, &box);
+    /* Store pointer to edge */
+    rtree_insert(rtree, &box, i);
+  }
+  return rtree;
+}
+
+/*****************************************************************************/
+
+/**
+ * @brief Return a temporal geometric point with linear interpolation 
+ * restricted to a 2D geometry
+ * @details The temporal point may be 2D or 3D and the Z dimension is also
+ * computed
+ * @note For performance reasons we avoid the call to ST_Intersection
+ * which delegates the computation to GEOS
  * @pre The arguments have the same SRID, the geometry is 2D and is not empty.
  * This is verified in #tgeo_restrict_geom
  */
-TSequenceSet *
-tpointseq_linear_at_geom(const TSequence *seq, const GSERIALIZED *gs)
+Temporal *
+tpoint_linear_at_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
-  assert(seq); assert(gs); assert(seq->temptype == T_TGEOMPOINT);
-  assert(MEOS_FLAGS_LINEAR_INTERP(seq->flags)); assert(seq->count > 1);
+  assert(temp); assert(gs); assert(temp->temptype == T_TGEOMPOINT);
+  assert(MEOS_FLAGS_LINEAR_INTERP(temp->flags));
+  assert(temp->subtype != TINSTANT);
+  assert(! MEOS_FLAGS_GET_GEODETIC(temp->flags));
   assert(! gserialized_is_empty(gs)); 
-  assert(! MEOS_FLAGS_GET_GEODETIC(seq->flags));
 
   /* Bounding box test */
   STBox box1, box2;
-  tspatialseq_set_stbox(seq, &box1);
+  tspatial_set_stbox(temp, &box1);
   /* Non-empty geometries have a bounding box */
   geo_set_stbox(gs, &box2);
   if (! overlaps_stbox_stbox(&box1, &box2))
@@ -826,16 +979,15 @@ tpointseq_linear_at_geom(const TSequence *seq, const GSERIALIZED *gs)
 
   /* Extract the edges */
   LWGEOM *geom = lwgeom_from_gserialized(gs);
-  bool is_polygonal = false;
-  MeosArray *edges = geom_extract_edges(geom, &is_polygonal);
+  MeosArray *edges = geom_extract_edges(geom);
   /* Create an array of edge pointers */
   Edge **edge_ptrs = palloc(sizeof(Edge *) * edges->count);
   /* Transform the edge array into an edge pointer array */
   for (int i = 0; i < (int) edges->count; i++)
     edge_ptrs[i] = (Edge *) meos_array_get_n(edges, i);
 
-  /* R-tree pointer: A NULL pointer passed to function #tpointseq_clip_geom means
-   * that no index is used */
+  /* R-tree pointer: A NULL pointer passed to function #tpointseq_clip_edges
+   * means that no index is used */
   RTree *rtree = NULL;
   /* Array of edge pointers for storing the edges filtered by the R-tree */
   Edge **cand_edges = NULL;
@@ -844,23 +996,89 @@ tpointseq_linear_at_geom(const TSequence *seq, const GSERIALIZED *gs)
   if (edges->count > RTREE_MIN_NUMBER_ELEMS)
   {
     /* Build R-tree */
-    int32_t srid = tspatial_srid((Temporal *) seq);
+    int32_t srid = tspatial_srid(temp);
     rtree = build_edge_rtree(edges->elems, edges->count, srid);
     /* Array of edge pointers for storing the edges filtered by the R-tree */
     cand_edges = palloc(sizeof(Edge *) * edges->count);
   }
 
-  /* Perform the clipping */
-  TSequenceSet *result = tpointseq_clip_geom(seq, edge_ptrs, edges->count,
-    rtree, cand_edges, is_polygonal);
+  /* Initialize the static global arrays accumulating the clipping results */
+  events = meos_array_init(sizeof(double));
+  intervals = meos_array_init(sizeof(Span));
+  periods = meos_array_init(sizeof(Span));
+  
+  /* Collect the clipping periods */
+  assert(temptype_subtype(temp->subtype));
+  switch (temp->subtype)
+  {
+    case TINSTANT:
+      tpointinst_clip_edges((TInstant *) temp, edge_ptrs, edges->count,
+        rtree, cand_edges);
+      break;
+    case TSEQUENCE:
+      tpointseq_clip_edges((TSequence *) temp, edge_ptrs, edges->count,
+        rtree, cand_edges);
+      break;
+    default: /* TSEQUENCESET */
+    {
+      /* Loop for each segment */
+      TSequenceSet *ss = (TSequenceSet *) temp;
+      for (int i = 0; i < ss->count; i++)
+        tpointseq_clip_edges(TSEQUENCESET_SEQ_N(ss, i), edge_ptrs,
+          edges->count, rtree, cand_edges);
+    }
+  }
 
+  Temporal *result = NULL;
+  if (periods->count > 0)
+  {
+    SpanSet *ss = spanset_make_exp(periods->elems, periods->count,
+      periods->count, NORMALIZE, ORDER);
+    result = temporal_restrict_tstzspanset(temp, ss, REST_AT);
+    pfree(ss);
+  }
+  
   /* Clean up and return */
+  meos_array_destroy(events, false);
+  meos_array_destroy(intervals, false);
+  meos_array_destroy(periods, false);
   if (edges->count > RTREE_MIN_NUMBER_ELEMS)
   {
     rtree_free(rtree); pfree(cand_edges);
   }
   lwgeom_free(geom); meos_array_destroy(edges, true);
   return result;  
+}
+
+/**
+ * @brief Return a temporal geometric point with linear interpolation 
+ * restricted to a 2D geometry
+ * @details The temporal point may be 2D or 3D and the Z dimension is also
+ * computed
+ * @pre The arguments have the same SRID, the geometry is 2D and is not empty.
+ * This is verified in #tgeo_restrict_geom
+ */
+Temporal *
+tpoint_linear_restrict_geom(const Temporal *temp, const GSERIALIZED *gs,
+  bool atfunc)
+{
+  assert(temp); assert(gs); assert(MEOS_FLAGS_LINEAR_INTERP(temp->flags));
+
+  /* Compute atGeometry for the temporal point */
+  Temporal *result_at = tpoint_linear_at_geom(temp, gs);
+
+  /* If "at" restriction, return */
+  if (atfunc)
+    return result_at;
+
+  /* If "minus" restriction, compute the complement wrt time */
+  if (! result_at)
+    return temporal_copy(temp);
+
+  SpanSet *ss = temporal_time(result_at);
+  Temporal *result = temporal_restrict_tstzspanset(temp, ss, atfunc);
+  pfree(ss); pfree(result_at);
+  return result;
 }
 
 /*****************************************************************************/

--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -1076,7 +1076,7 @@ tpoint_linear_restrict_geom(const Temporal *temp, const GSERIALIZED *gs,
     return temporal_copy(temp);
 
   SpanSet *ss = temporal_time(result_at);
-  Temporal *result = temporal_restrict_tstzspanset(temp, ss, atfunc);
+  Temporal *result = temporal_restrict_tstzspanset(temp, ss, REST_MINUS);
   pfree(ss); pfree(result_at);
   return result;
 }

--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -1,0 +1,866 @@
+/***********************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Universite libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Fast 2D/3D temporal point clipping against 2D geometries
+ * @details Support (multi)point, (multi)line, triangle, (multi)polygons with
+ * holes and islands inside holes (recursively), and collection of the above
+ * @note Avoid processing in GEOS to improve performance
+ */
+
+/* C */
+#include <math.h>
+/* PostgreSQL */
+#include "postgres.h"
+#include <utils/float.h>
+/* PostGIS */
+#include "liblwgeom.h"
+#include "liblwgeom_internal.h"
+/* MEOS */
+#include "meos.h"
+#include "meos_internal_geo.h"
+#include "temporal/span.h"
+#include "temporal/temporal.h"
+#include "temporal/temporal_restrict.h"
+#include "geo/tgeo.h"
+#include "geo/tgeo_spatialfuncs.h"
+
+/* Minimum number of edges to use an R-tree index in order to compensate the
+ * overhead of the tree construction and destruction */
+#define RTREE_MIN_NUMBER_ELEMS 100
+
+/*****************************************************************************
+ * Data structures
+ *****************************************************************************/
+
+/**
+ * @brief Structure keeping a geometry edge
+ */
+typedef struct
+{
+  double x1, y1, x2, y2; /**< Coordinates of the start and end 2D points */
+  double xmin, ymin, xmax, ymax; /**< Bounding box of the edge */
+} Edge;
+
+/**
+ * @brief Enumeration defining the intersection types 
+ */
+typedef enum
+{
+  INTERSECT_NONE = 0,
+  INTERSECT_POINT,
+  INTERSECT_OVERLAP
+} IntersectType;
+
+/**
+ * @brief Structure keeping an intersection result
+ */
+typedef struct
+{
+  IntersectType type;  /**< Intersection type */
+  double t0;           /**< Always valid if type != NONE */
+  double t1;           /**< Only valid for OVERLAP */
+} IntersectResult;
+
+/*****************************************************************************
+ * Line segment intersection
+ *****************************************************************************/
+
+/**
+ * @brief Return the intersection value obtained by computing the intersection 
+ * of a line segment defined by two 2D points intersects an edge
+ * @details Possible result values
+ * - No intersection: INTERSECT_NONE -> t0 and t1 undefined
+ * - Single point: INTERSECT_POINT -> t1 in [0,1], t1 ignored
+ * - Overlap segment: INTERSECT_OVERLAP -> t0 <= t1 in [0,1]
+ * Invariants:
+ * - 0 <= t0 <= 1
+ * - 0 <= t1 <= 1
+ * - t0 <= t1
+ * - Overlap must satisfy: t1 - t0 > FP_TOLERANCE
+ * @param[in] ax,ay Coordinates of the first point defining the first segment
+ * @param[in] rx,ry Vector AB
+ * @param[in] cx,cy,dx,dy Coordinates of the points defining the second segment
+ * @note To avoid recomputing vector AB in EVERY call to linesegm_intersect,
+ * we pass the vector instead of the second point b computed as follows
+ * @code
+ * double rx = bx - ax, ry = by - ay;
+ * @endcode
+ */
+static inline IntersectResult
+linesegm_intersect(double ax, double ay, double rx, double ry,
+  double cx, double cy, double dx, double dy)
+{
+  IntersectResult res = {INTERSECT_NONE, 0, 0};
+  double sx = dx - cx, sy = dy - cy; /* vector CD */
+  /* Where is the start of the second segment relative to the first? */
+  double qpx = cx - ax, qpy = cy - ay;
+
+  /* Are the two segments parallel?  */
+  double rxs = rx * sy - ry * sx;
+  /* Is point C aligned with segment AB? */
+  double qpxr = qpx * ry - qpy * rx;
+
+  /* Collinear / parallel */
+  if (fabs(rxs) < FP_TOLERANCE)
+  {
+    /* If qpxr != 0: parallel, if qpxr == 0: collinear */
+    if (fabs(qpxr) > FP_TOLERANCE)
+      return res;
+
+    /* Collinear case */
+    double r2 = rx * rx + ry * ry;
+    if (r2 < FP_TOLERANCE)
+      return res;
+
+    double t0 = (qpx * rx + qpy * ry) / r2;
+    double t1 = t0 + (sx * rx + sy * ry) / r2;
+
+    /* Order t0 < t1 */
+    if (t0 > t1) { double tmp = t0; t0 = t1; t1 = tmp; }
+    if (t1 < 0 || t0 > 1)
+      return res;
+    /* Clamp values */
+    if (t0 < 0) t0 = 0;
+    if (t1 > 1) t1 = 1;
+
+    if (fabs(t1 - t0) < FP_TOLERANCE)
+    {
+      res.type = INTERSECT_POINT;
+      res.t0 = t0;
+      return res;
+    }
+
+    res.type = INTERSECT_OVERLAP;
+    res.t0 = t0;
+    res.t1 = t1;
+    return res;
+  }
+
+  /* Proper intersection */
+  double t = (qpx * sy - qpy * sx) / rxs;
+  double u = (qpx * ry - qpy * rx) / rxs;
+
+  if (t < -FP_TOLERANCE || t > 1 + FP_TOLERANCE ||
+      u < -FP_TOLERANCE || u > 1 + FP_TOLERANCE)
+    return res;
+
+  /* Clamp values */
+  if (fabs(t) < FP_TOLERANCE) t = 0;
+  if (fabs(t - 1) < FP_TOLERANCE) t = 1;
+
+  res.type = INTERSECT_POINT;
+  res.t0 = t;
+  return res;
+}
+
+/*****************************************************************************
+ * Compute the intervals in [0,1] resulting from the intersection of a
+ * trajectory segment and an array of edges obtained from a (collection of)
+ * polygon/line/point geometries
+ * N.B. A point is a particular case of a line
+ *****************************************************************************/
+
+/**
+ * @brief Return true if a point is located on a segment
+ * @details The computation is done using vectors
+ */
+static bool
+point_on_segment(double px, double py, double x1, double y1, double x2,
+  double y2)
+{
+  /* Vector AP and AB */
+  double apx = px - x1;
+  double apy = py - y1;
+  double abx = x2 - x1;
+  double aby = y2 - y1;
+  /* Collinearity check via cross product */
+  double cross = apx * aby - apy * abx;
+  if (fabs(cross) > FP_TOLERANCE)
+    return false;
+  /* Projection check via dot product */
+  double dot = apx * abx + apy * aby;
+  if (dot < -FP_TOLERANCE)
+    return false;
+  /* Check P lies between A and B */
+  double ab2 = abx * abx + aby * aby;
+  if (dot > ab2 + FP_TOLERANCE)
+    return false;
+  return true;
+}
+
+/**
+ * @brief Return true if a point is located in a polygon 
+ * @details The computation is done using vectors and an even-odd rule
+ */
+static int
+point_in_polygon(double x, double y, Edge **edges, int n)
+{
+  /* Boundary check */
+  for (int i = 0; i < n; i++)
+  {
+    double x1 = edges[i]->x1, y1 = edges[i]->y1;
+    double x2 = edges[i]->x2, y2 = edges[i]->y2;
+
+    double dx = x2 - x1;
+    double dy = y2 - y1;
+    double dxp = x - x1;
+    double dyp = y - y1;
+
+    double crossp = dx * dyp - dy * dxp;
+    if (fabs(crossp) < FP_TOLERANCE)
+    {
+      double dotp = dxp * dx + dyp * dy;
+      if (dotp >= -FP_TOLERANCE &&
+          dotp <= (dx * dx + dy * dy) + FP_TOLERANCE)
+        return 1;  /* On boundary */
+    }
+  }
+
+  /* Perform even‑odd crossing */
+  int crossings = 0;
+  for (int i = 0; i < n; i++)
+  {
+    double x1 = edges[i]->x1, y1 = edges[i]->y1;
+    double x2 = edges[i]->x2, y2 = edges[i]->y2;
+    if ((y1 <= y && y < y2) || (y2 <= y && y < y1))
+    {
+      double xinters = x1 + (y - y1) * (x2 - x1) / (y2 - y1);
+      if (xinters > x)
+        crossings ^= 1;
+    }
+  }
+  return crossings;
+}
+
+/**
+ * @brief Compute the intersection intervals of a trajectory segment with an
+ * array of linear or point edges
+ */
+static void
+linear_intervals(POINT4D a, POINT4D b, Edge **edges, int nedges,
+  MeosArray *intervals)
+{
+  /* Compute the bounding box of the segment */
+  double seg_xmin = FP_MIN(a.x, b.x);
+  double seg_xmax = FP_MAX(a.x, b.x);
+  double seg_ymin = FP_MIN(a.y, b.y);
+  double seg_ymax = FP_MAX(a.y, b.y);
+  
+  bool has_intersection = false;
+  Span in;
+  /* To avoid recomputing the vector AB in the call to linesegm_intersect
+   * inside the loop, we pass the vector instead of the second point b */
+  double rx = b.x - a.x, ry = b.y - a.y;
+  for (int i = 0; i < nedges; i++)
+  {
+    Edge *e = edges[i];
+
+    /* Bounding box filter */
+    if (e->xmax < seg_xmin || e->xmin > seg_xmax ||
+        e->ymax < seg_ymin || e->ymin > seg_ymax)
+      continue;
+    /* Compute the intersection */
+    IntersectResult r = linesegm_intersect(a.x, a.y, rx, ry,
+      e->x1, e->y1, e->x2, e->y2);
+    /* If there is no intersection  */
+    if (r.type == INTERSECT_NONE)
+      continue;
+
+    /* Intersection found: compute the interval */
+    has_intersection = true;
+    if (r.type == INTERSECT_POINT)
+      span_set(Float8GetDatum(r.t0), Float8GetDatum(r.t0), true, true,
+        T_FLOAT8, T_FLOATSPAN, &in);
+    else
+      span_set(Float8GetDatum(r.t0), Float8GetDatum(r.t1), true, true,
+        T_FLOAT8, T_FLOATSPAN, &in);
+    meos_array_add(intervals, &in);
+  }
+
+  /* Full collinear segment */
+  if (! has_intersection)
+  {
+    /* test midpoint */
+    double mx = (a.x + b.x) * 0.5;
+    double my = (a.y + b.y) * 0.5;
+    for (int i = 0; i < nedges; i++)
+    {
+      Edge *e = edges[i];
+      if (point_on_segment(mx, my, e->x1, e->y1, e->x2, e->y2))
+      {
+        span_set(Float8GetDatum(0.0), Float8GetDatum(1.0), true, true,
+          T_FLOAT8, T_FLOATSPAN, &in);
+        meos_array_add(intervals, &in);
+        return;
+      }
+    }
+  }
+  return;
+}
+
+/**
+ * @brief Comparison function for sorting float8 values
+ * @note Derived from PostgreSQL file rangetypes_typanalyze.c
+ */
+static int
+float8_qsort_cmp(const void *a1, const void *a2)
+{
+  const float8 *f1 = (const float8 *) a1;
+  const float8 *f2 = (const float8 *) a2;
+  if (*f1 < *f2)
+    return -1;
+  if (*f1 == *f2)
+    return 0;
+  return 1;
+}
+
+/**
+ * @brief Compute the intersection intervals of a trajectory segment with an
+ * array of polygon edges using an even-odd rule
+ * @note Function performing robust duplicate handling
+ */
+static void
+polygon_intervals(POINT4D a, POINT4D b, Edge **edges, int nedges,
+  MeosArray *events, MeosArray *intervals, int *inside)
+{
+  assert(edges); assert(nedges >= 0); assert(events); assert(intervals);
+  assert(inside); 
+  
+  /* Reset event array */
+  events->count = 0;
+  Span in;
+
+  /* Compute the bounding box of the segment */
+  double seg_xmin = FP_MIN(a.x, b.x);
+  double seg_xmax = FP_MAX(a.x, b.x);
+  double seg_ymin = FP_MIN(a.y, b.y);
+  double seg_ymax = FP_MAX(a.y, b.y);
+
+  /* To avoid recomputing the vector AB in the call to linesegm_intersect
+   * inside the loop, we pass the vector instead of the second point b */
+  double rx = b.x - a.x, ry = b.y - a.y;
+
+  /* Collect intersection events */
+  for (int i = 0; i < nedges; i++)
+  {
+    Edge *e = edges[i];
+    /* Bounding box filter  */
+    if (e->xmax < seg_xmin || e->xmin > seg_xmax ||
+        e->ymax < seg_ymin || e->ymin > seg_ymax)
+      continue;
+      
+    IntersectResult r = linesegm_intersect(a.x, a.y, rx, ry,
+      e->x1, e->y1, e->x2, e->y2);
+
+    if (r.type == INTERSECT_POINT)
+      meos_array_add(events, &r.t0);
+    else if (r.type == INTERSECT_OVERLAP)
+    {
+      meos_array_add(events, &r.t0);
+      meos_array_add(events, &r.t1);
+    }
+  }
+
+  /* No intersections */
+  if (events->count == 0)
+  {
+    if (*inside)
+    {
+      span_set(Float8GetDatum(0.0), Float8GetDatum(1.0), true, true,
+        T_FLOAT8, T_FLOATSPAN, &in);
+      meos_array_add(intervals, &in);
+    }
+    return;
+  }
+
+  /* Sort events */
+  qsort(events->elems, events->count, sizeof(double), float8_qsort_cmp);
+  double *evtarr = (double *) events->elems;
+
+  /* Robust duplicate clustering */
+  int inside_flag = *inside;
+  double start = 0.0;
+    double last_kept = evtarr[0]; // - 2 * FP_TOLERANCE; /* force first keep */
+  for (int i = 0; i < (int) events->count; i++)
+  {
+    double t = evtarr[i];
+    if (fabs(t - last_kept) < FP_TOLERANCE)
+      continue;
+
+    last_kept = t;
+    if (!inside_flag)
+    {
+      start = t;
+      inside_flag = 1;
+    }
+    else
+    {
+      span_set(Float8GetDatum(start), Float8GetDatum(t), true, true,
+        T_FLOAT8, T_FLOATSPAN, &in);
+      meos_array_add(intervals, &in);
+      inside_flag = 0;
+    }
+  }
+
+  /* If inside generate an interval */
+  if (inside_flag)
+  {
+    span_set(Float8GetDatum(start), Float8GetDatum(1.0), true, true,
+      T_FLOAT8, T_FLOATSPAN, &in);
+    meos_array_add(intervals, &in);
+  }
+  /* Set ouput parameter and return */
+  *inside = inside_flag;
+  return;
+}
+
+/*****************************************************************************
+ * Extract edges from a geometry that can be of type point, line, polygon or
+ * collection of these
+ *****************************************************************************/
+
+/**
+ * @brief Add to the dynamic array in the last argument the edges obtained
+ * from a ring
+ */
+static void
+emit_ring_edges(const POINTARRAY *pa, MeosArray *edges)
+{
+  for (int i = 0; i < (int) pa->npoints - 1; i++)
+  {
+    POINT4D a, b;
+    (void) getPoint4d_p(pa, i, &a);
+    (void) getPoint4d_p(pa, i + 1, &b);
+    Edge e;
+    e.x1 = a.x; e.y1 = a.y;
+    e.x2 = b.x; e.y2 = b.y;
+    e.xmin = FP_MIN(e.x1, e.x2); e.xmax = FP_MAX(e.x1, e.x2);
+    e.ymin = FP_MIN(e.y1, e.y2); e.ymax = FP_MAX(e.y1, e.y2);
+    meos_array_add(edges, &e);
+  }
+  return;
+}
+
+/**
+ * @brief Add to the dynamic array in the last argument the edge obtained
+ * from a point
+ */
+static void
+extract_point(const LWPOINT *pt, MeosArray *edges)
+{
+  POINT4D p;
+  (void) getPoint4d_p(pt->point, 0, &p);
+  Edge e;
+  e.x1 = e.x2 = e.xmin = e.xmax = p.x;
+  e.y1 = e.y2 = e.ymin = e.ymax = p.y;
+  meos_array_add(edges, &e);
+  return;
+}
+
+/**
+ * @brief Add to the dynamic array in the last argument the edges obtained
+ * from a multipoint
+ */
+static void
+extract_mpoint(const LWMPOINT *mp, MeosArray *edges)
+{
+  for (int i = 0; i < (int) mp->ngeoms; i++)
+    extract_point((const LWPOINT *) mp->geoms[i], edges);
+  return;
+}
+
+/**
+ * @brief Add to the dynamic array in the last argument the segments obtained
+ * from a line
+ */
+static void
+extract_line(const LWLINE *line, MeosArray *edges)
+{
+  emit_ring_edges(line->points, edges);
+  return;
+}
+
+/**
+ * @brief Add to the dynamic array in the last argument the segments obtained
+ * from a multiline
+ */
+static void
+extract_mline(const LWMLINE *ml, MeosArray *edges)
+{
+  for (int i = 0; i < (int) ml->ngeoms; i++)
+    extract_line(ml->geoms[i], edges);
+  return;
+}
+
+/**
+ * @brief Add to the dynamic array in the last argument the edges obtained
+ * from a polygon
+ */
+static void
+extract_poly(const LWPOLY *poly, MeosArray *edges)
+{
+  for (int r = 0; r < (int) poly->nrings; r++)
+    emit_ring_edges(poly->rings[r], edges);
+  return;
+}
+
+/**
+ * @brief Add to the dynamic array in the last argument the edges obtained
+ * from a multipolygon
+ */
+static void
+extract_mpoly(const LWMPOLY *mp, MeosArray *edges)
+{
+  for (int i = 0; i < (int) mp->ngeoms; i++)
+    extract_poly(mp->geoms[i], edges);
+  return;
+}
+
+/**
+ * @brief Add to the dynamic array in the last argument the edges obtained
+ * from a triangle
+ * @details In PostGIS a triangle has a single (outer) ring stored as
+ * POINTARRAY, which is already closed or implicitly closed
+ */
+static void
+extract_triangle(const LWTRIANGLE *tri, MeosArray *edges)
+{
+  emit_ring_edges(tri->points, edges);
+  return;
+}
+
+/**
+ * @brief Return the edges of a geometry in a dynamic array (iterator)
+ */
+static void
+geom_extract_edges_iter(const LWGEOM *geom, MeosArray *edges,
+  bool *is_polygonal)
+{
+  if (! geom)
+    return;
+
+  switch (geom->type)
+  {
+    case POINTTYPE:
+      extract_point((const LWPOINT *) geom, edges);
+      break;
+
+    case MULTIPOINTTYPE:
+      extract_mpoint((const LWMPOINT *) geom, edges);
+      break;
+
+    case LINETYPE:
+      extract_line((const LWLINE *) geom, edges);
+      break;
+
+    case MULTILINETYPE:
+      extract_mline((const LWMLINE *) geom, edges);
+      break;
+
+    case POLYGONTYPE:
+      *is_polygonal = true;
+      extract_poly((const LWPOLY *) geom, edges);
+      break;
+
+    case MULTIPOLYGONTYPE:
+      *is_polygonal = true;
+      extract_mpoly((const LWMPOLY *) geom, edges);
+      break;
+
+    case TRIANGLETYPE:
+      *is_polygonal = true;
+      extract_triangle((const LWTRIANGLE *) geom, edges);
+      break;
+
+    case COLLECTIONTYPE:
+      const LWCOLLECTION *col = (const LWCOLLECTION *) geom;
+      for (int i = 0; i < (int) col->ngeoms; i++)
+        geom_extract_edges_iter(col->geoms[i], edges, is_polygonal);
+      break;
+
+    /* Unsupported type */
+    default:
+      meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
+        "Unsupported geometry type");
+      break;
+  }
+  return;
+}
+
+/**
+ * @brief Return the edges of a geometry in a dynamic array 
+ */
+static MeosArray *
+geom_extract_edges(const LWGEOM *geom, bool *is_polygonal)
+{
+  MeosArray *edges = meos_array_init(sizeof(Edge));
+  geom_extract_edges_iter(geom, edges, is_polygonal);
+  return edges;
+}
+
+/**
+ * @brief Build an R-tree from edges
+ */
+static RTree *
+build_edge_rtree(const Edge *edges, int nedges, int32_t srid)
+{
+  RTree *rtree = rtree_create_stbox();
+  for (int i = 0; i < nedges; i++)
+  {
+    const Edge *e = &edges[i];
+    STBox box;
+    stbox_set(true, false, false, srid, e->xmin, e->xmax, e->ymin, e->ymax,
+      0, 0, NULL, &box);
+    /* Store pointer to edge */
+    rtree_insert(rtree, &box, i);
+  }
+  return rtree;
+}
+
+/*****************************************************************************
+ * Clip a temporal geometry point sequence
+ *****************************************************************************/
+
+/**
+ * @brief Clip a 2D/3D trajectory with linear interpolation with respect to a
+ * geometry
+ * @param[in] seq Temporal sequence
+ * @param[in] edges Array of geometry edges
+ * @param[in] nedges Number of edges in the array
+ * @param[in] rtree R-tree for the edges, may be `NULL` if no index is used
+ * @param[in] cand_edges Edge array buffer of size `nedges` for storing the
+ * result of an R-tree look up, may be `NULL` if no index is used
+ */
+static TSequenceSet *
+tpointseq_clip_geom(const TSequence *seq, Edge **edges, int nedges,
+  RTree *rtree, Edge **cand_edges, bool is_polygonal)
+{
+  assert(seq); assert(edges); assert(nedges > 0);
+  assert(seq->temptype == T_TGEOMPOINT);
+  assert(MEOS_FLAGS_LINEAR_INTERP(seq->flags)); assert(seq->count > 1);
+
+  bool use_index = (rtree != NULL);
+  int32_t srid = tspatial_srid((Temporal *) seq);
+  MeosArray *events = meos_array_init(sizeof(double));
+  MeosArray *intervals = meos_array_init(sizeof(Span));
+  MeosArray *periods = meos_array_init(sizeof(Span));
+
+  /* Initialize variables for the loop */
+  const TInstant *inst1 = TSEQUENCE_INST_N(seq, 0);
+  POINT4D a;
+  datum_point4d(tinstant_value(inst1), &a);
+  int inside = is_polygonal ? point_in_polygon(a.x, a.y, edges, nedges) : 0;
+  bool lower_inc = seq->period.lower_inc;
+  /* Loop for each segment */
+  for (int i = 1; i < seq->count; i++)
+  {
+    const TInstant *inst2 = TSEQUENCE_INST_N(seq, i);
+    POINT4D b;
+    datum_point4d(tinstant_value(inst2), &b);
+    bool upper_inc = (i < seq->count - 1) ? false : seq->period.upper_inc;
+    /* Reset the interval array */
+    intervals->count = 0;
+
+    /* Select the edges to process: either all of them or those filtered by
+     * an R-tree */
+    Edge **sel_edges;
+    int sel_nedges;
+    if (! use_index)
+    {
+      sel_edges = edges;
+      sel_nedges = nedges;
+    }
+    else
+    {
+      /* Build the segment bounding box */
+      STBox query;
+      stbox_set(true, false, false, srid, FP_MIN(a.x, b.x), FP_MAX(a.x, b.x),
+        FP_MIN(a.y, b.y), FP_MAX(a.y, b.y), 0, 0, NULL, &query);
+      /* Query the R-tree */
+      int *results = rtree_search(rtree, RTREE_OVERLAPS, &query, &sel_nedges);
+      if (sel_nedges == 0)
+      {
+        a = b;
+        continue;
+      }
+      /* Transform the result of the R-tree look up into an edge pointer array */
+      for (int j = 0; j < sel_nedges; j++)
+        cand_edges[j] = (Edge *) &edges[results[j]];
+      sel_edges = cand_edges;
+      pfree(results);
+    }
+
+    /* Compute the intervals */
+    if (is_polygonal)
+      polygon_intervals(a, b, sel_edges, sel_nedges, events, intervals,
+        &inside);
+    else
+      linear_intervals(a, b, sel_edges, sel_nedges, intervals);
+    if (intervals->count == 0)
+    {
+      a = b;
+      continue;
+    }
+
+    /* Normalize the intervals */
+    Span *intervarr;
+    int count;
+    if (intervals->count > 1)
+      intervarr = spanarr_normalize(intervals->elems, intervals->count,
+        ORDER_NO, &count);
+    else
+    {
+      intervarr = intervals->elems;
+      count = 1;
+    }
+
+    /* Generate the periods from the float spans taking into account exclusive
+     * temporal bounds */
+    double duration = (double) (inst2->t - inst1->t);
+    for (int j = 0; j < count; j++)
+    {
+      Span s;
+      double lower = DatumGetFloat8(intervarr[j].lower);
+      double upper = DatumGetFloat8(intervarr[j].upper);
+      if (fabs(upper - lower) < FP_TOLERANCE)
+      {
+        /* Remove intersection points on exclusive lower and upper bounds */
+        if (! lower_inc && fabs(lower) < FP_TOLERANCE &&
+            fabs(upper) < FP_TOLERANCE)
+          continue;
+        if (! upper_inc && fabs(lower - 1.0) < FP_TOLERANCE &&
+            fabs(upper - 1.0) < FP_TOLERANCE)
+          continue;
+
+        /* Interpolate only if 0 < lower/upper < 1 */
+        TimestampTz t = (lower == 0.0) ?
+          inst1->t : inst1->t + (TimestampTz) (duration * lower);
+        span_set(TimestampTzGetDatum(t), TimestampTzGetDatum(t), true, true,
+          T_TIMESTAMPTZ, T_TSTZSPAN, &s);
+        meos_array_add(periods, &s);
+      }
+      else
+      {
+        TimestampTz t1 = (lower == 0.0) ?
+          inst1->t : inst1->t + (TimestampTz) (duration * lower);
+        TimestampTz t2 = (upper == 0.0) ?
+          inst2->t : inst1->t + (TimestampTz) (duration * upper);
+        span_set(TimestampTzGetDatum(t1), TimestampTzGetDatum(t2), true, true,
+          T_TIMESTAMPTZ, T_TSTZSPAN, &s);
+        meos_array_add(periods, &s);
+      }
+    }
+    
+    /* Prepare the next iteration */
+    if (intervals->count > 1)
+      pfree(intervarr);
+    a = b;
+  }
+
+  TSequenceSet *result = NULL;
+  if (periods->count > 0)
+  {
+    SpanSet *ss = spanset_make_exp(periods->elems, periods->count,
+      periods->count, NORMALIZE, ORDER);
+    result = tcontseq_restrict_tstzspanset(seq, ss, REST_AT);
+    pfree(ss);
+  }
+  /* Clean up and return */
+  meos_array_destroy(events, false);
+  meos_array_destroy(intervals, false);
+  meos_array_destroy(periods, false);
+  return result;
+}
+
+/**
+ * @brief Return a temporal point sequence with linear interpolation
+ * restricted to a geometry
+ * @details For performance reasons we avoid the call to ST_Intersection
+ * which delegates the computation to GEOS. 
+ * @pre The arguments have the same SRID, the geometry is 2D and is not empty.
+ * This is verified in #tgeo_restrict_geom
+ */
+TSequenceSet *
+tpointseq_linear_at_geom(const TSequence *seq, const GSERIALIZED *gs)
+{
+  assert(seq); assert(gs); assert(seq->temptype == T_TGEOMPOINT);
+  assert(MEOS_FLAGS_LINEAR_INTERP(seq->flags)); assert(seq->count > 1);
+  assert(! gserialized_is_empty(gs)); 
+  assert(! MEOS_FLAGS_GET_GEODETIC(seq->flags));
+
+  /* Bounding box test */
+  STBox box1, box2;
+  tspatialseq_set_stbox(seq, &box1);
+  /* Non-empty geometries have a bounding box */
+  geo_set_stbox(gs, &box2);
+  if (! overlaps_stbox_stbox(&box1, &box2))
+    return NULL;
+
+  /* Extract the edges */
+  LWGEOM *geom = lwgeom_from_gserialized(gs);
+  bool is_polygonal = false;
+  MeosArray *edges = geom_extract_edges(geom, &is_polygonal);
+  /* Create an array of edge pointers */
+  Edge **edge_ptrs = palloc(sizeof(Edge *) * edges->count);
+  /* Transform the edge array into an edge pointer array */
+  for (int i = 0; i < (int) edges->count; i++)
+    edge_ptrs[i] = (Edge *) meos_array_get_n(edges, i);
+
+  /* R-tree pointer: A NULL pointer passed to function #tpointseq_clip_geom means
+   * that no index is used */
+  RTree *rtree = NULL;
+  /* Array of edge pointers for storing the edges filtered by the R-tree */
+  Edge **cand_edges = NULL;
+  /* Minimum number of edges to use an R-tree index in order to compensate the
+   * overhead of the tree construction and destruction */
+  if (edges->count > RTREE_MIN_NUMBER_ELEMS)
+  {
+    /* Build R-tree */
+    int32_t srid = tspatial_srid((Temporal *) seq);
+    rtree = build_edge_rtree(edges->elems, edges->count, srid);
+    /* Array of edge pointers for storing the edges filtered by the R-tree */
+    cand_edges = palloc(sizeof(Edge *) * edges->count);
+  }
+
+  /* Perform the clipping */
+  TSequenceSet *result = tpointseq_clip_geom(seq, edge_ptrs, edges->count,
+    rtree, cand_edges, is_polygonal);
+
+  /* Clean up and return */
+  if (edges->count > RTREE_MIN_NUMBER_ELEMS)
+  {
+    rtree_free(rtree); pfree(cand_edges);
+  }
+  lwgeom_free(geom); meos_array_destroy(edges, true);
+  return result;  
+}
+
+/*****************************************************************************/

--- a/meos/src/geo/tpoint_spatialfuncs.c
+++ b/meos/src/geo/tpoint_spatialfuncs.c
@@ -3707,6 +3707,9 @@ tpointseq_discstep_find_splits(const TSequence *seq, int *count)
   return bitarr;
 }
 
+/**
+ * @brief Merge a POINT2D and a GBOX
+ */
 static void gbox_merge_point2d(const POINT2D *p, GBOX *gbox)
 {
   if ( gbox->xmin > p->x ) gbox->xmin = p->x;
@@ -3715,6 +3718,9 @@ static void gbox_merge_point2d(const POINT2D *p, GBOX *gbox)
   if ( gbox->ymax < p->y ) gbox->ymax = p->y;
 }
 
+/**
+ * @brief Initialize a GBOX with a POINT2D
+ */
 static void gbox_init_point2d(const POINT2D *p, GBOX *gbox)
 {
   gbox->xmin = gbox->xmax = p->x;

--- a/meos/src/geo/tspatial.c
+++ b/meos/src/geo/tspatial.c
@@ -122,7 +122,7 @@ spatialbase_as_ewkt(Datum value, meosType type, int maxdd)
   /* Get the SRID */
   char srid_str[18];
   srid_str[0] = '\0';
-  int32 srid = spatial_srid(value, type);
+  int32_t srid = spatial_srid(value, type);
   if (srid <= 0)
     return base_str;
 
@@ -160,7 +160,7 @@ spatialset_out_fn(const Set *s, int maxdd, outfunc wkt_out, bool extended)
   /* Get the SRID if extended */
   char srid_str[18];
   srid_str[0] = '\0';
-  int32 srid = spatialset_srid(s);
+  int32_t srid = spatialset_srid(s);
   if (srid <= 0)
     return set_str;
 

--- a/meos/src/geo/tspatial_parser.c
+++ b/meos/src/geo/tspatial_parser.c
@@ -368,7 +368,6 @@ spatial_parse_elem(const char **str, meosType temptype, char delim,
  * @param[in] end Set to true when reading a single instant to ensure there is
  * no more input after the sequence
  * @param[in,out] temp_srid SRID of the spatiotemporal value
- * @param[out] result New instant, may be NULL
  */
 TInstant *
 tspatialinst_parse(const char **str, meosType temptype, bool end,
@@ -449,7 +448,6 @@ error:
  * @param[in] end Set to true when reading a single instant to ensure there is
  * no moreinput after the sequence
  * @param[in,out] temp_srid SRID of the spatiotemporal value
- * @param[out] result New sequence, may be NULL
  */
 TSequence *
 tspatialseq_cont_parse(const char **str, meosType temptype, interpType interp, 

--- a/meos/src/geo/tspatial_tempspatialrels.c
+++ b/meos/src/geo/tspatial_tempspatialrels.c
@@ -57,6 +57,7 @@
 #include <meos_internal.h>
 #include <meos_internal_geo.h>
 #include "temporal/lifting.h"
+#include "temporal/span.h"
 #include "temporal/tbool_ops.h"
 #include "temporal/temporal_compops.h"
 #include "temporal/tinstant.h"
@@ -102,6 +103,222 @@ geometry 'linestring(0 1,4 1)',
 geometry 'polygon((0 0,1 1,2 0.5,3 1,4 1,4 0,0 0))'))
 -- "GEOMETRYCOLLECTION(POINT(1 1),LINESTRING(3 1,4 1))"
 */
+
+/*****************************************************************************/
+
+/**
+ * @brief Return the timestamp at which a segment of a temporal point takes a
+ * base value (iterator function)
+ * @details To take into account roundoff errors, the function considers that
+ * two values are equal even if their coordinates may differ by `MEOS_EPSILON`.
+ * @param[in] inst1,inst2 Temporal values
+ * @param[in] value Base value
+ * @param[out] t Timestamp
+ * @return Return true if the point is found in the temporal point segment
+ * @pre The segment is not constant and has linear interpolation
+ * @note The resulting timestamptz may be at an exclusive bound
+ */
+static bool
+tpointsegm_timestamp_at_value1_iter(const TInstant *inst1,
+  const TInstant *inst2, Datum value, TimestampTz *t)
+{
+  Datum value1 = tinstant_value_p(inst1);
+  Datum value2 = tinstant_value_p(inst2);
+  /* Is the lower bound the answer? */
+  bool result = true;
+  if (datum_point_eq(value1, value))
+    *t = inst1->t;
+  /* Is the upper bound the answer? */
+  else if (datum_point_eq(value2, value))
+    *t = inst2->t;
+  else
+  {
+    double dist;
+    double fraction = (double) pointsegm_locate(value1, value2, value, &dist);
+    if (fraction < 0 || fabs(dist) >= MEOS_EPSILON)
+      result = false;
+    else
+    {
+      double duration = (double) (inst2->t - inst1->t);
+      *t = inst1->t + (TimestampTz) (duration * fraction);
+    }
+  }
+  return result;
+}
+
+/**
+ * @brief Return the timestamp at which a temporal point sequence is equal to a
+ * point
+ * @details This function is called by the #tpointseq_interperiods function
+ * while computing atGeometry to find the timestamp at which an intersection
+ * point found by PostGIS is located.
+ * @param[in] seq Temporal point sequence
+ * @param[in] value Base value
+ * @param[out] t Timestamp
+ * @return Return true if the point is found in the temporal point
+ * @pre The point is known to belong to the temporal sequence (taking into
+ * account roundoff errors), the temporal sequence has linear interpolation,
+ * and is simple
+ * @note The resulting timestamp may be at an exclusive bound
+ */
+static bool
+tpointseq_timestamp_at_value(const TSequence *seq, Datum value,
+  TimestampTz *t)
+{
+  const TInstant *inst1 = TSEQUENCE_INST_N(seq, 0);
+  for (int i = 1; i < seq->count; i++)
+  {
+    const TInstant *inst2 = TSEQUENCE_INST_N(seq, i);
+    /* We are sure that the segment is not constant since the
+     * sequence is simple */
+    if (tpointsegm_timestamp_at_value1_iter(inst1, inst2, value, t))
+      return true;
+    inst1 = inst2;
+  }
+  /* We should never arrive here */
+  meos_error(ERROR, MEOS_ERR_TEXT_INPUT,
+    "The value has not been found due to roundoff errors");
+  return false;
+}
+
+/**
+ * @brief Get the periods at which a temporal point sequence with linear
+ * interpolation intersects a geometry
+ * @param[in] seq Temporal point
+ * @param[in] gsinter Intersection of the temporal point and the geometry
+ * @param[out] count Number of elements in the resulting array
+ * @pre The temporal sequence is simple, that is, non self-intersecting and
+ * the intersecting geometry is non empty
+ */
+Span *
+tpointseq_interperiods(const TSequence *seq, const GSERIALIZED *gsinter,
+  int *count)
+{
+  /* The temporal sequence has at least 2 instants since
+   * (1) the test for instantaneous full sequence is done in the calling function
+   * (2) the simple components of a non self-intersecting sequence have at least
+   *     two instants */
+  assert(seq->count > 1);
+  const TInstant *start = TSEQUENCE_INST_N(seq, 0);
+  const TInstant *end = TSEQUENCE_INST_N(seq, seq->count - 1);
+  Span *result;
+
+  /* If the sequence is stationary the whole sequence intersects with the
+   * geometry since gsinter is not empty */
+  if (seq->count == 2 &&
+    datum_point_eq(tinstant_value_p(start), tinstant_value_p(end)))
+  {
+    result = palloc(sizeof(Span));
+    result[0] = seq->period;
+    *count = 1;
+    return result;
+  }
+
+  /* General case */
+  LWGEOM *geom_inter = lwgeom_from_gserialized(gsinter);
+  int type = geom_inter->type;
+  int ninter;
+  LWPOINT *point_inter = NULL; /* make compiler quiet */
+  LWLINE *line_inter = NULL; /* make compiler quiet */
+  LWCOLLECTION *coll = NULL; /* make compiler quiet */
+  if (type == POINTTYPE)
+  {
+    ninter = 1;
+    point_inter = lwgeom_as_lwpoint(geom_inter);
+  }
+  else if (type == LINETYPE)
+  {
+    ninter = 1;
+    line_inter = lwgeom_as_lwline(geom_inter);
+  }
+  else
+  /* It is a collection of type MULTIPOINTTYPE, MULTILINETYPE, or
+   * COLLECTIONTYPE */
+  {
+    coll = lwgeom_as_lwcollection(geom_inter);
+    ninter = coll->ngeoms;
+  }
+  Span *periods = palloc(sizeof(Span) * ninter);
+  int npers = 0;
+  for (int i = 0; i < ninter; i++)
+  {
+    if (ninter > 1)
+    {
+      /* Find the i-th intersection */
+      LWGEOM *subgeom = coll->geoms[i];
+      if (subgeom->type == POINTTYPE)
+        point_inter = lwgeom_as_lwpoint(subgeom);
+      else /* type == LINETYPE */
+        line_inter = lwgeom_as_lwline(subgeom);
+      type = subgeom->type;
+    }
+    TimestampTz t1, t2;
+    GSERIALIZED *gspoint;
+    /* Each intersection is either a point or a linestring */
+    if (type == POINTTYPE)
+    {
+      gspoint = geo_serialize((LWGEOM *) point_inter);
+      tpointseq_timestamp_at_value(seq, PointerGetDatum(gspoint), &t1);
+      pfree(gspoint);
+      /* If the intersection is not at an exclusive bound */
+      if ((seq->period.lower_inc || t1 > start->t) &&
+          (seq->period.upper_inc || t1 < end->t))
+        span_set(t1, t1, true, true, T_TIMESTAMPTZ, T_TSTZSPAN,
+          &periods[npers++]);
+    }
+    else
+    {
+      /* Get the fraction of the start point of the intersecting line */
+      LWPOINT *point = lwline_get_lwpoint(line_inter, 0);
+      gspoint = geo_serialize((LWGEOM *) point);
+      lwpoint_free(point);
+      tpointseq_timestamp_at_value(seq, PointerGetDatum(gspoint), &t1);
+      pfree(gspoint);
+      /* Get the fraction of the end point of the intersecting line */
+      point = lwline_get_lwpoint(line_inter, line_inter->points->npoints - 1);
+      gspoint = geo_serialize((LWGEOM *) point);
+      lwpoint_free(point);
+      tpointseq_timestamp_at_value(seq, PointerGetDatum(gspoint), &t2);
+      pfree(gspoint);
+      /* If t1 == t2 and the intersection is not at an exclusive bound */
+      if (t1 == t2)
+      {
+        if ((seq->period.lower_inc || t1 > start->t) &&
+            (seq->period.upper_inc || t1 < end->t))
+          span_set(t1, t1, true, true, T_TIMESTAMPTZ, T_TSTZSPAN,
+            &periods[npers++]);
+      }
+      else
+      {
+        TimestampTz lower1 = Min(t1, t2);
+        TimestampTz upper1 = Max(t1, t2);
+        bool lower_inc1 = (lower1 == start->t) ? seq->period.lower_inc : true;
+        bool upper_inc1 = (upper1 == end->t) ? seq->period.upper_inc : true;
+        span_set(lower1, upper1, lower_inc1, upper_inc1, T_TIMESTAMPTZ,
+          T_TSTZSPAN, &periods[npers++]);
+      }
+    }
+  }
+  lwgeom_free(geom_inter);
+
+  if (npers == 0)
+  {
+    *count = npers;
+    pfree(periods);
+    return NULL;
+  }
+  if (npers == 1)
+  {
+    *count = npers;
+    return periods;
+  }
+
+  int newcount;
+  result = spanarr_normalize(periods, npers, ORDER, &newcount);
+  *count = newcount;
+  pfree(periods);
+  return result;
+}
 
 /*****************************************************************************
  * `tintersects` and `tdisjoint` functions

--- a/meos/src/npoint/tnpoint_spatialfuncs.c
+++ b/meos/src/npoint/tnpoint_spatialfuncs.c
@@ -483,7 +483,7 @@ tnpoint_restrict_geom(const Temporal *temp, const GSERIALIZED *gs, bool atfunc)
     return atfunc ? NULL : temporal_copy(temp);
 
   Temporal *tpoint = tnpoint_to_tgeompoint(temp);
-  Temporal *res = tgeo_restrict_geom(tpoint, gs, NULL, atfunc);
+  Temporal *res = tgeo_restrict_geom(tpoint, gs, atfunc);
   Temporal *result = NULL;
   if (res)
   {

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -1021,7 +1021,7 @@ pose_srid(const Pose *pose)
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(pose, SRID_INVALID);
 
-  int32 srid = 0;
+  int32_t srid = 0;
   srid = srid | (pose->srid[0] << 16);
   srid = srid | (pose->srid[1] << 8);
   srid = srid | (pose->srid[2]);
@@ -1346,8 +1346,7 @@ pose_cmp(const Pose *pose1, const Pose *pose2)
   if (hasz1 != hasz2)
     return (hasz1 ? 1 : -1);
 
-  int32 srid1 = pose_srid(pose1),
-        srid2 = pose_srid(pose2);
+  int32_t srid1 = pose_srid(pose1), srid2 = pose_srid(pose2);
   if (srid1 < srid2)
     return -1;
   else if (srid1 > srid2)

--- a/meos/src/pose/tpose_spatialfuncs.c
+++ b/meos/src/pose/tpose_spatialfuncs.c
@@ -75,11 +75,9 @@ tpose_trajectory(const Temporal *temp)
 /**
  * @ingroup meos_internal_pose_restrict
  * @brief Return a temporal pose restricted to (the complement of) a geometry
- * @note `zspan` may be `NULL`
  */
 Temporal *
-tpose_restrict_geom(const Temporal *temp, const GSERIALIZED *gs,
-  const Span *zspan, bool atfunc)
+tpose_restrict_geom(const Temporal *temp, const GSERIALIZED *gs, bool atfunc)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tpose_geo(temp, gs) || ! ensure_has_not_Z_geo(gs))
@@ -90,7 +88,7 @@ tpose_restrict_geom(const Temporal *temp, const GSERIALIZED *gs,
     return atfunc ? NULL : temporal_copy(temp);
 
   Temporal *tpoint = tpose_to_tpoint(temp);
-  Temporal *res = tgeo_restrict_geom(tpoint, gs, zspan, atfunc);
+  Temporal *res = tgeo_restrict_geom(tpoint, gs, atfunc);
   Temporal *result = NULL;
   if (res)
   {
@@ -109,14 +107,12 @@ tpose_restrict_geom(const Temporal *temp, const GSERIALIZED *gs,
  * @brief Return a temporal pose restricted to a geometry
  * @param[in] temp Temporal pose
  * @param[in] gs Geometry
- * @param[in] zspan Span of values to restrict the Z dimension
  * @csqlfn #Tpose_at_geom()
  */
 inline Temporal *
-tpose_at_geom(const Temporal *temp, const GSERIALIZED *gs,
-  const Span *zspan)
+tpose_at_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
-  return tpose_restrict_geom(temp, gs, zspan, REST_AT);
+  return tpose_restrict_geom(temp, gs, REST_AT);
 }
 
 /**
@@ -124,14 +120,12 @@ tpose_at_geom(const Temporal *temp, const GSERIALIZED *gs,
  * @brief Return a temporal point restricted to (the complement of) a geometry
  * @param[in] temp Temporal pose
  * @param[in] gs Geometry
- * @param[in] zspan Span of values to restrict the Z dimension
  * @csqlfn #Tpose_minus_geom()
  */
 inline Temporal *
-tpose_minus_geom(const Temporal *temp, const GSERIALIZED *gs,
-  const Span *zspan)
+tpose_minus_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
-  return tpose_restrict_geom(temp, gs, zspan, REST_MINUS);
+  return tpose_restrict_geom(temp, gs, REST_MINUS);
 }
 #endif /* MEOS */
 

--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -1246,13 +1246,13 @@ trgeo_minus_tstzspanset(const Temporal *temp, const SpanSet *ss)
  * @csqlfn #Temporal_before_timestamptz()
  */
 Temporal *
-trgeo_before_timestamptz(const Temporal *temp, TimestampTz t, bool atfunc)
+trgeo_before_timestamptz(const Temporal *temp, TimestampTz t, bool strict)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
 
   Temporal *tpose = trgeo_to_tpose(temp);
-  Temporal *res = temporal_before_timestamptz(tpose, t, atfunc);
+  Temporal *res = temporal_before_timestamptz(tpose, t, strict);
   pfree(tpose); 
   if (! res)
     return NULL;
@@ -1272,13 +1272,13 @@ trgeo_before_timestamptz(const Temporal *temp, TimestampTz t, bool atfunc)
  * @csqlfn #Temporal_after_timestamptz()
  */
 Temporal *
-trgeo_after_timestamptz(const Temporal *temp, TimestampTz t, bool atfunc)
+trgeo_after_timestamptz(const Temporal *temp, TimestampTz t, bool strict)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
 
   Temporal *tpose = trgeo_to_tpose(temp);
-  Temporal *res = temporal_after_timestamptz(tpose, t, atfunc);
+  Temporal *res = temporal_after_timestamptz(tpose, t, strict);
   pfree(tpose); 
   if (! res)
     return NULL;

--- a/meos/src/rgeo/trgeo_inst.c
+++ b/meos/src/rgeo/trgeo_inst.c
@@ -130,7 +130,7 @@ trgeoinst_make_valid(const GSERIALIZED *gs, const Pose *pose)
       "Dimension of geometry and pose must correspond");
     return false;
   }
-  if (srid_pose != SRID_UNKNOWN && srid_pose != SRID_UNKNOWN &&
+  if (srid_geom != SRID_UNKNOWN && srid_pose != SRID_UNKNOWN &&
     srid_geom != srid_pose)
   {
     meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,

--- a/meos/src/rgeo/trgeo_parser.c
+++ b/meos/src/rgeo/trgeo_parser.c
@@ -136,7 +136,6 @@ error:
  * no moreinput after the sequence
  * @param[in,out] temp_srid SRID of the temporal rigid geometry
  * @param[in] geom Reference geometry
- * @param[out] result New sequence, may be NULL
  */
 TSequence *
 trgeoseq_cont_parse(const char **str, meosType temptype, interpType interp, 

--- a/meos/src/temporal/CMakeLists.txt
+++ b/meos/src/temporal/CMakeLists.txt
@@ -25,6 +25,7 @@ set(TEMPORAL_SRCS
   temporal_compops.c
   temporal_modif.c
   temporal_restrict.c
+  temporal_rtree.c
   temporal_tile.c
   temporal_waggfuncs.c
   tinstant.c
@@ -57,7 +58,6 @@ if(MEOS)
     temporal_meos.c
     temporal_posops_meos.c
     temporal_restrict_meos.c
-    temporal_rtree.c
     temporal_tile_meos.c
     tinstant_meos.c
     tnumber_distance_meos.c

--- a/meos/src/temporal/doublen.c
+++ b/meos/src/temporal/doublen.c
@@ -352,7 +352,7 @@ double2 *
 double2segm_interpolate(const double2 *start, const double2 *end,
   long double ratio)
 {
-  assert(ratio >= 0.0 || ratio <= 1.0);
+  assert(ratio >= 0.0 && ratio <= 1.0);
   double2 *result = palloc(sizeof(double2));
   result->a = start->a + (double) ((long double)(end->a - start->a) * ratio);
   result->b = start->b + (double) ((long double)(end->b - start->b) * ratio);
@@ -371,7 +371,7 @@ double3 *
 double3segm_interpolate(const double3 *start, const double3 *end,
   long double ratio)
 {
-  assert(ratio >= 0.0 || ratio <= 1.0);
+  assert(ratio >= 0.0 && ratio <= 1.0);
   double3 *result = palloc(sizeof(double3));
   result->a = start->a + (double) ((long double)(end->a - start->a) * ratio);
   result->b = start->b + (double) ((long double)(end->b - start->b) * ratio);
@@ -391,7 +391,7 @@ double4 *
 double4segm_interpolate(const double4 *start, const double4 *end,
   long double ratio)
 {
-  assert(ratio >= 0.0 || ratio <= 1.0);
+  assert(ratio >= 0.0 && ratio <= 1.0);
   double4 *result = palloc(sizeof(double4));
   result->a = start->a + (double) ((long double)(end->a - start->a) * ratio);
   result->b = start->b + (double) ((long double)(end->b - start->b) * ratio);

--- a/meos/src/temporal/meos_array.c
+++ b/meos/src/temporal/meos_array.c
@@ -32,7 +32,6 @@
  * @brief Functions for expandable Datum arrays.
  */
 
-
 /* MEOS */
 #include <meos.h>
 #include <meos_internal.h>
@@ -107,6 +106,8 @@ meos_array_add(MeosArray *array, void *value)
 
 /**
  * @brief Get the n-th element of the array (0-based)
+ * @param[in] array Dynamic array
+ * @param[in] n Index
  * @return For varlength arrays, the stored pointer; for fixed-size arrays,
  * a pointer to the element in the internal buffer
  */
@@ -128,6 +129,7 @@ meos_array_get_n(const MeosArray *array, int n)
 
 /**
  * @brief Reset the array
+ * @param[in] array Dynamic array
  * @param[in] free_elems If true and the array is varlength, pfree each stored
  * pointer before resetting
  */
@@ -146,6 +148,7 @@ meos_array_reset(MeosArray *array, bool free_elems)
 
 /**
  * @brief Destroy the array
+ * @param[in] array Dynamic array
  * @param[in] free_elems If true and the array is varlength, pfree each stored
  * pointer before freeing the array
  */

--- a/meos/src/temporal/meos_catalog.c
+++ b/meos/src/temporal/meos_catalog.c
@@ -629,6 +629,10 @@ basetype_varlength(meosType type)
  * @brief Return the length of a MEOS type
  * @return On error return SHRT_MAX
  */
+/**
+ * @brief Return the length of a base type
+ * @return On error return SHRT_MAX
+ */
 int16
 meostype_length(meosType type)
 {

--- a/meos/src/temporal/meos_catalog.c
+++ b/meos/src/temporal/meos_catalog.c
@@ -629,10 +629,6 @@ basetype_varlength(meosType type)
  * @brief Return the length of a MEOS type
  * @return On error return SHRT_MAX
  */
-/**
- * @brief Return the length of a base type
- * @return On error return SHRT_MAX
- */
 int16
 meostype_length(meosType type)
 {

--- a/meos/src/temporal/span.c
+++ b/meos/src/temporal/span.c
@@ -310,7 +310,7 @@ span_decr_bound(Datum lower, meosType basetype)
  * The normalized spans are new spans that must be freed.
  * @param[in] spans Array of spans
  * @param[in] count Number of elements in the input array
- * @param[in] order True if the spans should be ordered
+ * @param[in] order True if the spans should be ordered before normalization
  * @param[out] newcount Number of elements in the output array
  * @pre @p count is greater than 0
  */

--- a/meos/src/temporal/spanset.c
+++ b/meos/src/temporal/spanset.c
@@ -1479,9 +1479,9 @@ spanset_cmp(const SpanSet *ss1, const SpanSet *ss2)
   /* The first count spans of the two span sets are equal */
   if (! result)
   {
-    if (count < count1) /* ss1 has more spans than ss2 */
+    if (count1 > count2) /* ss1 has more spans than ss2 */
       result = 1;
-    else if (count < count2) /* ss2 has more spans than ss1 */
+    else if (count2 > count1) /* ss2 has more spans than ss1 */
       result = -1;
     else
       result = 0;

--- a/meos/src/temporal/spanset.c
+++ b/meos/src/temporal/spanset.c
@@ -337,7 +337,7 @@ spanset_make(Span *spans, int count)
   VALIDATE_NOT_NULL(spans, NULL);
   if (! ensure_positive(count))
     return NULL;
-  return spanset_make_exp(spans, count, count, true, true);
+  return spanset_make_exp(spans, count, count, NORMALIZE, ORDER);
 }
 #endif /* MEOS */
 

--- a/meos/src/temporal/temporal_aggfuncs.c
+++ b/meos/src/temporal/temporal_aggfuncs.c
@@ -543,6 +543,7 @@ tsequence_tagg_iter(const TSequence *seq1, const TSequence *seq2,
   TSequence *syncseq1, *syncseq2;
   synchronize_tsequence_tsequence(seq1, seq2, &syncseq1, &syncseq2, crossings);
   TInstant **instants = palloc(sizeof(TInstant *) * syncseq1->count);
+  // meosType basetype = temptype_basetype(seq1->temptype);
   for (int i = 0; i < syncseq1->count; i++)
   {
     const TInstant *inst1 = TSEQUENCE_INST_N(syncseq1, i);
@@ -551,6 +552,7 @@ tsequence_tagg_iter(const TSequence *seq1, const TSequence *seq2,
     {
       Datum value = func(tinstant_value_p(inst1), tinstant_value_p(inst2));
       instants[i] = tinstant_make(value, seq1->temptype, inst1->t);
+      // DATUM_FREE(value, basetype); // TODO
     }
     else
     {

--- a/meos/src/temporal/temporal_restrict.c
+++ b/meos/src/temporal/temporal_restrict.c
@@ -3579,7 +3579,7 @@ tcontseq_after_timestamptz(const TSequence *seq, TimestampTz t, bool strict)
       /* The last two values of sequences with step interpolation and
          exclusive upper bound must be equal */
       meosType basetype = temptype_basetype(seq->temptype);
-      if (ninsts > 1 && interp != LINEAR &&
+      if (interp != LINEAR &&
           datum_ne(tinstant_value_p(instants[ninsts - 2]),
             tinstant_value_p(instants[ninsts - 1]), basetype))
       {

--- a/meos/src/temporal/temporal_rtree.c
+++ b/meos/src/temporal/temporal_rtree.c
@@ -79,7 +79,9 @@ get_axis_tbox(const void *box, int axis, bool upper)
   assert(box); assert(axis == 0 || axis == 1);
   TBox *tbox = (TBox *) box;
   if (axis == 0)
+  {
     return upper ? (double) tbox->span.upper : (double) tbox->span.lower;
+  }
   else /* axis == 1 */
     return upper ? (double)((int64) tbox->period.upper) :
       (double)((int64) tbox->period.lower);

--- a/meos/src/temporal/temporal_rtree.c
+++ b/meos/src/temporal/temporal_rtree.c
@@ -100,7 +100,7 @@ get_axis_tbox(const void *box, int axis, bool upper)
 static double
 get_axis_stbox(const void *box, int axis, bool upper)
 {
-  assert(box); assert(axis >= 0 || axis <= 3);
+  assert(box); assert(axis >= 0 && axis <= 3);
   STBox *stbox = (STBox *) box;
   if (axis == 0)
     return upper ? stbox->xmax : stbox->xmin;

--- a/meos/src/temporal/tsequence.c
+++ b/meos/src/temporal/tsequence.c
@@ -238,7 +238,7 @@ datumsegm_locate(Datum value1, Datum value2, Datum value, meosType basetype)
 double
 floatsegm_interpolate(double start, double end, long double ratio)
 {
-  assert(ratio >= 0.0 || ratio <= 1.0);
+  assert(ratio >= 0.0 && ratio <= 1.0);
   return start + (double) ((long double) (end - start) * ratio);
 }
 

--- a/meos/src/temporal/tsequence.c
+++ b/meos/src/temporal/tsequence.c
@@ -1107,7 +1107,7 @@ tsequence_make_free(TInstant **instants, int count, bool lower_inc,
  */
 TSequence *
 tpointseq_make_coords(const double *xcoords, const double *ycoords,
-  const double *zcoords, const TimestampTz *times, int count, int32 srid,
+  const double *zcoords, const TimestampTz *times, int count, int32_t srid,
   bool geodetic, bool lower_inc, bool upper_inc, interpType interp,
   bool normalize)
 {

--- a/meos/src/temporal/type_parser.c
+++ b/meos/src/temporal/type_parser.c
@@ -534,7 +534,10 @@ set_parse(const char **str, meosType settype)
       spatial_set_srid(values[i], basetype, set_srid);
   }
   result = set_make(values, array->count, basetype, ORDER);
-  pfree(values);
+  if (meostype_length(basetype) < 0)
+    pfree_array((void **) values, array->count);
+  else
+    pfree(values);
 
 error:
   meos_array_destroy(array, false);

--- a/meos/src/temporal/type_parser.c
+++ b/meos/src/temporal/type_parser.c
@@ -740,7 +740,6 @@ error:
  * @param[in] interp Interpolation
  * @param[in] end Set to true when reading a single sequence to ensure there is
  * no more input after the sequence
- * @param[out] result New sequence, may be NULL
  * @return On error return false
  */
 TSequence *

--- a/meos/src/temporal/type_util.c
+++ b/meos/src/temporal/type_util.c
@@ -654,8 +654,7 @@ tstzarr_sort(TimestampTz *times, int count)
 void
 spanarr_sort(Span *spans, int count)
 {
-  qsort(spans, (size_t) count, sizeof(Span),
-    (qsort_comparator) &span_cmp);
+  qsort(spans, (size_t) count, sizeof(Span), (qsort_comparator) &span_cmp);
   return;
 }
 

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -1852,8 +1852,16 @@ int main(void)
     free(tgeompt_result);
   free(char_result);
 
-  /* Temporal *tpoint_at_geom(const Temporal *temp, const GSERIALIZED *gs, const Span *zspan); */
-  tgeompt_result = tpoint_at_geom(tgeompt3d1, geom1, fspan1);
+  /* Temporal *tpoint_at_elevation(const Temporal *temp, const Span *s); */
+  tgeompt_result = tpoint_at_elevation(tgeompt3d1, fspan1);
+  char_result = tgeompt_result ? tspatial_as_ewkt(tgeompt_result, 6) : text_out(text_null);
+  printf("tpoint_at_geom(%s, %s): %s\n", tgeompt3d1_out, fspan1_out, char_result);
+  if (tgeompt_result)
+    free(tgeompt_result);
+  free(char_result);
+
+  /* Temporal *tpoint_at_geom(const Temporal *temp, const GSERIALIZED *gs); */
+  tgeompt_result = tpoint_at_geom(tgeompt3d1, geom1);
   char_result = tgeompt_result ? tspatial_as_ewkt(tgeompt_result, 6) : text_out(text_null);
   printf("tpoint_at_geom(%s, %s, %s): %s\n", tgeompt3d1_out, geom1_out, fspan1_out, char_result);
   if (tgeompt_result)
@@ -1868,14 +1876,22 @@ int main(void)
     free(tgeompt_result);
   free(char_result);
 
-  /* Temporal *tpoint_minus_geom(const Temporal *temp, const GSERIALIZED *gs, const Span *zspan); */
-  tgeompt_result = tpoint_minus_geom(tgeompt3d1, geom1, fspan1);
+  /* Temporal *tpoint_minus_geom(const Temporal *temp, const GSERIALIZED *gs); */
+  tgeompt_result = tpoint_minus_geom(tgeompt3d1, geom1);
   char_result = tgeompt_result ? tspatial_as_ewkt(tgeompt_result, 6) : text_out(text_null);
-  printf("tpoint_minus_geom(%s, %s, %s): %s\n", tgeompt3d1_out, geom1_out, fspan1_out, char_result);
+  printf("tpoint_minus_geom(%s, %s): %s\n", tgeompt3d1_out, geom1_out, char_result);
   if (tgeompt_result)
     free(tgeompt_result);
   free(char_result);
 
+  /* Temporal *tpoint_minus_elevation(const Temporal *temp, const Span *s); */
+  tgeompt_result = tpoint_minus_elevation(tgeompt3d1, fspan1);
+  char_result = tgeompt_result ? tspatial_as_ewkt(tgeompt_result, 6) : text_out(text_null);
+  printf("tpoint_minus_geom(%s, %s): %s\n", tgeompt3d1_out, fspan1_out, char_result);
+  if (tgeompt_result)
+    free(tgeompt_result);
+  free(char_result);
+  
   /* Temporal *tpoint_minus_value(const Temporal *temp, GSERIALIZED *gs); */
   tgeompt_result = tpoint_minus_value(tgeompt1, geom1);
   char_result = tgeompt_result ? tspatial_as_ewkt(tgeompt_result, 6) : text_out(text_null);

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -284,7 +284,7 @@ int main(void)
 
   /* uint8_t *geo_as_ewkb(const GSERIALIZED *gs, const char *endian, size_t *size); */
   binchar_result = geo_as_ewkb(geom1, "XDR", &size);
-  printf("geo_as_ewkb(%s, \"XDR\", %ld): ", tfloat1_out, size);
+  printf("geo_as_ewkb(%s, \"XDR\", %zu): ", tfloat1_out, size);
   fwrite(binchar_result, size, 1, stdout);
   printf("\n");
   free(binchar_result);
@@ -314,7 +314,7 @@ int main(void)
   char_result = geo_as_ewkt(geom_result, 6);
   printf("geo_from_ewkb(");
   fwrite(geom1_wkb, geom_size_wkb, 1, stdout);
-  printf(", %ld): %s\n", size, char_result);
+  printf(", %zu): %s\n", size, char_result);
   free(geom_result); free(char_result);
 
   /* GSERIALIZED *geo_from_geojson(const char *geojson); */
@@ -337,7 +337,7 @@ int main(void)
   /* GSERIALIZED *geog_from_binary(const char *wkb_bytea); */
   geom_result = geo_from_ewkb(geog1_wkb, geog_size_wkb, 4326);
   char_result = geo_as_ewkt(geom_result, 6);
-  printf("geog_from_binary(%s, %ld): %s\n", geog1_wkb, geog_size_wkb, char_result);
+  printf("geog_from_binary(%s, %zu): %s\n", geog1_wkb, geog_size_wkb, char_result);
   free(geom_result); free(char_result);
 
   /* GSERIALIZED *geog_from_hexewkb(const char *wkt); */
@@ -963,7 +963,7 @@ int main(void)
 
   /* uint8_t *stbox_as_wkb(const STBox *box, uint8_t variant, size_t *size_out); */
   binchar_result = stbox_as_wkb(stbox1, 1, &size);
-  printf("tbox_as_wkb(%s, 1, %ld): ", stbox1_out, size);
+  printf("tbox_as_wkb(%s, 1, %zu): ", stbox1_out, size);
   fwrite(binchar_result, size, 1, stdout);
   printf("\n");
   free(binchar_result);
@@ -977,7 +977,7 @@ int main(void)
   /* STBox *stbox_from_wkb(const uint8_t *wkb, size_t size); */
   stbox_result = stbox_from_wkb(stbox1_wkb, stbox_size_wkb);
   char_result = stbox_out(stbox_result, 6);
-  printf("stbox_from_wkb(%s, %ld): %s\n", stbox1_wkb, stbox_size_wkb, char_result);
+  printf("stbox_from_wkb(%s, %zu): %s\n", stbox1_wkb, stbox_size_wkb, char_result);
   free(stbox_result); free(char_result);
 
   /* STBox *stbox_in(const char *str); */
@@ -2743,7 +2743,7 @@ int main(void)
   printf("geo_cluster_kmeans(%s, 2, 2): {", geom1_out);
   for (int i = 0; i < 2; i++)
   {
-    printf("%u", int32array_result[i]);
+    printf("%d", int32array_result[i]);
     if (i < count - 1)
       printf(", ");
     else

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -1012,7 +1012,7 @@ int main(void)
   printf("stbox_copy(%s): %s\n", stbox1_out, char_result);
   free(stbox_result); free(char_result);
 
-  /* STBox *stbox_make(bool hasx, bool hasz, bool geodetic, int32 srid, double xmin, double xmax, double ymin, double ymax, double zmin, double zmax, const Span *s); */
+  /* STBox *stbox_make(bool hasx, bool hasz, bool geodetic, int32_t srid, double xmin, double xmax, double ymin, double ymax, double zmin, double zmax, const Span *s); */
   stbox_result = stbox_make(true, true, false, 4326, 1, 3, 1, 3, 1, 3, tstzspan1);
   char_result = stbox_out(stbox_result, 6);
   printf("stbox_make(true, true, false, 4326, 1, 3, 1, 3, 1, 3, %s): %s\n", tstzspan1_out, char_result);
@@ -1492,7 +1492,7 @@ int main(void)
   printf("tpointseq_from_base_tstzspan(%s, %s, LINEAR): %s\n", geompt1_out, tstzspan1_out, char_result);
   free(tgeompt_result); free(char_result);
 
-  /* TSequence *tpointseq_make_coords(const double *xcoords, const double *ycoords, const double *zcoords, const TimestampTz *times, int count, int32 srid, bool geodetic, bool lower_inc, bool upper_inc, interpType interp, bool normalize); */
+  /* TSequence *tpointseq_make_coords(const double *xcoords, const double *ycoords, const double *zcoords, const TimestampTz *times, int count, int32_t srid, bool geodetic, bool lower_inc, bool upper_inc, interpType interp, bool normalize); */
   float8array1[0] = float8array2[0] = float8array3[0] = 1;
   float8array1[1] = float8array2[1] = float8array3[1] = 1;
   tstzarray[0] = tstz1;

--- a/meos/test/npoint_test.c
+++ b/meos/test/npoint_test.c
@@ -288,7 +288,7 @@ int main(void)
 
   /* int64 npoint_route(const Npoint *np); */
   int64_result = npoint_route(npoint1);
-  printf("npoint_route(%s): %lu\n", npoint1_out, int64_result);
+  printf("npoint_route(%s): %ld\n", npoint1_out, int64_result);
 
   /* double nsegment_end_position(const Nsegment *ns); */
   float8_result = nsegment_end_position(nsegment1);
@@ -296,7 +296,7 @@ int main(void)
 
   /* int64 nsegment_route(const Nsegment *ns); */
   int64_result = nsegment_route(nsegment1);
-  printf("nsegment_route(%s): %lu\n", nsegment1_out, int64_result);
+  printf("nsegment_route(%s): %ld\n", nsegment1_out, int64_result);
 
   /* double nsegment_start_position(const Nsegment *ns); */
   float8_result = nsegment_start_position(nsegment1);

--- a/meos/test/tbl_tcbuffer_geometry.c
+++ b/meos/test/tbl_tcbuffer_geometry.c
@@ -88,7 +88,7 @@ int main(void)
   if (! file2)
   {
     printf("Error opening second input file\n");
-    fclose(file2);
+    fclose(file1);
     return 1;
   }
 

--- a/meos/test/tbl_tpoint_geo.c
+++ b/meos/test/tbl_tpoint_geo.c
@@ -90,7 +90,7 @@ int main(void)
   if (! file2)
   {
     printf("Error opening second input file\n");
-    fclose(file2);
+    fclose(file1);
     return 1;
   }
 

--- a/mobilitydb/sql/geo/056_tpoint_spatialfuncs.in.sql
+++ b/mobilitydb/sql/geo/056_tpoint_spatialfuncs.in.sql
@@ -318,16 +318,7 @@ CREATE FUNCTION atGeometry(tgeompoint, geometry)
   RETURNS tgeompoint
   AS 'MODULE_PATHNAME', 'Tgeo_at_geom'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION atGeometry(tgeompoint, geometry, floatspan)
-  RETURNS tgeompoint
-  AS 'MODULE_PATHNAME', 'Tgeo_at_geom'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
 CREATE FUNCTION minusGeometry(tgeompoint, geometry)
-  RETURNS tgeompoint
-  AS 'MODULE_PATHNAME', 'Tgeo_minus_geom'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION minusGeometry(tgeompoint, geometry, floatspan)
   RETURNS tgeompoint
   AS 'MODULE_PATHNAME', 'Tgeo_minus_geom'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -349,5 +340,15 @@ CREATE FUNCTION minusStbox(tgeogpoint, stbox, borderInc bool DEFAULT TRUE)
   RETURNS tgeogpoint
   AS 'MODULE_PATHNAME', 'Tgeo_minus_stbox'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION atElevation(tgeompoint, floatspan)
+  RETURNS tgeompoint
+  AS 'MODULE_PATHNAME', 'Tgeo_at_elevation'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION minusElevation(tgeompoint, floatspan)
+  RETURNS tgeompoint
+  AS 'MODULE_PATHNAME', 'Tgeo_minus_elevation'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 
 /*****************************************************************************/

--- a/mobilitydb/src/cbuffer/tcbuffer.c
+++ b/mobilitydb/src/cbuffer/tcbuffer.c
@@ -68,7 +68,7 @@
 static Temporal *
 tcbuffer_valid_typmod(Temporal *temp, int32_t typmod)
 {
-  int32 srid = tspatial_srid(temp);
+  int32_t srid = tspatial_srid(temp);
   uint8 subtype = temp->subtype;
   uint8 typmod_subtype = TYPMOD_GET_TEMPSUBTYPE(typmod);
   int32 typmod_srid = TYPMOD_GET_SRID(typmod);

--- a/mobilitydb/src/geo/spatialset.c
+++ b/mobilitydb/src/geo/spatialset.c
@@ -270,7 +270,7 @@ Datum
 Spatialset_set_srid(PG_FUNCTION_ARGS)
 {
   Set *s = PG_GETARG_SET_P(0);
-  int32 srid = PG_GETARG_INT32(1);
+  int32_t srid = PG_GETARG_INT32(1);
   Set *result = spatialset_set_srid(s, srid);
   PG_FREE_IF_COPY(s, 0);
   PG_RETURN_SET_P(result);
@@ -287,7 +287,7 @@ Datum
 Spatialset_transform(PG_FUNCTION_ARGS)
 {
   Set *s = PG_GETARG_SET_P(0);
-  int32 srid = PG_GETARG_INT32(1);
+  int32_t srid = PG_GETARG_INT32(1);
   Set *result = spatialset_transform(s, srid);
   PG_FREE_IF_COPY(s, 0);
   if (! result)

--- a/mobilitydb/src/geo/stbox.c
+++ b/mobilitydb/src/geo/stbox.c
@@ -1113,7 +1113,7 @@ Datum
 Stbox_set_srid(PG_FUNCTION_ARGS)
 {
   STBox *box = PG_GETARG_STBOX_P(0);
-  int32 srid = PG_GETARG_INT32(1);
+  int32_t srid = PG_GETARG_INT32(1);
   PG_RETURN_STBOX_P(stbox_set_srid(box, srid));
 }
 
@@ -1128,7 +1128,7 @@ Datum
 Stbox_transform(PG_FUNCTION_ARGS)
 {
   STBox *box = PG_GETARG_STBOX_P(0);
-  int32 srid = PG_GETARG_INT32(1);
+  int32_t srid = PG_GETARG_INT32(1);
   STBox *result = stbox_transform(box, srid);
   if (! result)
     PG_RETURN_NULL();

--- a/mobilitydb/src/geo/tgeo.c
+++ b/mobilitydb/src/geo/tgeo.c
@@ -376,7 +376,7 @@ Tspatial_typmod_out(PG_FUNCTION_ARGS)
   size_t len = 0;
   int32 typmod = PG_GETARG_INT32(0);
   int16 tempsubtype = TYPMOD_GET_TEMPSUBTYPE(typmod);
-  int32 srid = TYPMOD_GET_SRID(typmod);
+  int32_t srid = TYPMOD_GET_SRID(typmod);
   uint8_t geometry_type = (uint8_t) TYPMOD_GET_TYPE(typmod);
   int32 hasz = TYPMOD_GET_Z(typmod);
 
@@ -422,7 +422,7 @@ tspatial_valid_typmod(Temporal *temp, int32_t typmod)
 {
   /* Get the characteristics of the temporal value */
   uint8 subtype = temp->subtype;
-  int32 srid = tspatial_srid(temp);
+  int32_t srid = tspatial_srid(temp);
   int32 hasz = MEOS_FLAGS_GET_Z(temp->flags);
   /* Get the characteristics of the typmod */
   uint8 typmod_subtype = TYPMOD_GET_TEMPSUBTYPE(typmod);

--- a/mobilitydb/src/geo/tgeo_spatialfuncs.c
+++ b/mobilitydb/src/geo/tgeo_spatialfuncs.c
@@ -713,16 +713,9 @@ Tpoint_make_simple(PG_FUNCTION_ARGS)
 static Datum
 Tgeo_restrict_geom(FunctionCallInfo fcinfo, bool atfunc)
 {
-  /*
-  CREATE FUNCTION at/minusGeometry(tgeometry, geometry)
-  CREATE FUNCTION at/minusGeometry(tgeometry, geometry, floatspan)
-  */
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(1);
-  Span *zspan = NULL;
-  if (PG_NARGS() == 3)
-    zspan = PG_GETARG_SPAN_P(2);
-  Temporal *result = tgeo_restrict_geom(temp, gs, zspan, atfunc);
+  Temporal *result = tgeo_restrict_geom(temp, gs, atfunc);
   PG_FREE_IF_COPY(temp, 0);
   PG_FREE_IF_COPY(gs, 1);
   if (! result)
@@ -802,6 +795,52 @@ inline Datum
 Tgeo_minus_stbox(PG_FUNCTION_ARGS)
 {
   return Tgeo_restrict_stbox(fcinfo, REST_MINUS);
+}
+
+/*****************************************************************************
+ * Restriction functions
+ *****************************************************************************/
+
+/**
+ * @brief Return a temporal geo restricted to (the complement of) an elevation
+ * span
+ */
+static Datum
+Tgeo_restrict_elevation(FunctionCallInfo fcinfo, bool atfunc)
+{
+  Temporal *temp = PG_GETARG_TEMPORAL_P(0);
+  Span *s = PG_GETARG_SPAN_P(1);
+  Temporal *result = tgeo_restrict_elevation(temp, s, atfunc);
+  PG_FREE_IF_COPY(temp, 0);
+  if (! result)
+    PG_RETURN_NULL();
+  PG_RETURN_TEMPORAL_P(result);
+}
+
+PGDLLEXPORT Datum Tgeo_at_elevation(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tgeo_at_elevation);
+/**
+ * @ingroup mobilitydb_geo_restrict
+ * @brief Return a temporal geo restricted to an elevation span
+ * @sqlfn atGeometry()
+ */
+inline Datum
+Tgeo_at_elevation(PG_FUNCTION_ARGS)
+{
+  return Tgeo_restrict_elevation(fcinfo, REST_AT);
+}
+
+PGDLLEXPORT Datum Tgeo_minus_elevation(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tgeo_minus_elevation);
+/**
+ * @ingroup mobilitydb_geo_restrict
+ * @brief Return a temporal geo restricted to the complement an elevation span
+ * @sqlfn minusGeometry()
+ */
+inline Datum
+Tgeo_minus_elevation(PG_FUNCTION_ARGS)
+{
+  return Tgeo_restrict_elevation(fcinfo, REST_MINUS);
 }
 
 /*****************************************************************************/

--- a/mobilitydb/src/geo/tspatial.c
+++ b/mobilitydb/src/geo/tspatial.c
@@ -242,7 +242,7 @@ Datum
 Tspatial_set_srid(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
-  int32 srid = PG_GETARG_INT32(1);
+  int32_t srid = PG_GETARG_INT32(1);
   Temporal *result = tspatial_set_srid(temp, srid);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_TEMPORAL_P(result);

--- a/mobilitydb/src/pose/tpose_distance.c
+++ b/mobilitydb/src/pose/tpose_distance.c
@@ -32,6 +32,8 @@
  * @brief Temporal distance for temporal poses
  */
 
+/* C */
+#include <float.h>
 /* MEOS */
 #include <meos.h>
 #include <meos_pose.h>

--- a/mobilitydb/src/pose/tpose_spatialfuncs.c
+++ b/mobilitydb/src/pose/tpose_spatialfuncs.c
@@ -79,7 +79,7 @@ Tpose_restrict_geom(FunctionCallInfo fcinfo, bool atfunc)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(1);
-  Temporal *result = tpose_restrict_geom(temp, gs, NULL, atfunc);
+  Temporal *result = tpose_restrict_geom(temp, gs, atfunc);
   PG_FREE_IF_COPY(temp, 0);
   PG_FREE_IF_COPY(gs, 1);
   if (! result)

--- a/mobilitydb/test/geo/expected/056_tpoint_spatialfuncs.test.out
+++ b/mobilitydb/test/geo/expected/056_tpoint_spatialfuncs.test.out
@@ -3265,18 +3265,6 @@ SELECT asText(atGeometry(tgeompoint '[Point(1 1 1)@2000-01-01, Point(1 1 1)@2000
  
 (1 row)
 
-SELECT asText(atGeometry(tgeompoint 'Point(1 1 1)@2000-01-01', geometry 'Linestring(0 0, 2 2)', floatspan '[0, 2]'));
-                    astext                    
-----------------------------------------------
- POINT Z (1 1 1)@Sat Jan 01 00:00:00 2000 PST
-(1 row)
-
-select asText(atGeometry(tgeompoint 'Interp=Step;[Point(1 1 1)@2000-01-01, Point(1 1 3)@2000-01-02]', geometry 'Point(1 1)', floatspan '[1, 2]'));
-                                                   astext                                                   
-------------------------------------------------------------------------------------------------------------
- Interp=Step;{[POINT Z (1 1 1)@Sat Jan 01 00:00:00 2000 PST, POINT Z (1 1 1)@Sun Jan 02 00:00:00 2000 PST)}
-(1 row)
-
 SELECT asText(atGeometry(tgeompoint '[Point(1 1)@2000-01-01]', geometry 'Linestring(0 0,1 1)'));
                    astext                    
 ---------------------------------------------
@@ -3503,10 +3491,10 @@ SELECT minusGeometry(tgeompoint 'Point(1 1)@2000-01-01', geometry 'SRID=5676;Lin
 ERROR:  Operation on mixed SRID
 SELECT minusGeometry(tgeompoint 'Point(1 1)@2000-01-01', geometry 'Linestring(1 1 1,2 2 2)');
 ERROR:  The geometry cannot have Z dimension
-WITH temp(trip, geo, zspan) AS (
+WITH temp(trip, geo) AS (
   SELECT tgeompoint '[Point(1 1 1)@2000-01-01, Point(3 1 1)@2000-01-03,
-    Point(3 1 3)@2000-01-05]', geometry 'Polygon((2 0,2 2,4 2,4 0,2 0))', floatspan '[0,2]' )
-SELECT trip = merge(atGeometry(trip, geo, zspan), minusGeometry(trip, geo, zspan))
+    Point(3 1 3)@2000-01-05]', geometry 'Polygon((2 0,2 2,4 2,4 0,2 0))' )
+SELECT trip = merge(atGeometry(trip, geo), minusGeometry(trip, geo))
 FROM temp;
  ?column? 
 ----------

--- a/mobilitydb/test/geo/expected/056_tpoint_spatialfuncs.test.out
+++ b/mobilitydb/test/geo/expected/056_tpoint_spatialfuncs.test.out
@@ -3106,8 +3106,7 @@ SELECT asText(atGeometry(tgeompoint '[Point(0 3)@2000-01-01, Point(1 1)@2000-01-
  {[POINT(0.5 2)@Sat Jan 01 12:00:00 2000 PST, POINT(1 1)@Sun Jan 02 00:00:00 2000 PST, POINT(2 1.5)@Sun Jan 02 12:00:00 2000 PST]}
 (1 row)
 
-SELECT astext(atGeometry(tgeompoint '[Point(0 0)@2000-01-01, Point(3 3)@2000-01-02, Point(0 3)@2000-01-03, Point(
-3 0)@2000-01-04]', 'Polygon((1 1,2 1,2 2,1 2,1 1))'));
+SELECT astext(atGeometry(tgeompoint '[Point(0 0)@2000-01-01, Point(3 3)@2000-01-02, Point(0 3)@2000-01-03, Point(3 0)@2000-01-04]', 'Polygon((1 1,2 1,2 2,1 2,1 1))'));
                                                                                   astext                                                                                  
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  {[POINT(1 1)@Sat Jan 01 08:00:00 2000 PST, POINT(2 2)@Sat Jan 01 16:00:00 2000 PST], [POINT(1 2)@Mon Jan 03 08:00:00 2000 PST, POINT(2 1)@Mon Jan 03 16:00:00 2000 PST]}
@@ -3463,9 +3462,9 @@ SELECT asText(minusGeometry(tgeompoint 'Interp=Step;{[Point(1 1 1)@2000-01-01, P
 (1 row)
 
 SELECT asText(minusGeometry(tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02)', geometry 'Linestring(0 1,2 1)'));
-                                        astext                                        
---------------------------------------------------------------------------------------
- {[POINT(0 0)@Sat Jan 01 00:00:00 2000 PST, POINT(1 1)@Sun Jan 02 00:00:00 2000 PST)}
+                                       astext                                       
+------------------------------------------------------------------------------------
+ [POINT(0 0)@Sat Jan 01 00:00:00 2000 PST, POINT(1 1)@Sun Jan 02 00:00:00 2000 PST)
 (1 row)
 
 SELECT asText(minusGeometry(tgeompoint '{[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02)}', geometry 'Linestring(0 1,2 1)'));

--- a/mobilitydb/test/geo/expected/056_tpoint_spatialfuncs_tbl.test.out
+++ b/mobilitydb/test/geo/expected/056_tpoint_spatialfuncs_tbl.test.out
@@ -642,3 +642,9 @@ SELECT COUNT(*) FROM tbl_tgeogpoint3d t1, tbl_geodstbox3d t2 WHERE temp != merge
      1
 (1 row)
 
+SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_floatspan t2 WHERE temp != merge(atElevation(temp, f), minusElevation(temp, f));
+ count 
+-------
+     0
+(1 row)
+

--- a/mobilitydb/test/geo/queries/056_tpoint_spatialfuncs.test.sql
+++ b/mobilitydb/test/geo/queries/056_tpoint_spatialfuncs.test.sql
@@ -858,8 +858,7 @@ SELECT asText(atGeometry(tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-
 SELECT asText(atGeometry(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03]', geometry 'Linestring(0 0,3 3)'));
 SELECT asText(atGeometry(tgeompoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03],[Point(3 3)@2000-01-04, Point(3 3)@2000-01-05]}', geometry 'Linestring(0 0,3 3)'));
 SELECT asText(atGeometry(tgeompoint '[Point(0 3)@2000-01-01, Point(1 1)@2000-01-02, Point(3 2)@2000-01-03, Point(0 3)@2000-01-04]', geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))'));
-SELECT astext(atGeometry(tgeompoint '[Point(0 0)@2000-01-01, Point(3 3)@2000-01-02, Point(0 3)@2000-01-03, Point(
-3 0)@2000-01-04]', 'Polygon((1 1,2 1,2 2,1 2,1 1))'));
+SELECT astext(atGeometry(tgeompoint '[Point(0 0)@2000-01-01, Point(3 3)@2000-01-02, Point(0 3)@2000-01-03, Point(3 0)@2000-01-04]', 'Polygon((1 1,2 1,2 2,1 2,1 1))'));
 SELECT asText(atGeometry(tgeompoint 'Interp=Step;[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03]', geometry 'Linestring(0 0,3 3)'));
 SELECT asText(atGeometry(tgeompoint 'Interp=Step;{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03],[Point(3 3)@2000-01-04, Point(3 3)@2000-01-05]}', geometry 'Linestring(0 0,3 3)'));
 SELECT asText(atGeometry(tgeompoint 'Interp=Step;[Point(0 3)@2000-01-01, Point(1 1)@2000-01-02, Point(3 2)@2000-01-03, Point(0 3)@2000-01-04]', geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))'));

--- a/mobilitydb/test/geo/queries/056_tpoint_spatialfuncs.test.sql
+++ b/mobilitydb/test/geo/queries/056_tpoint_spatialfuncs.test.sql
@@ -891,10 +891,6 @@ SELECT asText(atGeometry(tgeompoint 'Interp=Step;{[Point(1 1 1)@2000-01-01, Poin
 
 SELECT asText(atGeometry(tgeompoint '[Point(1 1 1)@2000-01-01, Point(1 1 1)@2000-01-02]', geometry 'Linestring(0 0,0 2,2 2)'));
 
---3D Zspan
-SELECT asText(atGeometry(tgeompoint 'Point(1 1 1)@2000-01-01', geometry 'Linestring(0 0, 2 2)', floatspan '[0, 2]'));
-select asText(atGeometry(tgeompoint 'Interp=Step;[Point(1 1 1)@2000-01-01, Point(1 1 3)@2000-01-02]', geometry 'Point(1 1)', floatspan '[1, 2]'));
-
 SELECT asText(atGeometry(tgeompoint '[Point(1 1)@2000-01-01]', geometry 'Linestring(0 0,1 1)'));
 SELECT asText(atGeometry(tgeompoint '[Point(1 1)@2000-01-01, Point(3 3)@2000-01-02]','Point(2 2)'));
 SELECT asText(atGeometry(tgeompoint '[Point(0 1)@2000-01-01,Point(5 1)@2000-01-05]', geometry 'Linestring(0 0,2 2,3 1,4 1,5 0)'));
@@ -949,10 +945,10 @@ SELECT minusGeometry(tgeompoint 'Point(1 1)@2000-01-01', geometry 'Linestring(1 
 --------------------------------------------------------
 
 -- Equivalences
-WITH temp(trip, geo, zspan) AS (
+WITH temp(trip, geo) AS (
   SELECT tgeompoint '[Point(1 1 1)@2000-01-01, Point(3 1 1)@2000-01-03,
-    Point(3 1 3)@2000-01-05]', geometry 'Polygon((2 0,2 2,4 2,4 0,2 0))', floatspan '[0,2]' )
-SELECT trip = merge(atGeometry(trip, geo, zspan), minusGeometry(trip, geo, zspan))
+    Point(3 1 3)@2000-01-05]', geometry 'Polygon((2 0,2 2,4 2,4 0,2 0))' )
+SELECT trip = merge(atGeometry(trip, geo), minusGeometry(trip, geo))
 FROM temp;
 
 --------------------------------------------------------

--- a/mobilitydb/test/geo/queries/056_tpoint_spatialfuncs_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/056_tpoint_spatialfuncs_tbl.test.sql
@@ -188,4 +188,7 @@ SELECT COUNT(*) FROM tbl_tgeompoint3d t1, tbl_stbox3d t2 WHERE temp != merge(atS
 -- TODO THE FOLLOWING FUNCTION RETURNS 1, WE NEED TO DEBUG TO UNDERSTAND WHY
 SELECT COUNT(*) FROM tbl_tgeogpoint3d t1, tbl_geodstbox3d t2 WHERE temp != merge(atStbox(temp, b), minusStbox(temp, b));
 
+SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_floatspan t2 WHERE temp != merge(atElevation(temp, f), minusElevation(temp, f));
+
+
 -------------------------------------------------------------------------------

--- a/postgis/liblwgeom/lwinline.h
+++ b/postgis/liblwgeom/lwinline.h
@@ -71,7 +71,8 @@ ptarray_point_size(const POINTARRAY *pa)
  * WARNING: Don't cast this to a POINT!
  * it would not be reliable due to memory alignment constraints
  */
-static inline uint8_t *
+static 
+inline uint8_t *
 getPoint_internal(const POINTARRAY *pa, uint32_t n)
 {
 	size_t size;


### PR DESCRIPTION
This PR provides a MEOS implementation of the clipping algorithms for a temporal geometric point with respect to a geometry composed of (collections of) points, lines, and polygons with holes and islands in the holes (recursively). In other words, circular strings (and geometries derived from them) and polyhedral surfaces are not supported. Achieving this required to implement robust computational geometry algorithms that are expensive to compute in GEOS. An in-memory R-tree index is used to avoid computing the intersection of all trajectory segments with all geometry edges. 

I tested this with one day of AIS data and a set of geometries representing protected natural areas in the waters around Denmark. Although there are regressions that must still be solved, I wanted to discuss the approach to see whether other performance gains can be achieved.

```sql
tcbuffer=# SELECT COUNT(*) FROM VesselTrip;
 count
-------
  2111
(1 row)

tcbuffer=# SELECT COUNT(*) FROM NaturalAreas;
 count
-------
   283
(1 row)

tcbuffer=# SELECT MIN(numInstants(Trip)),  MAX(numInstants(Trip)), AVG(numInstants(Trip)) FROM VesselTrip;
 min |  max  |          avg
-----+-------+-----------------------
   1 | 27006 | 2158.0672666982472762
(1 row)

tcbuffer=# SELECT MIN(ST_NPoints(Geom)),  MAX(ST_NPoints(Geom)), AVG(ST_NPoints(Geom)) FROM NaturalAreas;
 min |  max  |          avg
-----+-------+-----------------------
   4 | 67907 | 6970.7915194346289753
(1 row)
```

Comparing with the current implementation in master with this PR shows the performance gain.

```sql
-- This PR
tcbuffer=# SELECT COUNT(*) FROM VesselTrip t1, NaturalAreas t2 WHERE atGeometry(Trip, geom) IS NOT NULL;
 count
-------
  1095
(1 row)

Time: 244175.800 ms (04:04.176)

-- Current implementation in master
tcbuffer=# SELECT COUNT(*) FROM VesselTrip t1, NaturalAreas t2 WHERE atGeometry(Trip, geom) IS NOT NULL;
 count
-------
   877
(1 row)

Time: 844088.568 ms (14:04.089)
```