### PR TITLE
Bootstrap native Windows MEOS build (issue #513)

### DIFF
--- a/.github/workflows/windows_msys2_meos.yml
+++ b/.github/workflows/windows_msys2_meos.yml
@@ -1,0 +1,126 @@
+name: Build MEOS on Windows (MSYS2/UCRT64)
+
+# Builds the standalone MEOS C library natively on Windows under MSYS2's
+# UCRT64 runtime. This is the bootstrap step for issue #513 — it does not
+# yet build the MobilityDB PostgreSQL extension under MEOS-mode (the
+# existing windows_msys2.yml already covers the extension build, which
+# inherits Windows support from PostgreSQL itself).
+#
+# What this job verifies:
+#   * cmake -DMEOS=ON resolves all dependencies under MSYS2 mingw-w64
+#     (json-c, geos, proj, gsl).
+#   * The standalone libmeos.dll links cleanly without -Wl,-undefined,
+#     dynamic_lookup (a macOS-only flag).
+#   * A minimal smoke test (meos/test/temporal_test) builds and runs.
+#
+# Note: full MSVC support requires sweeping PGDLLEXPORT onto every public
+# extern declaration in meos.h / meos_*.h. That is intentionally left as
+# a follow-up; MinGW-GCC under MSYS2 exports symbols by default
+# (--export-all-symbols) so this CI runs without that sweep.
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/windows_msys2_meos.yml'
+      - 'cmake/**'
+      - 'meos/**'
+      - 'postgis/**'
+      - 'postgres/**'
+      - 'CMakeLists.txt'
+    branch_ignore: gh-pages
+  pull_request:
+    paths:
+      - '.github/workflows/windows_msys2_meos.yml'
+      - 'cmake/**'
+      - 'meos/**'
+      - 'postgis/**'
+      - 'postgres/**'
+      - 'CMakeLists.txt'
+    branch_ignore: gh-pages
+
+jobs:
+  build-meos:
+    name: meos-windows
+    runs-on: windows-latest
+    # Bootstrap signal only — the standalone MEOS build is known to be
+    # incomplete on Windows (the embedded PostgreSQL pg_bitutils.h /
+    # get_share_path expects a configured PG build env, which we don't
+    # set up yet). This job runs to surface what's still broken and is
+    # marked non-blocking until the follow-up PRs land. The job logs are
+    # the canonical reference for the next iteration.
+    continue-on-error: true
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup MSYS2 (UCRT64)
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-ninja
+            mingw-w64-ucrt-x86_64-json-c
+            mingw-w64-ucrt-x86_64-geos
+            mingw-w64-ucrt-x86_64-proj
+            mingw-w64-ucrt-x86_64-gsl
+
+      # Each build/test step is marked continue-on-error so the bootstrap
+      # CI signal stays on the run page even when the embedded PostgreSQL
+      # subtree fails to compile on Windows. The job's overall conclusion
+      # is then "success" so the PR is not blocked. Once the follow-up
+      # PostgreSQL Windows build fixes land, drop the per-step flags.
+
+      - name: Configure (MEOS=ON, no PostgreSQL extension)
+        continue-on-error: true
+        run: |
+          # POSE pulls in RGEO via CMAKE_DEPENDENT_OPTION; we leave RGEO off
+          # for now because rgeo's compilation on Windows depends on PostGIS
+          # build-tree generated headers that have not been verified there.
+          # Keeping the smoke build minimal lets CI surface the next layer
+          # of issues in isolation.
+          cmake -S . -B build-meos \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$PWD/meos-install" \
+            -DMEOS=ON \
+            -DCBUFFER=ON -DNPOINT=ON -DPOSE=OFF -DRGEO=OFF
+
+      - name: Build libmeos
+        continue-on-error: true
+        run: cmake --build build-meos -j
+
+      - name: Install libmeos
+        continue-on-error: true
+        run: cmake --install build-meos
+
+      - name: Show built artifacts
+        continue-on-error: true
+        run: |
+          ls -la build-meos/
+          ls -la meos-install/bin meos-install/lib meos-install/include 2>/dev/null || true
+          # CMake on MSYS2/MinGW puts the .dll in the install bin/ dir and
+          # the .dll.a import lib in lib/. Confirm both exist.
+          test -f build-meos/libmeos.dll || (echo "libmeos.dll not produced"; exit 1)
+
+      - name: Smoke test (build temporal_test against installed libmeos)
+        continue-on-error: true
+        run: |
+          # The install step renames meos_export.h -> meos.h in the include
+          # tree, so we point gcc at the install prefix to compile against
+          # the public API as a downstream consumer would.
+          gcc -I meos-install/include \
+            -L meos-install/lib \
+            -o meos-install/temporal_test.exe \
+            meos/test/temporal_test.c \
+            -lmeos
+          # Make the DLL discoverable to the .exe loader.
+          PATH="$PWD/meos-install/bin:$PWD/build-meos:$PATH" ./meos-install/temporal_test.exe \
+            || (echo "temporal_test.exe failed at runtime"; exit 1)

--- a/.github/workflows/windows_msys2_meos.yml
+++ b/.github/workflows/windows_msys2_meos.yml
@@ -1,20 +1,16 @@
 name: Build MEOS on Windows (MSYS2/UCRT64)
 
 # Builds the standalone MEOS C library natively on Windows under MSYS2's
-# UCRT64 runtime. This is the bootstrap step for issue #513 — it does not
-# yet build the MobilityDB PostgreSQL extension under MEOS-mode (the
-# existing windows_msys2.yml already covers the extension build, which
-# inherits Windows support from PostgreSQL itself).
+# UCRT64 runtime.  This workflow gates issue #513 (native Windows MEOS support).
 #
 # What this job verifies:
 #   * cmake -DMEOS=ON resolves all dependencies under MSYS2 mingw-w64
-#     (json-c, geos, proj, gsl).
-#   * The standalone libmeos.dll links cleanly without -Wl,-undefined,
-#     dynamic_lookup (a macOS-only flag).
+#     (json-c, geos, proj, gsl, tzdata).
+#   * The standalone libmeos.dll links cleanly.
 #   * A minimal smoke test (meos/test/temporal_test) builds and runs.
 #
 # Note: full MSVC support requires sweeping PGDLLEXPORT onto every public
-# extern declaration in meos.h / meos_*.h. That is intentionally left as
+# extern declaration in meos.h / meos_*.h.  That is intentionally left as
 # a follow-up; MinGW-GCC under MSYS2 exports symbols by default
 # (--export-all-symbols) so this CI runs without that sweep.
 
@@ -43,13 +39,6 @@ jobs:
   build-meos:
     name: meos-windows
     runs-on: windows-latest
-    # Bootstrap signal only — the standalone MEOS build is known to be
-    # incomplete on Windows (the embedded PostgreSQL pg_bitutils.h /
-    # get_share_path expects a configured PG build env, which we don't
-    # set up yet). This job runs to surface what's still broken and is
-    # marked non-blocking until the follow-up PRs land. The job logs are
-    # the canonical reference for the next iteration.
-    continue-on-error: true
     defaults:
       run:
         shell: msys2 {0}
@@ -71,38 +60,36 @@ jobs:
             mingw-w64-ucrt-x86_64-geos
             mingw-w64-ucrt-x86_64-proj
             mingw-w64-ucrt-x86_64-gsl
+            mingw-w64-ucrt-x86_64-tzdata
 
-      # Each build/test step is marked continue-on-error so the bootstrap
-      # CI signal stays on the run page even when the embedded PostgreSQL
-      # subtree fails to compile on Windows. The job's overall conclusion
-      # is then "success" so the PR is not blocked. Once the follow-up
-      # PostgreSQL Windows build fixes land, drop the per-step flags.
+      - name: Resolve native timezone data path
+        run: |
+          # cygpath -m converts the MSYS2 POSIX path to a Windows-native path
+          # (forward slashes, e.g. C:/msys64/ucrt64/share/zoneinfo) that fopen()
+          # inside the compiled DLL can open at runtime.
+          TZDATA_WIN=$(cygpath -m "$MSYSTEM_PREFIX/share/zoneinfo")
+          echo "MEOS_TZDATA_WIN=$TZDATA_WIN" >> "$GITHUB_ENV"
 
       - name: Configure (MEOS=ON, no PostgreSQL extension)
-        continue-on-error: true
         run: |
           # POSE pulls in RGEO via CMAKE_DEPENDENT_OPTION; we leave RGEO off
           # for now because rgeo's compilation on Windows depends on PostGIS
           # build-tree generated headers that have not been verified there.
-          # Keeping the smoke build minimal lets CI surface the next layer
-          # of issues in isolation.
           cmake -S . -B build-meos \
             -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="$PWD/meos-install" \
             -DMEOS=ON \
-            -DCBUFFER=ON -DNPOINT=ON -DPOSE=OFF -DRGEO=OFF
+            -DCBUFFER=ON -DNPOINT=ON -DPOSE=OFF -DRGEO=OFF \
+            -DMEOS_TZDATA_DIR="$MEOS_TZDATA_WIN"
 
       - name: Build libmeos
-        continue-on-error: true
         run: cmake --build build-meos -j
 
       - name: Install libmeos
-        continue-on-error: true
         run: cmake --install build-meos
 
       - name: Show built artifacts
-        continue-on-error: true
         run: |
           ls -la build-meos/
           ls -la meos-install/bin meos-install/lib meos-install/include 2>/dev/null || true
@@ -111,16 +98,11 @@ jobs:
           test -f build-meos/libmeos.dll || (echo "libmeos.dll not produced"; exit 1)
 
       - name: Smoke test (build temporal_test against installed libmeos)
-        continue-on-error: true
         run: |
-          # The install step renames meos_export.h -> meos.h in the include
-          # tree, so we point gcc at the install prefix to compile against
-          # the public API as a downstream consumer would.
           gcc -I meos-install/include \
             -L meos-install/lib \
             -o meos-install/temporal_test.exe \
             meos/test/temporal_test.c \
             -lmeos
-          # Make the DLL discoverable to the .exe loader.
           PATH="$PWD/meos-install/bin:$PWD/build-meos:$PATH" ./meos-install/temporal_test.exe \
             || (echo "temporal_test.exe failed at runtime"; exit 1)

--- a/cmake/ConfigurePgConfig.cmake
+++ b/cmake/ConfigurePgConfig.cmake
@@ -24,6 +24,8 @@ check_type_size("void *"          SIZEOF_VOID_P           BUILTIN_TYPES_ONLY)
 check_type_size("long"            SIZEOF_LONG             BUILTIN_TYPES_ONLY)
 check_type_size("size_t"          SIZEOF_SIZE_T)
 check_type_size("long long int"   SIZEOF_LONG_LONG_INT    BUILTIN_TYPES_ONLY)
+# pg_bitutils.h uses SIZEOF_LONG_LONG (no _INT suffix); alias the detected value.
+set(SIZEOF_LONG_LONG ${SIZEOF_LONG_LONG_INT})
 
 #-----------------------------------------------------------------------
 # 2. Alignment (no native CMake check; use offsetof trick via CHECK_C_SOURCE_RUNS)

--- a/meos/CMakeLists.txt
+++ b/meos/CMakeLists.txt
@@ -19,9 +19,17 @@ set(MEOS_LIB_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}")
 set(MEOS_LIB_NAME "meos")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
-# Set the location of the directory of the time zone database
-add_definitions(-DSYSTEMTZDIR="/usr/share/zoneinfo")
-message(STATUS "Directory of the time zone database: /usr/share/zoneinfo")
+# Set the location of the directory of the time zone database. On UNIX-like
+# systems we point the embedded PostgreSQL timezone code at the standard
+# /usr/share/zoneinfo. On Windows there is no system zoneinfo directory; the
+# embedded code falls back to using the timezone name set at runtime via
+# meos_initialize_timezone() rather than reading IANA files from disk.
+if(NOT WIN32)
+  add_definitions(-DSYSTEMTZDIR="/usr/share/zoneinfo")
+  message(STATUS "Directory of the time zone database: /usr/share/zoneinfo")
+else()
+  message(STATUS "Skipping SYSTEMTZDIR (Windows: timezone resolved at runtime)")
+endif()
 
 # Option to build MEOS as a shared or static library
 option(BUILD_SHARED_LIBS

--- a/meos/CMakeLists.txt
+++ b/meos/CMakeLists.txt
@@ -19,17 +19,44 @@ set(MEOS_LIB_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}")
 set(MEOS_LIB_NAME "meos")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
-# Set the location of the directory of the time zone database. On UNIX-like
-# systems we point the embedded PostgreSQL timezone code at the standard
-# /usr/share/zoneinfo. On Windows there is no system zoneinfo directory; the
-# embedded code falls back to using the timezone name set at runtime via
-# meos_initialize_timezone() rather than reading IANA files from disk.
-if(NOT WIN32)
-  add_definitions(-DSYSTEMTZDIR="/usr/share/zoneinfo")
-  message(STATUS "Directory of the time zone database: /usr/share/zoneinfo")
-else()
-  message(STATUS "Skipping SYSTEMTZDIR (Windows: timezone resolved at runtime)")
+# Set the location of the IANA timezone database directory.  pgtz.c uses the
+# SYSTEMTZDIR macro to avoid calling get_share_path() (a PostgreSQL-internal
+# function not available in the MEOS standalone build).
+#
+# Override at cmake time with -DMEOS_TZDATA_DIR=<path>.  The path must be a
+# native OS path that fopen() can open (i.e. a Windows path such as
+# C:/msys64/ucrt64/share/zoneinfo on Windows, not an MSYS2 POSIX path).
+if(NOT DEFINED MEOS_TZDATA_DIR)
+  if(NOT WIN32)
+    set(MEOS_TZDATA_DIR "/usr/share/zoneinfo")
+  else()
+    # Auto-discover from the MSYS2 environment: MSYSTEM_PREFIX is set by the
+    # MSYS2 shell (e.g. /ucrt64).  cygpath -m converts the POSIX path to a
+    # Windows-native path (e.g. C:/msys64/ucrt64/share/zoneinfo) that the
+    # compiled DLL — a native Windows binary — can open with fopen().
+    if(DEFINED ENV{MSYSTEM_PREFIX})
+      execute_process(
+        COMMAND cygpath -m "$ENV{MSYSTEM_PREFIX}/share/zoneinfo"
+        OUTPUT_VARIABLE MEOS_TZDATA_DIR
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        RESULT_VARIABLE _cygpath_rc
+      )
+      if(NOT _cygpath_rc EQUAL 0 OR NOT MEOS_TZDATA_DIR)
+        set(MEOS_TZDATA_DIR "C:/msys64/ucrt64/share/zoneinfo")
+        message(WARNING "cygpath failed; falling back to ${MEOS_TZDATA_DIR}")
+      endif()
+    else()
+      # Outside MSYS2 (e.g. MSVC developer command prompt): caller must pass
+      # -DMEOS_TZDATA_DIR=... or install tzdata to this default location.
+      set(MEOS_TZDATA_DIR "C:/msys64/ucrt64/share/zoneinfo")
+      message(WARNING "MEOS_TZDATA_DIR not set and MSYSTEM_PREFIX not found; "
+                      "defaulting to ${MEOS_TZDATA_DIR}")
+    endif()
+  endif()
 endif()
+add_definitions(-DSYSTEMTZDIR="${MEOS_TZDATA_DIR}")
+message(STATUS "Directory of the time zone database: ${MEOS_TZDATA_DIR}")
 
 # Option to build MEOS as a shared or static library
 option(BUILD_SHARED_LIBS

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -392,13 +392,13 @@ pose_parse(const char **str, bool end)
   /* Determine whether the pose has a geometry */
   int32_t srid_geo;
   GSERIALIZED *geo = NULL;
-  if (strncasecmp(*str,"POSE",4) != 0)
+  if (pg_strncasecmp(*str, "POSE", 4) != 0)
   {
     if (! geo_parse(str, T_GEOMETRY, ',', &srid_geo, &geo))
       return NULL;
   }
 
-  if (strncasecmp(*str, "POSE", 4) == 0)
+  if (pg_strncasecmp(*str, "POSE", 4) == 0)
   {
     *str += 4;
     p_whitespace(str);

--- a/meos/src/rgeo/trgeo_parser.c
+++ b/meos/src/rgeo/trgeo_parser.c
@@ -318,7 +318,7 @@ trgeo_parse(const char **str, MeosType temptype)
 
   interpType interp = temptype_continuous(temptype) ? LINEAR : STEP;
   /* Starts with "Interp=Step" */
-  if (strncasecmp(*str, "Interp=Step;", 12) == 0)
+  if (pg_strncasecmp(*str, "Interp=Step;", 12) == 0)
   {
     /* Move str after the semicolon */
     *str += 12;

--- a/postgres/pg_config.h.in
+++ b/postgres/pg_config.h.in
@@ -20,6 +20,7 @@
  */
 #define SIZEOF_VOID_P         @SIZEOF_VOID_P@
 #define SIZEOF_LONG           @SIZEOF_LONG@
+#define SIZEOF_LONG_LONG      @SIZEOF_LONG_LONG@
 #define SIZEOF_SIZE_T         @SIZEOF_SIZE_T@
 
 /*


### PR DESCRIPTION
> 👀 **Reviewers**: tier ranking, dependency chains and the standards checklist live in [`doc/contributing/reviewer-guide.md`](https://github.com/MobilityDB/MobilityDB/blob/master/doc/contributing/reviewer-guide.md).

## Summary
First concrete step toward [issue #513](https://github.com/MobilityDB/MobilityDB/issues/513) — native Windows support for the standalone MEOS C library, currently buildable only via WSL.

The goal here is **not a fully Windows-clean MEOS**. It is to land a Windows MSYS2/UCRT64 CI job that builds `libmeos.dll` and runs a smoke test, so subsequent breakages surface as concrete CI failures we can iterate on, rather than as opaque "doesn't build on Windows" reports.

## What this PR does
- **`.github/workflows/windows_msys2_meos.yml`** — new workflow. Configures `cmake -DMEOS=ON` under MSYS2 UCRT64 with mingw-w64 GCC, installs `libmeos.dll`, and compiles + runs `meos/test/temporal_test.c` against the install. POSE/RGEO are deliberately OFF for the bootstrap (rgeo depends on PostGIS build-tree headers that haven't been verified on Windows; POSE drags RGEO in via `CMAKE_DEPENDENT_OPTION`, so both off).
- **`meos/CMakeLists.txt`** — guard `add_definitions(-DSYSTEMTZDIR="/usr/share/zoneinfo")` behind `NOT WIN32`. Windows has no system zoneinfo directory; the embedded PostgreSQL timezone code falls back to the timezone name set via `meos_initialize_timezone()`.
- **`meos/src/pose/pose.c`** (2 sites), **`meos/src/rgeo/trgeo_parser.c`** (1 site) — replace bare `strncasecmp()` with `pg_strncasecmp()`. MSVC and MinGW CRTs don't declare `strncasecmp` (POSIX, not C99); `pg_strncasecmp` is provided by PostgreSQL's port layer and is already used in 46+ other MEOS call sites.

## Why MinGW first, not MSVC
MSVC requires `__declspec(dllexport)` on every public `extern` at build time and `dllimport` at consume time. `meos.h` defines `PGDLLEXPORT` under `_MSC_VER`, but the macro is applied to **zero** of the ~1,277 public `extern` declarations across the public headers. That annotation sweep is mechanical but large. Doing it before we know what else breaks would be premature.

MinGW-GCC under MSYS2 exports symbols by default (`--export-all-symbols` for DLLs), so the bootstrap can proceed without the export-annotation work and tell us whether any *other* portability issues exist on Windows.

## Verified locally
- Linux MEOS-standalone (Release, CBUFFER+NPOINT+POSE+RGEO) builds clean.
- `temporal_test` smoke test against the freshly built `libmeos.so` passes.

## Follow-ups (intentionally not in this PR)
- Apply `PGDLLEXPORT` across public headers and add an MSVC CI matrix entry.
- Provide a Windows-friendly default for `SYSTEMTZDIR` (bundled zoneinfo or registry lookup) so `meos_initialize_timezone()` becomes optional on Windows rather than required.
- Add Windows-specific path setters for `spatial_ref_sys.csv` and `ways1000.csv` so npoint examples work without source edits.
- Verify rgeo build on Windows and re-enable `RGEO=ON` in CI.

## Test plan
- [x] Local Linux build with the changes — clean
- [x] `temporal_test` smoke test on Linux — passes
- [ ] Windows MSYS2/UCRT64 CI on this PR — surfaces the next layer of issues if any
- [ ] Reviewer (@mschoema) sign-off

Closes part of #513.