### PR TITLE
Fix allocator mismatch in temporal_as_mfjson (re-enable pfree at caller)

### DIFF
--- a/meos/src/temporal/type_out.c
+++ b/meos/src/temporal/type_out.c
@@ -819,11 +819,15 @@ temporal_as_mfjson(const Temporal *temp, bool with_bbox, int flags,
   if (flags == 0)
     return result;
 
-  /* Convert to JSON and back to a C string to apply flags using json-c */
+  /* Convert to JSON and back to a C string to apply flags using json-c.
+   * Use pstrdup so the result is palloc-managed; mixing libc strdup with
+   * palloc/pfree corrupts PostgreSQL's memory bookkeeping (the workaround
+   * in the PG-extension caller had to comment out a pfree because of
+   * this). */
   json_tokener *jstok = json_tokener_new();
   struct json_object *jobj = json_tokener_parse_ex(jstok, result, -1);
   pfree(result);
-  result = strdup(json_object_to_json_string_ext(jobj, flags));
+  result = pstrdup(json_object_to_json_string_ext(jobj, flags));
   json_tokener_free(jstok);
   json_object_put(jobj);
   return result;

--- a/mobilitydb/src/temporal/type_out.c
+++ b/mobilitydb/src/temporal/type_out.c
@@ -185,9 +185,7 @@ Temporal_as_mfjson(PG_FUNCTION_ARGS)
 
   char *mfjson = temporal_as_mfjson(temp, with_bbox, flags, precision, srs);
   text *result = cstring2text(mfjson);
-  // CURRENTLY we cannot pfree since we get the error message
-  // pfree called with invalid pointer
-  // pfree(mfjson);
+  pfree(mfjson);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_TEXT_P(result);
 }


### PR DESCRIPTION
Pre-existing master bug: when `temporal_as_mfjson` is called with a non-zero `flags` argument (i.e. JSON pretty-print or any other json-c reformat option), it reformats the result through `json-c` and returns a `strdup()`-allocated buffer.

The PG-extension caller in `mobilitydb/src/temporal/type_out.c` (`Temporal_as_mfjson`) had to comment out `pfree(mfjson)` with a `// CURRENTLY we cannot pfree since we get the error message // pfree called with invalid pointer` workaround — because PostgreSQL's palloc bookkeeping rejects the libc-malloc'd pointer.

Side effects:
* Small per-call leak when the user passes a non-default flags argument to `asMFJSON()`.
* On stricter PG configurations the inability to free the buffer can compound over a session.
* Same root-cause family as the strdup/pfree mismatch in PR #802 (set_escape) where the bug was crashing PG14/15 backends in the load_tables fixture.

## Fix

Switch the inner allocation to `pstrdup`, so the buffer is palloc-managed. Re-enable the `pfree(mfjson)` at the call site.

## Why on master directly

The bug exists on master and every feature branch inherits it. Landing the fix on master directly is faster than threading it through a feature stack — every other PR will pick up the fix on rebase without the FIXME comment.

## Verified

Local build clean against PG17 (Debug) on Ubuntu 24.04. The change is two-line: switch `strdup` to `pstrdup` and uncomment the `pfree` at the caller.