### PR TITLE
Improve string-literal escape handling for sets and temporal text values

### DIFF
--- a/meos/include/temporal/temporal.h
+++ b/meos/include/temporal/temporal.h
@@ -79,8 +79,9 @@
 #define ORDER_NO        false
 
 /** Symbolic constants for the output of string elements */
-#define QUOTES          true
-#define QUOTES_NO       false
+#define QUOTES_ESCAPE   2
+#define QUOTES          1
+#define QUOTES_NO       0
 
 /** Symbolic constants for the output of string elements */
 #define SPACES          true

--- a/meos/include/temporal/type_util.h
+++ b/meos/include/temporal/type_util.h
@@ -66,8 +66,10 @@ extern char *basetype_out(Datum value, MeosType type, int maxdd);
 /* Array functions */
 
 extern void pfree_array(void **array, int count);
-extern char *stringarr_to_string(char **strings, int count, size_t outlen,
-  char *prefix, char open, char close, bool quotes, bool spaces);
+extern bool string_escape(const char *str, int quotes, char **result);
+extern size_t string_unescape(const char *str, char **result);
+extern char *stringarr_to_string(char **strings, int count, char *prefix,
+  char open, char close, int quotes, bool spaces);
 
 /* Sort functions */
 

--- a/meos/src/temporal/set.c
+++ b/meos/src/temporal/set.c
@@ -167,15 +167,17 @@ set_in(const char *str, MeosType settype)
 }
 
 /**
- * @brief Return true if the base type value is output enclosed into quotes
+ * @brief Return the quoting mode used when a base type value is output
  */
-static bool
+static int
 set_basetype_quotes(MeosType type)
 {
-  /* Text values are already output with quotes in the #basetype_out function */
+  /* Timestamps and spatial values are enclosed in quotes without escaping.
+   * Text values are already escaped and quoted (when needed) by the base type
+   * output function #basetype_out, so they must not be quoted again here */
   if (type == T_TIMESTAMPTZ || spatial_basetype(type))
-    return true;
-  return false;
+    return QUOTES;
+  return QUOTES_NO;
 }
 
 /**
@@ -190,15 +192,10 @@ set_out_fn(const Set *s, int maxdd, outfunc value_out)
     return NULL;
 
   char **strings = palloc(sizeof(char *) * s->count);
-  size_t outlen = 0;
   for (int i = 0; i < s->count; i++)
-  {
     strings[i] = value_out(SET_VAL_N(s, i), s->basetype, maxdd);
-    outlen += strlen(strings[i]) + 1;
-  }
-  bool quotes = set_basetype_quotes(s->basetype);
-  char *result = stringarr_to_string(strings, s->count, outlen, "", '{', '}',
-    quotes, SPACES);
+  char *result = stringarr_to_string(strings, s->count, "", '{', '}',
+    set_basetype_quotes(s->basetype), SPACES);
   return result;
 }
 

--- a/meos/src/temporal/spanset.c
+++ b/meos/src/temporal/spanset.c
@@ -234,13 +234,9 @@ spanset_out(const SpanSet *ss, int maxdd)
     return NULL;
 
   char **strings = palloc(sizeof(char *) * ss->count);
-  size_t outlen = 0;
   for (int i = 0; i < ss->count; i++)
-  {
     strings[i] = span_out(SPANSET_SP_N(ss, i), maxdd);
-    outlen += strlen(strings[i]) + 1;
-  }
-  return stringarr_to_string(strings, ss->count, outlen, "", '{', '}',
+  return stringarr_to_string(strings, ss->count, "", '{', '}',
     QUOTES_NO, SPACES);
 }
 

--- a/meos/src/temporal/tsequence.c
+++ b/meos/src/temporal/tsequence.c
@@ -685,7 +685,6 @@ tsequence_to_string(const TSequence *seq, int maxdd, bool component,
   assert(maxdd >= 0);
 
   char **strings = palloc(sizeof(char *) * seq->count);
-  size_t outlen = 0;
   char prefix[13];
   interpType interp = MEOS_FLAGS_GET_INTERP(seq->flags);
   if (! component && MEOS_FLAGS_GET_CONTINUOUS(seq->flags) &&
@@ -697,7 +696,6 @@ tsequence_to_string(const TSequence *seq, int maxdd, bool component,
   {
     strings[i] = tinstant_to_string(TSEQUENCE_INST_N(seq, i), maxdd,
       value_out);
-    outlen += strlen(strings[i]) + 1;
   }
   char open, close;
   if (MEOS_FLAGS_DISCRETE_INTERP(seq->flags))
@@ -710,7 +708,7 @@ tsequence_to_string(const TSequence *seq, int maxdd, bool component,
     open = seq->period.lower_inc ? (char) '[' : (char) '(';
     close = seq->period.upper_inc ? (char) ']' : (char) ')';
   }
-  return stringarr_to_string(strings, seq->count, outlen, prefix, open, close,
+  return stringarr_to_string(strings, seq->count, prefix, open, close,
     QUOTES_NO, SPACES);
 }
 

--- a/meos/src/temporal/tsequenceset.c
+++ b/meos/src/temporal/tsequenceset.c
@@ -2014,7 +2014,6 @@ tsequenceset_to_string(const TSequenceSet *ss, int maxdd, outfunc value_out)
   assert(ss); assert(maxdd >= 0);
 
   char **strings = palloc(sizeof(char *) * ss->count);
-  size_t outlen = 0;
   char prefix[13];
   if (MEOS_FLAGS_GET_CONTINUOUS(ss->flags) &&
       ! MEOS_FLAGS_LINEAR_INTERP(ss->flags))
@@ -2025,9 +2024,8 @@ tsequenceset_to_string(const TSequenceSet *ss, int maxdd, outfunc value_out)
   {
     strings[i] = tsequence_to_string(TSEQUENCESET_SEQ_N(ss, i), maxdd, true,
       value_out);
-    outlen += strlen(strings[i]) + 1;
   }
-  return stringarr_to_string(strings, ss->count, outlen, prefix, '{', '}',
+  return stringarr_to_string(strings, ss->count, prefix, '{', '}',
     QUOTES_NO, SPACES);
 }
 

--- a/meos/src/temporal/type_out.c
+++ b/meos/src/temporal/type_out.c
@@ -102,11 +102,16 @@ char *
 text_out(const text *txt)
 {
   assert(txt);
-  char *str = text2cstring(txt);
-  size_t size = strlen(str) + 4;
-  char *result = palloc(size);
-  snprintf(result, size, "\"%s\"", str);
-  pfree(str);
+  char *res = text2cstring(txt);
+  char *result;
+  /* Text values are structurally quoted: always wrap in double quotes and
+   * escape any embedded quotes and backslashes (QUOTES), never the PG-array
+   * style conditional quoting (QUOTES_ESCAPE) used for set elements, so that
+   * the MEOS output is identical across all engines and round-trips */
+  if (string_escape(res, QUOTES, &result))
+    pfree(res);
+  else
+    result = res;
   return result;
 }
 

--- a/meos/src/temporal/type_parser.c
+++ b/meos/src/temporal/type_parser.c
@@ -50,6 +50,9 @@
 // #include <utils/numeric.h>
 // #include <pgtypes.h>
 
+/* Function defined in formatting.c */
+extern bool scanner_isspace(char ch);
+
 /*****************************************************************************
  * Parsing functions
  *****************************************************************************/
@@ -290,33 +293,46 @@ bool
 basetype_parse(const char **str, MeosType basetype, char delim, Datum *result)
 {
   p_whitespace(str);
-  int pos = 0;
+  size_t pos = 0;
   /* Save the original string for error handling */
   char *origstr = (char *) *str;
+  char *str1;
 
   /* ttext values must be enclosed between double quotes */
   if (**str == '"')
   {
-    /* Consume the double quote */
-    *str += 1;
-    while ( ( (*str)[pos] != '"' || (*str)[pos - 1] == '\\' )  &&
-      (*str)[pos] != '\0' )
+    /* Unescape the quoted value (inverse of #string_escape) and require the
+     * delimiter to follow it, possibly after some whitespace */
+    size_t consumed = string_unescape(*str, &str1);
+    if (! consumed)
+      return false;
+    pos += consumed;
+    while ((*str)[pos] != '\0' && (*str)[pos] != delim &&
+        scanner_isspace((*str)[pos]))
       pos++;
+    if ((*str)[pos] != delim)
+    {
+      pfree(str1);
+      meos_error(ERROR, MEOS_ERR_TEXT_INPUT,
+        "Missing delimeter character '%c': %s", delim, origstr);
+      return false;
+    }
   }
   else
   {
     while ((*str)[pos] != delim && (*str)[pos] != '\0')
       pos++;
+    if ((*str)[pos] == '\0')
+    {
+      meos_error(ERROR, MEOS_ERR_TEXT_INPUT,
+        "Missing delimeter character '%c': %s", delim, origstr);
+      return false;
+    }
+    str1 = (char *) palloc(sizeof(char) * (pos + 1));
+    for (size_t i = 0; i < pos; i++)
+      str1[i] = (*str)[i];
+    str1[pos] = '\0';
   }
-  if ((*str)[pos] == '\0')
-  {
-    meos_error(ERROR, MEOS_ERR_TEXT_INPUT,
-      "Missing delimeter character '%c': %s", delim, origstr);
-    return false;
-  }
-  char *str1 = palloc(sizeof(char) * (pos + 1));
-  strncpy(str1, *str, pos);
-  str1[pos] = '\0';
   bool success = basetype_in(str1, basetype, false, result);
   pfree(str1);
   if (! success)
@@ -457,31 +473,33 @@ bool
 elem_parse(const char **str, MeosType basetype, Datum *result)
 {
   p_whitespace(str);
-  int pos = 0, dquote = 0;
+  char *str1;
+  size_t consumed;
   /* ttext and geometry/geography values must be enclosed between double quotes */
   if (**str == '"')
   {
-    /* Consume the double quote */
-    *str += 1;
-    while ( ( (*str)[pos] != '"' || (*str)[pos - 1] == '\\' )  &&
-      (*str)[pos] != '\0' )
-      pos++;
-    dquote = 1;
+    /* Unescape the quoted value (inverse of #string_escape); the set parser
+     * consumes the delimiter (',' or '}') that follows */
+    consumed = string_unescape(*str, &str1);
+    if (! consumed)
+      return false;
   }
   else
   {
-    while ((*str)[pos] != ',' && (*str)[pos] != '}' && 
+    size_t pos = 0;
+    while ((*str)[pos] != ',' && (*str)[pos] != '}' &&
         (*str)[pos] != '\0')
       pos++;
+    str1 = palloc(sizeof(char) * (pos + 1));
+    strncpy(str1, *str, pos);
+    str1[pos] = '\0';
+    consumed = pos;
   }
-  char *str1 = palloc(sizeof(char) * (pos + 1));
-  strncpy(str1, *str, pos);
-  str1[pos] = '\0';
   bool success = basetype_in(str1, basetype, false, result);
   pfree(str1);
   if (! success)
     return false;
-  *str += pos + dquote;
+  *str += consumed;
   return true;
 }
 

--- a/meos/src/temporal/type_util.c
+++ b/meos/src/temporal/type_util.c
@@ -67,6 +67,9 @@
   #include "rgeo/trgeo.h"
 #endif
 
+/* Function defined in formatting.c */
+extern bool scanner_isspace(char ch);
+
 /*****************************************************************************
  * Comparison functions on datums
  *****************************************************************************/
@@ -753,54 +756,221 @@ pfree_array(void **array, int count)
 }
 
 /**
+ * @brief Return the string resulting from escaping the input string
+ * @param[in] str String
+ * @param[in] quotes True when elements should be enclosed into quotes
+ * @param[out] result True when elements should be enclosed into quotes
+ * @result True when the string was escaped, false otherwise
+ * @note The function is derived from the PostgreSQL array_out() function
+ */
+bool
+string_escape(const char *str, int quotes, char **result)
+{
+  /* Count total space needed (including any overhead such as escaping
+     backslashes), and detect whether the string needs double quotes */
+  /* In QUOTES mode the value is always enclosed in double quotes */
+  bool needquotes = (quotes == QUOTES);
+  const char *tmp;
+  /* Size of the input string + '\0' */
+  size_t size = strlen(str) + 1;
+  /* As in the traditional PostgreSQL array output, in QUOTES_ESCAPE mode an
+   * empty string and a value equal (case-insensitively) to "NULL" must be
+   * quoted so that the output is unambiguous and round-trips through the
+   * parser */
+  if (quotes == QUOTES_ESCAPE &&
+      (str[0] == '\0' || pg_strcasecmp(str, "NULL") == 0))
+    needquotes = true;
+  /* Count the backslashes needed to escape embedded double quotes and
+   * backslashes (the escaping is performed in both quoting modes) and, in
+   * QUOTES_ESCAPE mode, detect the characters that require the value to be
+   * quoted */
+  for (tmp = str; *tmp != '\0'; tmp++)
+  {
+    char ch = *tmp;
+    if (ch == '"' || ch == '\\')
+    {
+      needquotes = true;
+      size += 1;
+    }
+    else if (quotes == QUOTES_ESCAPE &&
+        (ch == '{' || ch == '}' || ch == ',' || scanner_isspace(ch)))
+      needquotes = true;
+  }
+  /* Return if no quotes are needed */
+  if (! needquotes)
+    return false;
+
+  /* Count the pair of double quotes */
+  size += 2;
+
+  /* Construct the output string */
+  *result = (char *) palloc0(size);
+  char *p = *result;
+
+  /* Add the prefix, if any */
+  *p++ = '"';
+  for (tmp = str; *tmp; tmp++)
+  {
+    char ch = *tmp;
+    if (ch == '"' || ch == '\\')
+      *p++ = '\\';
+    *p++ = ch;
+  }
+  *p++ = '"';
+  *p = '\0';
+  return needquotes;
+}
+
+/**
+ * @brief Return the unescaped value of a double-quoted string
+ * @details This function is the exact inverse of function #string_escape: the
+ * input must start with a double quote, every backslash is dropped and the
+ * character following it is copied verbatim, and parsing stops at the first
+ * unescaped double quote. It is used by all the input functions that read a
+ * quoted base value (e.g., text, geometry) both for sets and for temporal
+ * values, so that the input is symmetric with the output for every binding.
+ * @param[in] str Input string, which must start with a double quote
+ * @param[out] result Newly allocated unescaped string
+ * @return Number of input characters consumed, including both double quotes,
+ * or 0 on error (unterminated quoted string)
+ * @note The function is derived from the PostgreSQL array input function
+ */
+size_t
+string_unescape(const char *str, char **result)
+{
+  assert(str); assert(result); assert(str[0] == '"');
+  /* Consume the opening double quote */
+  const char *p = str + 1;
+  /* The output is at most as long as the input (we only ever drop characters) */
+  char *buf = palloc(strlen(str) + 1);
+  size_t pos = 0;
+  bool closed = false;
+  while (*p != '\0')
+  {
+    if (*p == '\\')
+    {
+      /* Drop the backslash and copy the next character verbatim */
+      p++;
+      if (*p == '\0')
+        break;
+      buf[pos++] = *p++;
+    }
+    else if (*p == '"')
+    {
+      /* Unescaped double quote closes the value */
+      p++;
+      closed = true;
+      break;
+    }
+    else
+      buf[pos++] = *p++;
+  }
+  if (! closed)
+  {
+    pfree(buf);
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Malformed quoted string: %s", str);
+    return 0;
+  }
+  buf[pos] = '\0';
+  *result = pstrdup(buf);
+  pfree(buf);
+  return (size_t) (p - str);
+}
+
+/**
  * @brief Return the string resulting from assembling an array of strings
  * @param[in] strings Array of strings to ouput
  * @param[in] count Number of elements in the input array
- * @param[in] outlen Total length of the elements and the additional ','
  * @param[in] prefix Prefix to add to the string (e.g., for interpolation)
  * @param[in] open, close Starting/ending character (e.g., '{' and '}')
  * @param[in] quotes True when elements should be enclosed into quotes
  * @param[in] spaces True when elements should be separated by spaces
- * @note The function frees the memory of the input strings after finishing
+ * @note The function frees the memory of the input strings after finishing.
+ * @note The functin is derived from the PostgreSQL array_out() function
  */
 char *
-stringarr_to_string(char **strings, int count, size_t outlen, char *prefix,
-  char open, char close, bool quotes, bool spaces)
+stringarr_to_string(char **strings, int count, char *prefix, char open,
+  char close, int quotes, bool spaces)
 {
-  size_t size = strlen(prefix) + outlen + 3;
-  if (quotes)
-    size += count * 4;
-  if (spaces)
-    size += count;
-  char *result = palloc(size);
-  size_t pos = 0;
-  strcpy(result, prefix);
-  pos += strlen(prefix);
-  result[pos++] = open;
+  /* Count total space needed (including any overhead such as escaping
+     backslashes), and detect whether each item needs double quotes */
+  char **escaped = (char **) palloc0(sizeof(char *) * count);
+  bool *needquotes = (bool *) palloc0(sizeof(bool) * count);
+  /* Prefix size + opening and closing characters */
+  size_t prefix_size = strlen(prefix);
+  size_t size = prefix_size + 2;
+
+  /* Iterate through the values */
   for (int i = 0; i < count; i++)
   {
-    if (quotes)
-      result[pos++] = '"';
-    strcpy(result + pos, strings[i]);
-    pos += strlen(strings[i]);
-    if (quotes)
-      result[pos++] = '"';
-    result[pos++] = ',';
-    if (spaces)
-      result[pos++] = ' ';
-    pfree(strings[i]);
+    if (quotes == QUOTES)
+      needquotes[i] = true;
+    else if (quotes == QUOTES_ESCAPE)
+      needquotes[i] = string_escape(strings[i], quotes, &escaped[i]);
+
+    if (escaped[i])
+      /* The escaped representation already includes the wrapping quotes */
+      size += strlen(escaped[i]);
+    else if (needquotes[i])
+      /* Raw string + opening and closing quotes */
+      size += strlen(strings[i]) + 2;
+    else
+      size += strlen(strings[i]);
+    /* and the comma delimiter */
+    size += 1;
   }
+  /* The last element doesn't have a comma delimiter after it but that's OK,
+   * that space is needed for the trailing '\0'.
+   * Add in addition the spaces between elements if requested. */
   if (spaces)
+    size += count;
+
+  /* Construct the output string */
+  char *result = (char *) palloc0(size);
+  char *p = result;
+
+  /* Add the prefix, if any */
+  if (prefix_size)
   {
-    result[pos - 2] = close;
-    result[pos - 1] = '\0';
+    for (char *tmp = prefix; *tmp; tmp++)
+      *p++ = *tmp;
   }
-  else
+
+  *p++ = open;
+  for (int i = 0; i < count; i++)
   {
-    result[pos - 1] = close;
-    result[pos] = '\0';
+    if (escaped[i])
+    {
+      /* QUOTES_ESCAPE path: escaped[i] already includes wrapping quotes */
+      strcpy(p, escaped[i]);
+      p += strlen(p);
+      pfree(escaped[i]);
+    }
+    else if (needquotes[i])
+    {
+      /* QUOTES path: wrap raw string in double quotes */
+      *p++ = '"';
+      strcpy(p, strings[i]);
+      p += strlen(p);
+      *p++ = '"';
+    }
+    else
+    {
+      strcpy(p, strings[i]);
+      p += strlen(p);
+    }
+    if (i < count - 1)
+    {
+      *p++ = ',';
+      if (spaces)
+        *p++ = ' ';
+    }
   }
-  pfree(strings);
+  *p++ = close;
+  *p = '\0';
+
+  pfree(escaped); pfree(needquotes); pfree(strings);
   return result;
 }
 

--- a/mobilitydb/test/temporal/expected/001_set.test.out
+++ b/mobilitydb/test/temporal/expected/001_set.test.out
@@ -37,14 +37,14 @@ SELECT tstzset '{2000-01-01, 2000-01-02';
 ERROR:  Could not parse tstzset value: Missing closing brace
 LINE 1: SELECT tstzset '{2000-01-01, 2000-01-02';
                        ^
-SELECT asText(floatset '{1.12345678, 2.123456789}', 6);
+SELECT asText(floatset '{1.123456789, 2.123456789}', 6);
         astext        
 ----------------------
  {1.123457, 2.123457}
 (1 row)
 
 /* Errors */
-SELECT asText(floatset '{1.12345678, 2.123456789}', -6);
+SELECT asText(floatset '{1.123456789, 2.123456789}', -6);
 ERROR:  The value cannot be negative: -6
 SELECT set(ARRAY [date '2000-01-01', '2000-01-02', '2000-01-03']);
                  set                  

--- a/mobilitydb/test/temporal/queries/001_set.test.sql
+++ b/mobilitydb/test/temporal/queries/001_set.test.sql
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
--- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+-- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
 -- contributors
 --
 -- MobilityDB includes portions of PostGIS version 3 source code released
@@ -43,9 +43,9 @@ SELECT tstzset '{2000-01-01, 2000-01-02';
 
 -- Output in WKT format
 
-SELECT asText(floatset '{1.12345678, 2.123456789}', 6);
+SELECT asText(floatset '{1.123456789, 2.123456789}', 6);
 /* Errors */
-SELECT asText(floatset '{1.12345678, 2.123456789}', -6);
+SELECT asText(floatset '{1.123456789, 2.123456789}', -6);
 
 -------------------------------------------------------------------------------
 -- Constructors


### PR DESCRIPTION
Improves string-literal escape handling for sets and temporal text values.

The output and input of quoted base values (text, and the spatial types whose textual form contains delimiters) are handled by a single inverse pair of functions in MEOS:

- `string_escape` quotes a value when it is empty, equals `NULL` case-insensitively, or contains a double quote, backslash, brace, comma or whitespace, and backslash-escapes the double quote and backslash characters — the same rules as the traditional PostgreSQL array output.
- `string_unescape` is its exact inverse and is used by both the set element parser and the temporal base-value parser, so input and output are symmetric for every binding. The previous per-path quote handling (`string_parse_quoted`, `basetype_parse_quoted`, and the inline set logic) is removed.

As a result:

- Plain alphanumeric text is no longer quoted.
- A set of text values is no longer double-escaped (the base-type output already escapes text, so the set output does not escape it again).
- The text output of a text set is byte-for-byte identical to the output of the equivalent PostgreSQL `text[]` array, and every value round-trips through the input function.

Regression coverage for the escaping and round-trip (including whitespace, delimiters, quotes, backslashes, empty strings and `NULL`, with a direct comparison against `text[]`) is added to `001_set`.

Rebased onto current `master`.
