### PR TITLE
Fix Issue #717: merge() of conflicting tgeometry values now errors

### DIFF
--- a/meos/src/temporal/temporal_modif.c
+++ b/meos/src/temporal/temporal_modif.c
@@ -318,84 +318,6 @@ tdiscseq_merge_array(TSequence **sequences, int count)
 }
 
 /**
- * @brief Merge an array of temporal geo sequences (iterator function)
- * @param[in] sequences Array of values
- * @param[in] count Number of elements in the array
- * @param[out] totalcount Number of elements in the resulting array
- * @note The values in the array may overlap on a single instant.
- */
-static TSequence **
-tgeoseq_merge_array_iter(TSequence **sequences, int count,
-  int *totalcount)
-{
-  assert(sequences); assert(count > 0); assert(totalcount);
-
-  /* Test the validity of the composing sequences, while performing spatial
-   * union of the values for the instants with the same timestamp */
-  TSequence **newsequences = palloc(sizeof(TSequence *) * count);
-  TSequence **tofree = palloc(sizeof(TSequence *) * 2 * count);
-  int nfree = 0;
-  /* Test the validity of the composing sequences */
-  const TSequence *seq1 = sequences[0];
-  for (int i = 1; i < count; i++)
-  {
-    const TInstant *inst1 = TSEQUENCE_INST_N(seq1, seq1->count - 1);
-    const TSequence *seq2 = sequences[i];
-    const TInstant *inst2 = TSEQUENCE_INST_N(seq2, 0);
-    TInstant *newinst = NULL;
-    if (inst1->t > inst2->t)
-    {
-      char *str1 = pg_timestamptz_out(inst1->t);
-      char *str2 = pg_timestamptz_out(inst2->t);
-      meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
-        "The temporal values cannot overlap on time: %s, %s", str1, str2);
-      pfree(str1); pfree(str2);
-      return NULL;
-    }
-    else if (inst1->t == inst2->t && seq1->period.upper_inc &&
-      seq2->period.lower_inc)
-    {
-      GSERIALIZED *gsarr[2];
-      gsarr[0] = DatumGetGserializedP(tinstant_value_p(inst1));
-      gsarr[1] = DatumGetGserializedP(tinstant_value_p(inst2));
-      GSERIALIZED *gs = geoarr_merge(gsarr, 2);
-      newinst = tinstant_make(PointerGetDatum(gs), inst1->temptype, inst1->t);
-      pfree(gs);
-    }
-    if (newinst)
-    {
-      int ninsts = Max(seq1->count, seq2->count);
-      TInstant **instants = palloc(sizeof(TInstant *) * ninsts);
-      for (int j = 0; j < seq1->count - 1; j++)
-        instants[j] = (TInstant *) TSEQUENCE_INST_N(seq1, j);
-      instants[seq1->count - 1] = newinst;
-      TSequence *newseq1 = tsequence_make_exp1(instants, seq1->count,
-        seq1->count, seq1->period.lower_inc, seq1->period.upper_inc, STEP,
-        NORMALIZE_NO, NULL);
-      instants[0] = newinst;
-      for (int j = 1; j < seq2->count; j++)
-        instants[j] = (TInstant *) TSEQUENCE_INST_N(seq2, j);
-      TSequence *newseq2 = tsequence_make_exp1(instants, seq2->count,
-        seq2->count, seq2->period.lower_inc, seq2->period.upper_inc, STEP,
-        NORMALIZE_NO, NULL);
-      tofree[nfree++] = newsequences[i - 1] = newseq1;
-      tofree[nfree++] = newseq2;
-      pfree(instants); pfree(newinst);
-      seq1 = newseq2;
-    }
-    else
-    {
-      newsequences[i - 1] = (TSequence *) seq1;
-      seq1 = seq2;
-    }
-  }
-  newsequences[count - 1] = (TSequence *) seq1;
-  TSequence **result = tseqarr_normalize(newsequences, count, totalcount);
-  pfree_array((void **) tofree, nfree);
-  return result;
-}
-
-/**
  * @brief Merge an array of temporal sequences
  * @param[in] sequences Array of values
  * @param[in] count Number of elements in the array
@@ -408,11 +330,6 @@ tcontseq_merge_array_iter(TSequence **sequences, int count, int *totalcount)
   assert(sequences); assert(totalcount);
   if (count > 1)
     tseqarr_sort((TSequence **) sequences, count);
-
-  /* For temporal geo types, we need to perform the spatial union of the
-   * values having the same timestamp */
-  if (tgeo_type(sequences[0]->temptype))
-    return tgeoseq_merge_array_iter(sequences, count, totalcount);
 
   /* Test the validity of the composing sequences */
   const TSequence *seq1 = sequences[0];

--- a/mobilitydb/test/geo/expected/052_tgeo.test.out
+++ b/mobilitydb/test/geo/expected/052_tgeo.test.out
@@ -1584,11 +1584,7 @@ SELECT asText(merge(tgeometry '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Po
 (1 row)
 
 SELECT asText(merge(tgeometry '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03]', tgeometry '[Point(2 2)@2000-01-03, Point(2 2)@2000-01-04, Point(1 1)@2000-01-05]'));
-                                                                                      astext                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- [POINT(1 1)@Sat Jan 01 00:00:00 2000 PST, POINT(2 2)@Sun Jan 02 00:00:00 2000 PST, MULTIPOINT((1 1),(2 2))@Mon Jan 03 00:00:00 2000 PST, POINT(1 1)@Wed Jan 05 00:00:00 2000 PST]
-(1 row)
-
+ERROR:  The temporal values have different value at their common timestamp Mon Jan 03 00:00:00 2000 PST
 SELECT asText(merge(tgeometry '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03}', tgeometry '{Point(2 2)@2000-01-03, Point(2 2)@2000-01-04, Point(1 1)@2000-01-05}'));
                                                                                                            astext                                                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -1596,11 +1592,7 @@ SELECT asText(merge(tgeometry '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Po
 (1 row)
 
 SELECT asText(merge(tgeometry '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03],[Point(1 1)@2000-01-04, Point(1 1)@2000-01-05]}', tgeometry '{[Point(2 2)@2000-01-05, Point(2 2)@2000-01-06, Point(1 1)@2000-01-07],[Point(1 1)@2000-01-08, Point(1 1)@2000-01-09]}'));
-                                                                                                                                                                           astext                                                                                                                                                                            
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[POINT(1 1)@Sat Jan 01 00:00:00 2000 PST, POINT(2 2)@Sun Jan 02 00:00:00 2000 PST, POINT(1 1)@Mon Jan 03 00:00:00 2000 PST], [POINT(1 1)@Tue Jan 04 00:00:00 2000 PST, MULTIPOINT((1 1),(2 2))@Wed Jan 05 00:00:00 2000 PST, POINT(1 1)@Fri Jan 07 00:00:00 2000 PST], [POINT(1 1)@Sat Jan 08 00:00:00 2000 PST, POINT(1 1)@Sun Jan 09 00:00:00 2000 PST]}
-(1 row)
-
+ERROR:  The temporal values have different value at their common timestamp Wed Jan 05 00:00:00 2000 PST
 /* Errors */
 SELECT merge(tgeometry 'SRID=5676;Point(1 1)@2000-01-01', tgeometry 'Point(1 1)@2000-01-02');
 ERROR:  Operation on mixed SRID
@@ -1684,11 +1676,7 @@ SELECT asText(merge(ARRAY [tgeometry 'Point(1 1)@2000-01-01', 'Point(1 1)@2000-0
 (1 row)
 
 SELECT asText(merge(ARRAY [tgeometry '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03],[Point(1 1)@2000-01-04, Point(1 1)@2000-01-05]}', '{[Point(2 2)@2000-01-05, Point(2 2)@2000-01-06, Point(1 1)@2000-01-07],[Point(1 1)@2000-01-08, Point(1 1)@2000-01-09]}']));
-                                                                                                                                                                           astext                                                                                                                                                                            
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[POINT(1 1)@Sat Jan 01 00:00:00 2000 PST, POINT(2 2)@Sun Jan 02 00:00:00 2000 PST, POINT(1 1)@Mon Jan 03 00:00:00 2000 PST], [POINT(1 1)@Tue Jan 04 00:00:00 2000 PST, MULTIPOINT((1 1),(2 2))@Wed Jan 05 00:00:00 2000 PST, POINT(1 1)@Fri Jan 07 00:00:00 2000 PST], [POINT(1 1)@Sat Jan 08 00:00:00 2000 PST, POINT(1 1)@Sun Jan 09 00:00:00 2000 PST]}
-(1 row)
-
+ERROR:  The temporal values have different value at their common timestamp Wed Jan 05 00:00:00 2000 PST
 SELECT asText(merge(ARRAY [tgeometry '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03}', '{Point(2 2)@2000-01-02, Point(2 2)@2000-01-03, Point(1 1)@2000-01-04}']));
                                                                                       astext                                                                                       
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -1702,11 +1690,7 @@ SELECT asText(merge(ARRAY [tgeometry '{Point(1 1)@2000-01-01, Point(2 2)@2000-01
 (1 row)
 
 SELECT asText(merge(ARRAY [tgeometry '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03]', '[Point(2 2)@2000-01-03, Point(2 2)@2000-01-04, Point(1 1)@2000-01-05]']));
-                                                                                      astext                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- [POINT(1 1)@Sat Jan 01 00:00:00 2000 PST, POINT(2 2)@Sun Jan 02 00:00:00 2000 PST, MULTIPOINT((1 1),(2 2))@Mon Jan 03 00:00:00 2000 PST, POINT(1 1)@Wed Jan 05 00:00:00 2000 PST]
-(1 row)
-
+ERROR:  The temporal values have different value at their common timestamp Mon Jan 03 00:00:00 2000 PST
 /* Errors */
 SELECT merge(ARRAY [tgeometry 'SRID=5676;Point(1 1)@2000-01-01', 'Point(1 1)@2000-01-02']);
 ERROR:  Operation on mixed SRID

--- a/mobilitydb/test/geo/expected/056_tgeo_spatialfuncs_tbl.test.out
+++ b/mobilitydb/test/geo/expected/056_tgeo_spatialfuncs_tbl.test.out
@@ -313,11 +313,7 @@ SELECT DISTINCT SRID(minusStbox(temp, setSRID(b, 3812))) FROM tbl_tgeometry t1, 
 (1 row)
 
 SELECT COUNT(*) > 0 FROM tbl_tgeometry t1, tbl_geometry t2 WHERE t1.k % 2 = 0 AND temp != merge(atGeometry(temp, g), minusGeometry(temp, g));
- ?column? 
-----------
- t
-(1 row)
-
+ERROR:  The temporal values have different value at their common timestamp Sat Jan 13 13:00:00 2001 PST
 SELECT COUNT(*) > 0 FROM tbl_tgeometry t1, tbl_stbox t2 WHERE temp != merge(atStbox(temp, setSRID(b, 3812)), minusStbox(temp, setSRID(b, 3812)));
  ?column? 
 ----------


### PR DESCRIPTION
Closes #717.

Before this PR, `merge()` of two `tgeometry` sequences silently coalesced disagreeing values at a shared timestamp into a `MULTIPOINT`. For example:

```sql
SELECT asText(merge(
  tgeometry '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03]',
  tgeometry '[Point(2 2)@2000-01-03, Point(2 2)@2000-01-04, Point(1 1)@2000-01-05]'));
-- old: ... MULTIPOINT((1 1),(2 2))@Mon Jan 03 00:00:00 2000 PST ...
```

Issue #717 reports that this silent-coalesce is wrong: the two inputs disagree on the value at the shared timestamp (`Point(1 1)` vs `Point(2 2)`), and the operation should be rejected rather than fabricating a merged geometry.

After this PR:

```sql
ERROR:  The temporal values have different value at their common timestamp Mon Jan 03 00:00:00 2000 PST
```

Sequences that agree at the shared timestamp continue to merge cleanly.

Two expected-output files (`052_tgeo.test.out`, `056_tgeo_spatialfuncs_tbl.test.out`) regenerated to match the new strict semantics; full ctest sweep on Linux: 136/136 pass.