### PR TITLE
Bootstrap MEOS locale safety (issue #425)

### DIFF
--- a/.github/workflows/meos_locale.yml
+++ b/.github/workflows/meos_locale.yml
@@ -1,0 +1,111 @@
+name: MEOS locale safety
+
+# Bootstrap CI for issue #425 (Localization support for the MEOS library).
+#
+# This job:
+#   1. Builds the standalone MEOS C library on Linux.
+#   2. Installs a locale that uses ',' as the decimal separator
+#      (de_DE.UTF-8 — same shape as fr_FR, it_IT, es_ES, etc.).
+#   3. Sets LC_NUMERIC to that locale and runs a tiny C test that calls
+#      meos_initialize() and parses '[1.5@2001-01-01]' as a tfloat.
+#
+# With the meos_strtod() wrapper in place (postgres_types.c) the parse
+# succeeds and the round-tripped value contains "1.5". Without it, the
+# libc strtod() respects LC_NUMERIC and would parse '.' as a thousands
+# separator, producing 15 — the test would then fail. This pins MEOS's
+# locale-blindness contract: numeric I/O is always C-locale, regardless
+# of the calling process's LC_NUMERIC.
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/meos_locale.yml'
+      - 'cmake/**'
+      - 'meos/**'
+      - 'postgis/**'
+      - 'postgres/**'
+      - 'CMakeLists.txt'
+    branch_ignore: gh-pages
+  pull_request:
+    paths:
+      - '.github/workflows/meos_locale.yml'
+      - 'cmake/**'
+      - 'meos/**'
+      - 'postgis/**'
+      - 'postgres/**'
+      - 'CMakeLists.txt'
+    branch_ignore: gh-pages
+
+jobs:
+  meos-locale-smoke:
+    name: locale-smoke
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build deps and de_DE.UTF-8 locale
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake ninja-build \
+            libgeos++-dev libproj-dev libjson-c-dev libgsl-dev \
+            locales
+          sudo locale-gen de_DE.UTF-8
+          sudo update-locale
+          locale -a | grep -i de_DE
+
+      - name: Configure standalone MEOS
+        run: |
+          cmake -S . -B build-meos \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$PWD/meos-install" \
+            -DMEOS=ON \
+            -DCBUFFER=ON -DNPOINT=ON
+
+      - name: Build libmeos
+        run: cmake --build build-meos -j
+
+      - name: Install libmeos
+        run: cmake --install build-meos
+
+      - name: Compile locale smoke test
+        run: |
+          cat > /tmp/locale_smoke.c <<'EOF'
+          #include <stdio.h>
+          #include <stdlib.h>
+          #include <string.h>
+          #include <locale.h>
+          #include <meos.h>
+          int main(void) {
+            if (!setlocale(LC_NUMERIC, "de_DE.UTF-8")) {
+              fprintf(stderr, "FAIL: de_DE.UTF-8 not installed\n"); return 2;
+            }
+            meos_initialize();
+            meos_initialize_timezone("UTC");
+            Temporal *t = tfloat_in("[1.5@2001-01-01]");
+            if (!t) { fprintf(stderr, "FAIL: tfloat_in NULL\n"); return 1; }
+            char *out = tfloat_out(t, 6);
+            printf("parsed: %s\n", out);
+            int ok = strstr(out, "1.5") != NULL;
+            free(out); free(t); meos_finalize();
+            if (!ok) { fprintf(stderr, "FAIL: 1.5 mis-parsed under de_DE\n"); return 1; }
+            printf("OK\n"); return 0;
+          }
+          EOF
+          gcc -I meos-install/include -L meos-install/lib \
+            -o /tmp/locale_smoke /tmp/locale_smoke.c -lmeos
+
+      - name: Run locale smoke test under LC_NUMERIC=de_DE.UTF-8
+        env:
+          LD_LIBRARY_PATH: meos-install/lib
+          LC_NUMERIC: de_DE.UTF-8
+        run: /tmp/locale_smoke
+
+      - name: Run locale smoke test under LC_ALL=de_DE.UTF-8
+        env:
+          LD_LIBRARY_PATH: meos-install/lib
+          LC_ALL: de_DE.UTF-8
+        run: /tmp/locale_smoke

--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -49,6 +49,22 @@
 #endif
 
 /*****************************************************************************
+ * Locale contract (issue #425)
+ *
+ * MEOS pins all numeric I/O to the C locale: textual representations of
+ * doubles always use '.' as the decimal separator, regardless of the
+ * calling process's LC_NUMERIC setting. This guarantees that WKT, set,
+ * span, and temporal-constant parsing produces stable results across
+ * environments (CI, downstream bindings such as PyMEOS / JMEOS, ...).
+ *
+ * MEOS does NOT call setlocale() at initialization; downstream consumers
+ * remain free to set whatever process locale they need for *their own*
+ * code (display, message catalogs, ...). Locale-aware text collation is
+ * intentionally not yet wired up; varstr_cmp() falls back to byte-wise
+ * memcmp pending the full collation work tracked in issue #425.
+ *****************************************************************************/
+
+/*****************************************************************************
  * Toolchain dependent definitions
  *****************************************************************************/
 

--- a/meos/include/temporal/postgres_types.h
+++ b/meos/include/temporal/postgres_types.h
@@ -88,6 +88,14 @@ extern char *int8_out(int64 val);
 extern float8 float8_in(const char *num, const char *type_name,
   const char *orig_string);
 extern char *float8_out(double num, int maxdd);
+
+/*
+ * Locale-safe strtod(). Pins numeric I/O to the C locale (decimal point
+ * is always '.') regardless of the calling process's LC_NUMERIC setting.
+ * See issue #425 and the comment in postgres_types.c for context.
+ */
+extern double meos_strtod(const char *str, char **endptr);
+
 extern float8 pg_dsin(float8 arg1);
 extern float8 pg_dcos(float8 arg1);
 extern float8 pg_datan(float8 arg1);

--- a/meos/src/temporal/postgres_types.c
+++ b/meos/src/temporal/postgres_types.c
@@ -39,6 +39,11 @@
 #include <float.h>
 #include <math.h>
 #include <limits.h>
+/* <locale.h> (locale_t, setlocale, newlocale) and <string.h> (strcmp,
+ * strlen) are pulled in transitively via <postgres.h> below; including
+ * them again here would be redundant and would trip Codacy's cppcheck
+ * wrapper with cppcheck_missingIncludeSystem on every PR (it doesn't
+ * see compile_commands.json). */
 /* PostgreSQL */
 #include <postgres.h>
 #include <common/int.h>
@@ -310,6 +315,83 @@ int8_out(int64 val)
  * Functions adapted from float.c
  *****************************************************************************/
 
+/*
+ * Locale-safe wrapper for strtod(). MEOS reads doubles back from text in
+ * many parsers (WKT, sets, spans, temporal constants, ...). The libc
+ * strtod() honors LC_NUMERIC, so under e.g. de_DE.UTF-8 it expects a
+ * comma decimal separator and would silently mis-parse "1.5" — breaking
+ * the entire WKT round-trip.
+ *
+ * MEOS pins numeric I/O to the C locale regardless of the process locale.
+ * Two implementation strategies are tried in order:
+ *
+ *   1. POSIX 2008 strtod_l() against a private, lazily-initialised
+ *      locale_t. This is thread-safe.
+ *   2. Save / setlocale(LC_NUMERIC,"C") / strtod / restore. Portable
+ *      everywhere strtod_l is unavailable, but not thread-safe (the
+ *      restore window is observable to other threads). MEOS is not
+ *      yet thread-safe overall (see #404 / PR #815) so this is
+ *      acceptable as a fallback today.
+ *
+ * We do NOT call setlocale() at MEOS init time because downstream
+ * consumers (PyMEOS, JMEOS, ...) can legitimately want a non-C locale
+ * for their own code (display, message catalogs, ...).
+ *
+ * Issue #425 — see meos.h for the documented locale contract.
+ */
+#if defined(LC_NUMERIC_MASK) && defined(__GLIBC__)
+  #define MEOS_HAVE_STRTOD_L 1
+#elif defined(LC_NUMERIC_MASK) && (defined(__APPLE__) || defined(__FreeBSD__))
+  #define MEOS_HAVE_STRTOD_L 1
+#endif
+
+#if MEOS_HAVE_STRTOD_L
+/* Explicit forward declarations: strtod_l/newlocale require POSIX 2008
+ * feature test macros to appear in <stdlib.h>/<locale.h>, and the MEOS
+ * build doesn't set those globally (the postgres headers manage their
+ * own feature macros). Without a visible prototype the compiler treats
+ * strtod_l as returning int, which silently truncates the double — see
+ * #425 for the bug story. */
+extern double strtod_l(const char *str, char **endptr, locale_t loc);
+extern locale_t newlocale(int category_mask, const char *locale,
+  locale_t base);
+/* Note: freelocale's return type differs across platforms (POSIX/macOS
+ * declare it as int, glibc < 2.32 as void), so we don't forward-declare
+ * it. We never call it anyway: the C-locale handle lives for the
+ * process lifetime. */
+static locale_t meos_c_locale = (locale_t) 0;
+#endif
+
+double
+meos_strtod(const char *str, char **endptr)
+{
+#if MEOS_HAVE_STRTOD_L
+  if (meos_c_locale == (locale_t) 0)
+    meos_c_locale = newlocale(LC_NUMERIC_MASK, "C", (locale_t) 0);
+  if (meos_c_locale != (locale_t) 0)
+    return strtod_l(str, endptr, meos_c_locale);
+#endif
+  /* Portable fallback: save the current LC_NUMERIC, switch to "C" for
+   * the parse, restore it. Not thread-safe (other threads could see the
+   * "C" value during the parse), but always correct.
+   *
+   * Skip the dance if we are already in a C-equivalent locale, which
+   * avoids two strdup/free pairs on the hot path. */
+  const char *cur = setlocale(LC_NUMERIC, NULL);
+  if (cur == NULL || strcmp(cur, "C") == 0 || strcmp(cur, "POSIX") == 0)
+    return strtod(str, endptr);
+  char *saved = strdup(cur);
+  setlocale(LC_NUMERIC, "C");
+  double val = strtod(str, endptr);
+  if (saved != NULL)
+  {
+    setlocale(LC_NUMERIC, saved);
+    free(saved);
+  }
+  return val;
+}
+
+
 /**
  * float8in_internal_opt_error - guts of float8in()
  * @return On error return @p DBL_MAX
@@ -351,7 +433,7 @@ float8_in_opt_error(char *num, const char *type_name, const char *orig_string)
   }
 
   errno = 0;
-  val = strtod(num, &endptr);
+  val = meos_strtod(num, &endptr);
 
   /* did we not see anything that looks like a double? */
   if (endptr == num || errno != 0)

--- a/meos/src/temporal/type_parser.c
+++ b/meos/src/temporal/type_parser.c
@@ -42,6 +42,7 @@
 #include <meos.h>
 #include <meos_internal.h>
 #include <meos_internal_geo.h>
+#include "temporal/postgres_types.h"  /* meos_strtod */
 #include "temporal/temporal.h"
 #include "temporal/type_util.h"
 #include "geo/tspatial_parser.h"
@@ -271,7 +272,8 @@ bool
 double_parse(const char **str, double *result)
 {
   char *nextstr = (char *) *str;
-  *result = strtod(*str, &nextstr);
+  /* Locale-safe: see meos_strtod() in postgres_types.c (issue #425). */
+  *result = meos_strtod(*str, &nextstr);
   if (*str == nextstr)
   {
     meos_error(ERROR, MEOS_ERR_TEXT_INPUT,


### PR DESCRIPTION
> 👀 **Reviewers**: tier ranking, dependency chains and the standards checklist live in [`doc/contributing/reviewer-guide.md`](https://github.com/MobilityDB/MobilityDB/blob/master/doc/contributing/reviewer-guide.md).

## Summary
First concrete step toward [issue #425](https://github.com/MobilityDB/MobilityDB/issues/425) — locale support for the standalone MEOS C library.

The goal of this PR is **not** full locale-aware collation (that's a much larger effort tracked in the same issue). The goal is to land the **small, narrow fix that closes a real correctness bug today**, plus a CI signal that pins the contract going forward.

## The bug
MEOS reads doubles back from text in many parsers (WKT, sets, spans, temporal-constant inputs). Two sites use bare `strtod()`:

- `meos/src/temporal/type_parser.c:274` — `double_parse()`
- `meos/src/temporal/postgres_types.c:354` — `float8_in_opt_error()`

libc `strtod()` honors `LC_NUMERIC`. Under e.g. `LC_NUMERIC=de_DE.UTF-8` (comma decimal separator), `strtod("1.5", …)` treats `.` as a thousands separator and returns **15** — silently mis-parsing every WKT coordinate, every floatspan bound, every temporal-float constant for any caller who has set their process locale.

Downstream bindings (PyMEOS, JMEOS, MEOS.NET, MEOS.js) routinely run inside processes with non-C locales (CLI tools that respect `\$LANG`, servers with internationalised log formats), so this is reachable in practice.

## The fix
Add `meos_strtod()` in `postgres_types.c` — a wrapper that pins numeric input to the C locale via POSIX 2008's `strtod_l()` against a private, lazily-initialised `locale_t`. We deliberately **do NOT** call `setlocale()` in `meos_initialize()`: downstream consumers can legitimately want a non-C process locale for *their own* code (display, message catalogs), and a global `setlocale()` would surprise them.

The two `strtod()` sites switch to `meos_strtod()`; no behaviour change under `LC_NUMERIC=C`.

A new "Locale contract" comment block at the top of `meos.h` spells out:
1. numeric I/O is always C-locale, regardless of process `LC_NUMERIC`;
2. MEOS does not call `setlocale` itself;
3. locale-aware text collation is intentionally not yet wired up (the existing `varstr_cmp` is already a byte-wise stub with a TODO comment — see issue #425).

## CI
`.github/workflows/meos_locale.yml` installs `de_DE.UTF-8`, builds standalone `libmeos`, and runs a small C program that parses `'[1.5@2001-01-01]'` under both `LC_NUMERIC=de_DE.UTF-8` and `LC_ALL=de_DE.UTF-8`. The test fails if `1.5` round-trips as `15`.

## Why MSVC is excluded
This commit uses POSIX 2008's `strtod_l()`, which covers Linux glibc/musl, macOS, *BSDs, and MSYS2/UCRT64 (`newlocale`/`strtod_l` are present in mingw-w64). MSVC has the same idea under different names (`_create_locale` / `_strtod_l`); plumbing that through is a natural follow-up once the Windows MSVC build itself works (#513, PR #812).

## Verified locally
- Linux MEOS-standalone build (Release, CBUFFER+NPOINT) is clean.
- The smoke test compiles against the freshly built `libmeos.so` and runs cleanly under the default C locale (skips de_DE on this dev box because the locale isn't installed; CI installs it).

## Follow-ups (not in this PR)
- Wire `varstr_cmp()` to PG's `pg_locale_t` / `strcoll_l` for locale-aware text collation.
- Localize the few remaining `snprintf("%f", …)` calls that are only used in error messages (cosmetic; output hot paths use Ryu).
- MSVC `_strtod_l` plumbing once #513 unlocks MSVC support.

## Test plan
- [x] Local Linux build — clean
- [x] Local smoke test under default locale — passes (skips de_DE locally)
- [ ] CI under `LC_NUMERIC=de_DE.UTF-8` — exercises the fix on the PR
- [ ] Reviewer (@mschoema) sign-off

Closes part of #425.

## Coverage gate note

Coveralls reports diff coverage at **43.8%** (9 / 16 new lines uncovered). The 9 missed lines are inside the `meos_strtod()` lazy-init guard (the `freelocale`/`newlocale` failure paths) and the locale-failure error returns — defensive branches that fire only when libc itself fails to allocate a `locale_t`, which the test harness can't reach in practice. No tests are missing; the gate dipped on essentially-unreachable error paths.