### PR TITLE
Fix atValues on tpose when segment endpoints share a position

### DIFF
--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -257,13 +257,13 @@ posesegm_locate(const Pose *start, const Pose *end, const Pose *value)
     double Y2 = end->data[5],   Z2 = end->data[6];
     double W  = value->data[3], X  = value->data[4];
     double Y  = value->data[5], Z  = value->data[6];
-    /* Align q2 and q_value to the same hemisphere as q1 */
+    /* Align q2 and q_value to the same hemisphere as q1. We only need
+     * the absolute value of the dot product downstream, so negating
+     * dot12 is sufficient — the individual W2/X2/Y2/Z2 components are
+     * not read again (the same trick is applied to dot1v below). */
     double dot12 = W1 * W2 + X1 * X2 + Y1 * Y2 + Z1 * Z2;
     if (dot12 < 0.0)
-    {
-      W2 = -W2; X2 = -X2; Y2 = -Y2; Z2 = -Z2;
       dot12 = -dot12;
-    }
     double dot1v = W1 * W + X1 * X + Y1 * Y + Z1 * Z;
     if (dot1v < 0.0)
     {

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -223,9 +223,8 @@ posesegm_interpolate(const Pose *start, const Pose *end, double ratio)
 long double
 posesegm_locate(const Pose *start, const Pose *end, const Pose *value)
 {
-   /* Return if the value to locate has a different road identifier */
-  if (ensure_valid_pose_pose(start, end) || 
-      ensure_valid_pose_pose(start, value))
+  if (! ensure_valid_pose_pose(start, end) ||
+      ! ensure_valid_pose_pose(start, value))
     return -1.0;
 
   GSERIALIZED *gs1 = pose_to_point(start);
@@ -248,13 +247,46 @@ posesegm_locate(const Pose *start, const Pose *end, const Pose *value)
   }
   if (MEOS_FLAGS_GET_Z(start->flags))
   {
-    // TODO
+    /* Invert the SLERP applied in posesegm_interpolate. For
+     * q(t) = SLERP(q1, q2, t) with theta_0 = acos(dot(q1, q2)),
+     *   dot(q1, q(t)) = cos(t * theta_0)
+     * hence t = acos(dot(q1, q_value)) / theta_0. */
+    double W1 = start->data[3], X1 = start->data[4];
+    double Y1 = start->data[5], Z1 = start->data[6];
+    double W2 = end->data[3],   X2 = end->data[4];
+    double Y2 = end->data[5],   Z2 = end->data[6];
+    double W  = value->data[3], X  = value->data[4];
+    double Y  = value->data[5], Z  = value->data[6];
+    /* Align q2 and q_value to the same hemisphere as q1 */
+    double dot12 = W1 * W2 + X1 * X2 + Y1 * Y2 + Z1 * Z2;
+    if (dot12 < 0.0)
+    {
+      W2 = -W2; X2 = -X2; Y2 = -Y2; Z2 = -Z2;
+      dot12 = -dot12;
+    }
+    double dot1v = W1 * W + X1 * X + Y1 * Y + Z1 * Z;
+    if (dot1v < 0.0)
+    {
+      dot1v = -dot1v;
+    }
+    if (dot12 >  1.0) dot12 =  1.0;
+    if (dot1v >  1.0) dot1v =  1.0;
+    /* Constant rotation segment */
+    if (dot12 > 1.0 - MEOS_EPSILON)
+    {
+      if (dot1v < 1.0 - MEOS_EPSILON)
+        return -1.0;
+      return result1;
+    }
+    double theta_0 = acos(dot12);
+    result2 = (long double) (acos(dot1v) / theta_0);
+    if (result2 < 0.0 || result2 > 1.0)
       return -1.0;
   }
   else
   {
     double rotation1 = pose_rotation(start);
-    double rotation2 = pose_rotation(value);
+    double rotation2 = pose_rotation(end);
     double rotation = pose_rotation(value);
     if (rotation1 != rotation2)
     {
@@ -264,17 +296,19 @@ posesegm_locate(const Pose *start, const Pose *end, const Pose *value)
     }
     else
     {
-      /* If the rotiation are equal return result1 where
-       * - result1 = -1.0 if gs1 == gs2 == gs, or
-       * - result1 in [0,1] if gs1 != gs2 */
+      /* Constant rotation segment: only valid if the value has the same
+       * rotation; returns result1, which is -1.0 if gs1 == gs2 == gs, or
+       * in [0,1] if gs1 != gs2 */
+      if (rotation1 != rotation)
+        return -1.0;
       return result1;
     }
   }
   if (result1 >= 0.0 && result2 >= 0.0)
     return (fabsl(result1 - result2) <= MEOS_EPSILON) ? result1 : -1.0;
-  if (result1 < 0.0 && result2 >= 0)
+  if (result1 < 0.0 && result2 >= 0.0)
     return result2;
-  else if(result1 >= 0 && result2 <= 0)
+  else if (result1 >= 0.0 && result2 < 0.0)
     return result1;
   else /* The three values are equal */
     return -1.0;

--- a/meos/src/pose/tpose.c
+++ b/meos/src/pose/tpose.c
@@ -121,58 +121,19 @@ tposesegm_intersection_value(Datum start, Datum end, Datum value,
   TimestampTz lower, TimestampTz upper, TimestampTz *t1, TimestampTz *t2)
 {
   assert(lower < upper); assert(t1); assert(t2);
-  /* We are sure that the trajectory is a line */
-  Datum geom_start = datum_pose_point(start);
-  Datum geom_end = datum_pose_point(end);
-  Datum geom = datum_pose_point(value);
-  double dist;
-  /* Compute the value taking into account position only */
-  double fraction = (double) pointsegm_locate(geom_start, geom_end, geom,
-    &dist);
-  pfree(DatumGetPointer(geom_start)); pfree(DatumGetPointer(geom_end));
-  pfree(DatumGetPointer(geom));
-  if (fraction < 0.0)
-    return 0;
-  /* Compare value with interpolated pose to take into account orientation as
-   * well */
   const Pose *pose1 = DatumGetPoseP(start);
   const Pose *pose2 = DatumGetPoseP(end);
-  Pose *pose_interp = posesegm_interpolate(pose1, pose2, fraction);
-  Pose *pose = DatumGetPoseP(value);
-  bool same = pose_same(pose, pose_interp);
-  /* Temporal rigid geometries have poses as base values but are restricted
-   * to geometries */
-  // bool same;
-  // if (inst1->temptype == T_TRGEOMETRY)
-  // {
-    // const GSERIALIZED *gs1 = DatumGetGserializedP(start);
-    // const GSERIALIZED *gs2 = DatumGetGserializedP(value);
-    // LWGEOM *geom1 = lwgeom_from_gserialized(gs1);
-    // LWGEOM *geom2 = lwgeom_from_gserialized(gs2);
-    // LWGEOM *geom_interp = lwgeom_clone_deep(geom2);
-    // lwgeom_apply_pose(pose_interp, geom_interp);
-    // if (geom_interp->bbox)
-      // lwgeom_refresh_bbox(geom_interp);
-    // same = lwgeom_same(geom1, geom_interp);
-    // lwgeom_free(geom1); lwgeom_free(geom2); lwgeom_free(geom_interp);
-  // }
-  // else
-  // {
-    // Pose *pose = DatumGetPoseP(value);
-    // same = pose_same(pose, pose_interp);
-  // }
-  pfree(pose_interp);
-  if (! same)
+  const Pose *pose = DatumGetPoseP(value);
+  /* Locate the value in the segment accounting for both position and
+   * rotation; this handles the case where pose1 and pose2 share the same
+   * point but differ in rotation. */
+  long double fraction = posesegm_locate(pose1, pose2, pose);
+  if (fraction < 0.0)
     return 0;
-  if (t1)
-  {
-    double duration = (double) (upper - lower);
-    /* Note that due to roundoff errors it may be the case that the
-     * resulting timestamp t may be equal to inst1->t or to inst2->t */
-    *t1 = lower + (TimestampTz) (duration * fraction);
-    if (t2)
-      *t2 = *t1;
-  }
+  double duration = (double) (upper - lower);
+  *t1 = lower + (TimestampTz) (duration * (double) fraction);
+  if (t2)
+    *t2 = *t1;
   return 1;
 }
 

--- a/meos/src/temporal/tsequence.c
+++ b/meos/src/temporal/tsequence.c
@@ -284,10 +284,11 @@ datumsegm_interpolate(Datum start, Datum end, meosType temptype,
     return PointerGetDatum(npointsegm_interpolate(DatumGetNpointP(start),
       DatumGetNpointP(end), ratio));
 #endif
-// #if POSE || RGEO
-  // else if (temptype == T_TPOSE)
-    // return PointerGetDatum(posesegm_interpolate(start, end, ratio));
-// #endif
+#if POSE || RGEO
+  else if (temptype == T_TPOSE)
+    return PointerGetDatum(posesegm_interpolate(DatumGetPoseP(start),
+      DatumGetPoseP(end), (double) ratio));
+#endif
   else
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,

--- a/mobilitydb/test/pose/expected/102_tpose.test.out
+++ b/mobilitydb/test/pose/expected/102_tpose.test.out
@@ -1586,6 +1586,102 @@ SELECT asText(minusTime(tpose '{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 
  {(Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST], [Pose(POINT(2 2),0.6)@Tue Jan 04 00:00:00 2000 PST, Pose(POINT(2 2),0.6)@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
+SELECT asText(beforeTimestamp(tpose 'Pose(Point(1 1), 0.5)@2000-01-01', timestamptz '2000-01-01'));
+ astext 
+--------
+ 
+(1 row)
+
+SELECT asText(beforeTimestamp(tpose '{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}', timestamptz '2000-01-01'));
+ astext 
+--------
+ 
+(1 row)
+
+SELECT asText(beforeTimestamp(tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]', timestamptz '2000-01-01'));
+ astext 
+--------
+ 
+(1 row)
+
+SELECT asText(beforeTimestamp(tpose '{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}', timestamptz '2000-01-01'));
+ astext 
+--------
+ 
+(1 row)
+
+SELECT asText(beforeTimestamp(tpose 'Pose(Point(1 1), 0.5)@2000-01-01', timestamptz '2000-01-01', false));
+                      astext                       
+---------------------------------------------------
+ Pose(POINT(1 1),0.5)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(beforeTimestamp(tpose '{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}', timestamptz '2000-01-01', false));
+                       astext                        
+-----------------------------------------------------
+ {Pose(POINT(1 1),0.3)@Sat Jan 01 00:00:00 2000 PST}
+(1 row)
+
+SELECT asText(beforeTimestamp(tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]', timestamptz '2000-01-01', false));
+                       astext                        
+-----------------------------------------------------
+ [Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST]
+(1 row)
+
+SELECT asText(beforeTimestamp(tpose '{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}', timestamptz '2000-01-01', false));
+                        astext                         
+-------------------------------------------------------
+ {[Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(afterTimestamp(tpose 'Pose(Point(1 1), 0.5)@2000-01-01', timestamptz '2000-01-01'));
+ astext 
+--------
+ 
+(1 row)
+
+SELECT asText(afterTimestamp(tpose '{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}', timestamptz '2000-01-01'));
+ astext 
+--------
+ 
+(1 row)
+
+SELECT asText(afterTimestamp(tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]', timestamptz '2000-01-01'));
+                                                                          astext                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ (Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
+SELECT asText(afterTimestamp(tpose '{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}', timestamptz '2000-01-01'));
+                                                                                                                               astext                                                                                                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {(Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST], [Pose(POINT(2 2),0.6)@Tue Jan 04 00:00:00 2000 PST, Pose(POINT(2 2),0.6)@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(afterTimestamp(tpose 'Pose(Point(1 1), 0.5)@2000-01-01', timestamptz '2000-01-01', false));
+                      astext                       
+---------------------------------------------------
+ Pose(POINT(1 1),0.5)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(afterTimestamp(tpose '{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}', timestamptz '2000-01-01', false));
+                                                                          astext                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ {Pose(POINT(1 1),0.3)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
+SELECT asText(afterTimestamp(tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]', timestamptz '2000-01-01', false));
+                                                                          astext                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ [Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
+SELECT asText(afterTimestamp(tpose '{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}', timestamptz '2000-01-01', false));
+                                                                                                                               astext                                                                                                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST], [Pose(POINT(2 2),0.6)@Tue Jan 04 00:00:00 2000 PST, Pose(POINT(2 2),0.6)@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
 SELECT asText(deleteTime(tpose 'Pose(Point(1 1), 0.5)@2000-01-01', timestamptz '2000-01-01'));
  astext 
 --------


### PR DESCRIPTION
The bug: atValues(tpose [Pose(p, r1)@t1, Pose(p, r2)@t2], pose(p, rv)) returned empty when rv interpolated correctly between r1 and r2 because tposesegm_intersection_value used pointsegm_locate, which sees only the position. When the segment's endpoints share the same point, the locate call returned fraction 0 and the rotation dimension was silently dropped.

- posesegm_locate: flip the inverted validity guard, fix the rotation2 read-from-value typo, tighten the constant-rotation branch, and implement the 3D branch as the SLERP inverse t = acos(dot(q1,qv)) / acos(dot(q1,q2)), mirroring the hemisphere alignment and near-identity fallback used in posesegm_interpolate.
- tposesegm_intersection_value: delegate to posesegm_locate so the rotation dimension is part of the locate from the start.
- datumsegm_interpolate: re-enable the T_TPOSE dispatch (was commented out, causing "Unknown interpolate function for type: tpose").
- 102_tpose expected output: regenerate to cover the beforeTimestamp / afterTimestamp cases added to the query file.