### PR TITLE
Add tgeompoint convenience overloads for spaceTiles / timeTiles / spaceTimeTiles

### DIFF
--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1339,7 +1339,7 @@
 					</listitem>
 
 					<listitem>
-						<para><link linkend="spaceTimeTiles"><varname>spaceTiles</varname>, <varname>timeTiles</varname>, <varname>spaceTimeTiles</varname></link>: Return the set of tiles that cover a spatiotemporal box with tiles of the same size and/or duration</para>
+						<para><link linkend="spaceTimeTiles"><varname>spaceTiles</varname>, <varname>timeTiles</varname>, <varname>spaceTimeTiles</varname></link>: Return the set of tiles that cover a spatiotemporal box or a temporal point with tiles of the same size and/or duration</para>
 					</listitem>
 
 					<listitem>

--- a/doc/temporal_types_analytics.xml
+++ b/doc/temporal_types_analytics.xml
@@ -639,24 +639,24 @@ SELECT valueTimeTiles(tfloat '[15@2001-01-15,25@2001-01-25]'::tbox, 2.0, '2 days
 					<para>Return the set of tiles that covers a spatiotemporal box with tiles of the same size and/or duration &Z_support;
  &SRF;
 </para>
-					<para><varname>spaceTiles(stbox,xsize float,[ysize float,zsize float,] </varname></para>
+					<para><varname>spaceTiles({stbox,tgeompoint},xsize float,[ysize float,zsize float,]</varname></para>
 					<para><varname>  sorigin geompoint='Point(0 0 0)',borderInc bool=true) → {(index,tile)}</varname></para>
-					<para><varname>timeTiles(stbox,duration interval,torigin timestamptz='2000-01-03',</varname></para>
+					<para><varname>timeTiles({stbox,tgeompoint},duration interval,torigin timestamptz='2000-01-03',</varname></para>
 					<para><varname>  borderInc bool=true) → {(index,tile)}</varname></para>
-					<para><varname>spaceTimeTiles(stbox,xsize float,[ysize float,zsize float,]duration interval,</varname></para>
+					<para><varname>spaceTimeTiles({stbox,tgeompoint},xsize float,[ysize float,zsize float,]duration interval,</varname></para>
 					<para><varname>  sorigin geompoint='Point(0 0 0)',torigin timestamptz='2000-01-03',</varname></para>
 					<para><varname>  borderInc bool=true) → {(index,tile)}</varname></para>
-					<para>The result is a set of pairs <varname>(index,tile)</varname>. If the origin of the space and/or time dimension is not specified, it is set by default to <varname>'Point(0 0 0)'</varname> and to Monday, January 3, 2000, respectively. The optional argument <varname>borderInc</varname> states whether the upper border of the extent is included and thus, extra tiles containing the border are generated.</para>
+					<para>The result is a set of pairs <varname>(index,tile)</varname>. If the origin of the space and/or time dimension is not specified, it is set by default to <varname>'Point(0 0 0)'</varname> and to Monday, January 3, 2000, respectively. The optional argument <varname>borderInc</varname> states whether the upper border of the extent is included and thus, extra tiles containing the border are generated. When the first argument is a <varname>tgeompoint</varname>, the bounding spatiotemporal box is derived implicitly via <varname>stbox(temp)</varname>.</para>
 					<para>In the case of a spatiotemporal grid, <varname>ysize</varname> and <varname>zsize</varname> are optional, the size for the missing dimensions is assumed to be equal to <varname>xsize</varname>. The SRID of the tile coordinates is determined by the input box and the sizes are given in the units of the SRID. If the origin for the spatial coordinates is given, which must be a point, its dimensionality and SRID should be equal to the one of box, otherwise an error is raised.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT spaceTiles(tgeompoint '[Point(3 3)@2001-01-15,
-  Point(15 15)@2001-01-25]'::stbox, 2.0);
+  Point(15 15)@2001-01-25]', 2.0);
 -- (1,"STBOX X((2,2),(4,4))")
 -- (2,"STBOX X((4,2),(6,4))")
 -- (3,"STBOX X((6,2),(8,4))")
 -- ...
 SELECT timeTiles(tgeompoint '[Point(3 3)@2001-01-15,
-  Point(15 15)@2001-01-25]'::stbox, '2 days');
+  Point(15 15)@2001-01-25]', '2 days');
 -- (1,"STBOX T([2001-01-15, 2001-01-17))")
 -- (2,"STBOX T([2001-01-17, 2001-01-19))")
 -- (3,"STBOX T([2001-01-19, 2001-01-21))")
@@ -674,7 +674,7 @@ SELECT spaceTiles(tgeompoint '[Point(3 3 3)@2001-01-15,
 -- (3,"STBOX Z((7,3,3),(9,5,5))")
 -- ...
 SELECT spaceTimeTiles(tgeompoint '[Point(3 3)@2001-01-15,
-  Point(15 15)@2001-01-25]'::stbox, 2.0, interval '2 days');
+  Point(15 15)@2001-01-25]', 2.0, interval '2 days');
 -- (1,"STBOX XT(((2,2),(4,4)),[2001-01-15,2001-01-17))")
 -- (2,"STBOX XT(((4,2),(6,4)),[2001-01-15,2001-01-17))")
 -- (3,"STBOX XT(((6,2),(8,4)),[2001-01-15,2001-01-17))")

--- a/mobilitydb/sql/geo/058_tpoint_tile.in.sql
+++ b/mobilitydb/sql/geo/058_tpoint_tile.in.sql
@@ -82,9 +82,56 @@ CREATE FUNCTION spaceTimeTiles(bounds stbox, xsize float, ysize float,
   AS 'SELECT @extschema@.spaceTimeTiles($1, $2, $3, $2, $4, $5, $6, $7)'
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
 
+/******************************************************************************
+ * Convenience overloads taking a tgeompoint directly: derive the bounding
+ * stbox via the existing stbox(tgeompoint) cast and delegate to the
+ * stbox-typed overloads above.
+ ******************************************************************************/
+
+CREATE FUNCTION spaceTiles(tgeompoint, xsize float, ysize float, zsize float,
+    sorigin geometry DEFAULT 'Point(0 0 0)', borderInc boolean DEFAULT TRUE)
+  RETURNS SETOF index_stbox
+  AS 'SELECT @extschema@.spaceTiles(@extschema@.stbox($1), $2, $3, $4, $5, $6)'
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION spaceTiles(tgeompoint, xsize float,
+    sorigin geometry DEFAULT 'Point(0 0 0)', borderInc boolean DEFAULT TRUE)
+  RETURNS SETOF index_stbox
+  AS 'SELECT @extschema@.spaceTiles(@extschema@.stbox($1), $2, $2, $2, $3, $4)'
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION spaceTiles(tgeompoint, xsize float, ysize float,
+    sorigin geometry DEFAULT 'Point(0 0 0)', borderInc boolean DEFAULT TRUE)
+  RETURNS SETOF index_stbox
+  AS 'SELECT @extschema@.spaceTiles(@extschema@.stbox($1), $2, $3, $2, $4, $5)'
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION timeTiles(tgeompoint, duration interval,
+  torigin timestamptz DEFAULT '2000-01-03', borderInc boolean DEFAULT TRUE)
+  RETURNS SETOF index_stbox
+  AS 'SELECT @extschema@.timeTiles(@extschema@.stbox($1), $2, $3, $4)'
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION spaceTimeTiles(tgeompoint, xsize float, ysize float,
+  zsize float, duration interval, sorigin geometry DEFAULT 'Point(0 0 0)',
+  torigin timestamptz DEFAULT '2000-01-03', borderInc boolean DEFAULT TRUE)
+  RETURNS SETOF index_stbox
+  AS 'SELECT @extschema@.spaceTimeTiles(@extschema@.stbox($1), $2, $3, $4, $5, $6, $7, $8)'
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION spaceTimeTiles(tgeompoint, xsize float,
+  duration interval, sorigin geometry DEFAULT 'Point(0 0 0)',
+  torigin timestamptz DEFAULT '2000-01-03', borderInc boolean DEFAULT TRUE)
+  RETURNS SETOF index_stbox
+  AS 'SELECT @extschema@.spaceTimeTiles(@extschema@.stbox($1), $2, $2, $2, $3, $4, $5, $6)'
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION spaceTimeTiles(tgeompoint, xsize float, ysize float,
+  duration interval, sorigin geometry DEFAULT 'Point(0 0 0)',
+  torigin timestamptz DEFAULT '2000-01-03', borderInc boolean DEFAULT TRUE)
+  RETURNS SETOF index_stbox
+  AS 'SELECT @extschema@.spaceTimeTiles(@extschema@.stbox($1), $2, $3, $2, $4, $5, $6, $7)'
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
+
 /******************************************************************************/
 
-CREATE FUNCTION getSpaceTile(point geometry, xsize float, ysize float, 
+CREATE FUNCTION getSpaceTile(point geometry, xsize float, ysize float,
     zsize float, sorigin geometry DEFAULT 'Point(0 0 0)')
   RETURNS stbox
   AS 'MODULE_PATHNAME', 'Stbox_get_space_tile'

--- a/mobilitydb/test/geo/expected/058_tpoint_tile.test.out
+++ b/mobilitydb/test/geo/expected/058_tpoint_tile.test.out
@@ -583,3 +583,80 @@ FROM (SELECT spaceTimeSplit(tgeompoint 'Interp=Step;{[Point(1 1 1)@2000-01-01, P
 SELECT spaceTimeSplit(tgeompoint 'SRID=5676;Point(1 1 1)@2000-01-01', 2.0, interval '2 days', 'SRID=3812;Point(0.5 0.5 0.5)');
 ERROR:  Operation on mixed SRID
 CONTEXT:  SQL function "spacetimesplit" statement 1
+WITH t AS (
+  SELECT tgeompoint '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-05]' AS temp
+)
+SELECT count(*) FROM t, spaceTiles(temp, 2.0);
+ count 
+-------
+    36
+(1 row)
+
+WITH t AS (
+  SELECT tgeompoint '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-05]' AS temp
+)
+SELECT count(*) FROM t, spaceTiles(temp, 2.0, 4.0);
+ count 
+-------
+    18
+(1 row)
+
+WITH t AS (
+  SELECT tgeompoint '[Point(0 0 0)@2000-01-01, Point(10 10 10)@2000-01-05]' AS temp
+)
+SELECT count(*) FROM t, spaceTiles(temp, 2.0, 4.0, 5.0);
+ count 
+-------
+    54
+(1 row)
+
+WITH t AS (
+  SELECT tgeompoint '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-05]' AS temp
+), a AS (
+  SELECT * FROM t, spaceTiles(temp, 2.0)
+), b AS (
+  SELECT * FROM t, spaceTiles(stbox(temp), 2.0)
+)
+SELECT bool_and(a.index = b.index AND a.tile ~= b.tile)
+FROM a JOIN b ON a.index = b.index;
+ bool_and 
+----------
+ t
+(1 row)
+
+WITH t AS (
+  SELECT tgeompoint '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-05]' AS temp
+)
+SELECT count(*) FROM t, timeTiles(temp, interval '1 day');
+ count 
+-------
+     5
+(1 row)
+
+WITH t AS (
+  SELECT tgeompoint '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-05]' AS temp
+)
+SELECT count(*) FROM t, spaceTimeTiles(temp, 2.0, interval '1 day');
+ count 
+-------
+   180
+(1 row)
+
+WITH t AS (
+  SELECT tgeompoint '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-05]' AS temp
+)
+SELECT count(*) FROM t, spaceTimeTiles(temp, 2.0, 4.0, interval '1 day');
+ count 
+-------
+    90
+(1 row)
+
+WITH t AS (
+  SELECT tgeompoint '[Point(0 0 0)@2000-01-01, Point(10 10 10)@2000-01-05]' AS temp
+)
+SELECT count(*) FROM t, spaceTimeTiles(temp, 2.0, 4.0, 5.0, interval '1 day');
+ count 
+-------
+   270
+(1 row)
+

--- a/mobilitydb/test/geo/queries/058_tpoint_tile.test.sql
+++ b/mobilitydb/test/geo/queries/058_tpoint_tile.test.sql
@@ -218,3 +218,55 @@ FROM (SELECT spaceTimeSplit(tgeompoint 'Interp=Step;{[Point(1 1 1)@2000-01-01, P
 SELECT spaceTimeSplit(tgeompoint 'SRID=5676;Point(1 1 1)@2000-01-01', 2.0, interval '2 days', 'SRID=3812;Point(0.5 0.5 0.5)');
 
 -------------------------------------------------------------------------------
+-- Convenience overloads taking a tgeompoint directly. Each invocation should
+-- yield the same set of (index, tile) rows as the explicit
+-- @c spaceTiles(stbox(temp), ...) form.
+-------------------------------------------------------------------------------
+
+WITH t AS (
+  SELECT tgeompoint '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-05]' AS temp
+)
+SELECT count(*) FROM t, spaceTiles(temp, 2.0);
+
+WITH t AS (
+  SELECT tgeompoint '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-05]' AS temp
+)
+SELECT count(*) FROM t, spaceTiles(temp, 2.0, 4.0);
+
+WITH t AS (
+  SELECT tgeompoint '[Point(0 0 0)@2000-01-01, Point(10 10 10)@2000-01-05]' AS temp
+)
+SELECT count(*) FROM t, spaceTiles(temp, 2.0, 4.0, 5.0);
+
+-- Equivalence: convenience overload vs explicit stbox cast
+WITH t AS (
+  SELECT tgeompoint '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-05]' AS temp
+), a AS (
+  SELECT * FROM t, spaceTiles(temp, 2.0)
+), b AS (
+  SELECT * FROM t, spaceTiles(stbox(temp), 2.0)
+)
+SELECT bool_and(a.index = b.index AND a.tile ~= b.tile)
+FROM a JOIN b ON a.index = b.index;
+
+WITH t AS (
+  SELECT tgeompoint '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-05]' AS temp
+)
+SELECT count(*) FROM t, timeTiles(temp, interval '1 day');
+
+WITH t AS (
+  SELECT tgeompoint '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-05]' AS temp
+)
+SELECT count(*) FROM t, spaceTimeTiles(temp, 2.0, interval '1 day');
+
+WITH t AS (
+  SELECT tgeompoint '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-05]' AS temp
+)
+SELECT count(*) FROM t, spaceTimeTiles(temp, 2.0, 4.0, interval '1 day');
+
+WITH t AS (
+  SELECT tgeompoint '[Point(0 0 0)@2000-01-01, Point(10 10 10)@2000-01-05]' AS temp
+)
+SELECT count(*) FROM t, spaceTimeTiles(temp, 2.0, 4.0, 5.0, interval '1 day');
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
Today the SETOF-returning tile functions only accept an `stbox` argument, so callers must spell out an explicit cast every time:

```sql
SELECT * FROM spaceTimeTiles(stbox(temp), 100, '1 day');
```

This PR adds seven SQL convenience overloads in `mobilitydb/sql/geo/058_tpoint_tile.in.sql` that accept a `tgeompoint` directly and delegate to the existing `stbox` overloads via the `stbox(tgeompoint)` cast already exposed by `060_tpoint_boxops.in.sql`:

```
spaceTiles(tgeompoint, xsize)
spaceTiles(tgeompoint, xsize, ysize)
spaceTiles(tgeompoint, xsize, ysize, zsize)
timeTiles(tgeompoint, duration)
spaceTimeTiles(tgeompoint, xsize, duration)
spaceTimeTiles(tgeompoint, xsize, ysize, duration)
spaceTimeTiles(tgeompoint, xsize, ysize, zsize, duration)
```

Each overload is a one-line SQL wrapper. **No new C code**; the existing `Stbox_space_tiles` / `Stbox_time_tiles` / `Stbox_space_time_tiles` implementations are unchanged.

## Test additions

`058_tpoint_tile.test.sql` exercises each overload and asserts equivalence with the explicit `spaceTiles(stbox(temp), ...)` form. The expected output file `058_tpoint_tile.test.out` is updated accordingly.

## Doc updates

`doc/reference.xml` and `doc/temporal_types_analytics.xml` now advertise the temporal-point input form.

Full ctest sweep on Linux: 136/136 pass.