### PR TITLE
Change rtree API

### DIFF
--- a/meos/examples/rtree_example.c
+++ b/meos/examples/rtree_example.c
@@ -79,8 +79,9 @@ verify_search(const char *name, const RTree *rtree, const void *query,
 {
   /* Index search */
   clock_t t = clock();
-  int index_count;
-  int *ids = rtree_search(rtree, RTREE_OVERLAPS, query, &index_count);
+  int *ids = malloc(sizeof(int) * NO_BBOX);
+  memset(ids, 0, sizeof(int) * NO_BBOX);
+  int index_count = rtree_search(rtree, RTREE_OVERLAPS, query, &ids);
   double index_time = (double)(clock() - t) / CLOCKS_PER_SEC;
 
   /* Brute-force search */
@@ -109,8 +110,8 @@ verify_search(const char *name, const RTree *rtree, const void *query,
       errors++;
   }
 
-  printf("  %-10s  index: %.6fs (%d hits)  brute: %.6fs (%d hits)  %s\n",
-    name, index_time, index_count, brute_time, brute_count,
+  printf("  %-10s  index: %.6fs (%d hits)  brute: %.6fs (%d hits) ratio: %.6f %s\n",
+    name, index_time, index_count, brute_time, brute_count, index_time / brute_time,
     errors == 0 ? "OK" : "MISMATCH");
 
   free(actual);

--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -286,8 +286,8 @@ extern RTree *rtree_create_stbox();
 extern void rtree_free(RTree *rtree);
 extern void rtree_insert(RTree *rtree, void *box, int id);
 extern void rtree_insert_temporal(RTree *rtree, const Temporal *temp, int id);
-extern int *rtree_search(const RTree *rtree, RTreeSearchOp op, const void *query, int *count);
-extern int *rtree_search_temporal(const RTree *rtree, RTreeSearchOp op, const Temporal *temp, int *count);
+extern int rtree_search(const RTree *rtree, RTreeSearchOp op, const void *query, int **ids);
+extern int rtree_search_temporal(const RTree *rtree, RTreeSearchOp op, const Temporal *temp, int **ids);
 
 /*****************************************************************************
  * Error codes

--- a/meos/include/temporal/temporal_rtree.h
+++ b/meos/include/temporal/temporal_rtree.h
@@ -85,8 +85,9 @@ typedef struct RTreeNode
 struct RTree
 {
   size_t bboxsize;       /**< Size of the bouding box */
+  int count;             /**< Number of dimensions of the tree */
+  int dims;              /**< Number of dimensions of the tree */
   meosType bboxtype;     /**< Type of the bouding box */
-  int dims;
   RTreeNode *root;
   double (*get_axis)(const void *, int, bool);
   void (*bbox_expand)(const void *, void *);

--- a/meos/include/temporal/temporal_rtree.h
+++ b/meos/include/temporal/temporal_rtree.h
@@ -85,7 +85,7 @@ typedef struct RTreeNode
 struct RTree
 {
   size_t bboxsize;       /**< Size of the bouding box */
-  int count;             /**< Number of dimensions of the tree */
+  int count;             /**< Number of boxes in the tree */
   int dims;              /**< Number of dimensions of the tree */
   meosType bboxtype;     /**< Type of the bouding box */
   RTreeNode *root;

--- a/meos/src/temporal/meos_catalog.c
+++ b/meos/src/temporal/meos_catalog.c
@@ -928,7 +928,7 @@ span_canon_basetype(meosType type)
 /**
  * @brief Return true if the type is a span type
  */
-bool
+inline bool
 span_type(meosType type)
 {
   return (type == T_TSTZSPAN || type == T_DATESPAN || type == T_INTSPAN ||

--- a/meos/src/temporal/temporal_boxops.c
+++ b/meos/src/temporal/temporal_boxops.c
@@ -69,7 +69,7 @@
 bool
 bbox_type(meosType bboxtype)
 {
-  if (bboxtype == T_TSTZSPAN || bboxtype == T_TBOX || bboxtype == T_STBOX)
+  if (span_type(bboxtype) || bboxtype == T_TBOX || bboxtype == T_STBOX)
     return true;
   return false;
 }

--- a/meos/src/temporal/temporal_rtree.c
+++ b/meos/src/temporal/temporal_rtree.c
@@ -656,17 +656,6 @@ node_insert(RTree *rtree, void *node_bounding_box, RTreeNode *node,
 }
 
 /**
- * @brief Returns `true` if a number greater than 0 is a power of two, `false`
- * otherwise
- * @param[in] n Number to check
- */
-static inline bool
-is_power_of_two(const int n)
-{
-  return (n & (n - 1)) == 0;
-}
-
-/**
  * @brief Adds an ID to the dynamically allocated array with the answer of a
  * query
  * @param[in] id The integer ID to be added to the array
@@ -678,10 +667,6 @@ is_power_of_two(const int n)
 static void
 add_answer(const int id, int **ids, int *count)
 {
-  // /* Every power of two that exceeds the size of the array must be resized to
-   // * double the current size */
-  // if (*count >= SEARCH_ARRAY_STARTING_SIZE && is_power_of_two(*count))
-    // *ids = repalloc(*ids, sizeof(int) * (*count) * 2);
   (*ids)[*count] = id;
   (*count)++;
   return;
@@ -911,6 +896,7 @@ rtree_create_stbox()
 void
 rtree_insert(RTree *rtree, void *box, int id)
 {
+  rtree->count++;
   while (1)
   {
     if (! rtree->root)

--- a/meos/src/temporal/temporal_rtree.c
+++ b/meos/src/temporal/temporal_rtree.c
@@ -678,10 +678,10 @@ is_power_of_two(const int n)
 static void
 add_answer(const int id, int **ids, int *count)
 {
-  /* Every power of two that exceeds the size of the array must be resized to
-   * double the current size */
-  if (*count >= SEARCH_ARRAY_STARTING_SIZE && is_power_of_two(*count))
-    *ids = repalloc(*ids, sizeof(int) * (*count) * 2);
+  // /* Every power of two that exceeds the size of the array must be resized to
+   // * double the current size */
+  // if (*count >= SEARCH_ARRAY_STARTING_SIZE && is_power_of_two(*count))
+    // *ids = repalloc(*ids, sizeof(int) * (*count) * 2);
   (*ids)[*count] = id;
   (*count)++;
   return;
@@ -761,6 +761,29 @@ node_search(const RTree *rtree, const RTreeNode *node, RTreeSearchOp op,
     }
   }
   return;
+}
+
+/**
+ * @ingroup meos_geo_box_index
+ * @brief Queries an RTree with a bounding box. Returns an array of ids of
+ * bounding boxes.
+ * @param[in] rtree The RTree to query
+ * @param[in] op The search operation: @p RTREE_OVERLAPS finds boxes that
+ * overlap the query, @p RTREE_CONTAINS finds boxes that contain the query,
+ * @p RTREE_CONTAINED_BY finds boxes contained by the query
+ * @param[in] query The bounding box that serves as query
+ * @param[in] ids Array of ids that have a hit
+ * @return The number of hits the RTree found
+ * @note The `count` will be the output size of the array given.
+ */
+int
+rtree_search(const RTree *rtree, RTreeSearchOp op, const void *query,
+  int **ids)
+{
+  int result = 0;
+  if (rtree->root)
+    node_search(rtree, rtree->root, op, query, ids, &result);
+  return result;
 }
 
 /**
@@ -920,30 +943,6 @@ rtree_insert(RTree *rtree, void *box, int id)
 }
 
 /**
- * @ingroup meos_geo_box_index
- * @brief Queries an RTree with a bounding box. Returns an array of ids of
- * bounding boxes.
- * @param[in] rtree The RTree to query
- * @param[in] op The search operation: @p RTREE_OVERLAPS finds boxes that
- * overlap the query, @p RTREE_CONTAINS finds boxes that contain the query,
- * @p RTREE_CONTAINED_BY finds boxes contained by the query
- * @param[in] query The bounding box that serves as query
- * @param[out] count The number of hits the RTree found
- * @return Array of ids that have a hit.
- * @note The `count` will be the output size of the array given.
- */
-int *
-rtree_search(const RTree *rtree, RTreeSearchOp op, const void *query,
-  int *count)
-{
-  int *ids = palloc(sizeof(int) * SEARCH_ARRAY_STARTING_SIZE);
-  *count = 0;
-  if (rtree->root)
-    node_search(rtree, rtree->root, op, query, &ids, count);
-  return ids;
-}
-
-/**
  * @brief Return true if the RTree's bounding box type is compatible with the
  * temporal type, report an error otherwise
  * @param[in] rtree Pointer to the RTree structure
@@ -1000,23 +999,21 @@ rtree_insert_temporal(RTree *rtree, const Temporal *temp, int id)
  * @param[in] rtree The RTree to query
  * @param[in] op The search operation
  * @param[in] temp The temporal value whose bounding box serves as query
- * @param[out] count The number of hits the RTree found
+ * @param[in] ids Integer array where the ids of an R-tree search are stored
  * @return Array of ids that have a hit.
  */
-int *
+int
 rtree_search_temporal(const RTree *rtree, RTreeSearchOp op,
-  const Temporal *temp, int *count)
+  const Temporal *temp, int **ids)
 {
   if (! ensure_rtree_temporal_compatible(rtree, temp))
-  {
-    *count = 0;
-    return NULL;
-  }
+    return 0;
+
   /* Use a stack buffer large enough for any MEOS bounding box type */
   char buf[sizeof(STBox)];
   memset(buf, 0, sizeof(buf));
   temporal_set_bbox(temp, buf);
-  return rtree_search(rtree, op, buf, count);
+  return rtree_search(rtree, op, buf, ids);
 }
 
 /**

--- a/meos/test/tbl_temporal_value.c
+++ b/meos/test/tbl_temporal_value.c
@@ -101,11 +101,11 @@ int main(void)
   // FILE *file2 = fopen("csv/tbl_floatset.csv", "r");
   // FILE *file2 = fopen("csv/tbl_floatspan.csv", "r");
   // FILE *file2 = fopen("csv/tbl_floatspanset.csv", "r");
-  FILE *file2 = fopen("csv/tbl_interval.csv", "r");
+  // FILE *file2 = fopen("csv/tbl_interval.csv", "r");
   // FILE *file2 = fopen("csv/tbl_timestamptz.csv", "r");
   // FILE *file2 = fopen("csv/tbl_tstzset.csv", "r");
   // FILE *file2 = fopen("csv/tbl_tstzspan.csv", "r");
-  // FILE *file2 = fopen("csv/tbl_tstzspanset.csv", "r");
+  FILE *file2 = fopen("csv/tbl_geom.csv", "r");
 
   if (! file2)
   {
@@ -180,7 +180,7 @@ int main(void)
       {
 
         /* Transform the string read into a value */
-        Interval *i = interval_in(value_buffer, -1);
+        // Interval *i = interval_in(value_buffer, -1);
         // double d = float_in(value_buffer);
         // Set *t = floatset_in(value_buffer);
         // Span *t = floatspan_in(value_buffer);
@@ -189,22 +189,26 @@ int main(void)
         // Set *s = tstzset_in(value_buffer);
         // Span *s = tstzspan_in(value_buffer);
         // SpanSet *ss = tstzspanset_in(value_buffer);
+        GSERIALIZED *geo = geom_in(value_buffer, -1);
+
+        /******************* Restriction functions *******************/
 
         /* Uncomment the desired function to compute */
         // Temporal *rest = temporal_at_value(temp, t);
         // Temporal *rest = temporal_at_values(temp, t);
         // Temporal *rest = tnumber_at_span(temp, t);
         // Temporal *rest = tnumber_at_spanset(temp, t);
-       // Temporal *rest = temporal_at_timestamptz(temp, t);
+        // Temporal *rest = temporal_at_timestamptz(temp, t);
         // Temporal *rest = temporal_at_tstzset(temp, t);
         // Temporal *rest = temporal_at_tstzspan(temp, t);
         // Temporal *rest = temporal_at_tstzspanset(temp, t);
+        Temporal *rest = tpoint_at_geom(temp, geo);
 
         /******************* Reduction functions *******************/
 
-        TimestampTz origin = timestamptz_in("2000-01-03", -1);
+        // TimestampTz origin = timestamptz_in("2000-01-03", -1);
         // Temporal *rest = temporal_tprecision(temp, i, origin);
-        Temporal *rest = temporal_tsample(temp, i, origin, "Step");
+        // Temporal *rest = temporal_tsample(temp, i, origin, "Step");
 
         /******************* Modification functions *******************/
 
@@ -223,7 +227,7 @@ int main(void)
           nrows++;
         }
         /* Free value, uncomment as necessary */
-        free(i); 
+        free(geo); 
       }
     } while (! feof(file2));
     free(temp);


### PR DESCRIPTION
This PR changes the API of the MEOS rtree implementation. In the previous API the following function
```c
extern int *rtree_search(const RTree *rtree, RTreeSearchOp op, const void *query, int *count);
```
performed an `malloc` to create the integer array holding the results of the search. In the new version of the function
```c
extern int rtree_search(const RTree *rtree, RTreeSearchOp op, const void *query, int **ids);
```
the caller is responsible to pass to the search function in the last argument a buffer array on which the results of the search are written.

This enhances the performance of the rtree by comparing at a high-level viewpoint the previous usage of the function
```
<create the rtree for N boxes>
loop
  <input a value to search>
  int count;
  int *ids = rtree_search(rtree, op, bbox(value), &count);
  <process the input value>
  free(ids);
end loop
```
with the current one
```
<create the rtree for N boxes>
int *ids = malloc(sizeof(int) * N);
loop
  <input a value to search>
  int count = rtree_search(rtree, op, bbox(value), &ids);
  <process the input value>
end loop
free(ids)
```



  
  
