### PR TITLE
Guard stbox_level_cmp against centroids without a time dimension

### DIFF
--- a/mobilitydb/src/geo/tspatial_spgist.c
+++ b/mobilitydb/src/geo/tspatial_spgist.c
@@ -297,10 +297,12 @@ stboxnode_kdtree_next(const STboxNode *nodebox, const STBox *centroid,
   uint8 node, int level, STboxNode *next_nodebox)
 {
   bool hasz = MEOS_FLAGS_GET_Z(centroid->flags);
-  memcpy(next_nodebox, nodebox, sizeof(STboxNode));
   bool hast = MEOS_FLAGS_GET_T(centroid->flags);
   int dims = 4 + (hasz ? 2 : 0) + (hast ? 2 : 0);
+  int zdim = 4;
+  int tdim = 4 + (hasz ? 2 : 0);
   int mod = level % dims;
+  memcpy(next_nodebox, nodebox, sizeof(STboxNode));
   if (mod == 0)
   {
     /* Split the bounding box by lower bound  */
@@ -333,7 +335,7 @@ stboxnode_kdtree_next(const STboxNode *nodebox, const STBox *centroid,
     else
       next_nodebox->left.ymax = centroid->ymax;
   }
-  else if (hasz && mod == 4)
+  else if (hasz && mod == zdim)
   {
     /* Split the bounding box by lower bound  */
     if (node == 0)
@@ -341,7 +343,7 @@ stboxnode_kdtree_next(const STboxNode *nodebox, const STBox *centroid,
     else
       next_nodebox->left.zmin = centroid->zmin;
   }
-  else if (hasz && mod == 5)
+  else if (hasz && mod == zdim + 1)
   {
     /* Split the bounding box by upper bound */
     if (node == 0)
@@ -349,7 +351,7 @@ stboxnode_kdtree_next(const STboxNode *nodebox, const STBox *centroid,
     else
       next_nodebox->left.zmax = centroid->zmax;
   }
-  else if ((hasz && mod == 6) || (! hasz && mod == 4))
+  else if (hast && mod == tdim)
   {
     /* Split the bounding box by lower bound  */
     if (node == 0)
@@ -357,7 +359,7 @@ stboxnode_kdtree_next(const STboxNode *nodebox, const STBox *centroid,
     else
       next_nodebox->left.period.lower = centroid->period.lower;
   }
-  else /* (hasz && mod == 7) || (! hasz && mod == 5) */
+  else /* hast && mod == tdim + 1 */
   {
     /* Split the bounding box by upper bound */
     if (node == 0)
@@ -400,6 +402,8 @@ overlapKD(const STboxNode *nodebox, const STBox *query, int level)
   bool hasz = MEOS_FLAGS_GET_Z(nodebox->left.flags);
   bool hast = MEOS_FLAGS_GET_T(nodebox->left.flags);
   int dims = 4 + (hasz ? 2 : 0) + (hast ? 2 : 0);
+  int zdim = 4;
+  int tdim = 4 + (hasz ? 2 : 0);
   int mod = level % dims;
   bool result = true;
   /* Result value is computed only for the dimensions of the query */
@@ -416,17 +420,17 @@ overlapKD(const STboxNode *nodebox, const STBox *query, int level)
   }
   if (MEOS_FLAGS_GET_Z(query->flags))
   {
-    if (hasz && mod == 4)
+    if (hasz && mod == zdim)
       result &= nodebox->left.zmin <= query->zmax;
-    else if (hasz && mod == 5)
+    else if (hasz && mod == zdim + 1)
       result &= nodebox->right.zmax >= query->zmin;
   }
   if (MEOS_FLAGS_GET_T(query->flags))
   {
-    if ((hasz && mod == 6) || (! hasz && mod == 4))
+    if (hast && mod == tdim)
       result &= datum_le(nodebox->left.period.lower, query->period.upper,
         T_TIMESTAMPTZ);
-    else /* (hasz && mod == 7) || (! hasz && mod == 5) */
+    else if (hast && mod == tdim + 1)
       result &= datum_ge(nodebox->right.period.upper, query->period.lower,
         T_TIMESTAMPTZ);
   }
@@ -465,6 +469,8 @@ containKD(const STboxNode *nodebox, const STBox *query, int level)
   bool hasz = MEOS_FLAGS_GET_Z(nodebox->left.flags);
   bool hast = MEOS_FLAGS_GET_T(nodebox->left.flags);
   int dims = 4 + (hasz ? 2 : 0) + (hast ? 2 : 0);
+  int zdim = 4;
+  int tdim = 4 + (hasz ? 2 : 0);
   int mod = level % dims;
   bool result = true;
   /* Result value is computed only for the dimensions of the query */
@@ -481,17 +487,17 @@ containKD(const STboxNode *nodebox, const STBox *query, int level)
   }
   if (MEOS_FLAGS_GET_Z(query->flags))
   {
-    if (hasz && mod == 4)
+    if (hasz && mod == zdim)
       result &= nodebox->left.zmin <= query->zmin;
-    else if (hasz && mod == 5)
+    else if (hasz && mod == zdim + 1)
       result &= nodebox->right.zmax >= query->zmax;
   }
   if (MEOS_FLAGS_GET_T(query->flags))
   {
-    if ((hasz && mod == 6) || (! hasz && mod == 4))
+    if (hast && mod == tdim)
       result &= datum_le(nodebox->left.period.lower, query->period.lower,
         T_TIMESTAMPTZ);
-    else /* (hasz && mod == 7) || (! hasz && mod == 5) */
+    else if (hast && mod == tdim + 1)
       result &= datum_ge(nodebox->right.period.upper, query->period.upper,
         T_TIMESTAMPTZ);
   }
@@ -914,6 +920,8 @@ stbox_level_cmp(STBox *centroid, STBox *query, int level)
   bool hasz = MEOS_FLAGS_GET_Z(centroid->flags);
   bool hast = MEOS_FLAGS_GET_T(centroid->flags);
   int dims = 4 + (hasz ? 2 : 0) + (hast ? 2 : 0);
+  int zdim = 4;
+  int tdim = 4 + (hasz ? 2 : 0);
   int mod = level % dims;
   if (mod == 0)
     return stbox_xmin_cmp(query, centroid);
@@ -923,13 +931,13 @@ stbox_level_cmp(STBox *centroid, STBox *query, int level)
     return stbox_ymin_cmp(query, centroid);
   else if (mod == 3)
     return stbox_ymax_cmp(query, centroid);
-  else if (hasz && mod == 4)
+  else if (hasz && mod == zdim)
     return stbox_zmin_cmp(query, centroid);
-  else if (hasz && mod == 5)
+  else if (hasz && mod == zdim + 1)
     return stbox_zmax_cmp(query, centroid);
-  else if (hast && ((hasz && mod == 6) || (! hasz && mod == 4)))
+  else if (hast && mod == tdim)
     return stbox_tmin_cmp(query, centroid);
-  else if (hast && ((hasz && mod == 7) || (! hasz && mod == 5)))
+  else if (hast && mod == tdim + 1)
     return stbox_tmax_cmp(query, centroid);
   /* We should never arrive here */
   elog(ERROR, "stbox_level_cmp: unexpected error");
@@ -1112,6 +1120,8 @@ Stbox_kdtree_picksplit(PG_FUNCTION_ARGS)
   bool hasz = MEOS_FLAGS_GET_Z(sorted[0].box.flags);
   bool hast = MEOS_FLAGS_GET_T(sorted[0].box.flags);
   int dims = 4 + (hasz ? 2 : 0) + (hast ? 2 : 0);
+  int zdim = 4;
+  int tdim = 4 + (hasz ? 2 : 0);
   int mod = in->level % dims;
   qsort_comparator qsortfn;
   if (mod == 0)
@@ -1122,13 +1132,13 @@ Stbox_kdtree_picksplit(PG_FUNCTION_ARGS)
     qsortfn = (qsort_comparator) &stbox_ymin_cmp;
   else if (mod == 3)
     qsortfn = (qsort_comparator) &stbox_ymax_cmp;
-  else if (hasz && mod == 4)
+  else if (hasz && mod == zdim)
     qsortfn = (qsort_comparator) &stbox_zmin_cmp;
-  else if (hasz && mod == 5)
+  else if (hasz && mod == zdim + 1)
     qsortfn = (qsort_comparator) &stbox_zmax_cmp;
-  else if (hast && ((hasz && mod == 6) || (! hasz && mod == 4)))
+  else if (hast && mod == tdim)
     qsortfn = (qsort_comparator) &stbox_tmin_cmp;
-  else /* (hasz && mod == 7) || (! hasz && mod == 5) */
+  else /* hast && mod == tdim + 1 */
     qsortfn = (qsort_comparator) &stbox_tmax_cmp;
   qsort(sorted, in->nTuples, sizeof(SortedSTbox), qsortfn);
   int median = in->nTuples >> 1;

--- a/mobilitydb/src/geo/tspatial_spgist.c
+++ b/mobilitydb/src/geo/tspatial_spgist.c
@@ -903,6 +903,7 @@ static int
 stbox_level_cmp(STBox *centroid, STBox *query, int level)
 {
   bool hasz = MEOS_FLAGS_GET_Z(centroid->flags);
+  bool hast = MEOS_FLAGS_GET_T(centroid->flags);
   int mod = hasz ? level % 8 : level % 6;
   if (mod == 0)
     return stbox_xmin_cmp(query, centroid);
@@ -916,10 +917,12 @@ stbox_level_cmp(STBox *centroid, STBox *query, int level)
     return stbox_zmin_cmp(query, centroid);
   else if (hasz && mod == 5)
     return stbox_zmax_cmp(query, centroid);
-  else if ((hasz && mod == 6) || (! hasz && mod == 4))
+  else if (hast && ((hasz && mod == 6) || (! hasz && mod == 4)))
     return stbox_tmin_cmp(query, centroid);
-  else /* (hasz && mod == 7) || (! hasz && mod == 5) */
+  else if (hast && ((hasz && mod == 7) || (! hasz && mod == 5)))
     return stbox_tmax_cmp(query, centroid);
+  /* We should never arrive here */
+  elog(ERROR, "stbox_level_cmp: unexpected error");
 }
 
 PGDLLEXPORT Datum Stbox_kdtree_choose(PG_FUNCTION_ARGS);

--- a/mobilitydb/src/geo/tspatial_spgist.c
+++ b/mobilitydb/src/geo/tspatial_spgist.c
@@ -187,11 +187,14 @@ getQuadrant8D(const STBox *centroid, const STBox *inBox)
   if (inBox->xmax > centroid->xmax)
     quadrant |= 0x04;
 
-  if (datum_gt(inBox->period.lower, centroid->period.lower, T_TIMESTAMPTZ))
-    quadrant |= 0x02;
+  if (MEOS_FLAGS_GET_T(centroid->flags))
+  {
+    if (datum_gt(inBox->period.lower, centroid->period.lower, T_TIMESTAMPTZ))
+      quadrant |= 0x02;
 
-  if (datum_gt(inBox->period.upper, centroid->period.upper, T_TIMESTAMPTZ))
-    quadrant |= 0x01;
+    if (datum_gt(inBox->period.upper, centroid->period.upper, T_TIMESTAMPTZ))
+      quadrant |= 0x01;
+  }
 
   return quadrant;
 }
@@ -973,6 +976,7 @@ Stbox_quadtree_picksplit(PG_FUNCTION_ARGS)
   spgPickSplitOut *out = (spgPickSplitOut *) PG_GETARG_POINTER(1);
   STBox *box = DatumGetSTboxP(in->datums[0]);
   bool hasz = MEOS_FLAGS_GET_Z(box->flags);
+  bool hast = MEOS_FLAGS_GET_T(box->flags);
   STBox *centroid = palloc0(sizeof(STBox));
   centroid->srid = box->srid;
   centroid->flags = box->flags;
@@ -987,10 +991,14 @@ Stbox_quadtree_picksplit(PG_FUNCTION_ARGS)
     lowZs = palloc(sizeof(double) * in->nTuples);
     highZs = palloc(sizeof(double) * in->nTuples);
   }
-  TimestampTz *lowTs = palloc(sizeof(TimestampTz) * in->nTuples);
-  TimestampTz *highTs = palloc(sizeof(TimestampTz) * in->nTuples);
+  TimestampTz *lowTs = NULL, *highTs = NULL; /* make compiler quiet */
+  if (hast)
+  {
+    lowTs = palloc(sizeof(TimestampTz) * in->nTuples);
+    highTs = palloc(sizeof(TimestampTz) * in->nTuples);
+  }
 
-  /* Calculate median of all 8D coordinates */
+  /* Calculate median of all coordinates */
   for (i = 0; i < in->nTuples; i++)
   {
     box = DatumGetSTboxP(in->datums[i]);
@@ -1003,8 +1011,11 @@ Stbox_quadtree_picksplit(PG_FUNCTION_ARGS)
       lowZs[i] = box->zmin;
       highZs[i] = box->zmax;
     }
-    lowTs[i] = DatumGetTimestampTz(box->period.lower);
-    highTs[i] = DatumGetTimestampTz(box->period.upper);
+    if (hast)
+    {
+      lowTs[i] = DatumGetTimestampTz(box->period.lower);
+      highTs[i] = DatumGetTimestampTz(box->period.upper);
+    }
   }
 
   qsort(lowXs, (size_t) in->nTuples, sizeof(double), compareFloat8);
@@ -1016,8 +1027,13 @@ Stbox_quadtree_picksplit(PG_FUNCTION_ARGS)
     qsort(lowZs, (size_t) in->nTuples, sizeof(double), compareFloat8);
     qsort(highZs, (size_t) in->nTuples, sizeof(double), compareFloat8);
   }
-  qsort(lowTs, (size_t) in->nTuples, sizeof(TimestampTz), compareTimestampTz);
-  qsort(highTs, (size_t) in->nTuples, sizeof(TimestampTz), compareTimestampTz);
+  if (hast)
+  {
+    qsort(lowTs, (size_t) in->nTuples, sizeof(TimestampTz),
+      compareTimestampTz);
+    qsort(highTs, (size_t) in->nTuples, sizeof(TimestampTz),
+      compareTimestampTz);
+  }
 
   median = in->nTuples / 2;
 
@@ -1030,13 +1046,18 @@ Stbox_quadtree_picksplit(PG_FUNCTION_ARGS)
     centroid->zmin = lowZs[median];
     centroid->zmax = highZs[median];
   }
-  centroid->period.lower = TimestampTzGetDatum(lowTs[median]);
-  centroid->period.upper = TimestampTzGetDatum(highTs[median]);
+  if (hast)
+  {
+    centroid->period.lower = TimestampTzGetDatum(lowTs[median]);
+    centroid->period.upper = TimestampTzGetDatum(highTs[median]);
+  }
 
-  /* Fill the output */
+  /* getQuadrant8D uses fixed bit positions (Z at 7-6, T at 1-0, X+Y at 5-2),
+   * so the quadrant range is sparse. nNodes only depends on whether Z is
+   * present; T occupies the always-allocated low bits. */
   out->hasPrefix = true;
   out->prefixDatum = STboxPGetDatum(centroid);
-  out->nNodes = hasz ? 256 : 128;
+  out->nNodes = hasz ? 256 : 64;
   out->nodeLabels = NULL;    /* We don't need node labels. */
   out->mapTuplesToNodes = palloc(sizeof(int) * in->nTuples);
   out->leafTupleDatums = palloc(sizeof(Datum) * in->nTuples);
@@ -1059,7 +1080,10 @@ Stbox_quadtree_picksplit(PG_FUNCTION_ARGS)
   {
     pfree(lowZs); pfree(highZs);
   }
-  pfree(lowTs); pfree(highTs);
+  if (hast)
+  {
+    pfree(lowTs); pfree(highTs);
+  }
 
   PG_RETURN_VOID();
 }
@@ -1086,7 +1110,9 @@ Stbox_kdtree_picksplit(PG_FUNCTION_ARGS)
     sorted[i].i = i;
   }
   bool hasz = MEOS_FLAGS_GET_Z(sorted[0].box.flags);
-  int mod = hasz ? in->level % 8 : in->level % 6;
+  bool hast = MEOS_FLAGS_GET_T(sorted[0].box.flags);
+  int dims = 4 + (hasz ? 2 : 0) + (hast ? 2 : 0);
+  int mod = in->level % dims;
   qsort_comparator qsortfn;
   if (mod == 0)
     qsortfn = (qsort_comparator) &stbox_xmin_cmp;
@@ -1100,7 +1126,7 @@ Stbox_kdtree_picksplit(PG_FUNCTION_ARGS)
     qsortfn = (qsort_comparator) &stbox_zmin_cmp;
   else if (hasz && mod == 5)
     qsortfn = (qsort_comparator) &stbox_zmax_cmp;
-  else if ((hasz && mod == 6) || (! hasz && mod == 4))
+  else if (hast && ((hasz && mod == 6) || (! hasz && mod == 4)))
     qsortfn = (qsort_comparator) &stbox_tmin_cmp;
   else /* (hasz && mod == 7) || (! hasz && mod == 5) */
     qsortfn = (qsort_comparator) &stbox_tmax_cmp;

--- a/mobilitydb/src/geo/tspatial_spgist.c
+++ b/mobilitydb/src/geo/tspatial_spgist.c
@@ -165,35 +165,39 @@ static uint8
 getQuadrant8D(const STBox *centroid, const STBox *inBox)
 {
   uint8 quadrant = 0;
+  int bit = 0;
 
+  /* Pack bits contiguously starting at bit 0: X, Y, Z if hasz, T if
+   * hast. The result is in [0, 1 << dims), matching the nNodes set
+   * by Stbox_quadtree_picksplit. */
+  if (inBox->xmin > centroid->xmin)
+    quadrant |= (1 << bit);
+  bit++;
+  if (inBox->xmax > centroid->xmax)
+    quadrant |= (1 << bit);
+  bit++;
+  if (inBox->ymin > centroid->ymin)
+    quadrant |= (1 << bit);
+  bit++;
+  if (inBox->ymax > centroid->ymax)
+    quadrant |= (1 << bit);
+  bit++;
   if (MEOS_FLAGS_GET_Z(centroid->flags))
   {
     if (inBox->zmin > centroid->zmin)
-      quadrant |= 0x80;
-
+      quadrant |= (1 << bit);
+    bit++;
     if (inBox->zmax > centroid->zmax)
-      quadrant |= 0x40;
+      quadrant |= (1 << bit);
+    bit++;
   }
-
-  if (inBox->ymin > centroid->ymin)
-    quadrant |= 0x20;
-
-  if (inBox->ymax > centroid->ymax)
-    quadrant |= 0x10;
-
-  if (inBox->xmin > centroid->xmin)
-    quadrant |= 0x08;
-
-  if (inBox->xmax > centroid->xmax)
-    quadrant |= 0x04;
-
   if (MEOS_FLAGS_GET_T(centroid->flags))
   {
     if (datum_gt(inBox->period.lower, centroid->period.lower, T_TIMESTAMPTZ))
-      quadrant |= 0x02;
-
+      quadrant |= (1 << bit);
+    bit++;
     if (datum_gt(inBox->period.upper, centroid->period.upper, T_TIMESTAMPTZ))
-      quadrant |= 0x01;
+      quadrant |= (1 << bit);
   }
 
   return quadrant;
@@ -240,50 +244,55 @@ static void
 stboxnode_quadtree_next(const STboxNode *nodebox, const STBox *centroid,
   uint8 quadrant, STboxNode *next_nodebox)
 {
+  int bit = 0;
   memcpy(next_nodebox, nodebox, sizeof(STboxNode));
 
-  if (MEOS_FLAGS_GET_Z(centroid->flags))
-  {
-    if (quadrant & 0x80)
-      next_nodebox->left.zmin = centroid->zmin;
-    else
-      next_nodebox->left.zmax = centroid->zmin;
-
-    if (quadrant & 0x40)
-      next_nodebox->right.zmin = centroid->zmax;
-    else
-      next_nodebox->right.zmax = centroid->zmax;
-  }
-
-  if (quadrant & 0x20)
-    next_nodebox->left.ymin = centroid->ymin;
-  else
-    next_nodebox->left.ymax = centroid->ymin;
-
-  if (quadrant & 0x10)
-    next_nodebox->right.ymin = centroid->ymax;
-  else
-    next_nodebox->right.ymax = centroid->ymax;
-
-  if (quadrant & 0x08)
+  /* Bit layout matches getQuadrant8D. */
+  if (quadrant & (1 << bit))
     next_nodebox->left.xmin = centroid->xmin;
   else
     next_nodebox->left.xmax = centroid->xmin;
-
-  if (quadrant & 0x04)
+  bit++;
+  if (quadrant & (1 << bit))
     next_nodebox->right.xmin = centroid->xmax;
   else
     next_nodebox->right.xmax = centroid->xmax;
-
-  if (quadrant & 0x02)
-    next_nodebox->left.period.lower = centroid->period.lower;
+  bit++;
+  if (quadrant & (1 << bit))
+    next_nodebox->left.ymin = centroid->ymin;
   else
-    next_nodebox->left.period.upper = centroid->period.lower;
-
-  if (quadrant & 0x01)
-    next_nodebox->right.period.lower = centroid->period.upper;
+    next_nodebox->left.ymax = centroid->ymin;
+  bit++;
+  if (quadrant & (1 << bit))
+    next_nodebox->right.ymin = centroid->ymax;
   else
-    next_nodebox->right.period.upper = centroid->period.upper;
+    next_nodebox->right.ymax = centroid->ymax;
+  bit++;
+  if (MEOS_FLAGS_GET_Z(centroid->flags))
+  {
+    if (quadrant & (1 << bit))
+      next_nodebox->left.zmin = centroid->zmin;
+    else
+      next_nodebox->left.zmax = centroid->zmin;
+    bit++;
+    if (quadrant & (1 << bit))
+      next_nodebox->right.zmin = centroid->zmax;
+    else
+      next_nodebox->right.zmax = centroid->zmax;
+    bit++;
+  }
+  if (MEOS_FLAGS_GET_T(centroid->flags))
+  {
+    if (quadrant & (1 << bit))
+      next_nodebox->left.period.lower = centroid->period.lower;
+    else
+      next_nodebox->left.period.upper = centroid->period.lower;
+    bit++;
+    if (quadrant & (1 << bit))
+      next_nodebox->right.period.lower = centroid->period.upper;
+    else
+      next_nodebox->right.period.upper = centroid->period.upper;
+  }
 
   return;
 }
@@ -985,6 +994,7 @@ Stbox_quadtree_picksplit(PG_FUNCTION_ARGS)
   STBox *box = DatumGetSTboxP(in->datums[0]);
   bool hasz = MEOS_FLAGS_GET_Z(box->flags);
   bool hast = MEOS_FLAGS_GET_T(box->flags);
+  int dims = 4 + (hasz ? 2 : 0) + (hast ? 2 : 0);
   STBox *centroid = palloc0(sizeof(STBox));
   centroid->srid = box->srid;
   centroid->flags = box->flags;
@@ -1060,12 +1070,10 @@ Stbox_quadtree_picksplit(PG_FUNCTION_ARGS)
     centroid->period.upper = TimestampTzGetDatum(highTs[median]);
   }
 
-  /* getQuadrant8D uses fixed bit positions (Z at 7-6, T at 1-0, X+Y at 5-2),
-   * so the quadrant range is sparse. nNodes only depends on whether Z is
-   * present; T occupies the always-allocated low bits. */
+  /* getQuadrant8D packs bits contiguously into [0, 1 << dims). */
   out->hasPrefix = true;
   out->prefixDatum = STboxPGetDatum(centroid);
-  out->nNodes = hasz ? 256 : 64;
+  out->nNodes = 1 << dims;
   out->nodeLabels = NULL;    /* We don't need node labels. */
   out->mapTuplesToNodes = palloc(sizeof(int) * in->nTuples);
   out->leafTupleDatums = palloc(sizeof(Datum) * in->nTuples);

--- a/mobilitydb/src/geo/tspatial_spgist.c
+++ b/mobilitydb/src/geo/tspatial_spgist.c
@@ -295,7 +295,9 @@ stboxnode_kdtree_next(const STboxNode *nodebox, const STBox *centroid,
 {
   bool hasz = MEOS_FLAGS_GET_Z(centroid->flags);
   memcpy(next_nodebox, nodebox, sizeof(STboxNode));
-  int mod = hasz ? level % 8 : level % 6 ;
+  bool hast = MEOS_FLAGS_GET_T(centroid->flags);
+  int dims = 4 + (hasz ? 2 : 0) + (hast ? 2 : 0);
+  int mod = level % dims;
   if (mod == 0)
   {
     /* Split the bounding box by lower bound  */
@@ -393,7 +395,9 @@ static bool
 overlapKD(const STboxNode *nodebox, const STBox *query, int level)
 {
   bool hasz = MEOS_FLAGS_GET_Z(nodebox->left.flags);
-  int mod = hasz ? level % 8 : level % 6;
+  bool hast = MEOS_FLAGS_GET_T(nodebox->left.flags);
+  int dims = 4 + (hasz ? 2 : 0) + (hast ? 2 : 0);
+  int mod = level % dims;
   bool result = true;
   /* Result value is computed only for the dimensions of the query */
   if (MEOS_FLAGS_GET_X(query->flags))
@@ -456,7 +460,9 @@ static bool
 containKD(const STboxNode *nodebox, const STBox *query, int level)
 {
   bool hasz = MEOS_FLAGS_GET_Z(nodebox->left.flags);
-  int mod = hasz ? level % 8 : level % 6;
+  bool hast = MEOS_FLAGS_GET_T(nodebox->left.flags);
+  int dims = 4 + (hasz ? 2 : 0) + (hast ? 2 : 0);
+  int mod = level % dims;
   bool result = true;
   /* Result value is computed only for the dimensions of the query */
   if (MEOS_FLAGS_GET_X(query->flags))
@@ -904,7 +910,8 @@ stbox_level_cmp(STBox *centroid, STBox *query, int level)
 {
   bool hasz = MEOS_FLAGS_GET_Z(centroid->flags);
   bool hast = MEOS_FLAGS_GET_T(centroid->flags);
-  int mod = hasz ? level % 8 : level % 6;
+  int dims = 4 + (hasz ? 2 : 0) + (hast ? 2 : 0);
+  int mod = level % dims;
   if (mod == 0)
     return stbox_xmin_cmp(query, centroid);
   else if (mod == 1)

--- a/mobilitydb/test/geo/expected/051_stbox.test.out
+++ b/mobilitydb/test/geo/expected/051_stbox.test.out
@@ -1981,3 +1981,50 @@ SELECT stbox_hash_extended(stbox 'STBOX ZT(((1,2,3),(1,2,3)),[2001-01-04,2001-01
  4942726506971401033
 (1 row)
 
+DROP TABLE IF EXISTS tbl_stbox_notime;
+NOTICE:  table "tbl_stbox_notime" does not exist, skipping
+DROP TABLE
+CREATE TABLE tbl_stbox_notime AS
+SELECT k, stbox(ST_MakeEnvelope(k::float, k::float,
+                                (k+1)::float, (k+1)::float)) AS b
+FROM generate_series(1, 200) k;
+SELECT 200
+CREATE INDEX tbl_stbox_notime_quadtree_idx ON tbl_stbox_notime USING SPGIST(b);
+CREATE INDEX
+SELECT COUNT(*) FROM tbl_stbox_notime
+  WHERE b && stbox 'STBOX X((50,50),(60,60))';
+ count 
+-------
+    12
+(1 row)
+
+SELECT COUNT(*) FROM tbl_stbox_notime
+  WHERE b @> stbox 'STBOX X((100.5,100.5),(100.5,100.5))';
+ count 
+-------
+     1
+(1 row)
+
+DROP INDEX tbl_stbox_notime_quadtree_idx;
+DROP INDEX
+CREATE INDEX tbl_stbox_notime_kdtree_idx ON tbl_stbox_notime
+  USING SPGIST(b stbox_kdtree_ops);
+CREATE INDEX
+SELECT COUNT(*) FROM tbl_stbox_notime
+  WHERE b && stbox 'STBOX X((50,50),(60,60))';
+ count 
+-------
+    12
+(1 row)
+
+SELECT COUNT(*) FROM tbl_stbox_notime
+  WHERE b @> stbox 'STBOX X((100.5,100.5),(100.5,100.5))';
+ count 
+-------
+     1
+(1 row)
+
+DROP INDEX tbl_stbox_notime_kdtree_idx;
+DROP INDEX
+DROP TABLE tbl_stbox_notime;
+DROP TABLE

--- a/mobilitydb/test/geo/queries/051_stbox.test.sql
+++ b/mobilitydb/test/geo/queries/051_stbox.test.sql
@@ -574,3 +574,35 @@ SELECT stbox_hash(stbox 'STBOX ZT(((1,2,3),(1,2,3)),[2001-01-04,2001-01-04])');
 SELECT stbox_hash_extended(stbox 'STBOX ZT(((1,2,3),(1,2,3)),[2001-01-04,2001-01-04])', 1);
 
 -------------------------------------------------------------------------------
+-- Regression: stbox_level_cmp must not call the time comparators when the
+-- centroid has no time dimension. Before the hast guard, an SP-GiST
+-- traversal at level mod 4 (for hasz=false) or mod 6/7 (for hasz=true)
+-- would call stbox_tmin_cmp / stbox_tmax_cmp on uninitialized period
+-- fields. The 200-row table makes the SP-GiST tree deep enough (>= 4
+-- levels) to exercise the bug-prone dispatch branches.
+-------------------------------------------------------------------------------
+
+DROP TABLE IF EXISTS tbl_stbox_notime;
+CREATE TABLE tbl_stbox_notime AS
+SELECT k, stbox(ST_MakeEnvelope(k::float, k::float,
+                                (k+1)::float, (k+1)::float)) AS b
+FROM generate_series(1, 200) k;
+
+CREATE INDEX tbl_stbox_notime_quadtree_idx ON tbl_stbox_notime USING SPGIST(b);
+SELECT COUNT(*) FROM tbl_stbox_notime
+  WHERE b && stbox 'STBOX X((50,50),(60,60))';
+SELECT COUNT(*) FROM tbl_stbox_notime
+  WHERE b @> stbox 'STBOX X((100.5,100.5),(100.5,100.5))';
+DROP INDEX tbl_stbox_notime_quadtree_idx;
+
+CREATE INDEX tbl_stbox_notime_kdtree_idx ON tbl_stbox_notime
+  USING SPGIST(b stbox_kdtree_ops);
+SELECT COUNT(*) FROM tbl_stbox_notime
+  WHERE b && stbox 'STBOX X((50,50),(60,60))';
+SELECT COUNT(*) FROM tbl_stbox_notime
+  WHERE b @> stbox 'STBOX X((100.5,100.5),(100.5,100.5))';
+DROP INDEX tbl_stbox_notime_kdtree_idx;
+
+DROP TABLE tbl_stbox_notime;
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
`stbox_level_cmp(centroid, query, level)` in `mobilitydb/src/geo/tspatial_spgist.c` unconditionally dispatches to `stbox_tmin_cmp` / `stbox_tmax_cmp` at certain modulo levels (mod 6/7 when `hasz` is true, mod 4/5 when `hasz` is false), without first checking whether the centroid actually has a time dimension.

For an SP-GiST index built over a column of `stbox` values that lack the time dimension (e.g. an `stbox` column populated via the `stbox(geometry)` constructor), this reads garbage from `centroid->period.lower` / `centroid->period.upper` and produces undefined comparison results.

## Fix

* Add an `hast` (`MEOS_FLAGS_GET_T(centroid->flags)`) check on both time-dispatch branches.
* Replace the would-be-unreachable fallthroughs with an `elog(ERROR, ...)` so a misuse surfaces clearly rather than silently corrupting comparison results.

## Regression test

Adds `mobilitydb/test/geo/queries/051_stbox.test.sql` content that:

* creates a 200-row `stbox` column **without** a time dimension,
* builds both quadtree and kdtree SP-GiST indexes on it,
* runs `&&` and `@>` queries.

The 200-row size is chosen so the SP-GiST tree grows past level 4, exercising the bug-prone dispatch branches that the fix now guards. Without the fix, those queries can return wrong results or hit ASan-style undefined behavior; with the fix they're stable.

Full ctest sweep on Linux: 136/136 pass.