### PR TITLE
Generate pg_config.h at configure time (replace the Linux snapshot)

### DIFF
--- a/cmake/ConfigurePgConfig.cmake
+++ b/cmake/ConfigurePgConfig.cmake
@@ -1,0 +1,292 @@
+# ConfigurePgConfig.cmake
+#
+# Replaces the hand-crafted Linux snapshot of PostgreSQL's pg_config.h with
+# a minimal template rendered at configure time by CMake. This is the
+# per-host equivalent of what PG's `./configure` would do - narrowed to
+# the ~65 macros MEOS/MobilityDB actually references, so the generated
+# header is ~80 lines instead of ~1000.
+#
+# Callers: postgres/CMakeLists.txt invokes this, then configure_file()
+# renders ${CMAKE_CURRENT_BINARY_DIR}/pg_config.h from pg_config.h.in.
+
+include(CheckCSourceCompiles)
+include(CheckCSourceRuns)
+include(CheckIncludeFile)
+include(CheckStructHasMember)
+include(CheckSymbolExists)
+include(CheckTypeSize)
+include(TestBigEndian)
+
+#-----------------------------------------------------------------------
+# 1. Sizes
+#-----------------------------------------------------------------------
+check_type_size("void *"          SIZEOF_VOID_P           BUILTIN_TYPES_ONLY)
+check_type_size("long"            SIZEOF_LONG             BUILTIN_TYPES_ONLY)
+check_type_size("size_t"          SIZEOF_SIZE_T)
+check_type_size("long long int"   SIZEOF_LONG_LONG_INT    BUILTIN_TYPES_ONLY)
+
+#-----------------------------------------------------------------------
+# 2. Alignment (no native CMake check; use offsetof trick via CHECK_C_SOURCE_RUNS)
+#-----------------------------------------------------------------------
+function(_pg_check_alignof type outvar)
+  # Use C11 _Alignof if available (GCC/Clang/MSVC all support it); fall
+  # back to the struct offsetof trick otherwise.
+  check_c_source_runs("
+    #include <stdio.h>
+    #include <stddef.h>
+    struct t_s { char _pad; ${type} t; };
+    int main(void) {
+      printf(\"%d\", (int) offsetof(struct t_s, t));
+      return 0;
+    }
+  " _HAS_ALIGN_${outvar})
+  # The run-test only reports success/failure; we need the actual value.
+  # Use try_run to capture the program's output.
+  try_run(
+    _run_res _compile_res
+    ${CMAKE_BINARY_DIR}/CMakeFiles/_align_${outvar}
+    SOURCES ${CMAKE_BINARY_DIR}/CMakeFiles/_align_${outvar}.c
+    RUN_OUTPUT_VARIABLE _align_val
+    # Body will be generated below
+  )
+endfunction()
+
+# Simpler: write out a tiny program, compile+run, capture stdout.
+function(_pg_alignof type outvar)
+  set(_src "${CMAKE_BINARY_DIR}/CMakeFiles/_align_${outvar}.c")
+  file(WRITE "${_src}" "
+#include <stdio.h>
+#include <stddef.h>
+struct t_s { char _pad; ${type} t; };
+int main(void) { printf(\"%d\", (int) offsetof(struct t_s, t)); return 0; }
+")
+  try_run(_run _compile
+    ${CMAKE_BINARY_DIR}/CMakeFiles/_align_${outvar}
+    SOURCES "${_src}"
+    RUN_OUTPUT_VARIABLE _out)
+  if(_compile AND _run EQUAL 0 AND _out MATCHES "^[0-9]+$")
+    set(${outvar} "${_out}" PARENT_SCOPE)
+  else()
+    # Cross-compile or run failure: fall back to size-based best guess
+    # (power-of-two rounding of SIZEOF_VOID_P).
+    set(${outvar} "${SIZEOF_VOID_P}" PARENT_SCOPE)
+  endif()
+endfunction()
+
+_pg_alignof("short"             ALIGNOF_SHORT)
+_pg_alignof("int"               ALIGNOF_INT)
+_pg_alignof("long"              ALIGNOF_LONG)
+_pg_alignof("double"            ALIGNOF_DOUBLE)
+
+# MAXIMUM_ALIGNOF: PG uses the wider of long/double (and of int128 if present).
+set(MAXIMUM_ALIGNOF "${ALIGNOF_LONG}")
+if(ALIGNOF_DOUBLE GREATER MAXIMUM_ALIGNOF)
+  set(MAXIMUM_ALIGNOF "${ALIGNOF_DOUBLE}")
+endif()
+
+#-----------------------------------------------------------------------
+# 3. Integer types
+#-----------------------------------------------------------------------
+if(SIZEOF_LONG EQUAL 8)
+  set(HAVE_LONG_INT_64 1)
+  set(PG_INT64_TYPE  "long int")
+  set(INT64_MODIFIER "\"l\"")
+elseif(SIZEOF_LONG_LONG_INT EQUAL 8)
+  set(HAVE_LONG_LONG_INT_64 1)
+  set(PG_INT64_TYPE  "long long int")
+  set(INT64_MODIFIER "\"ll\"")
+else()
+  message(FATAL_ERROR "No 64-bit integer type available")
+endif()
+
+check_c_source_compiles("
+  __int128 x = 0;
+  int main(void){ return (int) x; }
+" HAVE_INT128)
+if(HAVE_INT128)
+  set(PG_INT128_TYPE "__int128")
+  _pg_alignof("__int128" ALIGNOF_PG_INT128_TYPE)
+endif()
+
+#-----------------------------------------------------------------------
+# 4. Endianness
+#-----------------------------------------------------------------------
+test_big_endian(_IS_BE)
+if(_IS_BE)
+  set(WORDS_BIGENDIAN 1)
+endif()
+
+#-----------------------------------------------------------------------
+# 5. Compiler builtins / intrinsics
+#-----------------------------------------------------------------------
+check_c_source_compiles(
+  "int main(void){ return (int) __builtin_bswap16((unsigned short) 1); }"
+  HAVE__BUILTIN_BSWAP16)
+check_c_source_compiles(
+  "int main(void){ return (int) __builtin_bswap32(1u); }"
+  HAVE__BUILTIN_BSWAP32)
+check_c_source_compiles(
+  "int main(void){ return (int) __builtin_bswap64(1ull); }"
+  HAVE__BUILTIN_BSWAP64)
+check_c_source_compiles(
+  "int main(void){ return __builtin_clz(1u); }"
+  HAVE__BUILTIN_CLZ)
+check_c_source_compiles(
+  "int main(void){ return __builtin_ctz(1u); }"
+  HAVE__BUILTIN_CTZ)
+check_c_source_compiles(
+  "int main(void){ return __builtin_popcount(1u); }"
+  HAVE__BUILTIN_POPCOUNT)
+check_c_source_compiles(
+  "int main(void){ __builtin_unreachable(); }"
+  HAVE__BUILTIN_UNREACHABLE)
+check_c_source_compiles("
+  int main(void){
+    int a = 0, b = 0, r;
+    return __builtin_add_overflow(a, b, &r);
+  }"
+  HAVE__BUILTIN_OP_OVERFLOW)
+check_c_source_compiles("
+  int main(void){
+    return __builtin_types_compatible_p(int, long);
+  }"
+  HAVE__BUILTIN_TYPES_COMPATIBLE_P)
+check_c_source_compiles("
+  int main(void){ _Static_assert(1, \"ok\"); return 0; }"
+  HAVE__STATIC_ASSERT)
+check_c_source_compiles("
+  #ifdef _MSC_VER
+  #include <intrin.h>
+  int main(void){ int info[4]; __cpuid(info, 0); return 0; }
+  #else
+  #include <cpuid.h>
+  int main(void){
+    unsigned int eax, ebx, ecx, edx;
+    return __get_cpuid(0, &eax, &ebx, &ecx, &edx);
+  }
+  #endif"
+  HAVE__CPUID)
+
+#-----------------------------------------------------------------------
+# 6. Standard headers
+#-----------------------------------------------------------------------
+check_include_file(string.h    HAVE_STRING_H)
+check_include_file(strings.h   HAVE_STRINGS_H)
+check_include_file(wctype.h    HAVE_WCTYPE_H)
+check_include_file(crtdefs.h   HAVE_CRTDEFS_H)
+
+#-----------------------------------------------------------------------
+# 7. Functions / decls
+#
+# Some glibc extensions (sync_file_range, posix_fadvise via <fcntl.h>)
+# are only exposed when _GNU_SOURCE is defined; mirror what PG's own
+# configure does by threading that through check_symbol_exists.
+#-----------------------------------------------------------------------
+set(_SAVED_REQ_DEFS "${CMAKE_REQUIRED_DEFINITIONS}")
+list(APPEND CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE")
+
+check_symbol_exists(gettimeofday    sys/time.h  HAVE_GETTIMEOFDAY)
+check_symbol_exists(readlink        unistd.h    HAVE_READLINK)
+check_symbol_exists(fdatasync       unistd.h    HAVE_FDATASYNC)
+if(HAVE_FDATASYNC)
+  set(HAVE_DECL_FDATASYNC 1)
+endif()
+check_symbol_exists(posix_fadvise   fcntl.h     HAVE_POSIX_FADVISE)
+if(HAVE_POSIX_FADVISE)
+  set(HAVE_DECL_POSIX_FADVISE 1)
+endif()
+check_symbol_exists(sync_file_range fcntl.h     HAVE_SYNC_FILE_RANGE)
+check_symbol_exists(strtoll         stdlib.h    HAVE_STRTOLL)
+if(HAVE_STRTOLL)
+  set(HAVE_DECL_STRTOLL 1)
+endif()
+check_symbol_exists(strtoull        stdlib.h    HAVE_STRTOULL)
+if(HAVE_STRTOULL)
+  set(HAVE_DECL_STRTOULL 1)
+endif()
+check_symbol_exists(strchrnul       string.h    HAVE_STRCHRNUL)
+
+set(CMAKE_REQUIRED_DEFINITIONS "${_SAVED_REQ_DEFS}")
+unset(_SAVED_REQ_DEFS)
+
+#-----------------------------------------------------------------------
+# 7b. `restrict` keyword support (AC_C_RESTRICT equivalent)
+#-----------------------------------------------------------------------
+# PG uses `pg_restrict` in function prototypes. With a modern compiler
+# the plain `restrict` keyword works; fall back to __restrict / nothing.
+check_c_source_compiles("
+  void f(int *restrict p) { (void) p; }
+  int main(void) { return 0; }"
+  PG_HAVE_C99_RESTRICT)
+if(PG_HAVE_C99_RESTRICT)
+  set(pg_restrict "restrict")
+else()
+  check_c_source_compiles("
+    void f(int *__restrict p) { (void) p; }
+    int main(void) { return 0; }"
+    PG_HAVE_GCC_RESTRICT)
+  if(PG_HAVE_GCC_RESTRICT)
+    set(pg_restrict "__restrict")
+  else()
+    set(pg_restrict "")
+  endif()
+endif()
+
+#-----------------------------------------------------------------------
+# 8. Struct members / unions
+#-----------------------------------------------------------------------
+check_struct_has_member("struct tm" tm_zone    time.h
+                        HAVE_STRUCT_TM_TM_ZONE)
+check_struct_has_member("struct sockaddr_un" sun_path
+                        "sys/types.h;sys/un.h"
+                        HAVE_STRUCT_SOCKADDR_UN)
+check_c_source_compiles("
+  #include <sys/types.h>
+  #include <sys/ipc.h>
+  #include <sys/sem.h>
+  int main(void){ union semun u; (void) u; return 0; }"
+  HAVE_UNION_SEMUN)
+check_c_source_compiles("
+  #include <time.h>
+  int main(void){ extern long int timezone; return (int) timezone; }"
+  HAVE_INT_TIMEZONE)
+
+#-----------------------------------------------------------------------
+# 9. Fixed PG values + feature flags
+#-----------------------------------------------------------------------
+# PG's own configure has these as compile-time constants (not autodetected).
+set(BLCKSZ           8192)
+set(XLOG_BLCKSZ      8192)
+set(NAMEDATALEN        64)
+set(MEMSET_LOOP_LIMIT 1024)
+set(PG_USE_STDBOOL      1)
+set(HAVE_FUNCNAME__FUNC     1)
+set(HAVE_FUNCNAME__FUNCTION 1)
+
+# Version string (supplied by the parent scope when available).
+if(NOT DEFINED PG_MAJORVERSION)
+  if(DEFINED POSTGRESQL_VERSION_MAJOR)
+    set(PG_MAJORVERSION "${POSTGRESQL_VERSION_MAJOR}")
+  else()
+    set(PG_MAJORVERSION "18")
+  endif()
+endif()
+
+# printf format attribute: GCC prefers "gnu_printf" for %m support,
+# everything else uses plain "printf". Clang accepts both.
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+  set(PG_PRINTF_ATTRIBUTE gnu_printf)
+else()
+  set(PG_PRINTF_ATTRIBUTE printf)
+endif()
+
+# USE_ASSERT_CHECKING is intentionally NOT set, even in Debug builds.
+# PostgreSQL's Assert() macro expands to a call to ExceptionalCondition(),
+# which is only provided by the PostgreSQL backend; MEOS links without it.
+# Enabling asserts in a MEOS Debug build therefore produces unresolved
+# symbols at link time - so keep it off here and rely on regular asserts
+# inside MEOS/MobilityDB code instead.
+
+# Features MobilityDB/MEOS deliberately does NOT use. Leaving them unset
+# makes configure_file emit `/* #undef ... */`, which is the correct state.
+#   USE_ICU, USE_OPENSSL, ENABLE_NLS, HAVE_PPC_LWARX_MUTEX_HINT

--- a/meos/CMakeLists.txt
+++ b/meos/CMakeLists.txt
@@ -89,8 +89,16 @@ add_definitions(-DPOSTGIS_PGSQL_VERSION=${POSTGIS_PGSQL_VERSION})
 # MobilityDB directories
 #--------------------------------
 
-# PostgreSQL
-configure_file(../postgres/pg_config.h.in ../postgres/pg_config.h)
+# PostgreSQL - detect host-specific values and render pg_config.h.
+# See cmake/ConfigurePgConfig.cmake for the rationale: the previous
+# postgres/pg_config.h.in was a Linux snapshot checked in as a static
+# file; this module does what PG's own ./configure would do, narrowed to
+# the macros MEOS/MobilityDB actually references.
+include(${CMAKE_SOURCE_DIR}/cmake/ConfigurePgConfig.cmake)
+configure_file(
+  ${CMAKE_SOURCE_DIR}/postgres/pg_config.h.in
+  ${CMAKE_BINARY_DIR}/postgres/pg_config.h
+  @ONLY)
 include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/postgres/timezone")
 include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/postgres")
 include_directories(SYSTEM "${CMAKE_BINARY_DIR}/postgres")

--- a/postgres/pg_config.h.in
+++ b/postgres/pg_config.h.in
@@ -1,1014 +1,142 @@
-/* src/include/pg_config.h.  Generated from pg_config.h.in by configure.  */
-/* src/include/pg_config.h.in.  Generated from configure.ac by autoheader.  */
+/*-------------------------------------------------------------------------
+ *
+ * pg_config.h.in  -  CMake-rendered PostgreSQL host configuration
+ *
+ * Generated at configure time by cmake/ConfigurePgConfig.cmake.
+ * DO NOT edit the output (pg_config.h); edit this template or the
+ * configure module instead.
+ *
+ * Narrowed to the set of macros actually referenced by MobilityDB,
+ * MEOS, and the embedded PostgreSQL port sources. See the comment at
+ * the top of ConfigurePgConfig.cmake for the rationale.
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef PG_CONFIG_H
+#define PG_CONFIG_H
 
-/* Define to the type of arg 1 of 'accept' */
-#define ACCEPT_TYPE_ARG1 int
+/*
+ * Sizes (from CMake check_type_size)
+ */
+#define SIZEOF_VOID_P         @SIZEOF_VOID_P@
+#define SIZEOF_LONG           @SIZEOF_LONG@
+#define SIZEOF_SIZE_T         @SIZEOF_SIZE_T@
 
-/* Define to the type of arg 2 of 'accept' */
-#define ACCEPT_TYPE_ARG2 struct sockaddr *
+/*
+ * Alignment of native types (measured via offsetof at configure time)
+ */
+#define ALIGNOF_SHORT         @ALIGNOF_SHORT@
+#define ALIGNOF_INT           @ALIGNOF_INT@
+#define ALIGNOF_LONG          @ALIGNOF_LONG@
+#define ALIGNOF_DOUBLE        @ALIGNOF_DOUBLE@
+#define MAXIMUM_ALIGNOF       @MAXIMUM_ALIGNOF@
 
-/* Define to the type of arg 3 of 'accept' */
-#define ACCEPT_TYPE_ARG3 socklen_t
+/*
+ * Byte order
+ */
+#cmakedefine WORDS_BIGENDIAN 1
 
-/* Define to the return type of 'accept' */
-#define ACCEPT_TYPE_RETURN int
+/*
+ * 64-bit integer type. At most one of HAVE_LONG_INT_64 /
+ * HAVE_LONG_LONG_INT_64 is defined - which one depends on the target's
+ * data model (LP64 vs LLP64). INT64_MODIFIER is the corresponding
+ * printf length modifier string ("l" or "ll").
+ */
+#cmakedefine HAVE_LONG_INT_64       1
+#cmakedefine HAVE_LONG_LONG_INT_64  1
+#define PG_INT64_TYPE               @PG_INT64_TYPE@
+#define INT64_MODIFIER              @INT64_MODIFIER@
 
-/* Define if building universal (internal helper macro) */
-/* #undef AC_APPLE_UNIVERSAL_BUILD */
+/*
+ * 128-bit integer type (optional; absent on MSVC and some 32-bit targets).
+ * c.h derives HAVE_INT128 itself from PG_INT128_TYPE + ALIGNOF_PG_INT128_TYPE.
+ */
+#cmakedefine PG_INT128_TYPE         @PG_INT128_TYPE@
+#cmakedefine ALIGNOF_PG_INT128_TYPE @ALIGNOF_PG_INT128_TYPE@
 
-/* The normal alignment of `double', in bytes. */
-#define ALIGNOF_DOUBLE 8
+/*
+ * Compiler builtins / intrinsics
+ */
+#cmakedefine HAVE__BUILTIN_BSWAP16           1
+#cmakedefine HAVE__BUILTIN_BSWAP32           1
+#cmakedefine HAVE__BUILTIN_BSWAP64           1
+#cmakedefine HAVE__BUILTIN_CLZ               1
+#cmakedefine HAVE__BUILTIN_CTZ               1
+#cmakedefine HAVE__BUILTIN_POPCOUNT          1
+#cmakedefine HAVE__BUILTIN_UNREACHABLE       1
+#cmakedefine HAVE__BUILTIN_OP_OVERFLOW       1
+#cmakedefine HAVE__BUILTIN_TYPES_COMPATIBLE_P 1
+#cmakedefine HAVE__STATIC_ASSERT             1
+#cmakedefine HAVE__CPUID                     1
 
-/* The normal alignment of `int', in bytes. */
-#define ALIGNOF_INT 4
+/*
+ * Standard headers
+ */
+#cmakedefine HAVE_STRING_H    1
+#cmakedefine HAVE_STRINGS_H   1
+#cmakedefine HAVE_WCTYPE_H    1
+#cmakedefine HAVE_CRTDEFS_H   1
 
-/* The normal alignment of `long', in bytes. */
-#define ALIGNOF_LONG 8
+/*
+ * Functions / declarations (a HAVE_DECL_* is defined only when the
+ * corresponding HAVE_* is defined)
+ */
+#cmakedefine HAVE_GETTIMEOFDAY        1
+#cmakedefine HAVE_READLINK            1
+#cmakedefine HAVE_FDATASYNC           1
+#cmakedefine HAVE_DECL_FDATASYNC      1
+#cmakedefine HAVE_POSIX_FADVISE       1
+#cmakedefine HAVE_DECL_POSIX_FADVISE  1
+#cmakedefine HAVE_SYNC_FILE_RANGE     1
+#cmakedefine HAVE_STRTOLL             1
+#cmakedefine HAVE_DECL_STRTOLL        1
+#cmakedefine HAVE_STRTOULL            1
+#cmakedefine HAVE_DECL_STRTOULL       1
+#cmakedefine HAVE_STRCHRNUL           1
 
-/* The normal alignment of `long long int', in bytes. */
-/* #undef ALIGNOF_LONG_LONG_INT */
+/*
+ * C99 `restrict` keyword (falls back to __restrict or nothing). Sources
+ * use `pg_restrict`; `restrict` itself is mapped for code that hasn't
+ * been adapted.
+ */
+#define pg_restrict @pg_restrict@
 
-/* The normal alignment of `PG_INT128_TYPE', in bytes. */
-#define ALIGNOF_PG_INT128_TYPE 16
+/*
+ * Struct / union feature tests
+ */
+#cmakedefine HAVE_STRUCT_TM_TM_ZONE   1
+#cmakedefine HAVE_STRUCT_SOCKADDR_UN  1
+#cmakedefine HAVE_UNION_SEMUN         1
+#cmakedefine HAVE_INT_TIMEZONE        1
 
-/* The normal alignment of `short', in bytes. */
-#define ALIGNOF_SHORT 2
+/*
+ * PostgreSQL constants (fixed; never autodetected by PG's configure either)
+ */
+#define BLCKSZ             @BLCKSZ@
+#define XLOG_BLCKSZ        @XLOG_BLCKSZ@
+#define NAMEDATALEN        @NAMEDATALEN@
+#define MEMSET_LOOP_LIMIT  @MEMSET_LOOP_LIMIT@
 
-/* Size of a disk block --- this also limits the size of a tuple. You can set
-   it bigger if you need bigger tuples (although TOAST should reduce the need
-   to have large tuples, since fields can be spread across multiple tuples).
-   BLCKSZ must be a power of 2. The maximum possible value of BLCKSZ is
-   currently 2^15 (32768). This is determined by the 15-bit widths of the
-   lp_off and lp_len fields in ItemIdData (see include/storage/itemid.h).
-   Changing BLCKSZ requires an initdb. */
-#define BLCKSZ 8192
+/*
+ * Preferred printf format attribute. GCC takes gnu_printf so that %m is
+ * recognised; other compilers take plain printf.
+ */
+#define PG_PRINTF_ATTRIBUTE @PG_PRINTF_ATTRIBUTE@
 
-/* Saved arguments from configure */
-#define CONFIGURE_ARGS " '--prefix=/usr/local/pgsql/14/' '--with-libxml' 'CFLAGS=-g -O0'"
+#cmakedefine PG_USE_STDBOOL            1
+#cmakedefine HAVE_FUNCNAME__FUNC       1
+#cmakedefine HAVE_FUNCNAME__FUNCTION   1
+#cmakedefine USE_ASSERT_CHECKING       1
 
-/* Define to the default TCP port number on which the server listens and to
-   which clients will try to connect. This can be overridden at run-time, but
-   it's convenient if your clients have the right default compiled in.
-   (--with-pgport=PORTNUM) */
-#define DEF_PGPORT 5432
+#define PG_MAJORVERSION "@PG_MAJORVERSION@"
 
-/* Define to the default TCP port number as a string constant. */
-#define DEF_PGPORT_STR "5432"
-
-/* Define to build with GSSAPI support. (--with-gssapi) */
-/* #undef ENABLE_GSS */
-
-/* Define to 1 if you want National Language Support. (--enable-nls) */
+/*
+ * Features MobilityDB/MEOS does not use. Left as explicit #undef lines
+ * to make the contrast with upstream PG configure obvious.
+ */
+/* #undef USE_ICU */
+/* #undef USE_OPENSSL */
 /* #undef ENABLE_NLS */
-
-/* Define to 1 to build client libraries as thread-safe code.
-   (--enable-thread-safety) */
-#define ENABLE_THREAD_SAFETY 1
-
-/* Define to 1 if gettimeofday() takes only 1 argument. */
-/* #undef GETTIMEOFDAY_1ARG */
-
-#ifdef GETTIMEOFDAY_1ARG
-# define gettimeofday(a,b) gettimeofday(a)
-#endif
-
-/* Define to 1 if you have the `append_history' function. */
-#define HAVE_APPEND_HISTORY 1
-
-/* Define to 1 if you have the `ASN1_STRING_get0_data' function. */
-/* #undef HAVE_ASN1_STRING_GET0_DATA */
-
-/* Define to 1 if you want to use atomics if available. */
-#define HAVE_ATOMICS 1
-
-/* Define to 1 if you have the <atomic.h> header file. */
-/* #undef HAVE_ATOMIC_H */
-
-/* Define to 1 if you have the `backtrace_symbols' function. */
-#define HAVE_BACKTRACE_SYMBOLS 1
-
-/* Define to 1 if you have the `BIO_get_data' function. */
-/* #undef HAVE_BIO_GET_DATA */
-
-/* Define to 1 if you have the `BIO_meth_new' function. */
-/* #undef HAVE_BIO_METH_NEW */
-
-/* Define to 1 if you have the `clock_gettime' function. */
-#define HAVE_CLOCK_GETTIME 1
-
-/* Define to 1 if your compiler handles computed gotos. */
-#define HAVE_COMPUTED_GOTO 1
-
-/* Define to 1 if you have the `copyfile' function. */
-/* #undef HAVE_COPYFILE */
-
-/* Define to 1 if you have the <copyfile.h> header file. */
-/* #undef HAVE_COPYFILE_H */
-
-/* Define to 1 if you have the <crtdefs.h> header file. */
-/* #undef HAVE_CRTDEFS_H */
-
-/* Define to 1 if you have the `CRYPTO_lock' function. */
-/* #undef HAVE_CRYPTO_LOCK */
-
-/* Define to 1 if you have the declaration of `fdatasync', and to 0 if you
-   don't. */
-#define HAVE_DECL_FDATASYNC 1
-
-/* Define to 1 if you have the declaration of `F_FULLFSYNC', and to 0 if you
-   don't. */
-#define HAVE_DECL_F_FULLFSYNC 0
-
-/* Define to 1 if you have the declaration of
-   `LLVMCreateGDBRegistrationListener', and to 0 if you don't. */
-/* #undef HAVE_DECL_LLVMCREATEGDBREGISTRATIONLISTENER */
-
-/* Define to 1 if you have the declaration of
-   `LLVMCreatePerfJITEventListener', and to 0 if you don't. */
-/* #undef HAVE_DECL_LLVMCREATEPERFJITEVENTLISTENER */
-
-/* Define to 1 if you have the declaration of `LLVMGetHostCPUFeatures', and to
-   0 if you don't. */
-/* #undef HAVE_DECL_LLVMGETHOSTCPUFEATURES */
-
-/* Define to 1 if you have the declaration of `LLVMGetHostCPUName', and to 0
-   if you don't. */
-/* #undef HAVE_DECL_LLVMGETHOSTCPUNAME */
-
-/* Define to 1 if you have the declaration of `LLVMOrcGetSymbolAddressIn', and
-   to 0 if you don't. */
-/* #undef HAVE_DECL_LLVMORCGETSYMBOLADDRESSIN */
-
-/* Define to 1 if you have the declaration of `posix_fadvise', and to 0 if you
-   don't. */
-#define HAVE_DECL_POSIX_FADVISE 1
-
-/* Define to 1 if you have the declaration of `preadv', and to 0 if you don't.
-   */
-#define HAVE_DECL_PREADV 1
-
-/* Define to 1 if you have the declaration of `pwritev', and to 0 if you
-   don't. */
-#define HAVE_DECL_PWRITEV 1
-
-/* Define to 1 if you have the declaration of `RTLD_GLOBAL', and to 0 if you
-   don't. */
-#define HAVE_DECL_RTLD_GLOBAL 1
-
-/* Define to 1 if you have the declaration of `RTLD_NOW', and to 0 if you
-   don't. */
-#define HAVE_DECL_RTLD_NOW 1
-
-/* Define to 1 if you have the declaration of `strlcat', and to 0 if you
-   don't. */
-#define HAVE_DECL_STRLCAT 0
-
-/* Define to 1 if you have the declaration of `strlcpy', and to 0 if you
-   don't. */
-#define HAVE_DECL_STRLCPY 0
-
-/* Define to 1 if you have the declaration of `strnlen', and to 0 if you
-   don't. */
-#define HAVE_DECL_STRNLEN 1
-
-/* Define to 1 if you have the declaration of `strtoll', and to 0 if you
-   don't. */
-#define HAVE_DECL_STRTOLL 1
-
-/* Define to 1 if you have the declaration of `strtoull', and to 0 if you
-   don't. */
-#define HAVE_DECL_STRTOULL 1
-
-/* Define to 1 if you have the `dlopen' function. */
-#define HAVE_DLOPEN 1
-
-/* Define to 1 if you have the <editline/history.h> header file. */
-/* #undef HAVE_EDITLINE_HISTORY_H */
-
-/* Define to 1 if you have the <editline/readline.h> header file. */
-/* #undef HAVE_EDITLINE_READLINE_H */
-
-/* Define to 1 if you have the <execinfo.h> header file. */
-#define HAVE_EXECINFO_H 1
-
-/* Define to 1 if you have the `explicit_bzero' function. */
-#define HAVE_EXPLICIT_BZERO 1
-
-/* Define to 1 if you have the `fdatasync' function. */
-#define HAVE_FDATASYNC 1
-
-/* Define to 1 if you have the `fls' function. */
-/* #undef HAVE_FLS */
-
-/* Define to 1 if fseeko (and presumably ftello) exists and is declared. */
-#define HAVE_FSEEKO 1
-
-/* Define to 1 if your compiler understands __func__. */
-#define HAVE_FUNCNAME__FUNC 1
-
-/* Define to 1 if your compiler understands __FUNCTION__. */
-/* #undef HAVE_FUNCNAME__FUNCTION */
-
-/* Define to 1 if you have __atomic_compare_exchange_n(int *, int *, int). */
-#define HAVE_GCC__ATOMIC_INT32_CAS 1
-
-/* Define to 1 if you have __atomic_compare_exchange_n(int64 *, int64 *,
-   int64). */
-#define HAVE_GCC__ATOMIC_INT64_CAS 1
-
-/* Define to 1 if you have __sync_lock_test_and_set(char *) and friends. */
-#define HAVE_GCC__SYNC_CHAR_TAS 1
-
-/* Define to 1 if you have __sync_val_compare_and_swap(int *, int, int). */
-#define HAVE_GCC__SYNC_INT32_CAS 1
-
-/* Define to 1 if you have __sync_lock_test_and_set(int *) and friends. */
-#define HAVE_GCC__SYNC_INT32_TAS 1
-
-/* Define to 1 if you have __sync_val_compare_and_swap(int64 *, int64, int64).
-   */
-#define HAVE_GCC__SYNC_INT64_CAS 1
-
-/* Define to 1 if you have the `getaddrinfo' function. */
-#define HAVE_GETADDRINFO 1
-
-/* Define to 1 if you have the `gethostbyname_r' function. */
-#define HAVE_GETHOSTBYNAME_R 1
-
-/* Define to 1 if you have the `getifaddrs' function. */
-#define HAVE_GETIFADDRS 1
-
-/* Define to 1 if you have the `getopt' function. */
-#define HAVE_GETOPT 1
-
-/* Define to 1 if you have the <getopt.h> header file. */
-#define HAVE_GETOPT_H 1
-
-/* Define to 1 if you have the `getopt_long' function. */
-#define HAVE_GETOPT_LONG 1
-
-/* Define to 1 if you have the `getpeereid' function. */
-/* #undef HAVE_GETPEEREID */
-
-/* Define to 1 if you have the `getpeerucred' function. */
-/* #undef HAVE_GETPEERUCRED */
-
-/* Define to 1 if you have the `getpwuid_r' function. */
-#define HAVE_GETPWUID_R 1
-
-/* Define to 1 if you have the `getrlimit' function. */
-#define HAVE_GETRLIMIT 1
-
-/* Define to 1 if you have the `getrusage' function. */
-#define HAVE_GETRUSAGE 1
-
-/* Define to 1 if you have the `gettimeofday' function. */
-#define HAVE_GETTIMEOFDAY /* MSYS2 UCRT64 provides this function */
-
-/* Define to 1 if you have the <gssapi/gssapi.h> header file. */
-/* #undef HAVE_GSSAPI_GSSAPI_H */
-
-/* Define to 1 if you have the <gssapi.h> header file. */
-/* #undef HAVE_GSSAPI_H */
-
-/* Define to 1 if you have the <history.h> header file. */
-/* #undef HAVE_HISTORY_H */
-
-/* Define to 1 if you have the `history_truncate_file' function. */
-#define HAVE_HISTORY_TRUNCATE_FILE 1
-
-/* Define to 1 if you have the `HMAC_CTX_free' function. */
-/* #undef HAVE_HMAC_CTX_FREE */
-
-/* Define to 1 if you have the `HMAC_CTX_new' function. */
-/* #undef HAVE_HMAC_CTX_NEW */
-
-/* Define to 1 if you have the <ifaddrs.h> header file. */
-#define HAVE_IFADDRS_H 1
-
-/* Define to 1 if you have the `inet_aton' function. */
-#define HAVE_INET_ATON 1
-
-/* Define to 1 if the system has the type `int64'. */
-/* #undef HAVE_INT64 */
-
-/* Define to 1 if the system has the type `int8'. */
-/* #undef HAVE_INT8 */
-
-/* Define to 1 if you have the <inttypes.h> header file. */
-#define HAVE_INTTYPES_H 1
-
-/* Define to 1 if you have the global variable 'int opterr'. */
-#define HAVE_INT_OPTERR 1
-
-/* Define to 1 if you have the global variable 'int optreset'. */
-/* #undef HAVE_INT_OPTRESET */
-
-/* Define to 1 if you have the global variable 'int timezone'. */
-#define HAVE_INT_TIMEZONE 1
-
-/* Define to 1 if you have support for IPv6. */
-#define HAVE_IPV6 1
-
-/* Define to 1 if __builtin_constant_p(x) implies "i"(x) acceptance. */
-/* #undef HAVE_I_CONSTRAINT__BUILTIN_CONSTANT_P */
-
-/* Define to 1 if you have the `kqueue' function. */
-/* #undef HAVE_KQUEUE */
-
-/* Define to 1 if you have the <langinfo.h> header file. */
-#define HAVE_LANGINFO_H 1
-
-/* Define to 1 if you have the <ldap.h> header file. */
-/* #undef HAVE_LDAP_H */
-
-/* Define to 1 if you have the `ldap_initialize' function. */
-/* #undef HAVE_LDAP_INITIALIZE */
-
-/* Define to 1 if you have the `crypto' library (-lcrypto). */
-/* #undef HAVE_LIBCRYPTO */
-
-/* Define to 1 if you have the `ldap' library (-lldap). */
-/* #undef HAVE_LIBLDAP */
-
-/* Define to 1 if you have the `lz4' library (-llz4). */
-/* #undef HAVE_LIBLZ4 */
-
-/* Define to 1 if you have the `m' library (-lm). */
-#define HAVE_LIBM 1
-
-/* Define to 1 if you have the `pam' library (-lpam). */
-/* #undef HAVE_LIBPAM */
-
-/* Define if you have a function readline library */
-#define HAVE_LIBREADLINE 1
-
-/* Define to 1 if you have the `selinux' library (-lselinux). */
-/* #undef HAVE_LIBSELINUX */
-
-/* Define to 1 if you have the `ssl' library (-lssl). */
-/* #undef HAVE_LIBSSL */
-
-/* Define to 1 if you have the `wldap32' library (-lwldap32). */
-/* #undef HAVE_LIBWLDAP32 */
-
-/* Define to 1 if you have the `xml2' library (-lxml2). */
-#define HAVE_LIBXML2 1
-
-/* Define to 1 if you have the `xslt' library (-lxslt). */
-/* #undef HAVE_LIBXSLT */
-
-/* Define to 1 if you have the `z' library (-lz). */
-#define HAVE_LIBZ 1
-
-/* Define to 1 if you have the `link' function. */
-#define HAVE_LINK 1
-
-/* Define to 1 if the system has the type `locale_t'. */
-#define HAVE_LOCALE_T 1
-
-/* Define to 1 if `long int' works and is 64 bits. */
-#define HAVE_LONG_INT_64 1
-
-/* Define to 1 if `long long int' works and is 64 bits. */
-/* #undef HAVE_LONG_LONG_INT_64 */
-
-/* Define to 1 if you have the <lz4.h> header file. */
-/* #undef HAVE_LZ4_H */
-
-/* Define to 1 if you have the <mbarrier.h> header file. */
-/* #undef HAVE_MBARRIER_H */
-
-/* Define to 1 if you have the `mbstowcs_l' function. */
-/* #undef HAVE_MBSTOWCS_L */
-
-/* Define to 1 if you have the <memory.h> header file. */
-#define HAVE_MEMORY_H 1
-
-/* Define to 1 if you have the `memset_s' function. */
-/* #undef HAVE_MEMSET_S */
-
-/* Define to 1 if the system has the type `MINIDUMP_TYPE'. */
-/* #undef HAVE_MINIDUMP_TYPE */
-
-/* Define to 1 if you have the `mkdtemp' function. */
-#define HAVE_MKDTEMP 1
-
-/* Define to 1 if you have the <netinet/tcp.h> header file. */
-#define HAVE_NETINET_TCP_H 1
-
-/* Define to 1 if you have the <net/if.h> header file. */
-#define HAVE_NET_IF_H 1
-
-/* Define to 1 if you have the `OPENSSL_init_ssl' function. */
-/* #undef HAVE_OPENSSL_INIT_SSL */
-
-/* Define to 1 if you have the <ossp/uuid.h> header file. */
-/* #undef HAVE_OSSP_UUID_H */
-
-/* Define to 1 if you have the <pam/pam_appl.h> header file. */
-/* #undef HAVE_PAM_PAM_APPL_H */
-
-/* Define to 1 if you have the `poll' function. */
-#define HAVE_POLL 1
-
-/* Define to 1 if you have the <poll.h> header file. */
-#define HAVE_POLL_H 1
-
-/* Define to 1 if you have the `posix_fadvise' function. */
-#define HAVE_POSIX_FADVISE 1
-
-/* Define to 1 if you have the `posix_fallocate' function. */
-#define HAVE_POSIX_FALLOCATE 1
-
-/* Define to 1 if the assembler supports PPC's LWARX mutex hint bit. */
 /* #undef HAVE_PPC_LWARX_MUTEX_HINT */
 
-/* Define to 1 if you have the `ppoll' function. */
-#define HAVE_PPOLL 1
-
-/* Define to 1 if you have the `pread' function. */
-#define HAVE_PREAD 1
-
-/* Define to 1 if you have the `pstat' function. */
-/* #undef HAVE_PSTAT */
-
-/* Define to 1 if the PS_STRINGS thing exists. */
-/* #undef HAVE_PS_STRINGS */
-
-/* Define if you have POSIX threads libraries and header files. */
-#define HAVE_PTHREAD 1
-
-/* Define to 1 if you have the `pthread_barrier_wait' function. */
-#define HAVE_PTHREAD_BARRIER_WAIT 1
-
-/* Define to 1 if you have the `pthread_is_threaded_np' function. */
-/* #undef HAVE_PTHREAD_IS_THREADED_NP */
-
-/* Have PTHREAD_PRIO_INHERIT. */
-#define HAVE_PTHREAD_PRIO_INHERIT 1
-
-/* Define to 1 if you have the `pwrite' function. */
-#define HAVE_PWRITE 1
-
-/* Define to 1 if you have the `random' function. */
-#define HAVE_RANDOM 1
-
-/* Define to 1 if you have the <readline.h> header file. */
-/* #undef HAVE_READLINE_H */
-
-/* Define to 1 if you have the <readline/history.h> header file. */
-#define HAVE_READLINE_HISTORY_H 1
-
-/* Define to 1 if you have the <readline/readline.h> header file. */
-#define HAVE_READLINE_READLINE_H 1
-
-/* Define to 1 if you have the `readlink' function. */
-#define HAVE_READLINK 1
-
-/* Define to 1 if you have the `readv' function. */
-#define HAVE_READV 1
-
-/* Define to 1 if you have the global variable
-   'rl_completion_append_character'. */
-#define HAVE_RL_COMPLETION_APPEND_CHARACTER 1
-
-/* Define to 1 if you have the `rl_completion_matches' function. */
-#define HAVE_RL_COMPLETION_MATCHES 1
-
-/* Define to 1 if you have the global variable 'rl_completion_suppress_quote'.
-   */
-#define HAVE_RL_COMPLETION_SUPPRESS_QUOTE 1
-
-/* Define to 1 if you have the `rl_filename_completion_function' function. */
-#define HAVE_RL_FILENAME_COMPLETION_FUNCTION 1
-
-/* Define to 1 if you have the global variable 'rl_filename_quote_characters'.
-   */
-#define HAVE_RL_FILENAME_QUOTE_CHARACTERS 1
-
-/* Define to 1 if you have the global variable 'rl_filename_quoting_function'.
-   */
-#define HAVE_RL_FILENAME_QUOTING_FUNCTION 1
-
-/* Define to 1 if you have the `rl_reset_screen_size' function. */
-#define HAVE_RL_RESET_SCREEN_SIZE 1
-
-/* Define to 1 if you have the <security/pam_appl.h> header file. */
-/* #undef HAVE_SECURITY_PAM_APPL_H */
-
-/* Define to 1 if you have the `setenv' function. */
-#define HAVE_SETENV 1
-
-/* Define to 1 if you have the `setproctitle' function. */
-/* #undef HAVE_SETPROCTITLE */
-
-/* Define to 1 if you have the `setproctitle_fast' function. */
-/* #undef HAVE_SETPROCTITLE_FAST */
-
-/* Define to 1 if you have the `setsid' function. */
-#define HAVE_SETSID 1
-
-/* Define to 1 if you have the `shm_open' function. */
-#define HAVE_SHM_OPEN 1
-
-/* Define to 1 if you have spinlocks. */
-#define HAVE_SPINLOCKS 1
-
-/* Define to 1 if you have the `srandom' function. */
-#define HAVE_SRANDOM 1
-
-/* Define to 1 if stdbool.h conforms to C99. */
-#define HAVE_STDBOOL_H 1
-
-/* Define to 1 if you have the <stdint.h> header file. */
-#define HAVE_STDINT_H 1
-
-/* Define to 1 if you have the <stdlib.h> header file. */
-#define HAVE_STDLIB_H 1
-
-/* Define to 1 if you have the `strchrnul' function. */
-#cmakedefine HAVE_STRCHRNUL @HAVE_STRCHRNUL@
-
-/* Define to 1 if you have the `strerror_r' function. */
-#define HAVE_STRERROR_R 1
-
-/* Define to 1 if you have the <strings.h> header file. */
-#define HAVE_STRINGS_H 1
-
-/* Define to 1 if you have the <string.h> header file. */
-#define HAVE_STRING_H 1
-
-/* Define to 1 if you have the `strlcat' function. */
-/* #undef HAVE_STRLCAT */
-
-/* Define to 1 if you have the `strlcpy' function. */
-/* #undef HAVE_STRLCPY */
-
-/* Define to 1 if you have the `strnlen' function. */
-#define HAVE_STRNLEN 1
-
-/* Define to 1 if you have the `strsignal' function. */
-#define HAVE_STRSIGNAL 1
-
-/* Define to 1 if you have the `strtof' function. */
-#define HAVE_STRTOF 1
-
-/* Define to 1 if you have the `strtoll' function. */
-#define HAVE_STRTOLL 1
-
-/* Define to 1 if you have the `strtoq' function. */
-/* #undef HAVE_STRTOQ */
-
-/* Define to 1 if you have the `strtoull' function. */
-#define HAVE_STRTOULL 1
-
-/* Define to 1 if you have the `strtouq' function. */
-/* #undef HAVE_STRTOUQ */
-
-/* Define to 1 if the system has the type `struct addrinfo'. */
-#define HAVE_STRUCT_ADDRINFO 1
-
-/* Define to 1 if the system has the type `struct cmsgcred'. */
-/* #undef HAVE_STRUCT_CMSGCRED */
-
-/* Define to 1 if the system has the type `struct option'. */
-#define HAVE_STRUCT_OPTION 1
-
-/* Define to 1 if `sa_len' is a member of `struct sockaddr'. */
-/* #undef HAVE_STRUCT_SOCKADDR_SA_LEN */
-
-/* Define to 1 if the system has the type `struct sockaddr_storage'. */
-#define HAVE_STRUCT_SOCKADDR_STORAGE 1
-
-/* Define to 1 if `ss_family' is a member of `struct sockaddr_storage'. */
-#define HAVE_STRUCT_SOCKADDR_store_SS_FAMILY 1
-
-/* Define to 1 if `ss_len' is a member of `struct sockaddr_storage'. */
-/* #undef HAVE_STRUCT_SOCKADDR_store_SS_LEN */
-
-/* Define to 1 if `__ss_family' is a member of `struct sockaddr_storage'. */
-/* #undef HAVE_STRUCT_SOCKADDR_store___SS_FAMILY */
-
-/* Define to 1 if `__ss_len' is a member of `struct sockaddr_storage'. */
-/* #undef HAVE_STRUCT_SOCKADDR_store___SS_LEN */
-
-/* Define to 1 if the system has the type `struct sockaddr_un'. */
-#define HAVE_STRUCT_SOCKADDR_UN 1
-
-/* Define to 1 if `tm_zone' is a member of `struct tm'. */
-#define HAVE_STRUCT_TM_TM_ZONE 1
-
-/* Define to 1 if you have the `symlink' function. */
-#define HAVE_SYMLINK 1
-
-/* Define to 1 if you have the `syncfs' function. */
-#define HAVE_SYNCFS 1
-
-/* Define to 1 if you have the `sync_file_range' function. */
-#define HAVE_SYNC_FILE_RANGE 1
-
-/* Define to 1 if you have the syslog interface. */
-#define HAVE_SYSLOG 1
-
-/* Define to 1 if you have the <sys/epoll.h> header file. */
-#define HAVE_SYS_EPOLL_H 1
-
-/* Define to 1 if you have the <sys/event.h> header file. */
-/* #undef HAVE_SYS_EVENT_H */
-
-/* Define to 1 if you have the <sys/ipc.h> header file. */
-#define HAVE_SYS_IPC_H 1
-
-/* Define to 1 if you have the <sys/prctl.h> header file. */
-#define HAVE_SYS_PRCTL_H 1
-
-/* Define to 1 if you have the <sys/procctl.h> header file. */
-/* #undef HAVE_SYS_PROCCTL_H */
-
-/* Define to 1 if you have the <sys/pstat.h> header file. */
-/* #undef HAVE_SYS_PSTAT_H */
-
-/* Define to 1 if you have the <sys/resource.h> header file. */
-#define HAVE_SYS_RESOURCE_H 1
-
-/* Define to 1 if you have the <sys/select.h> header file. */
-#define HAVE_SYS_SELECT_H 1
-
-/* Define to 1 if you have the <sys/sem.h> header file. */
-#define HAVE_SYS_SEM_H 1
-
-/* Define to 1 if you have the <sys/shm.h> header file. */
-#define HAVE_SYS_SHM_H 1
-
-/* Define to 1 if you have the <sys/sockio.h> header file. */
-/* #undef HAVE_SYS_SOCKIO_H */
-
-/* Define to 1 if you have the <sys/stat.h> header file. */
-#define HAVE_SYS_STAT_H 1
-
-/* Define to 1 if you have the <sys/tas.h> header file. */
-/* #undef HAVE_SYS_TAS_H */
-
-/* Define to 1 if you have the <sys/types.h> header file. */
-#define HAVE_SYS_TYPES_H 1
-
-/* Define to 1 if you have the <sys/ucred.h> header file. */
-/* #undef HAVE_SYS_UCRED_H */
-
-/* Define to 1 if you have the <sys/uio.h> header file. */
-#define HAVE_SYS_UIO_H 1
-
-/* Define to 1 if you have the <sys/un.h> header file. */
-#define HAVE_SYS_UN_H 1
-
-/* Define to 1 if you have the <termios.h> header file. */
-#define HAVE_TERMIOS_H 1
-
-/* Define to 1 if your compiler understands `typeof' or something similar. */
-#define HAVE_TYPEOF 1
-
-/* Define to 1 if you have the <ucred.h> header file. */
-/* #undef HAVE_UCRED_H */
-
-/* Define to 1 if the system has the type `uint64'. */
-/* #undef HAVE_UINT64 */
-
-/* Define to 1 if the system has the type `uint8'. */
-/* #undef HAVE_UINT8 */
-
-/* Define to 1 if the system has the type `union semun'. */
-/* #undef HAVE_UNION_SEMUN */
-
-/* Define to 1 if you have the <unistd.h> header file. */
-#define HAVE_UNISTD_H 1
-
-/* Define to 1 if you have the `unsetenv' function. */
-#define HAVE_UNSETENV 1
-
-/* Define to 1 if you have the `uselocale' function. */
-#define HAVE_USELOCALE 1
-
-/* Define to 1 if you have BSD UUID support. */
-/* #undef HAVE_UUID_BSD */
-
-/* Define to 1 if you have E2FS UUID support. */
-/* #undef HAVE_UUID_E2FS */
-
-/* Define to 1 if you have the <uuid.h> header file. */
-/* #undef HAVE_UUID_H */
-
-/* Define to 1 if you have OSSP UUID support. */
-/* #undef HAVE_UUID_OSSP */
-
-/* Define to 1 if you have the <uuid/uuid.h> header file. */
-/* #undef HAVE_UUID_UUID_H */
-
-/* Define to 1 if you have the `wcstombs_l' function. */
-/* #undef HAVE_WCSTOMBS_L */
-
-/* Define to 1 if you have the <wctype.h> header file. */
-#define HAVE_WCTYPE_H 1
-
-/* Define to 1 if you have the <winldap.h> header file. */
-/* #undef HAVE_WINLDAP_H */
-
-/* Define to 1 if you have the `writev' function. */
-#define HAVE_WRITEV 1
-
-/* Define to 1 if you have the `X509_get_signature_nid' function. */
-/* #undef HAVE_X509_GET_SIGNATURE_NID */
-
-/* Define to 1 if the assembler supports X86_64's POPCNTQ instruction. */
-#cmakedefine HAVE_X86_64_POPCNTQ @HAVE_X86_64_POPCNTQ@
-
-/* Define to 1 if the system has the type `_Bool'. */
-#define HAVE__BOOL 1
-
-/* Define to 1 if your compiler understands __builtin_bswap16. */
-#define HAVE__BUILTIN_BSWAP16 1
-
-/* Define to 1 if your compiler understands __builtin_bswap32. */
-#define HAVE__BUILTIN_BSWAP32 1
-
-/* Define to 1 if your compiler understands __builtin_bswap64. */
-#define HAVE__BUILTIN_BSWAP64 1
-
-/* Define to 1 if your compiler understands __builtin_clz. */
-#define HAVE__BUILTIN_CLZ 1
-
-/* Define to 1 if your compiler understands __builtin_constant_p. */
-#define HAVE__BUILTIN_CONSTANT_P 1
-
-/* Define to 1 if your compiler understands __builtin_ctz. */
-#define HAVE__BUILTIN_CTZ 1
-
-/* Define to 1 if your compiler understands __builtin_$op_overflow. */
-#define HAVE__BUILTIN_OP_OVERFLOW 1
-
-/* Define to 1 if your compiler understands __builtin_popcount. */
-#define HAVE__BUILTIN_POPCOUNT 1
-
-/* Define to 1 if your compiler understands __builtin_types_compatible_p. */
-#define HAVE__BUILTIN_TYPES_COMPATIBLE_P 1
-
-/* Define to 1 if your compiler understands __builtin_unreachable. */
-#define HAVE__BUILTIN_UNREACHABLE 1
-
-/* Define to 1 if you have the `_configthreadlocale' function. */
-/* #undef HAVE__CONFIGTHREADLOCALE */
-
-/* Define to 1 if you have __cpuid. */
-/* #undef HAVE__CPUID */
-
-/* Define to 1 if you have __get_cpuid. */
-#cmakedefine HAVE__GET_CPUID @HAVE__GET_CPUID@
-
-/* Define to 1 if your compiler understands _Static_assert. */
-#define HAVE__STATIC_ASSERT 1
-
-/* Define to 1 if you have the `__strtoll' function. */
-/* #undef HAVE___STRTOLL */
-
-/* Define to 1 if you have the `__strtoull' function. */
-/* #undef HAVE___STRTOULL */
-
-/* Define to the appropriate printf length modifier for 64-bit ints. */
-#define INT64_MODIFIER "l"
-
-/* Define to 1 if `locale_t' requires <xlocale.h>. */
-/* #undef LOCALE_T_IN_XLOCALE */
-
-/* Define as the maximum alignment requirement of any C data type. */
-#define MAXIMUM_ALIGNOF 8
-
-/* Define bytes to use libc memset(). */
-#define MEMSET_LOOP_LIMIT 1024
-
-/* Define to the OpenSSL API version in use. This avoids deprecation warnings
-   from newer OpenSSL versions. */
-/* #undef OPENSSL_API_COMPAT */
-
-/* Define to the address where bug reports for this package should be sent. */
-#define PACKAGE_BUGREPORT "pgsql-bugs@lists.postgresql.org"
-
-/* Define to the full name of this package. */
-#define PACKAGE_NAME "PostgreSQL"
-
-/* Define to the full name and version of this package. */
-#define PACKAGE_STRING "PostgreSQL 14.2"
-
-/* Define to the one symbol short name of this package. */
-#define PACKAGE_TARNAME "postgresql"
-
-/* Define to the home page for this package. */
-#define PACKAGE_URL "https://www.postgresql.org/"
-
-/* Define to the version of this package. */
-#define PACKAGE_VERSION "14.2"
-
-/* Define to the name of a signed 128-bit integer type. */
-#define PG_INT128_TYPE __int128
-
-/* Define to the name of a signed 64-bit integer type. */
-#define PG_INT64_TYPE long int
-
-/* Define to the name of the default PostgreSQL service principal in Kerberos
-   (GSSAPI). (--with-krb-srvnam=NAME) */
-#define PG_KRB_SRVNAM "postgres"
-
-/* PostgreSQL major version as a string */
-#define PG_MAJORVERSION "14"
-
-/* PostgreSQL major version number */
-#define PG_MAJORVERSION_NUM 14
-
-/* PostgreSQL minor version number */
-#define PG_MINORVERSION_NUM 2
-
-/* Define to best printf format archetype, usually gnu_printf if available. */
-#define PG_PRINTF_ATTRIBUTE gnu_printf
-
-/* Define to 1 to use <stdbool.h> to define type bool. */
-#define PG_USE_STDBOOL 1
-
-/* PostgreSQL version as a string */
-#define PG_VERSION "14.2"
-
-/* PostgreSQL version as a number */
-#define PG_VERSION_NUM 140002
-
-/* A string containing the version number, platform, and C compiler */
-#define PG_VERSION_STR "PostgreSQL 14.2 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0, 64-bit"
-
-/* Define to 1 to allow profiling output to be saved separately for each
-   process. */
-/* #undef PROFILE_PID_DIR */
-
-/* Define to necessary symbol if this constant uses a non-standard name on
-   your system. */
-/* #undef PTHREAD_CREATE_JOINABLE */
-
-/* RELSEG_SIZE is the maximum number of blocks allowed in one disk file. Thus,
-   the maximum size of a single file is RELSEG_SIZE * BLCKSZ; relations bigger
-   than that are divided into multiple files. RELSEG_SIZE * BLCKSZ must be
-   less than your OS' limit on file size. This is often 2 GB or 4GB in a
-   32-bit operating system, unless you have large file support enabled. By
-   default, we make the limit 1 GB to avoid any possible integer-overflow
-   problems within the OS. A limit smaller than necessary only means we divide
-   a large relation into more chunks than necessary, so it seems best to err
-   in the direction of a small limit. A power-of-2 value is recommended to
-   save a few cycles in md.c, but is not absolutely required. Changing
-   RELSEG_SIZE requires an initdb. */
-#define RELSEG_SIZE 131072
-
-/* The size of `bool', as computed by sizeof. */
-#define SIZEOF_BOOL 1
-
-/* The size of `long', as computed by sizeof. */
-#define SIZEOF_LONG 8
-
-/* The size of `off_t', as computed by sizeof. */
-#define SIZEOF_OFF_T 8
-
-/* The size of `size_t', as computed by sizeof. */
-#define SIZEOF_SIZE_T 8
-
-/* The size of `void *', as computed by sizeof. */
-#define SIZEOF_VOID_P 8
-
-/* Define to 1 if you have the ANSI C header files. */
-#define STDC_HEADERS 1
-
-/* Define to 1 if strerror_r() returns int. */
-/* #undef STRERROR_R_INT */
-
-/* Define to 1 to use ARMv8 CRC Extension. */
-/* #undef USE_ARMV8_CRC32C */
-
-/* Define to 1 to use ARMv8 CRC Extension with a runtime check. */
-/* #undef USE_ARMV8_CRC32C_WITH_RUNTIME_CHECK */
-
-/* Define to 1 to build with assertion checks. (--enable-cassert) */
-/* #undef USE_ASSERT_CHECKING */
-
-/* Define to 1 to build with Bonjour support. (--with-bonjour) */
-/* #undef USE_BONJOUR */
-
-/* Define to 1 to build with BSD Authentication support. (--with-bsd-auth) */
-/* #undef USE_BSD_AUTH */
-
-/* Define to build with ICU support. (--with-icu) */
-/* #undef USE_ICU */
-
-/* Define to 1 to build with LDAP support. (--with-ldap) */
-/* #undef USE_LDAP */
-
-/* Define to 1 to build with XML support. (--with-libxml) */
-#define USE_LIBXML 1
-
-/* Define to 1 to use XSLT support when building contrib/xml2.
-   (--with-libxslt) */
-/* #undef USE_LIBXSLT */
-
-/* Define to 1 to build with LLVM based JIT support. (--with-llvm) */
-/* #undef USE_LLVM */
-
-/* Define to 1 to build with LZ4 support. (--with-lz4) */
-/* #undef USE_LZ4 */
-
-/* Define to select named POSIX semaphores. */
-/* #undef USE_NAMED_POSIX_SEMAPHORES */
-
-/* Define to 1 to build with OpenSSL support. (--with-ssl=openssl) */
-/* #undef USE_OPENSSL */
-
-/* Define to 1 to build with PAM support. (--with-pam) */
-/* #undef USE_PAM */
-
-/* Define to 1 to use software CRC-32C implementation (slicing-by-8). */
-/* #undef USE_SLICING_BY_8_CRC32C */
-
-/* Define to 1 use Intel SSE 4.2 CRC instructions. */
-/* #undef USE_SSE42_CRC32C */
-
-/* Define to 1 to use Intel SSE 4.2 CRC instructions with a runtime check. */
-#define USE_SSE42_CRC32C_WITH_RUNTIME_CHECK 1
-
-/* Define to build with systemd support. (--with-systemd) */
-/* #undef USE_SYSTEMD */
-
-/* Define to select SysV-style semaphores. */
-/* #undef USE_SYSV_SEMAPHORES */
-
-/* Define to select SysV-style shared memory. */
-#define USE_SYSV_SHARED_MEMORY 1
-
-/* Define to select unnamed POSIX semaphores. */
-#define USE_UNNAMED_POSIX_SEMAPHORES 1
-
-/* Define to select Win32-style semaphores. */
-/* #undef USE_WIN32_SEMAPHORES */
-
-/* Define to select Win32-style shared memory. */
-/* #undef USE_WIN32_SHARED_MEMORY */
-
-/* Define to 1 if `wcstombs_l' requires <xlocale.h>. */
-/* #undef WCSTOMBS_L_IN_XLOCALE */
-
-/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
-   significant byte first (like Motorola and SPARC, unlike Intel). */
-#if defined AC_APPLE_UNIVERSAL_BUILD
-# if defined __BIG_ENDIAN__
-#  define WORDS_BIGENDIAN 1
-# endif
-#else
-# ifndef WORDS_BIGENDIAN
-/* #  undef WORDS_BIGENDIAN */
-# endif
-#endif
-
-/* Size of a WAL file block. This need have no particular relation to BLCKSZ.
-   XLOG_BLCKSZ must be a power of 2, and if your system supports O_DIRECT I/O,
-   XLOG_BLCKSZ must be a multiple of the alignment requirement for direct-I/O
-   buffers, else direct I/O may fail. Changing XLOG_BLCKSZ requires an initdb.
-   */
-#define XLOG_BLCKSZ 8192
-
-
-
-/* Number of bits in a file offset, on hosts where this is settable. */
-/* #undef _FILE_OFFSET_BITS */
-
-/* Define to 1 to make fseeko visible on some hosts (e.g. glibc 2.2). */
-/* #undef _LARGEFILE_SOURCE */
-
-/* Define for large files, on AIX-style hosts. */
-/* #undef _LARGE_FILES */
-
-/* Define to `__inline__' or `__inline' if that's what the C compiler
-   calls it, or to nothing if 'inline' is not supported under any name.  */
-#ifndef __cplusplus
-/* #undef inline */
-#endif
-
-/* Define to keyword to use for C99 restrict support, or to nothing if not
-   supported */
-#define pg_restrict __restrict
-
-/* Define to the equivalent of the C99 'restrict' keyword, or to
-   nothing if this is not supported.  Do not define if restrict is
-   supported directly.  */
-#define restrict __restrict
-/* Work around a bug in Sun C++: it does not support _Restrict or
-   __restrict__, even though the corresponding Sun C compiler ends up with
-   "#define restrict _Restrict" or "#define restrict __restrict__" in the
-   previous line.  Perhaps some future version of Sun C++ will work with
-   restrict; if so, hopefully it defines __RESTRICT like Sun C does.  */
-#if defined __SUNPRO_CC && !defined __RESTRICT
-# define _Restrict
-# define __restrict__
-#endif
-
-/* Define to how the compiler spells `typeof'. */
-/* #undef typeof */
+#endif /* PG_CONFIG_H */


### PR DESCRIPTION
Replace the hand-curated `postgres/pg_config.h.in` with a CMake-generated header built at configure time.

### Why

`postgres/pg_config.h.in` was a ~1 000-line snapshot of what `./configure` produces on one particular Linux/gcc host. Every value in it (`WORDS_BIGENDIAN`, `SIZEOF_*`, `ALIGNOF_*`, `HAVE_*`, `PG_PRINTF_ATTRIBUTE`, `PG_INT128_TYPE`, …) was baked in to whatever that machine detected, which is wrong on:

- **macOS**: no `fdatasync`, no `sync_file_range`.
- **Windows (MSYS2 / MinGW, LLP64)**: `long` is 32-bit → `HAVE_LONG_INT_64` must be off, `HAVE_LONG_LONG_INT_64` on; `INT64_MODIFIER` must be `"ll"`; MSVC has no `__int128`.
- **non-x86_64 Linux**: alignment and endian guesses can diverge.

The snapshot was explicitly flagged as *"… waiting to find a proper solution"*. This PR is that solution.

### What

- **New** `cmake/ConfigurePgConfig.cmake` (~290 lines). Does the per-host detection using CMake's standard primitives (`CheckTypeSize`, `CheckSymbolExists`, `CheckIncludeFile`, `CheckStructHasMember`, `CheckCSourceCompiles`, `TestBigEndian`), plus a small `offsetof`-based helper for `ALIGNOF_*` (CMake lacks a native primitive for that).
- **Rewritten** `postgres/pg_config.h.in` (~142 lines vs ~1 014). Uses `#cmakedefine` / `@var@` placeholders. Narrowed to the ~65 macros MEOS/MobilityDB actually references — audited by grepping every `.c` and `.h` in `meos/`, `mobilitydb/`, and `postgres/` against the old snapshot's define list.
- **Updated** `meos/CMakeLists.txt` to `include()` the module and `configure_file()` the header into `${CMAKE_BINARY_DIR}/postgres/pg_config.h` (out of the source tree).

The extension build (`MEOS=OFF`) is untouched — it consumes the installed PostgreSQL's own `pg_config.h`, never the one we generate.

### Diff size

```
 cmake/ConfigurePgConfig.cmake | +290
 postgres/pg_config.h.in       | +142 / -1014
 meos/CMakeLists.txt           |  +12 / -4
                               ─────────────────
 3 files changed, +441 / -1013
```

### Platform coverage

All six CI jobs on the branch pass:

- Main Build (Linux × {PG 14, 15, 16, 17, 18} × gcc)
- Build for Ubuntu with clang
- Build for macOS (macos-14 + macos-15, × {PG 17, 18})
- Build for Windows (MSYS2 UCRT64)
- Test MEOS compilation (Debug build + installed-library example link)
- CodeQL

### Features explicitly left as `#undef`

`USE_ICU`, `USE_OPENSSL`, `ENABLE_NLS`, `HAVE_PPC_LWARX_MUTEX_HINT` — MobilityDB/MEOS does not use any of them. Keeping them unset on every host shrinks the surface and makes the contrast with upstream PG's `configure` obvious.

### Note on `USE_ASSERT_CHECKING`

Debug builds do **not** enable it, even though it would be the intuitive thing to do. `Assert(...)` expands to a call to `ExceptionalCondition()` which is only provided by the PostgreSQL backend — MEOS standalone would not link. See the comment in `ConfigurePgConfig.cmake`.
