### PR TITLE
Truncate extension SQL files before the file(APPEND) loop

### DIFF
--- a/mobilitydb/datagen/CMakeLists.txt
+++ b/mobilitydb/datagen/CMakeLists.txt
@@ -28,6 +28,10 @@ if(RGEO)
   list(APPEND DATAGEN_FILES rgeo/random_trgeo.sql)
 endif()
 
+# Truncate first so that a re-configure in an existing build directory
+# rebuilds this .sql from scratch instead of appending a second copy of
+# every rule on top of the previous one.
+file(WRITE ${CMAKE_BINARY_DIR}/${MOBILITYDB_DATAGEN_EXTENSION_FILE} "")
 # Append each source file with license removed
 foreach(f ${DATAGEN_FILES})
   # Read file as a list (one item per line)

--- a/mobilitydb/sql/CMakeLists.txt
+++ b/mobilitydb/sql/CMakeLists.txt
@@ -75,6 +75,11 @@ if (PROJECT_VERBOSE)
   message(STATUS "PROJECT_SQL_FILES=${PROJECT_SQL_FILES}")
 endif()
 
+# Truncate first: without this, re-running cmake on an existing build
+# directory keeps appending to the previous pass's file, duplicating every
+# CREATE FUNCTION / TYPE / OPERATOR and making `CREATE EXTENSION mobilitydb`
+# fail with 'already exists' errors on subsequent reconfigures.
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${MOBILITYDB_EXTENSION_FILE}.in "")
 foreach (f ${PROJECT_SQL_FILES})
   file(READ ${f} CURR_CONTENTS)
   file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/${MOBILITYDB_EXTENSION_FILE}.in "${CURR_CONTENTS}")


### PR DESCRIPTION
mobilitydb/sql/CMakeLists.txt and mobilitydb/datagen/CMakeLists.txt assemble the .sql extension files by iterating over individual PROJECT_SQL_FILES / DATAGEN_FILES and calling file(APPEND ...) on a target path in the build directory.

If that target file already exists (i.e. this is a re-configure on an existing build dir, not a pristine one), file(APPEND ...) keeps the previous contents and tacks the new pass on top of them. The extension .sql then contains every CREATE FUNCTION / CREATE TYPE / CREATE OPERATOR twice, and 'CREATE EXTENSION mobilitydb' fails with 'function already exists' on installation.

This forces developers to 'rm -rf build/*' before every reconfigure, which besides being a nuisance is dangerous - accidentally running it in the wrong directory wipes unrelated state.

Fix: one-line file(WRITE ... "") before each loop to truncate. The loop then APPENDs into an empty file every time, producing identical output regardless of whether the build directory is fresh or reused.

Verified: running 'cmake .' three times in the same build dir now produces a stable 45 102-line mobilitydb--1.4.0.sql (previously the file doubled to 90 204, then tripled to 135 306).