### PR TITLE
Use MeosArray in rtree_search API

### DIFF
--- a/meos/examples/rtree_example.c
+++ b/meos/examples/rtree_example.c
@@ -79,8 +79,8 @@ verify_search(const char *name, const RTree *rtree, const void *query,
 {
   /* Index search */
   clock_t t = clock();
-  int index_count;
-  int *ids = rtree_search(rtree, RTREE_OVERLAPS, query, &index_count);
+  MeosArray *ids = meos_array_create(sizeof(int));
+  int index_count = rtree_search(rtree, RTREE_OVERLAPS, query, ids);
   double index_time = (double)(clock() - t) / CLOCKS_PER_SEC;
 
   /* Brute-force search */
@@ -100,7 +100,10 @@ verify_search(const char *name, const RTree *rtree, const void *query,
   /* Compare results */
   bool *indexed = calloc(NO_BBOX, sizeof(bool));
   for (int i = 0; i < index_count; i++)
-    indexed[ids[i]] = true;
+  {
+    int id = *(int *) meos_array_get(ids, i);
+    indexed[id] = true;
+  }
 
   int errors = 0;
   for (int i = 0; i < NO_BBOX; i++)
@@ -109,13 +112,13 @@ verify_search(const char *name, const RTree *rtree, const void *query,
       errors++;
   }
 
-  printf("  %-10s  index: %.6fs (%d hits)  brute: %.6fs (%d hits)  %s\n",
-    name, index_time, index_count, brute_time, brute_count,
+  printf("  %-10s  index: %.6fs (%d hits)  brute: %.6fs (%d hits) ratio: %.6f %s\n",
+    name, index_time, index_count, brute_time, brute_count, index_time / brute_time,
     errors == 0 ? "OK" : "MISMATCH");
 
   free(actual);
   free(indexed);
-  free(ids);
+  meos_array_destroy(ids);
 }
 
 /*****************************************************************************/

--- a/meos/examples/rtree_example.c
+++ b/meos/examples/rtree_example.c
@@ -177,18 +177,22 @@ test_tstzspan(MeosArray *ids)
 
   for (int i = 0; i < NO_BBOX; i++)
   {
-    int tmin = random_int(1, 29);
-    int tmax = tmin + random_int(1, 29);
+    int tmin = random_int(0, 999);
+    int tmax = tmin + random_int(1, 10);
+    int tmin_h = tmin / 60, tmin_m = tmin % 60;
+    int tmax_h = tmax / 60, tmax_m = tmax % 60;
     snprintf(str, sizeof(str),
-      "[2023-01-01 01:00:%02d+00, 2023-01-01 01:00:%02d+00]", tmin, tmax);
+      "[2020-01-01 %02d:%02d:00+00, 2020-01-01 %02d:%02d:00+00]",
+      tmin_h, tmin_m, tmax_h, tmax_m);
     Span *s = tstzspan_in(str);
     boxes[i] = *s;
     rtree_insert(rtree, &boxes[i], i);
     free(s);
   }
 
+  /* Query covers ~100/1000 = 10% of the time range */
   Span *query = tstzspan_in(
-    "[2023-01-01 01:00:00+00, 2023-01-01 01:00:60+00]");
+    "[2020-01-01 00:00:00+00, 2020-01-01 01:40:00+00]");
   verify_search("TSTZSPAN", rtree, query, (char *) boxes, sizeof(Span), ids,
     overlaps_span_wrapper);
 
@@ -208,11 +212,14 @@ test_tbox(MeosArray *ids)
   {
     int xmin = random_int(1, 1000);
     int xmax = xmin + random_int(1, 10);
-    int tmin = random_int(1, 29);
-    int tmax = tmin + random_int(1, 29);
+    int tmin = random_int(0, 999);
+    int tmax = tmin + random_int(1, 10);
+    int tmin_h = tmin / 60, tmin_m = tmin % 60;
+    int tmax_h = tmax / 60, tmax_m = tmax % 60;
     snprintf(str, sizeof(str),
-      "TBOX XT([%d, %d],[2023-01-01 01:00:%02d+00, 2023-01-01 01:00:%02d+00])",
-      xmin, xmax, tmin, tmax);
+      "TBOX XT([%d, %d],"
+      "[2020-01-01 %02d:%02d:00+00, 2020-01-01 %02d:%02d:00+00])",
+      xmin, xmax, tmin_h, tmin_m, tmax_h, tmax_m);
     TBox *b = tbox_in(str);
     boxes[i] = *b;
     rtree_insert(rtree, &boxes[i], i);
@@ -220,7 +227,7 @@ test_tbox(MeosArray *ids)
   }
 
   TBox *query = tbox_in(
-    "TBOX XT([0,100],[2023-01-01 01:00:00+00, 2023-01-01 01:00:60+00])");
+    "TBOX XT([0,100],[2020-01-01 00:00:00+00, 2020-01-01 01:40:00+00])");
   verify_search("TBOX", rtree, query, (char *) boxes, sizeof(TBox), ids,
     overlaps_tbox_wrapper);
 
@@ -242,12 +249,14 @@ test_stbox(MeosArray *ids)
     int xmax = xmin + random_int(1, 10);
     int ymin = random_int(1, 1000);
     int ymax = ymin + random_int(1, 10);
-    int tmin = random_int(1, 29);
-    int tmax = tmin + random_int(1, 29);
+    int tmin = random_int(0, 999);
+    int tmax = tmin + random_int(1, 10);
+    int tmin_h = tmin / 60, tmin_m = tmin % 60;
+    int tmax_h = tmax / 60, tmax_m = tmax % 60;
     snprintf(str, sizeof(str),
       "SRID=25832;STBOX XT(((%d %d),(%d %d)),"
-      "[2023-01-01 01:00:%02d+00, 2023-01-01 01:00:%02d+00])",
-      xmin, xmax, ymin, ymax, tmin, tmax);
+      "[2020-01-01 %02d:%02d:00+00, 2020-01-01 %02d:%02d:00+00])",
+      xmin, xmax, ymin, ymax, tmin_h, tmin_m, tmax_h, tmax_m);
     STBox *b = stbox_in(str);
     boxes[i] = *b;
     rtree_insert(rtree, &boxes[i], i);
@@ -256,7 +265,7 @@ test_stbox(MeosArray *ids)
 
   STBox *query = stbox_in(
     "SRID=25832;STBOX XT(((0 0),(100 100)),"
-    "[2023-01-01 01:00:00+00, 2023-01-01 01:00:60+00])");
+    "[2020-01-01 00:00:00+00, 2020-01-01 01:40:00+00])");
   verify_search("STBOX", rtree, query, (char *) boxes, sizeof(STBox), ids,
     overlaps_stbox_wrapper);
 

--- a/meos/examples/rtree_example.c
+++ b/meos/examples/rtree_example.c
@@ -74,12 +74,11 @@ random_int(int min, int max)
  */
 static void
 verify_search(const char *name, const RTree *rtree, const void *query,
-  const char *boxes, size_t bboxsize,
+  const char *boxes, size_t bboxsize, MeosArray *ids,
   bool (*overlaps_fn)(const void *, const void *))
 {
-  /* Index search */
+  /* Index search — reuses the caller's MeosArray (reset internally) */
   clock_t t = clock();
-  MeosArray *ids = meos_array_create(sizeof(int));
   int index_count = rtree_search(rtree, RTREE_OVERLAPS, query, ids);
   double index_time = (double)(clock() - t) / CLOCKS_PER_SEC;
 
@@ -118,7 +117,6 @@ verify_search(const char *name, const RTree *rtree, const void *query,
 
   free(actual);
   free(indexed);
-  meos_array_destroy(ids);
 }
 
 /*****************************************************************************/
@@ -144,7 +142,7 @@ overlaps_stbox_wrapper(const void *a, const void *b)
 /*****************************************************************************/
 
 static void
-test_floatspan(void)
+test_floatspan(MeosArray *ids)
 {
   char str[MAX_LEN_BBOX];
   Span *boxes = malloc(sizeof(Span) * NO_BBOX);
@@ -162,7 +160,7 @@ test_floatspan(void)
   }
 
   Span *query = floatspan_in("[0, 100]");
-  verify_search("FLOATSPAN", rtree, query, (char *) boxes, sizeof(Span),
+  verify_search("FLOATSPAN", rtree, query, (char *) boxes, sizeof(Span), ids,
     overlaps_span_wrapper);
 
   free(query);
@@ -171,7 +169,7 @@ test_floatspan(void)
 }
 
 static void
-test_tstzspan(void)
+test_tstzspan(MeosArray *ids)
 {
   char str[MAX_LEN_BBOX];
   Span *boxes = malloc(sizeof(Span) * NO_BBOX);
@@ -191,7 +189,7 @@ test_tstzspan(void)
 
   Span *query = tstzspan_in(
     "[2023-01-01 01:00:00+00, 2023-01-01 01:00:60+00]");
-  verify_search("TSTZSPAN", rtree, query, (char *) boxes, sizeof(Span),
+  verify_search("TSTZSPAN", rtree, query, (char *) boxes, sizeof(Span), ids,
     overlaps_span_wrapper);
 
   free(query);
@@ -200,7 +198,7 @@ test_tstzspan(void)
 }
 
 static void
-test_tbox(void)
+test_tbox(MeosArray *ids)
 {
   char str[MAX_LEN_BBOX];
   TBox *boxes = malloc(sizeof(TBox) * NO_BBOX);
@@ -223,7 +221,7 @@ test_tbox(void)
 
   TBox *query = tbox_in(
     "TBOX XT([0,100],[2023-01-01 01:00:00+00, 2023-01-01 01:00:60+00])");
-  verify_search("TBOX", rtree, query, (char *) boxes, sizeof(TBox),
+  verify_search("TBOX", rtree, query, (char *) boxes, sizeof(TBox), ids,
     overlaps_tbox_wrapper);
 
   free(query);
@@ -232,7 +230,7 @@ test_tbox(void)
 }
 
 static void
-test_stbox(void)
+test_stbox(MeosArray *ids)
 {
   char str[MAX_LEN_BBOX];
   STBox *boxes = malloc(sizeof(STBox) * NO_BBOX);
@@ -259,7 +257,7 @@ test_stbox(void)
   STBox *query = stbox_in(
     "SRID=25832;STBOX XT(((0 0),(100 100)),"
     "[2023-01-01 01:00:00+00, 2023-01-01 01:00:60+00])");
-  verify_search("STBOX", rtree, query, (char *) boxes, sizeof(STBox),
+  verify_search("STBOX", rtree, query, (char *) boxes, sizeof(STBox), ids,
     overlaps_stbox_wrapper);
 
   free(query);
@@ -276,10 +274,14 @@ int main(void)
   srand(1);
 
   printf("RTree index test (%d boxes per type)\n", NO_BBOX);
-  test_floatspan();
-  test_tstzspan();
-  test_tbox();
-  test_stbox();
+
+  /* Create a single MeosArray and reuse it across all searches */
+  MeosArray *ids = meos_array_create(sizeof(int));
+  test_floatspan(ids);
+  test_tstzspan(ids);
+  test_tbox(ids);
+  test_stbox(ids);
+  meos_array_destroy(ids);
 
   meos_finalize();
   return EXIT_SUCCESS;

--- a/meos/examples/rtree_example.c
+++ b/meos/examples/rtree_example.c
@@ -30,10 +30,13 @@
 /**
  * @file
  * @brief A simple program that demonstrates the RTree index for searching
- * MEOS bounding boxes: floatspan, tstzspan, tbox, and stbox.
+ * MEOS bounding boxes: floatspan, tstzspan, tbox, stbox, and temporal types.
  *
- * The program runs all four bounding box types, inserting random boxes into
- * the index and verifying search results against a brute-force scan.
+ * The program tests all bounding box types with OVERLAPS, CONTAINS, and
+ * CONTAINED_BY operations, inserting random boxes into the index and
+ * verifying search results against a brute-force scan. It also demonstrates
+ * the temporal convenience functions (rtree_insert_temporal,
+ * rtree_search_temporal) using tfloat sequences.
  *
  * The program can be built as follows
  * @code
@@ -313,6 +316,72 @@ test_stbox(MeosArray *ids)
 
 /*****************************************************************************/
 
+/**
+ * @brief Demonstrate rtree_insert_temporal / rtree_search_temporal with tfloat
+ */
+static void
+test_temporal(MeosArray *ids)
+{
+  char str[MAX_LEN_BBOX];
+  /* Store the bounding boxes for brute-force verification */
+  TBox *boxes = malloc(sizeof(TBox) * NO_BBOX);
+  RTree *rtree = rtree_create_tbox();
+
+  for (int i = 0; i < NO_BBOX; i++)
+  {
+    int xmin = random_int(1, 1000);
+    int xmax = xmin + random_int(1, 10);
+    int tmin = random_int(0, 999);
+    int tmax = tmin + random_int(1, 10);
+    int tmin_h = tmin / 60, tmin_m = tmin % 60;
+    int tmax_h = tmax / 60, tmax_m = tmax % 60;
+    snprintf(str, sizeof(str),
+      "[%d@2020-01-01 %02d:%02d:00+00, %d@2020-01-01 %02d:%02d:00+00]",
+      xmin, tmin_h, tmin_m, xmax, tmax_h, tmax_m);
+    Temporal *temp = (Temporal *) tfloat_in(str);
+    /* Use the temporal insert convenience function */
+    rtree_insert_temporal(rtree, temp, i);
+    /* Extract bounding box for brute-force comparison */
+    TBox *b = tnumber_to_tbox(temp);
+    boxes[i] = *b;
+    free(b);
+    free(temp);
+  }
+
+  printf("TEMPORAL (tfloat):\n");
+  /* Build a tfloat query and use rtree_search_temporal */
+  Temporal *query = (Temporal *) tfloat_in(
+    "[0@2020-01-01 00:00:00+00, 100@2020-01-01 01:40:00+00]");
+  TBox *query_box = tnumber_to_tbox(query);
+
+  /* Index search via temporal API */
+  clock_t t = clock();
+  int index_count = rtree_search_temporal(rtree, RTREE_OVERLAPS, query, ids);
+  double index_time = (double)(clock() - t) / CLOCKS_PER_SEC;
+
+  /* Brute-force search */
+  t = clock();
+  int brute_count = 0;
+  for (int i = 0; i < NO_BBOX; i++)
+  {
+    if (overlaps_tbox_tbox(&boxes[i], query_box))
+      brute_count++;
+  }
+  double brute_time = (double)(clock() - t) / CLOCKS_PER_SEC;
+
+  printf("  %-20s  index: %.6fs (%d hits)  brute: %.6fs (%d hits) ratio: %.6f %s\n",
+    "overlaps", index_time, index_count, brute_time, brute_count,
+    index_time / brute_time,
+    index_count == brute_count ? "OK" : "MISMATCH");
+
+  free(query_box);
+  free(query);
+  rtree_free(rtree);
+  free(boxes);
+}
+
+/*****************************************************************************/
+
 int main(void)
 {
   meos_initialize();
@@ -327,6 +396,7 @@ int main(void)
   test_tstzspan(ids);
   test_tbox(ids);
   test_stbox(ids);
+  test_temporal(ids);
   meos_array_destroy(ids);
 
   meos_finalize();

--- a/meos/examples/rtree_example.c
+++ b/meos/examples/rtree_example.c
@@ -64,22 +64,24 @@ random_int(int min, int max)
 
 /**
  * @brief Generic test harness: compare R-tree search results against a
- * brute-force overlap scan
- * @param[in] name Label for the test (e.g., "FLOATSPAN")
+ * brute-force scan using the given predicate
+ * @param[in] name Label for the test (e.g., "FLOATSPAN overlaps")
  * @param[in] rtree The R-tree to search
+ * @param[in] op The search operation (overlaps, contains, contained by)
  * @param[in] query The query bounding box
  * @param[in] boxes Array of stored bounding boxes
  * @param[in] bboxsize Size of each bounding box in bytes
- * @param[in] overlaps_fn Function that checks if two boxes overlap
+ * @param[in] ids Reusable MeosArray for collecting results
+ * @param[in] predicate Brute-force predicate matching the search operation
  */
 static void
-verify_search(const char *name, const RTree *rtree, const void *query,
-  const char *boxes, size_t bboxsize, MeosArray *ids,
-  bool (*overlaps_fn)(const void *, const void *))
+verify_search(const char *name, const RTree *rtree, RTreeSearchOp op,
+  const void *query, const char *boxes, size_t bboxsize, MeosArray *ids,
+  bool (*predicate)(const void *, const void *))
 {
   /* Index search — reuses the caller's MeosArray (reset internally) */
   clock_t t = clock();
-  int index_count = rtree_search(rtree, RTREE_OVERLAPS, query, ids);
+  int index_count = rtree_search(rtree, op, query, ids);
   double index_time = (double)(clock() - t) / CLOCKS_PER_SEC;
 
   /* Brute-force search */
@@ -88,7 +90,7 @@ verify_search(const char *name, const RTree *rtree, const void *query,
   bool *actual = calloc(NO_BBOX, sizeof(bool));
   for (int i = 0; i < NO_BBOX; i++)
   {
-    if (overlaps_fn(boxes + i * bboxsize, query))
+    if (predicate(boxes + i * bboxsize, query))
     {
       brute_count++;
       actual[i] = true;
@@ -111,7 +113,7 @@ verify_search(const char *name, const RTree *rtree, const void *query,
       errors++;
   }
 
-  printf("  %-10s  index: %.6fs (%d hits)  brute: %.6fs (%d hits) ratio: %.6f %s\n",
+  printf("  %-20s  index: %.6fs (%d hits)  brute: %.6fs (%d hits) ratio: %.6f %s\n",
     name, index_time, index_count, brute_time, brute_count, index_time / brute_time,
     errors == 0 ? "OK" : "MISMATCH");
 
@@ -121,23 +123,38 @@ verify_search(const char *name, const RTree *rtree, const void *query,
 
 /*****************************************************************************/
 
+/* Span predicates */
 static bool
 overlaps_span_wrapper(const void *a, const void *b)
-{
-  return overlaps_span_span((Span *) a, (Span *) b);
-}
+{ return overlaps_span_span((Span *) a, (Span *) b); }
+static bool
+contains_span_wrapper(const void *a, const void *b)
+{ return contains_span_span((Span *) a, (Span *) b); }
+static bool
+contained_span_wrapper(const void *a, const void *b)
+{ return contained_span_span((Span *) a, (Span *) b); }
 
+/* TBox predicates */
 static bool
 overlaps_tbox_wrapper(const void *a, const void *b)
-{
-  return overlaps_tbox_tbox((TBox *) a, (TBox *) b);
-}
+{ return overlaps_tbox_tbox((TBox *) a, (TBox *) b); }
+static bool
+contains_tbox_wrapper(const void *a, const void *b)
+{ return contains_tbox_tbox((TBox *) a, (TBox *) b); }
+static bool
+contained_tbox_wrapper(const void *a, const void *b)
+{ return contained_tbox_tbox((TBox *) a, (TBox *) b); }
 
+/* STBox predicates */
 static bool
 overlaps_stbox_wrapper(const void *a, const void *b)
-{
-  return overlaps_stbox_stbox((STBox *) a, (STBox *) b);
-}
+{ return overlaps_stbox_stbox((STBox *) a, (STBox *) b); }
+static bool
+contains_stbox_wrapper(const void *a, const void *b)
+{ return contains_stbox_stbox((STBox *) a, (STBox *) b); }
+static bool
+contained_stbox_wrapper(const void *a, const void *b)
+{ return contained_stbox_stbox((STBox *) a, (STBox *) b); }
 
 /*****************************************************************************/
 
@@ -159,9 +176,14 @@ test_floatspan(MeosArray *ids)
     free(s);
   }
 
+  printf("FLOATSPAN:\n");
   Span *query = floatspan_in("[0, 100]");
-  verify_search("FLOATSPAN", rtree, query, (char *) boxes, sizeof(Span), ids,
-    overlaps_span_wrapper);
+  verify_search("overlaps", rtree, RTREE_OVERLAPS, query,
+    (char *) boxes, sizeof(Span), ids, overlaps_span_wrapper);
+  verify_search("contains", rtree, RTREE_CONTAINS, query,
+    (char *) boxes, sizeof(Span), ids, contains_span_wrapper);
+  verify_search("contained by", rtree, RTREE_CONTAINED_BY, query,
+    (char *) boxes, sizeof(Span), ids, contained_span_wrapper);
 
   free(query);
   rtree_free(rtree);
@@ -190,11 +212,16 @@ test_tstzspan(MeosArray *ids)
     free(s);
   }
 
+  printf("TSTZSPAN:\n");
   /* Query covers ~100/1000 = 10% of the time range */
   Span *query = tstzspan_in(
     "[2020-01-01 00:00:00+00, 2020-01-01 01:40:00+00]");
-  verify_search("TSTZSPAN", rtree, query, (char *) boxes, sizeof(Span), ids,
-    overlaps_span_wrapper);
+  verify_search("overlaps", rtree, RTREE_OVERLAPS, query,
+    (char *) boxes, sizeof(Span), ids, overlaps_span_wrapper);
+  verify_search("contains", rtree, RTREE_CONTAINS, query,
+    (char *) boxes, sizeof(Span), ids, contains_span_wrapper);
+  verify_search("contained by", rtree, RTREE_CONTAINED_BY, query,
+    (char *) boxes, sizeof(Span), ids, contained_span_wrapper);
 
   free(query);
   rtree_free(rtree);
@@ -226,10 +253,15 @@ test_tbox(MeosArray *ids)
     free(b);
   }
 
+  printf("TBOX:\n");
   TBox *query = tbox_in(
     "TBOX XT([0,100],[2020-01-01 00:00:00+00, 2020-01-01 01:40:00+00])");
-  verify_search("TBOX", rtree, query, (char *) boxes, sizeof(TBox), ids,
-    overlaps_tbox_wrapper);
+  verify_search("overlaps", rtree, RTREE_OVERLAPS, query,
+    (char *) boxes, sizeof(TBox), ids, overlaps_tbox_wrapper);
+  verify_search("contains", rtree, RTREE_CONTAINS, query,
+    (char *) boxes, sizeof(TBox), ids, contains_tbox_wrapper);
+  verify_search("contained by", rtree, RTREE_CONTAINED_BY, query,
+    (char *) boxes, sizeof(TBox), ids, contained_tbox_wrapper);
 
   free(query);
   rtree_free(rtree);
@@ -263,11 +295,16 @@ test_stbox(MeosArray *ids)
     free(b);
   }
 
+  printf("STBOX:\n");
   STBox *query = stbox_in(
     "SRID=25832;STBOX XT(((0 0),(100 100)),"
     "[2020-01-01 00:00:00+00, 2020-01-01 01:40:00+00])");
-  verify_search("STBOX", rtree, query, (char *) boxes, sizeof(STBox), ids,
-    overlaps_stbox_wrapper);
+  verify_search("overlaps", rtree, RTREE_OVERLAPS, query,
+    (char *) boxes, sizeof(STBox), ids, overlaps_stbox_wrapper);
+  verify_search("contains", rtree, RTREE_CONTAINS, query,
+    (char *) boxes, sizeof(STBox), ids, contains_stbox_wrapper);
+  verify_search("contained by", rtree, RTREE_CONTAINED_BY, query,
+    (char *) boxes, sizeof(STBox), ids, contained_stbox_wrapper);
 
   free(query);
   rtree_free(rtree);

--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -304,8 +304,8 @@ extern RTree *rtree_create_stbox();
 extern void rtree_free(RTree *rtree);
 extern void rtree_insert(RTree *rtree, void *box, int id);
 extern void rtree_insert_temporal(RTree *rtree, const Temporal *temp, int id);
-extern int *rtree_search(const RTree *rtree, RTreeSearchOp op, const void *query, int *count);
-extern int *rtree_search_temporal(const RTree *rtree, RTreeSearchOp op, const Temporal *temp, int *count);
+extern int rtree_search(const RTree *rtree, RTreeSearchOp op, const void *query, MeosArray *result);
+extern int rtree_search_temporal(const RTree *rtree, RTreeSearchOp op, const Temporal *temp, MeosArray *result);
 
 /*****************************************************************************
  * Error codes

--- a/meos/include/temporal/temporal_rtree.h
+++ b/meos/include/temporal/temporal_rtree.h
@@ -44,7 +44,6 @@
  *****************************************************************************/
 
 #define MAXITEMS 64
-#define SEARCH_ARRAY_STARTING_SIZE 64
 #define MINITEMS_PERCENTAGE 10
 #define MINITEMS ((MAXITEMS) * (MINITEMS_PERCENTAGE) / 100 + 1)
 

--- a/meos/src/temporal/temporal_rtree.c
+++ b/meos/src/temporal/temporal_rtree.c
@@ -655,37 +655,6 @@ node_insert(RTree *rtree, void *node_bounding_box, RTreeNode *node,
   return;
 }
 
-/**
- * @brief Returns `true` if a number greater than 0 is a power of two, `false`
- * otherwise
- * @param[in] n Number to check
- */
-static inline bool
-is_power_of_two(const int n)
-{
-  return (n & (n - 1)) == 0;
-}
-
-/**
- * @brief Adds an ID to the dynamically allocated array with the answer of a
- * query
- * @param[in] id The integer ID to be added to the array
- * @param[in] ids Pointer to a pointer to the dynamically allocated array of
- * integers
- * @param[in] count Pointer to an integer representing the current number of
- * elements in the array.
- */
-static void
-add_answer(const int id, int **ids, int *count)
-{
-  /* Every power of two that exceeds the size of the array must be resized to
-   * double the current size */
-  if (*count >= SEARCH_ARRAY_STARTING_SIZE && is_power_of_two(*count))
-    *ids = repalloc(*ids, sizeof(int) * (*count) * 2);
-  (*ids)[*count] = id;
-  (*count)++;
-  return;
-}
 
 /**
  * @brief Return true if a leaf entry is consistent with the search query
@@ -738,26 +707,25 @@ inner_consistent(const RTree *rtree, const void *key, const void *query,
  * @brief Searches recursively a node looking for hits with a query
  * @param[in] rtree Pointer to the RTree structure
  * @param[in] node The node to be searched
- * @param[in] query The bounding box that serves as query
  * @param[in] op The search operation (overlaps, contains, or contained by)
- * @param[in] ids The array with the list of answers
- * @param[in] count Total of elements found
+ * @param[in] query The bounding box that serves as query
+ * @param[out] result MeosArray to collect matching IDs
  */
 static void
 node_search(const RTree *rtree, const RTreeNode *node, RTreeSearchOp op,
-  const void *query, int **ids, int *count)
+  const void *query, MeosArray *result)
 {
   for (int i = 0; i < node->count; ++i)
   {
     if (node->node_type == RTREE_LEAF)
     {
       if (leaf_consistent(rtree, RTREE_NODE_BBOX_N(node, i), query, op))
-        add_answer(node->ids[i], ids, count);
+        meos_array_add(result, &node->ids[i]);
     }
     else
     {
       if (inner_consistent(rtree, RTREE_NODE_BBOX_N(node, i), query, op))
-        node_search(rtree, node->nodes[i], op, query, ids, count);
+        node_search(rtree, node->nodes[i], op, query, result);
     }
   }
   return;
@@ -921,26 +889,28 @@ rtree_insert(RTree *rtree, void *box, int id)
 
 /**
  * @ingroup meos_geo_box_index
- * @brief Queries an RTree with a bounding box. Returns an array of ids of
- * bounding boxes.
+ * @brief Search an RTree with a bounding box, collecting matching IDs into
+ * a MeosArray
+ * @details The result array is reset before the search. After the call,
+ * use the returned count and #meos_array_get to read the matching IDs.
+ * The same array can be reused across multiple searches without reallocating.
  * @param[in] rtree The RTree to query
  * @param[in] op The search operation: @p RTREE_OVERLAPS finds boxes that
  * overlap the query, @p RTREE_CONTAINS finds boxes that contain the query,
  * @p RTREE_CONTAINED_BY finds boxes contained by the query
  * @param[in] query The bounding box that serves as query
- * @param[out] count The number of hits the RTree found
- * @return Array of ids that have a hit.
- * @note The `count` will be the output size of the array given.
+ * @param[out] result MeosArray of int to collect matching IDs (created by the
+ * caller with `meos_array_create(sizeof(int))`)
+ * @return Number of matching IDs
  */
-int *
+int
 rtree_search(const RTree *rtree, RTreeSearchOp op, const void *query,
-  int *count)
+  MeosArray *result)
 {
-  int *ids = palloc(sizeof(int) * SEARCH_ARRAY_STARTING_SIZE);
-  *count = 0;
+  meos_array_reset(result);
   if (rtree->root)
-    node_search(rtree, rtree->root, op, query, &ids, count);
-  return ids;
+    node_search(rtree, rtree->root, op, query, result);
+  return meos_array_count(result);
 }
 
 /**
@@ -994,29 +964,30 @@ rtree_insert_temporal(RTree *rtree, const Temporal *temp, int id)
 
 /**
  * @ingroup meos_temporal_box_index
- * @brief Search an RTree using a temporal value's bounding box
+ * @brief Search an RTree using a temporal value's bounding box, collecting
+ * matching IDs into a MeosArray
  * @details The bounding box is automatically extracted from the temporal value
- * and used as the search query.
+ * and used as the search query. The result array is reset before the search.
  * @param[in] rtree The RTree to query
  * @param[in] op The search operation
  * @param[in] temp The temporal value whose bounding box serves as query
- * @param[out] count The number of hits the RTree found
- * @return Array of ids that have a hit.
+ * @param[out] result MeosArray of int to collect matching IDs
+ * @return Number of matching IDs
  */
-int *
+int
 rtree_search_temporal(const RTree *rtree, RTreeSearchOp op,
-  const Temporal *temp, int *count)
+  const Temporal *temp, MeosArray *result)
 {
   if (! ensure_rtree_temporal_compatible(rtree, temp))
   {
-    *count = 0;
-    return NULL;
+    meos_array_reset(result);
+    return 0;
   }
   /* Use a stack buffer large enough for any MEOS bounding box type */
   char buf[sizeof(STBox)];
   memset(buf, 0, sizeof(buf));
   temporal_set_bbox(temp, buf);
-  return rtree_search(rtree, op, buf, count);
+  return rtree_search(rtree, op, buf, result);
 }
 
 /**


### PR DESCRIPTION
Replace the internally-allocated int array with a caller-provided MeosArray, allowing reuse across multiple searches without repeated allocation. Remove is_power_of_two, add_answer, and SEARCH_ARRAY_STARTING_SIZE which are no longer needed.