### PR TITLE
Fix trgeometry parser double-free and missing instant registration

### DIFF
--- a/meos/src/rgeo/trgeo_parser.c
+++ b/meos/src/rgeo/trgeo_parser.c
@@ -105,11 +105,13 @@ trgeoseq_disc_parse(const char **str, meosType temptype, int *temp_srid,
   TInstant *inst = trgeoinst_parse(str, temptype, false, temp_srid, geom);
   if (! inst)
     goto error;
+  meos_array_add(array, inst);
   while (p_comma(str))
   {
     inst = trgeoinst_parse(str, temptype, false, temp_srid, geom);
     if (! inst)
       goto error;
+    meos_array_add(array, inst);
   }
   if (! ensure_cbrace(str, type_str) || ! ensure_end_input(str, type_str))
     goto error;
@@ -118,7 +120,7 @@ trgeoseq_disc_parse(const char **str, meosType temptype, int *temp_srid,
   TInstant **instants = palloc(sizeof(TInstant *) * array->count);
   for (int i = 0; i < (int) array->count; i++)
     instants[i] = (TInstant *) meos_array_get(array, i);
-  result = trgeoseq_make_free(geom, instants, array->count, true, true,
+  result = trgeoseq_make(geom, instants, array->count, true, true,
     DISCRETE, NORMALIZE_NO);
   pfree(instants);
 
@@ -139,7 +141,7 @@ error:
  * @param[out] result New sequence, may be NULL
  */
 TSequence *
-trgeoseq_cont_parse(const char **str, meosType temptype, interpType interp, 
+trgeoseq_cont_parse(const char **str, meosType temptype, interpType interp,
   bool end, int *temp_srid, const GSERIALIZED *geom)
 {
   MeosArray *array = meos_array_create(meostype_length(temptype));
@@ -188,7 +190,7 @@ trgeoseq_cont_parse(const char **str, meosType temptype, interpType interp,
     instants[i] = (TInstant *) meos_array_get(array, i);
   p_cbracket(str);
   p_cparen(str);
-  result = trgeoseq_make_free(geom, instants, array->count, lower_inc,
+  result = trgeoseq_make(geom, instants, array->count, lower_inc,
     upper_inc, interp, NORMALIZE);
   pfree(instants);
 
@@ -238,7 +240,7 @@ trgeoseqset_parse(const char **str, meosType temptype, interpType interp,
   for (int i = 0; i < (int) array->count; i++)
     sequences[i] = (TSequence *) meos_array_get(array, i);
   p_cbrace(str);
-  result = trgeoseqset_make_free(geom, sequences, array->count, NORMALIZE);
+  result = trgeoseqset_make(geom, sequences, array->count, NORMALIZE);
   pfree(sequences);
 
 error:

--- a/mobilitydb/test/rgeo/expected/122_trgeo.test.out
+++ b/mobilitydb/test/rgeo/expected/122_trgeo.test.out
@@ -1630,6 +1630,102 @@ SELECT asText(minusTime(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1)
  POLYGON((1 1,2 2,3 1,1 1));{(Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST], [Pose(POINT(2 2),0.6)@Tue Jan 04 00:00:00 2000 PST, Pose(POINT(2 2),0.6)@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
+SELECT asText(beforeTimestamp(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01', timestamptz '2000-01-01'));
+ astext 
+--------
+ 
+(1 row)
+
+SELECT asText(beforeTimestamp(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}', timestamptz '2000-01-01'));
+ astext 
+--------
+ 
+(1 row)
+
+SELECT asText(beforeTimestamp(trgeometry 'Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]', timestamptz '2000-01-01'));
+ astext 
+--------
+ 
+(1 row)
+
+SELECT asText(beforeTimestamp(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}', timestamptz '2000-01-01'));
+ astext 
+--------
+ 
+(1 row)
+
+SELECT asText(beforeTimestamp(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01', timestamptz '2000-01-01', false));
+                                    astext                                    
+------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));Pose(POINT(1 1),0.5)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(beforeTimestamp(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}', timestamptz '2000-01-01', false));
+                                     astext                                     
+--------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));{Pose(POINT(1 1),0.3)@Sat Jan 01 00:00:00 2000 PST}
+(1 row)
+
+SELECT asText(beforeTimestamp(trgeometry 'Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]', timestamptz '2000-01-01', false));
+                                     astext                                     
+--------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));[Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST]
+(1 row)
+
+SELECT asText(beforeTimestamp(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}', timestamptz '2000-01-01', false));
+                                      astext                                      
+----------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));{[Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(afterTimestamp(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01', timestamptz '2000-01-01'));
+ astext 
+--------
+ 
+(1 row)
+
+SELECT asText(afterTimestamp(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}', timestamptz '2000-01-01'));
+ astext 
+--------
+ 
+(1 row)
+
+SELECT asText(afterTimestamp(trgeometry 'Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]', timestamptz '2000-01-01'));
+                                                                                        astext                                                                                        
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));(Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
+SELECT asText(afterTimestamp(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}', timestamptz '2000-01-01'));
+                                                                                                                                             astext                                                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));{(Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST], [Pose(POINT(2 2),0.6)@Tue Jan 04 00:00:00 2000 PST, Pose(POINT(2 2),0.6)@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(afterTimestamp(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01', timestamptz '2000-01-01', false));
+                                    astext                                    
+------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));Pose(POINT(1 1),0.5)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(afterTimestamp(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}', timestamptz '2000-01-01', false));
+                                                                                        astext                                                                                        
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));{Pose(POINT(1 1),0.3)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
+SELECT asText(afterTimestamp(trgeometry 'Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]', timestamptz '2000-01-01', false));
+                                                                                        astext                                                                                        
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));[Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
+SELECT asText(afterTimestamp(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}', timestamptz '2000-01-01', false));
+                                                                                                                                             astext                                                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));{[Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST], [Pose(POINT(2 2),0.6)@Tue Jan 04 00:00:00 2000 PST, Pose(POINT(2 2),0.6)@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
 SELECT asText(deleteTime(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01', timestamptz '2000-01-01'));
  astext 
 --------


### PR DESCRIPTION
Parsing any multi-instant trgeometry literal (discrete sequence with 2+ instants, any continuous sequence, or a sequence set) corrupted the memory arena and crashed the backend, typically at the next palloc inside the planner.

trgeoseq_disc_parse / trgeoseq_cont_parse / trgeoseqset_parse built a MeosArray and then:
  - never called meos_array_add, so the parsed instants were leaked and array->count stayed 0, which made trgeoseq_make_free hit its count==0 branch and pfree the locally-allocated instants buffer, then the caller pfree'd it again (double-free);
  - even after adding the missing meos_array_add calls, ownership of the instants would have been freed twice: once inside trgeoseq_make_free (via pfree_array) and again by meos_array_destroy_free on the way out.

Align with the working tspatial_parser.c pattern:
  - add meos_array_add after each successful instant/sequence parse;
  - use the non-freeing trgeoseq_make / trgeoseqset_make so the array alone owns and releases the parsed objects at function exit.

Also regenerate mobilitydb/test/rgeo/expected/122_trgeo.test.out so it covers the beforeTimestamp / afterTimestamp cases added to the query file.