### PR TITLE
feat(meos): export temporal_merge_transfn / temporal_merge_combinefn

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -1777,6 +1777,8 @@ extern int nad_tint_tint(const Temporal *temp1, const Temporal *temp2);
 extern SkipList *tbool_tand_transfn(SkipList *state, const Temporal *temp);
 extern SkipList *tbool_tor_transfn(SkipList *state, const Temporal *temp);
 extern Span *temporal_extent_transfn(Span *s, const Temporal *temp);
+extern SkipList *temporal_merge_transfn(SkipList *state, const Temporal *temp);
+extern SkipList *temporal_merge_combinefn(SkipList *state1, SkipList *state2);
 extern Temporal *temporal_tagg_finalfn(SkipList *state);
 extern SkipList *temporal_tcount_transfn(SkipList *state, const Temporal *temp);
 extern SkipList *tfloat_tmax_transfn(SkipList *state, const Temporal *temp);

--- a/meos/src/temporal/temporal_aggfuncs_meos.c
+++ b/meos/src/temporal/temporal_aggfuncs_meos.c
@@ -278,6 +278,34 @@ ttext_tmax_transfn(SkipList *state, const Temporal *temp)
   return temporal_tagg_transfn(state, temp, &datum_max_text, CROSSINGS_NO);
 }
 
+/**
+ * @ingroup meos_temporal_agg
+ * @brief Transition function for the merge aggregate of temporal values
+ * @param[in,out] state Current aggregate state
+ * @param[in] temp Temporal value to aggregate
+ * @csqlfn #Temporal_merge_transfn()
+ */
+SkipList *
+temporal_merge_transfn(SkipList *state, const Temporal *temp)
+{
+  /* Null temporal: return state */
+  if (! temp)
+    return state;
+  return temporal_tagg_transfn(state, temp, NULL, CROSSINGS_NO);
+}
+
+/**
+ * @ingroup meos_temporal_agg
+ * @brief Combine function for the merge aggregate of temporal values
+ * @param[in,out] state1, state2 Current aggregate states
+ * @csqlfn #Temporal_merge_combinefn()
+ */
+SkipList *
+temporal_merge_combinefn(SkipList *state1, SkipList *state2)
+{
+  return temporal_tagg_combinefn(state1, state2, NULL, CROSSINGS_NO);
+}
+
 #endif /* MEOS */
 
 /*****************************************************************************


### PR DESCRIPTION
## Summary
- Adds public MEOS exports for `temporal_merge_transfn(SkipList *, const Temporal *)` and `temporal_merge_combinefn(SkipList *, SkipList *)`.
- Both delegate to the existing internal `temporal_tagg_transfn` / `temporal_tagg_combinefn` with a `NULL` combiner — the same dispatch used by the PG-side `Temporal_merge_transfn` / `Temporal_merge_combinefn`.
- Header declarations placed alphabetically next to the other `temporal_*_transfn` exports in `meos/include/meos.h`; bodies guarded by `#if MEOS` in `temporal_aggfuncs_meos.c`.

## Motivation
External MEOS consumers (e.g. MobilityDuck) cannot currently expose a SQL `merge(temporal)` aggregate without re-implementing skiplist machinery or pulling in private headers, because the merge variant is the only `tagg` whose transfn is not part of the public surface (`tbool_tand_transfn`, `tint_tmin_transfn`, …, `ttext_tmax_transfn` are all already exported).

Closes #822.

## Test plan
- [x] Verified the new `meos/src/temporal/temporal_aggfuncs_meos.c` compiles cleanly under MEOS mode with the project's standard CFLAGS.
- [x] Verified `nm` reports `T temporal_merge_transfn` / `T temporal_merge_combinefn` as exported.
- [ ] CI MEOS build on PR.