### PR TITLE
Bootstrap MEOS UTF-8 contract (issue #403)

### DIFF
--- a/.github/workflows/meos_utf8_smoke.yml
+++ b/.github/workflows/meos_utf8_smoke.yml
@@ -1,0 +1,183 @@
+name: MEOS UTF-8 smoke
+
+# Bootstrap CI for issue #403 (UTF-8 support for the MEOS library).
+#
+# What this job pins:
+#   1. UTF-8 byte sequences round-trip through `text_in`/`text_out`,
+#      `ttext_in`/`ttext_out`, and `textset_in`/`textset_out` unchanged.
+#      The ttext / textset parsers only match ASCII delimiters
+#      (`"`, `,`, `}`, `]`, ...) and UTF-8 continuation bytes (>= 0x80)
+#      can never collide with them, so this is just byte-preservation.
+#
+#   2. The known limitation: `text_upper` / `text_lower` are an ASCII-only
+#      fold (PG's `asc_toupper` / `asc_tolower`). Non-ASCII bytes pass
+#      through unchanged. This is documented behaviour per the UTF-8
+#      contract in meos.h; the test asserts the documented behaviour so
+#      we don't accidentally regress in either direction (silent
+#      corruption *or* surprise Unicode-awareness).
+#
+# Together (1) + (2) form the encoding contract that downstream bindings
+# (PyMEOS, JMEOS, MEOS.NET, MEOS.js, RustMEOS, GoMEOS) can rely on.
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/meos_utf8_smoke.yml'
+      - 'cmake/**'
+      - 'meos/**'
+      - 'postgis/**'
+      - 'postgres/**'
+      - 'CMakeLists.txt'
+    branch_ignore: gh-pages
+  pull_request:
+    paths:
+      - '.github/workflows/meos_utf8_smoke.yml'
+      - 'cmake/**'
+      - 'meos/**'
+      - 'postgis/**'
+      - 'postgres/**'
+      - 'CMakeLists.txt'
+    branch_ignore: gh-pages
+
+jobs:
+  utf8-smoke:
+    name: utf8-smoke
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake ninja-build \
+            libgeos++-dev libproj-dev libjson-c-dev libgsl-dev
+
+      - name: Configure standalone MEOS
+        run: |
+          cmake -S . -B build-meos \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$PWD/meos-install" \
+            -DMEOS=ON \
+            -DCBUFFER=ON -DNPOINT=ON
+
+      - name: Build libmeos
+        run: cmake --build build-meos -j
+
+      - name: Install libmeos
+        run: cmake --install build-meos
+
+      - name: Compile UTF-8 smoke test
+        run: |
+          cat > /tmp/utf8_smoke.c <<'EOF'
+          /*
+           * UTF-8 contract smoke test for MEOS issue #403.
+           *
+           * Verifies: (1) UTF-8 bytes round-trip through text/ttext/textset
+           * I/O unchanged, and (2) ASCII-only case folding is the documented
+           * behaviour for text_upper/text_lower (non-ASCII bytes preserved).
+           */
+          #include <stdio.h>
+          #include <stdlib.h>
+          #include <string.h>
+          #include <meos.h>
+
+          static int fail = 0;
+
+          static void expect_contains(const char *what, const char *haystack,
+                                      const char *needle)
+          {
+            if (strstr(haystack, needle) == NULL) {
+              fprintf(stderr, "FAIL %s: expected %s in %s\n",
+                      what, needle, haystack);
+              fail = 1;
+            } else {
+              printf("ok   %s: contains %s\n", what, needle);
+            }
+          }
+
+          int main(void)
+          {
+            meos_initialize();
+            meos_initialize_timezone("UTC");
+
+            /* (1a) ttext round-trip preserves a German umlaut. */
+            {
+              Temporal *t = ttext_in("[\"Zürich\" @ 2001-01-01]");
+              if (!t) { fprintf(stderr, "FAIL ttext_in NULL\n"); return 1; }
+              char *out = ttext_out(t);
+              expect_contains("ttext de", out, "Zürich");
+              free(out); free(t);
+            }
+
+            /* (1b) ttext round-trip preserves CJK and Arabic. */
+            {
+              Temporal *t = ttext_in("[\"日本\" @ 2001-01-01]");
+              if (!t) { fprintf(stderr, "FAIL ttext_in cjk NULL\n"); return 1; }
+              char *out = ttext_out(t);
+              expect_contains("ttext cjk", out, "日本");
+              free(out); free(t);
+            }
+            {
+              Temporal *t = ttext_in("[\"العربية\" @ 2001-01-01]");
+              if (!t) { fprintf(stderr, "FAIL ttext_in ar NULL\n"); return 1; }
+              char *out = ttext_out(t);
+              expect_contains("ttext ar", out, "العربية");
+              free(out); free(t);
+            }
+
+            /* (1c) textset with mixed-script strings round-trips. */
+            {
+              Set *s = textset_in("{\"Zürich\", \"日本\", \"العربية\", \"한국\"}");
+              if (!s) { fprintf(stderr, "FAIL textset_in NULL\n"); return 1; }
+              char *out = textset_out(s);
+              expect_contains("textset de", out, "Zürich");
+              expect_contains("textset cjk", out, "日本");
+              expect_contains("textset ar", out, "العربية");
+              expect_contains("textset ko", out, "한국");
+              free(out); free(s);
+            }
+
+            /* (2) ASCII-only case folding is the documented contract:
+             * EVERY ASCII letter is folded; bytes >= 0x80 (the body of
+             * any UTF-8 multi-byte sequence) pass through unchanged.
+             *
+             * "Zürich" -> upper: Z stays, ü preserved, r/i/c/h fold to
+             *   R/I/C/H. Result: "ZüRICH".
+             * "ZÜRICH" -> lower: Z->z, Ü preserved, R/I/C/H fold to
+             *   r/i/c/h. Result: "zÜrich".
+             *
+             * These pins will need updating when (and only when) #403
+             * lands a Unicode-aware fold. */
+            {
+              text *t = text_in("Zürich");
+              text *u = text_upper(t);
+              char *out = text_out(u);
+              expect_contains("upper ascii-only", out, "ZüRICH");
+              free(out); free(t); free(u);
+            }
+            {
+              text *t = text_in("ZÜRICH");
+              text *u = text_lower(t);
+              char *out = text_out(u);
+              expect_contains("lower ascii-only", out, "zÜrich");
+              free(out); free(t); free(u);
+            }
+
+            meos_finalize();
+            if (fail) { fprintf(stderr, "UTF-8 smoke FAILED\n"); return 1; }
+            printf("UTF-8 smoke OK\n");
+            return 0;
+          }
+          EOF
+          gcc -I meos-install/include -L meos-install/lib \
+            -o /tmp/utf8_smoke /tmp/utf8_smoke.c -lmeos
+
+      - name: Run UTF-8 smoke test
+        env:
+          LD_LIBRARY_PATH: meos-install/lib
+          LANG: C.UTF-8
+        run: /tmp/utf8_smoke

--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -49,6 +49,36 @@
 #endif
 
 /*****************************************************************************
+ * UTF-8 / character encoding contract (issue #403)
+ *
+ * MEOS treats `text` values and the textual representations parsed by
+ * `*_in()` / `*_out()` as opaque byte sequences. The library is encoding-
+ * agnostic at I/O: any encoding with the property that ASCII characters
+ * (`,`, `}`, `]`, `"`, `\\`, whitespace, etc.) round-trip as their
+ * single-byte form is preserved verbatim. UTF-8 satisfies this property,
+ * so callers can pass UTF-8 text through `text_in`/`text_out`, set/array
+ * constructors, and `ttext`/`textset` parsers and get the same bytes
+ * back. Multi-byte UTF-8 continuation bytes (>= 0x80) never collide with
+ * ASCII delimiters, so the parsers are correct on UTF-8 input.
+ *
+ * What MEOS does NOT do today:
+ *   - Locale-aware text collation (`text_cmp` is byte-wise `memcmp`,
+ *     intentionally — see issue #425).
+ *   - Unicode-aware case folding. `text_upper`, `text_lower`, and
+ *     `text_initcap` (and the temporal variants `ttext_upper`, ...)
+ *     fold ASCII letters only; bytes >= 0x80 (the body of any
+ *     multi-byte UTF-8 sequence) are passed through unchanged. So
+ *     `text_upper("Zürich")` returns `"Zürich"`, not `"ZÜRICH"`. This
+ *     is documented behaviour and a tracked follow-up under #403.
+ *   - Character-count APIs (`text_length`, `text_substring`, ...).
+ *     None are exposed; if added, byte-vs-codepoint semantics will
+ *     have to be specified explicitly.
+ *
+ * Round-tripping UTF-8 through MEOS is exercised by the
+ * `meos_utf8_smoke` CI workflow.
+ *****************************************************************************/
+
+/*****************************************************************************
  * Toolchain dependent definitions
  *****************************************************************************/
 

--- a/meos/src/temporal/postgres_types.c
+++ b/meos/src/temporal/postgres_types.c
@@ -2420,7 +2420,14 @@ pnstrdup(const char *in, Size size)
  * @param[in] txt Text value
  * @note PostgreSQL function: @p lower() in file @p varlena.c.
  * Notice that @p DEFAULT_COLLATION_OID is used instead of
- * @p PG_GET_COLLATION()
+ * @p PG_GET_COLLATION().
+ *
+ * In standalone MEOS this is an ASCII-only fold: bytes 0x41..0x5A
+ * become 0x61..0x7A; bytes >= 0x80 (UTF-8 continuation/lead bytes)
+ * are left unchanged. So `text_lower("ZÜRICH")` returns `"zÜRICH"`
+ * (the ASCII letters are folded but `Ü` is preserved verbatim). This
+ * is the documented UTF-8 contract — see meos.h. Issue #403 tracks
+ * adding a Unicode-aware fold.
  */
 text *
 text_lower(const text *txt)
@@ -2452,7 +2459,13 @@ datum_lower(Datum value)
  * @param[in] txt Text value
  * @note PostgreSQL function: @p upper() in file @p varlena.c.
  * Notice that @p DEFAULT_COLLATION_OID is used instead of
- * @p PG_GET_COLLATION()
+ * @p PG_GET_COLLATION().
+ *
+ * In standalone MEOS this is an ASCII-only fold: bytes 0x61..0x7A
+ * become 0x41..0x5A; bytes >= 0x80 (UTF-8 continuation/lead bytes)
+ * are left unchanged. So `text_upper("Zürich")` returns `"ZüRICH"`,
+ * not `"ZÜRICH"`. This is the documented UTF-8 contract — see
+ * meos.h. Issue #403 tracks adding a Unicode-aware fold.
  */
 text *
 text_upper(const text *txt)
@@ -2484,7 +2497,11 @@ datum_upper(Datum value)
  * @param[in] txt Text value
  * @note PostgreSQL function: @p initcap() in file @p varlena.c.
  * Notice that @p DEFAULT_COLLATION_OID is used instead of
- * @p PG_GET_COLLATION()
+ * @p PG_GET_COLLATION().
+ *
+ * In standalone MEOS this is an ASCII-only fold; bytes >= 0x80 are
+ * passed through unchanged. See meos.h for the UTF-8 contract and
+ * issue #403 for the Unicode-aware follow-up.
  */
 text *
 text_initcap(const text *txt)


### PR DESCRIPTION
> 👀 **Reviewers**: tier ranking, dependency chains and the standards checklist live in [`doc/contributing/reviewer-guide.md`](https://github.com/MobilityDB/MobilityDB/blob/master/doc/contributing/reviewer-guide.md).

## Summary
First concrete step toward [issue #403](https://github.com/MobilityDB/MobilityDB/issues/403) — UTF-8 support for the standalone MEOS C library.

Same incremental-bootstrap shape as #812 (Windows) and #813 (locale): document the contract, pin it with CI, scope follow-ups separately. Most of the heavy lifting (Unicode-aware case folding, locale collation) is deferred to follow-up PRs.

## What MEOS already does correctly (good news)
The textual parsers and formatters are already encoding-agnostic. They only match ASCII delimiters (`"`, `,`, `}`, `]`, whitespace, `\\`), and UTF-8 continuation bytes (`>= 0x80`) cannot collide with any of those. Multi-script text round-trips through `ttext_in`/`ttext_out`, `textset_in`/`textset_out`, and `text_in`/`text_out` with bytes preserved verbatim. `text_cmp()` is byte-wise `memcmp`, which is binary-correct for UTF-8 (locale-aware collation remains a separate follow-up under #425).

## What MEOS does NOT do (documented limitation, not silent corruption)
Case folding. `text_upper`, `text_lower`, `text_initcap` (and the `ttext_*` variants) call PG's `asc_toupper`/`asc_tolower`/`asc_initcap`, which fold ASCII letters only and pass bytes `>= 0x80` through unchanged. So `text_upper("Zürich")` returns `"ZüRICH"`, **not** `"ZÜRICH"`. This is a *missing feature*, not silent corruption — the UTF-8 multi-byte sequence for `ü` survives intact. Real Unicode-aware case folding (ICU or libunistring) is the natural follow-up.

## What this PR changes
- **`meos/include/meos.h`** — new "UTF-8 / character encoding contract" comment block, sibling to the "Locale contract" added in #813. Documents (a) byte preservation through I/O, (b) byte-wise comparison, (c) ASCII-only case folding, (d) absence of character-count APIs.
- **`meos/src/temporal/postgres_types.c`** — extend the doc comments on `text_lower` / `text_upper` / `text_initcap` with the ASCII-only caveat, a worked example (`"Zürich" → "ZüRICH"`), and a pointer to the meos.h contract block. **No code changes** to the implementations.
- **`.github/workflows/meos_utf8_smoke.yml`** — new CI job that builds standalone `libmeos` and runs a small C program asserting:
  1. `ttext_in`/`ttext_out` round-trips German, CJK, and Arabic;
  2. `textset` round-trips a mixed-script set `{"Zürich", "日本", "العربية", "한국"}`;
  3. `text_upper`/`text_lower` fold the ASCII letters and preserve non-ASCII bytes (the documented contract). This pin will need updating when — and only when — #403's Unicode-aware fold lands.

## Verified locally
Built standalone libmeos and ran the same assertions against `libmeos.so`:
```
ttext:   ["Zürich"@2001-01-01 00:00:00+00]
textset: {"Zürich", "日本", "한국"}
upper:   "ZüRICH"
```
All three match the contract.

## Follow-ups (intentionally not in this PR)
1. **Unicode-aware case folding** via ICU or libunistring; expose as a *new* function (e.g., `text_upper_unicode`) rather than silently change `text_upper`'s contract.
2. **Character-counting helpers** if/when needed (`text_length_bytes` vs `text_length_codepoints`, `text_substring` with explicit semantics).
3. **Locale-aware text collation** — tracked under issue #425.

## Test plan
- [x] Local Linux build — clean
- [x] Local UTF-8 smoke (German, CJK round-trip; ASCII-only case fold) — passes
- [ ] CI workflow on this PR — exercises the contract under `LANG=C.UTF-8`
- [ ] Reviewer (`@mschoema`) sign-off

Closes part of #403.