### PR TITLE
Drop support for PostgreSQL 14 and 15 (require ≥ 16)

### DIFF
--- a/.github/workflows/pgversion.yml
+++ b/.github/workflows/pgversion.yml
@@ -1,7 +1,8 @@
 name: Main Build
 
-# Test for supported PosgreSQL/PostGIS versions
-# 5 (PosgreSQL) * 1 (PostGIS) * 1 (Linux) + 1 (coverage) = 6 jobs are triggered
+# Test for supported PostgreSQL/PostGIS versions.
+# Minimum supported PG is 16 (see mobilitydb/CMakeLists.txt PG_MIN_MAJOR_VERSION).
+# 3 (PostgreSQL) * 1 (PostGIS) * 1 (Linux) + 1 (coverage) = 4 jobs are triggered.
 # Allow manual trigger
 
 on:
@@ -33,7 +34,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          psql: [14,15,16,17,18]
+          psql: [16, 17, 18]
           postgis: [3]
           os: ["ubuntu-24.04"]
           coverage: [0]

--- a/mobilitydb/CMakeLists.txt
+++ b/mobilitydb/CMakeLists.txt
@@ -46,11 +46,18 @@ endif()
 #-------------------------------------
 
 # Find PostgreSQL
-set(PG_MIN_MAJOR_VERSION "13")
-set(PG_MAX_MAJOR_VERSION "14")
+# Minimum supported version is 16. Older versions (14, 15) carry an
+# accumulating maintenance burden (per-version conditional code, allocator
+# differences exposed by the PG14/15 backend in load_jsonb_tables) that no
+# longer pays off; PostgreSQL 14 reaches end-of-life on 2026-11-12. Build
+# fails clearly here rather than letting the host pretend to be supported
+# and crashing later in fixtures.
+set(PG_MIN_MAJOR_VERSION "16")
 find_package(POSTGRESQL ${PG_MIN_MAJOR_VERSION} REQUIRED)
-if(NOT POSTGRES_VERSION VERSION_LESS PG_MAX_MAJOR_VERSION)
-  message(FATAL_ERROR "Not supporting PostgreSQL ${POSTGRESQL_VERSION}")
+if(POSTGRESQL_VERSION_MAJOR VERSION_LESS PG_MIN_MAJOR_VERSION)
+  message(FATAL_ERROR
+    "MobilityDB requires PostgreSQL ${PG_MIN_MAJOR_VERSION} or newer. "
+    "Found ${POSTGRESQL_VERSION_STRING} at ${POSTGRESQL_PG_CONFIG}.")
 endif()
 
 include_directories(SYSTEM ${POSTGRESQL_INCLUDE_DIR})

--- a/mobilitydb/src/temporal/meos_catalog.c
+++ b/mobilitydb/src/temporal/meos_catalog.c
@@ -58,9 +58,6 @@
 #include <access/heapam.h>
 #include <access/htup_details.h>
 #include <access/tableam.h>
-#if POSTGRESQL_VERSION_NUMBER < 140000
-#include <catalog/indexing.h>
-#endif
 #include <catalog/namespace.h>
 #include <catalog/pg_extension.h>
 #include <commands/extension.h>
@@ -194,39 +191,6 @@ RelnameNspGetRelid(const char *relname, Oid nsp_oid)
   return GetSysCacheOid2(RELNAMENSP, Anum_pg_class_oid,
     PointerGetDatum(relname), ObjectIdGetDatum(nsp_oid));
 }
-
-#if POSTGRESQL_VERSION_NUMBER < 160000
-/*
- * get_extension_schema - given an extension OID, fetch its extnamespace
- *
- * Returns InvalidOid if no such extension.
- */
-static Oid
-get_extension_schema(Oid ext_oid)
-{
-  Relation rel = table_open(ExtensionRelationId, AccessShareLock);
-
-  ScanKeyData entry[1];
-  ScanKeyInit(&entry[0], Anum_pg_extension_oid, BTEqualStrategyNumber, F_OIDEQ,
-  ObjectIdGetDatum(ext_oid));
-
-  SysScanDesc scandesc = systable_beginscan(rel, ExtensionOidIndexId, true,
-    NULL, 1, entry);
-
-  HeapTuple tuple = systable_getnext(scandesc);
-
-  /* We assume that there can be at most one matching tuple */
-  Oid result;
-  if (HeapTupleIsValid(tuple))
-    result = ((Form_pg_extension) GETSTRUCT(tuple))->extnamespace;
-  else
-    result = InvalidOid;
-
-  systable_endscan(scandesc);
-  table_close(rel, AccessShareLock);
-  return result;
-}
-#endif
 
 /**
  * @brief Return namespace Oid for the extension


### PR DESCRIPTION
## Summary

Bump the minimum supported PostgreSQL version from PG13 (effectively PG14 since the existing PG_MAX_MAJOR_VERSION check was broken — it referenced an undefined variable and never fired) to PG16. Drops PG14, PG15 from the CI matrix and removes one block of now-dead version-conditional code.

## Why

* **EOL**: PG14 reaches end-of-life on 2026-11-12; PG15 on 2027-11-11.
* **Maintenance burden**: the pgtypes-vendored jsonb path SIGSEGVs during `load_jsonb_tables` on PG14 (verified locally with apt.postgresql.org's PG14 + `postgresql-14-postgis-3`); the same path is clean on PG16+. Fixing it for PG14 would require diverging from upstream PostgreSQL.
* **Conditional clutter**: `#if POSTGRESQL_VERSION_NUMBER < 14/16` branches were accumulating per release with no compensating user gain.

## Changes

| File | Change |
|---|---|
| `mobilitydb/CMakeLists.txt` | `PG_MIN_MAJOR_VERSION` 13 → 16. Drop the broken `PG_MAX_MAJOR_VERSION` check (`NOT POSTGRES_VERSION VERSION_LESS …` referenced an undefined variable). Add an explicit `VERSION_LESS` defense-in-depth fatal_error naming the rejected `pg_config`. |
| `.github/workflows/pgversion.yml` | Matrix: `[14, 15, 16, 17, 18]` → `[16, 17, 18]`. Update the leading comment. Coverage job stays on 17. |
| `mobilitydb/src/temporal/meos_catalog.c` | Drop the now-dead `#if POSTGRESQL_VERSION_NUMBER < 140000` include for `catalog/indexing.h` and the local `get_extension_schema` fallback that PG 16 provides natively. |

## Verification

* `cmake -DPOSTGRESQL_PG_CONFIG=/usr/lib/postgresql/14/bin/pg_config …` fails clearly:
  ```
  Could NOT find POSTGRESQL: Found unsuitable version "14.22",
  but required is at least "16" (found /usr/lib/postgresql/14/bin)
  ```
* `cmake` against PG17/18 configures and builds clean (verified locally).

## Future cleanup

This PR focuses on the **constraint** itself. The remaining `#if POSTGRESQL_VERSION_NUMBER < 170000` (e.g. `INTERVAL_NOBEGIN` shim in `meos/include/temporal/postgres_types.h`) is still needed for PG16 callers and is not dead. The `>= 150000` blocks scattered in `meos/src/temporal/span.c`, `stbox.c`, etc. are eligible for unconditional unwrapping in a follow-up; doing that here would inflate the diff without changing user-facing behaviour.