### PR TITLE
Uniformize type names

### DIFF
--- a/meos/include/geo/tgeo.h
+++ b/meos/include/geo/tgeo.h
@@ -56,9 +56,9 @@ extern GSERIALIZED *stbox_geo(const STBox *box);
 /* Temporal comparisons */
 
 extern Temporal *tcomp_geo_tgeo(const GSERIALIZED *gs,
-  const Temporal *temp, Datum (*func)(Datum, Datum, meosType));
+  const Temporal *temp, Datum (*func)(Datum, Datum, MeosType));
 extern Temporal *tcomp_tgeo_geo(const Temporal *temp,
-  const GSERIALIZED *gs, Datum (*func)(Datum, Datum, meosType));
+  const GSERIALIZED *gs, Datum (*func)(Datum, Datum, MeosType));
 
 /*****************************************************************************/
 

--- a/meos/include/geo/tgeo_spatialfuncs.h
+++ b/meos/include/geo/tgeo_spatialfuncs.h
@@ -82,7 +82,7 @@ extern Datum datum_geom_distance3d(Datum geom1, Datum geom2);
 extern Datum datum_geog_distance(Datum geog1, Datum geog2);
 extern Datum datum_pt_distance2d(Datum geom1, Datum geom2);
 extern Datum datum_pt_distance3d(Datum geom1, Datum geom2);
-extern int16 spatial_flags(Datum d, meosType basetype);
+extern int16 spatial_flags(Datum d, MeosType basetype);
 
 /* Validity functions */
 
@@ -150,7 +150,7 @@ extern Temporal *tpoint_get_coord(const Temporal *temp, int coord);
 /* Ever/always comparisons */
 
 extern int eacomp_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
-  Datum (*func)(Datum, Datum, meosType), bool ever);
+  Datum (*func)(Datum, Datum, MeosType), bool ever);
 
 /* Functions derived from PostGIS to increase floating-point precision */
 

--- a/meos/include/geo/tspatial.h
+++ b/meos/include/geo/tspatial.h
@@ -45,11 +45,11 @@
 
 /*****************************************************************************/
 
-extern char **spatialarr_wkt_out(const Datum *spatialarr, meosType basetype,
+extern char **spatialarr_wkt_out(const Datum *spatialarr, MeosType basetype,
   int count, int maxdd, bool extended);
 
-extern char *spatialbase_as_text(Datum value, meosType type, int maxdd);
-extern char *spatialbase_as_ewkt(Datum value, meosType type, int maxdd);
+extern char *spatialbase_as_text(Datum value, MeosType type, int maxdd);
+extern char *spatialbase_as_ewkt(Datum value, MeosType type, int maxdd);
 
 extern bool point_transf_pj(GSERIALIZED *gs, int32_t srid_to, const LWPROJ *pj);
 

--- a/meos/include/geo/tspatial_boxops.h
+++ b/meos/include/geo/tspatial_boxops.h
@@ -58,7 +58,7 @@ extern void tspatialseqarr_set_stbox(TSequence **sequences, int count,
   STBox *box);
 extern void tspatialseq_expand_stbox(TSequence *seq, const TInstant *inst);
 
-extern void spatialarr_set_bbox(const Datum *values, meosType basetype,
+extern void spatialarr_set_bbox(const Datum *values, MeosType basetype,
   int count, void *box);
 
 /* Generic box functions */

--- a/meos/include/geo/tspatial_parser.h
+++ b/meos/include/geo/tspatial_parser.h
@@ -44,22 +44,22 @@
 /*****************************************************************************/
 
 extern bool srid_parse(const char **str, int *srid);
-extern bool spatial_parse_elem(const char **str, meosType temptype, char delim,
+extern bool spatial_parse_elem(const char **str, MeosType temptype, char delim,
   int *temp_srid, Datum *result);
-extern bool geo_parse(const char **str, meosType basetype, char delim, 
+extern bool geo_parse(const char **str, MeosType basetype, char delim, 
   int *srid, GSERIALIZED **result);
 extern STBox *stbox_parse(const char **str);
-extern Temporal *tpoint_parse(const char **str, meosType temptype);
+extern Temporal *tpoint_parse(const char **str, MeosType temptype);
 
-extern TInstant *tspatialinst_parse(const char **str, meosType temptype,
+extern TInstant *tspatialinst_parse(const char **str, MeosType temptype,
   bool end, int *temp_srid);
-extern TSequence *tspatialseq_disc_parse(const char **str, meosType temptype,
+extern TSequence *tspatialseq_disc_parse(const char **str, MeosType temptype,
   int *temp_srid);
-extern TSequence *tspatialseq_cont_parse(const char **str, meosType temptype,
+extern TSequence *tspatialseq_cont_parse(const char **str, MeosType temptype,
   interpType interp, bool end, int *temp_srid);
-extern TSequenceSet *tspatialseqset_parse(const char **str, meosType temptype,
+extern TSequenceSet *tspatialseqset_parse(const char **str, MeosType temptype,
   interpType interp, int *temp_srid);
-extern Temporal *tspatial_parse(const char **str, meosType temptype);
+extern Temporal *tspatial_parse(const char **str, MeosType temptype);
 
 /*****************************************************************************/
 

--- a/meos/include/meos_internal.h
+++ b/meos/include/meos_internal.h
@@ -46,7 +46,7 @@
 /* PostgreSQL */
 /* MEOS */
 #include <meos.h>
-#include "temporal/meos_catalog.h" /* For meosType */
+#include "temporal/meos_catalog.h" /* For MeosType */
 
 /*****************************************************************************
  * Validity macros
@@ -771,8 +771,8 @@ extern Datum datum_ceil(Datum d);
 extern Datum datum_degrees(Datum d, Datum normalize);
 extern Datum datum_float_round(Datum value, Datum size);
 extern Datum datum_floor(Datum d);
-extern uint32 datum_hash(Datum d, meosType basetype);
-extern uint64 datum_hash_extended(Datum d, meosType basetype, uint64 seed);
+extern uint32 datum_hash(Datum d, MeosType basetype);
+extern uint64 datum_hash_extended(Datum d, MeosType basetype, uint64 seed);
 extern Datum datum_radians(Datum d);
 extern void floatspan_round_set(const Span *s, int maxdd, Span *result);
 
@@ -782,22 +782,22 @@ extern void floatspan_round_set(const Span *s, int maxdd, Span *result);
 
 /* Input and output functions for set and span types */
 
-extern Set *set_in(const char *str, meosType basetype);
+extern Set *set_in(const char *str, MeosType basetype);
 extern char *set_out(const Set *s, int maxdd);
-extern Span *span_in(const char *str, meosType spantype);
+extern Span *span_in(const char *str, MeosType spantype);
 extern char *span_out(const Span *s, int maxdd);
-extern SpanSet *spanset_in(const char *str, meosType spantype);
+extern SpanSet *spanset_in(const char *str, MeosType spantype);
 extern char *spanset_out(const SpanSet *ss, int maxdd);
 
 /*****************************************************************************/
 
 /* Constructor functions for set and span types */
 
-extern Set *set_make(const Datum *values, int count, meosType basetype, bool order);
-extern Set *set_make_exp(const Datum *values, int count, int maxcount, meosType basetype, bool order);
-extern Set *set_make_free(Datum *values, int count, meosType basetype, bool order);
-extern Span *span_make(Datum lower, Datum upper, bool lower_inc, bool upper_inc, meosType basetype);
-extern void span_set(Datum lower, Datum upper, bool lower_inc, bool upper_inc, meosType basetype, meosType spantype, Span *s);
+extern Set *set_make(const Datum *values, int count, MeosType basetype, bool order);
+extern Set *set_make_exp(const Datum *values, int count, int maxcount, MeosType basetype, bool order);
+extern Set *set_make_free(Datum *values, int count, MeosType basetype, bool order);
+extern Span *span_make(Datum lower, Datum upper, bool lower_inc, bool upper_inc, MeosType basetype);
+extern void span_set(Datum lower, Datum upper, bool lower_inc, bool upper_inc, MeosType basetype, MeosType spantype, Span *s);
 extern SpanSet *spanset_make_exp(Span *spans, int count, int maxcount, bool normalize, bool order);
 extern SpanSet *spanset_make_free(Span *spans, int count, bool normalize, bool order);
 
@@ -807,10 +807,10 @@ extern SpanSet *spanset_make_free(Span *spans, int count, bool normalize, bool o
 
 extern Span *set_span(const Set *s);
 extern SpanSet *set_spanset(const Set *s);
-extern void value_set_span(Datum value, meosType basetype, Span *s);
-extern Set *value_set(Datum d, meosType basetype);
-extern Span *value_span(Datum d, meosType basetype);
-extern SpanSet *value_spanset(Datum d, meosType basetype);
+extern void value_set_span(Datum value, MeosType basetype, Span *s);
+extern Set *value_set(Datum d, MeosType basetype);
+extern Span *value_span(Datum d, MeosType basetype);
+extern SpanSet *value_spanset(Datum d, MeosType basetype);
 
 /*****************************************************************************/
 
@@ -845,7 +845,7 @@ extern SpanSet *numspanset_shift_scale(const SpanSet *ss, Datum shift, Datum wid
 extern Set *set_compact(const Set *s);
 extern void span_expand(const Span *s1, Span *s2);
 extern SpanSet *spanset_compact(const SpanSet *ss);
-extern TBox *tbox_expand_value(const TBox *box, Datum value, meosType basetyp);
+extern TBox *tbox_expand_value(const TBox *box, Datum value, MeosType basetyp);
 extern Set *textcat_textset_text_common(const Set *s, const text *txt, bool invert);
 extern void tstzspan_set_datespan(const Span *s1, Span *s2);
 
@@ -905,13 +905,13 @@ extern bool right_spanset_value(const SpanSet *ss, Datum value);
 
 /* Functions on generic bounding boxes of temporal types */
 
-extern bool bbox_type(meosType bboxtype);
-extern size_t bbox_get_size(meosType bboxtype);
-extern int bbox_max_dims(meosType bboxtype);
+extern bool bbox_type(MeosType bboxtype);
+extern size_t bbox_get_size(MeosType bboxtype);
+extern int bbox_max_dims(MeosType bboxtype);
 extern bool temporal_bbox_eq(const void *box1, const void *box2,
-  meosType temptype);
+  MeosType temptype);
 extern int temporal_bbox_cmp(const void *box1, const void *box2,
-  meosType temptype);
+  MeosType temptype);
 
 /* Set functions for set and span types */
 
@@ -949,14 +949,14 @@ extern Datum distance_span_value(const Span *s, Datum value);
 extern Datum distance_spanset_span(const SpanSet *ss, const Span *s);
 extern Datum distance_spanset_spanset(const SpanSet *ss1, const SpanSet *ss2);
 extern Datum distance_spanset_value(const SpanSet *ss, Datum value);
-extern Datum distance_value_value(Datum l, Datum r, meosType basetype);
+extern Datum distance_value_value(Datum l, Datum r, MeosType basetype);
 
 /*****************************************************************************/
 
 /* Aggregate functions for set and span types */
 
-extern Span *spanbase_extent_transfn(Span *state, Datum value, meosType basetype);
-extern Set *value_union_transfn(Set *state, Datum value, meosType basetype);
+extern Span *spanbase_extent_transfn(Span *state, Datum value, MeosType basetype);
+extern Set *value_union_transfn(Set *state, Datum value, MeosType basetype);
 
 /******************************************************************************
  * Functions for box types
@@ -964,8 +964,8 @@ extern Set *value_union_transfn(Set *state, Datum value, meosType basetype);
 
 /* Constructor functions for box types */
 
-extern TBox *number_tstzspan_to_tbox(Datum d, meosType basetype, const Span *s);
-extern TBox *number_timestamptz_to_tbox(Datum d, meosType basetype, TimestampTz t);
+extern TBox *number_tstzspan_to_tbox(Datum d, MeosType basetype, const Span *s);
+extern TBox *number_timestamptz_to_tbox(Datum d, MeosType basetype, TimestampTz t);
 extern void tbox_set(const Span *s, const Span *p, TBox *box);
 
 /*****************************************************************************/
@@ -974,8 +974,8 @@ extern void tbox_set(const Span *s, const Span *p, TBox *box);
 
 extern void float_set_tbox(double d, TBox *box);
 extern void int_set_tbox(int i, TBox *box);
-extern void number_set_tbox(Datum d, meosType basetype, TBox *box);
-extern TBox *number_tbox(Datum value, meosType basetype);
+extern void number_set_tbox(Datum d, MeosType basetype, TBox *box);
+extern TBox *number_tbox(Datum value, MeosType basetype);
 extern void numset_set_tbox(const Set *s, TBox *box);
 extern void numspan_set_tbox(const Span *span, TBox *box);
 extern void timestamptz_set_tbox(TimestampTz t, TBox *box);
@@ -1012,7 +1012,7 @@ extern TSequence *tboolseq_from_mfjson(json_object *mfjson);
 extern TSequence *tboolseq_in(const char *str, interpType interp);
 extern TSequenceSet *tboolseqset_from_mfjson(json_object *mfjson);
 extern TSequenceSet *tboolseqset_in(const char *str);
-extern Temporal *temporal_in(const char *str, meosType temptype);
+extern Temporal *temporal_in(const char *str, MeosType temptype);
 extern char *temporal_out(const Temporal *temp, int maxdd);
 extern char **temparr_out(Temporal **temparr, int count, int maxdd);
 extern TInstant *tfloatinst_from_mfjson(json_object *mfjson);
@@ -1021,8 +1021,8 @@ extern TSequence *tfloatseq_from_mfjson(json_object *mfjson, interpType interp);
 extern TSequence *tfloatseq_in(const char *str, interpType interp);
 extern TSequenceSet *tfloatseqset_from_mfjson(json_object *mfjson, interpType interp);
 extern TSequenceSet *tfloatseqset_in(const char *str);
-extern TInstant *tinstant_from_mfjson(json_object *mfjson, bool spatial, int32_t srid, meosType temptype);
-extern TInstant *tinstant_in(const char *str, meosType temptype);
+extern TInstant *tinstant_from_mfjson(json_object *mfjson, bool spatial, int32_t srid, MeosType temptype);
+extern TInstant *tinstant_in(const char *str, MeosType temptype);
 extern char *tinstant_out(const TInstant *inst, int maxdd);
 extern TInstant *tintinst_from_mfjson(json_object *mfjson);
 extern TInstant *tintinst_in(const char *str);
@@ -1030,11 +1030,11 @@ extern TSequence *tintseq_from_mfjson(json_object *mfjson);
 extern TSequence *tintseq_in(const char *str, interpType interp);
 extern TSequenceSet *tintseqset_from_mfjson(json_object *mfjson);
 extern TSequenceSet *tintseqset_in(const char *str);
-extern TSequence *tsequence_from_mfjson(json_object *mfjson, bool spatial, int32_t srid, meosType temptype, interpType interp);
-extern TSequence *tsequence_in(const char *str, meosType temptype, interpType interp);
+extern TSequence *tsequence_from_mfjson(json_object *mfjson, bool spatial, int32_t srid, MeosType temptype, interpType interp);
+extern TSequence *tsequence_in(const char *str, MeosType temptype, interpType interp);
 extern char *tsequence_out(const TSequence *seq, int maxdd);
-extern TSequenceSet *tsequenceset_from_mfjson(json_object *mfjson, bool spatial, int32_t srid, meosType temptype, interpType interp);
-extern TSequenceSet *tsequenceset_in(const char *str, meosType temptype, interpType interp);
+extern TSequenceSet *tsequenceset_from_mfjson(json_object *mfjson, bool spatial, int32_t srid, MeosType temptype, interpType interp);
+extern TSequenceSet *tsequenceset_in(const char *str, MeosType temptype, interpType interp);
 extern char *tsequenceset_out(const TSequenceSet *ss, int maxdd);
 extern TInstant *ttextinst_from_mfjson(json_object *mfjson);
 extern TInstant *ttextinst_in(const char *str);
@@ -1042,26 +1042,26 @@ extern TSequence *ttextseq_from_mfjson(json_object *mfjson);
 extern TSequence *ttextseq_in(const char *str, interpType interp);
 extern TSequenceSet *ttextseqset_from_mfjson(json_object *mfjson);
 extern TSequenceSet *ttextseqset_in(const char *str);
-extern Temporal *temporal_from_mfjson(const char *mfjson, meosType temptype);
+extern Temporal *temporal_from_mfjson(const char *mfjson, MeosType temptype);
 
 /*****************************************************************************/
 
 /* Constructor functions for temporal types */
 
-extern Temporal *temporal_from_base_temp(Datum value, meosType temptype, const Temporal *temp);
+extern Temporal *temporal_from_base_temp(Datum value, MeosType temptype, const Temporal *temp);
 extern TInstant *tinstant_copy(const TInstant *inst);
-extern TInstant *tinstant_make(Datum value, meosType temptype, TimestampTz t);
-extern TInstant *tinstant_make_free(Datum value, meosType temptype, TimestampTz t);
+extern TInstant *tinstant_make(Datum value, MeosType temptype, TimestampTz t);
+extern TInstant *tinstant_make_free(Datum value, MeosType temptype, TimestampTz t);
 extern TSequence *tsequence_copy(const TSequence *seq);
-extern TSequence *tsequence_from_base_temp(Datum value, meosType temptype, const TSequence *seq);
-extern TSequence *tsequence_from_base_tstzset(Datum value, meosType temptype, const Set *s);
-extern TSequence *tsequence_from_base_tstzspan(Datum value, meosType temptype, const Span *s, interpType interp);
+extern TSequence *tsequence_from_base_temp(Datum value, MeosType temptype, const TSequence *seq);
+extern TSequence *tsequence_from_base_tstzset(Datum value, MeosType temptype, const Set *s);
+extern TSequence *tsequence_from_base_tstzspan(Datum value, MeosType temptype, const Span *s, interpType interp);
 extern TSequence *tsequence_make_exp(TInstant **instants, int count, int maxcount, bool lower_inc, bool upper_inc, interpType interp, bool normalize);
 extern TSequence *tsequence_make_free(TInstant **instants, int count, bool lower_inc, bool upper_inc, interpType interp, bool normalize);
 extern TSequenceSet *tsequenceset_copy(const TSequenceSet *ss);
 extern TSequenceSet *tseqsetarr_to_tseqset(TSequenceSet **seqsets, int count, int totalseqs);
-extern TSequenceSet *tsequenceset_from_base_temp(Datum value, meosType temptype, const TSequenceSet *ss);
-extern TSequenceSet *tsequenceset_from_base_tstzspanset(Datum value, meosType temptype, const SpanSet *ss, interpType interp);
+extern TSequenceSet *tsequenceset_from_base_temp(Datum value, MeosType temptype, const TSequenceSet *ss);
+extern TSequenceSet *tsequenceset_from_base_tstzspanset(Datum value, MeosType temptype, const SpanSet *ss, interpType interp);
 extern TSequenceSet *tsequenceset_make_exp(TSequence **sequences, int count, int maxcount, bool normalize);
 extern TSequenceSet *tsequenceset_make_free(TSequence **sequences, int count, bool normalize);
 
@@ -1366,7 +1366,7 @@ extern Span *spanset_bins(const SpanSet *ss, Datum size, Datum origin, int *coun
 extern Span *tnumber_value_bins(const Temporal *temp, Datum size, Datum origin, int *count);
 extern TBox *tnumber_value_time_boxes(const Temporal *temp, Datum vsize, const Interval *duration, Datum vorigin, TimestampTz torigin, int *count);
 extern Temporal **tnumber_value_split(const Temporal *temp, Datum vsize, Datum vorigin, Datum **bins, int *count);
-extern TBox *tbox_get_value_time_tile(Datum value, TimestampTz t, Datum vsize, const Interval *duration, Datum vorigin, TimestampTz torigin, meosType basetype, meosType spantype);
+extern TBox *tbox_get_value_time_tile(Datum value, TimestampTz t, Datum vsize, const Interval *duration, Datum vorigin, TimestampTz torigin, MeosType basetype, MeosType spantype);
 extern Temporal **tnumber_value_time_split(const Temporal *temp, Datum size, const Interval *duration, Datum vorigin, TimestampTz torigin, Datum **value_bins, TimestampTz **time_bins, int *count);
 
 /*****************************************************************************/

--- a/meos/include/meos_internal_geo.h
+++ b/meos/include/meos_internal_geo.h
@@ -121,7 +121,7 @@ extern void stbox_set(bool hasx, bool hasz, bool geodetic, int32 srid, double xm
 extern void gbox_set_stbox(const GBOX *box, int32_t srid, STBox *result);
 extern bool geo_set_stbox(const GSERIALIZED *gs, STBox *box);
 extern void geoarr_set_stbox(const Datum *values, int count, STBox *box);
-extern bool spatial_set_stbox(Datum d, meosType basetype, STBox *box);
+extern bool spatial_set_stbox(Datum d, MeosType basetype, STBox *box);
 extern void spatialset_set_stbox(const Set *set, STBox *box);
 extern void stbox_set_box3d(const STBox *box, BOX3D *box3d);
 extern void stbox_set_gbox(const STBox *box, GBOX *gbox);
@@ -237,8 +237,8 @@ extern TSequenceSet *tgeoseqset_restrict_stbox(const TSequenceSet *ss, const STB
 
 /* Spatial accessor functions for temporal points */
 
-extern int32_t spatial_srid(Datum d, meosType basetype);
-extern bool spatial_set_srid(Datum d, meosType basetype, int32_t srid);
+extern int32_t spatial_srid(Datum d, MeosType basetype);
+extern bool spatial_set_srid(Datum d, MeosType basetype, int32_t srid);
 extern int tspatialinst_srid(const TInstant *inst);
 extern TSequenceSet *tpointseq_azimuth(const TSequence *seq);
 extern TSequence *tpointseq_cumulative_length(const TSequence *seq, double prevlength);

--- a/meos/include/rgeo/trgeo_parser.h
+++ b/meos/include/rgeo/trgeo_parser.h
@@ -42,7 +42,7 @@
 
 /*****************************************************************************/
 
-extern Temporal *trgeo_parse(const char **str, meosType temptype);
+extern Temporal *trgeo_parse(const char **str, MeosType temptype);
 
 /*****************************************************************************/
 

--- a/meos/include/temporal/lifting.h
+++ b/meos/include/temporal/lifting.h
@@ -58,8 +58,8 @@ typedef struct
   varfunc func;               /**< Variadic function that is lifted */
   int numparam;               /**< Number of parameters of the function */
   Datum param[MAX_PARAMS];    /**< Datum array for the parameters of the function */
-  meosType argtype[MAX_ARGS]; /**< Type of the arguments of the function */
-  meosType restype;           /**< Type of the result of the function */
+  MeosType argtype[MAX_ARGS]; /**< Type of the arguments of the function */
+  MeosType restype;           /**< Type of the result of the function */
   bool reslinear;             /**< True if the result has linear interpolation */
   bool invert;                /**< True if the arguments of the function must be inverted */
   bool discont;               /**< True if the function has instantaneous discontinuities */

--- a/meos/include/temporal/meos_catalog.h
+++ b/meos/include/temporal/meos_catalog.h
@@ -117,8 +117,8 @@ typedef enum
   T_TGEOGRAPHY     = 61,  /**< temporal geography type */
   T_TRGEOMETRY     = 62,  /**< temporal rigid geometry type */
   NO_MEOS_TYPES           /* Dummy value that determines the size of the 
-                           * lookup array meosType -> Oid */
-} meosType;
+                           * lookup array MeosType -> Oid */
+} MeosType;
 
 /**
  * Enumeration that defines the classes of Boolean operators used in
@@ -176,8 +176,8 @@ typedef enum
  */
 typedef struct
 {
-  meosType temptype;    /**< Enum value of the temporal type */
-  meosType basetype;    /**< Enum value of the base type */
+  MeosType temptype;    /**< Enum value of the temporal type */
+  MeosType basetype;    /**< Enum value of the base type */
 } temptype_catalog_struct;
 
 /**
@@ -185,8 +185,8 @@ typedef struct
  */
 typedef struct
 {
-  meosType settype;     /**< Enum value of the set type */
-  meosType basetype;    /**< Enum value of the base type */
+  MeosType settype;     /**< Enum value of the set type */
+  MeosType basetype;    /**< Enum value of the base type */
 } settype_catalog_struct;
 
 /**
@@ -194,8 +194,8 @@ typedef struct
  */
 typedef struct
 {
-  meosType spantype;    /**< Enum value of the span type */
-  meosType basetype;    /**< Enum value of the base type */
+  MeosType spantype;    /**< Enum value of the span type */
+  MeosType basetype;    /**< Enum value of the base type */
 } spantype_catalog_struct;
 
 /**
@@ -203,8 +203,8 @@ typedef struct
  */
 typedef struct
 {
-  meosType spansettype;    /**< Enum value of the span type */
-  meosType spantype;       /**< Enum value of the base type */
+  MeosType spansettype;    /**< Enum value of the span type */
+  MeosType spantype;       /**< Enum value of the base type */
 } spansettype_catalog_struct;
 
 /*****************************************************************************/
@@ -222,88 +222,88 @@ extern interpType interptype_from_string(const char *interp_str);
 
 /* Type conversion functions */
 
-extern const char *meostype_name(meosType type);
-extern meosType temptype_basetype(meosType type);
-extern meosType settype_basetype(meosType type);
-extern meosType spantype_basetype(meosType type);
-extern meosType spantype_spansettype(meosType type);
-extern meosType spansettype_spantype(meosType type);
-extern meosType basetype_spantype(meosType type);
-extern meosType basetype_settype(meosType type);
+extern const char *meostype_name(MeosType type);
+extern MeosType temptype_basetype(MeosType type);
+extern MeosType settype_basetype(MeosType type);
+extern MeosType spantype_basetype(MeosType type);
+extern MeosType spantype_spansettype(MeosType type);
+extern MeosType spansettype_spantype(MeosType type);
+extern MeosType basetype_spantype(MeosType type);
+extern MeosType basetype_settype(MeosType type);
 
 /* Catalog functions */
 
-extern bool tnumber_basetype(meosType type);
-extern bool geo_basetype(meosType type);
+extern bool tnumber_basetype(MeosType type);
+extern bool geo_basetype(MeosType type);
 #ifndef NDEBUG
-extern bool meos_basetype(meosType type);
-extern bool alphanum_basetype(meosType type);
-extern bool alphanum_temptype(meosType type);
+extern bool meos_basetype(MeosType type);
+extern bool alphanum_basetype(MeosType type);
+extern bool alphanum_temptype(MeosType type);
 #endif
 
-extern bool time_type(meosType type);
+extern bool time_type(MeosType type);
 #ifndef NDEBUG
-extern bool set_basetype(meosType type);
+extern bool set_basetype(MeosType type);
 #endif
 
-extern bool set_type(meosType type);
-extern bool numset_type(meosType type);
-extern bool ensure_numset_type(meosType type);
-extern bool timeset_type(meosType type);
-extern bool set_spantype(meosType type);
-extern bool ensure_set_spantype(meosType type);
-extern bool alphanumset_type(meosType settype);
-extern bool geoset_type(meosType type);
-extern bool ensure_geoset_type(meosType type);
-extern bool spatialset_type(meosType type);
-extern bool ensure_spatialset_type(meosType type);
+extern bool set_type(MeosType type);
+extern bool numset_type(MeosType type);
+extern bool ensure_numset_type(MeosType type);
+extern bool timeset_type(MeosType type);
+extern bool set_spantype(MeosType type);
+extern bool ensure_set_spantype(MeosType type);
+extern bool alphanumset_type(MeosType settype);
+extern bool geoset_type(MeosType type);
+extern bool ensure_geoset_type(MeosType type);
+extern bool spatialset_type(MeosType type);
+extern bool ensure_spatialset_type(MeosType type);
 
-extern bool span_basetype(meosType type);
-extern bool span_canon_basetype(meosType type);
-extern bool span_type(meosType type);
-extern bool type_span_bbox(meosType type);
-extern bool span_tbox_type(meosType type);
-extern bool ensure_span_tbox_type(meosType type);
-extern bool numspan_basetype(meosType type);
-extern bool numspan_type(meosType type);
-extern bool ensure_numspan_type(meosType type);
-extern bool timespan_basetype(meosType type);
-extern bool timespan_type(meosType type);
+extern bool span_basetype(MeosType type);
+extern bool span_canon_basetype(MeosType type);
+extern bool span_type(MeosType type);
+extern bool type_span_bbox(MeosType type);
+extern bool span_tbox_type(MeosType type);
+extern bool ensure_span_tbox_type(MeosType type);
+extern bool numspan_basetype(MeosType type);
+extern bool numspan_type(MeosType type);
+extern bool ensure_numspan_type(MeosType type);
+extern bool timespan_basetype(MeosType type);
+extern bool timespan_type(MeosType type);
 
-extern bool spanset_type(meosType type);
-extern bool timespanset_type(meosType type);
-extern bool ensure_timespanset_type(meosType type);
+extern bool spanset_type(MeosType type);
+extern bool timespanset_type(MeosType type);
+extern bool ensure_timespanset_type(MeosType type);
 
-extern bool temporal_type(meosType type);
+extern bool temporal_type(MeosType type);
 #ifndef NDEBUG
-extern bool temporal_basetype(meosType type);
+extern bool temporal_basetype(MeosType type);
 #endif
-extern bool temptype_continuous(meosType type);
-extern bool basetype_byvalue(meosType type);
-extern bool basetype_varlength(meosType type);
-extern int16 meostype_length(meosType type);
+extern bool temptype_continuous(MeosType type);
+extern bool basetype_byvalue(MeosType type);
+extern bool basetype_varlength(MeosType type);
+extern int16 meostype_length(MeosType type);
 #ifndef NDEBUG
-extern bool talphanum_type(meosType type);
+extern bool talphanum_type(MeosType type);
 #endif
-extern bool talpha_type(meosType type);
-extern bool tnumber_type(meosType type);
-extern bool ensure_tnumber_type(meosType type);
-extern bool ensure_tnumber_basetype(meosType type);
-extern bool tnumber_spantype(meosType type);
-extern bool spatial_basetype(meosType type);
-extern bool tspatial_type(meosType type);
-extern bool ensure_tspatial_type(meosType type);
-extern bool tpoint_type(meosType type);
-extern bool ensure_tpoint_type(meosType type);
-extern bool tgeo_type(meosType type);
-extern bool ensure_tgeo_type(meosType type);
-extern bool tgeo_type_all(meosType type);
-extern bool ensure_tgeo_type_all(meosType type);
-extern bool tgeometry_type(meosType type);
-extern bool ensure_tgeometry_type(meosType type);
-extern bool tgeodetic_type(meosType type);
-extern bool ensure_tgeodetic_type(meosType type);
-extern bool ensure_tnumber_tpoint_type(meosType type);
+extern bool talpha_type(MeosType type);
+extern bool tnumber_type(MeosType type);
+extern bool ensure_tnumber_type(MeosType type);
+extern bool ensure_tnumber_basetype(MeosType type);
+extern bool tnumber_spantype(MeosType type);
+extern bool spatial_basetype(MeosType type);
+extern bool tspatial_type(MeosType type);
+extern bool ensure_tspatial_type(MeosType type);
+extern bool tpoint_type(MeosType type);
+extern bool ensure_tpoint_type(MeosType type);
+extern bool tgeo_type(MeosType type);
+extern bool ensure_tgeo_type(MeosType type);
+extern bool tgeo_type_all(MeosType type);
+extern bool ensure_tgeo_type_all(MeosType type);
+extern bool tgeometry_type(MeosType type);
+extern bool ensure_tgeometry_type(MeosType type);
+extern bool tgeodetic_type(MeosType type);
+extern bool ensure_tgeodetic_type(MeosType type);
+extern bool ensure_tnumber_tpoint_type(MeosType type);
 
 /*****************************************************************************/
 

--- a/meos/include/temporal/set.h
+++ b/meos/include/temporal/set.h
@@ -82,7 +82,7 @@ typedef struct
 
 extern char *set_out_fn(const Set *s, int maxdd, outfunc value_out);
 
-extern bool ensure_set_isof_type(const Set *s, meosType settype);
+extern bool ensure_set_isof_type(const Set *s, MeosType settype);
 extern bool ensure_valid_set_set(const Set *s1, const Set *s2);
 
 extern bool set_find_value(const Set *s, Datum, int *loc);

--- a/meos/include/temporal/span.h
+++ b/meos/include/temporal/span.h
@@ -78,8 +78,8 @@ typedef struct
 
 /* General functions */
 
-extern bool ensure_span_isof_type(const Span *s, meosType spantype);
-extern bool ensure_span_isof_basetype(const Span *s, meosType basetype);
+extern bool ensure_span_isof_type(const Span *s, MeosType spantype);
+extern bool ensure_span_isof_basetype(const Span *s, MeosType basetype);
 extern bool ensure_same_span_type(const Span *s1, const Span *s2);
 extern bool ensure_valid_span_span(const Span *s1, const Span *s2);
 
@@ -89,12 +89,12 @@ extern int span_bound_cmp(const SpanBound *b1, const SpanBound *b2);
 extern int span_bound_qsort_cmp(const void *s1, const void *s2);
 extern int span_lower_cmp(const Span *s1, const Span *s2);
 extern int span_upper_cmp(const Span *s1, const Span *s2);
-extern Datum span_decr_bound(Datum upper, meosType basetype);
-extern Datum span_incr_bound(Datum upper, meosType basetype);
+extern Datum span_decr_bound(Datum upper, MeosType basetype);
+extern Datum span_incr_bound(Datum upper, MeosType basetype);
 extern Span *spanarr_normalize(Span *spans, int count, bool sort,
   int *newcount);
 extern void span_bounds_shift_scale_value(Datum shift, Datum width,
-  meosType type, bool hasshift, bool haswidth, Datum *lower, Datum *upper);
+  MeosType type, bool hasshift, bool haswidth, Datum *lower, Datum *upper);
 extern void span_bounds_shift_scale_time(const Interval *shift,
   const Interval *duration, TimestampTz *lower, TimestampTz *upper);
 extern void floatspan_floor_ceil_iter(Span *s, datum_func1 func);
@@ -110,7 +110,7 @@ extern void tstzspan_shift_scale1(Span *s, const Interval *shift,
 extern int mi_span_span(const Span *s1, const Span *s2, Span *result);
 extern int mi_span_value(const Span *s, Datum value, Span *result);
 
-extern double dist_double_value_value(Datum l, Datum r, meosType type);
+extern double dist_double_value_value(Datum l, Datum r, MeosType type);
 
 /*****************************************************************************/
 

--- a/meos/include/temporal/spanset.h
+++ b/meos/include/temporal/spanset.h
@@ -44,7 +44,7 @@
 
 /* General functions */
 
-extern bool ensure_spanset_isof_type(const SpanSet *ss, meosType spansettype);
+extern bool ensure_spanset_isof_type(const SpanSet *ss, MeosType spansettype);
 extern bool ensure_same_spanset_type(const SpanSet *ss1, const SpanSet *ss2);
 extern bool ensure_same_spanset_span_type(const SpanSet *ss, const Span *s);
 extern bool ensure_valid_spanset_span(const SpanSet *ss, const Span *s);

--- a/meos/include/temporal/temporal.h
+++ b/meos/include/temporal/temporal.h
@@ -286,7 +286,7 @@ typedef union bboxunion
  *****************************************************************************/
 
 /* Definition of output function */
-typedef char *(*outfunc)(Datum value, meosType type, int maxdd);
+typedef char *(*outfunc)(Datum value, MeosType type, int maxdd);
 
 /* Definition of qsort comparator for integers */
 typedef int (*qsort_comparator) (const void *a, const void *b);
@@ -376,23 +376,23 @@ typedef int (*tpfunc_temp)(Datum, Datum, Datum, Datum, Datum, TimestampTz,
 
 /* Parameter tests */
 
-extern bool ensure_has_X(meosType type, int16 flags);
-extern bool ensure_has_Z(meosType type, int16 flags);
-extern bool ensure_has_T(meosType type, int16 flags);
-extern bool ensure_has_not_Z(meosType type, int16 flags);
+extern bool ensure_has_X(MeosType type, int16 flags);
+extern bool ensure_has_Z(MeosType type, int16 flags);
+extern bool ensure_has_T(MeosType type, int16 flags);
+extern bool ensure_has_not_Z(MeosType type, int16 flags);
 extern bool ensure_not_null(void *ptr);
 extern bool ensure_one_not_null(void *ptr1, void *ptr2);
 extern bool ensure_one_true(bool hasshift, bool haswidth);
-extern bool ensure_valid_interp(meosType temptype, interpType interp);
+extern bool ensure_valid_interp(MeosType temptype, interpType interp);
 extern bool ensure_continuous(const Temporal *temp);
 extern bool ensure_same_interp(const Temporal *temp1, const Temporal *temp2);
 extern bool ensure_same_continuous_interp(int16 flags1, int16 flags2);
 extern bool ensure_linear_interp(int16 flags);
 extern bool ensure_nonlinear_interp(int16 flags);
 extern bool ensure_common_dimension(int16 flags1, int16 flags2);
-extern bool ensure_temporal_isof_type(const Temporal *temp, meosType type);
+extern bool ensure_temporal_isof_type(const Temporal *temp, MeosType type);
 extern bool ensure_temporal_isof_basetype(const Temporal *temp,
-  meosType basetype);
+  MeosType basetype);
 extern bool ensure_temporal_isof_subtype(const Temporal *temp,
   tempSubtype type);
 extern bool ensure_same_temporal_type(const Temporal *temp1,
@@ -407,10 +407,10 @@ extern bool ensure_valid_temporal_temporal(const Temporal *temp1, const Temporal
 extern bool ensure_valid_tnumber_tnumber(const Temporal *temp1, const Temporal *temp2);
 extern bool ensure_not_negative(int i);
 extern bool ensure_positive(int i);
-extern bool not_negative_datum(Datum size, meosType basetype);
-extern bool ensure_not_negative_datum(Datum size, meosType basetype);
-extern bool positive_datum(Datum size, meosType basetype);
-extern bool ensure_positive_datum(Datum size, meosType basetype);
+extern bool not_negative_datum(Datum size, MeosType basetype);
+extern bool ensure_not_negative_datum(Datum size, MeosType basetype);
+extern bool positive_datum(Datum size, MeosType basetype);
+extern bool ensure_positive_datum(Datum size, MeosType basetype);
 extern bool ensure_valid_day_duration(const Interval *duration);
 extern bool positive_duration(const Interval *duration);
 extern bool ensure_positive_duration(const Interval *duration);
@@ -429,7 +429,7 @@ extern char *mobilitydb_full_version(void);
 
 /* Transformations */
 
-extern datum_func2 round_fn(meosType basetype);
+extern datum_func2 round_fn(MeosType basetype);
 
 /* Restriction functions */
 

--- a/meos/include/temporal/temporal_boxops.h
+++ b/meos/include/temporal/temporal_boxops.h
@@ -55,7 +55,7 @@
 
 /* Compute the bounding box at the creation of temporal values */
 
-extern size_t temporal_bbox_size(meosType tempype);
+extern size_t temporal_bbox_size(MeosType tempype);
 extern void tinstant_set_bbox(const TInstant *inst, void *bbox);
 extern void tinstarr_set_bbox(TInstant **instants, int count,
   bool lower_inc, bool upper_inc, interpType interp, void *bbox);

--- a/meos/include/temporal/temporal_compops.h
+++ b/meos/include/temporal/temporal_compops.h
@@ -46,18 +46,18 @@
 /*****************************************************************************/
 
 extern int eacomp_base_temporal(Datum value, const Temporal *temp,
-  Datum (*func)(Datum, Datum, meosType), bool ever);
+  Datum (*func)(Datum, Datum, MeosType), bool ever);
 extern int eacomp_temporal_base(const Temporal *temp, Datum value,
-  Datum (*func)(Datum, Datum, meosType), bool ever);
+  Datum (*func)(Datum, Datum, MeosType), bool ever);
 extern int eacomp_temporal_temporal(const Temporal *temp1,
-  const Temporal *temp2, Datum (*func)(Datum, Datum, meosType), bool ever);
+  const Temporal *temp2, Datum (*func)(Datum, Datum, MeosType), bool ever);
 
 extern Temporal *tcomp_base_temporal(Datum value, const Temporal *temp,
-  Datum (*func)(Datum, Datum, meosType));
+  Datum (*func)(Datum, Datum, MeosType));
 extern Temporal *tcomp_temporal_base(const Temporal *temp, Datum value,
-  Datum (*func)(Datum, Datum, meosType));
+  Datum (*func)(Datum, Datum, MeosType));
 extern Temporal *tcomp_temporal_temporal(const Temporal *temp1,
-  const Temporal *temp2, Datum (*func)(Datum, Datum, meosType));
+  const Temporal *temp2, Datum (*func)(Datum, Datum, MeosType));
 
 /*****************************************************************************/
 

--- a/meos/include/temporal/temporal_rtree.h
+++ b/meos/include/temporal/temporal_rtree.h
@@ -84,7 +84,7 @@ typedef struct RTreeNode
 struct RTree
 {
   size_t bboxsize;       /**< Size of the bouding box */
-  meosType bboxtype;     /**< Type of the bouding box */
+  MeosType bboxtype;     /**< Type of the bouding box */
   int dims;
   RTreeNode *root;
   double (*get_axis)(const void *, int, bool);

--- a/meos/include/temporal/temporal_tile.h
+++ b/meos/include/temporal/temporal_tile.h
@@ -90,7 +90,7 @@ extern TboxGridState *tbox_tile_state_make(const Temporal *temp,
   TimestampTz torigin);
 extern void tbox_tile_state_next(TboxGridState *state);
 extern void tbox_tile_state_set(Datum value, TimestampTz t, Datum vsize,
-  int64 tunits, meosType basetype, meosType spantype, TBox *box);
+  int64 tunits, MeosType basetype, MeosType spantype, TBox *box);
 
 /*****************************************************************************/
 
@@ -98,7 +98,7 @@ extern int64 interval_units(const Interval *interval);
 extern TimestampTz timestamptz_bin_start(TimestampTz timestamp, int64 tunits,
   TimestampTz torigin);
 extern Datum datum_bin(Datum value, Datum size, Datum offset,
-  meosType basetype);
+  MeosType basetype);
 
 extern TboxGridState *tnumber_value_time_tile_init(const Temporal *temp,
   Datum vsize, const Interval *duration, Datum vorigin, TimestampTz torigin,

--- a/meos/include/temporal/tnumber_mathfuncs.h
+++ b/meos/include/temporal/tnumber_mathfuncs.h
@@ -62,10 +62,10 @@ extern int tfloat_arithop_turnpt(Datum start1, Datum end1, Datum start2,
   TimestampTz *t1, TimestampTz *t2);
 
 extern Temporal *arithop_tnumber_number(const Temporal *temp, Datum value,
-  TArithmetic oper, Datum (*func)(Datum, Datum, meosType), bool invert);
+  TArithmetic oper, Datum (*func)(Datum, Datum, MeosType), bool invert);
 extern Temporal *arithop_tnumber_tnumber(const Temporal *temp1,
   const Temporal *temp2, TArithmetic oper,
-  Datum (*func)(Datum, Datum, meosType), tpfunc_temp tpfunc);
+  Datum (*func)(Datum, Datum, MeosType), tpfunc_temp tpfunc);
 
 /*****************************************************************************/
 

--- a/meos/include/temporal/tsequence.h
+++ b/meos/include/temporal/tsequence.h
@@ -55,13 +55,13 @@ extern long double floatsegm_locate(double value1, double value2,
   double value);
 
 extern int tnumbersegm_intersection(Datum start1, Datum end1, Datum start2,
-  Datum end2, meosType basetype, TimestampTz lower, TimestampTz upper,
+  Datum end2, MeosType basetype, TimestampTz lower, TimestampTz upper,
   TimestampTz *t1, TimestampTz *t2);
 
 /* Normalization functions */
 
 extern bool tsequence_norm_test(Datum value1, Datum value2, Datum value3,
-  meosType basetype, interpType interp, TimestampTz t1, TimestampTz t2,
+  MeosType basetype, interpType interp, TimestampTz t1, TimestampTz t2,
   TimestampTz t3);
 extern bool tsequence_join_test(const TSequence *seq1, const TSequence *seq2,
   bool *removelast, bool *removefirst);
@@ -94,13 +94,13 @@ extern bool synchronize_tsequence_tsequence(const TSequence *seq1,
 extern int tfloatsegm_intersection_value(Datum start, Datum end, Datum value,
   TimestampTz lower, TimestampTz upper, TimestampTz *t);
 extern int tsegment_intersection_value(Datum start, Datum end, Datum value,
-  meosType temptype, TimestampTz lower, TimestampTz upper, TimestampTz *t1,
+  MeosType temptype, TimestampTz lower, TimestampTz upper, TimestampTz *t1,
   TimestampTz *t2);
 extern int tsegment_intersection(Datum start1, Datum end1, Datum start2,
-  Datum end2, meosType temptype, TimestampTz lower, TimestampTz upper,
+  Datum end2, MeosType temptype, TimestampTz lower, TimestampTz upper,
   TimestampTz *t1, TimestampTz *t2);
 extern Datum tsegment_value_at_timestamptz(Datum start, Datum end,
-  meosType temptype, TimestampTz lower, TimestampTz upper, TimestampTz t);
+  MeosType temptype, TimestampTz lower, TimestampTz upper, TimestampTz t);
   
 extern bool intersection_tdiscseq_tdiscseq(const TSequence *seq1,
   const TSequence *seq2, TSequence **inter1, TSequence **inter2);
@@ -123,7 +123,7 @@ extern char *tsequence_to_string(const TSequence *seq, int maxdd,
 
 extern bool ensure_increasing_timestamps(const TInstant *inst1,
   const TInstant *inst2, bool strict);
-extern void bbox_expand(const void *box1, void *box2, meosType temptype);
+extern void bbox_expand(const void *box1, void *box2, MeosType temptype);
 extern bool ensure_valid_tinstarr(TInstant **instants, int count, bool merge,
   interpType interp);
 extern bool tsequence_make_valid(TInstant **instants, int count,

--- a/meos/include/temporal/tsequenceset.h
+++ b/meos/include/temporal/tsequenceset.h
@@ -48,7 +48,7 @@ extern bool tsequenceset_find_timestamptz(const TSequenceSet *ss,
   TimestampTz t, int *loc);
 extern TSequence **tseqarr_normalize(TSequence **sequences, int count,
   int *newcount);
-extern double datum_distance(Datum value1, Datum value2, meosType basetype,
+extern double datum_distance(Datum value1, Datum value2, MeosType basetype,
   int16 flags);
 extern int *ensure_valid_tinstarr_gaps(TInstant **instants, int count,
   bool merge, double maxdist, const Interval *maxt, int *nsplits);

--- a/meos/include/temporal/type_inout.h
+++ b/meos/include/temporal/type_inout.h
@@ -62,13 +62,13 @@
 
 /*****************************************************************************/
 
-extern uint8_t *datum_as_wkb(Datum value, meosType type, uint8_t variant,
+extern uint8_t *datum_as_wkb(Datum value, MeosType type, uint8_t variant,
   size_t *size_out);
-extern char *datum_as_hexwkb(Datum value, meosType type, uint8_t variant,
+extern char *datum_as_hexwkb(Datum value, MeosType type, uint8_t variant,
   size_t *size);
 
-extern Datum type_from_wkb(const uint8_t *wkb, size_t size, meosType type);
-extern Datum type_from_hexwkb(const char *hexwkb, size_t size, meosType type);
+extern Datum type_from_wkb(const uint8_t *wkb, size_t size, MeosType type);
+extern Datum type_from_hexwkb(const char *hexwkb, size_t size, MeosType type);
 
 /*****************************************************************************/
 

--- a/meos/include/temporal/type_parser.h
+++ b/meos/include/temporal/type_parser.h
@@ -54,23 +54,23 @@ extern bool ensure_oparen(const char **str, const char *type);
 extern bool p_cparen(const char **str);
 extern bool ensure_cparen(const char **str, const char *type);
 extern bool p_comma(const char **str);
-extern bool basetype_parse(const char **str, meosType basetypid, char delim,
+extern bool basetype_parse(const char **str, MeosType basetypid, char delim,
   Datum *result);
 extern bool double_parse(const char **str, double *result);
-extern bool elem_parse(const char **str, meosType basetype, Datum *result);
-extern Set *set_parse(const char **str, meosType basetype);
-extern bool span_parse(const char **str, meosType spantype, bool end,
+extern bool elem_parse(const char **str, MeosType basetype, Datum *result);
+extern Set *set_parse(const char **str, MeosType basetype);
+extern bool span_parse(const char **str, MeosType spantype, bool end,
   Span *span);
-extern SpanSet *spanset_parse(const char **str, meosType spantype);
+extern SpanSet *spanset_parse(const char **str, MeosType spantype);
 extern TBox *tbox_parse(const char **str);
 extern TimestampTz timestamp_parse(const char **str);
-extern TInstant *tinstant_parse(const char **str, meosType temptype, bool end);
-extern TSequence *tdiscseq_parse(const char **str, meosType temptype);
-extern TSequence *tcontseq_parse(const char **str, meosType temptype, 
+extern TInstant *tinstant_parse(const char **str, MeosType temptype, bool end);
+extern TSequence *tdiscseq_parse(const char **str, MeosType temptype);
+extern TSequence *tcontseq_parse(const char **str, MeosType temptype, 
   interpType interp, bool end);
-extern TSequenceSet *tsequenceset_parse(const char **str, meosType temptype,
+extern TSequenceSet *tsequenceset_parse(const char **str, MeosType temptype,
   interpType interp);
-extern Temporal *temporal_parse(const char **str, meosType temptype);
+extern Temporal *temporal_parse(const char **str, MeosType temptype);
 
 /*****************************************************************************/
 

--- a/meos/include/temporal/type_util.h
+++ b/meos/include/temporal/type_util.h
@@ -53,15 +53,15 @@
 
 /* Miscellaneous functions */
 
-extern Datum datum_copy(Datum value, meosType typid);
-extern double datum_double(Datum d, meosType type);
-extern Datum double_datum(double d, meosType type);
+extern Datum datum_copy(Datum value, MeosType typid);
+extern double datum_double(Datum d, MeosType type);
+extern Datum double_datum(double d, MeosType type);
 extern bytea *bstring2bytea(const uint8_t *wkb, size_t size);
 
 /* Input/output functions */
 
-extern bool basetype_in(const char *str, meosType type, bool end, Datum *result);
-extern char *basetype_out(Datum value, meosType type, int maxdd);
+extern bool basetype_in(const char *str, MeosType type, bool end, Datum *result);
+extern char *basetype_out(Datum value, MeosType type, int maxdd);
 
 /* Array functions */
 
@@ -71,7 +71,7 @@ extern char *stringarr_to_string(char **strings, int count, size_t outlen,
 
 /* Sort functions */
 
-extern void datumarr_sort(Datum *values, int count, meosType basetype);
+extern void datumarr_sort(Datum *values, int count, MeosType basetype);
 extern void tstzarr_sort(TimestampTz *times, int count);
 extern void spanarr_sort(Span *spans, int count);
 extern void tinstarr_sort(TInstant **instants, int count);
@@ -80,7 +80,7 @@ extern void tseqarr_sort(TSequence **sequences, int count);
 /* Remove duplicate functions */
 
 extern int datumarr_remove_duplicates(Datum *values, int count,
-  meosType basetype);
+  MeosType basetype);
 extern int tstzarr_remove_duplicates(TimestampTz *values, int count);
 extern int tinstarr_remove_duplicates(TInstant **instants, int count);
 
@@ -89,27 +89,27 @@ extern int tinstarr_remove_duplicates(TInstant **instants, int count);
 
 /* Arithmetic functions */
 
-extern Datum datum_add(Datum l, Datum r, meosType type);
-extern Datum datum_sub(Datum l, Datum r, meosType type);
-extern Datum datum_mult(Datum l, Datum r, meosType type);
-extern Datum datum_div(Datum l, Datum r, meosType type);
+extern Datum datum_add(Datum l, Datum r, MeosType type);
+extern Datum datum_sub(Datum l, Datum r, MeosType type);
+extern Datum datum_mult(Datum l, Datum r, MeosType type);
+extern Datum datum_div(Datum l, Datum r, MeosType type);
 
 /* Comparison functions on datums */
 
-extern int datum_cmp(Datum l, Datum r, meosType type);
-extern bool datum_eq(Datum l, Datum r, meosType type);
-extern bool datum_ne(Datum l, Datum r, meosType type);
-extern bool datum_lt(Datum l, Datum r, meosType type);
-extern bool datum_le(Datum l, Datum r, meosType type);
-extern bool datum_gt(Datum l, Datum r, meosType type);
-extern bool datum_ge(Datum l, Datum r, meosType type);
+extern int datum_cmp(Datum l, Datum r, MeosType type);
+extern bool datum_eq(Datum l, Datum r, MeosType type);
+extern bool datum_ne(Datum l, Datum r, MeosType type);
+extern bool datum_lt(Datum l, Datum r, MeosType type);
+extern bool datum_le(Datum l, Datum r, MeosType type);
+extern bool datum_gt(Datum l, Datum r, MeosType type);
+extern bool datum_ge(Datum l, Datum r, MeosType type);
 
-extern Datum datum2_eq(Datum l, Datum r, meosType type);
-extern Datum datum2_ne(Datum l, Datum r, meosType type);
-extern Datum datum2_lt(Datum l, Datum r, meosType type);
-extern Datum datum2_le(Datum l, Datum r, meosType type);
-extern Datum datum2_gt(Datum l, Datum r, meosType type);
-extern Datum datum2_ge(Datum l, Datum r, meosType type);
+extern Datum datum2_eq(Datum l, Datum r, MeosType type);
+extern Datum datum2_ne(Datum l, Datum r, MeosType type);
+extern Datum datum2_lt(Datum l, Datum r, MeosType type);
+extern Datum datum2_le(Datum l, Datum r, MeosType type);
+extern Datum datum2_gt(Datum l, Datum r, MeosType type);
+extern Datum datum2_ge(Datum l, Datum r, MeosType type);
 
 /* Hypothenuse functions */
 

--- a/meos/src/cbuffer/tcbuffer.c
+++ b/meos/src/cbuffer/tcbuffer.c
@@ -805,7 +805,7 @@ tcbufferseq_members(const TSequence *seq, bool point)
     values[i] = point ?
       PointerGetDatum(&cb->point) : Float8GetDatum(cb->radius);
   }
-  meosType basetype = point ? T_GEOMETRY : T_FLOAT8;
+  MeosType basetype = point ? T_GEOMETRY : T_FLOAT8;
   datumarr_sort(values, seq->count, basetype);
   int count = datumarr_remove_duplicates(values, seq->count, basetype);
   if (point)
@@ -834,7 +834,7 @@ tcbufferseqset_members(const TSequenceSet *ss, bool point)
         PointerGetDatum(&cb->point) : Float8GetDatum(cb->radius);
     }
   }
-  meosType basetype = point ? T_GEOMETRY : T_TFLOAT;
+  MeosType basetype = point ? T_GEOMETRY : T_TFLOAT;
   datumarr_sort(values, ss->count, basetype);
   int count = datumarr_remove_duplicates(values, ss->count, basetype);
   /* Free the duplicate values that have been found */

--- a/meos/src/cbuffer/tcbuffer_compops.c
+++ b/meos/src/cbuffer/tcbuffer_compops.c
@@ -56,7 +56,7 @@
  */
 int
 eacomp_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb,
-  Datum (*func)(Datum, Datum, meosType), bool ever)
+  Datum (*func)(Datum, Datum, MeosType), bool ever)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tcbuffer_cbuffer(temp, cb))
@@ -73,7 +73,7 @@ eacomp_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb,
  */
 int
 eacomp_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
-  Datum (*func)(Datum, Datum, meosType), bool ever)
+  Datum (*func)(Datum, Datum, MeosType), bool ever)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tcbuffer_tcbuffer(temp1, temp2))
@@ -258,7 +258,7 @@ always_ne_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
  */
 static Temporal *
 tcomp_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp,
-  Datum (*func)(Datum, Datum, meosType))
+  Datum (*func)(Datum, Datum, MeosType))
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tcbuffer_cbuffer(temp, cb))
@@ -275,7 +275,7 @@ tcomp_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp,
  */
 static Temporal *
 tcomp_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb,
-  Datum (*func)(Datum, Datum, meosType))
+  Datum (*func)(Datum, Datum, MeosType))
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tcbuffer_cbuffer(temp, cb))

--- a/meos/src/geo/geoset_meos.c
+++ b/meos/src/geo/geoset_meos.c
@@ -112,7 +112,7 @@ geoset_make(GSERIALIZED **values, int count)
   Datum *datums = palloc(sizeof(Datum) * count);
   for (int i = 0; i < count; ++i)
     datums[i] = PointerGetDatum(values[i]);
-  meosType geotype = FLAGS_GET_GEODETIC(values[0]->gflags) ?
+  MeosType geotype = FLAGS_GET_GEODETIC(values[0]->gflags) ?
     T_GEOGRAPHY : T_GEOMETRY;
   return set_make_free(datums, count, geotype, ORDER);
 }
@@ -135,7 +135,7 @@ geo_set(const GSERIALIZED *gs)
     return NULL;
 
   Datum v = PointerGetDatum(gs);
-  meosType geotype = FLAGS_GET_GEODETIC(gs->gflags) ? T_GEOGRAPHY : T_GEOMETRY;
+  MeosType geotype = FLAGS_GET_GEODETIC(gs->gflags) ? T_GEOGRAPHY : T_GEOMETRY;
   return set_make_exp(&v, 1, 1, geotype, ORDER_NO);
 }
 
@@ -385,7 +385,7 @@ geo_union_transfn(Set *state, const GSERIALIZED *gs)
   VALIDATE_NOT_NULL(gs, NULL);
   if (state && ! ensure_geoset_type(state->settype))
     return NULL;
-  meosType geotype = FLAGS_GET_GEODETIC(gs->gflags) ? T_GEOGRAPHY : T_GEOMETRY;
+  MeosType geotype = FLAGS_GET_GEODETIC(gs->gflags) ? T_GEOGRAPHY : T_GEOMETRY;
   return value_union_transfn(state, PointerGetDatum(gs), geotype);
 }
 

--- a/meos/src/geo/stbox.c
+++ b/meos/src/geo/stbox.c
@@ -1022,7 +1022,7 @@ tstzspanset_to_stbox(const SpanSet *ss)
  * @param[out] box Spatiotemporal box
  */
 bool
-spatial_set_stbox(Datum d, meosType basetype, STBox *box)
+spatial_set_stbox(Datum d, MeosType basetype, STBox *box)
 {
   assert(spatial_basetype(basetype));
   switch (basetype)

--- a/meos/src/geo/tgeo.c
+++ b/meos/src/geo/tgeo.c
@@ -60,7 +60,7 @@ tpointinst_make(const GSERIALIZED *gs, TimestampTz t)
   if (! ensure_not_empty(gs) || ! ensure_point_type(gs) ||
       ! ensure_has_not_M_geo(gs))
     return NULL;
-  meosType temptype = FLAGS_GET_GEODETIC(gs->gflags) ?
+  MeosType temptype = FLAGS_GET_GEODETIC(gs->gflags) ?
     T_TGEOGPOINT : T_TGEOMPOINT;
   return tinstant_make(PointerGetDatum(gs), temptype, t);
 }
@@ -79,7 +79,7 @@ tgeoinst_make(const GSERIALIZED *gs, TimestampTz t)
   VALIDATE_NOT_NULL(gs, NULL);
   if (! ensure_not_empty(gs))
     return NULL;
-  meosType temptype = FLAGS_GET_GEODETIC(gs->gflags) ?
+  MeosType temptype = FLAGS_GET_GEODETIC(gs->gflags) ?
     T_TGEOGRAPHY : T_TGEOMETRY;
   return tinstant_make(PointerGetDatum(gs), temptype, t);
 }

--- a/meos/src/geo/tgeo_boxops.c
+++ b/meos/src/geo/tgeo_boxops.c
@@ -222,7 +222,7 @@ void
 tspatialinstarr_set_stbox(TInstant **instants, int count, bool lower_inc,
   bool upper_inc, interpType interp, void *box)
 {
-  meosType temptype = instants[0]->temptype;
+  MeosType temptype = instants[0]->temptype;
   assert(tspatial_type(temptype));
   if (tgeo_type_all(temptype))
     tgeoinstarr_set_stbox(instants, count, (STBox *) box);
@@ -338,7 +338,7 @@ tspatialseqarr_set_stbox(TSequence **sequences, int count, STBox *box)
  * @note Currently, only spatial set types have bounding box
  */
 void
-spatialarr_set_bbox(const Datum *values, meosType basetype, int count,
+spatialarr_set_bbox(const Datum *values, MeosType basetype, int count,
   void *box)
 {
   assert(spatial_basetype(basetype));

--- a/meos/src/geo/tgeo_compops.c
+++ b/meos/src/geo/tgeo_compops.c
@@ -58,7 +58,7 @@
  */
 int
 eacomp_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
-  Datum (*func)(Datum, Datum, meosType), bool ever)
+  Datum (*func)(Datum, Datum, MeosType), bool ever)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TGEO(temp, -1); VALIDATE_NOT_NULL(gs, -1);
@@ -76,7 +76,7 @@ eacomp_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
  */
 int
 eacomp_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2,
-  Datum (*func)(Datum, Datum, meosType), bool ever)
+  Datum (*func)(Datum, Datum, MeosType), bool ever)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TGEO(temp1, -1); VALIDATE_TGEO(temp2, -1);
@@ -254,7 +254,7 @@ always_ne_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
  */
 static Temporal *
 tcomp_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp,
-  Datum (*func)(Datum, Datum, meosType))
+  Datum (*func)(Datum, Datum, MeosType))
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TGEO(temp, NULL); VALIDATE_NOT_NULL(gs, NULL);
@@ -272,7 +272,7 @@ tcomp_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp,
  */
 static Temporal *
 tcomp_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
-  Datum (*func)(Datum, Datum, meosType))
+  Datum (*func)(Datum, Datum, MeosType))
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TGEO(temp, NULL); VALIDATE_NOT_NULL(gs, NULL);

--- a/meos/src/geo/tgeo_meos.c
+++ b/meos/src/geo/tgeo_meos.c
@@ -530,7 +530,7 @@ tpointseq_from_base_tstzset(const GSERIALIZED *gs, const Set *s)
  VALIDATE_NOT_NULL(gs, NULL); VALIDATE_TSTZSET(s, NULL);
   if (! ensure_not_empty(gs) || ! ensure_point_type(gs))
     return NULL;
-  meosType temptype = FLAGS_GET_GEODETIC(gs->gflags) ?
+  MeosType temptype = FLAGS_GET_GEODETIC(gs->gflags) ?
     T_TGEOGPOINT : T_TGEOMPOINT;
   return tsequence_from_base_tstzset(PointerGetDatum(gs), temptype, s);
 }
@@ -549,7 +549,7 @@ tgeoseq_from_base_tstzset(const GSERIALIZED *gs, const Set *s)
   VALIDATE_NOT_NULL(gs, NULL); VALIDATE_TSTZSET(s, NULL);
   if (! ensure_not_empty(gs))
     return NULL;
-  meosType temptype = FLAGS_GET_GEODETIC(gs->gflags) ?
+  MeosType temptype = FLAGS_GET_GEODETIC(gs->gflags) ?
     T_TGEOGRAPHY : T_TGEOMETRY;
   return tsequence_from_base_tstzset(PointerGetDatum(gs), temptype, s);
 }
@@ -571,7 +571,7 @@ tpointseq_from_base_tstzspan(const GSERIALIZED *gs, const Span *s,
   VALIDATE_NOT_NULL(gs, NULL); VALIDATE_TSTZSPAN(s, NULL);
   if (gserialized_is_empty(gs))
     return NULL;
-  meosType temptype = FLAGS_GET_GEODETIC(gs->gflags) ?
+  MeosType temptype = FLAGS_GET_GEODETIC(gs->gflags) ?
     T_TGEOGPOINT : T_TGEOMPOINT;
   return tsequence_from_base_tstzspan(PointerGetDatum(gs), temptype, s,
     interp);
@@ -593,7 +593,7 @@ tgeoseq_from_base_tstzspan(const GSERIALIZED *gs, const Span *s,
   VALIDATE_NOT_NULL(gs, NULL); VALIDATE_TSTZSPAN(s, NULL);
   if (gserialized_is_empty(gs))
     return NULL;
-  meosType temptype = FLAGS_GET_GEODETIC(gs->gflags) ?
+  MeosType temptype = FLAGS_GET_GEODETIC(gs->gflags) ?
     T_TGEOGRAPHY : T_TGEOMETRY;
   return tsequence_from_base_tstzspan(PointerGetDatum(gs), temptype, s,
     interp);
@@ -617,7 +617,7 @@ tpointseqset_from_base_tstzspanset(const GSERIALIZED *gs, const SpanSet *ss,
   VALIDATE_NOT_NULL(gs, NULL); VALIDATE_TSTZSPANSET(ss, NULL);
   if (! ensure_not_empty(gs) || ! ensure_point_type(gs))
     return NULL;
-  meosType temptype = FLAGS_GET_GEODETIC(gs->gflags) ?
+  MeosType temptype = FLAGS_GET_GEODETIC(gs->gflags) ?
     T_TGEOGPOINT : T_TGEOMPOINT;
   return tsequenceset_from_base_tstzspanset(PointerGetDatum(gs), temptype, ss,
     interp);
@@ -639,7 +639,7 @@ tgeoseqset_from_base_tstzspanset(const GSERIALIZED *gs, const SpanSet *ss,
   VALIDATE_NOT_NULL(gs, NULL); VALIDATE_TSTZSPANSET(ss, NULL);
   if (! ensure_not_empty(gs))
     return NULL;
-  meosType temptype = FLAGS_GET_GEODETIC(gs->gflags) ?
+  MeosType temptype = FLAGS_GET_GEODETIC(gs->gflags) ?
     T_TGEOGRAPHY : T_TGEOMETRY;
   return tsequenceset_from_base_tstzspanset(PointerGetDatum(gs), temptype, ss,
     interp);
@@ -664,7 +664,7 @@ tgeo_from_base_temp_int(const GSERIALIZED *gs, const Temporal *temp,
   VALIDATE_NOT_NULL(temp, NULL); VALIDATE_NOT_NULL(gs, NULL);
   if (! ensure_not_empty(gs))
     return NULL;
-  meosType tgeotype;
+  MeosType tgeotype;
   if (ispoint)
     tgeotype = FLAGS_GET_GEODETIC(gs->gflags) ? T_TGEOGPOINT : T_TGEOMPOINT;
   else
@@ -766,7 +766,7 @@ tgeo_values(const Temporal *temp, int *count)
   VALIDATE_TGEO(temp, NULL); VALIDATE_NOT_NULL(count, NULL);
   int count1;
   Datum *datumarr = temporal_values_p(temp, &count1);
-  meosType basetype = temptype_basetype(temp->temptype);
+  MeosType basetype = temptype_basetype(temp->temptype);
   datumarr_sort(datumarr, count1, basetype);
   *count = datumarr_remove_duplicates(datumarr, count1, basetype);
   GSERIALIZED **result = palloc(sizeof(GSERIALIZED *) * *count);

--- a/meos/src/geo/tgeo_spatialfuncs.c
+++ b/meos/src/geo/tgeo_spatialfuncs.c
@@ -435,7 +435,7 @@ pose_flags(Pose *pose)
  * @brief Get the MEOS flags from a spatial value
  */
 int16
-spatial_flags(Datum d, meosType basetype)
+spatial_flags(Datum d, MeosType basetype)
 {
   assert(spatial_basetype(basetype));
   switch (basetype)
@@ -548,7 +548,7 @@ ensure_same_geodetic_tspatial_geo(const Temporal *temp, const GSERIALIZED *gs)
 bool
 ensure_same_geodetic_tspatial_base(const Temporal *temp, Datum base)
 {
-  meosType basetype = temptype_basetype(temp->temptype);
+  MeosType basetype = temptype_basetype(temp->temptype);
   assert(spatial_basetype(basetype));
   int16 flags = spatial_flags(base, basetype);
   if (MEOS_FLAGS_GET_GEODETIC(temp->flags) != MEOS_FLAGS_GET_GEODETIC(flags))
@@ -895,7 +895,7 @@ ensure_valid_tspatial_base(const Temporal *temp, Datum base)
 {
   VALIDATE_TSPATIAL(temp, false);
   VALIDATE_NOT_NULL(DatumGetPointer(base), false);;
-  meosType basetype = temptype_basetype(temp->temptype);
+  MeosType basetype = temptype_basetype(temp->temptype);
   if (! ensure_same_srid(tspatial_srid(temp), spatial_srid(base, basetype)) ||
       ! ensure_same_geodetic_tspatial_base(temp, base))
     return false;
@@ -972,7 +972,7 @@ tgeominst_tgeoginst(const TInstant *inst, bool oper)
     res = geom_to_geog(gs);
   else
     res = geog_to_geom(gs);
-  meosType temptype;
+  MeosType temptype;
   if (oper == TGEOMP_TO_TGEOGP)
     temptype = (inst->temptype == T_TGEOMPOINT) ? T_TGEOGPOINT : T_TGEOGRAPHY;
   else
@@ -1168,7 +1168,7 @@ tgeoinst_tpointinst(const TInstant *inst, bool oper)
   if (oper == TGEO_TO_TPOINT && ! ensure_point_type(gs))
     return NULL;
 
-  meosType temptype;
+  MeosType temptype;
   if (oper == TGEO_TO_TPOINT)
     temptype = (inst->temptype == T_TGEOMETRY) ? T_TGEOMPOINT : T_TGEOGPOINT;
   else
@@ -1616,7 +1616,7 @@ tgeo_traversed_area(const Temporal *temp, bool unary_union)
   /* Get the array of pointers to the component values */
   int count;
   Datum *values = temporal_values_p(temp, &count);
-  meosType basetype = temptype_basetype(temp->temptype);
+  MeosType basetype = temptype_basetype(temp->temptype);
   datumarr_sort(values, count, basetype);
   int newcount = datumarr_remove_duplicates(values, count, basetype);
   GSERIALIZED **gsarr = palloc(sizeof(GSERIALIZED *) * newcount);

--- a/meos/src/geo/tspatial.c
+++ b/meos/src/geo/tspatial.c
@@ -78,7 +78,7 @@
  * @return On error return @p NULL
  */
 char *
-spatialbase_as_text(Datum value, meosType type, int maxdd)
+spatialbase_as_text(Datum value, MeosType type, int maxdd)
 {
   assert(spatial_basetype(type)); assert(maxdd >= 0);
 
@@ -112,7 +112,7 @@ spatialbase_as_text(Datum value, meosType type, int maxdd)
  * @return On error return @p NULL
  */
 char *
-spatialbase_as_ewkt(Datum value, meosType type, int maxdd)
+spatialbase_as_ewkt(Datum value, MeosType type, int maxdd)
 {
   assert(spatial_basetype(type)); assert(maxdd >= 0);
 
@@ -320,7 +320,7 @@ tspatial_as_ewkt(const Temporal *temp, int maxdd)
  * @param[in] extended True if the output is in EWKT
  */
 char **
-spatialarr_wkt_out(const Datum *spatialarr, meosType elemtype, int count,
+spatialarr_wkt_out(const Datum *spatialarr, MeosType elemtype, int count,
   int maxdd, bool extended)
 {
   /* Ensure the validity of the arguments */
@@ -354,7 +354,7 @@ spatialarr_wkt_out(const Datum *spatialarr, meosType elemtype, int count,
  * @param[in] maxdd Maximum number of decimal digits to output
  */
 inline char **
-spatialarr_as_text(const Datum *spatialarr, meosType elemtype, int count, 
+spatialarr_as_text(const Datum *spatialarr, MeosType elemtype, int count, 
   int maxdd)
 {
   return spatialarr_wkt_out(spatialarr, elemtype, count, maxdd, false);
@@ -370,7 +370,7 @@ spatialarr_as_text(const Datum *spatialarr, meosType elemtype, int count,
  * @param[in] maxdd Maximum number of decimal digits to output
  */
 inline char **
-spatialarr_as_ewkt(const Datum *spatialarr, meosType elemtype, int count, 
+spatialarr_as_ewkt(const Datum *spatialarr, MeosType elemtype, int count, 
   int maxdd)
 {
   return spatialarr_wkt_out(spatialarr, elemtype, count, maxdd, true);

--- a/meos/src/geo/tspatial_parser.c
+++ b/meos/src/geo/tspatial_parser.c
@@ -271,7 +271,7 @@ stbox_parse(const char **str)
  * @param[out] result New geometry, may be NULL
  */
 bool 
-geo_parse(const char **str, meosType basetype, char delim, int *srid,
+geo_parse(const char **str, MeosType basetype, char delim, int *srid,
   GSERIALIZED **result)
 {
   p_whitespace(str);
@@ -323,13 +323,13 @@ geo_parse(const char **str, meosType basetype, char delim, int *srid,
  * @param[out] result New spatial base value, may be NULL
  */
 bool 
-spatial_parse_elem(const char **str, meosType temptype, char delim, 
+spatial_parse_elem(const char **str, MeosType temptype, char delim, 
   int *temp_srid, Datum *result)
 {
   p_whitespace(str);
   /* The next instruction will throw an exception if it fails */
   Datum d;
-  meosType basetype = temptype_basetype(temptype);
+  MeosType basetype = temptype_basetype(temptype);
   if (! basetype_parse(str, basetype, delim, &d))
     return false;
 
@@ -371,7 +371,7 @@ spatial_parse_elem(const char **str, meosType temptype, char delim,
  * @param[out] result New instant, may be NULL
  */
 TInstant *
-tspatialinst_parse(const char **str, meosType temptype, bool end,
+tspatialinst_parse(const char **str, MeosType temptype, bool end,
   int *temp_srid)
 {
   Datum base;
@@ -401,7 +401,7 @@ tspatialinst_parse(const char **str, meosType temptype, bool end,
  * @param[in,out] temp_srid SRID of the spatiotemporal value
  */
 TSequence *
-tspatialseq_disc_parse(const char **str, meosType temptype, int *temp_srid)
+tspatialseq_disc_parse(const char **str, MeosType temptype, int *temp_srid)
 {
   MeosArray *array = meos_array_create(meostype_length(temptype));
   const char *type_str = meostype_name(temptype);
@@ -452,7 +452,7 @@ error:
  * @param[out] result New sequence, may be NULL
  */
 TSequence *
-tspatialseq_cont_parse(const char **str, meosType temptype, interpType interp, 
+tspatialseq_cont_parse(const char **str, MeosType temptype, interpType interp, 
   bool end, int *temp_srid)
 {
   MeosArray *array = meos_array_create(meostype_length(temptype));
@@ -518,7 +518,7 @@ error:
  * @param[in,out] temp_srid SRID of the spatiotemporal value
  */
 TSequenceSet *
-tspatialseqset_parse(const char **str, meosType temptype, interpType interp,
+tspatialseqset_parse(const char **str, MeosType temptype, interpType interp,
   int *temp_srid)
 {
   MeosArray *array = meos_array_create(meostype_length(temptype));
@@ -565,7 +565,7 @@ error:
   * @param[in] temptype Temporal type
 */
 Temporal *
-tspatial_parse(const char **str, meosType temptype)
+tspatial_parse(const char **str, MeosType temptype)
 {
   /* Ensure the validity of the arguments */
    VALIDATE_NOT_NULL(str, NULL);
@@ -636,7 +636,7 @@ tspatial_parse(const char **str, meosType temptype)
  * @param[in] temptype Temporal type
  */
 Temporal *
-tpoint_parse(const char **str, meosType temptype)
+tpoint_parse(const char **str, MeosType temptype)
 {
   Temporal *result = tspatial_parse(str, temptype);
   if (! result)

--- a/meos/src/geo/tspatial_srid.c
+++ b/meos/src/geo/tspatial_srid.c
@@ -78,7 +78,7 @@
  * @brief Return the SRID of a spatial value
  */
 int32_t
-spatial_srid(Datum d, meosType basetype)
+spatial_srid(Datum d, MeosType basetype)
 {
   assert(spatial_basetype(basetype));
   switch (basetype)
@@ -110,7 +110,7 @@ spatial_srid(Datum d, meosType basetype)
  * to another SRID
  */
 bool
-spatial_set_srid(Datum d, meosType basetype, int32_t srid)
+spatial_set_srid(Datum d, MeosType basetype, int32_t srid)
 {
   assert(spatial_basetype(basetype));
   switch (basetype)
@@ -200,7 +200,7 @@ int32_t
 tspatialinst_srid(const TInstant *inst)
 {
   assert(inst); assert(tspatial_type(inst->temptype));
-  meosType basetype = temptype_basetype(inst->temptype);
+  MeosType basetype = temptype_basetype(inst->temptype);
   return spatial_srid(tinstant_value_p(inst), basetype);
 }
 
@@ -243,7 +243,7 @@ void
 tspatialinst_set_srid(TInstant *inst, int32_t srid)
 {
   assert(inst); assert(tspatial_type(inst->temptype));
-  meosType basetype = temptype_basetype(inst->temptype);
+  MeosType basetype = temptype_basetype(inst->temptype);
   spatial_set_srid(tinstant_value_p(inst), basetype, srid);
   return;
 }
@@ -439,10 +439,10 @@ point_transf_pj(GSERIALIZED *gs, int32_t srid_to, const LWPROJ *pj)
  */
 Datum
 #if CBUFFER
-  datum_transf_pj(Datum d, meosType basetype, int32_t srid_to,
+  datum_transf_pj(Datum d, MeosType basetype, int32_t srid_to,
     const LWPROJ *pj)
 #else
-  datum_transf_pj(Datum d, meosType basetype, int32_t srid_to UNUSED,
+  datum_transf_pj(Datum d, MeosType basetype, int32_t srid_to UNUSED,
     const LWPROJ *pj)
 #endif /* CBUFFER */
 {
@@ -582,7 +582,7 @@ TInstant *
 tspatialinst_transf_pj(const TInstant *inst, int32_t srid_to, const LWPROJ *pj)
 {
   assert(inst); assert(pj); assert(tspatial_type(inst->temptype));
-  meosType basetype = temptype_basetype(inst->temptype);
+  MeosType basetype = temptype_basetype(inst->temptype);
   /* The SRID of the geometry is set in the following function */
   Datum d = datum_transf_pj(tinstant_value_p(inst), basetype, srid_to, pj);
   if (! DatumGetPointer(d))

--- a/meos/src/geo/tspatial_tempspatialrels.c
+++ b/meos/src/geo/tspatial_tempspatialrels.c
@@ -417,7 +417,7 @@ tinterrel_tspatial_base(const Temporal *temp, Datum base, bool tinter,
 {
   assert(temp); assert(DatumGetPointer(base));
   /* Bounding box test */
-  meosType basetype = temptype_basetype(temp->temptype);
+  MeosType basetype = temptype_basetype(temp->temptype);
   STBox box1, box2;
   tspatial_set_stbox(temp, &box1);
   /* Non-empty geometries have a bounding box */
@@ -1245,7 +1245,7 @@ tdwithin_tlinearseq_tlinearseq_iter(const TSequence *seq1,
   Datum sv2 = tinstant_value_p(start2);
   TimestampTz lower = start1->t;
   bool lower_inc = seq1->period.lower_inc;
-  meosType basetype = temptype_basetype(seq1->temptype);
+  MeosType basetype = temptype_basetype(seq1->temptype);
   /* We create three temporal instants with arbitrary values that are set in
    * the for loop to avoid creating and freeing the instants each time a
    * segment of the result is computed */
@@ -1381,7 +1381,7 @@ tdwithin_tlinearseq_base_iter(const TSequence *seq, Datum point, Datum dist,
   bool linear = MEOS_FLAGS_LINEAR_INTERP(seq->flags);
   TimestampTz lower = start->t;
   bool lower_inc = seq->period.lower_inc;
-  meosType basetype = temptype_basetype(seq->temptype);
+  MeosType basetype = temptype_basetype(seq->temptype);
   /* We create three temporal instants with arbitrary values that are set in
    * the for loop to avoid creating and freeing the instants each time a
    * segment of the result is computed */

--- a/meos/src/npoint/tnpoint_compops.c
+++ b/meos/src/npoint/tnpoint_compops.c
@@ -55,7 +55,7 @@
  */
 int
 eacomp_tnpoint_npoint(const Temporal *temp, const Npoint *np,
-  Datum (*func)(Datum, Datum, meosType), bool ever)
+  Datum (*func)(Datum, Datum, MeosType), bool ever)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TNPOINT(temp, -1); VALIDATE_NOT_NULL(np, -1);
@@ -72,7 +72,7 @@ eacomp_tnpoint_npoint(const Temporal *temp, const Npoint *np,
  */
 int
 eacomp_tnpoint_tnpoint(const Temporal *temp1, const Temporal *temp2,
-  Datum (*func)(Datum, Datum, meosType), bool ever)
+  Datum (*func)(Datum, Datum, MeosType), bool ever)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TNPOINT(temp1, -1); VALIDATE_TNPOINT(temp2, -1);
@@ -266,7 +266,7 @@ always_ne_tnpoint_tnpoint(const Temporal *temp1, const Temporal *temp2)
  */
 static Temporal *
 tcomp_tnpoint_npoint(const Temporal *temp, const Npoint *np,
-  Datum (*func)(Datum, Datum, meosType))
+  Datum (*func)(Datum, Datum, MeosType))
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TNPOINT(temp, NULL); VALIDATE_NOT_NULL(np, NULL);

--- a/meos/src/pose/tpose_compops.c
+++ b/meos/src/pose/tpose_compops.c
@@ -60,7 +60,7 @@
  */
 static int
 eacomp_tpose_pose(const Temporal *temp, const Pose *pose,
-  Datum (*func)(Datum, Datum, meosType), bool ever)
+  Datum (*func)(Datum, Datum, MeosType), bool ever)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tpose_pose(temp, pose))
@@ -78,7 +78,7 @@ eacomp_tpose_pose(const Temporal *temp, const Pose *pose,
  */
 static int
 eacomp_tpose_tpose(const Temporal *temp1, const Temporal *temp2,
-  Datum (*func)(Datum, Datum, meosType), bool ever)
+  Datum (*func)(Datum, Datum, MeosType), bool ever)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tpose_tpose(temp1, temp2))
@@ -260,7 +260,7 @@ always_ne_tpose_tpose(const Temporal *temp1, const Temporal *temp2)
  */
 static Temporal *
 tcomp_pose_tpose(const Pose *pose, const Temporal *temp,
-  Datum (*func)(Datum, Datum, meosType))
+  Datum (*func)(Datum, Datum, MeosType))
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TPOSE(temp, NULL); VALIDATE_NOT_NULL(pose, NULL);
@@ -279,7 +279,7 @@ tcomp_pose_tpose(const Pose *pose, const Temporal *temp,
  */
 static Temporal *
 tcomp_tpose_pose(const Temporal *temp, const Pose *pose,
-  Datum (*func)(Datum, Datum, meosType))
+  Datum (*func)(Datum, Datum, MeosType))
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TPOSE(temp, NULL); VALIDATE_NOT_NULL(pose, NULL);

--- a/meos/src/rgeo/trgeo_compops.c
+++ b/meos/src/rgeo/trgeo_compops.c
@@ -59,7 +59,7 @@
  */
 static int
 eacomp_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
-  Datum (*func)(Datum, Datum, meosType), bool ever)
+  Datum (*func)(Datum, Datum, MeosType), bool ever)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
@@ -77,7 +77,7 @@ eacomp_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
  */
 static int
 eacomp_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2,
-  Datum (*func)(Datum, Datum, meosType), bool ever)
+  Datum (*func)(Datum, Datum, MeosType), bool ever)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_trgeo(temp1, temp2))
@@ -262,7 +262,7 @@ always_ne_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
  */
 static Temporal *
 tcomp_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp,
-  Datum (*func)(Datum, Datum, meosType))
+  Datum (*func)(Datum, Datum, MeosType))
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
@@ -280,7 +280,7 @@ tcomp_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp,
  */
 static Temporal *
 tcomp_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
-  Datum (*func)(Datum, Datum, meosType))
+  Datum (*func)(Datum, Datum, MeosType))
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))

--- a/meos/src/rgeo/trgeo_parser.c
+++ b/meos/src/rgeo/trgeo_parser.c
@@ -57,7 +57,7 @@
  * @param[in] geom Reference geometry
  */
 TInstant * 
-trgeoinst_parse(const char **str, meosType temptype, bool end,
+trgeoinst_parse(const char **str, MeosType temptype, bool end,
   int *temp_srid, const GSERIALIZED *geom)
 {
   Datum base;
@@ -89,7 +89,7 @@ trgeoinst_parse(const char **str, meosType temptype, bool end,
  * @param[in] geom Reference geometry
  */
 TSequence *
-trgeoseq_disc_parse(const char **str, meosType temptype, int *temp_srid,
+trgeoseq_disc_parse(const char **str, MeosType temptype, int *temp_srid,
   GSERIALIZED *geom)
 {
   MeosArray *array = meos_array_create(meostype_length(temptype));
@@ -139,7 +139,7 @@ error:
  * @param[out] result New sequence, may be NULL
  */
 TSequence *
-trgeoseq_cont_parse(const char **str, meosType temptype, interpType interp, 
+trgeoseq_cont_parse(const char **str, MeosType temptype, interpType interp, 
   bool end, int *temp_srid, const GSERIALIZED *geom)
 {
   MeosArray *array = meos_array_create(meostype_length(temptype));
@@ -206,7 +206,7 @@ error:
  * @param[in] geom Reference geometry
  */
 TSequenceSet *
-trgeoseqset_parse(const char **str, meosType temptype, interpType interp,
+trgeoseqset_parse(const char **str, MeosType temptype, interpType interp,
   int *temp_srid, const GSERIALIZED *geom)
 {
   MeosArray *array = meos_array_create(meostype_length(temptype));
@@ -306,7 +306,7 @@ trgeo_parse_geom(const char **str, int32_t temp_srid)
  * @param[in] temptype Temporal type
  */
 Temporal *
-trgeo_parse(const char **str, meosType temptype)
+trgeo_parse(const char **str, MeosType temptype)
 {
   p_whitespace(str);
 

--- a/meos/src/temporal/lifting.c
+++ b/meos/src/temporal/lifting.c
@@ -368,8 +368,8 @@ static int
 tfunc_tlinearseq_base_turnpt(const TSequence *seq, Datum value,
   LiftedFunctionInfo *lfinfo, TSequence **result)
 {
-  meosType basetype = temptype_basetype(seq->temptype);
-  meosType resbasetype = temptype_basetype(lfinfo->restype);
+  MeosType basetype = temptype_basetype(seq->temptype);
+  MeosType resbasetype = temptype_basetype(lfinfo->restype);
   int ninsts = 0;
   TInstant **instants = palloc(sizeof(TInstant *) * seq->count * 3);
   const TInstant *inst1 = TSEQUENCE_INST_N(seq, 0);
@@ -441,7 +441,7 @@ tfunc_tlinearseq_base_discfn(const TSequence *seq, Datum value,
   Datum startvalue = tinstant_value_p(start);
   Datum startresult = tfunc_base_base(startvalue, value, lfinfo);
   TInstant **instants = palloc(sizeof(TInstant *) * seq->count * 2);
-  meosType resbasetype = temptype_basetype(lfinfo->restype);
+  MeosType resbasetype = temptype_basetype(lfinfo->restype);
 
   /* Instantaneous sequence */
   if (seq->count == 1)
@@ -452,8 +452,8 @@ tfunc_tlinearseq_base_discfn(const TSequence *seq, Datum value,
   }
 
   /* General case */
-  meosType basetype = temptype_basetype(seq->temptype);
-  meosType restype = lfinfo->restype;
+  MeosType basetype = temptype_basetype(seq->temptype);
+  MeosType restype = lfinfo->restype;
   bool lower_inc = seq->period.lower_inc;
   int ninsts = 0, nseqs = 0;
   for (int i = 1; i < seq->count; i++)
@@ -702,7 +702,7 @@ static void
 lfinfo_invert_args(LiftedFunctionInfo *lfinfo)
 {
   lfinfo->invert = ! lfinfo->invert;
-  meosType temp = lfinfo->argtype[0];
+  MeosType temp = lfinfo->argtype[0];
   lfinfo->argtype[0] = lfinfo->argtype[1];
   lfinfo->argtype[1] = temp;
   return;
@@ -916,7 +916,7 @@ tfunc_tsequenceset_tdiscseq(const TSequenceSet *ss, const TSequence *seq,
 {
   TInstant **instants = palloc(sizeof(TInstant *) * seq->count);
   int i = 0, j = 0, ninsts = 0;
-  meosType basetype = temptype_basetype(ss->temptype);
+  MeosType basetype = temptype_basetype(ss->temptype);
   while (i < ss->count && j < seq->count)
   {
     const TSequence *seq1 = TSEQUENCESET_SEQ_N(ss, i);
@@ -984,8 +984,8 @@ tfunc_tcontseq_tcontseq_single(const TSequence *seq1, const TSequence *seq2,
    * where S, T, and * are values computed, respectively, at the
    * synchronization points, optional turning points, and common points
    */
-  meosType basetype = temptype_basetype(seq1->temptype);
-  meosType basetype_res = temptype_basetype(lfinfo->restype);
+  MeosType basetype = temptype_basetype(seq1->temptype);
+  MeosType basetype_res = temptype_basetype(lfinfo->restype);
   TInstant *inst1 = (TInstant *) TSEQUENCE_INST_N(seq1, 0);
   TInstant *inst2 = (TInstant *) TSEQUENCE_INST_N(seq2, 0);
   TInstant *prev1 = NULL, *prev2 = NULL; /* make compiler quiet */
@@ -1121,9 +1121,9 @@ tfunc_tcontseq_tcontseq_discfn(const TSequence *seq1, const TSequence *seq2,
   TInstant **tofree = palloc(sizeof(TInstant *) * count);
   interpType interp1 = MEOS_FLAGS_GET_INTERP(seq1->flags);
   interpType interp2 = MEOS_FLAGS_GET_INTERP(seq2->flags);
-  meosType basetype = temptype_basetype(seq1->temptype);
-  meosType restype = lfinfo->restype;
-  meosType resbasetype = temptype_basetype(lfinfo->restype);
+  MeosType basetype = temptype_basetype(seq1->temptype);
+  MeosType restype = lfinfo->restype;
+  MeosType resbasetype = temptype_basetype(lfinfo->restype);
   interpType interp = lfinfo->reslinear ? LINEAR : STEP;
 
   TInstant *start1 = (TInstant *) TSEQUENCE_INST_N(seq1, 0);
@@ -1351,8 +1351,8 @@ tfunc_tlinearseq_tstepseq(const TSequence *seq1, const TSequence *seq2,
     j = tcontseq_find_timestamptz(seq2, inter->lower) + 1;
   }
   bool lower_inc = inter->lower_inc;
-  meosType restype = lfinfo->restype;
-  meosType resbasetype = temptype_basetype(restype);
+  MeosType restype = lfinfo->restype;
+  MeosType resbasetype = temptype_basetype(restype);
   /* Compute the function at the start instant */
   Datum startvalue1 = tinstant_value_p(start1);
   Datum startvalue2 = tinstant_value_p(start2);
@@ -1780,7 +1780,7 @@ eafunc_tlinearseq_base(const TSequence *seq, Datum value,
 
   /* General case */
   bool lower_inc = seq->period.lower_inc;
-  meosType basetype = temptype_basetype(seq->temptype);
+  MeosType basetype = temptype_basetype(seq->temptype);
   TInstant *start = (TInstant *) TSEQUENCE_INST_N(seq, 0);
   Datum startvalue;
   bool res;
@@ -2235,7 +2235,7 @@ eafunc_tcontseq_tcontseq_discfn(const TSequence *seq1,
   interpType interp1 = MEOS_FLAGS_GET_INTERP(seq1->flags);
   interpType interp2 = MEOS_FLAGS_GET_INTERP(seq2->flags);
   Datum startvalue1, startvalue2;
-  meosType basetype = temptype_basetype(seq1->temptype);
+  MeosType basetype = temptype_basetype(seq1->temptype);
   bool res;
   while (i < seq1->count && j < seq2->count)
   {

--- a/meos/src/temporal/meos_catalog.c
+++ b/meos/src/temporal/meos_catalog.c
@@ -57,7 +57,7 @@
 
 /**
  * @brief Global constant array containing the type names corresponding to the
- * enumeration meosType defined in file `meos_catalog.h`
+ * enumeration MeosType defined in file `meos_catalog.h`
  */
 static const char *MEOS_TYPE_NAMES[] =
 {
@@ -286,7 +286,7 @@ static const temptype_catalog_struct MEOS_TEMPTYPE_CATALOG[] =
  * @brief Return the string representation of the MEOS type
  */
 inline const char *
-meostype_name(meosType type)
+meostype_name(MeosType type)
 {
   return MEOS_TYPE_NAMES[type];
 }
@@ -446,8 +446,8 @@ interptype_from_string(const char *str)
 /**
  * @brief Return the base type from the temporal type
  */
-meosType
-temptype_basetype(meosType type)
+MeosType
+temptype_basetype(MeosType type)
 {
   int n = sizeof(MEOS_TEMPTYPE_CATALOG) / sizeof(temptype_catalog_struct);
   for (int i = 0; i < n; i++)
@@ -468,8 +468,8 @@ temptype_basetype(meosType type)
 /**
  * @brief Return the base type from a set type
  */
-meosType
-settype_basetype(meosType type)
+MeosType
+settype_basetype(MeosType type)
 {
   int n = sizeof(MEOS_SETTYPE_CATALOG) / sizeof(settype_catalog_struct);
   for (int i = 0; i < n; i++)
@@ -486,8 +486,8 @@ settype_basetype(meosType type)
 /**
  * @brief Return the base type from the set type
  */
-meosType
-basetype_settype(meosType type)
+MeosType
+basetype_settype(MeosType type)
 {
   int n = sizeof(MEOS_SETTYPE_CATALOG) / sizeof(settype_catalog_struct);
   for (int i = 0; i < n; i++)
@@ -504,8 +504,8 @@ basetype_settype(meosType type)
 /**
  * @brief Return the base type from the span type
  */
-meosType
-spantype_basetype(meosType type)
+MeosType
+spantype_basetype(MeosType type)
 {
   int n = sizeof(MEOS_SPANTYPE_CATALOG) / sizeof(spantype_catalog_struct);
   for (int i = 0; i < n; i++)
@@ -522,8 +522,8 @@ spantype_basetype(meosType type)
 /**
  * @brief Return the span type from the span set type
  */
-meosType
-spansettype_spantype(meosType type)
+MeosType
+spansettype_spantype(MeosType type)
 {
   int n = sizeof(MEOS_SPANSETTYPE_CATALOG) / sizeof(spansettype_catalog_struct);
   for (int i = 0; i < n; i++)
@@ -540,8 +540,8 @@ spansettype_spantype(meosType type)
 /**
  * @brief Return the span type of a base type
  */
-meosType
-basetype_spantype(meosType type)
+MeosType
+basetype_spantype(MeosType type)
 {
   int n = sizeof(MEOS_SPANTYPE_CATALOG) / sizeof(spantype_catalog_struct);
   for (int i = 0; i < n; i++)
@@ -558,8 +558,8 @@ basetype_spantype(meosType type)
 /**
  * @brief Return the span type from the span set type
  */
-meosType
-spantype_spansettype(meosType type)
+MeosType
+spantype_spansettype(MeosType type)
 {
   int n = sizeof(MEOS_SPANSETTYPE_CATALOG) / sizeof(spansettype_catalog_struct);
   for (int i = 0; i < n; i++)
@@ -582,7 +582,7 @@ spantype_spansettype(meosType type)
  * @note This function is only used in the asserts
  */
 inline bool
-meos_basetype(meosType type)
+meos_basetype(MeosType type)
 {
   return (type == T_BOOL || type == T_INT4 || type == T_INT8 || type == T_FLOAT8 ||
     type == T_TEXT || type == T_DATE || type == T_TIMESTAMPTZ ||
@@ -606,7 +606,7 @@ meos_basetype(meosType type)
  * @brief Return true if the values of the base type are passed by value
  */
 inline bool
-basetype_byvalue(meosType type)
+basetype_byvalue(MeosType type)
 {
   return (type == T_BOOL || type == T_INT4 || type == T_INT8 || type == T_FLOAT8 ||
     type == T_DATE || type == T_TIMESTAMPTZ);
@@ -616,7 +616,7 @@ basetype_byvalue(meosType type)
  * @brief Return true if the values of the base type are of variable length
  */
 inline bool
-basetype_varlength(meosType type)
+basetype_varlength(MeosType type)
 {
   return (type == T_TEXT || type == T_GEOMETRY || type == T_GEOGRAPHY
 #if POSE || RGEO
@@ -630,7 +630,7 @@ basetype_varlength(meosType type)
  * @return On error return SHRT_MAX
  */
 int16
-meostype_length(meosType type)
+meostype_length(MeosType type)
 {
   if (basetype_byvalue(type))
     return sizeof(Datum);
@@ -671,7 +671,7 @@ meostype_length(meosType type)
  * @note This function is only used in the asserts
  */
 inline bool
-alphanum_basetype(meosType type)
+alphanum_basetype(MeosType type)
 {
   return (type == T_BOOL || type == T_INT4 || type == T_INT8 ||
     type == T_FLOAT8 || type == T_TEXT || type == T_DATE ||
@@ -683,7 +683,7 @@ alphanum_basetype(meosType type)
  * @note This function is only used in the asserts
  */
 inline bool
-alphanum_temptype(meosType type)
+alphanum_temptype(MeosType type)
 {
   return (type == T_TBOOL || type == T_TINT || type == T_TFLOAT ||
     type == T_TTEXT);
@@ -694,7 +694,7 @@ alphanum_temptype(meosType type)
  * @brief Return true if the type is a geo base type
  */
 inline bool
-geo_basetype(meosType type)
+geo_basetype(MeosType type)
 {
   return (type == T_GEOMETRY || type == T_GEOGRAPHY);
 }
@@ -703,7 +703,7 @@ geo_basetype(meosType type)
  * @brief Return true if the type is a spatial base type
  */
 inline bool
-spatial_basetype(meosType type)
+spatial_basetype(MeosType type)
 {
   return (type == T_GEOMETRY || type == T_GEOGRAPHY 
 #if CBUFFER
@@ -724,7 +724,7 @@ spatial_basetype(meosType type)
  * @brief Return true if the type is a time type
  */
 inline bool
-time_type(meosType type)
+time_type(MeosType type)
 {
   return (type == T_DATE || type == T_DATESET || type == T_DATESPAN ||
     type == T_DATESPANSET || type == T_TIMESTAMPTZ || type == T_TSTZSET ||
@@ -739,7 +739,7 @@ time_type(meosType type)
  * @note This function is only used in the asserts
  */
 inline bool
-set_basetype(meosType type)
+set_basetype(MeosType type)
 {
   return (type == T_TIMESTAMPTZ || type == T_DATE || type == T_INT4 ||
       type == T_INT8 || type == T_FLOAT8 || type == T_TEXT ||
@@ -761,7 +761,7 @@ set_basetype(meosType type)
  * @brief Return true if the type is a set type
  */
 inline bool
-set_type(meosType type)
+set_type(MeosType type)
 {
   return (type == T_TSTZSET || type == T_DATESET || type == T_INTSET ||
       type == T_BIGINTSET || type == T_FLOATSET || type == T_TEXTSET ||
@@ -782,7 +782,7 @@ set_type(meosType type)
  * @brief Return true if the type is a number set type
  */
 inline bool
-numset_type(meosType type)
+numset_type(MeosType type)
 {
   return (type == T_INTSET || type == T_BIGINTSET || type == T_FLOATSET ||
     /* Dates are represented as integers */
@@ -794,7 +794,7 @@ numset_type(meosType type)
  * @brief Ensure that the type is a number set type
  */
 bool
-ensure_numset_type(meosType type)
+ensure_numset_type(MeosType type)
 {
   if (numset_type(type))
     return true;
@@ -808,7 +808,7 @@ ensure_numset_type(meosType type)
  * @brief Return true if the type is a time set type
  */
 inline bool
-timeset_type(meosType type)
+timeset_type(MeosType type)
 {
   return (type == T_DATESET || type == T_TSTZSET);
 }
@@ -817,7 +817,7 @@ timeset_type(meosType type)
  * @brief Return true if the type is a set type with a span as a bounding box
  */
 inline bool
-set_spantype(meosType type)
+set_spantype(MeosType type)
 {
   return (type == T_INTSET || type == T_BIGINTSET || type == T_FLOATSET ||
     type == T_DATESET || type == T_TSTZSET);
@@ -827,7 +827,7 @@ set_spantype(meosType type)
  * @brief Ensure that a set value is a set type with a span as a bounding box
  */
 bool
-ensure_set_spantype(meosType type)
+ensure_set_spantype(MeosType type)
 {
   if (set_spantype(type))
     return true;
@@ -840,7 +840,7 @@ ensure_set_spantype(meosType type)
  * @brief Return true if the type is a set type
  */
 inline bool
-alphanumset_type(meosType type)
+alphanumset_type(MeosType type)
 {
   return (type == T_TSTZSET || type == T_DATESET || type == T_INTSET ||
     type == T_BIGINTSET || type == T_FLOATSET || type == T_TEXTSET);
@@ -851,7 +851,7 @@ alphanumset_type(meosType type)
  * @brief Return true if the type is a geo set type
  */
 inline bool
-geoset_type(meosType type)
+geoset_type(MeosType type)
 {
   return (type == T_GEOMSET || type == T_GEOGSET);
 }
@@ -860,7 +860,7 @@ geoset_type(meosType type)
  * @brief Ensure that a set value is a geo set
  */
 bool
-ensure_geoset_type(meosType type)
+ensure_geoset_type(MeosType type)
 {
   if (geoset_type(type))
     return true;
@@ -874,7 +874,7 @@ ensure_geoset_type(meosType type)
  * @brief Return true if the type is a geo set type
  */
 inline bool
-spatialset_type(meosType type)
+spatialset_type(MeosType type)
 {
   return (type == T_GEOMSET || type == T_GEOGSET
 #if CBUFFER
@@ -894,7 +894,7 @@ spatialset_type(meosType type)
  * @brief Ensure that a temporal value is a temporal number
  */
 bool
-ensure_spatialset_type(meosType type)
+ensure_spatialset_type(MeosType type)
 {
   if (spatialset_type(type))
     return true;
@@ -910,7 +910,7 @@ ensure_spatialset_type(meosType type)
  * @brief Return true if the type is a span base type
  */
 inline bool
-span_basetype(meosType type)
+span_basetype(MeosType type)
 {
   return (type == T_TIMESTAMPTZ || type == T_DATE || type == T_INT4 ||
     type == T_INT8 || type == T_FLOAT8);
@@ -920,7 +920,7 @@ span_basetype(meosType type)
  * @brief Return true if the type is a canonical base type of a span type
  */
 inline bool
-span_canon_basetype(meosType type)
+span_canon_basetype(MeosType type)
 {
   return (type == T_DATE || type == T_INT4 || type == T_INT8);
 }
@@ -929,7 +929,7 @@ span_canon_basetype(meosType type)
  * @brief Return true if the type is a span type
  */
 bool
-span_type(meosType type)
+span_type(MeosType type)
 {
   return (type == T_TSTZSPAN || type == T_DATESPAN || type == T_INTSPAN ||
     type == T_BIGINTSPAN || type == T_FLOATSPAN);
@@ -940,7 +940,7 @@ span_type(meosType type)
  * @note This function is only used in the asserts
  */
 inline bool
-type_span_bbox(meosType type)
+type_span_bbox(MeosType type)
 {
   return (set_spantype(type) || span_type(type) || spanset_type(type) ||
     talpha_type(type));
@@ -951,7 +951,7 @@ type_span_bbox(meosType type)
  * @note This function is only used in the asserts
  */
 inline bool
-span_tbox_type(meosType type)
+span_tbox_type(MeosType type)
 {
   return (type == T_INTSPAN || type == T_FLOATSPAN || type == T_TSTZSPAN);
 }
@@ -961,7 +961,7 @@ span_tbox_type(meosType type)
  * @note This function is only used in the asserts
  */
 bool
-ensure_span_tbox_type(meosType type)
+ensure_span_tbox_type(MeosType type)
 {
   if (span_tbox_type(type))
     return true;
@@ -974,7 +974,7 @@ ensure_span_tbox_type(meosType type)
  * @brief Return true if the type is a number span type
  */
 inline bool
-numspan_basetype(meosType type)
+numspan_basetype(MeosType type)
 {
   return (type == T_INT4 || type == T_INT8 || type == T_FLOAT8 ||
     /* Dates are represented as integers */
@@ -985,7 +985,7 @@ numspan_basetype(meosType type)
  * @brief Return true if the type is a number span type
  */
 inline bool
-numspan_type(meosType type)
+numspan_type(MeosType type)
 {
   return (type == T_INTSPAN || type == T_BIGINTSPAN || type == T_FLOATSPAN ||
     type == T_DATESPAN);
@@ -995,7 +995,7 @@ numspan_type(meosType type)
  * @brief Ensure that a span is a number span type
  */
 bool
-ensure_numspan_type(meosType type)
+ensure_numspan_type(MeosType type)
 {
   if (numspan_type(type))
     return true;
@@ -1008,7 +1008,7 @@ ensure_numspan_type(meosType type)
  * @brief Return true if the type is a time span type
  */
 inline bool
-timespan_basetype(meosType type)
+timespan_basetype(MeosType type)
 {
   return (type == T_TIMESTAMPTZ || type == T_DATE);
 }
@@ -1017,7 +1017,7 @@ timespan_basetype(meosType type)
  * @brief Return true if the type is a time span type
  */
 inline bool
-timespan_type(meosType type)
+timespan_type(MeosType type)
 {
   return (type == T_TSTZSPAN || type == T_DATESPAN);
 }
@@ -1028,7 +1028,7 @@ timespan_type(meosType type)
  * @brief Return true if the type is a span set type
  */
 inline bool
-spanset_type(meosType type)
+spanset_type(MeosType type)
 {
   return (type == T_TSTZSPANSET || type == T_DATESPANSET ||
     type == T_INTSPANSET || type == T_BIGINTSPANSET || type == T_FLOATSPANSET);
@@ -1038,7 +1038,7 @@ spanset_type(meosType type)
  * @brief Return true if the type is a time span type
  */
 inline bool
-timespanset_type(meosType type)
+timespanset_type(MeosType type)
 {
   return (type == T_TSTZSPANSET || type == T_DATESPANSET);
 }
@@ -1048,7 +1048,7 @@ timespanset_type(meosType type)
  * @brief Ensure that a span is a time span type
  */
 bool
-ensure_timespanset_type(meosType type)
+ensure_timespanset_type(MeosType type)
 {
   if (timespanset_type(type))
     return true;
@@ -1065,7 +1065,7 @@ ensure_timespanset_type(meosType type)
  * @note Function used in particular in the indexes
  */
 inline bool
-temporal_type(meosType type)
+temporal_type(MeosType type)
 {
   return (type == T_TBOOL || type == T_TINT || type == T_TFLOAT ||
     type == T_TTEXT || type == T_TGEOMPOINT || type == T_TGEOGPOINT ||
@@ -1093,7 +1093,7 @@ temporal_type(meosType type)
  * @note This function is only used in the asserts
  */
 inline bool
-temporal_basetype(meosType type)
+temporal_basetype(MeosType type)
 {
   return (type == T_BOOL || type == T_INT4 || type == T_FLOAT8 ||
     type == T_TEXT ||
@@ -1117,7 +1117,7 @@ temporal_basetype(meosType type)
  * @brief Return true if the type is a temporal continuous type
  */
 inline bool
-temptype_continuous(meosType type)
+temptype_continuous(MeosType type)
 {
   return (type == T_TFLOAT || type == T_TDOUBLE2 || type == T_TDOUBLE3 ||
       type == T_TDOUBLE4 || type == T_TGEOMPOINT || type == T_TGEOGPOINT
@@ -1142,7 +1142,7 @@ temptype_continuous(meosType type)
  * @note This function is only used in the asserts
  */
 inline bool
-talphanum_type(meosType type)
+talphanum_type(MeosType type)
 {
   return (type == T_TBOOL || type == T_TINT || type == T_TFLOAT ||
     type == T_TTEXT);
@@ -1154,7 +1154,7 @@ talphanum_type(meosType type)
  * bounding box is a timestamptz span)
  */
 inline bool
-talpha_type(meosType type)
+talpha_type(MeosType type)
 {
   return (type == T_TBOOL || type == T_TTEXT || type == T_TDOUBLE2 ||
     type == T_TDOUBLE3 || type == T_TDOUBLE4);
@@ -1164,7 +1164,7 @@ talpha_type(meosType type)
  * @brief Return true if the type is a temporal number type
  */
 inline bool
-tnumber_type(meosType type)
+tnumber_type(MeosType type)
 {
   return (type == T_TINT || type == T_TFLOAT);
 }
@@ -1173,7 +1173,7 @@ tnumber_type(meosType type)
  * @brief Ensure that a type is a temporal number
  */
 bool
-ensure_tnumber_type(meosType type)
+ensure_tnumber_type(MeosType type)
 {
   if (tnumber_type(type))
     return true;
@@ -1186,7 +1186,7 @@ ensure_tnumber_type(meosType type)
  * @brief Return true if the type is a temporal number base type
  */
 bool
-tnumber_basetype(meosType type)
+tnumber_basetype(MeosType type)
 {
   return (type == T_INT4 || type == T_FLOAT8);
 }
@@ -1195,7 +1195,7 @@ tnumber_basetype(meosType type)
  * @brief Ensure that a type is a temporal number base type
  */
 bool
-ensure_tnumber_basetype(meosType type)
+ensure_tnumber_basetype(MeosType type)
 {
   if (tnumber_basetype(type))
     return true;
@@ -1210,7 +1210,7 @@ ensure_tnumber_basetype(meosType type)
  * @note Function used in particular in the indexes
  */
 bool
-tnumber_spantype(meosType type)
+tnumber_spantype(MeosType type)
 {
   return (type == T_INTSPAN || type == T_FLOATSPAN);
 }
@@ -1226,7 +1226,7 @@ tnumber_spantype(meosType type)
  * Therefore, it is used for the indexes and selectivity functions.
  */
 inline bool
-tspatial_type(meosType type)
+tspatial_type(MeosType type)
 {
   return (type == T_TGEOMPOINT || type == T_TGEOGPOINT || 
     type == T_TGEOMETRY || type == T_TGEOGRAPHY
@@ -1250,7 +1250,7 @@ tspatial_type(meosType type)
  * @brief Ensure that attype is a spatiotemporal type
  */
 bool
-ensure_tspatial_type(meosType type)
+ensure_tspatial_type(MeosType type)
 {
   if (tspatial_type(type))
     return true;
@@ -1264,7 +1264,7 @@ ensure_tspatial_type(meosType type)
  * @brief Return true if a type is a temporal point type
  */
 inline bool
-tpoint_type(meosType type)
+tpoint_type(MeosType type)
 {
   return (type == T_TGEOMPOINT || type == T_TGEOGPOINT);
 }
@@ -1273,7 +1273,7 @@ tpoint_type(meosType type)
  * @brief Ensure that a type is a temporal point type
  */
 bool
-ensure_tpoint_type(meosType type)
+ensure_tpoint_type(MeosType type)
 {
   if (tpoint_type(type))
     return true;
@@ -1286,7 +1286,7 @@ ensure_tpoint_type(meosType type)
  * @brief Return true if a type is a temporal geo type
  */
 inline bool
-tgeo_type(meosType type)
+tgeo_type(MeosType type)
 {
   return (type == T_TGEOMETRY || type == T_TGEOGRAPHY);
 }
@@ -1296,7 +1296,7 @@ tgeo_type(meosType type)
  * @brief Ensure that a type is a temporal geo type
  */
 bool
-ensure_tgeo_type(meosType type)
+ensure_tgeo_type(MeosType type)
 {
   if (tgeo_type(type))
     return true;
@@ -1311,7 +1311,7 @@ ensure_tgeo_type(meosType type)
  * base type
  */
 inline bool
-tgeo_type_all(meosType type)
+tgeo_type_all(MeosType type)
 {
   return (type == T_TGEOMETRY || type == T_TGEOGRAPHY ||
     type == T_TGEOMPOINT || type == T_TGEOGPOINT);
@@ -1322,7 +1322,7 @@ tgeo_type_all(meosType type)
  * base type
  */
 bool
-ensure_tgeo_type_all(meosType type)
+ensure_tgeo_type_all(MeosType type)
 {
   if (tgeo_type_all(type))
     return true;
@@ -1336,7 +1336,7 @@ ensure_tgeo_type_all(meosType type)
  * @brief Return true if a type is a temporal geometry type
  */
 inline bool
-tgeometry_type(meosType type)
+tgeometry_type(MeosType type)
 {
   return (type == T_TGEOMPOINT || type == T_TGEOMETRY);
 }
@@ -1345,7 +1345,7 @@ tgeometry_type(meosType type)
  * @brief Ensure that a type is a temporal geometry type
  */
 bool
-ensure_tgeometry_type(meosType type)
+ensure_tgeometry_type(MeosType type)
 {
   if (tgeometry_type(type))
     return true;
@@ -1359,7 +1359,7 @@ ensure_tgeometry_type(meosType type)
  * @brief Return true if a type is a temporal geodetic type
  */
 inline bool
-tgeodetic_type(meosType type)
+tgeodetic_type(MeosType type)
 {
   return (type == T_TGEOGPOINT || type == T_TGEOGRAPHY);
 }
@@ -1369,7 +1369,7 @@ tgeodetic_type(meosType type)
  * @brief Ensure that a type is a temporal geodetic type
  */
 bool
-ensure_tgeodetic_type(meosType type)
+ensure_tgeodetic_type(MeosType type)
 {
   if (tgeodetic_type(type))
     return true;
@@ -1384,7 +1384,7 @@ ensure_tgeodetic_type(meosType type)
  * type
  */
 bool
-ensure_tnumber_tpoint_type(meosType type)
+ensure_tnumber_tpoint_type(MeosType type)
 {
   if (tnumber_type(type) || tpoint_type(type))
     return true;

--- a/meos/src/temporal/set.c
+++ b/meos/src/temporal/set.c
@@ -66,7 +66,7 @@
  * @brief Ensure that a set is of a given set type
  */
 bool
-ensure_set_isof_type(const Set *s, meosType settype)
+ensure_set_isof_type(const Set *s, MeosType settype)
 {
   if (s->settype == settype)
     return true;
@@ -160,7 +160,7 @@ set_find_value(const Set *s, Datum d, int *loc)
  * @csqlfn #Set_in()
  */
 Set *
-set_in(const char *str, meosType settype)
+set_in(const char *str, MeosType settype)
 {
   assert(str);
   return set_parse(&str, settype);
@@ -170,7 +170,7 @@ set_in(const char *str, meosType settype)
  * @brief Return true if the base type value is output enclosed into quotes
  */
 static bool
-set_basetype_quotes(meosType type)
+set_basetype_quotes(MeosType type)
 {
   /* Text values are already output with quotes in the #basetype_out function */
   if (type == T_TIMESTAMPTZ || spatial_basetype(type))
@@ -228,7 +228,7 @@ set_out(const Set *s, int maxdd)
  * @return On error return SIZE_MAX
  */
 static size_t
-set_bbox_size(meosType settype)
+set_bbox_size(MeosType settype)
 {
   assert(alphanumset_type(settype) || spatialset_type(settype));
   if (alphanumset_type(settype))
@@ -318,7 +318,7 @@ SET_VAL_N(const Set *s, int index)
  * should be removed
  */
 Set *
-set_make_exp(const Datum *values, int count, int maxcount, meosType basetype,
+set_make_exp(const Datum *values, int count, int maxcount, MeosType basetype,
   bool order)
 {
   assert(values); assert(count > 0); assert(count <= maxcount);
@@ -363,7 +363,7 @@ set_make_exp(const Datum *values, int count, int maxcount, meosType basetype,
   }
 
   /* Get the bounding box size */
-  meosType settype = basetype_settype(basetype);
+  MeosType settype = basetype_settype(basetype);
   size_t bboxsize = DOUBLE_PAD(set_bbox_size(settype));
 
   /* Determine whether the values are passed by value or by reference  */
@@ -464,7 +464,7 @@ set_make_exp(const Datum *values, int count, int maxcount, meosType basetype,
  * @csqlfn #Set_constructor()
  */
 Set *
-set_make(const Datum *values, int count, meosType basetype, bool order)
+set_make(const Datum *values, int count, MeosType basetype, bool order)
 {
   assert(values); assert(count > 0);
   return set_make_exp(values, count, count, basetype, order);
@@ -481,7 +481,7 @@ set_make(const Datum *values, int count, meosType basetype, bool order)
  * should be removed
  */
 Set *
-set_make_free(Datum *values, int count, meosType basetype, bool order)
+set_make_free(Datum *values, int count, MeosType basetype, bool order)
 {
   assert(values); assert(count >= 0);
   if (! count)
@@ -521,7 +521,7 @@ set_copy(const Set *s)
  * @csqlfn #Value_to_set()
  */
 Set *
-value_set(Datum value, meosType basetype)
+value_set(Datum value, MeosType basetype)
 {
   return set_make_exp(&value, 1, 1, basetype, ORDER_NO);
 }
@@ -925,7 +925,7 @@ Set *
 numset_shift_scale(const Set *s, Datum shift, Datum width, bool hasshift,
   bool haswidth)
 {
-  meosType type = s->basetype;
+  MeosType type = s->basetype;
   /* Ensure the validity of the arguments */
   VALIDATE_NUMSET(s, NULL);
   if (! ensure_one_true(hasshift, haswidth) ||

--- a/meos/src/temporal/set_aggfuncs_meos.c
+++ b/meos/src/temporal/set_aggfuncs_meos.c
@@ -74,7 +74,7 @@
  * @param[out] box Bounding box
  */
 void
-set_expand_bbox(Datum value, meosType basetype, void *box)
+set_expand_bbox(Datum value, MeosType basetype, void *box)
 {
   /* Currently, only spatial set types have bounding box */
   assert(set_basetype(basetype));
@@ -203,7 +203,7 @@ set_append_value(Set *set, Datum value)
  * @endcode
  */
 Set *
-value_union_transfn(Set *state, Datum value, meosType basetype)
+value_union_transfn(Set *state, Datum value, MeosType basetype)
 {
   /* Null state: create a new state with the value */
   if (! state)

--- a/meos/src/temporal/set_ops.c
+++ b/meos/src/temporal/set_ops.c
@@ -124,7 +124,7 @@ setop_set_set(const Set *s1, const Set *s2, SetOper op)
   int i = 0, j = 0, nvals = 0;
   Datum value1 = SET_VAL_N(s1, 0);
   Datum value2 = SET_VAL_N(s2, 0);
-  meosType basetype = s1->basetype;
+  MeosType basetype = s1->basetype;
   while (i < s1->count && j < s2->count)
   {
     int cmp = datum_cmp(value1, value2, basetype);

--- a/meos/src/temporal/span.c
+++ b/meos/src/temporal/span.c
@@ -64,7 +64,7 @@
  * @brief Ensure that a span is of a given span type
  */
 bool
-ensure_span_isof_type(const Span *s, meosType spantype)
+ensure_span_isof_type(const Span *s, MeosType spantype)
 {
   if (s->spantype == spantype)
     return true;
@@ -77,7 +77,7 @@ ensure_span_isof_type(const Span *s, meosType spantype)
  * @brief Ensure that a span is of a given base type
  */
 bool
-ensure_span_isof_basetype(const Span *s, meosType basetype)
+ensure_span_isof_basetype(const Span *s, MeosType basetype)
 {
   if (s->basetype == basetype)
     return true;
@@ -260,7 +260,7 @@ span_upper_cmp(const Span *s1, const Span *s2)
  * @brief Return the bound increased by 1 for accounting for canonicalized spans
  */
 Datum
-span_incr_bound(Datum lower, meosType basetype)
+span_incr_bound(Datum lower, MeosType basetype)
 {
   Datum result;
   switch (basetype)
@@ -284,7 +284,7 @@ span_incr_bound(Datum lower, meosType basetype)
  * @brief Return the bound decreased by 1 for accounting for canonicalized spans
  */
 Datum
-span_decr_bound(Datum lower, meosType basetype)
+span_decr_bound(Datum lower, MeosType basetype)
 {
   Datum result;
   switch (basetype)
@@ -353,7 +353,7 @@ spanarr_normalize(Span *spans, int count, bool order, int *newcount)
  * @param[in] spantype Span type
  */
 Span *
-span_in(const char *str, meosType spantype)
+span_in(const char *str, MeosType spantype)
 {
   assert(str);
   Span result;
@@ -420,10 +420,10 @@ span_out(const Span *s, int maxdd)
  */
 Span *
 span_make(Datum lower, Datum upper, bool lower_inc, bool upper_inc,
-  meosType basetype)
+  MeosType basetype)
 {
   Span *s = palloc(sizeof(Span));
-  meosType spantype = basetype_spantype(basetype);
+  MeosType spantype = basetype_spantype(basetype);
   span_set(lower, upper, lower_inc, upper_inc, basetype, spantype, s);
   return s;
 }
@@ -441,7 +441,7 @@ span_make(Datum lower, Datum upper, bool lower_inc, bool upper_inc,
  */
 void
 span_set(Datum lower, Datum upper, bool lower_inc, bool upper_inc,
-  meosType basetype, meosType spantype, Span *s)
+  MeosType basetype, MeosType spantype, Span *s)
 {
   assert(s); assert(basetype_spantype(basetype) == spantype);
   /* Canonicalize */
@@ -514,10 +514,10 @@ span_copy(const Span *s)
  * @param[out] s Result span
 */
 void
-value_set_span(Datum value, meosType basetype, Span *s)
+value_set_span(Datum value, MeosType basetype, Span *s)
 {
   assert(s); assert(span_basetype(basetype));
-  meosType spantype = basetype_spantype(basetype);
+  MeosType spantype = basetype_spantype(basetype);
   span_set(value, value, true, true, basetype, spantype, s);
   return;
 }
@@ -529,7 +529,7 @@ value_set_span(Datum value, meosType basetype, Span *s)
  * @param[in] basetype Type of the value
  */
 Span *
-value_span(Datum value, meosType basetype)
+value_span(Datum value, MeosType basetype)
 {
   Span *result = palloc(sizeof(Span));
   value_set_span(value, basetype, result);
@@ -548,7 +548,7 @@ void
 set_set_subspan(const Set *s, int fromidx, int toidx, Span *result)
 {
   assert(s); assert(result);
-  meosType spantype = basetype_spantype(s->basetype);
+  MeosType spantype = basetype_spantype(s->basetype);
   span_set(SET_VAL_N(s, fromidx), SET_VAL_N(s, toidx), true, true,
     s->basetype, spantype, result);
   return;
@@ -1091,7 +1091,7 @@ tstzspan_expand(const Span *s, const Interval *interv)
  * @param[in,out] lower,upper Bounds of the period
  */
 void
-span_bounds_shift_scale_value(Datum shift, Datum width, meosType basetype,
+span_bounds_shift_scale_value(Datum shift, Datum width, MeosType basetype,
   bool hasshift, bool haswidth, Datum *lower, Datum *upper)
 {
   assert(hasshift || haswidth); assert(lower); assert(upper);
@@ -1152,7 +1152,7 @@ numspan_delta_scale_iter(Span *s, Datum origin, Datum delta, bool hasdelta,
 {
   assert(s);
 
-  meosType type = s->basetype;
+  MeosType type = s->basetype;
   /* The default value when shift is not given is 0 */
   if (hasdelta)
   {
@@ -1238,7 +1238,7 @@ numspan_shift_scale_iter(Span *s, Datum shift, Datum width, bool hasshift,
   assert(s); assert(delta); assert(scale);
   Datum lower = s->lower;
   Datum upper = s->upper;
-  meosType type = s->basetype;
+  MeosType type = s->basetype;
   span_bounds_shift_scale_value(shift, width, type, hasshift, haswidth,
     &lower, &upper);
   /* Compute delta and scale before overwriting s->lower and s->upper */

--- a/meos/src/temporal/span_aggfuncs.c
+++ b/meos/src/temporal/span_aggfuncs.c
@@ -55,7 +55,7 @@
  * @param[in] basetype Type of the value
  */
 Span *
-spanbase_extent_transfn(Span *state, Datum value, meosType basetype)
+spanbase_extent_transfn(Span *state, Datum value, MeosType basetype)
 {
   /* Null span: return the span of the base value */
   if (! state)

--- a/meos/src/temporal/span_ops.c
+++ b/meos/src/temporal/span_ops.c
@@ -54,7 +54,7 @@
  * @brief Return the minimum value of two span base values
  */
 Datum
-span_min_value(Datum l, Datum r, meosType type)
+span_min_value(Datum l, Datum r, MeosType type)
 {
   assert(span_basetype(type));
   switch (type)
@@ -82,7 +82,7 @@ span_min_value(Datum l, Datum r, meosType type)
  * @brief Return the maximum value of two span base values
  */
 Datum
-span_max_value(Datum l, Datum r, meosType type)
+span_max_value(Datum l, Datum r, MeosType type)
 {
   assert(span_basetype(type));
   switch (type)
@@ -853,7 +853,7 @@ minus_span_span(const Span *s1, const Span *s2)
  * @return On error return -1
  */
 double
-dist_double_value_value(Datum l, Datum r, meosType type)
+dist_double_value_value(Datum l, Datum r, MeosType type)
 {
   assert(span_basetype(type));
   switch (type)
@@ -887,7 +887,7 @@ dist_double_value_value(Datum l, Datum r, meosType type)
  * @return On error return -1
  */
 Datum
-distance_value_value(Datum l, Datum r, meosType type)
+distance_value_value(Datum l, Datum r, MeosType type)
 {
   assert(span_basetype(type));
   switch (type)

--- a/meos/src/temporal/spanset.c
+++ b/meos/src/temporal/spanset.c
@@ -62,7 +62,7 @@
  * @brief Ensure that a span set is of a given span set type
  */
 bool
-ensure_spanset_isof_type(const SpanSet *ss, meosType spansettype)
+ensure_spanset_isof_type(const SpanSet *ss, MeosType spansettype)
 {
   if (ss->spansettype == spansettype)
     return true;
@@ -210,7 +210,7 @@ SPANSET_SP_N(const SpanSet *ss, int index)
  * @param[in] spansettype Span set type
  */
 SpanSet *
-spanset_in(const char *str, meosType spansettype)
+spanset_in(const char *str, MeosType spansettype)
 {
   assert(str);
   return spanset_parse(&str, spansettype);
@@ -388,10 +388,10 @@ spanset_copy(const SpanSet *ss)
  * @param[in] basetype Type of the value
  */
 SpanSet *
-value_spanset(Datum value, meosType basetype)
+value_spanset(Datum value, MeosType basetype)
 {
   assert(span_basetype(basetype));
-  meosType spantype = basetype_spantype(basetype);
+  MeosType spantype = basetype_spantype(basetype);
   Span s;
   span_set(value, value, true, true, basetype, spantype, &s);
   return spanset_make_exp(&s, 1, 1, NORMALIZE_NO, ORDER_NO);
@@ -408,7 +408,7 @@ set_spanset(const Set *s)
 {
   assert(s); assert(set_spantype(s->settype));
   Span *spans = palloc(sizeof(Span) * s->count);
-  meosType spantype = basetype_spantype(s->basetype);
+  MeosType spantype = basetype_spantype(s->basetype);
   for (int i = 0; i < s->count; i++)
   {
     Datum value = SET_VAL_N(s, i);

--- a/meos/src/temporal/tbox.c
+++ b/meos/src/temporal/tbox.c
@@ -231,10 +231,10 @@ tbox_copy(const TBox *box)
  * @csqlfn #Number_timestamptz_to_tbox()
  */
 TBox *
-number_timestamptz_to_tbox(Datum value, meosType basetype, TimestampTz t)
+number_timestamptz_to_tbox(Datum value, MeosType basetype, TimestampTz t)
 {
   Span s, p;
-  meosType spantype = basetype_spantype(basetype);
+  MeosType spantype = basetype_spantype(basetype);
   span_set(value, value, true, true, basetype, spantype, &s);
   Datum dt = TimestampTzGetDatum(t);
   span_set(dt, dt, true, true, T_TIMESTAMPTZ, T_TSTZSPAN, &p);
@@ -278,10 +278,10 @@ float_timestamptz_to_tbox(double d, TimestampTz t)
  * @csqlfn #Number_tstzspan_to_tbox()
  */
 TBox *
-number_tstzspan_to_tbox(Datum value, meosType basetype, const Span *s)
+number_tstzspan_to_tbox(Datum value, MeosType basetype, const Span *s)
 {
   assert(s);
-  meosType spantype = basetype_spantype(basetype);
+  MeosType spantype = basetype_spantype(basetype);
   Span s1;
   span_set(value, value, true, true, basetype, spantype, &s1);
   return tbox_make(&s1, s);
@@ -366,11 +366,11 @@ numspan_tstzspan_to_tbox(const Span *s, const Span *p)
  * @param[out] box Result
  */
 void
-number_set_tbox(Datum value, meosType basetype, TBox *box)
+number_set_tbox(Datum value, MeosType basetype, TBox *box)
 {
   assert(box); assert(tnumber_basetype(basetype));
   Span s;
-  meosType spantype = basetype_spantype(basetype);
+  MeosType spantype = basetype_spantype(basetype);
   span_set(value, value, true, true, basetype, spantype, &s);
   tbox_set(&s, NULL, box);
   return;
@@ -384,7 +384,7 @@ number_set_tbox(Datum value, meosType basetype, TBox *box)
  * @csqlfn #Number_to_tbox()
  */
 TBox *
-number_tbox(Datum value, meosType basetype)
+number_tbox(Datum value, MeosType basetype)
 {
   if (! ensure_tnumber_basetype(basetype))
     return NULL;
@@ -1266,7 +1266,7 @@ tfloatbox_expand(const TBox *box, const double d)
  * @csqlfn #Tbox_expand_value()
  */
 TBox *
-tbox_expand_value(const TBox *box, Datum value, meosType basetype)
+tbox_expand_value(const TBox *box, Datum value, MeosType basetype)
 {
   /* Ensure the validity of the arguments */
   assert(box); assert(tnumber_basetype(basetype));

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -81,7 +81,7 @@
  * @brief Ensure that a MEOS type has X dimension
  */
 bool
-ensure_has_X(meosType type, int16 flags)
+ensure_has_X(MeosType type, int16 flags)
 {
   if (MEOS_FLAGS_GET_X(flags))
     return true;
@@ -94,7 +94,7 @@ ensure_has_X(meosType type, int16 flags)
  * @brief Ensure that a MEOS type has Z dimension
  */
 bool
-ensure_has_Z(meosType type, int16 flags)
+ensure_has_Z(MeosType type, int16 flags)
 {
   if (MEOS_FLAGS_GET_Z(flags))
     return true;
@@ -107,7 +107,7 @@ ensure_has_Z(meosType type, int16 flags)
  * @brief Ensure that a MEOS type has not Z dimension
  */
 bool
-ensure_has_not_Z(meosType type, int16 flags)
+ensure_has_not_Z(MeosType type, int16 flags)
 {
   if (! MEOS_FLAGS_GET_Z(flags))
     return true;
@@ -120,7 +120,7 @@ ensure_has_not_Z(meosType type, int16 flags)
  * @brief Ensure that a MEOS type has Z dimension
  */
 bool
-ensure_has_T(meosType type, int16 flags)
+ensure_has_T(MeosType type, int16 flags)
 {
   if (MEOS_FLAGS_GET_T(flags))
     return true;
@@ -172,7 +172,7 @@ ensure_one_true(bool hasshift, bool haswidth)
  * @note Used for the constructor functions
  */
 bool
-ensure_valid_interp(meosType temptype, interpType interp)
+ensure_valid_interp(MeosType temptype, interpType interp)
 {
   if (interp == LINEAR && ! temptype_continuous(temptype))
   {
@@ -277,7 +277,7 @@ ensure_common_dimension(int16 flags1, int16 flags2)
  * @param[in] basetype Base type
  */
 bool
-ensure_temporal_isof_basetype(const Temporal *temp, meosType basetype)
+ensure_temporal_isof_basetype(const Temporal *temp, MeosType basetype)
 {
   if (temptype_basetype(temp->temptype) == basetype)
     return true;
@@ -291,7 +291,7 @@ ensure_temporal_isof_basetype(const Temporal *temp, meosType basetype)
  * @brief Ensure that a temporal value is of a temporal type
  */
 bool
-ensure_temporal_isof_type(const Temporal *temp, meosType temptype)
+ensure_temporal_isof_type(const Temporal *temp, MeosType temptype)
 {
   if (temp->temptype == temptype)
     return true;
@@ -472,7 +472,7 @@ ensure_positive(int i)
  * @brief Return true if a number is not negative
  */
 bool
-not_negative_datum(Datum d, meosType basetype)
+not_negative_datum(Datum d, MeosType basetype)
 {
   assert(span_basetype(basetype));
   if (basetype == T_INT4 && DatumGetInt32(d) < 0)
@@ -489,7 +489,7 @@ not_negative_datum(Datum d, meosType basetype)
  * @brief Ensure that a number is not negative
  */
 bool
-ensure_not_negative_datum(Datum d, meosType basetype)
+ensure_not_negative_datum(Datum d, MeosType basetype)
 {
   if (not_negative_datum(d, basetype))
     return true;
@@ -511,7 +511,7 @@ ensure_not_negative_datum(Datum d, meosType basetype)
  * @brief Return true if a number is strictly positive
  */
 bool
-positive_datum(Datum d, meosType basetype)
+positive_datum(Datum d, MeosType basetype)
 {
   assert(basetype == T_INT4 || basetype == T_INT8 || basetype == T_FLOAT8 ||
     basetype == T_DATE || basetype == T_TIMESTAMPTZ);
@@ -534,7 +534,7 @@ positive_datum(Datum d, meosType basetype)
  * @brief Ensure that a number is strictly positive
  */
 bool
-ensure_positive_datum(Datum d, meosType basetype)
+ensure_positive_datum(Datum d, MeosType basetype)
 {
   if (positive_datum(d, basetype))
     return true;
@@ -802,7 +802,7 @@ mobilitydb_full_version(void)
  * @param[in] temptype Temporal type
  */
 Temporal *
-temporal_in(const char *str, meosType temptype)
+temporal_in(const char *str, MeosType temptype)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(str, NULL);
@@ -879,7 +879,7 @@ temporal_copy(const Temporal *temp)
  * of another temporal discrete sequence
  */
 static TSequence *
-tdiscseq_from_base_temp(Datum value, meosType temptype, const TSequence *seq)
+tdiscseq_from_base_temp(Datum value, MeosType temptype, const TSequence *seq)
 {
   assert(seq); assert(MEOS_FLAGS_DISCRETE_INTERP(seq->flags));
   TInstant **instants = palloc(sizeof(TInstant *) * seq->count);
@@ -894,7 +894,7 @@ tdiscseq_from_base_temp(Datum value, meosType temptype, const TSequence *seq)
  * another temporal sequence
  */
 TSequence *
-tsequence_from_base_temp(Datum value, meosType temptype, const TSequence *seq)
+tsequence_from_base_temp(Datum value, MeosType temptype, const TSequence *seq)
 {
   assert(seq);
   return MEOS_FLAGS_DISCRETE_INTERP(seq->flags) ? 
@@ -913,7 +913,7 @@ tsequence_from_base_temp(Datum value, meosType temptype, const TSequence *seq)
  * the base type is continous or not.
  */
 TSequenceSet *
-tsequenceset_from_base_temp(Datum value, meosType temptype,
+tsequenceset_from_base_temp(Datum value, MeosType temptype,
   const TSequenceSet *ss)
 {
   assert(ss);
@@ -940,7 +940,7 @@ tsequenceset_from_base_temp(Datum value, meosType temptype,
  * @param[in] temp Temporal value
  */
 Temporal *
-temporal_from_base_temp(Datum value, meosType temptype, const Temporal *temp)
+temporal_from_base_temp(Datum value, MeosType temptype, const Temporal *temp)
 {
   assert(temp);
   assert(temptype_subtype(temp->subtype));
@@ -1119,8 +1119,8 @@ tnumber_set_span(const Temporal *temp, Span *s)
   assert(temp); assert(s); assert(tnumber_type(temp->temptype));
   assert(temptype_subtype(temp->subtype));
 
-  meosType basetype = temptype_basetype(temp->temptype);
-  meosType spantype = basetype_spantype(basetype);
+  MeosType basetype = temptype_basetype(temp->temptype);
+  MeosType spantype = basetype_spantype(basetype);
   if (temp->subtype == TINSTANT)
   {
     Datum value = tinstant_value_p((TInstant *) temp);
@@ -1176,7 +1176,7 @@ tnumber_to_tbox(const Temporal *temp)
  * @brief Return the function for rounding a base type
  */
 datum_func2
-round_fn(meosType basetype)
+round_fn(MeosType basetype)
 {
   assert(meos_basetype(basetype));
   switch (basetype)
@@ -1675,7 +1675,7 @@ tnumber_shift_scale_value(const Temporal *temp, Datum shift, Datum width,
   bool hasshift, bool haswidth)
 {
   assert(temp);
-  meosType basetype = temptype_basetype(temp->temptype);
+  MeosType basetype = temptype_basetype(temp->temptype);
   /* Ensure the validity of the arguments */
   if (! ensure_one_true(hasshift, haswidth) ||
       (width && ! ensure_positive_datum(width, basetype)))
@@ -1881,7 +1881,7 @@ temporal_values(const Temporal *temp, int *count)
   assert(temp); assert(count);
   int count1;
   Datum *values = temporal_values_p(temp, &count1);
-  meosType basetype = temptype_basetype(temp->temptype);
+  MeosType basetype = temptype_basetype(temp->temptype);
   datumarr_sort(values, count1, basetype);
   int newcount = datumarr_remove_duplicates(values, count1, basetype);
   Datum *result = palloc(sizeof(Datum) * newcount);
@@ -1997,7 +1997,7 @@ Datum
 temporal_min_value(const Temporal *temp)
 {
   assert(temp);
-  meosType basetype = temptype_basetype(temp->temptype);
+  MeosType basetype = temptype_basetype(temp->temptype);
   assert(temptype_subtype(temp->subtype));
   Datum result;
   switch (temp->subtype)
@@ -2025,7 +2025,7 @@ Datum
 temporal_max_value(const Temporal *temp)
 {
   assert(temp);
-  meosType basetype = temptype_basetype(temp->temptype);
+  MeosType basetype = temptype_basetype(temp->temptype);
   assert(temptype_subtype(temp->subtype));
   Datum result;
   switch (temp->subtype)
@@ -2962,7 +2962,7 @@ tsequence_derivative(const TSequence *seq)
     return NULL;
 
   /* General case */
-  meosType basetype = temptype_basetype(seq->temptype);
+  MeosType basetype = temptype_basetype(seq->temptype);
   TInstant **instants = palloc(sizeof(TInstant *) * seq->count);
   const TInstant *inst1 = TSEQUENCE_INST_N(seq, 0);
   Datum value1 = tinstant_value_p(inst1);

--- a/meos/src/temporal/temporal_analytics.c
+++ b/meos/src/temporal/temporal_analytics.c
@@ -219,7 +219,7 @@ tsequence_tprecision(const TSequence *seq, const Interval *duration,
   lower = lower_bin;
   upper = lower_bin + tunits;
   interpType interp = MEOS_FLAGS_GET_INTERP(seq->flags);
-  meosType temptype_out = (seq->temptype == T_TINT) ? T_TFLOAT : seq->temptype;
+  MeosType temptype_out = (seq->temptype == T_TINT) ? T_TFLOAT : seq->temptype;
   /* Determine whether we are computing the twAvg or the twCentroid */
   bool twavg = tnumber_type(seq->temptype);
   /* New instants computing the value at the beginning/end of the bin */
@@ -366,8 +366,8 @@ tsequenceset_tprecision(const TSequenceSet *ss, const Interval *duration,
   lower = lower_bin;
   upper = lower_bin + tunits;
   interpType interp = MEOS_FLAGS_GET_INTERP(ss->flags);
-  meosType temptype_out = (ss->temptype == T_TINT) ? T_TFLOAT : ss->temptype;
-  meosType basetype_out = temptype_basetype(temptype_out);
+  MeosType temptype_out = (ss->temptype == T_TINT) ? T_TFLOAT : ss->temptype;
+  MeosType basetype_out = temptype_basetype(temptype_out);
   /* Determine whether we are computing the twAvg or the twCentroid */
   bool twavg = tnumber_type(ss->temptype);
   int ninsts = 0;
@@ -486,7 +486,7 @@ int
 tsequence_tsample_iter(const TSequence *seq, TimestampTz lower_bin,
   TimestampTz upper_bin, int64 tunits, TInstant **result)
 {
-  meosType basetype = temptype_basetype(seq->temptype);
+  MeosType basetype = temptype_basetype(seq->temptype);
   interpType interp = MEOS_FLAGS_GET_INTERP(seq->flags);
   const TInstant *start = TSEQUENCE_INST_N(seq, 0);
   TimestampTz lower = lower_bin;

--- a/meos/src/temporal/temporal_boxops.c
+++ b/meos/src/temporal/temporal_boxops.c
@@ -67,7 +67,7 @@
  * @brief Return true if the type is a bounding box type
  */
 bool
-bbox_type(meosType bboxtype)
+bbox_type(MeosType bboxtype)
 {
   if (bboxtype == T_TSTZSPAN || bboxtype == T_TBOX || bboxtype == T_STBOX)
     return true;
@@ -78,7 +78,7 @@ bbox_type(meosType bboxtype)
  * @brief Return the size of a bounding box type
  */
 size_t
-bbox_get_size(meosType bboxtype)
+bbox_get_size(MeosType bboxtype)
 {
   assert(bbox_type(bboxtype));
   if (bboxtype == T_TSTZSPAN)
@@ -93,7 +93,7 @@ bbox_get_size(meosType bboxtype)
  * @brief Return the maximum number of dimensions of a bounding box type
  */
 int
-bbox_max_dims(meosType bboxtype)
+bbox_max_dims(MeosType bboxtype)
 {
   assert(bbox_type(bboxtype));
   if (bboxtype == T_TSTZSPAN)
@@ -110,7 +110,7 @@ bbox_max_dims(meosType bboxtype)
  * @param[in] temptype Temporal type
  */
 bool
-temporal_bbox_eq(const void *box1, const void *box2, meosType temptype)
+temporal_bbox_eq(const void *box1, const void *box2, MeosType temptype)
 {
   assert(talpha_type(temptype) || tnumber_type(temptype) ||
     tspatial_type(temptype));
@@ -135,7 +135,7 @@ temporal_bbox_eq(const void *box1, const void *box2, meosType temptype)
  * @param[in] temptype Temporal type
  */
 int
-temporal_bbox_cmp(const void *box1, const void *box2, meosType temptype)
+temporal_bbox_cmp(const void *box1, const void *box2, MeosType temptype)
 {
   assert(talpha_type(temptype) || tnumber_type(temptype) ||
     tspatial_type(temptype));
@@ -155,7 +155,7 @@ temporal_bbox_cmp(const void *box1, const void *box2, meosType temptype)
  * @brief Return the size of a bounding box of a temporal type
  */
 size_t
-temporal_bbox_size(meosType temptype)
+temporal_bbox_size(MeosType temptype)
 {
   assert(talpha_type(temptype) || tnumber_type(temptype) ||
     tspatial_type(temptype));
@@ -179,8 +179,8 @@ tnumberinst_set_tbox(const TInstant *inst, TBox *box)
 {
   assert(inst); assert(temporal_type(inst->temptype)); assert(box);
   assert(tnumber_type(inst->temptype));
-  meosType basetype = temptype_basetype(inst->temptype);
-  meosType spantype = basetype_spantype(basetype);
+  MeosType basetype = temptype_basetype(inst->temptype);
+  MeosType spantype = basetype_spantype(basetype);
   Datum value = tinstant_value_p(inst);
   Datum time = TimestampTzGetDatum(inst->t);
   TBox *tbox = (TBox *) box;
@@ -316,8 +316,8 @@ tnumberinstarr_set_tbox(TInstant **instants, int count, bool lower_inc,
   bool upper_inc, interpType interp, TBox *box)
 {
   assert(tnumber_type(instants[0]->temptype));
-  meosType basetype = temptype_basetype(instants[0]->temptype);
-  meosType spantype = basetype_spantype(basetype);
+  MeosType basetype = temptype_basetype(instants[0]->temptype);
+  MeosType spantype = basetype_spantype(basetype);
   /* For discrete or step interpolation the bounds are always inclusive */
   bool lower_inc1 = lower_inc;
   bool upper_inc1 = upper_inc;

--- a/meos/src/temporal/temporal_compops.c
+++ b/meos/src/temporal/temporal_compops.c
@@ -64,11 +64,11 @@
  */
 int
 eacomp_base_temporal(Datum value, const Temporal *temp,
-  Datum (*func)(Datum, Datum, meosType), bool ever)
+  Datum (*func)(Datum, Datum, MeosType), bool ever)
 {
   assert(temp); assert(func);
   /* Fill the lifted structure */
-  meosType basetype = temptype_basetype(temp->temptype);
+  MeosType basetype = temptype_basetype(temp->temptype);
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) func;
@@ -94,11 +94,11 @@ eacomp_base_temporal(Datum value, const Temporal *temp,
  */
 int
 eacomp_temporal_base(const Temporal *temp, Datum value,
-  Datum (*func)(Datum, Datum, meosType), bool ever)
+  Datum (*func)(Datum, Datum, MeosType), bool ever)
 {
   assert(temp); assert(func);
   /* Fill the lifted structure */
-  meosType basetype = temptype_basetype(temp->temptype);
+  MeosType basetype = temptype_basetype(temp->temptype);
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) func;
@@ -122,12 +122,12 @@ eacomp_temporal_base(const Temporal *temp, Datum value,
  */
 int
 eacomp_temporal_temporal(const Temporal *temp1, const Temporal *temp2,
-  Datum (*func)(Datum, Datum, meosType), bool ever)
+  Datum (*func)(Datum, Datum, MeosType), bool ever)
 {
   assert(temp1); assert(temp2); assert(func);
   assert(temp1->temptype == temp2->temptype);
   /* Fill the lifted structure */
-  meosType basetype = temptype_basetype(temp1->temptype);
+  MeosType basetype = temptype_basetype(temp1->temptype);
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) func;
@@ -676,11 +676,11 @@ always_ge_temporal_temporal(const Temporal *temp1, const Temporal *temp2)
  */
 Temporal *
 tcomp_base_temporal(Datum value, const Temporal *temp,
-  Datum (*func)(Datum, Datum, meosType))
+  Datum (*func)(Datum, Datum, MeosType))
 {
   assert(temp); assert(func);
   /* Fill the lifted structure */
-  meosType basetype = temptype_basetype(temp->temptype);
+  MeosType basetype = temptype_basetype(temp->temptype);
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) func;
@@ -704,11 +704,11 @@ tcomp_base_temporal(Datum value, const Temporal *temp,
  */
 Temporal *
 tcomp_temporal_base(const Temporal *temp, Datum value,
-  Datum (*func)(Datum, Datum, meosType))
+  Datum (*func)(Datum, Datum, MeosType))
 {
   assert(temp); assert(func);
   /* Fill the lifted structure */
-  meosType basetype = temptype_basetype(temp->temptype);
+  MeosType basetype = temptype_basetype(temp->temptype);
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) func;
@@ -731,12 +731,12 @@ tcomp_temporal_base(const Temporal *temp, Datum value,
  */
 Temporal *
 tcomp_temporal_temporal(const Temporal *temp1, const Temporal *temp2,
-  Datum (*func)(Datum, Datum, meosType))
+  Datum (*func)(Datum, Datum, MeosType))
 {
   assert(temp1); assert(temp2); assert(func);
   assert(temp1->temptype == temp2->temptype);
   /* Fill the lifted structure */
-  meosType basetype = temptype_basetype(temp1->temptype);
+  MeosType basetype = temptype_basetype(temp1->temptype);
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) func;

--- a/meos/src/temporal/temporal_modif.c
+++ b/meos/src/temporal/temporal_modif.c
@@ -71,7 +71,7 @@
  */
 bool
 ensure_tinstant_same_value(const TInstant *inst1, const TInstant *inst2,
-  meosType basetype)
+  MeosType basetype)
 {
   assert(inst1->t == inst2->t);
   if (! datum_eq(tinstant_value_p(inst1), tinstant_value_p(inst2), basetype))
@@ -416,7 +416,7 @@ tcontseq_merge_array_iter(TSequence **sequences, int count, int *totalcount)
 
   /* Test the validity of the composing sequences */
   const TSequence *seq1 = sequences[0];
-  meosType basetype = temptype_basetype(seq1->temptype);
+  MeosType basetype = temptype_basetype(seq1->temptype);
   for (int i = 1; i < count; i++)
   {
     const TInstant *inst1 = TSEQUENCE_INST_N(seq1, seq1->count - 1);
@@ -803,7 +803,7 @@ tcontseq_insert(const TSequence *seq1, const TSequence *seq2)
   }
   else /* overlap on the boundary */
   {
-    meosType basetype = temptype_basetype(seq1->temptype);
+    MeosType basetype = temptype_basetype(seq1->temptype);
     if (! ensure_tinstant_same_value(instants[0], instants[1], basetype))
       return NULL;
   }
@@ -1239,7 +1239,7 @@ tsequenceset_insert(const TSequenceSet *ss1, const TSequenceSet *ss2)
   TSequence **sequences = palloc(sizeof(TSequence *) * count);
   TSequence **tofree = palloc(sizeof(TSequence *) *
     Min(ss1->count, ss2->count) * 2);
-  meosType basetype = temptype_basetype(ss1->temptype);
+  MeosType basetype = temptype_basetype(ss1->temptype);
   /* Add the first sequence of ss1 to the result */
   sequences[0] = (TSequence *) TSEQUENCESET_SEQ_N(ss1, 0);
   int i = 1, /* counter for the first sequence */
@@ -1738,7 +1738,7 @@ tsequence_append_tinstant(TSequence *seq, const TInstant *inst, double maxdist,
 {
   assert(seq); assert(inst); assert(seq->temptype == inst->temptype);
   interpType interp = MEOS_FLAGS_GET_INTERP(seq->flags);
-  meosType basetype = temptype_basetype(seq->temptype);
+  MeosType basetype = temptype_basetype(seq->temptype);
   TInstant *last = (TInstant *) TSEQUENCE_INST_N(seq, seq->count - 1);
 #if NPOINT
   if (last->temptype == T_TNPOINT && interp != DISCRETE &&
@@ -1912,7 +1912,7 @@ tsequence_append_tsequence(const TSequence *seq1, const TSequence *seq2,
   else if (inst1->t == inst2->t && seq1->period.upper_inc &&
     seq2->period.lower_inc)
   {
-    meosType basetype = temptype_basetype(seq1->temptype);
+    MeosType basetype = temptype_basetype(seq1->temptype);
     if (! ensure_tinstant_same_value(inst1, inst2, basetype))
       return NULL;
   }
@@ -2079,7 +2079,7 @@ tsequenceset_append_tsequence(TSequenceSet *ss, const TSequence *seq,
   else if (inst1->t == inst2->t && ss->period.upper_inc &&
     seq->period.lower_inc)
   {
-    meosType basetype = temptype_basetype(ss->temptype);
+    MeosType basetype = temptype_basetype(ss->temptype);
     if (! ensure_tinstant_same_value(inst1, inst2, basetype))
       return NULL;
   }

--- a/meos/src/temporal/temporal_restrict.c
+++ b/meos/src/temporal/temporal_restrict.c
@@ -88,10 +88,10 @@ temporal_bbox_restrict_value(const Temporal *temp, Datum value)
 #if RGEO
     /* Temporal rigid geometries have poses as base values but are restricted
      * to geometries */
-    meosType basetype = (temp->temptype == T_TRGEOMETRY) ? T_GEOMETRY :
+    MeosType basetype = (temp->temptype == T_TRGEOMETRY) ? T_GEOMETRY :
       temptype_basetype(temp->temptype);
 #else
-    meosType basetype = temptype_basetype(temp->temptype);
+    MeosType basetype = temptype_basetype(temp->temptype);
 #endif /* RGEO */
     assert(tspatial_srid(temp) == spatial_srid(value, basetype));
     if (tgeo_type_all(temp->temptype)
@@ -158,10 +158,10 @@ temporal_restrict_value(const Temporal *temp, Datum value, bool atfunc)
 #if RGEO
     /* Temporal rigid geometries have poses as base values but are restricted
      * to geometries */
-    meosType basetype = (temp->temptype == T_TRGEOMETRY) ? T_GEOMETRY :
+    MeosType basetype = (temp->temptype == T_TRGEOMETRY) ? T_GEOMETRY :
       temptype_basetype(temp->temptype);
 #else
-    meosType basetype = temptype_basetype(temp->temptype);
+    MeosType basetype = temptype_basetype(temp->temptype);
 #endif /* RGEO */
     if (! ensure_same_srid(tspatial_srid(temp),
             spatial_srid(value, basetype)) ||
@@ -683,10 +683,10 @@ tinstant_restrict_values_test(const TInstant *inst, const Set *s, bool atfunc)
 #if RGEO
   /* Temporal rigid geometries have poses as base values but are restricted
    * to geometries */
-  meosType basetype = (inst->temptype == T_TRGEOMETRY) ? T_GEOMETRY :
+  MeosType basetype = (inst->temptype == T_TRGEOMETRY) ? T_GEOMETRY :
     temptype_basetype(inst->temptype);
 #else
-    meosType basetype = temptype_basetype(inst->temptype);
+    MeosType basetype = temptype_basetype(inst->temptype);
 #endif /* RGEO */
   for (int i = 0; i < s->count; i++)
   {
@@ -910,10 +910,10 @@ tdiscseq_restrict_value(const TSequence *seq, Datum value, bool atfunc)
 #if RGEO
   /* Temporal rigid geometries have poses as base values but are restricted
    * to geometries */
-  meosType basetype = (seq->temptype == T_TRGEOMETRY) ? T_GEOMETRY :
+  MeosType basetype = (seq->temptype == T_TRGEOMETRY) ? T_GEOMETRY :
     temptype_basetype(seq->temptype);
 #else
-    meosType basetype = temptype_basetype(seq->temptype);
+    MeosType basetype = temptype_basetype(seq->temptype);
 #endif /* RGEO */
 
   /* Instantaneous sequence */
@@ -1001,10 +1001,10 @@ tsegment_restrict_value(const TInstant *inst1, const TInstant *inst2,
   assert(inst1->temptype == inst2->temptype); assert(interp != DISCRETE);
   Datum start = tinstant_value_p(inst1);
   Datum end = tinstant_value_p(inst2);
-  meosType basetype = temptype_basetype(inst1->temptype);
+  MeosType basetype = temptype_basetype(inst1->temptype);
   // /* Temporal rigid geometries have poses as base values but are restricted
    // * to geometries */
-  // meosType basetype1 = (inst1->temptype == T_TRGEOMETRY) ? T_GEOMETRY :
+  // MeosType basetype1 = (inst1->temptype == T_TRGEOMETRY) ? T_GEOMETRY :
     // basetype;
   TInstant *instants[2];
   /* Is the segment constant? */
@@ -1403,8 +1403,8 @@ tnumbersegm_restrict_span(const TInstant *inst1, const TInstant *inst2,
 {
   Datum start = tinstant_value_p(inst1);
   Datum end = tinstant_value_p(inst2);
-  meosType basetype = temptype_basetype(inst1->temptype);
-  meosType spantype = basetype_spantype(basetype);
+  MeosType basetype = temptype_basetype(inst1->temptype);
+  MeosType spantype = basetype_spantype(basetype);
   TInstant *instants[2];
   bool found;
 
@@ -3423,7 +3423,7 @@ tcontseq_before_timestamptz(const TSequence *seq, TimestampTz t, bool strict)
     {
       /* The last two values of sequences with step interpolation and
          exclusive upper bound must be equal */
-      meosType basetype = temptype_basetype(seq->temptype);
+      MeosType basetype = temptype_basetype(seq->temptype);
       if (interp != LINEAR && datum_ne(tinstant_value_p(instants[ninsts - 2]),
           tinstant_value_p(instants[ninsts - 1]), basetype))
       {
@@ -3578,7 +3578,7 @@ tcontseq_after_timestamptz(const TSequence *seq, TimestampTz t, bool strict)
     {
       /* The last two values of sequences with step interpolation and
          exclusive upper bound must be equal */
-      meosType basetype = temptype_basetype(seq->temptype);
+      MeosType basetype = temptype_basetype(seq->temptype);
       if (interp != LINEAR &&
           datum_ne(tinstant_value_p(instants[ninsts - 2]),
             tinstant_value_p(instants[ninsts - 1]), basetype))

--- a/meos/src/temporal/temporal_rtree.c
+++ b/meos/src/temporal/temporal_rtree.c
@@ -733,11 +733,11 @@ node_search(const RTree *rtree, const RTreeNode *node, RTreeSearchOp op,
 
 /**
  * @brief Creates an RTree index.
- * @param[in] bboxtype The meosType of the elements to index.
+ * @param[in] bboxtype The MeosType of the elements to index.
  * @return RTree initialized.
  */
 RTree *
-rtree_create(meosType bboxtype)
+rtree_create(MeosType bboxtype)
 {
   assert(span_type(bboxtype) || bboxtype == T_TBOX || bboxtype == T_STBOX);
   size_t bboxsize = bbox_get_size(bboxtype);
@@ -922,7 +922,7 @@ rtree_search(const RTree *rtree, RTreeSearchOp op, const void *query,
 static bool
 ensure_rtree_temporal_compatible(const RTree *rtree, const Temporal *temp)
 {
-  meosType temptype = temp->temptype;
+  MeosType temptype = temp->temptype;
   bool compatible =
     (talpha_type(temptype) && rtree->bboxtype == T_TSTZSPAN) ||
     (tnumber_type(temptype) && rtree->bboxtype == T_TBOX) ||

--- a/meos/src/temporal/temporal_tile.c
+++ b/meos/src/temporal/temporal_tile.c
@@ -336,7 +336,7 @@ timestamptz_get_bin(TimestampTz t, const Interval *duration,
  * have a month component
  */
 Datum
-datum_bin(Datum value, Datum size, Datum origin, meosType type)
+datum_bin(Datum value, Datum size, Datum origin, MeosType type)
 {
   /* This function is called directly by the MobilityDB API */
   if (! ensure_positive_datum(size, type))
@@ -690,7 +690,7 @@ tbox_tile_state_make(const Temporal *temp, const TBox *box, Datum vsize,
  */
 void
 tbox_tile_state_set(Datum value, TimestampTz t, Datum vsize, int64 tunits,
-  meosType basetype, meosType spantype, TBox *box)
+  MeosType basetype, MeosType spantype, TBox *box)
 {
   assert(box);
 
@@ -815,7 +815,7 @@ tbox_tile_state_next(TboxGridState *state)
 TBox *
 tbox_get_value_time_tile(Datum value, TimestampTz t, Datum vsize,
   const Interval *duration, Datum vorigin, TimestampTz torigin,
-  meosType basetype, meosType spantype)
+  MeosType basetype, MeosType spantype)
 {
   /* Ensure the validity of the arguments */
   if (duration && ! ensure_positive_duration(duration))

--- a/meos/src/temporal/temporal_tile_meos.c
+++ b/meos/src/temporal/temporal_tile_meos.c
@@ -690,7 +690,7 @@ temporal_time_split(const Temporal *temp, const Interval *duration,
  * @param[in] type Type of the arguments
  */
 static int
-bin_position(Datum value, Datum size, Datum origin, meosType type)
+bin_position(Datum value, Datum size, Datum origin, MeosType type)
 {
   assert(tnumber_basetype(type));
   if (type == T_INT4)
@@ -719,7 +719,7 @@ tnumberinst_value_split(const TInstant *inst, Datum start_bin, Datum size,
   assert(inst); assert(bins); assert(newcount);
 
   Datum value = tinstant_value_p(inst);
-  meosType basetype = temptype_basetype(inst->temptype);
+  MeosType basetype = temptype_basetype(inst->temptype);
   TInstant **result = palloc(sizeof(TInstant *));
   Datum *values = palloc(sizeof(Datum));
   result[0] = tinstant_copy(inst);
@@ -747,7 +747,7 @@ tnumberseq_disc_value_split(const TSequence *seq, Datum start_bin,
 {
   assert(seq); assert(bins); assert(newcount);
 
-  meosType basetype = temptype_basetype(seq->temptype);
+  MeosType basetype = temptype_basetype(seq->temptype);
   TSequence **result;
   Datum *values, value, bin_value;
 
@@ -820,7 +820,7 @@ tnumberseq_step_value_split(const TSequence *seq, Datum start_bin,
   assert(seq); assert(result); assert(nseqs);
   assert(MEOS_FLAGS_GET_INTERP(seq->flags) == STEP);
 
-  meosType basetype = temptype_basetype(seq->temptype);
+  MeosType basetype = temptype_basetype(seq->temptype);
   Datum value, bin_value;
   int bin_no, seq_no;
 
@@ -897,8 +897,8 @@ tnumberseq_linear_value_split(const TSequence *seq, Datum start_bin,
   assert(seq); assert(result); assert(nseqs);
   assert(MEOS_FLAGS_LINEAR_INTERP(seq->flags));
 
-  meosType basetype = temptype_basetype(seq->temptype);
-  meosType spantype = basetype_spantype(basetype);
+  MeosType basetype = temptype_basetype(seq->temptype);
+  MeosType spantype = basetype_spantype(basetype);
   Datum value1, bin_value1;
   int bin_no1, seq_no;
   Span segspan;
@@ -1065,7 +1065,7 @@ tnumberseq_cont_value_split(const TSequence *seq, Datum start_bin, Datum size,
 
   interpType interp = MEOS_FLAGS_GET_INTERP(seq->flags);
   assert(interp != DISCRETE);
-  meosType basetype = temptype_basetype(seq->temptype);
+  MeosType basetype = temptype_basetype(seq->temptype);
 
   /* Instantaneous sequence */
   if (seq->count == 1)
@@ -1137,7 +1137,7 @@ tnumberseqset_value_split(const TSequenceSet *ss, Datum start_bin, Datum size,
       size, count, bins, newcount);
 
   /* General case */
-  meosType basetype = temptype_basetype(ss->temptype);
+  MeosType basetype = temptype_basetype(ss->temptype);
   TSequence **binseqs = palloc(sizeof(TSequence *) * ss->totalcount * count);
   /* palloc0 to initialize the counters to 0 */
   int *nseqs = palloc0(sizeof(int) * count);
@@ -1232,7 +1232,7 @@ tnumber_value_time_split(const Temporal *temp, Datum size,
   const Interval *duration, Datum vorigin, TimestampTz torigin,
   Datum **value_bins, TimestampTz **time_bins, int *count)
 {
-  meosType basetype = temptype_basetype(temp->temptype);
+  MeosType basetype = temptype_basetype(temp->temptype);
   ensure_positive_datum(size, basetype);
   ensure_positive_duration(duration);
 
@@ -1261,7 +1261,7 @@ tnumber_value_time_split(const Temporal *temp, Datum size,
   fragments = palloc(sizeof(Temporal *) * ntiles);
   int nfrags = 0;
   Datum lower_value = start_bin;
-  meosType spantype = basetype_spantype(basetype);
+  MeosType spantype = basetype_spantype(basetype);
   while (datum_lt(lower_value, end_bin, basetype))
   {
     Datum upper_value = datum_add(lower_value, size, basetype);

--- a/meos/src/temporal/temporal_waggfuncs.c
+++ b/meos/src/temporal/temporal_waggfuncs.c
@@ -108,7 +108,7 @@ tcontseq_extend(const TSequence *seq, const Interval *interv, bool min,
   Datum value1 = tinstant_value_p(inst1);
   interpType interp = MEOS_FLAGS_GET_INTERP(seq->flags);
   bool lower_inc = seq->period.lower_inc;
-  meosType basetype = temptype_basetype(seq->temptype);
+  MeosType basetype = temptype_basetype(seq->temptype);
   for (int i = 0; i < seq->count - 1; i++)
   {
     TInstant *inst2 = (TInstant *) TSEQUENCE_INST_N(seq, i + 1);

--- a/meos/src/temporal/tinstant.c
+++ b/meos/src/temporal/tinstant.c
@@ -136,7 +136,7 @@ tnumberinst_double(const TInstant *inst)
  * @param[in] temptype Temporal type
  */
 TInstant *
-tinstant_in(const char *str, meosType temptype)
+tinstant_in(const char *str, MeosType temptype)
 {
   assert(str);
   return tinstant_parse(&str, temptype, true);
@@ -155,7 +155,7 @@ tinstant_to_string(const TInstant *inst, int maxdd, outfunc value_out)
 {
   assert(inst); assert(maxdd >= 0);
   char *t = pg_timestamptz_out(inst->t);
-  meosType basetype = temptype_basetype(inst->temptype);
+  MeosType basetype = temptype_basetype(inst->temptype);
   char *value = value_out(tinstant_value_p(inst), basetype, maxdd);
   size_t size = strlen(value) + strlen(t) + 2;
   char *result = palloc(size);
@@ -199,14 +199,14 @@ tinstant_out(const TInstant *inst, int maxdd)
  * @param[in] t Timestamp
  */
 TInstant *
-tinstant_make(Datum value, meosType temptype, TimestampTz t)
+tinstant_make(Datum value, MeosType temptype, TimestampTz t)
 {
   /* Ensure validity of arguments */
   int32_t tspatial_srid;
   // TODO Should we bypass the tests on tnpoint ?
   if (tspatial_type(temptype) && temptype != T_TNPOINT)
   {
-    meosType basetype = temptype_basetype(temptype);
+    MeosType basetype = temptype_basetype(temptype);
     tspatial_srid = spatial_srid(value, basetype);
     /* Ensure that the SRID is geodetic for geography */
     if (tgeodetic_type(temptype) && tspatial_srid != SRID_UNKNOWN && 
@@ -223,7 +223,7 @@ tinstant_make(Datum value, meosType temptype, TimestampTz t)
   /* Create the temporal instant */
   size_t value_size;
   void *value_from;
-  meosType basetype = temptype_basetype(temptype);
+  MeosType basetype = temptype_basetype(temptype);
   bool typbyval = basetype_byvalue(basetype);
   /* Copy value */
   if (typbyval)
@@ -271,7 +271,7 @@ tinstant_make(Datum value, meosType temptype, TimestampTz t)
  * @param[in] t Timestamp
  */
 TInstant *
-tinstant_make_free(Datum value, meosType temptype, TimestampTz t)
+tinstant_make_free(Datum value, MeosType temptype, TimestampTz t)
 {
   TInstant *result = tinstant_make(value, temptype, t);
   DATUM_FREE(value, temptype_basetype(temptype));
@@ -325,8 +325,8 @@ tnumberinst_valuespans(const TInstant *inst)
 {
   assert(inst);
   Datum value = tinstant_value_p(inst);
-  meosType basetype = temptype_basetype(inst->temptype);
-  meosType spantype = basetype_spantype(basetype);
+  MeosType basetype = temptype_basetype(inst->temptype);
+  MeosType spantype = basetype_spantype(basetype);
   Span s;
   span_set(value, value, true, true, basetype, spantype, &s);
   return span_to_spanset(&s);
@@ -513,7 +513,7 @@ tnumberinst_shift_value(const TInstant *inst, Datum shift)
   assert(inst);
   TInstant *result = tinstant_copy(inst);
   Datum value = tinstant_value_p(result);
-  meosType basetype = temptype_basetype(result->temptype);
+  MeosType basetype = temptype_basetype(result->temptype);
   value = datum_add(value, shift, basetype);
   tinstant_set(result, value, result->t);
   return result;
@@ -639,7 +639,7 @@ tinstant_hash(const TInstant *inst)
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(inst, INT_MAX);
 
-  meosType basetype = temptype_basetype(inst->temptype);
+  MeosType basetype = temptype_basetype(inst->temptype);
   /* Apply the hash function to the base type */
   uint32 value_hash = datum_hash(tinstant_value_p(inst), basetype);
   /* Apply the hash function to the timestamp */

--- a/meos/src/temporal/tnumber_distance.c
+++ b/meos/src/temporal/tnumber_distance.c
@@ -118,7 +118,7 @@ tdistance_tnumber_number(const Temporal *temp, Datum value)
 {
   assert(temp);
   /* Fill the lifted structure */
-  meosType basetype = temptype_basetype(temp->temptype);
+  MeosType basetype = temptype_basetype(temp->temptype);
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) &distance_value_value;
@@ -149,7 +149,7 @@ tdistance_tnumber_tnumber(const Temporal *temp1, const Temporal *temp2)
     return NULL;
 
   /* Fill the lifted structure */
-  meosType basetype = temptype_basetype(temp1->temptype);
+  MeosType basetype = temptype_basetype(temp1->temptype);
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) &distance_value_value;
@@ -182,7 +182,7 @@ double
 nad_tnumber_number(const Temporal *temp, Datum value)
 {
   assert(temp); assert(tnumber_type(temp->temptype));
-  meosType basetype = temptype_basetype(temp->temptype);
+  MeosType basetype = temptype_basetype(temp->temptype);
   TBox box1, box2;
   tnumber_set_tbox(temp, &box1);
   number_set_tbox(value, basetype, &box2);

--- a/meos/src/temporal/tnumber_mathfuncs.c
+++ b/meos/src/temporal/tnumber_mathfuncs.c
@@ -110,10 +110,10 @@ tfloat_arithop_turnpt(Datum start1, Datum end1, Datum start2, Datum end2,
  */
 Temporal *
 arithop_tnumber_number(const Temporal *temp, Datum value, TArithmetic oper,
-  Datum (*func)(Datum, Datum, meosType), bool invert)
+  Datum (*func)(Datum, Datum, MeosType), bool invert)
 {
   assert(tnumber_type(temp->temptype));
-  meosType basetype = temptype_basetype(temp->temptype);
+  MeosType basetype = temptype_basetype(temp->temptype);
   /* If division test whether the denominator is zero */
   if (oper == DIV)
   {
@@ -159,7 +159,7 @@ arithop_tnumber_number(const Temporal *temp, Datum value, TArithmetic oper,
  */
 Temporal *
 arithop_tnumber_tnumber(const Temporal *temp1, const Temporal *temp2,
-  TArithmetic oper, Datum (*func)(Datum, Datum, meosType), tpfunc_temp tpfunc)
+  TArithmetic oper, Datum (*func)(Datum, Datum, MeosType), tpfunc_temp tpfunc)
 {
   assert(tnumber_type(temp1->temptype));
   assert(temp1->temptype == temp2->temptype);
@@ -191,7 +191,7 @@ arithop_tnumber_tnumber(const Temporal *temp1, const Temporal *temp2,
   }
 
   /* Fill the lifted structure */
-  meosType basetype = temptype_basetype(temp1->temptype);
+  MeosType basetype = temptype_basetype(temp1->temptype);
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) func;
@@ -221,7 +221,7 @@ TInstant *
 tnumberinst_abs(const TInstant *inst)
 {
   assert(inst); assert(tnumber_type(inst->temptype));
-  meosType basetype = temptype_basetype(inst->temptype);
+  MeosType basetype = temptype_basetype(inst->temptype);
   assert(tnumber_basetype(basetype));
   Datum value = tinstant_value_p(inst);
   Datum absvalue;
@@ -256,7 +256,7 @@ tnumberseq_linear_abs(const TSequence *seq)
   assert(seq);
   assert(tnumber_type(seq->temptype));
   const TInstant *inst1;
-  meosType basetype = temptype_basetype(seq->temptype);
+  MeosType basetype = temptype_basetype(seq->temptype);
 
   /* Instantaneous sequence */
   if (seq->count == 1)
@@ -364,7 +364,7 @@ tnumber_abs(const Temporal *temp)
  * @brief Return the delta value of two numbers
  */
 static Datum
-delta_value(Datum value1, Datum value2, meosType basetype)
+delta_value(Datum value1, Datum value2, MeosType basetype)
 {
   assert(basetype == T_INT4 || basetype == T_FLOAT8);
   if (basetype == T_INT4)
@@ -390,7 +390,7 @@ tnumberseq_delta_value(const TSequence *seq)
   TInstant **instants = palloc(sizeof(TInstant *) * seq->count);
   const TInstant *inst1 = TSEQUENCE_INST_N(seq, 0);
   Datum value1 = tinstant_value_p(inst1);
-  meosType basetype = temptype_basetype(seq->temptype);
+  MeosType basetype = temptype_basetype(seq->temptype);
   Datum delta = 0; /* make compiler quiet */
   for (int i = 1; i < seq->count; i++)
   {
@@ -611,7 +611,7 @@ tnumberseq_trend(const TSequence *seq)
     return NULL;
 
   /* General case */
-  meosType basetype = temptype_basetype(seq->temptype);
+  MeosType basetype = temptype_basetype(seq->temptype);
   TInstant **instants = palloc(sizeof(TInstant *) * seq->count);
   const TInstant *inst1 = TSEQUENCE_INST_N(seq, 0);
   Datum value1 = tinstant_value_p(inst1);

--- a/meos/src/temporal/tnumber_mathfuncs_meos.c
+++ b/meos/src/temporal/tnumber_mathfuncs_meos.c
@@ -289,7 +289,7 @@ mult_tnumber_tnumber(const Temporal *temp1, const Temporal *temp2)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tnumber_tnumber(temp1, temp2))
     return NULL;
-  meosType basetype = temptype_basetype(temp1->temptype);
+  MeosType basetype = temptype_basetype(temp1->temptype);
   assert(basetype == T_INT4 || basetype == T_FLOAT8);
   return arithop_tnumber_tnumber(temp1, temp2, MULT, &datum_mult,
     (basetype == T_INT4) ? NULL : &tfloat_arithop_turnpt);
@@ -374,7 +374,7 @@ div_tnumber_tnumber(const Temporal *temp1, const Temporal *temp2)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tnumber_tnumber(temp1, temp2))
     return NULL;
-  meosType basetype = temptype_basetype(temp1->temptype);
+  MeosType basetype = temptype_basetype(temp1->temptype);
   assert(basetype == T_INT4 || basetype == T_FLOAT8);
   return arithop_tnumber_tnumber(temp1, temp2, DIV, &datum_div,
     (basetype == T_INT4) ? NULL : &tfloat_arithop_turnpt);

--- a/meos/src/temporal/tsequence.c
+++ b/meos/src/temporal/tsequence.c
@@ -107,7 +107,7 @@ float_collinear(double x1, double x2, double x3, double ratio)
  * @param[in] t1,t2,t3 Input timestamps
  */
 static bool
-datum_collinear(Datum value1, Datum value2, Datum value3, meosType basetype,
+datum_collinear(Datum value1, Datum value2, Datum value3, MeosType basetype,
   TimestampTz t1, TimestampTz t2, TimestampTz t3)
 {
   double duration1 = (double) (t2 - t1);
@@ -197,7 +197,7 @@ floatsegm_locate(double start, double end, double value)
  * after testing whether the bounds of the segments are equal to a value.
  */
 long double
-datumsegm_locate(Datum value1, Datum value2, Datum value, meosType basetype)
+datumsegm_locate(Datum value1, Datum value2, Datum value, MeosType basetype)
 {
   if (basetype == T_FLOAT8)
     return floatsegm_locate(DatumGetFloat8(value1), DatumGetFloat8(value2),
@@ -257,7 +257,7 @@ floatsegm_interpolate(double start, double end, long double ratio)
  * are equal to the given value.
  */
 Datum
-datumsegm_interpolate(Datum start, Datum end, meosType temptype,
+datumsegm_interpolate(Datum start, Datum end, MeosType temptype,
   long double ratio)
 {
   if (temptype == T_TFLOAT)
@@ -306,7 +306,7 @@ datumsegm_interpolate(Datum start, Datum end, meosType temptype,
  * ones during normalization
  */
 bool
-tsequence_norm_test(Datum value1, Datum value2, Datum value3, meosType basetype,
+tsequence_norm_test(Datum value1, Datum value2, Datum value3, MeosType basetype,
   interpType interp, TimestampTz t1, TimestampTz t2, TimestampTz t3)
 {
   bool v1v2eq = datum_eq(value1, value2, basetype);
@@ -349,7 +349,7 @@ tinstarr_normalize(TInstant **instants, interpType interp, int count,
   int *newcount)
 {
   assert(count > 1);
-  meosType basetype = temptype_basetype(instants[0]->temptype);
+  MeosType basetype = temptype_basetype(instants[0]->temptype);
   TInstant **result = palloc(sizeof(TInstant *) * count);
   /* Remove redundant instants */
   TInstant *inst1 = (TInstant *) instants[0];
@@ -396,7 +396,7 @@ tsequence_join_test(const TSequence *seq1, const TSequence *seq2,
   bool *removelast, bool *removefirst)
 {
   assert(seq1->temptype == seq2->temptype);
-  meosType basetype = temptype_basetype(seq1->temptype);
+  MeosType basetype = temptype_basetype(seq1->temptype);
   interpType interp = MEOS_FLAGS_GET_INTERP(seq1->flags);
   bool result = false;
   TInstant *last2 = (seq1->count == 1 || interp == DISCRETE) ? NULL :
@@ -655,7 +655,7 @@ tseqarr2_to_tseqarr(TSequence ***sequences, int *countseqs, int count,
  * @param[in] interp Interpolation
  */
 TSequence *
-tsequence_in(const char *str, meosType temptype, interpType interp)
+tsequence_in(const char *str, MeosType temptype, interpType interp)
 {
   assert(str);
   if (interp == DISCRETE)
@@ -909,7 +909,7 @@ ensure_increasing_timestamps(const TInstant *inst1, const TInstant *inst2,
  * @brief Expand the second bounding box with the first one
  */
 void
-bbox_expand(const void *box1, void *box2, meosType temptype)
+bbox_expand(const void *box1, void *box2, MeosType temptype)
 {
   assert(box1); assert(box2);
   assert(temporal_type(temptype));
@@ -940,7 +940,7 @@ ensure_valid_tinstarr_common(TInstant **instants, int count, bool lower_inc,
       "Instant sequence must have inclusive bounds");
     return false;
   }
-  meosType basetype = temptype_basetype(instants[0]->temptype);
+  MeosType basetype = temptype_basetype(instants[0]->temptype);
   if (interp == STEP && count > 1 && ! upper_inc &&
     datum_ne(tinstant_value_p(instants[count - 1]),
       tinstant_value_p(instants[count - 2]), basetype))
@@ -1113,7 +1113,7 @@ tpointseq_make_coords(const double *xcoords, const double *ycoords,
 {
   assert(xcoords); assert(ycoords); assert(times); assert(count > 0);
   bool hasz = (zcoords != NULL);
-  meosType temptype = geodetic ? T_TGEOGPOINT : T_TGEOMPOINT;
+  MeosType temptype = geodetic ? T_TGEOGPOINT : T_TGEOMPOINT;
   TInstant **instants = palloc(sizeof(TInstant *) * count);
   for (int i = 0; i < count; i ++)
   {
@@ -1153,7 +1153,7 @@ tsequence_copy(const TSequence *seq)
  * etc.
  */
 TSequence *
-tsequence_from_base_tstzset(Datum value, meosType temptype, const Set *s)
+tsequence_from_base_tstzset(Datum value, MeosType temptype, const Set *s)
 {
   assert(s); assert(s->settype == T_TSTZSET);
   TInstant **instants = palloc(sizeof(TInstant *) * s->count);
@@ -1175,7 +1175,7 @@ tsequence_from_base_tstzset(Datum value, meosType temptype, const Set *s)
  * @param[in] interp Interpolation
  */
 TSequence *
-tsequence_from_base_tstzspan(Datum value, meosType temptype, const Span *s,
+tsequence_from_base_tstzspan(Datum value, MeosType temptype, const Span *s,
   interpType interp)
 {
   assert(s);
@@ -1394,7 +1394,7 @@ tcontseq_to_step(const TSequence *seq)
     return tsequence_copy(seq);
 
   /* interp == LINEAR */
-  meosType basetype = temptype_basetype(seq->temptype);
+  MeosType basetype = temptype_basetype(seq->temptype);
   if ((seq->count > 2) ||
       (seq->count == 2 && ! datum_eq(
         tinstant_value_p(TSEQUENCE_INST_N(seq, 0)),
@@ -1437,7 +1437,7 @@ tstepseq_to_linear_iter(const TSequence *seq, TSequence **result)
   Datum value2;
   bool lower_inc = seq->period.lower_inc;
   int nseqs = 0;
-  meosType basetype = temptype_basetype(seq->temptype);
+  MeosType basetype = temptype_basetype(seq->temptype);
   for (int i = 1; i < seq->count; i++)
   {
     inst2 = TSEQUENCE_INST_N(seq, i);
@@ -1526,7 +1526,7 @@ void
 tnumberseq_shift_scale_value_iter(TSequence *seq, Datum origin, Datum delta,
   bool hasdelta, double scale)
 {
-  meosType basetype = temptype_basetype(seq->temptype);
+  MeosType basetype = temptype_basetype(seq->temptype);
   for (int i = 0; i < seq->count; i++)
   {
     TInstant *inst = (TInstant *) TSEQUENCE_INST_N(seq, i);
@@ -1671,7 +1671,7 @@ tsequence_values_p(const TSequence *seq, int *count)
     result[i] = tinstant_value_p(TSEQUENCE_INST_N(seq, i));
   if (seq->count > 1)
   {
-    meosType basetype = temptype_basetype(seq->temptype);
+    MeosType basetype = temptype_basetype(seq->temptype);
     datumarr_sort(result, seq->count, basetype);
     *count = datumarr_remove_duplicates(result, seq->count, basetype);
   }
@@ -1703,8 +1703,8 @@ tnumberseq_valuespans(const TSequence *seq)
 
   /* Temporal sequence number with discrete or step interpolation */
   int count;
-  meosType basetype = temptype_basetype(seq->temptype);
-  meosType spantype = basetype_spantype(basetype);
+  MeosType basetype = temptype_basetype(seq->temptype);
+  MeosType spantype = basetype_spantype(basetype);
   Datum *values = tsequence_values_p(seq, &count);
   Span *spans = palloc(sizeof(Span) * count);
   for (int i = 0; i < count; i++)
@@ -1748,12 +1748,12 @@ tsequence_time(const TSequence *seq)
  */
 const TInstant *
 tsequence_minmax_inst_p(const TSequence *seq,
-  bool (*func)(Datum, Datum, meosType))
+  bool (*func)(Datum, Datum, MeosType))
 {
   assert(seq);
   Datum min = tinstant_value_p(TSEQUENCE_INST_N(seq, 0));
   int idx = 0;
-  meosType basetype = temptype_basetype(seq->temptype);
+  MeosType basetype = temptype_basetype(seq->temptype);
   for (int i = 1; i < seq->count; i++)
   {
     Datum value = tinstant_value_p(TSEQUENCE_INST_N(seq, i));
@@ -1814,7 +1814,7 @@ tsequence_min_val(const TSequence *seq)
     return box->span.lower;
   }
 
-  meosType basetype = temptype_basetype(seq->temptype);
+  MeosType basetype = temptype_basetype(seq->temptype);
   Datum result = tinstant_value_p(TSEQUENCE_INST_N(seq, 0));
   for (int i = 1; i < seq->count; i++)
   {
@@ -1840,13 +1840,13 @@ tsequence_max_val(const TSequence *seq)
     TBox *box = TSEQUENCE_BBOX_PTR(seq);
     Datum max = box->span.upper;
     /* The upper bound of an integer span in canonical form is non exclusive */
-    meosType basetype = temptype_basetype(seq->temptype);
+    MeosType basetype = temptype_basetype(seq->temptype);
     if (basetype == T_INT4)
       max = Int32GetDatum(DatumGetInt32(max) - 1);
     return max;
   }
 
-  meosType basetype = temptype_basetype(seq->temptype);
+  MeosType basetype = temptype_basetype(seq->temptype);
   Datum result = tinstant_value_p(TSEQUENCE_INST_N(seq, 0));
   for (int i = 1; i < seq->count; i++)
   {
@@ -1866,7 +1866,7 @@ tnumberseq_avg_val(const TSequence *seq)
 {
   assert(seq); assert(tnumber_type(seq->temptype));
 
-  meosType basetype = temptype_basetype(seq->temptype);
+  MeosType basetype = temptype_basetype(seq->temptype);
   double result = 0.0;
   for (int i = 0; i < seq->count; i++)
     result += datum_double(tinstant_value_p(TSEQUENCE_INST_N(seq, i)), basetype);
@@ -1944,7 +1944,7 @@ tsequence_segments_iter(const TSequence *seq, TSequence **result)
   bool lower_inc = seq->period.lower_inc;
   TInstant *inst1, *inst2;
   int nseqs = 0;
-  meosType basetype = temptype_basetype(seq->temptype);
+  MeosType basetype = temptype_basetype(seq->temptype);
   for (int i = 1; i < seq->count; i++)
   {
     inst1 = (TInstant *) TSEQUENCE_INST_N(seq, i - 1);
@@ -2117,11 +2117,11 @@ tdiscseq_value_at_timestamptz(const TSequence *seq, TimestampTz t,
  * @note The function creates a new value that must be freed
  */
 Datum
-tsegment_value_at_timestamptz(Datum start, Datum end, meosType temptype,
+tsegment_value_at_timestamptz(Datum start, Datum end, MeosType temptype,
   TimestampTz lower, TimestampTz upper, TimestampTz t)
 {
   assert(lower < upper);
-  meosType basetype = temptype_basetype(temptype);
+  MeosType basetype = temptype_basetype(temptype);
   /* Constant segment or t is equal to lower bound or step interpolation */
   if (datum_eq(start, end, basetype || lower == t))
     return datum_copy(start, basetype);
@@ -2293,8 +2293,8 @@ synchronize_tsequence_tsequence(const TSequence *seq1, const TSequence *seq2,
   TInstant **instants1 = palloc(sizeof(TInstant *) * count);
   TInstant **instants2 = palloc(sizeof(TInstant *) * count);
   TInstant **tofree = palloc(sizeof(TInstant *) * count * 2);
-  meosType basetype1 = temptype_basetype(seq1->temptype);
-  meosType basetype2 = temptype_basetype(seq2->temptype);
+  MeosType basetype1 = temptype_basetype(seq1->temptype);
+  MeosType basetype2 = temptype_basetype(seq2->temptype);
   while (i < seq1->count && j < seq2->count &&
     (inst1->t <= DatumGetTimestampTz(inter.upper) ||
      inst2->t <= DatumGetTimestampTz(inter.upper)))
@@ -2536,11 +2536,11 @@ tfloatsegm_intersection_value(Datum start, Datum end, Datum value,
  */
 int
 tsegment_intersection_value(Datum start, Datum end, Datum value,
-  meosType temptype, TimestampTz lower, TimestampTz upper, TimestampTz *t1,
+  MeosType temptype, TimestampTz lower, TimestampTz upper, TimestampTz *t1,
   TimestampTz *t2)
 {
   assert(lower < upper); assert(t1); assert(t2);
-  meosType basetype = temptype_basetype(temptype);
+  MeosType basetype = temptype_basetype(temptype);
   if (datum_eq(value, start, basetype) || datum_eq(value, end, basetype))
     return 0;
 
@@ -2593,7 +2593,7 @@ tsegment_intersection_value(Datum start, Datum end, Datum value,
  */
 int
 tnumbersegm_intersection(Datum start1, Datum end1, Datum start2, Datum end2,
-  meosType basetype, TimestampTz lower, TimestampTz upper, TimestampTz *t1,
+  MeosType basetype, TimestampTz lower, TimestampTz upper, TimestampTz *t1,
   TimestampTz *t2)
 {
   assert(lower < upper); assert(t1); assert(t2);
@@ -2659,11 +2659,11 @@ tnumbersegm_intersection(Datum start1, Datum end1, Datum start2, Datum end2,
  */
 int
 tsegment_intersection(Datum start1, Datum end1, Datum start2, Datum end2,
-  meosType temptype, TimestampTz lower, TimestampTz upper, TimestampTz *t1,
+  MeosType temptype, TimestampTz lower, TimestampTz upper, TimestampTz *t1,
   TimestampTz *t2)
 {
   assert(lower < upper); assert(t1); assert(t2);
-  meosType basetype = temptype_basetype(temptype);
+  MeosType basetype = temptype_basetype(temptype);
   /* If one of the segments is constant */
   if (datum_eq(start1, end1, basetype))
     return tsegment_intersection_value(start2, end2, start1, temptype,

--- a/meos/src/temporal/tsequenceset.c
+++ b/meos/src/temporal/tsequenceset.c
@@ -171,7 +171,7 @@ tseqarr_normalize(TSequence **sequences, int count, int *newcount)
  * @return On error return -1.0
  */
 double
-datum_distance(Datum value1, Datum value2, meosType type, int16 flags)
+datum_distance(Datum value1, Datum value2, MeosType type, int16 flags)
 {
   if (tnumber_basetype(type))
     return datum_double(distance_value_value(value1, value2, type), type);
@@ -453,7 +453,7 @@ int *
 ensure_valid_tinstarr_gaps(TInstant **instants, int count, bool merge,
   double maxdist, const Interval *maxt, int *nsplits)
 {
-  meosType basetype = temptype_basetype(instants[0]->temptype);
+  MeosType basetype = temptype_basetype(instants[0]->temptype);
   /* Ensure that zero-fill is done */
   int *result = palloc0(sizeof(int) * count);
   Datum value1 = tinstant_value_p(instants[0]);
@@ -651,7 +651,7 @@ tseqsetarr_to_tseqset(TSequenceSet **seqsets, int count, int totalseqs)
  * @param[in] interp Interpolation
  */
 TSequenceSet *
-tsequenceset_from_base_tstzspanset(Datum value, meosType temptype,
+tsequenceset_from_base_tstzspanset(Datum value, MeosType temptype,
   const SpanSet *ss, interpType interp)
 {
   assert(ss);
@@ -689,7 +689,7 @@ tsequenceset_values_p(const TSequenceSet *ss, int *count)
   }
   if (nvals > 1)
   {
-    meosType basetype = temptype_basetype(ss->temptype);
+    MeosType basetype = temptype_basetype(ss->temptype);
     datumarr_sort(result, nvals, basetype);
     nvals = datumarr_remove_duplicates(result, nvals, basetype);
   }
@@ -724,8 +724,8 @@ tnumberseqset_valuespans(const TSequenceSet *ss)
   }
 
   /* Temporal sequence number with discrete or step interpolation */
-  meosType basetype = temptype_basetype(ss->temptype);
-  meosType spantype = basetype_spantype(basetype);
+  MeosType basetype = temptype_basetype(ss->temptype);
+  MeosType spantype = basetype_spantype(basetype);
   Datum *values = tsequenceset_values_p(ss, &count);
   spans = palloc(sizeof(Span) * count);
   for (i = 0; i < count; i++)
@@ -743,13 +743,13 @@ tnumberseqset_valuespans(const TSequenceSet *ss)
  */
 const TInstant *
 tsequenceset_minmax_inst_p(const TSequenceSet *ss,
-  bool (*func)(Datum, Datum, meosType))
+  bool (*func)(Datum, Datum, MeosType))
 {
   assert(ss);
   const TSequence *seq = TSEQUENCESET_SEQ_N(ss, 0);
   const TInstant *result = TSEQUENCE_INST_N(seq, 0);
   Datum min = tinstant_value_p(result);
-  meosType basetype = temptype_basetype(seq->temptype);
+  MeosType basetype = temptype_basetype(seq->temptype);
   for (int i = 0; i < ss->count; i++)
   {
     seq = TSEQUENCESET_SEQ_N(ss, i);
@@ -816,7 +816,7 @@ tsequenceset_min_val(const TSequenceSet *ss)
     return box->span.lower;
   }
 
-  meosType basetype = temptype_basetype(ss->temptype);
+  MeosType basetype = temptype_basetype(ss->temptype);
   Datum result = tsequence_min_val(TSEQUENCESET_SEQ_N(ss, 0));
   for (int i = 1; i < ss->count; i++)
   {
@@ -843,13 +843,13 @@ tsequenceset_max_val(const TSequenceSet *ss)
     TBox *box = TSEQUENCESET_BBOX_PTR(ss);
     Datum max = box->span.upper;
     /* The upper bound of an integer span in canonical form is non exclusive */
-    meosType basetype = temptype_basetype(ss->temptype);
+    MeosType basetype = temptype_basetype(ss->temptype);
     if (basetype == T_INT4)
       max = Int32GetDatum(DatumGetInt32(max) - 1);
     return max;
   }
 
-  meosType basetype = temptype_basetype(ss->temptype);
+  MeosType basetype = temptype_basetype(ss->temptype);
   Datum result = tsequence_max_val(TSEQUENCESET_SEQ_N(ss, 0));
   for (int i = 1; i < ss->count; i++)
   {
@@ -1591,7 +1591,7 @@ tsequenceset_to_step(const TSequenceSet *ss)
     return tsequenceset_copy(ss);
 
   /* Test whether it is possible to set the interpolation to step */
-  meosType basetype = temptype_basetype(ss->temptype);
+  MeosType basetype = temptype_basetype(ss->temptype);
   const TSequence *seq;
   for (int i = 0; i < ss->count; i++)
   {
@@ -1995,7 +1995,7 @@ intersection_tsequence_tsequenceset(const TSequence *seq, const TSequenceSet *ss
  * @param[in] interp Interpolation
  */
 TSequenceSet *
-tsequenceset_in(const char *str, meosType temptype, interpType interp)
+tsequenceset_in(const char *str, MeosType temptype, interpType interp)
 {
   assert(str);
   return tsequenceset_parse(&str, temptype, interp);

--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -103,9 +103,9 @@ extern LWGEOM *parse_geojson(json_object *geojson, int *hasz);
  */
 bool
 #if CBUFFER || NPOINT || POSE || RGEO
-basetype_in(const char *str, meosType type, bool end, Datum *result)
+basetype_in(const char *str, MeosType type, bool end, Datum *result)
 #else
-basetype_in(const char *str, meosType type,
+basetype_in(const char *str, MeosType type,
   bool end UNUSED, Datum *result)
 #endif
 {
@@ -322,7 +322,7 @@ parse_mfjson_coord(json_object *poObj, int32_t srid, bool geodetic)
  * @brief Return an array of values from its MF-JSON representation
  */
 static Datum *
-parse_mfjson_values(json_object *mfjson, meosType temptype, int *count)
+parse_mfjson_values(json_object *mfjson, MeosType temptype, int *count)
 {
   json_object *mfjsonTmp = mfjson;
   json_object *jvalues = NULL;
@@ -749,7 +749,7 @@ parse_mfjson_datetimes(json_object *mfjson, int *count)
  */
 TInstant *
 tinstant_from_mfjson(json_object *mfjson, bool spatial, int32_t srid,
-  meosType temptype)
+  MeosType temptype)
 {
   assert(mfjson); assert(temporal_type(temptype));
   bool geodetic = tgeodetic_type(temptype);
@@ -796,7 +796,7 @@ tinstant_from_mfjson(json_object *mfjson, bool spatial, int32_t srid,
  */
 static TInstant **
 tinstarr_from_mfjson(json_object *mfjson, bool isgeo, int32_t srid,
-  meosType temptype, int *count)
+  MeosType temptype, int *count)
 {
   assert(mfjson); assert(count);
   bool geodetic = tgeodetic_type(temptype);
@@ -853,7 +853,7 @@ tinstarr_from_mfjson(json_object *mfjson, bool isgeo, int32_t srid,
  */
 TSequence *
 tsequence_from_mfjson(json_object *mfjson, bool spatial, int32_t srid,
-  meosType temptype, interpType interp)
+  MeosType temptype, interpType interp)
 {
   assert(mfjson);
   /* Get the array of temporal point instants */
@@ -901,7 +901,7 @@ tsequence_from_mfjson(json_object *mfjson, bool spatial, int32_t srid,
  */
 TSequenceSet *
 tsequenceset_from_mfjson(json_object *mfjson, bool spatial, int32_t srid,
-  meosType temptype, interpType interp)
+  MeosType temptype, interpType interp)
 {
   assert(mfjson);
   json_object *seqs = NULL;
@@ -972,7 +972,7 @@ ensure_temptype_mfjson(const char *typestr)
  * @see #tsequenceset_from_mfjson()
  */
 Temporal *
-temporal_from_mfjson(const char *mfjson, meosType temptype)
+temporal_from_mfjson(const char *mfjson, MeosType temptype)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(mfjson, NULL);
@@ -1007,7 +1007,7 @@ temporal_from_mfjson(const char *mfjson, meosType temptype)
 
   /* Determine the type of temporal type */
   const char *typestr = json_object_get_string(poObjType);
-  meosType jtemptype = T_UNKNOWN;
+  MeosType jtemptype = T_UNKNOWN;
   if (! ensure_temptype_mfjson(typestr))
     return NULL;
   if (strcmp(typestr, "MovingBoolean") == 0)
@@ -1098,7 +1098,7 @@ temporal_from_mfjson(const char *mfjson, meosType temptype)
 #if RGEO
   /* We change the temptype to T_TPose to read a temporal pose and construct
    * the temporal rigid geometry from the geometry and the temporal pose */
-  meosType temptype_orig = temptype;
+  MeosType temptype_orig = temptype;
   GSERIALIZED *gs = NULL;
 #endif /* RGEO */
   if (pszInterp)
@@ -1973,7 +1973,7 @@ temporal_from_wkb_state(meos_wkb_parse_state *s)
 
 #if RGEO
   GSERIALIZED *gs;
-  meosType temptype_orig = SRID_UNKNOWN;
+  MeosType temptype_orig = SRID_UNKNOWN;
   if (s->temptype == T_TRGEOMETRY)
   {
     gs = geo_from_wkb_state(s);
@@ -2016,7 +2016,7 @@ temporal_from_wkb_state(meos_wkb_parse_state *s)
  * @brief Return a value from its Well-Known Binary (WKB) representation
  */
 Datum
-type_from_wkb(const uint8_t *wkb, size_t size, meosType type)
+type_from_wkb(const uint8_t *wkb, size_t size, MeosType type)
 {
   /* Initialize the state appropriately */
   meos_wkb_parse_state s;
@@ -2083,7 +2083,7 @@ type_from_wkb(const uint8_t *wkb, size_t size, meosType type)
  * @brief Return a value from its HexEWKB representation
  */
 Datum
-type_from_hexwkb(const char *hexwkb, size_t size, meosType type)
+type_from_hexwkb(const char *hexwkb, size_t size, MeosType type)
 {
   uint8_t *wkb = bytes_from_hexbytes(hexwkb, size);
   Datum result = type_from_wkb(wkb, size / 2, type);

--- a/meos/src/temporal/type_out.c
+++ b/meos/src/temporal/type_out.c
@@ -115,7 +115,7 @@ text_out(const text *txt)
  * @return On error return @p NULL
  */
 char *
-basetype_out(Datum value, meosType type, int maxdd)
+basetype_out(Datum value, MeosType type, int maxdd)
 {
   assert(meos_basetype(type)); assert(maxdd >= 0);
 
@@ -291,7 +291,7 @@ stringbuffer_append_char(sb, '}');
  * @brief Write into the buffer a base value in the MF-JSON representation
  */
 static bool
-temporal_base_as_mfjson_sb(stringbuffer_t *sb, Datum value, meosType temptype,
+temporal_base_as_mfjson_sb(stringbuffer_t *sb, Datum value, MeosType temptype,
   int precision)
 {
   assert(alphanum_temptype(temptype));
@@ -428,7 +428,7 @@ stbox_as_mfjson_sb(stringbuffer_t *sb, const STBox *box, int precision)
  * type in the MF-JSON representation
  */
 static bool
-bbox_as_mfjson_sb(stringbuffer_t *sb, meosType temptype, const bboxunion *box,
+bbox_as_mfjson_sb(stringbuffer_t *sb, MeosType temptype, const bboxunion *box,
   int precision)
 {
   assert(temporal_type(temptype));
@@ -463,7 +463,7 @@ bbox_as_mfjson_sb(stringbuffer_t *sb, meosType temptype, const bboxunion *box,
  * @brief Write into the buffer a temporal type in the MF-JSON representation
  */
 static bool
-temptype_as_mfjson_sb(stringbuffer_t *sb, meosType temptype)
+temptype_as_mfjson_sb(stringbuffer_t *sb, MeosType temptype)
 {
   assert(temporal_type(temptype));
   switch (temptype)
@@ -948,7 +948,7 @@ pose_to_wkb_size(const Pose *pose, uint8_t variant, bool component)
  * @return On error return SIZE_MAX
  */
 static size_t
-base_to_wkb_size(Datum value, meosType basetype, uint8_t variant)
+base_to_wkb_size(Datum value, MeosType basetype, uint8_t variant)
 {
   switch (basetype)
   {
@@ -1102,7 +1102,7 @@ static size_t
 tinstarr_to_wkb_size(TInstant **instants, int count, uint8_t variant)
 {
   size_t result = 0;
-  meosType basetype = temptype_basetype(instants[0]->temptype);
+  MeosType basetype = temptype_basetype(instants[0]->temptype);
   for (int i = 0; i < count; i++)
   {
     Datum value = tinstant_value_p(instants[i]);
@@ -1213,7 +1213,7 @@ temporal_to_wkb_size(const Temporal *temp, uint8_t variant)
  * @return On error return SIZE_MAX
  */
 static size_t
-datum_to_wkb_size(Datum value, meosType type, uint8_t variant)
+datum_to_wkb_size(Datum value, MeosType type, uint8_t variant)
 {
   if (set_type(type))
     return set_to_wkb_size(DatumGetSetP(value), variant);
@@ -1624,7 +1624,7 @@ pose_to_wkb_buf(const Pose *pose, uint8_t *buf, uint8_t variant,
  * - timestamp
  */
 static uint8_t *
-base_to_wkb_buf(Datum value, meosType basetype, uint8_t *buf,
+base_to_wkb_buf(Datum value, MeosType basetype, uint8_t *buf,
   uint8_t variant)
 {
   switch (basetype)
@@ -2047,7 +2047,7 @@ static uint8_t *
 tinstant_base_time_to_wkb_buf(const TInstant *inst, uint8_t *buf,
   uint8_t variant)
 {
-  meosType basetype = temptype_basetype(inst->temptype);
+  MeosType basetype = temptype_basetype(inst->temptype);
   assert(temporal_basetype(basetype));
   buf = base_to_wkb_buf(tinstant_value_p(inst), basetype, buf, variant);
   buf = timestamptz_to_wkb_buf(inst->t, buf, variant);
@@ -2203,7 +2203,7 @@ temporal_to_wkb_buf(const Temporal *temp, uint8_t *buf, uint8_t variant)
  * @return On error return @p NULL
  */
 static uint8_t *
-datum_to_wkb_buf(Datum value, meosType type, uint8_t *buf, uint8_t variant)
+datum_to_wkb_buf(Datum value, MeosType type, uint8_t *buf, uint8_t variant)
 {
   if (set_type(type))
     buf = set_to_wkb_buf(DatumGetSetP(value), buf, variant);
@@ -2255,7 +2255,7 @@ datum_to_wkb_buf(Datum value, meosType type, uint8_t *buf, uint8_t variant)
  * @note Caller is responsible for freeing the returned array.
  */
 uint8_t *
-datum_as_wkb(Datum value, meosType type, uint8_t variant, size_t *size_out)
+datum_as_wkb(Datum value, MeosType type, uint8_t variant, size_t *size_out)
 {
   size_t buf_size;
   uint8_t *buf = NULL;
@@ -2331,7 +2331,7 @@ datum_as_wkb(Datum value, meosType type, uint8_t variant, size_t *size_out)
  * @brief Return the HexWKB representation of a datum value
  */
 char *
-datum_as_hexwkb(Datum value, meosType type, uint8_t variant, size_t *size)
+datum_as_hexwkb(Datum value, MeosType type, uint8_t variant, size_t *size)
 {
   /* Create WKB hex string */
   return (char *) datum_as_wkb(value, type,

--- a/meos/src/temporal/type_parser.c
+++ b/meos/src/temporal/type_parser.c
@@ -287,7 +287,7 @@ double_parse(const char **str, double *result)
  * @return On error return false
  */
 bool
-basetype_parse(const char **str, meosType basetype, char delim, Datum *result)
+basetype_parse(const char **str, MeosType basetype, char delim, Datum *result)
 {
   p_whitespace(str);
   int pos = 0;
@@ -342,7 +342,7 @@ tbox_parse(const char **str)
 
   p_whitespace(str);
   /* By default the span type is float span */
-  meosType spantype = T_FLOATSPAN;
+  MeosType spantype = T_FLOATSPAN;
   if (pg_strncasecmp(*str, "TBOXINT", 7) == 0)
   {
     spantype = T_INTSPAN;
@@ -454,7 +454,7 @@ timestamp_parse(const char **str)
  * @return On error return false
  */
 bool
-elem_parse(const char **str, meosType basetype, Datum *result)
+elem_parse(const char **str, MeosType basetype, Datum *result)
 {
   p_whitespace(str);
   int pos = 0, dquote = 0;
@@ -490,9 +490,9 @@ elem_parse(const char **str, meosType basetype, Datum *result)
  * @return On error return @p NULL
  */
 Set *
-set_parse(const char **str, meosType settype)
+set_parse(const char **str, MeosType settype)
 {
-  meosType basetype = settype_basetype(settype);
+  MeosType basetype = settype_basetype(settype);
   MeosArray *array = meos_array_create(sizeof(Datum));
   const char *type_str = meostype_name(settype);
   Set *result = NULL;
@@ -546,7 +546,7 @@ error:
  * @return On error return false
  */
 bool
-bound_parse(const char **str, meosType basetype, Datum *result)
+bound_parse(const char **str, MeosType basetype, Datum *result)
 {
   p_whitespace(str);
   int pos = 0;
@@ -569,7 +569,7 @@ bound_parse(const char **str, meosType basetype, Datum *result)
  * @return On error return false
  */
 bool
-span_parse(const char **str, meosType spantype, bool end, Span *span)
+span_parse(const char **str, MeosType spantype, bool end, Span *span)
 {
   const char *type_str = meostype_name(spantype);
   bool lower_inc = false, upper_inc = false;
@@ -583,7 +583,7 @@ span_parse(const char **str, meosType spantype, bool end, Span *span)
       "Could not parse %s value: Missing opening bracket/parenthesis", type_str);
     return false;
   }
-  meosType basetype = spantype_basetype(spantype);
+  MeosType basetype = spantype_basetype(spantype);
   Datum lower, upper;
   if (! bound_parse(str, basetype, &lower))
     return false;
@@ -615,12 +615,12 @@ span_parse(const char **str, meosType spantype, bool end, Span *span)
  * @return On error return @p NULL
  */
 SpanSet *
-spanset_parse(const char **str, meosType spansettype)
+spanset_parse(const char **str, MeosType spansettype)
 {
   const char *type_str = meostype_name(spansettype);
   if (! ensure_obrace(str, type_str))
     return NULL;
-  meosType spantype = spansettype_spantype(spansettype);
+  MeosType spantype = spansettype_spantype(spansettype);
 
   /* Parsing */
   MeosArray *array = meos_array_create(meostype_length(spantype));
@@ -661,10 +661,10 @@ error:
  * @return On error return NULL
  */
 TInstant *
-tinstant_parse(const char **str, meosType temptype, bool end)
+tinstant_parse(const char **str, MeosType temptype, bool end)
 {
   p_whitespace(str);
-  meosType basetype = temptype_basetype(temptype);
+  MeosType basetype = temptype_basetype(temptype);
   /* The next two instructions will throw an exception if they fail */
   Datum elem;
   if (! basetype_parse(str, basetype, '@', &elem))
@@ -690,7 +690,7 @@ tinstant_parse(const char **str, meosType temptype, bool end)
  * @return On error return @p NULL
  */
 TSequence *
-tdiscseq_parse(const char **str, meosType temptype)
+tdiscseq_parse(const char **str, MeosType temptype)
 {
   MeosArray *array = meos_array_create(meostype_length(temptype));
   const char *type_str = meostype_name(temptype);
@@ -741,7 +741,7 @@ error:
  * @return On error return false
  */
 TSequence *
-tcontseq_parse(const char **str, meosType temptype, interpType interp,
+tcontseq_parse(const char **str, MeosType temptype, interpType interp,
   bool end)
 {
   MeosArray *array = meos_array_create(meostype_length(temptype));
@@ -805,7 +805,7 @@ error:
  * @return On error return @p NULL
  */
 TSequenceSet *
-tsequenceset_parse(const char **str, meosType temptype, interpType interp)
+tsequenceset_parse(const char **str, MeosType temptype, interpType interp)
 {
   MeosArray *array = meos_array_create(meostype_length(temptype));
   const char *type_str = meostype_name(temptype);
@@ -850,7 +850,7 @@ error:
  * @return On error return @p NULL
  */
 Temporal *
-temporal_parse(const char **str, meosType temptype)
+temporal_parse(const char **str, MeosType temptype)
 {
   p_whitespace(str);
   Temporal *result = NULL;  /* keep compiler quiet */

--- a/meos/src/temporal/type_util.c
+++ b/meos/src/temporal/type_util.c
@@ -98,7 +98,7 @@ int64_cmp(int64 l, int64 r)
  * equal to, or greater than the second one
  */
 int
-datum_cmp(Datum l, Datum r, meosType type)
+datum_cmp(Datum l, Datum r, MeosType type)
 {
   assert(meos_basetype(type));
   switch (type)
@@ -148,7 +148,7 @@ datum_cmp(Datum l, Datum r, meosType type)
  * @brief Return true if the first value is less than the second one
  */
 bool
-datum_lt(Datum l, Datum r, meosType type)
+datum_lt(Datum l, Datum r, MeosType type)
 {
   return datum_cmp(l, r, type) < 0;
 }
@@ -158,7 +158,7 @@ datum_lt(Datum l, Datum r, meosType type)
  * one
  */
 bool
-datum_le(Datum l, Datum r, meosType type)
+datum_le(Datum l, Datum r, MeosType type)
 {
   return datum_cmp(l, r, type) <= 0;
 }
@@ -167,7 +167,7 @@ datum_le(Datum l, Datum r, meosType type)
  * @brief Return true if the first value is greater than the second one
  */
 bool
-datum_gt(Datum l, Datum r, meosType type)
+datum_gt(Datum l, Datum r, MeosType type)
 {
   return datum_cmp(l, r, type) > 0;
 }
@@ -177,7 +177,7 @@ datum_gt(Datum l, Datum r, meosType type)
  * one
  */
 bool
-datum_ge(Datum l, Datum r, meosType type)
+datum_ge(Datum l, Datum r, MeosType type)
 {
   return datum_cmp(l, r, type) >= 0;
 }
@@ -187,7 +187,7 @@ datum_ge(Datum l, Datum r, meosType type)
  * @note This function should be faster than the function #datum_cmp()
  */
 bool
-datum_eq(Datum l, Datum r, meosType type)
+datum_eq(Datum l, Datum r, MeosType type)
 {
   assert(meos_basetype(type));
   switch (type)
@@ -244,7 +244,7 @@ datum_eq(Datum l, Datum r, meosType type)
  * @brief Return true if the values are different
  */
 bool
-datum_ne(Datum l, Datum r, meosType type)
+datum_ne(Datum l, Datum r, MeosType type)
 {
   return ! datum_eq(l, r, type);
 }
@@ -256,7 +256,7 @@ datum_ne(Datum l, Datum r, meosType type)
  * @brief Return a Datum true if the values are equal
  */
 Datum
-datum2_eq(Datum l, Datum r, meosType type)
+datum2_eq(Datum l, Datum r, MeosType type)
 {
   return BoolGetDatum(datum_eq(l, r, type));
 }
@@ -265,7 +265,7 @@ datum2_eq(Datum l, Datum r, meosType type)
  * @brief Return a Datum true if the values are different
  */
 Datum
-datum2_ne(Datum l, Datum r, meosType type)
+datum2_ne(Datum l, Datum r, MeosType type)
 {
   return BoolGetDatum(datum_ne(l, r, type));
 }
@@ -274,7 +274,7 @@ datum2_ne(Datum l, Datum r, meosType type)
  * @brief Return a Datum true if the first value is less than the second one
  */
 Datum
-datum2_lt(Datum l, Datum r, meosType type)
+datum2_lt(Datum l, Datum r, MeosType type)
 {
   return BoolGetDatum(datum_lt(l, r, type));
 }
@@ -284,7 +284,7 @@ datum2_lt(Datum l, Datum r, meosType type)
  * second one
  */
 Datum
-datum2_le(Datum l, Datum r, meosType type)
+datum2_le(Datum l, Datum r, MeosType type)
 {
   return BoolGetDatum(datum_le(l, r, type));
 }
@@ -293,7 +293,7 @@ datum2_le(Datum l, Datum r, meosType type)
  * @brief Return a Datum true if the first value is greater than the second one
  */
 Datum
-datum2_gt(Datum l, Datum r, meosType type)
+datum2_gt(Datum l, Datum r, MeosType type)
 {
   return BoolGetDatum(datum_gt(l, r, type));
 }
@@ -303,7 +303,7 @@ datum2_gt(Datum l, Datum r, meosType type)
  * the second one
  */
 Datum
-datum2_ge(Datum l, Datum r, meosType type)
+datum2_ge(Datum l, Datum r, MeosType type)
 {
   return BoolGetDatum(datum_ge(l, r, type));
 }
@@ -317,7 +317,7 @@ datum2_ge(Datum l, Datum r, meosType type)
  * @brief Return the addition of the two numbers
  */
 Datum
-datum_add(Datum l, Datum r, meosType type)
+datum_add(Datum l, Datum r, MeosType type)
 {
   switch (type)
   {
@@ -344,7 +344,7 @@ datum_add(Datum l, Datum r, meosType type)
  * @brief Return the subtraction of the two numbers
  */
 Datum
-datum_sub(Datum l, Datum r, meosType type)
+datum_sub(Datum l, Datum r, MeosType type)
 {
   switch (type)
   {
@@ -368,7 +368,7 @@ datum_sub(Datum l, Datum r, meosType type)
  * @brief Return the multiplication of the two numbers
  */
 Datum
-datum_mult(Datum l, Datum r, meosType type)
+datum_mult(Datum l, Datum r, MeosType type)
 {
   switch (type)
   {
@@ -389,7 +389,7 @@ datum_mult(Datum l, Datum r, meosType type)
  * @brief Return the division of the two numbers
  */
 Datum
-datum_div(Datum l, Datum r, meosType type)
+datum_div(Datum l, Datum r, MeosType type)
 {
   switch (type)
   {
@@ -417,7 +417,7 @@ datum_div(Datum l, Datum r, meosType type)
  * @return On error return @p INT_MAX
  */
 uint32
-datum_hash(Datum d, meosType type)
+datum_hash(Datum d, MeosType type)
 {
   assert(meos_basetype(type));
   switch (type)
@@ -466,7 +466,7 @@ datum_hash(Datum d, meosType type)
  * @return On error return @p INT_MAX
  */
 uint64
-datum_hash_extended(Datum d, meosType type, uint64 seed)
+datum_hash_extended(Datum d, MeosType type, uint64 seed)
 {
   assert(meos_basetype(type));
   switch (type)
@@ -512,7 +512,7 @@ datum_hash_extended(Datum d, meosType type, uint64 seed)
  * @brief Copy a Datum if it is passed by reference
  */
 Datum
-datum_copy(Datum value, meosType basetype)
+datum_copy(Datum value, MeosType basetype)
 {
   /* For types passed by value */
   if (basetype_byvalue(basetype))
@@ -531,7 +531,7 @@ datum_copy(Datum value, meosType basetype)
  * @return On error return @p DBL_MAX
  */
 double
-datum_double(Datum d, meosType type)
+datum_double(Datum d, MeosType type)
 {
   assert(numspan_basetype(type));
   switch (type)
@@ -556,7 +556,7 @@ datum_double(Datum d, meosType type)
  * @brief Return a Datum of a given type from a double value
  */
 Datum
-double_datum(double d, meosType type)
+double_datum(double d, MeosType type)
 {
   assert(numspan_basetype(type));
   switch (type)
@@ -585,11 +585,11 @@ double_datum(double d, meosType type)
  * @brief Comparator function for datums
  */
 static int
-datum_sort_cmp(const Datum *l, const Datum *r, const meosType *type)
+datum_sort_cmp(const Datum *l, const Datum *r, const MeosType *type)
 {
   Datum x = *l;
   Datum y = *r;
-  meosType t = *type;
+  MeosType t = *type;
   return datum_cmp(x, y, t);
 }
 
@@ -630,7 +630,7 @@ tsequence_sort_cmp(TSequence **l, TSequence **r)
  * @brief Sort function for datums
  */
 void
-datumarr_sort(Datum *values, int count, meosType type)
+datumarr_sort(Datum *values, int count, MeosType type)
 {
   qsort_arg(values, (size_t) count, sizeof(Datum),
     (qsort_arg_comparator) &datum_sort_cmp, &type);
@@ -692,7 +692,7 @@ tseqarr_sort(TSequence **sequences, int count)
  * @pre The array has been sorted before
  */
 int
-datumarr_remove_duplicates(Datum *values, int count, meosType type)
+datumarr_remove_duplicates(Datum *values, int count, MeosType type)
 {
   assert(values); assert(count > 0);
   int newcount = 0;

--- a/mobilitydb/pg_include/pg_temporal/meos_catalog.h
+++ b/mobilitydb/pg_include/pg_temporal/meos_catalog.h
@@ -44,15 +44,15 @@
 
 /* MobilityDB functions */
 
-extern Oid meostype_oid(meosType type);
-extern Oid meosoper_oid(meosOper op, meosType l, meosType r);
-extern meosType oid_meostype(Oid typid);
-extern meosOper oid_meosoper(Oid operOid, meosType *l, meosType *r);
+extern Oid meostype_oid(MeosType type);
+extern Oid meosoper_oid(meosOper op, MeosType l, MeosType r);
+extern MeosType oid_meostype(Oid typid);
+extern meosOper oid_meosoper(Oid operOid, MeosType *l, MeosType *r);
 
-extern bool range_basetype(meosType type);
-extern bool ensure_range_basetype(meosType type);
-extern meosType basetype_rangetype(meosType type);
-extern meosType basetype_multirangetype(meosType type);
+extern bool range_basetype(MeosType type);
+extern bool ensure_range_basetype(MeosType type);
+extern MeosType basetype_rangetype(MeosType type);
+extern MeosType basetype_multirangetype(MeosType type);
 
 /*****************************************************************************/
 

--- a/mobilitydb/pg_include/pg_temporal/temporal.h
+++ b/mobilitydb/pg_include/pg_temporal/temporal.h
@@ -198,10 +198,10 @@ extern interpType input_interp_string(FunctionCallInfo fcinfo, int argno);
 extern Temporal *temporal_recv(StringInfo buf);
 extern void temporal_write(const Temporal *temp, StringInfo buf);
 
-extern bytea *Datum_as_wkb(FunctionCallInfo fcinfo, Datum value, meosType type,
+extern bytea *Datum_as_wkb(FunctionCallInfo fcinfo, Datum value, MeosType type,
   bool extended);
 extern text *Datum_as_hexwkb(FunctionCallInfo fcinfo, Datum value,
-  meosType type);
+  MeosType type);
 
 /* Parameter tests */
 
@@ -212,10 +212,10 @@ extern bool ensure_not_empty_array(ArrayType *array);
 extern Datum EAcomp_temporal_temporal(FunctionCallInfo fcinfo,
   int (*func)(const Temporal *, const Temporal *));
 extern Datum Tcomp_temporal_temporal(FunctionCallInfo fcinfo,
-  Datum (*func)(Datum, Datum, meosType));
+  Datum (*func)(Datum, Datum, MeosType));
 
 extern Datum Tcomp_temporal_base(FunctionCallInfo fcinfo,
-  Datum (*func)(Datum, Datum, meosType));
+  Datum (*func)(Datum, Datum, MeosType));
 
 /* Indexing functions */
 

--- a/mobilitydb/pg_include/pg_temporal/tinstant.h
+++ b/mobilitydb/pg_include/pg_temporal/tinstant.h
@@ -44,7 +44,7 @@
 
 /* Send/receive functions */
 
-extern TInstant *tinstant_recv(StringInfo buf, meosType temptype);
+extern TInstant *tinstant_recv(StringInfo buf, MeosType temptype);
 extern void tinstant_write(const TInstant *inst, StringInfo buf);
 
 /*****************************************************************************/

--- a/mobilitydb/pg_include/pg_temporal/tnumber_gist.h
+++ b/mobilitydb/pg_include/pg_temporal/tnumber_gist.h
@@ -69,14 +69,14 @@ typedef struct
 
 /* The following functions are also called by tpoint_gist.c */
 extern void bbox_gist_fallback_split(GistEntryVector *entryvec,
-  GIST_SPLITVEC *v, meosType bboxtype, void (*bbox_adjust)(void *, void *));
+  GIST_SPLITVEC *v, MeosType bboxtype, void (*bbox_adjust)(void *, void *));
 extern int interval_cmp_lower(const void *i1, const void *i2);
 extern int interval_cmp_upper(const void *i1, const void *i2);
 extern float non_negative(float val);
 extern void bbox_gist_consider_split(ConsiderSplitContext *context, int dimNum,
-  meosType bboxtype, double rightLower, int minLeftCount, double leftUpper,
+  MeosType bboxtype, double rightLower, int minLeftCount, double leftUpper,
   int maxLeftCount);
-extern Datum bbox_gist_picksplit(FunctionCallInfo fcinfo, meosType bboxtype,
+extern Datum bbox_gist_picksplit(FunctionCallInfo fcinfo, MeosType bboxtype,
   void (*bbox_adjust)(void *, void *), double (*bbox_penalty)(void *, void *));
 
 /* The following functions are also called by tnumber_spgist.c */

--- a/mobilitydb/pg_include/pg_temporal/tsequence.h
+++ b/mobilitydb/pg_include/pg_temporal/tsequence.h
@@ -44,7 +44,7 @@
 
 /* Send/receive functions */
 
-extern TSequence *tsequence_recv(StringInfo buf, meosType temptype);
+extern TSequence *tsequence_recv(StringInfo buf, MeosType temptype);
 extern void tsequence_write(const TSequence *seq, StringInfo buf);
 
 /*****************************************************************************/

--- a/mobilitydb/pg_include/pg_temporal/type_util.h
+++ b/mobilitydb/pg_include/pg_temporal/type_util.h
@@ -61,8 +61,8 @@
 
 extern Datum call_input(Oid typid, char *str, bool end);
 extern char *call_output(Oid typid, Datum value);
-extern Datum call_recv(meosType type, StringInfo buf);
-extern bytea *call_send(meosType type, Datum value);
+extern Datum call_recv(MeosType type, StringInfo buf);
+extern bytea *call_send(MeosType type, Datum value);
 
 extern Datum call_function1(PGFunction func, Datum arg1);
 extern Datum call_function2(PGFunction func, Datum arg1, Datum arg2);
@@ -80,7 +80,7 @@ extern Datum CallerFInfoFunctionCall4(PGFunction func, FmgrInfo *flinfo,
 /* Range functions */
 
 extern RangeType *range_make(Datum from, Datum to, bool lower_inc,
-  bool upper_inc, meosType basetype);
+  bool upper_inc, MeosType basetype);
 #if POSTGRESQL_VERSION_NUMBER >= 140000
   extern MultirangeType *multirange_make(const SpanSet *ss);
 #endif /* POSTGRESQL_VERSION_NUMBER >= 140000 */
@@ -101,7 +101,7 @@ extern Span *spanarr_extract(ArrayType *array, int *count);
 extern STBox *stboxarr_extract(ArrayType *array, int *count);
 extern Temporal **temparr_extract(ArrayType *array, int *count);
 
-extern ArrayType *datumarr_to_array(Datum *values, int count, meosType type);
+extern ArrayType *datumarr_to_array(Datum *values, int count, MeosType type);
 extern ArrayType *int64arr_to_array(int64 *longints, int count);
 extern ArrayType *datearr_to_array(DateADT *dates, int count);
 extern ArrayType *tstzarr_to_array(TimestampTz *times, int count);

--- a/mobilitydb/src/geo/spatialset.c
+++ b/mobilitydb/src/geo/spatialset.c
@@ -156,7 +156,7 @@ Spatialarr_as_text_common(FunctionCallInfo fcinfo, bool extended)
     dbl_dig_for_wkt = PG_GETARG_INT32(1);
 
   Datum *datumarr = datumarr_extract(array, &count);
-  meosType basetype = oid_meostype(array->elemtype);
+  MeosType basetype = oid_meostype(array->elemtype);
   char **strarr = spatialarr_wkt_out(datumarr, basetype, count, 
     dbl_dig_for_wkt, extended);
   /* We cannot use pfree_array */

--- a/mobilitydb/src/geo/stbox.c
+++ b/mobilitydb/src/geo/stbox.c
@@ -263,7 +263,7 @@ Stbox_constructor(FunctionCallInfo fcinfo, bool hasx, bool hasz,
   }
   if (hast)
   {
-    meosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, i));
+    MeosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, i));
     assert(basetype == T_TSTZSPAN || basetype == T_TIMESTAMPTZ);
     if (basetype == T_TSTZSPAN)
       period = PG_GETARG_SPAN_P(i++);

--- a/mobilitydb/src/geo/tspatial_analyze.c
+++ b/mobilitydb/src/geo/tspatial_analyze.c
@@ -603,7 +603,7 @@ gserialized_compute_stats(VacAttrStats *stats, AnalyzeAttrFetchFunc fetchfunc,
      * This changes wrt the original PostGIS function. We get a spatial set or
      * a temporal point while the original function gets a geometry.
      */
-    meosType type = oid_meostype(stats->attrtypid);
+    MeosType type = oid_meostype(stats->attrtypid);
     assert(spatialset_type(type) || tspatial_type(type));
     if (spatialset_type(type))
     {

--- a/mobilitydb/src/geo/tspatial_gist.c
+++ b/mobilitydb/src/geo/tspatial_gist.c
@@ -62,7 +62,7 @@
  * that must not be taken into account by the operators to infinity
  */
 static bool
-tspatial_gist_get_stbox(FunctionCallInfo fcinfo, STBox *result, meosType type)
+tspatial_gist_get_stbox(FunctionCallInfo fcinfo, STBox *result, MeosType type)
 {
   if (type == T_TSTZSPAN)
   {

--- a/mobilitydb/src/geo/tspatial_spgist.c
+++ b/mobilitydb/src/geo/tspatial_spgist.c
@@ -694,7 +694,7 @@ distance_stbox_nodebox(const STBox *query, const STboxNode *nodebox)
 static bool
 tspatial_spgist_get_stbox(const ScanKeyData *scankey, STBox *result)
 {
-  meosType type = oid_meostype(scankey->sk_subtype);
+  MeosType type = oid_meostype(scankey->sk_subtype);
   if (type == T_TSTZSPAN)
   {
     Span *s = DatumGetSpanP(scankey->sk_argument);

--- a/mobilitydb/src/rgeo/trgeo.c
+++ b/mobilitydb/src/rgeo/trgeo.c
@@ -282,7 +282,7 @@ Datum
 Trgeometry_seq_constructor(PG_FUNCTION_ARGS)
 {
   ArrayType *array = PG_GETARG_ARRAYTYPE_P(0);
-  meosType temptype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
+  MeosType temptype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
   interpType interp = temptype_continuous(temptype) ? LINEAR : STEP;
   if (PG_NARGS() > 1 && ! PG_ARGISNULL(1))
   {
@@ -348,7 +348,7 @@ Trgeometry_seqset_constructor_gaps(PG_FUNCTION_ARGS)
   ensure_not_empty_array(array);
   double maxdist = -1.0;
   Interval *maxt = NULL;
-  meosType temptype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
+  MeosType temptype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
   interpType interp = temptype_continuous(temptype) ? LINEAR : STEP;
   if (PG_NARGS() > 1 && ! PG_ARGISNULL(1))
     maxt = PG_GETARG_INTERVAL_P(1);

--- a/mobilitydb/src/temporal/meos_catalog.c
+++ b/mobilitydb/src/temporal/meos_catalog.c
@@ -81,7 +81,7 @@ extern int namestrcmp(Name name, const char *str);
 typedef struct
 {
   Oid typid;         /**< Oid of the type (hashtable key) */
-  meosType type;     /**< MEOS type */
+  MeosType type;     /**< MEOS type */
   char status;       /* hash status */
 } oid_meostype_entry;
 
@@ -105,8 +105,8 @@ typedef struct
 {
   Oid oproid;        /**< Oid of the operator (hashtable key) */
   meosOper oper;     /**< Operator type number */
-  meosType ltype;    /**< Type number of the left argument */
-  meosType rtype;    /**< Type number of the right argument */
+  MeosType ltype;    /**< Type number of the left argument */
+  MeosType rtype;    /**< Type number of the right argument */
   char status;       /* hash status */
 } oid_meosoper_entry;
 
@@ -133,8 +133,8 @@ typedef struct
  * @brief Global variable that states whether the type and operator Oid caches
  * have been initialized
  * @details
- * - Global array that enables the mapping meosType -> Oid
- * - Global hash table that enables the mapping Oid -> meosType
+ * - Global array that enables the mapping MeosType -> Oid
+ * - Global hash table that enables the mapping Oid -> MeosType
  * - Global hash table that enables the mapping meosOper -> Oid
  * - Global 3-dimensional array that enables the mapping meosOper -> Oid
  *   in MobilityDB.
@@ -146,7 +146,7 @@ typedef struct
 
 typedef struct
 {
-  Oid meostype_oid[NO_MEOS_TYPES];         /* meosType -> Oid */
+  Oid meostype_oid[NO_MEOS_TYPES];         /* MeosType -> Oid */
   struct oid_meostype_hash *oid_meostype;
   struct opertable_hash *meosoper_oid;
   Oid oper_oid_args[NO_MEOS_TYPES][NO_MEOS_TYPES][NO_MEOS_TYPES];
@@ -224,7 +224,7 @@ get_mobilitydb_constants()
   mobilitydb_constants* constants =
     MemoryContextAllocZero(context, sizeof(mobilitydb_constants));
 
-  /* Populate the meosType -> Oid array */
+  /* Populate the MeosType -> Oid array */
   Oid nsp_oid = mobilitydb_namespace_oid();
   for (int i = 0; i < NO_MEOS_TYPES; i++)
   {
@@ -241,9 +241,9 @@ get_mobilitydb_constants()
     }
   }
 
-  /* Create the Oid -> meosType hash table and populate it */
+  /* Create the Oid -> MeosType hash table and populate it */
   constants->oid_meostype = oid_meostype_create(CacheMemoryContext, 64, NULL);
-  /* Initialize the oid -> meosType array */
+  /* Initialize the oid -> MeosType array */
   for (int i = 0; i < NO_MEOS_TYPES; i++)
   {
     Oid oid = constants->meostype_oid[i];
@@ -255,7 +255,7 @@ get_mobilitydb_constants()
     if (found)
       ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
         errmsg("Duplicate Oid %u in MobilityDB type catalog", oid)));
-    entry->type = (meosType) i;
+    entry->type = (MeosType) i;
   }
 
   /* Create the operator hash table and populate the operator array and the
@@ -317,7 +317,7 @@ mobilitydb_initialize_cache()
  * @arg[in] type Type number
  */
 Oid
-meostype_oid(meosType type)
+meostype_oid(MeosType type)
 {
   mobilitydb_initialize_cache();
   Oid result = MOBILITYDB_CONSTANTS->meostype_oid[type];
@@ -334,7 +334,7 @@ meostype_oid(meosType type)
  * it is used for all types that appear in the `pg_operator` table when the
  * extension is created
  */
-meosType
+MeosType
 oid_meostype(Oid typid)
 {
   mobilitydb_initialize_cache();
@@ -342,7 +342,7 @@ oid_meostype(Oid typid)
     MOBILITYDB_CONSTANTS->oid_meostype, typid);
   /* Do not throw an error as in function #meostype_oid since when looking up
      an operator id we get PostgreSQL types that do not have a corresponding
-     meosType, for example, the char type with Oid 18 */
+     MeosType, for example, the char type with Oid 18 */
   if (! entry)
     return T_UNKNOWN;
   else
@@ -358,7 +358,7 @@ oid_meostype(Oid typid)
  * @arg[in] rt Type number for the right argument
  */
 Oid
-meosoper_oid(meosOper oper, meosType lt, meosType rt)
+meosoper_oid(meosOper oper, MeosType lt, MeosType rt)
 {
   mobilitydb_initialize_cache();
 
@@ -378,7 +378,7 @@ meosoper_oid(meosOper oper, meosType lt, meosType rt)
  * @arg[out] ltype,rtype Type number of the left/right argument
  */
 meosOper
-oid_meosoper(Oid oproid, meosType *ltype, meosType *rtype)
+oid_meosoper(Oid oproid, MeosType *ltype, MeosType *rtype)
 {
   mobilitydb_initialize_cache();
 
@@ -472,8 +472,8 @@ fill_oid_cache(PG_FUNCTION_ARGS)
       &isnull));
     /* Get the type and operator numbers */
     meosOper oper = meosoper_from_string(oprname);
-    meosType ltype = oid_meostype(oprleft);
-    meosType rtype = oid_meostype(oprright);
+    MeosType ltype = oid_meostype(oprleft);
+    MeosType rtype = oid_meostype(oprright);
     /* Fill the cache if the operator and all its types are recognized */
     if (oper != UNKNOWN_OP && ltype != T_UNKNOWN && rtype != T_UNKNOWN)
     {
@@ -503,7 +503,7 @@ fill_oid_cache(PG_FUNCTION_ARGS)
  * type
  */
 inline bool
-range_basetype(meosType type)
+range_basetype(MeosType type)
 {
   return (type == T_TIMESTAMPTZ || type == T_DATE || type == T_INT4 ||
     type == T_INT8);
@@ -513,7 +513,7 @@ range_basetype(meosType type)
  * @brief Ensure that a type is a built-in PostgreSQL range type
  */
 bool
-ensure_range_basetype(meosType type)
+ensure_range_basetype(MeosType type)
 {
   if (range_basetype(type))
     return true;
@@ -525,8 +525,8 @@ ensure_range_basetype(meosType type)
 /**
  * @brief Return the range type of a base type
  */
-meosType
-basetype_rangetype(meosType type)
+MeosType
+basetype_rangetype(MeosType type)
 {
   ensure_range_basetype(type);
   if (type == T_INT4)
@@ -547,8 +547,8 @@ basetype_rangetype(meosType type)
 /**
  * @brief Return the range type of a base type
  */
-meosType
-basetype_multirangetype(meosType type)
+MeosType
+basetype_multirangetype(MeosType type)
 {
   ensure_range_basetype(type);
   if (type == T_INT4)

--- a/mobilitydb/src/temporal/set.c
+++ b/mobilitydb/src/temporal/set.c
@@ -201,7 +201,7 @@ Set_as_wkb(PG_FUNCTION_ARGS)
 {
   /* Ensure that the value is detoasted if necessary */
   Set *s = PG_GETARG_SET_P(0);
-  meosType settype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 0));
+  MeosType settype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 0));
   bytea *result = Datum_as_wkb(fcinfo, PointerGetDatum(s), settype, true);
   PG_FREE_IF_COPY(s, 0);
   PG_RETURN_BYTEA_P(result);
@@ -220,7 +220,7 @@ Set_as_hexwkb(PG_FUNCTION_ARGS)
 {
   /* Ensure that the value is detoasted if necessary */
   Set *s = PG_GETARG_SET_P(0);
-  meosType settype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 0));
+  MeosType settype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 0));
   text *result = Datum_as_hexwkb(fcinfo, PointerGetDatum(s), settype);
   PG_FREE_IF_COPY(s, 0);
   PG_RETURN_TEXT_P(result);
@@ -242,8 +242,8 @@ Set_constructor(PG_FUNCTION_ARGS)
 {
   ArrayType *array = PG_GETARG_ARRAYTYPE_P(0);
   ensure_not_empty_array(array);
-  meosType settype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
-  meosType basetype = settype_basetype(settype);
+  MeosType settype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
+  MeosType basetype = settype_basetype(settype);
   int count;
   Datum *values = datumarr_extract(array, &count);
   Set *result = set_make_free(values, count, basetype, ORDER);
@@ -266,7 +266,7 @@ Datum
 Value_to_set(PG_FUNCTION_ARGS)
 {
   Datum d = PG_GETARG_DATUM(0);
-  meosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 0));
+  MeosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 0));
   /* Detoast the value if necessary */
   if (basetype_varlength(basetype))
     d = PointerGetDatum(PG_DETOAST_DATUM(d));

--- a/mobilitydb/src/temporal/set_aggfuncs.c
+++ b/mobilitydb/src/temporal/set_aggfuncs.c
@@ -100,9 +100,9 @@ Set_union_transfn(PG_FUNCTION_ARGS)
     elog(ERROR, "Set_union_transfn called in non-aggregate context");
 
   Oid setoid = get_fn_expr_argtype(fcinfo->flinfo, 1);
-  meosType settype = oid_meostype(setoid);
+  MeosType settype = oid_meostype(setoid);
   assert(set_type(settype));
-  meosType basetype = settype_basetype(settype);
+  MeosType basetype = settype_basetype(settype);
   Oid baseoid = meostype_oid(basetype);
 
   ArrayBuildState *state;
@@ -149,8 +149,8 @@ Set_union_finalfn(PG_FUNCTION_ARGS)
     PG_RETURN_NULL();
 
   Oid setoid = get_fn_expr_rettype(fcinfo->flinfo);
-  meosType settype = oid_meostype(setoid);
-  meosType basetype = settype_basetype(settype);
+  MeosType settype = oid_meostype(setoid);
+  MeosType basetype = settype_basetype(settype);
   bool typbyval = basetype_byvalue(basetype);
   int16 typlen = meostype_length(basetype);
 

--- a/mobilitydb/src/temporal/span.c
+++ b/mobilitydb/src/temporal/span.c
@@ -238,8 +238,8 @@ Span_constructor(PG_FUNCTION_ARGS)
   Datum upper = PG_GETARG_DATUM(1);
   bool lower_inc = PG_GETARG_BOOL(2);
   bool upper_inc = PG_GETARG_BOOL(3);
-  meosType spantype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
-  meosType basetype = spantype_basetype(spantype);
+  MeosType spantype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
+  MeosType basetype = spantype_basetype(spantype);
   PG_RETURN_SPAN_P(span_make(lower, upper, lower_inc, upper_inc, basetype));
 }
 
@@ -259,7 +259,7 @@ Datum
 Value_to_span(PG_FUNCTION_ARGS)
 {
   Datum value = PG_GETARG_DATUM(0);
-  meosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 0));
+  MeosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 0));
   PG_RETURN_SPAN_P(value_span(value, basetype));
 }
 
@@ -439,7 +439,7 @@ range_set_span(RangeType *range, TypeCacheEntry *typcache, Span *result)
   Oid type_id = typcache->rngelemtype->type_id;
   assert(type_id == INT4OID || type_id == INT8OID || type_id == DATEOID || 
     type_id == TIMESTAMPTZOID);
-  meosType basetype;
+  MeosType basetype;
   if (type_id == INT4OID)
     basetype = T_INT4;
   else if (type_id == INT8OID)
@@ -448,7 +448,7 @@ range_set_span(RangeType *range, TypeCacheEntry *typcache, Span *result)
     basetype = T_DATE;
   else /* type_id == TIMESTAMPTZOID */
     basetype = T_TIMESTAMPTZ;
-  meosType spantype = basetype_spantype(basetype);
+  MeosType spantype = basetype_spantype(basetype);
   span_set(lower.val, upper.val, lower.inclusive, upper.inclusive, basetype,
     spantype, result);
   return;

--- a/mobilitydb/src/temporal/span_aggfuncs.c
+++ b/mobilitydb/src/temporal/span_aggfuncs.c
@@ -107,7 +107,7 @@ Spanbase_extent_transfn(PG_FUNCTION_ARGS)
   if (PG_ARGISNULL(1))
     PG_RETURN_SPAN_P(s);
   Datum value = PG_GETARG_DATUM(1);
-  meosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 1));
+  MeosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 1));
   PG_RETURN_SPAN_P(spanbase_extent_transfn(s, value, basetype));
 }
 
@@ -179,9 +179,9 @@ Spanset_union_transfn(PG_FUNCTION_ARGS)
     elog(ERROR, "Spanset_union_transfn called in non-aggregate context");
 
   Oid spansetoid = get_fn_expr_argtype(fcinfo->flinfo, 1);
-  meosType spansettype = oid_meostype(spansetoid);
+  MeosType spansettype = oid_meostype(spansetoid);
   assert(spanset_type(spansettype));
-  meosType spantype = spansettype_spantype(spansettype);
+  MeosType spantype = spansettype_spantype(spansettype);
   Oid spanoid = meostype_oid(spantype);
 
   ArrayBuildState *state;

--- a/mobilitydb/src/temporal/span_analyze.c
+++ b/mobilitydb/src/temporal/span_analyze.c
@@ -247,7 +247,7 @@ span_compute_stats(VacAttrStats *stats, AnalyzeAttrFetchFunc fetchfunc,
 {
   int null_cnt = 0, non_null_cnt = 0;
   double total_width = 0;
-  meosType type = oid_meostype(stats->attrtypid);
+  MeosType type = oid_meostype(stats->attrtypid);
 
   /* Allocate memory to hold span bounds and lengths of the sample spans */
   SpanBound *lowers = palloc(sizeof(SpanBound) * samplerows);

--- a/mobilitydb/src/temporal/span_gist.c
+++ b/mobilitydb/src/temporal/span_gist.c
@@ -62,12 +62,12 @@
 bool
 span_gist_get_span(FunctionCallInfo fcinfo, Span *result, Oid typid)
 {
-  meosType type = oid_meostype(typid);
+  MeosType type = oid_meostype(typid);
   if (span_basetype(type))
   {
     /* Since function span_gist_inner_consistent is strict, value is not NULL */
     Datum value = PG_GETARG_DATUM(1);
-    meosType spantype = basetype_spantype(type);
+    MeosType spantype = basetype_spantype(type);
     span_set(value, value, true, true, type, spantype, result);
   }
   else if (set_type(type))

--- a/mobilitydb/src/temporal/span_ops.c
+++ b/mobilitydb/src/temporal/span_ops.c
@@ -588,7 +588,7 @@ Distance_value_value(PG_FUNCTION_ARGS)
 {
   Datum value1 = PG_GETARG_DATUM(0);
   Datum value2 = PG_GETARG_DATUM(1);
-  meosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 0));
+  MeosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 0));
   PG_RETURN_DATUM(distance_value_value(value1, value2, basetype));
 }
 

--- a/mobilitydb/src/temporal/span_selfuncs.c
+++ b/mobilitydb/src/temporal/span_selfuncs.c
@@ -82,8 +82,8 @@ span_joinsel_default(meosOper oper UNUSED)
  * @brief Determine whether we can estimate selectivity for the operator
  */
 static bool
-value_oper_sel(Oid operid UNUSED, meosType ltype,
-  meosType rtype)
+value_oper_sel(Oid operid UNUSED, MeosType ltype,
+  MeosType rtype)
 {
   if ((numset_type(ltype) || numspan_basetype(ltype) || numspan_type(ltype) ||
         spanset_type(ltype)) &&
@@ -97,8 +97,8 @@ value_oper_sel(Oid operid UNUSED, meosType ltype,
  * @brief Determine whether we can estimate selectivity for the operator
  */
 bool
-time_oper_sel(meosOper oper UNUSED, meosType ltype,
-  meosType rtype)
+time_oper_sel(meosOper oper UNUSED, MeosType ltype,
+  MeosType rtype)
 {
   if ((timeset_type(ltype) || timespan_basetype(ltype) || timespan_type(ltype) ||
         timespanset_type(ltype)) &&
@@ -766,7 +766,7 @@ void
 span_const_to_span(Node *other, Span *span)
 {
   Oid consttype = ((Const *) other)->consttype;
-  meosType type = oid_meostype(consttype);
+  MeosType type = oid_meostype(consttype);
   assert(span_basetype(type) || set_spantype(type) || span_type(type) ||
     spanset_type(type) || talpha_type(type));
   if (span_basetype(type))
@@ -774,7 +774,7 @@ span_const_to_span(Node *other, Span *span)
     /* The right argument is a set or span base constant. We convert it into
      * a singleton span */
     Datum value = ((Const *) other)->constvalue;
-    meosType spantype = basetype_spantype(type);
+    MeosType spantype = basetype_spantype(type);
     span_set(value, value, true, true, type, spantype, span);
   }
   else if (set_spantype(type))
@@ -863,7 +863,7 @@ span_sel(PlannerInfo *root, Oid operid, List *args, int varRelid)
    */
   span_const_to_span(other, &span);
   /* Determine whether we can estimate selectivity for the operator */
-  meosType ltype, rtype;
+  MeosType ltype, rtype;
   meosOper oper = oid_meosoper(operid, &ltype, &rtype);
   bool value = value_oper_sel(oper, ltype, rtype);
   if (! value)
@@ -979,7 +979,7 @@ _mobdb_span_sel(PG_FUNCTION_ARGS)
   /* Determine whether we target the value or the time dimension */
   bool value = (s->basetype != T_TIMESTAMPTZ);
   /* Determine whether we can estimate selectivity for the operator */
-  meosType ltype, rtype;
+  MeosType ltype, rtype;
   meosOper oper = oid_meosoper(operid, &ltype, &rtype);
   bool found = value ?
     value_oper_sel(oper, ltype, rtype) : time_oper_sel(oper, ltype, rtype);
@@ -1465,7 +1465,7 @@ Span_joinsel(PG_FUNCTION_ARGS)
     PG_RETURN_FLOAT8(span_joinsel_default(operid));
 
   /* Determine whether we can estimate selectivity for the operator */
-  meosType ltype, rtype;
+  MeosType ltype, rtype;
   meosOper oper = oid_meosoper(operid, &ltype, &rtype);
   bool value = value_oper_sel(oper, ltype, rtype);
   if (! value)
@@ -1512,7 +1512,7 @@ _mobdb_span_joinsel(PG_FUNCTION_ARGS)
   if (! att1_num)
     elog(ERROR, "attribute \"%s\" does not exist", att1_name);
   // /* Get the attribute type */
-  // meosType atttype1 = oid_meostype(get_atttype(table1_oid, att1_num));
+  // MeosType atttype1 = oid_meostype(get_atttype(table1_oid, att1_num));
 
   char *table2_name = get_rel_name(table2_oid);
   if (! table2_name)
@@ -1525,10 +1525,10 @@ _mobdb_span_joinsel(PG_FUNCTION_ARGS)
   if (! att2_num)
     elog(ERROR, "attribute \"%s\" does not exist", att2_name);
   // /* Get the attribute type */
-  // meosType atttype2 = oid_meostype(get_atttype(table1_oid, att1_num));
+  // MeosType atttype2 = oid_meostype(get_atttype(table1_oid, att1_num));
 
   /* Determine whether we can estimate selectivity for the operator */
-  meosType ltype, rtype;
+  MeosType ltype, rtype;
   meosOper oper = oid_meosoper(operid, &ltype, &rtype);
   bool value = value_oper_sel(oper, ltype, rtype);
   if (! value)

--- a/mobilitydb/src/temporal/span_spgist.c
+++ b/mobilitydb/src/temporal/span_spgist.c
@@ -111,7 +111,7 @@ span_upper_qsort_cmp(const void *a, const void *b)
  * initialize the struct to cover the whole 2D space.
  */
 void
-spannode_init(SpanNode *nodebox, meosType spantype, meosType basetype)
+spannode_init(SpanNode *nodebox, MeosType spantype, MeosType basetype)
 {
   memset(nodebox, 0, sizeof(SpanNode));
   Datum min, max;
@@ -363,11 +363,11 @@ distance_span_nodespan(Span *query, SpanNode *nodebox)
 bool
 span_spgist_get_span(const ScanKeyData *scankey, Span *result)
 {
-  meosType type = oid_meostype(scankey->sk_subtype);
+  MeosType type = oid_meostype(scankey->sk_subtype);
   if (span_basetype(type))
   {
     Datum value = scankey->sk_argument;
-    meosType spantype = basetype_spantype(type);
+    MeosType spantype = basetype_spantype(type);
     span_set(value, value, true, true, type, spantype, result);
   }
   else if (set_type(type))

--- a/mobilitydb/src/temporal/spanset.c
+++ b/mobilitydb/src/temporal/spanset.c
@@ -265,7 +265,7 @@ Datum
 Value_to_spanset(PG_FUNCTION_ARGS)
 {
   Datum value = PG_GETARG_DATUM(0);
-  meosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 0));
+  MeosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 0));
   PG_RETURN_SPANSET_P(value_spanset(value, basetype));
 }
 

--- a/mobilitydb/src/temporal/tbox.c
+++ b/mobilitydb/src/temporal/tbox.c
@@ -237,7 +237,7 @@ Number_timestamptz_to_tbox(PG_FUNCTION_ARGS)
 {
   Datum value = PG_GETARG_DATUM(0);
   TimestampTz t = PG_GETARG_TIMESTAMPTZ(1);
-  meosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 0));
+  MeosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 0));
   PG_RETURN_TBOX_P(number_timestamptz_to_tbox(value, basetype, t));
 }
 
@@ -253,7 +253,7 @@ Number_tstzspan_to_tbox(PG_FUNCTION_ARGS)
 {
   Datum value = PG_GETARG_DATUM(0);
   Span *s = PG_GETARG_SPAN_P(1);
-  meosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 0));
+  MeosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 0));
   PG_RETURN_TBOX_P(number_tstzspan_to_tbox(value, basetype, s));
 }
 
@@ -303,7 +303,7 @@ Datum
 Number_to_tbox(PG_FUNCTION_ARGS)
 {
   Datum value = PG_GETARG_DATUM(0);
-  meosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 0));
+  MeosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 0));
   PG_RETURN_TBOX_P(number_tbox(value, basetype));
 }
 
@@ -729,7 +729,7 @@ Tbox_expand_value(PG_FUNCTION_ARGS)
 {
   TBox *box = PG_GETARG_TBOX_P(0);
   Datum value = PG_GETARG_DATUM(1);
-  meosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 1));
+  MeosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 1));
   TBox *result = tbox_expand_value(box, value, basetype);
   if (! result)
     PG_RETURN_NULL();

--- a/mobilitydb/src/temporal/temporal.c
+++ b/mobilitydb/src/temporal/temporal.c
@@ -317,7 +317,7 @@ Mobilitydb_full_version(PG_FUNCTION_ARGS UNUSED)
  * @param[in] temptype Temporal type
  */
 TInstant *
-tinstant_recv(StringInfo buf, meosType temptype)
+tinstant_recv(StringInfo buf, MeosType temptype)
 {
   TimestampTz t = call_recv(T_TIMESTAMPTZ, buf);
   int size = pq_getmsgint(buf, 4);
@@ -328,7 +328,7 @@ tinstant_recv(StringInfo buf, meosType temptype)
     .maxlen = size,
     .data = buf->data + buf->cursor
   };
-  meosType basetype = temptype_basetype(temptype);
+  MeosType basetype = temptype_basetype(temptype);
   Datum value = call_recv(basetype, &buf2);
   buf->cursor += size;
   return tinstant_make(value, temptype, t);
@@ -342,7 +342,7 @@ tinstant_recv(StringInfo buf, meosType temptype)
 void
 tinstant_write(const TInstant *inst, StringInfo buf)
 {
-  meosType basetype = temptype_basetype(inst->temptype);
+  MeosType basetype = temptype_basetype(inst->temptype);
   bytea *bt = call_send(T_TIMESTAMPTZ, TimestampTzGetDatum(inst->t));
   bytea *bv = call_send(basetype, tinstant_value_p(inst));
   pq_sendbytes(buf, VARDATA(bt), VARSIZE(bt) - VARHDRSZ);
@@ -360,7 +360,7 @@ tinstant_write(const TInstant *inst, StringInfo buf)
  * @param[in] temptype Temporal type
  */
 TSequence *
-tsequence_recv(StringInfo buf, meosType temptype)
+tsequence_recv(StringInfo buf, MeosType temptype)
 {
   int count = (int) pq_getmsgint(buf, 4);
   bool lower_inc = (char) pq_getmsgbyte(buf);
@@ -540,7 +540,7 @@ Tinstant_constructor(PG_FUNCTION_ARGS)
 {
   Datum value = PG_GETARG_ANYDATUM(0);
   TimestampTz t = PG_GETARG_TIMESTAMPTZ(1);
-  meosType temptype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
+  MeosType temptype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
   PG_RETURN_TINSTANT_P(tinstant_make(value, temptype, t));
 }
 
@@ -556,7 +556,7 @@ Tsequence_constructor(PG_FUNCTION_ARGS)
 {
   ArrayType *array = PG_GETARG_ARRAYTYPE_P(0);
   ensure_not_empty_array(array);
-  meosType temptype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
+  MeosType temptype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
   interpType interp = temptype_continuous(temptype) ? LINEAR : STEP;
   if (PG_NARGS() > 1 && ! PG_ARGISNULL(1))
     interp = input_interp_string(fcinfo, 1);
@@ -613,7 +613,7 @@ Tsequenceset_constructor_gaps(PG_FUNCTION_ARGS)
   ensure_not_empty_array(array);
   double maxdist = -1.0;
   Interval *maxt = NULL;
-  meosType temptype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
+  MeosType temptype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
   interpType interp = temptype_continuous(temptype) ? LINEAR : STEP;
   if (PG_NARGS() > 1 && ! PG_ARGISNULL(1))
     maxt = PG_GETARG_INTERVAL_P(1);
@@ -650,7 +650,7 @@ Tsequence_from_base_tstzset(PG_FUNCTION_ARGS)
 {
   Datum value = PG_GETARG_ANYDATUM(0);
   Set *s = PG_GETARG_SET_P(1);
-  meosType temptype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
+  MeosType temptype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
   TSequence *result = tsequence_from_base_tstzset(value, temptype, s);
   PG_FREE_IF_COPY(s, 1);
   PG_RETURN_TSEQUENCE_P(result);
@@ -668,7 +668,7 @@ Tsequence_from_base_tstzspan(PG_FUNCTION_ARGS)
 {
   Datum value = PG_GETARG_ANYDATUM(0);
   Span *s = PG_GETARG_SPAN_P(1);
-  meosType temptype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
+  MeosType temptype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
   interpType interp = temptype_continuous(temptype) ? LINEAR : STEP;
   if (PG_NARGS() > 2 && !PG_ARGISNULL(2))
     interp = input_interp_string(fcinfo, 2);
@@ -689,7 +689,7 @@ Tsequenceset_from_base_tstzspanset(PG_FUNCTION_ARGS)
 {
   Datum value = PG_GETARG_ANYDATUM(0);
   SpanSet *ss = PG_GETARG_SPANSET_P(1);
-  meosType temptype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
+  MeosType temptype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
   interpType interp = temptype_continuous(temptype) ? LINEAR : STEP;
   if (PG_NARGS() > 2 && !PG_ARGISNULL(2))
     interp = input_interp_string(fcinfo, 2);
@@ -892,7 +892,7 @@ Temporal_valueset(PG_FUNCTION_ARGS)
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   int count;
   Datum *values = temporal_values_p(temp, &count);
-  meosType basetype = temptype_basetype(temp->temptype);
+  MeosType basetype = temptype_basetype(temp->temptype);
   /* Currently, there is no boolset type */
   if (temp->temptype == T_TBOOL)
   {
@@ -1876,7 +1876,7 @@ Temporal_append_tinstant(PG_FUNCTION_ARGS)
   if (PG_NARGS() == 2 || PG_ARGISNULL(2))
   {
     /* Set default interpolation according to the base type */
-    meosType temptype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 1));
+    MeosType temptype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 1));
     interp = temptype_continuous(temptype) ? LINEAR : STEP;
   }
   else
@@ -1974,7 +1974,7 @@ Temporal_restrict_value(FunctionCallInfo fcinfo, bool atfunc)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   Datum value = PG_GETARG_ANYDATUM(1);
-  meosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 1));
+  MeosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 1));
 #if RGEO
   Temporal *result = (temp->temptype == T_TRGEOMETRY) ?
     trgeo_restrict_value(temp, value, atfunc) :

--- a/mobilitydb/src/temporal/temporal_aggfuncs.c
+++ b/mobilitydb/src/temporal/temporal_aggfuncs.c
@@ -677,7 +677,7 @@ Temporal_app_tinst_transfn(PG_FUNCTION_ARGS)
   if (PG_NARGS() == 2 || PG_ARGISNULL(2))
   {
     /* Set default interpolation according to the base type */
-    meosType temptype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 1));
+    MeosType temptype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 1));
     interp = temptype_continuous(temptype) ? LINEAR : STEP;
   }
   else

--- a/mobilitydb/src/temporal/temporal_analyze.c
+++ b/mobilitydb/src/temporal/temporal_analyze.c
@@ -119,7 +119,7 @@ temporal_compute_stats(VacAttrStats *stats, AnalyzeAttrFetchFunc fetchfunc,
   SpanBound *value_lowers = NULL, *value_uppers = NULL; /* make compiler quiet */
   SpanBound *time_lowers, *time_uppers;
   double total_width = 0;
-  meosType type = oid_meostype(stats->attrtypid);
+  MeosType type = oid_meostype(stats->attrtypid);
   assert(temporal_type(type));
   bool tnumber = tnumber_type(type);
 
@@ -264,7 +264,7 @@ temporal_extra_info(VacAttrStats *stats)
   extra_data->hash = &typentry->hash_proc_finfo;
 
   /* Gather information about the value type */
-  meosType basetype = temptype_basetype(oid_meostype(stats->attrtypid));
+  MeosType basetype = temptype_basetype(oid_meostype(stats->attrtypid));
   typentry = lookup_type_cache(meostype_oid(basetype),
     TYPECACHE_EQ_OPR | TYPECACHE_LT_OPR | TYPECACHE_CMP_PROC_FINFO |
     TYPECACHE_HASH_PROC_FINFO);

--- a/mobilitydb/src/temporal/temporal_compops.c
+++ b/mobilitydb/src/temporal/temporal_compops.c
@@ -65,7 +65,7 @@ EAcomp_base_temporal(FunctionCallInfo fcinfo,
 {
   Datum value = PG_GETARG_ANYDATUM(0);
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
-  meosType basetype = temptype_basetype(temp->temptype);
+  MeosType basetype = temptype_basetype(temp->temptype);
   int result = func(value, temp);
   DATUM_FREE_IF_COPY(value, basetype, 0);
   PG_FREE_IF_COPY(temp, 1);
@@ -83,7 +83,7 @@ EAcomp_temporal_base(FunctionCallInfo fcinfo,
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   Datum value = PG_GETARG_ANYDATUM(1);
-  meosType basetype = temptype_basetype(temp->temptype);
+  MeosType basetype = temptype_basetype(temp->temptype);
   int result = func(temp, value);
   PG_FREE_IF_COPY(temp, 0);
   DATUM_FREE_IF_COPY(value, basetype, 1);
@@ -648,11 +648,11 @@ Always_ge_temporal_temporal(PG_FUNCTION_ARGS)
  */
 static Datum
 Tcomp_base_temporal(FunctionCallInfo fcinfo,
-  Datum (*func)(Datum, Datum, meosType))
+  Datum (*func)(Datum, Datum, MeosType))
 {
   Datum value = PG_GETARG_ANYDATUM(0);
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
-  meosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 0));
+  MeosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 0));
   Temporal *result = tcomp_base_temporal(value, temp, func);
   assert(result);
   DATUM_FREE_IF_COPY(value, basetype, 0);
@@ -665,11 +665,11 @@ Tcomp_base_temporal(FunctionCallInfo fcinfo,
  */
 Datum
 Tcomp_temporal_base(FunctionCallInfo fcinfo,
-  Datum (*func)(Datum, Datum, meosType))
+  Datum (*func)(Datum, Datum, MeosType))
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   Datum value = PG_GETARG_ANYDATUM(1);
-  meosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 1));
+  MeosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 1));
   Temporal *result = tcomp_temporal_base(temp, value, func);
   assert(result);
   PG_FREE_IF_COPY(temp, 0);
@@ -682,7 +682,7 @@ Tcomp_temporal_base(FunctionCallInfo fcinfo,
  */
 Datum
 Tcomp_temporal_temporal(FunctionCallInfo fcinfo,
-  Datum (*func)(Datum, Datum, meosType))
+  Datum (*func)(Datum, Datum, MeosType))
 {
   Temporal *temp1 = PG_GETARG_TEMPORAL_P(0);
   Temporal *temp2 = PG_GETARG_TEMPORAL_P(1);

--- a/mobilitydb/src/temporal/temporal_selfuncs.c
+++ b/mobilitydb/src/temporal/temporal_selfuncs.c
@@ -75,7 +75,7 @@ temporal_const_to_tstzspan(Node *other, Span *s)
 {
   Oid consttype = ((Const *) other)->consttype;
   Datum constvalue = ((Const *) other)->constvalue;
-  meosType type = oid_meostype(consttype);
+  MeosType type = oid_meostype(consttype);
   if (time_type(type))
     span_const_to_span(other, s);
   else if (talpha_type(type))
@@ -92,7 +92,7 @@ bool
 tnumber_const_to_span_tstzspan(const Node *other, Span **s, Span **p)
 {
   Oid consttypid = ((Const *) other)->consttype;
-  meosType type = oid_meostype(consttypid);
+  MeosType type = oid_meostype(consttypid);
   Span *span;
   if (numspan_type(type))
   {
@@ -139,7 +139,7 @@ tspatial_const_to_stbox(Node *other, STBox *box)
 {
   Oid consttype = ((Const *) other)->consttype;
   Datum constvalue = ((Const *) other)->constvalue;
-  meosType type = oid_meostype(consttype);
+  MeosType type = oid_meostype(consttype);
   if (geo_basetype(type))
     geo_set_stbox(DatumGetGserializedP(constvalue), box);
   else if (type == T_TSTZSPAN)
@@ -356,8 +356,8 @@ tspatial_joinsel_default(meosOper oper)
  * @brief Return the enum value associated to the operator
  */
 static bool
-temporal_oper_sel(meosOper oper UNUSED, meosType ltype,
-  meosType rtype)
+temporal_oper_sel(meosOper oper UNUSED, MeosType ltype,
+  MeosType rtype)
 {
   if ((timespan_basetype(ltype) || timeset_type(ltype) ||
         timespan_type(ltype) || timespanset_type(ltype) ||
@@ -373,8 +373,8 @@ temporal_oper_sel(meosOper oper UNUSED, meosType ltype,
  * @brief Return the enum value associated to the operator
  */
 bool
-tnumber_oper_sel(Oid operid UNUSED, meosType ltype,
-  meosType rtype)
+tnumber_oper_sel(Oid operid UNUSED, MeosType ltype,
+  MeosType rtype)
 {
   if ((timespan_basetype(ltype) || timeset_type(ltype) ||
         timespan_type(ltype) || timespanset_type(ltype) ||
@@ -390,8 +390,8 @@ tnumber_oper_sel(Oid operid UNUSED, meosType ltype,
  * @brief Get the enum value associated to the operator
  */
 static bool
-tspatial_oper_sel(Oid operid UNUSED, meosType ltype,
-  meosType rtype)
+tspatial_oper_sel(Oid operid UNUSED, MeosType ltype,
+  MeosType rtype)
 {
   if ((timespan_basetype(ltype) || timeset_type(ltype) ||
         timespan_type(ltype) || timespanset_type(ltype) ||
@@ -408,8 +408,8 @@ tspatial_oper_sel(Oid operid UNUSED, meosType ltype,
  * family
  */
 static bool
-temporal_oper_sel_family(meosOper oper UNUSED, meosType ltype,
-  meosType rtype, TemporalFamily tempfamily)
+temporal_oper_sel_family(meosOper oper UNUSED, MeosType ltype,
+  MeosType rtype, TemporalFamily tempfamily)
 {
   /* Get enumeration value associated to the operator */
   assert(tempfamily == TEMPORALTYPE || tempfamily == TNUMBERTYPE ||
@@ -563,7 +563,7 @@ temporal_sel(PlannerInfo *root, Oid operid, List *args, int varRelid,
   Selectivity selec;
 
   /* Determine whether we can estimate selectivity for the operator */
-  meosType ltype, rtype;
+  MeosType ltype, rtype;
   meosOper oper = oid_meosoper(operid, &ltype, &rtype);
   if (! temporal_oper_sel_family(oper, ltype, rtype, tempfamily))
     /* In the case of unknown operator */
@@ -768,11 +768,11 @@ Tspatial_sel(PG_FUNCTION_ARGS)
  * the join selectivity
  */
 static bool
-tnumber_joinsel_components(meosOper oper, meosType oprleft,
-  meosType oprright, bool *value, bool *time)
+tnumber_joinsel_components(meosOper oper, MeosType oprleft,
+  MeosType oprright, bool *value, bool *time)
 {
   /* Get the argument which may not a temporal number */
-  meosType arg = tnumber_type(oprleft) ? oprright : oprleft;
+  MeosType arg = tnumber_type(oprleft) ? oprright : oprleft;
 
   /* Determine the components */
   if (tnumber_basetype(arg) || tnumber_spantype(arg) ||
@@ -811,11 +811,11 @@ tnumber_joinsel_components(meosOper oper, meosType oprleft,
  * join selectivity
  */
 static bool
-tspatial_joinsel_components(meosOper oper, meosType oprleft,
-  meosType oprright, bool *space, bool *time)
+tspatial_joinsel_components(meosOper oper, MeosType oprleft,
+  MeosType oprright, bool *space, bool *time)
 {
   /* Get the argument which may not be a temporal point */
-  meosType arg = tspatial_type(oprleft) ? oprright : oprleft;
+  MeosType arg = tspatial_type(oprleft) ? oprright : oprleft;
 
   /* Determine the components */
   if (spatial_basetype(arg) ||
@@ -880,7 +880,7 @@ temporal_joinsel(PlannerInfo *root, Oid operid, List *args, JoinType jointype,
     return DEFAULT_TEMP_JOINSEL;
 
   /* Determine whether we can estimate selectivity for the operator */
-  meosType ltype, rtype;
+  MeosType ltype, rtype;
   meosOper oper = oid_meosoper(operid, &ltype, &rtype);
   if (! temporal_oper_sel_family(oper, ltype, rtype, tempfamily))
     /* In the case of unknown operator */
@@ -898,16 +898,16 @@ temporal_joinsel(PlannerInfo *root, Oid operid, List *args, JoinType jointype,
   }
   else if (tempfamily == TNUMBERTYPE)
   {
-    meosType oprleft = oid_meostype(var1->vartype);
-    meosType oprright = oid_meostype(var2->vartype);
+    MeosType oprleft = oid_meostype(var1->vartype);
+    MeosType oprright = oid_meostype(var2->vartype);
     if (! tnumber_joinsel_components(oper, oprleft, oprright, &value, &time))
       /* In the case of unknown arguments */
       return tnumber_joinsel_default(oper);
   }
   else /* tempfamily == TSPATIALTYPE */
   {
-    meosType oprleft = oid_meostype(var1->vartype);
-    meosType oprright = oid_meostype(var2->vartype);
+    MeosType oprleft = oid_meostype(var1->vartype);
+    MeosType oprright = oid_meostype(var2->vartype);
     if (! tspatial_joinsel_components(oper, oprleft, oprright, &space, &time))
       /* In the case of unknown arguments */
       return tspatial_joinsel_default(oper);

--- a/mobilitydb/src/temporal/temporal_supportfn.c
+++ b/mobilitydb/src/temporal/temporal_supportfn.c
@@ -149,7 +149,7 @@ static const IndexableFunction TSpatialIndexableFunctions[] = {
 };
 
 static int16
-temporal_get_strategy_by_type(meosType temptype, uint16_t index)
+temporal_get_strategy_by_type(MeosType temptype, uint16_t index)
 {
   if (tnumber_type(temptype))
     return TNumberStrategies[index];
@@ -229,7 +229,7 @@ makeExpandExpr(Node *arg, Node *radiusarg, Oid argoid, Oid retoid,
   /* Expand function must be in same namespace as the caller */
   char *nspname = get_namespace_name(get_func_namespace(callingfunc));
   char *funcname = NULL; /* make compiler quiet */
-  meosType argtype = oid_meostype(argoid);
+  MeosType argtype = oid_meostype(argoid);
   if (argtype == T_GEOMETRY || argtype == T_GEOGRAPHY || argtype == T_STBOX ||
       argtype == T_TGEOMPOINT || argtype == T_TGEOGPOINT
 #if CBUFFER
@@ -268,7 +268,7 @@ makeBboxExpr(Node *arg, Oid argoid, Oid retoid, Oid callingfunc)
   /* Expand function must be in same namespace as the caller */
   char *nspname = get_namespace_name(get_func_namespace(callingfunc));
   char *funcname = NULL; /* make compiler quiet */
-  meosType argtype = oid_meostype(argoid);
+  MeosType argtype = oid_meostype(argoid);
   if (argtype == T_TBOOL || argtype == T_TTEXT)
     funcname = "span";
   else if (argtype == T_INT4 || argtype == T_FLOAT8 ||
@@ -300,8 +300,8 @@ makeBboxExpr(Node *arg, Oid argoid, Oid retoid, Oid callingfunc)
 /**
  * @brief Transform the constant into a bounding box
  */
-static meosType
-type_to_bbox(meosType type)
+static MeosType
+type_to_bbox(MeosType type)
 {
   if (span_basetype(type))
     return basetype_spantype(type);
@@ -342,11 +342,11 @@ Temporal_supportfn(FunctionCallInfo fcinfo, TemporalFamily tempfamily)
     SupportRequestSelectivity *req = (SupportRequestSelectivity *) rawreq;
     leftoid = exprType(linitial(req->args));
     rightoid = exprType(lsecond(req->args));
-    meosType ltype = oid_meostype(leftoid);
-    meosType rtype = oid_meostype(rightoid);
+    MeosType ltype = oid_meostype(leftoid);
+    MeosType rtype = oid_meostype(rightoid);
     /* Convert base type to bbox type */
-    meosType ltype1 = type_to_bbox(ltype);
-    meosType rtype1 = type_to_bbox(rtype);
+    MeosType ltype1 = type_to_bbox(ltype);
+    MeosType rtype1 = type_to_bbox(rtype);
     operid = meosoper_oid(OVERLAPS_OP, ltype1, rtype1);
     if (req->is_join)
       req->selectivity = temporal_joinsel(req->root, operid, req->args,
@@ -463,8 +463,8 @@ Temporal_supportfn(FunctionCallInfo fcinfo, TemporalFamily tempfamily)
        */
       leftoid = exprType(leftarg);
       rightoid = exprType(rightarg);
-      meosType lefttype = oid_meostype(leftoid);
-      meosType righttype = oid_meostype(rightoid);
+      MeosType lefttype = oid_meostype(leftoid);
+      MeosType righttype = oid_meostype(rightoid);
 
       /*
        * Given the index operator family and the arguments and the desired

--- a/mobilitydb/src/temporal/temporal_tile.c
+++ b/mobilitydb/src/temporal/temporal_tile.c
@@ -122,7 +122,7 @@ Value_bin(PG_FUNCTION_ARGS)
   Datum value = PG_GETARG_DATUM(0);
   Datum size = PG_GETARG_DATUM(1);
   Datum origin = PG_GETARG_DATUM(2);
-  meosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 1));
+  MeosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 1));
   Datum lower = datum_bin(value, size, origin, basetype);
   Datum upper = datum_add(lower, size, basetype);
   Span *result = span_make(lower, upper, true, false, basetype);
@@ -377,8 +377,8 @@ Tbox_get_value_time_tile_common(FunctionCallInfo fcinfo, bool valuetile,
     vorigin = PG_GETARG_DATUM(i++);
   if (timetile)
     torigin = PG_GETARG_TIMESTAMPTZ(i++);
-  meosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 0));
-  meosType spantype = basetype_spantype(basetype);
+  MeosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 0));
+  MeosType spantype = basetype_spantype(basetype);
   PG_RETURN_TBOX_P(tbox_get_value_time_tile(value, t, vsize, duration, vorigin,
     torigin, basetype, spantype));
 }
@@ -553,8 +553,8 @@ span_bin_state_make(const void *to_split, const Span *s, Datum size,
  * @param[out] span Output span
  */
 void
-span_bin_state_set(Datum lower, Datum size, meosType basetype,
-  meosType spantype, Span *span)
+span_bin_state_set(Datum lower, Datum size, MeosType basetype,
+  MeosType spantype, Span *span)
 {
   assert(span);
 

--- a/mobilitydb/src/temporal/tnumber_gist.c
+++ b/mobilitydb/src/temporal/tnumber_gist.c
@@ -68,7 +68,7 @@
  * that must not be taken into account by the operators to infinity
  */
 static bool
-tnumber_gist_get_tbox(FunctionCallInfo fcinfo, TBox *result, meosType type)
+tnumber_gist_get_tbox(FunctionCallInfo fcinfo, TBox *result, MeosType type)
 {
   Span *s;
   if (tnumber_spantype(type))
@@ -346,7 +346,7 @@ non_negative(float val)
  */
 inline void
 bbox_gist_consider_split(ConsiderSplitContext *context, int dimNum,
-  meosType bboxtype, double rightLower, int minLeftCount, double leftUpper,
+  MeosType bboxtype, double rightLower, int minLeftCount, double leftUpper,
   int maxLeftCount)
 {
   int leftCount, rightCount;
@@ -492,7 +492,7 @@ bbox_gist_consider_split(ConsiderSplitContext *context, int dimNum,
  */
 void
 bbox_gist_fallback_split(GistEntryVector *entryvec, GIST_SPLITVEC *v,
-  meosType bboxtype, void (*bbox_adjust)(void *, void *))
+  MeosType bboxtype, void (*bbox_adjust)(void *, void *))
 {
   OffsetNumber i;
   OffsetNumber maxoff = (OffsetNumber) (entryvec->n - 1);
@@ -549,7 +549,7 @@ bbox_gist_fallback_split(GistEntryVector *entryvec, GIST_SPLITVEC *v,
  * http://syrcose.ispras.ru/2011/files/SYRCoSE2011_Proceedings.pdf#page=36
  */
 Datum
-bbox_gist_picksplit(FunctionCallInfo fcinfo, meosType bboxtype,
+bbox_gist_picksplit(FunctionCallInfo fcinfo, MeosType bboxtype,
   void (*bbox_adjust)(void *, void *), double (*bbox_penalty)(void *, void *))
 {
   GistEntryVector *entryvec = (GistEntryVector *) PG_GETARG_POINTER(0);

--- a/mobilitydb/src/temporal/tnumber_mathfuncs.c
+++ b/mobilitydb/src/temporal/tnumber_mathfuncs.c
@@ -59,7 +59,7 @@
  */
 static Datum
 Arithop_number_tnumber(FunctionCallInfo fcinfo, TArithmetic oper,
-  Datum (*func)(Datum, Datum, meosType))
+  Datum (*func)(Datum, Datum, MeosType))
 {
   Datum value = PG_GETARG_DATUM(0);
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
@@ -76,7 +76,7 @@ Arithop_number_tnumber(FunctionCallInfo fcinfo, TArithmetic oper,
  */
 static Datum
 Arithop_tnumber_number(FunctionCallInfo fcinfo, TArithmetic oper,
-  Datum (*func)(Datum, Datum, meosType))
+  Datum (*func)(Datum, Datum, MeosType))
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   Datum value = PG_GETARG_DATUM(1);
@@ -93,11 +93,11 @@ Arithop_tnumber_number(FunctionCallInfo fcinfo, TArithmetic oper,
  */
 static Datum
 Arithop_tnumber_tnumber(FunctionCallInfo fcinfo, TArithmetic oper,
-  Datum (*func)(Datum, Datum, meosType))
+  Datum (*func)(Datum, Datum, MeosType))
 {
   Temporal *temp1 = PG_GETARG_TEMPORAL_P(0);
   Temporal *temp2 = PG_GETARG_TEMPORAL_P(1);
-  meosType basetype = temptype_basetype(temp1->temptype);
+  MeosType basetype = temptype_basetype(temp1->temptype);
   assert(basetype == T_INT4 || basetype == T_FLOAT8);
   Temporal *result;
   if (basetype == T_FLOAT8 && (oper == MULT || oper == DIV))

--- a/mobilitydb/src/temporal/tnumber_spgist.c
+++ b/mobilitydb/src/temporal/tnumber_spgist.c
@@ -643,7 +643,7 @@ static bool
 tnumber_spgist_get_tbox(const ScanKeyData *scankey, TBox *result)
 {
   Span *s;
-  meosType type = oid_meostype(scankey->sk_subtype);
+  MeosType type = oid_meostype(scankey->sk_subtype);
   if (tnumber_spantype(type))
   {
     s = DatumGetSpanP(scankey->sk_argument);
@@ -907,7 +907,7 @@ Tbox_quadtree_picksplit(PG_FUNCTION_ARGS)
 
   /* Get basetype of span in the datums */
   TBox *box = DatumGetTboxP(in->datums[0]);
-  meosType basetype = box->span.basetype;
+  MeosType basetype = box->span.basetype;
   /* Calculate median of all 4D coordinates */
   for (i = 0; i < in->nTuples; i++)
   {
@@ -929,7 +929,7 @@ Tbox_quadtree_picksplit(PG_FUNCTION_ARGS)
 
   centroid = palloc0(sizeof(TBox));
   Span s, p;
-  meosType spantype = basetype_spantype(basetype);
+  MeosType spantype = basetype_spantype(basetype);
   span_set(lowXs[median], highXs[median], true, true, basetype, spantype, &s);
   span_set(lowTs[median], highTs[median], true, true, T_TIMESTAMPTZ,
     T_TSTZSPAN, &p);

--- a/mobilitydb/src/temporal/type_in.c
+++ b/mobilitydb/src/temporal/type_in.c
@@ -103,7 +103,7 @@ Temporal_from_mfjson(PG_FUNCTION_ARGS)
 {
   text *mfjson_txt = PG_GETARG_TEXT_P(0);
   char *mfjson = text2cstring(mfjson_txt);
-  meosType temptype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
+  MeosType temptype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
   Temporal *result = temporal_from_mfjson(mfjson, temptype);
   pfree(mfjson);
   PG_FREE_IF_COPY(mfjson_txt, 0);

--- a/mobilitydb/src/temporal/type_out.c
+++ b/mobilitydb/src/temporal/type_out.c
@@ -221,7 +221,7 @@ get_endian_variant(const text *txt)
  * representation
  */
 bytea *
-Datum_as_wkb(FunctionCallInfo fcinfo, Datum value, meosType type,
+Datum_as_wkb(FunctionCallInfo fcinfo, Datum value, MeosType type,
   bool extended)
 {
   uint8_t variant = 0;
@@ -247,7 +247,7 @@ Datum_as_wkb(FunctionCallInfo fcinfo, Datum value, meosType type,
  * Binary (EWKB) representation in ASCII hex-encoded
  */
 text *
-Datum_as_hexwkb(FunctionCallInfo fcinfo, Datum value, meosType type)
+Datum_as_hexwkb(FunctionCallInfo fcinfo, Datum value, MeosType type)
 {
   uint8_t variant = 0;
   /* If user specified endianness, respect it */

--- a/mobilitydb/src/temporal/type_util.c
+++ b/mobilitydb/src/temporal/type_util.c
@@ -73,7 +73,7 @@ extern Datum multirange_out(PG_FUNCTION_ARGS);
  * @brief Call receive function of the base type
  */
 Datum
-call_recv(meosType type, StringInfo buf)
+call_recv(MeosType type, StringInfo buf)
 {
   if (type == T_DOUBLE2)
     return PointerGetDatum(double2_recv(buf));
@@ -98,7 +98,7 @@ call_recv(meosType type, StringInfo buf)
  * @brief Call send function of the base type
  */
 bytea *
-call_send(meosType type, Datum value)
+call_send(MeosType type, Datum value)
 {
   if (type == T_DOUBLE2)
     return double2_send(DatumGetDouble2P(value));
@@ -303,7 +303,7 @@ temparr_extract(ArrayType *array, int *count)
  * @note The values will be copied into the object even if pass-by-ref type
  */
 ArrayType *
-datumarr_to_array(Datum *values, int count, meosType type)
+datumarr_to_array(Datum *values, int count, MeosType type)
 {
   int16 elmlen;
   bool elmbyval;
@@ -473,7 +473,7 @@ temparr_to_array(Temporal **temparr, int count, bool free_all)
  */
 RangeType *
 range_make(Datum from, Datum to, bool lower_inc, bool upper_inc,
-  meosType basetype)
+  MeosType basetype)
 {
   Oid rangetypid = 0;
   assert(basetype == T_INT4 || basetype == T_INT8 || basetype == T_DATE ||


### PR DESCRIPTION
Replace `meosType` -> `MeosType` to match the type `MeosArray`