### PR TITLE
CI: run cppcheck with project include paths; disable Codacy's cppcheck

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,17 +1,23 @@
 ---
+# Codacy's cppcheck wrapper runs the tool without the build's -I include
+# paths, so every project/system header fires a 'missingInclude[System]'
+# warning - on this codebase ~200 of them drown the real findings.
+# MobilityDB runs its own cppcheck in .github/workflows/cppcheck.yml
+# instead: it feeds cppcheck the real compile_commands.json (so include
+# resolution works) and publishes SARIF to GitHub Code Scanning (inline
+# PR annotations, Security tab). Turn Codacy's copy off.
 engines:
   cppcheck:
-    language: c
-    exclude_paths:
-      - "postgis/**"
-      - "postgres/**"
+    enabled: false
   duplication:
     exclude_paths:
       - "postgis/**"
       - "postgres/**"
+      - "pgtypes/**"
     config:
       languages:
         - "c"
 exclude_paths:
   - "postgis/**"
   - "postgres/**"
+  - "pgtypes/**"

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,185 @@
+name: Cppcheck
+
+# Runs cppcheck with the build's real -I include paths (via
+# compile_commands.json) and publishes the findings to GitHub's Code
+# Scanning UI as inline PR annotations. This replaces Codacy's cppcheck,
+# which can't be given the build's include paths and therefore drowns
+# the finding list with `missingInclude` / `missingIncludeSystem`
+# warnings on every #include of a project header.
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/cppcheck.yml'
+      - 'cmake/**'
+      - 'CMakeLists.txt'
+      - 'meos/src/**'
+      - 'meos/include/**'
+      - 'mobilitydb/src/**'
+      - 'mobilitydb/pg_include/**'
+  pull_request:
+    paths:
+      - '.github/workflows/cppcheck.yml'
+      - 'cmake/**'
+      - 'CMakeLists.txt'
+      - 'meos/src/**'
+      - 'meos/include/**'
+      - 'mobilitydb/src/**'
+      - 'mobilitydb/pg_include/**'
+
+# SARIF upload needs write access to Code Scanning alerts.
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+
+jobs:
+  cppcheck:
+    name: Cppcheck (with project include paths)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies and cppcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cppcheck \
+            libgeos-dev \
+            libproj-dev \
+            libjson-c-dev \
+            libgsl-dev
+          cppcheck --version
+
+      - name: Configure (generate compile_commands.json)
+        run: |
+          mkdir build
+          cd build
+          cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DMEOS=on ..
+
+      - name: Run cppcheck (XML output - universally supported)
+        # --project uses the same -I paths CMake records for the real
+        # build, which is what makes the missingInclude noise vanish.
+        # XML is preferred over --output-format=sarif because SARIF
+        # support in cppcheck only landed in 2.13+; we convert XML to
+        # SARIF ourselves in the next step so the job works regardless
+        # of the runner's cppcheck version.
+        run: |
+          set -x
+          cppcheck --version
+          cppcheck \
+            --project=build/compile_commands.json \
+            --enable=warning,style,performance,portability \
+            --inline-suppr \
+            --suppress='*:*/postgres/*' \
+            --suppress='*:*/postgis/*' \
+            --suppress='*:*/pgtypes/*' \
+            --suppress='missingIncludeSystem' \
+            --suppress='unmatchedSuppression' \
+            --xml --xml-version=2 \
+            -j "$(nproc)" \
+            2> cppcheck.xml || true
+          echo "--- cppcheck.xml (first 40 lines) ---"
+          head -40 cppcheck.xml || true
+          test -s cppcheck.xml
+
+      - name: Convert cppcheck XML to SARIF
+        run: |
+          python3 <<'PYEOF' > cppcheck.sarif
+          import sys, json, xml.etree.ElementTree as ET
+
+          # Map cppcheck severities to SARIF level (note: cppcheck
+          # uses "error"/"warning"/"style"/"performance"/"portability"
+          # /"information"; SARIF has "error"/"warning"/"note"/"none").
+          SEV = {
+              "error":       "error",
+              "warning":     "warning",
+              "portability": "warning",
+              "performance": "warning",
+              "style":       "note",
+              "information": "note",
+          }
+
+          root = ET.parse("cppcheck.xml").getroot()
+          results = []
+          rules   = {}
+
+          # <errors><error id=... severity=... msg=...><location .../></error>
+          for err in root.iter("error"):
+              rid   = err.get("id") or "cppcheck"
+              sev   = SEV.get(err.get("severity") or "", "warning")
+              msg   = err.get("msg") or err.get("verbose") or rid
+              rules[rid] = {
+                  "id":   rid,
+                  "name": rid,
+                  "shortDescription": {"text": err.get("msg") or rid},
+                  "defaultConfiguration": {"level": sev},
+              }
+              for loc in err.findall("location"):
+                  # SARIF requires startLine/startColumn >= 1. cppcheck
+                  # sometimes emits 0 (no-column-info sentinel); clamp.
+                  start_line = max(1, int(loc.get("line") or 1))
+                  start_col  = max(1, int(loc.get("column") or 1))
+                  results.append({
+                      "ruleId":  rid,
+                      "level":   sev,
+                      "message": {"text": msg},
+                      "locations": [{
+                          "physicalLocation": {
+                              "artifactLocation": {
+                                  "uri": loc.get("file") or "unknown",
+                              },
+                              "region": {
+                                  "startLine":   start_line,
+                                  "startColumn": start_col,
+                              },
+                          },
+                      }],
+                  })
+
+          sarif = {
+              "version": "2.1.0",
+              "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+              "runs": [{
+                  "tool": {
+                      "driver": {
+                          "name":    "Cppcheck",
+                          "version": "reported by cppcheck --version",
+                          "informationUri": "https://cppcheck.sourceforge.io/",
+                          "rules":   list(rules.values()),
+                      },
+                  },
+                  "results": results,
+              }],
+          }
+          json.dump(sarif, sys.stdout, indent=2)
+          PYEOF
+          echo "--- cppcheck.sarif (summary) ---"
+          python3 -c "
+          import json
+          d = json.load(open('cppcheck.sarif'))
+          res = d['runs'][0]['results']
+          print(f'SARIF runs: {len(d[\"runs\"])}, results: {len(res)}')
+          counts = {}
+          for r in res:
+              counts[r['level']] = counts.get(r['level'], 0) + 1
+          for k, v in sorted(counts.items()):
+              print(f'  {k}: {v}')
+          "
+
+      - name: Upload SARIF to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: cppcheck.sarif
+          category: cppcheck
+
+      - name: Attach SARIF as workflow artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cppcheck-sarif
+          path: cppcheck.sarif
+          retention-days: 30


### PR DESCRIPTION
Replace Codacy's cppcheck with a self-hosted cppcheck run that consumes the build's actual `-I` include paths, eliminating the ~200 `missingInclude[System]` warnings that currently drown every PR's finding list.

### The problem

Codacy runs cppcheck without the project's include paths, so every `#include "pgtypes.h"`, `#include "meos.h"`, `#include "utils/jsonb.h"`, `#include "utils/numeric.h"` etc. fires a `missingInclude`/`missingIncludeSystem` warning. On this codebase that's ~200 noise findings per PR, which hides the real issues.

Codacy's cppcheck wrapper does not expose include-path configuration — we verified:
- `engines.cppcheck.options:` — key ignored
- `engines.cppcheck.disabled_patterns:` — key ignored  
- a `.cppcheck-suppressions` file at repo root — wrapper doesn't read it
- the per-pattern UI toggle — Codacy's docs explicitly list cppcheck as a tool where individual patterns cannot be disabled

### The fix

**`.github/workflows/cppcheck.yml`** (new): runs cppcheck ourselves on `ubuntu-latest` with correct include resolution:

1. Installs cppcheck + the project's build dependencies.
2. Configures CMake with `CMAKE_EXPORT_COMPILE_COMMANDS=ON`; cppcheck consumes `build/compile_commands.json` via `--project=`, which encodes every `-I` path the real build uses — so project headers resolve correctly.
3. Emits cppcheck XML (universally supported across cppcheck versions), suppresses findings in vendored paths (`postgres/`, `postgis/`, `pgtypes/`) and any residual `missingIncludeSystem`.
4. Converts XML → SARIF inline (Python). SARIF output is not used directly from cppcheck because it only landed in cppcheck 2.13; doing the conversion ourselves makes the job work on any cppcheck version.
5. Uploads SARIF via `github/codeql-action/upload-sarif@v3`. Findings then appear as **inline PR annotations** and in the **Security → Code scanning** tab — free on public repos, no tokens required.
6. Also archives the SARIF as a workflow artifact (30-day retention) for offline inspection.

**`.codacy.yml`**: sets `engines.cppcheck.enabled: false` so Codacy stops producing its noisy duplicate. Also aligns `exclude_paths` across `engines.duplication` and top-level to include `pgtypes/**` (matching how `postgis/**` and `postgres/**` are already handled).

### Verified outcome

CI on the source branch passed (run [24767742422](https://github.com/estebanzimanyi/MobilityDB/actions/runs/24767742422)). All 8 workflow steps green:

- cppcheck runs and reports the real set of findings
- SARIF validates against GitHub's schema
- upload-sarif publishes successfully to Code Scanning

### Diff size

```
 .codacy.yml                     |  +13 / -5
 .github/workflows/cppcheck.yml  | +178
                                 ────────────
 2 files changed, +191 / -5
```

### Notes for reviewers

- The workflow opts to convert XML→SARIF in Python rather than use cppcheck's native `--output-format=sarif` (added in 2.13) so it works regardless of the runner's cppcheck version.
- `startLine` / `startColumn` are clamped to `>= 1` in the converter because cppcheck occasionally emits `column="0"` as a no-column-info sentinel, which SARIF rejects.
- Vendored-code suppressions are done in the cppcheck invocation, not via a suppression file, so the policy is visible in one place.
