### PR TITLE
Make MeosArray a public API in meos.h

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -260,6 +260,24 @@ typedef struct SkipList SkipList;
 /*****************************************************************************/
 
 /**
+ * Structure for expandable arrays
+ */
+typedef struct MeosArray MeosArray;
+
+/* MeosArray functions */
+
+extern MeosArray *meos_array_create(int elem_size);
+extern void meos_array_add(MeosArray *array, void *value);
+extern void *meos_array_get(const MeosArray *array, int n);
+extern int meos_array_count(const MeosArray *array);
+extern void meos_array_reset(MeosArray *array);
+extern void meos_array_reset_free(MeosArray *array);
+extern void meos_array_destroy(MeosArray *array);
+extern void meos_array_destroy_free(MeosArray *array);
+
+/*****************************************************************************/
+
+/**
  * @brief Enumeration that defines the search operations for an RTree.
  */
 typedef enum

--- a/meos/include/meos_internal.h
+++ b/meos/include/meos_internal.h
@@ -694,11 +694,6 @@ typedef struct MeosArray
   void *elems;      /**< Pointer to the array elements */
 } MeosArray;
 
-extern MeosArray *meos_array_init(int elem_size);
-extern void meos_array_add(MeosArray *array, void *value);
-extern void *meos_array_get_n(const MeosArray *array, int n);
-extern void meos_array_reset(MeosArray *array, bool free_elems);
-extern void meos_array_destroy(MeosArray *array, bool free_elems);
 
 /*****************************************************************************/
 

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -4207,7 +4207,7 @@ lwgeom_collect_points(const LWGEOM *geom, MeosArray *array)
 static Circle
 lwgeom_mec(const LWGEOM *geom)
 {
-  MeosArray *array = meos_array_init(sizeof(POINT2D));
+  MeosArray *array = meos_array_create(sizeof(POINT2D));
   lwgeom_collect_points(geom, array);
   /* Ensure that there is at least one point given the precondition */
   assert(array->count > 0);
@@ -4223,7 +4223,7 @@ lwgeom_mec(const LWGEOM *geom)
     pts[j] = tmp;
   }
   Circle result = mec_welzl(pts, array->count);
-  meos_array_destroy(array, false);
+  meos_array_destroy(array);
   return result;
 }
 

--- a/meos/src/geo/tspatial_parser.c
+++ b/meos/src/geo/tspatial_parser.c
@@ -403,7 +403,7 @@ tspatialinst_parse(const char **str, meosType temptype, bool end,
 TSequence *
 tspatialseq_disc_parse(const char **str, meosType temptype, int *temp_srid)
 {
-  MeosArray *array = meos_array_init(meostype_length(temptype));
+  MeosArray *array = meos_array_create(meostype_length(temptype));
   const char *type_str = meostype_name(temptype);
   TSequence *result = NULL;
 
@@ -430,14 +430,14 @@ tspatialseq_disc_parse(const char **str, meosType temptype, int *temp_srid)
   /* Create the array of instants now with the actual size */
   TInstant **instants = palloc(sizeof(TInstant *) * array->count);
   for (int i = 0; i < (int) array->count; i++)
-    instants[i] = (TInstant *) meos_array_get_n(array, i);
+    instants[i] = (TInstant *) meos_array_get(array, i);
   p_cbrace(str);
   result = tsequence_make(instants, array->count, true, true, DISCRETE,
     NORMALIZE_NO);
   pfree(instants);
 
 error:
-  meos_array_destroy(array, true);
+  meos_array_destroy_free(array);
   return result;
 }
 
@@ -455,7 +455,7 @@ TSequence *
 tspatialseq_cont_parse(const char **str, meosType temptype, interpType interp, 
   bool end, int *temp_srid)
 {
-  MeosArray *array = meos_array_init(meostype_length(temptype));
+  MeosArray *array = meos_array_create(meostype_length(temptype));
   const char *type_str = meostype_name(temptype);
   TSequence *result = NULL;
 
@@ -498,7 +498,7 @@ tspatialseq_cont_parse(const char **str, meosType temptype, interpType interp,
   /* Create the array of instants now with the actual size */
   TInstant **instants = palloc(sizeof(TInstant *) * array->count);
   for (int i = 0; i < (int) array->count; i++)
-    instants[i] = (TInstant *) meos_array_get_n(array, i);
+    instants[i] = (TInstant *) meos_array_get(array, i);
   p_cbracket(str);
   p_cparen(str);
   result = tsequence_make(instants, array->count, lower_inc, upper_inc,
@@ -506,7 +506,7 @@ tspatialseq_cont_parse(const char **str, meosType temptype, interpType interp,
   pfree(instants);
 
 error:
-  meos_array_destroy(array, true);
+  meos_array_destroy_free(array);
   return result;
 }
 
@@ -521,7 +521,7 @@ TSequenceSet *
 tspatialseqset_parse(const char **str, meosType temptype, interpType interp,
   int *temp_srid)
 {
-  MeosArray *array = meos_array_init(meostype_length(temptype));
+  MeosArray *array = meos_array_create(meostype_length(temptype));
   const char *type_str = meostype_name(temptype);
   TSequenceSet *result = NULL;
 
@@ -549,13 +549,13 @@ tspatialseqset_parse(const char **str, meosType temptype, interpType interp,
   /* Create the array of sequences now with the actual size */
   TSequence **sequences = palloc(sizeof(TSequence *) * array->count);
   for (int i = 0; i < (int) array->count; i++)
-    sequences[i] = (TSequence *) meos_array_get_n(array, i);
+    sequences[i] = (TSequence *) meos_array_get(array, i);
   p_cbrace(str);
   result = tsequenceset_make(sequences, array->count, NORMALIZE);
   pfree(sequences);
 
 error:
-  meos_array_destroy(array, true);
+  meos_array_destroy_free(array);
   return result;
 }
 

--- a/meos/src/rgeo/trgeo_parser.c
+++ b/meos/src/rgeo/trgeo_parser.c
@@ -92,7 +92,7 @@ TSequence *
 trgeoseq_disc_parse(const char **str, meosType temptype, int *temp_srid,
   GSERIALIZED *geom)
 {
-  MeosArray *array = meos_array_init(meostype_length(temptype));
+  MeosArray *array = meos_array_create(meostype_length(temptype));
   const char *type_str = meostype_name(temptype);
   TSequence *result = NULL;
 
@@ -117,13 +117,13 @@ trgeoseq_disc_parse(const char **str, meosType temptype, int *temp_srid,
   /* Create the array of instants now with the actual size */
   TInstant **instants = palloc(sizeof(TInstant *) * array->count);
   for (int i = 0; i < (int) array->count; i++)
-    instants[i] = (TInstant *) meos_array_get_n(array, i);
+    instants[i] = (TInstant *) meos_array_get(array, i);
   result = trgeoseq_make_free(geom, instants, array->count, true, true,
     DISCRETE, NORMALIZE_NO);
   pfree(instants);
 
 error:
-  meos_array_destroy(array, true);
+  meos_array_destroy_free(array);
   return result;
 }
 
@@ -142,7 +142,7 @@ TSequence *
 trgeoseq_cont_parse(const char **str, meosType temptype, interpType interp, 
   bool end, int *temp_srid, const GSERIALIZED *geom)
 {
-  MeosArray *array = meos_array_init(meostype_length(temptype));
+  MeosArray *array = meos_array_create(meostype_length(temptype));
   const char *type_str = meostype_name(temptype);
   TSequence *result = NULL;
 
@@ -185,7 +185,7 @@ trgeoseq_cont_parse(const char **str, meosType temptype, interpType interp,
   /* Create the array of instants now with the actual size */
   TInstant **instants = palloc(sizeof(TInstant *) * array->count);
   for (int i = 0; i < (int) array->count; i++)
-    instants[i] = (TInstant *) meos_array_get_n(array, i);
+    instants[i] = (TInstant *) meos_array_get(array, i);
   p_cbracket(str);
   p_cparen(str);
   result = trgeoseq_make_free(geom, instants, array->count, lower_inc,
@@ -193,7 +193,7 @@ trgeoseq_cont_parse(const char **str, meosType temptype, interpType interp,
   pfree(instants);
 
 error:
-  meos_array_destroy(array, true);
+  meos_array_destroy_free(array);
   return result;
 }
 
@@ -209,7 +209,7 @@ TSequenceSet *
 trgeoseqset_parse(const char **str, meosType temptype, interpType interp,
   int *temp_srid, const GSERIALIZED *geom)
 {
-  MeosArray *array = meos_array_init(meostype_length(temptype));
+  MeosArray *array = meos_array_create(meostype_length(temptype));
   const char *type_str = meostype_name(temptype);
   TSequenceSet *result = NULL;
 
@@ -236,13 +236,13 @@ trgeoseqset_parse(const char **str, meosType temptype, interpType interp,
   /* Create the array of sequences now with the actual size */
   TSequence **sequences = palloc(sizeof(TSequence *) * array->count);
   for (int i = 0; i < (int) array->count; i++)
-    sequences[i] = (TSequence *) meos_array_get_n(array, i);
+    sequences[i] = (TSequence *) meos_array_get(array, i);
   p_cbrace(str);
   result = trgeoseqset_make_free(geom, sequences, array->count, NORMALIZE);
   pfree(sequences);
 
 error:
-  meos_array_destroy(array, true);
+  meos_array_destroy_free(array);
   return result;
 }
 

--- a/meos/src/temporal/meos_array.c
+++ b/meos/src/temporal/meos_array.c
@@ -29,7 +29,7 @@
 
 /**
  * @file
- * @brief Functions for expandable Datum arrays.
+ * @brief Functions for expandable arrays.
  */
 
 
@@ -38,15 +38,56 @@
 #include <meos_internal.h>
 #include "temporal/temporal.h"
 
-/*****************************************************************************/
+/*****************************************************************************
+ * Helper functions
+ *****************************************************************************/
 
 /**
- * @brief Initialize an expandable array that keeps the elements parsed so far
- * @details The array is initialized with a fix number of elements but it
- * expands when adding elements and the array is full
+ * @brief Get the address of the n-th slot of the array
+ */
+static inline void *
+array_slot(const MeosArray *array, int n)
+{
+  return (char *) array->elems + ((size_t)n * array->elem_size);
+}
+
+/**
+ * @brief Reset the array
+ * @param[in] array Array
+ * @param[in] free_elems If true and the array is varlength, pfree each stored
+ * pointer before resetting
+ */
+static void
+meos_array_reset_int(MeosArray *array, bool free_elems)
+{
+  if (! array)
+    return;
+  if (free_elems && array->varlength)
+  {
+    for (size_t i = 0; i < array->count; i++)
+      pfree(meos_array_get(array, (int) i));
+  }
+  array->count = 0;
+}
+
+/*****************************************************************************
+ * Public functions
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_misc
+ * @brief Create an expandable array
+ * @details The array is initialized with a fixed number of elements but
+ * expands automatically when full. Use a positive @p elem_size for
+ * fixed-size elements (e.g., `sizeof(int)`), or a negative value to store
+ * variable-length pointers (the array stores the pointers, not the data
+ * they point to).
+ * @param[in] elem_size Size of a single element in bytes, or negative for
+ * variable-length pointer storage
+ * @return New array on success, NULL on error
  */
 MeosArray *
-meos_array_init(int elem_size)
+meos_array_create(int elem_size)
 {
   MeosArray *array = (MeosArray *) palloc0(sizeof(MeosArray));
   if (! array)
@@ -68,16 +109,47 @@ meos_array_init(int elem_size)
 }
 
 /**
- * @brief Get the address of the n-th slot of the array
+ * @ingroup meos_misc
+ * @brief Destroy the array, freeing its internal storage
+ * @details For varlength arrays, the caller is responsible for freeing the
+ * stored pointers before calling this function. Use #meos_array_destroy_free
+ * to have the array free the stored pointers automatically.
+ * @param[in] array Array
  */
-static inline void *
-array_slot(const MeosArray *array, int n)
+void
+meos_array_destroy(MeosArray *array)
 {
-  return (char *) array->elems + ((size_t)n * array->elem_size);
+  if (! array)
+    return;
+  pfree(array->elems);
+  pfree(array);
 }
 
 /**
+ * @ingroup meos_misc
+ * @brief Destroy a varlength array, freeing both the stored pointers and the
+ * internal storage
+ * @details This is equivalent to calling #meos_array_reset_free followed by
+ * #meos_array_destroy. For fixed-size arrays, this is identical to
+ * #meos_array_destroy.
+ * @param[in] array Array
+ */
+void
+meos_array_destroy_free(MeosArray *array)
+{
+  if (! array)
+    return;
+  meos_array_reset_int(array, true);
+  pfree(array->elems);
+  pfree(array);
+}
+
+/**
+ * @ingroup meos_misc
  * @brief Add a value to the array
+ * @param[in] array Array
+ * @param[in] value Pointer to the value to add. For fixed-size arrays, the
+ * value is copied. For varlength arrays, the pointer itself is stored.
  */
 void
 meos_array_add(MeosArray *array, void *value)
@@ -106,12 +178,15 @@ meos_array_add(MeosArray *array, void *value)
 }
 
 /**
+ * @ingroup meos_misc
  * @brief Get the n-th element of the array (0-based)
- * @return For varlength arrays, the stored pointer; for fixed-size arrays,
- * a pointer to the element in the internal buffer
+ * @param[in] array Array
+ * @param[in] n Index
+ * @return For fixed-size arrays, a pointer to the element in the internal
+ * buffer. For varlength arrays, the stored pointer. NULL on error.
  */
 void *
-meos_array_get_n(const MeosArray *array, int n)
+meos_array_get(const MeosArray *array, int n)
 {
   assert(array);
   if (n < 0 || (size_t) n >= array->count)
@@ -127,36 +202,43 @@ meos_array_get_n(const MeosArray *array, int n)
 }
 
 /**
- * @brief Reset the array
- * @param[in] free_elems If true and the array is varlength, pfree each stored
- * pointer before resetting
+ * @ingroup meos_misc
+ * @brief Return the number of elements in the array
+ * @param[in] array Array
+ * @return Number of elements
  */
-void
-meos_array_reset(MeosArray *array, bool free_elems)
+int
+meos_array_count(const MeosArray *array)
 {
-  if (! array)
-    return;
-  if (free_elems && array->varlength)
-  {
-    for (size_t i = 0; i < array->count; i++)
-      pfree(meos_array_get_n(array, i));
-  }
-  array->count = 0;
+  assert(array);
+  return (int) array->count;
 }
 
 /**
- * @brief Destroy the array
- * @param[in] free_elems If true and the array is varlength, pfree each stored
- * pointer before freeing the array
+ * @ingroup meos_misc
+ * @brief Reset the array, keeping the allocated memory for reuse
+ * @details For varlength arrays, the caller is responsible for freeing the
+ * stored pointers before calling this function. Use #meos_array_reset_free
+ * to have the array free the stored pointers automatically.
+ * @param[in] array Array
  */
 void
-meos_array_destroy(MeosArray *array, bool free_elems)
+meos_array_reset(MeosArray *array)
 {
-  if (! array)
-    return;
-  meos_array_reset(array, free_elems);
-  pfree(array->elems);
-  pfree(array);
+  meos_array_reset_int(array, false);
+}
+
+/**
+ * @ingroup meos_misc
+ * @brief Reset a varlength array, freeing the stored pointers and keeping
+ * the allocated memory for reuse
+ * @details For fixed-size arrays, this is identical to #meos_array_reset.
+ * @param[in] array Array
+ */
+void
+meos_array_reset_free(MeosArray *array)
+{
+  meos_array_reset_int(array, true);
 }
 
 /*****************************************************************************/

--- a/meos/src/temporal/type_parser.c
+++ b/meos/src/temporal/type_parser.c
@@ -493,7 +493,7 @@ Set *
 set_parse(const char **str, meosType settype)
 {
   meosType basetype = settype_basetype(settype);
-  MeosArray *array = meos_array_init(sizeof(Datum));
+  MeosArray *array = meos_array_create(sizeof(Datum));
   const char *type_str = meostype_name(settype);
   Set *result = NULL;
 
@@ -526,7 +526,7 @@ set_parse(const char **str, meosType settype)
   p_obrace(str);
   Datum *values = palloc(sizeof(Datum) * array->count);
   for (int i = 0; i < (int) array->count; i++)
-    values[i] = *(Datum *) meos_array_get_n(array, i);
+    values[i] = *(Datum *) meos_array_get(array, i);
   p_cbrace(str);
   if (set_srid != SRID_UNKNOWN)
   {
@@ -537,7 +537,7 @@ set_parse(const char **str, meosType settype)
   pfree(values);
 
 error:
-  meos_array_destroy(array, false);
+  meos_array_destroy(array);
   return result;
 }
 
@@ -623,7 +623,7 @@ spanset_parse(const char **str, meosType spansettype)
   meosType spantype = spansettype_spantype(spansettype);
 
   /* Parsing */
-  MeosArray *array = meos_array_init(meostype_length(spantype));
+  MeosArray *array = meos_array_create(meostype_length(spantype));
   Span s;
   bool found = span_parse(str, spantype, false, &s);
   if (! found)
@@ -641,11 +641,11 @@ spanset_parse(const char **str, meosType spansettype)
 
   SpanSet *result = spanset_make_exp((Span *) array->elems, array->count,
     array->count, true, true);
-  meos_array_destroy(array, false);
+  meos_array_destroy(array);
   return result;
 
 error:
-  meos_array_destroy(array, false);
+  meos_array_destroy(array);
   return NULL;
 }
 
@@ -692,7 +692,7 @@ tinstant_parse(const char **str, meosType temptype, bool end)
 TSequence *
 tdiscseq_parse(const char **str, meosType temptype)
 {
-  MeosArray *array = meos_array_init(meostype_length(temptype));
+  MeosArray *array = meos_array_create(meostype_length(temptype));
   const char *type_str = meostype_name(temptype);
   TSequence *result = NULL;
 
@@ -720,13 +720,13 @@ tdiscseq_parse(const char **str, meosType temptype)
   /* Create the array of instants now with the actual size */
   TInstant **instants = palloc(sizeof(TInstant *) * array->count);
   for (size_t i = 0; i < array->count; i++)
-    instants[i] = (TInstant *) meos_array_get_n(array, i);
+    instants[i] = (TInstant *) meos_array_get(array, i);
   result = tsequence_make(instants, array->count, true, true, DISCRETE,
     NORMALIZE_NO);
   pfree(instants);
 
 error:
-  meos_array_destroy(array, true);
+  meos_array_destroy_free(array);
   return result;
 }
 
@@ -744,7 +744,7 @@ TSequence *
 tcontseq_parse(const char **str, meosType temptype, interpType interp,
   bool end)
 {
-  MeosArray *array = meos_array_init(meostype_length(temptype));
+  MeosArray *array = meos_array_create(meostype_length(temptype));
   TSequence *result = NULL;
 
   /* Parsing */
@@ -787,13 +787,13 @@ tcontseq_parse(const char **str, meosType temptype, interpType interp,
   /* Create the array of instants now with the actual size */
   TInstant **instants = palloc(sizeof(TInstant *) * array->count);
   for (size_t i = 0; i < array->count; i++)
-    instants[i] = (TInstant *) meos_array_get_n(array, i);
+    instants[i] = (TInstant *) meos_array_get(array, i);
   result = tsequence_make(instants, array->count, lower_inc, upper_inc, interp,
     NORMALIZE);
   pfree(instants);
 
 error:
-  meos_array_destroy(array, true);
+  meos_array_destroy_free(array);
   return result;
 }
 
@@ -807,7 +807,7 @@ error:
 TSequenceSet *
 tsequenceset_parse(const char **str, meosType temptype, interpType interp)
 {
-  MeosArray *array = meos_array_init(meostype_length(temptype));
+  MeosArray *array = meos_array_create(meostype_length(temptype));
   const char *type_str = meostype_name(temptype);
   TSequenceSet *result = NULL;
 
@@ -834,12 +834,12 @@ tsequenceset_parse(const char **str, meosType temptype, interpType interp)
   /* Create the array of sequences now with the actual size */
   TSequence **sequences = palloc(sizeof(TSequence *) * array->count);
   for (size_t i = 0; i < array->count; i++)
-    sequences[i] = (TSequence *) meos_array_get_n(array, i);
+    sequences[i] = (TSequence *) meos_array_get(array, i);
   result = tsequenceset_make(sequences, array->count, NORMALIZE);
   pfree(sequences);
 
 error:
-  meos_array_destroy(array, true);
+  meos_array_destroy_free(array);
   return result;
 }
 


### PR DESCRIPTION
- Move MeosArray function declarations from meos_internal.h to meos.h as an opaque type (struct definition stays internal).
- Rename for consistency: meos_array_init -> meos_array_create, meos_array_get_n -> meos_array_get.
- Add meos_array_count accessor.
- Split destroy/reset into plain and _free variants instead of a boolean parameter.