### PR TITLE
ci: enable -DCBUFFER=ON -DPOSE=ON in the coverage matrix

### DIFF
--- a/.github/workflows/pgversion.yml
+++ b/.github/workflows/pgversion.yml
@@ -92,20 +92,10 @@ jobs:
           export PATH=/usr/lib/postgresql/${{ matrix.psql }}/bin:$PATH
           mkdir build
           cd build
-          # Coverage matrix entry enables every in-tree opt-in subsystem
-          # so their sources are compiled with gcov instrumentation and
-          # the cross-cutting #if XX dispatch arms in shared files
-          # (temporal.c / span.c / tbox.c / meos_catalog.c / ...) are
-          # not preprocessed away. RGEO is a CMAKE_DEPENDENT_OPTION on
-          # POSE so it auto-enables. NPOINT is already ON by default.
-          # H3 / POINTCLOUD live behind their own CMake flags but their
-          # types haven't merged to master yet — those PRs (#807, #818)
-          # add the matching coverage-CI enablement on their own branch.
-          # Non-coverage matrix entries keep the lean default to verify
-          # that the gating (#if XX guards, opt-in compile) still works.
+          # Coverage build enables all opt-in subsystems so their sources get instrumented.
           cmake -DCMAKE_BUILD_TYPE=Release \
             -DWITH_COVERAGE=${{ matrix.coverage }} \
-            ${{ matrix.coverage == '1' && '-DCBUFFER=ON -DPOSE=ON' || '' }} \
+            ${{ matrix.coverage == '1' && '-DCBUFFER=ON -DPOSE=ON -DRGEO=ON' || '' }} \
             ..
 
       - name: Build

--- a/.github/workflows/pgversion.yml
+++ b/.github/workflows/pgversion.yml
@@ -92,7 +92,21 @@ jobs:
           export PATH=/usr/lib/postgresql/${{ matrix.psql }}/bin:$PATH
           mkdir build
           cd build
-          cmake -DCMAKE_BUILD_TYPE=Release -DWITH_COVERAGE=${{ matrix.coverage }} ..
+          # Coverage matrix entry enables every in-tree opt-in subsystem
+          # so their sources are compiled with gcov instrumentation and
+          # the cross-cutting #if XX dispatch arms in shared files
+          # (temporal.c / span.c / tbox.c / meos_catalog.c / ...) are
+          # not preprocessed away. RGEO is a CMAKE_DEPENDENT_OPTION on
+          # POSE so it auto-enables. NPOINT is already ON by default.
+          # H3 / POINTCLOUD live behind their own CMake flags but their
+          # types haven't merged to master yet — those PRs (#807, #818)
+          # add the matching coverage-CI enablement on their own branch.
+          # Non-coverage matrix entries keep the lean default to verify
+          # that the gating (#if XX guards, opt-in compile) still works.
+          cmake -DCMAKE_BUILD_TYPE=Release \
+            -DWITH_COVERAGE=${{ matrix.coverage }} \
+            ${{ matrix.coverage == '1' && '-DCBUFFER=ON -DPOSE=ON' || '' }} \
+            ..
 
       - name: Build
         run: |


### PR DESCRIPTION
## Summary

Enable `-DCBUFFER=ON` and `-DPOSE=ON` (which auto-enables `-DRGEO=ON` via the `CMAKE_DEPENDENT_OPTION`) in the coverage matrix entry of `.github/workflows/pgversion.yml`. Non-coverage entries keep the lean default build.

## Why

Coveralls' per-file API returns HTTP 404 on `meos/src/cbuffer/cbuffer.c`, `meos/src/pose/pose.c`, `meos/src/rgeo/trgeo.c` on master — those sources are never compiled in the gcov-instrumented build, so gcov emits no `.gcno`, lcov skips them, Coveralls receives nothing.

The same gating affects the *cross-cutting* files: `meos/src/temporal/{temporal,span,tbox,meos_catalog}.c` contain `#if CBUFFER` / `#if POSE` / `#if RGEO` blocks that get preprocessed away when the flags are OFF. The lines count as "no instructions emitted" by gcov, which Coveralls renders as missed. New temporal-type PRs (h3, pointcloud) saw this as artificially-poor diff coverage.

## What this enables

- `cbuffer` / `tcbuffer` source coverage from the existing `mobilitydb/test/cbuffer/queries/*.test.sql` suite.
- `pose` / `tpose` source coverage from `mobilitydb/test/pose/queries/*.test.sql`.
- `rgeo` / `trgeo` source coverage from `mobilitydb/test/rgeo/queries/*.test.sql`.
- Accurate dispatch-arm coverage in the cross-cutting temporal core files.

## Why master-side and not per-PR

These flags gate code that's already on master and has been for many releases. The coverage gap they cause affects every PR that touches the cross-cutting files, not just one. The matching per-PR enablement pattern applies to flags that gate *new code being added by that PR* — see PR #807 (H3) and PR #818 (POINTCLOUD) which carry their own commits to enable their respective flags.

## Test plan

- [x] YAML lint clean.
- [ ] CI run on this branch — once green, this PR's own coverage build will measure CBUFFER/POSE/RGEO source files; verify by comparing the per-file API result on this PR's Coveralls build to master's.
- [ ] Confirm non-coverage matrix entries (`coverage=0`) still produce a lean default build (regression of the gating itself).

## Companion PRs

- **PR #807** (`th3index`): adds `-DH3=ON` + `libh3-dev` on its own branch.
- **PR #818** (`pointcloud-review`): will add `-DPOINTCLOUD=ON` on its own branch (planned).
