### PR TITLE
Add Agg-suffixed aliases for the scalar/aggregate name collisions

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -797,15 +797,15 @@
 				</listitem>
 
 				<listitem>
-				<para><link linkend="appendInstant"><varname>appendInstant</varname></link>: Anexar un instante temporal a un valor temporal</para>
+				<para><link linkend="appendInstant"><varname>appendInstant</varname>, <varname>appendInstantAgg</varname></link>: Anexar un instante temporal a un valor temporal</para>
 				</listitem>
 
 				<listitem>
-				<para><link linkend="appendSequence"><varname>appendSequence</varname></link>: Anexar una secuencia temporal a un valor temporal</para>
+				<para><link linkend="appendSequence"><varname>appendSequence</varname>, <varname>appendSequenceAgg</varname></link>: Anexar una secuencia temporal a un valor temporal</para>
 				</listitem>
 
 				<listitem>
-				<para><link linkend="merge"><varname>merge</varname></link>: Fusionar los valores temporales</para>
+				<para><link linkend="merge"><varname>merge</varname>, <varname>mergeAgg</varname></link>: Fusionar los valores temporales</para>
 				</listitem>
 
 			</itemizedlist>
@@ -1409,7 +1409,7 @@
 				</listitem>
 
 				<listitem>
-					<para><link linkend="tMin"><varname>tMin</varname>, <varname>tMax</varname>, <varname>tSum</varname>, <varname>tAvg</varname></link>: Mínimo, máximo, suma y promedio temporal</para>
+					<para><link linkend="tMin"><varname>tMin</varname>, <varname>tMinAgg</varname>, <varname>tMax</varname>, <varname>tMaxAgg</varname>, <varname>tSum</varname>, <varname>tAvg</varname></link>: Mínimo, máximo, suma y promedio temporal</para>
 				</listitem>
 
 				<listitem>

--- a/doc/es/temporal_types_aggregation.xml
+++ b/doc/es/temporal_types_aggregation.xml
@@ -26,6 +26,10 @@
 			<listitem><para>Finalmente, para puntos temporales, la función <varname>tCentroid</varname> generaliza la función <varname>ST_Centroid</varname> proporcionada por PostGIS. Por ejemplo, dado un conjunto de objetos que se mueven juntos (es decir, un convoy o una bandada), el centroide temporal producirá un punto temporal que representa en cada instante el centro geométrico (o el centro de masa) de todos los objetos en movimiento.</para></listitem>
 		</itemizedlist>
 
+		<note>
+			<para>Los nombres <varname>tMin</varname>, <varname>tMax</varname>, <varname>merge</varname>, <varname>appendInstant</varname> y <varname>appendSequence</varname> designan tanto una función escalar como una agregación. El nombre canónico de la forma de agregación lleva el sufijo <varname>Agg</varname> (<varname>tMinAgg</varname>, <varname>tMaxAgg</varname>, <varname>mergeAgg</varname>, <varname>appendInstantAgg</varname> y <varname>appendSequenceAgg</varname>), de modo que los nombres escalar y de agregación sean distintos. Los nombres de agregación sin sufijo siguen disponibles como alias de compatibilidad y están obsoletos; se eliminarán en una versión mayor futura. Las formas escalares (los accesores de caja <varname>tMin</varname>/<varname>tMax</varname> y el constructor binario <varname>merge</varname>) conservan sus nombres.</para>
+		</note>
+
 		<para>En los ejemplos que siguen, suponemos que las tablas <varname>Department</varname> y <varname>Trip</varname> contienen las dos tuplas introducidas en la <xref linkend="ttype_examples" />.</para>
 		<itemizedlist>
 			<listitem xml:id="tCount">

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -794,15 +794,15 @@
 				</listitem>
 
 				<listitem>
-				<para><link linkend="appendInstant"><varname>appendInstant</varname></link>: Append a temporal instant to a temporal value</para>
+				<para><link linkend="appendInstant"><varname>appendInstant</varname>, <varname>appendInstantAgg</varname></link>: Append a temporal instant to a temporal value</para>
 				</listitem>
 
 				<listitem>
-				<para><link linkend="appendSequence"><varname>appendSequence</varname></link>: Append a temporal sequence to a temporal value</para>
+				<para><link linkend="appendSequence"><varname>appendSequence</varname>, <varname>appendSequenceAgg</varname></link>: Append a temporal sequence to a temporal value</para>
 				</listitem>
 
 				<listitem>
-				<para><link linkend="merge"><varname>merge</varname></link>: Merge temporal values</para>
+				<para><link linkend="merge"><varname>merge</varname>, <varname>mergeAgg</varname></link>: Merge temporal values</para>
 				</listitem>
 
 			</itemizedlist>
@@ -1410,7 +1410,7 @@
 				</listitem>
 
 				<listitem>
-					<para><link linkend="tMin"><varname>tMin</varname>, <varname>tMax</varname>, <varname>tSum</varname>, <varname>tAvg</varname></link>: Temporal minimum, maximum, sum, and average</para>
+					<para><link linkend="tMin"><varname>tMin</varname>, <varname>tMinAgg</varname>, <varname>tMax</varname>, <varname>tMaxAgg</varname>, <varname>tSum</varname>, <varname>tAvg</varname></link>: Temporal minimum, maximum, sum, and average</para>
 				</listitem>
 
 				<listitem>
@@ -1635,11 +1635,11 @@
 				<title>Modifications</title>
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="tpose_appendInstant"><varname>appendInstant</varname>, <varname>appendSequence</varname></link>: Append a temporal instant or a temporal sequence</para>
+						<para><link linkend="tpose_appendInstant"><varname>appendInstant</varname>, <varname>appendInstantAgg</varname>, <varname>appendSequence</varname>, <varname>appendSequenceAgg</varname></link>: Append a temporal instant or a temporal sequence</para>
 					</listitem>
 
 					<listitem>
-						<para><link linkend="tpose_merge"><varname>merge</varname></link>: Merge the temporal poses</para>
+						<para><link linkend="tpose_merge"><varname>merge</varname>, <varname>mergeAgg</varname></link>: Merge the temporal poses</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/temporal_types_aggregation.xml
+++ b/doc/temporal_types_aggregation.xml
@@ -26,6 +26,10 @@
 			<listitem><para>Finally, for temporal point types, the function <varname>tCentroid</varname> generalizes the function <varname>ST_Centroid</varname> provided by PostGIS. For example, given set of objects that move together (that is, a convoy or a flock) the temporal centroid will produce a temporal point that represents at each instant the geometric center (or the center of mass) of all the moving objects.</para></listitem>
 		</itemizedlist>
 
+		<note>
+			<para>The names <varname>tMin</varname>, <varname>tMax</varname>, <varname>merge</varname>, <varname>appendInstant</varname>, and <varname>appendSequence</varname> each denote both a scalar function and an aggregate. The canonical name of the aggregate form carries an <varname>Agg</varname> suffix (<varname>tMinAgg</varname>, <varname>tMaxAgg</varname>, <varname>mergeAgg</varname>, <varname>appendInstantAgg</varname>, and <varname>appendSequenceAgg</varname>), so that the scalar and aggregate names are distinct. The bare aggregate names remain available as backward-compatibility aliases and are deprecated; they will be removed in a future major release. The scalar forms (the box accessors <varname>tMin</varname>/<varname>tMax</varname> and the binary builder <varname>merge</varname>) keep their names.</para>
+		</note>
+
 		<para>In the examples that follow, we suppose the tables <varname>Department</varname> and <varname>Trip</varname> contain the two tuples introduced in <xref linkend="ttype_examples"/>.</para>
 		<itemizedlist>
 			<listitem xml:id="tCount">

--- a/mobilitydb/sql/cbuffer/211_tcbuffer_aggfuncs.in.sql
+++ b/mobilitydb/sql/cbuffer/211_tcbuffer_aggfuncs.in.sql
@@ -81,6 +81,18 @@ CREATE AGGREGATE merge(tcbuffer) (
   STYPE = internal,
   COMBINEFUNC = temporal_merge_combinefn,
   FINALFUNC = tcbuffer_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE mergeAgg(tcbuffer) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tcbuffer_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
   SERIALFUNC = taggstate_serialize,
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = safe
@@ -123,6 +135,13 @@ CREATE AGGREGATE appendInstant(tcbuffer) (
   PARALLEL = safe
 );
 
+CREATE AGGREGATE appendInstantAgg(tcbuffer) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tcbuffer,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
 CREATE AGGREGATE appendInstant(tcbuffer, text) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = tcbuffer,
@@ -130,7 +149,21 @@ CREATE AGGREGATE appendInstant(tcbuffer, text) (
   PARALLEL = safe
 );
 
+CREATE AGGREGATE appendInstantAgg(tcbuffer, text) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tcbuffer,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
 CREATE AGGREGATE appendInstant(tcbuffer, text, float, interval) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tcbuffer,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(tcbuffer, text, float, interval) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = tcbuffer,
   FINALFUNC = temporal_append_finalfn,
@@ -146,6 +179,13 @@ CREATE FUNCTION temporal_app_tseq_transfn(tcbuffer, tcbuffer)
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE AGGREGATE appendSequence(tcbuffer) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tcbuffer,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendSequenceAgg(tcbuffer) (
   SFUNC = temporal_app_tseq_transfn,
   STYPE = tcbuffer,
   FINALFUNC = temporal_append_finalfn,

--- a/mobilitydb/sql/geo/068_tgeo_aggfuncs.in.sql
+++ b/mobilitydb/sql/geo/068_tgeo_aggfuncs.in.sql
@@ -143,6 +143,18 @@ CREATE AGGREGATE merge(tgeometry) (
   STYPE = internal,
   COMBINEFUNC = temporal_merge_combinefn,
   FINALFUNC = tgeometry_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE mergeAgg(tgeometry) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tgeometry_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
   SERIALFUNC = taggstate_serialize,
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = safe
@@ -152,6 +164,18 @@ CREATE AGGREGATE merge(tgeography) (
   STYPE = internal,
   COMBINEFUNC = temporal_merge_combinefn,
   FINALFUNC = tgeography_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE mergeAgg(tgeography) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tgeography_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
   SERIALFUNC = taggstate_serialize,
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = safe
@@ -212,7 +236,21 @@ CREATE AGGREGATE appendInstant(tgeometry) (
   FINALFUNC = temporal_append_finalfn,
   PARALLEL = safe
 );
+
+CREATE AGGREGATE appendInstantAgg(tgeometry) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeometry,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
 CREATE AGGREGATE appendInstant(tgeography) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeography,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(tgeography) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = tgeography,
   FINALFUNC = temporal_append_finalfn,
@@ -225,7 +263,21 @@ CREATE AGGREGATE appendInstant(tgeometry, text) (
   FINALFUNC = temporal_append_finalfn,
   PARALLEL = safe
 );
+
+CREATE AGGREGATE appendInstantAgg(tgeometry, text) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeometry,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
 CREATE AGGREGATE appendInstant(tgeography, text) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeography,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(tgeography, text) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = tgeography,
   FINALFUNC = temporal_append_finalfn,
@@ -238,7 +290,21 @@ CREATE AGGREGATE appendInstant(tgeometry, text, float, interval) (
   FINALFUNC = temporal_append_finalfn,
   PARALLEL = safe
 );
+
+CREATE AGGREGATE appendInstantAgg(tgeometry, text, float, interval) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeometry,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
 CREATE AGGREGATE appendInstant(tgeography, text, float, interval) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeography,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(tgeography, text, float, interval) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = tgeography,
   FINALFUNC = temporal_append_finalfn,
@@ -263,7 +329,21 @@ CREATE AGGREGATE appendSequence(tgeometry) (
   FINALFUNC = temporal_append_finalfn,
   PARALLEL = safe
 );
+
+CREATE AGGREGATE appendSequenceAgg(tgeometry) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tgeometry,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
 CREATE AGGREGATE appendSequence(tgeography) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tgeography,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendSequenceAgg(tgeography) (
   SFUNC = temporal_app_tseq_transfn,
   STYPE = tgeography,
   FINALFUNC = temporal_append_finalfn,

--- a/mobilitydb/sql/geo/068_tpoint_aggfuncs.in.sql
+++ b/mobilitydb/sql/geo/068_tpoint_aggfuncs.in.sql
@@ -167,6 +167,18 @@ CREATE AGGREGATE merge(tgeompoint) (
   STYPE = internal,
   COMBINEFUNC = temporal_merge_combinefn,
   FINALFUNC = tgeompoint_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE mergeAgg(tgeompoint) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tgeompoint_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
   SERIALFUNC = taggstate_serialize,
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = safe
@@ -176,6 +188,18 @@ CREATE AGGREGATE merge(tgeogpoint) (
   STYPE = internal,
   COMBINEFUNC = temporal_merge_combinefn,
   FINALFUNC = tgeogpoint_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE mergeAgg(tgeogpoint) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tgeogpoint_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
   SERIALFUNC = taggstate_serialize,
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = safe
@@ -236,7 +260,21 @@ CREATE AGGREGATE appendInstant(tgeompoint) (
   FINALFUNC = temporal_append_finalfn,
   PARALLEL = safe
 );
+
+CREATE AGGREGATE appendInstantAgg(tgeompoint) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeompoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
 CREATE AGGREGATE appendInstant(tgeogpoint) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeogpoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(tgeogpoint) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = tgeogpoint,
   FINALFUNC = temporal_append_finalfn,
@@ -249,7 +287,21 @@ CREATE AGGREGATE appendInstant(tgeompoint, text) (
   FINALFUNC = temporal_append_finalfn,
   PARALLEL = safe
 );
+
+CREATE AGGREGATE appendInstantAgg(tgeompoint, text) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeompoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
 CREATE AGGREGATE appendInstant(tgeogpoint, text) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeogpoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(tgeogpoint, text) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = tgeogpoint,
   FINALFUNC = temporal_append_finalfn,
@@ -262,7 +314,21 @@ CREATE AGGREGATE appendInstant(tgeompoint, text, float, interval) (
   FINALFUNC = temporal_append_finalfn,
   PARALLEL = safe
 );
+
+CREATE AGGREGATE appendInstantAgg(tgeompoint, text, float, interval) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeompoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
 CREATE AGGREGATE appendInstant(tgeogpoint, text, float, interval) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeogpoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(tgeogpoint, text, float, interval) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = tgeogpoint,
   FINALFUNC = temporal_append_finalfn,
@@ -287,7 +353,21 @@ CREATE AGGREGATE appendSequence(tgeompoint) (
   FINALFUNC = temporal_append_finalfn,
   PARALLEL = safe
 );
+
+CREATE AGGREGATE appendSequenceAgg(tgeompoint) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tgeompoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
 CREATE AGGREGATE appendSequence(tgeogpoint) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tgeogpoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendSequenceAgg(tgeogpoint) (
   SFUNC = temporal_app_tseq_transfn,
   STYPE = tgeogpoint,
   FINALFUNC = temporal_append_finalfn,

--- a/mobilitydb/sql/npoint/314_tnpoint_aggfuncs.in.sql
+++ b/mobilitydb/sql/npoint/314_tnpoint_aggfuncs.in.sql
@@ -97,6 +97,18 @@ CREATE AGGREGATE merge(tnpoint) (
   STYPE = internal,
   COMBINEFUNC = temporal_merge_combinefn,
   FINALFUNC = tnpoint_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE mergeAgg(tnpoint) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tnpoint_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
   SERIALFUNC = taggstate_serialize,
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = safe
@@ -139,6 +151,13 @@ CREATE AGGREGATE appendInstant(tnpoint) (
   PARALLEL = safe
 );
 
+CREATE AGGREGATE appendInstantAgg(tnpoint) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tnpoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
 CREATE AGGREGATE appendInstant(tnpoint, text) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = tnpoint,
@@ -146,7 +165,21 @@ CREATE AGGREGATE appendInstant(tnpoint, text) (
   PARALLEL = safe
 );
 
+CREATE AGGREGATE appendInstantAgg(tnpoint, text) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tnpoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
 CREATE AGGREGATE appendInstant(tnpoint, text, float, interval) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tnpoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(tnpoint, text, float, interval) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = tnpoint,
   FINALFUNC = temporal_append_finalfn,
@@ -162,6 +195,13 @@ CREATE FUNCTION temporal_app_tseq_transfn(tnpoint, tnpoint)
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE AGGREGATE appendSequence(tnpoint) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tnpoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendSequenceAgg(tnpoint) (
   SFUNC = temporal_app_tseq_transfn,
   STYPE = tnpoint,
   FINALFUNC = temporal_append_finalfn,

--- a/mobilitydb/sql/pose/111_tpose_aggfuncs.in.sql
+++ b/mobilitydb/sql/pose/111_tpose_aggfuncs.in.sql
@@ -81,6 +81,18 @@ CREATE AGGREGATE merge(tpose) (
   STYPE = internal,
   COMBINEFUNC = temporal_merge_combinefn,
   FINALFUNC = tpose_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE mergeAgg(tpose) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tpose_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
   SERIALFUNC = taggstate_serialize,
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = safe
@@ -123,6 +135,13 @@ CREATE AGGREGATE appendInstant(tpose) (
   PARALLEL = safe
 );
 
+CREATE AGGREGATE appendInstantAgg(tpose) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tpose,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
 CREATE AGGREGATE appendInstant(tpose, text) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = tpose,
@@ -130,7 +149,21 @@ CREATE AGGREGATE appendInstant(tpose, text) (
   PARALLEL = safe
 );
 
+CREATE AGGREGATE appendInstantAgg(tpose, text) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tpose,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
 CREATE AGGREGATE appendInstant(tpose, text, float, interval) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tpose,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(tpose, text, float, interval) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = tpose,
   FINALFUNC = temporal_append_finalfn,
@@ -146,6 +179,13 @@ CREATE FUNCTION temporal_app_tseq_transfn(tpose, tpose)
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE AGGREGATE appendSequence(tpose) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tpose,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendSequenceAgg(tpose) (
   SFUNC = temporal_app_tseq_transfn,
   STYPE = tpose,
   FINALFUNC = temporal_append_finalfn,

--- a/mobilitydb/sql/rgeo/159_trgeo_aggfuncs.in.sql
+++ b/mobilitydb/sql/rgeo/159_trgeo_aggfuncs.in.sql
@@ -81,6 +81,18 @@ CREATE AGGREGATE merge(trgeometry) (
   STYPE = internal,
   COMBINEFUNC = temporal_merge_combinefn,
   FINALFUNC = trgeometry_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE mergeAgg(trgeometry) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = trgeometry_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
   SERIALFUNC = taggstate_serialize,
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = safe
@@ -123,6 +135,13 @@ CREATE AGGREGATE appendInstant(trgeometry) (
   PARALLEL = safe
 );
 
+CREATE AGGREGATE appendInstantAgg(trgeometry) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = trgeometry,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
 CREATE AGGREGATE appendInstant(trgeometry, text) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = trgeometry,
@@ -130,7 +149,21 @@ CREATE AGGREGATE appendInstant(trgeometry, text) (
   PARALLEL = safe
 );
 
+CREATE AGGREGATE appendInstantAgg(trgeometry, text) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = trgeometry,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
 CREATE AGGREGATE appendInstant(trgeometry, text, float, interval) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = trgeometry,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(trgeometry, text, float, interval) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = trgeometry,
   FINALFUNC = temporal_append_finalfn,
@@ -146,6 +179,13 @@ CREATE FUNCTION temporal_app_tseq_transfn(trgeometry, trgeometry)
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE AGGREGATE appendSequence(trgeometry) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = trgeometry,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendSequenceAgg(trgeometry) (
   SFUNC = temporal_app_tseq_transfn,
   STYPE = trgeometry,
   FINALFUNC = temporal_append_finalfn,

--- a/mobilitydb/sql/temporal/040_temporal_aggfuncs.in.sql
+++ b/mobilitydb/sql/temporal/040_temporal_aggfuncs.in.sql
@@ -286,6 +286,18 @@ CREATE AGGREGATE tmin(tint) (
   STYPE = internal,
   COMBINEFUNC = tint_tmin_combinefn,
   FINALFUNC = tint_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE tminAgg(tint) (
+  SFUNC = tint_tmin_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tint_tmin_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
   SERIALFUNC = taggstate_serialize,
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
@@ -295,6 +307,18 @@ CREATE AGGREGATE tmax(tint) (
   STYPE = internal,
   COMBINEFUNC = tint_tmax_combinefn,
   FINALFUNC = tint_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE tmaxAgg(tint) (
+  SFUNC = tint_tmax_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tint_tmax_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
   SERIALFUNC = taggstate_serialize,
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
@@ -373,6 +397,18 @@ CREATE AGGREGATE tmin(tfloat) (
   STYPE = internal,
   COMBINEFUNC = tfloat_tmin_combinefn,
   FINALFUNC = tfloat_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE tminAgg(tfloat) (
+  SFUNC = tfloat_tmin_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tfloat_tmin_combinefn,
+  FINALFUNC = tfloat_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
   SERIALFUNC = taggstate_serialize,
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
@@ -382,6 +418,18 @@ CREATE AGGREGATE tmax(tfloat) (
   STYPE = internal,
   COMBINEFUNC = tfloat_tmax_combinefn,
   FINALFUNC = tfloat_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE tmaxAgg(tfloat) (
+  SFUNC = tfloat_tmax_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tfloat_tmax_combinefn,
+  FINALFUNC = tfloat_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
   SERIALFUNC = taggstate_serialize,
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
@@ -449,6 +497,18 @@ CREATE AGGREGATE tmin(ttext) (
   STYPE = internal,
   COMBINEFUNC = ttext_tmin_combinefn,
   FINALFUNC = ttext_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE tminAgg(ttext) (
+  SFUNC = ttext_tmin_transfn,
+  STYPE = internal,
+  COMBINEFUNC = ttext_tmin_combinefn,
+  FINALFUNC = ttext_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
   SERIALFUNC = taggstate_serialize,
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
@@ -458,6 +518,18 @@ CREATE AGGREGATE tmax(ttext) (
   STYPE = internal,
   COMBINEFUNC = ttext_tmax_combinefn,
   FINALFUNC = ttext_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE tmaxAgg(ttext) (
+  SFUNC = ttext_tmax_transfn,
+  STYPE = internal,
+  COMBINEFUNC = ttext_tmax_combinefn,
+  FINALFUNC = ttext_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
   SERIALFUNC = taggstate_serialize,
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
@@ -493,6 +565,18 @@ CREATE AGGREGATE merge(tbool) (
   STYPE = internal,
   COMBINEFUNC = temporal_merge_combinefn,
   FINALFUNC = tbool_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE mergeAgg(tbool) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tbool_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
   SERIALFUNC = taggstate_serialize,
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = safe
@@ -502,6 +586,18 @@ CREATE AGGREGATE merge(tint) (
   STYPE = internal,
   COMBINEFUNC = temporal_merge_combinefn,
   FINALFUNC = tint_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE mergeAgg(tint) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
   SERIALFUNC = taggstate_serialize,
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = safe
@@ -511,6 +607,18 @@ CREATE AGGREGATE merge(tfloat) (
   STYPE = internal,
   COMBINEFUNC = temporal_merge_combinefn,
   FINALFUNC = tfloat_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE mergeAgg(tfloat) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tfloat_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
   SERIALFUNC = taggstate_serialize,
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = safe
@@ -520,6 +628,18 @@ CREATE AGGREGATE merge(ttext) (
   STYPE = internal,
   COMBINEFUNC = temporal_merge_combinefn,
   FINALFUNC = ttext_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE mergeAgg(ttext) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = ttext_tagg_finalfn,
+  FINALFUNC_MODIFY = READ_WRITE,
   SERIALFUNC = taggstate_serialize,
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = safe
@@ -610,7 +730,21 @@ CREATE AGGREGATE appendInstant(tbool) (
   FINALFUNC = temporal_append_finalfn,
   PARALLEL = safe
 );
+
+CREATE AGGREGATE appendInstantAgg(tbool) (
+  SFUNC = temporal_app_tinst_transfn(tbool, tbool),
+  STYPE = tbool,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
 CREATE AGGREGATE appendInstant(tbool, interp text) (
+  SFUNC = temporal_app_tinst_transfn(tbool, tbool, text),
+  STYPE = tbool,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(tbool, interp text) (
   SFUNC = temporal_app_tinst_transfn(tbool, tbool, text),
   STYPE = tbool,
   FINALFUNC = temporal_append_finalfn,
@@ -623,13 +757,34 @@ CREATE AGGREGATE appendInstant(tbool, interp text, maxt interval) (
   PARALLEL = safe
 );
 
+CREATE AGGREGATE appendInstantAgg(tbool, interp text, maxt interval) (
+  SFUNC = temporal_app_tinst_transfn(tbool, tbool, text, maxt),
+  STYPE = tbool,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
 CREATE AGGREGATE appendInstant(tint) (
   SFUNC = temporal_app_tinst_transfn(tint, tint),
   STYPE = tint,
   FINALFUNC = temporal_append_finalfn,
   PARALLEL = safe
 );
+
+CREATE AGGREGATE appendInstantAgg(tint) (
+  SFUNC = temporal_app_tinst_transfn(tint, tint),
+  STYPE = tint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
 CREATE AGGREGATE appendInstant(tint, interp text) (
+  SFUNC = temporal_app_tinst_transfn(tint, tint, text),
+  STYPE = tint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(tint, interp text) (
   SFUNC = temporal_app_tinst_transfn(tint, tint, text),
   STYPE = tint,
   FINALFUNC = temporal_append_finalfn,
@@ -643,13 +798,35 @@ CREATE AGGREGATE appendInstant(tint, interp text, maxdist float,
   PARALLEL = safe
 );
 
+CREATE AGGREGATE appendInstantAgg(tint, interp text, maxdist float, 
+    maxt interval) (
+  SFUNC = temporal_app_tinst_transfn(tint, tint, text, maxdist, maxt),
+  STYPE = tint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
 CREATE AGGREGATE appendInstant(tfloat) (
   SFUNC = temporal_app_tinst_transfn(tfloat, tfloat),
   STYPE = tfloat,
   FINALFUNC = temporal_append_finalfn,
   PARALLEL = safe
 );
+
+CREATE AGGREGATE appendInstantAgg(tfloat) (
+  SFUNC = temporal_app_tinst_transfn(tfloat, tfloat),
+  STYPE = tfloat,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
 CREATE AGGREGATE appendInstant(tfloat, interp text) (
+  SFUNC = temporal_app_tinst_transfn(tfloat, tfloat, text),
+  STYPE = tfloat,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(tfloat, interp text) (
   SFUNC = temporal_app_tinst_transfn(tfloat, tfloat, text),
   STYPE = tfloat,
   FINALFUNC = temporal_append_finalfn,
@@ -663,7 +840,22 @@ CREATE AGGREGATE appendInstant(tfloat, interp text, maxdist float,
   PARALLEL = safe
 );
 
+CREATE AGGREGATE appendInstantAgg(tfloat, interp text, maxdist float, 
+    maxt interval) (
+  SFUNC = temporal_app_tinst_transfn(tfloat, tfloat, text, maxdist, maxt),
+  STYPE = tfloat,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
 CREATE AGGREGATE appendInstant(ttext) (
+  SFUNC = temporal_app_tinst_transfn(ttext, ttext),
+  STYPE = ttext,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(ttext) (
   SFUNC = temporal_app_tinst_transfn(ttext, ttext),
   STYPE = ttext,
   FINALFUNC = temporal_append_finalfn,
@@ -675,7 +867,21 @@ CREATE AGGREGATE appendInstant(ttext, interp text) (
   FINALFUNC = temporal_append_finalfn,
   PARALLEL = safe
 );
+
+CREATE AGGREGATE appendInstantAgg(ttext, interp text) (
+  SFUNC = temporal_app_tinst_transfn(ttext, ttext, text),
+  STYPE = ttext,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
 CREATE AGGREGATE appendInstant(ttext, interp text, maxt interval) (
+  SFUNC = temporal_app_tinst_transfn(ttext, ttext, text, maxt),
+  STYPE = ttext,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(ttext, interp text, maxt interval) (
   SFUNC = temporal_app_tinst_transfn(ttext, ttext, text, maxt),
   STYPE = ttext,
   FINALFUNC = temporal_append_finalfn,
@@ -708,7 +914,21 @@ CREATE AGGREGATE appendSequence(tbool) (
   FINALFUNC = temporal_append_finalfn,
   PARALLEL = safe
 );
+
+CREATE AGGREGATE appendSequenceAgg(tbool) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tbool,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
 CREATE AGGREGATE appendSequence(tint) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendSequenceAgg(tint) (
   SFUNC = temporal_app_tseq_transfn,
   STYPE = tint,
   FINALFUNC = temporal_append_finalfn,
@@ -720,7 +940,21 @@ CREATE AGGREGATE appendSequence(tfloat) (
   FINALFUNC = temporal_append_finalfn,
   PARALLEL = safe
 );
+
+CREATE AGGREGATE appendSequenceAgg(tfloat) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tfloat,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
 CREATE AGGREGATE appendSequence(ttext) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = ttext,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendSequenceAgg(ttext) (
   SFUNC = temporal_app_tseq_transfn,
   STYPE = ttext,
   FINALFUNC = temporal_append_finalfn,

--- a/mobilitydb/test/temporal/expected/040_temporal_aggfuncs.test.out
+++ b/mobilitydb/test/temporal/expected/040_temporal_aggfuncs.test.out
@@ -771,3 +771,38 @@ SELECT numInstants(appendSequence(seq ORDER BY seq)) FROM temp2;
        35810
 (1 row)
 
+WITH temp(t) AS ( VALUES (tint '[1@2000-01-01, 3@2000-01-03]'), (tint '[5@2000-01-05, 7@2000-01-07]') )
+SELECT tmin(t) = tminAgg(t), tmax(t) = tmaxAgg(t), merge(t) = mergeAgg(t) FROM temp;
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+ t        | t        | t
+(1 row)
+
+WITH temp(t) AS ( VALUES (tfloat '[1@2000-01-01, 3@2000-01-03]'), (tfloat '[5@2000-01-05, 7@2000-01-07]') )
+SELECT tmin(t) = tminAgg(t), tmax(t) = tmaxAgg(t), merge(t) = mergeAgg(t) FROM temp;
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+ t        | t        | t
+(1 row)
+
+WITH temp(t) AS ( VALUES (ttext '[AAA@2000-01-01, CCC@2000-01-03]'), (ttext '[EEE@2000-01-05, GGG@2000-01-07]') )
+SELECT tmin(t) = tminAgg(t), tmax(t) = tmaxAgg(t), merge(t) = mergeAgg(t) FROM temp;
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+ t        | t        | t
+(1 row)
+
+WITH temp(inst) AS ( VALUES (tint '1@2000-01-01'), (tint '2@2000-01-02'), (tint '3@2000-01-03') )
+SELECT appendInstant(inst ORDER BY inst) = appendInstantAgg(inst ORDER BY inst) FROM temp;
+ ?column? 
+----------
+ t
+(1 row)
+
+WITH temp(seq) AS ( VALUES (tint '[1@2000-01-01, 2@2000-01-02]'), (tint '[3@2000-01-03, 4@2000-01-04]') )
+SELECT appendSequence(seq ORDER BY seq) = appendSequenceAgg(seq ORDER BY seq) FROM temp;
+ ?column? 
+----------
+ t
+(1 row)
+

--- a/mobilitydb/test/temporal/queries/040_temporal_aggfuncs.test.sql
+++ b/mobilitydb/test/temporal/queries/040_temporal_aggfuncs.test.sql
@@ -472,3 +472,16 @@ temp2(seq) AS (
 SELECT numInstants(appendSequence(seq ORDER BY seq)) FROM temp2;
 
 -------------------------------------------------------------------------------
+
+-- Each Agg-suffix alias equals its bare aggregate and the two coexist in one
+-- query (the bare and Agg forms must not share a destructive transition state)
+WITH temp(t) AS ( VALUES (tint '[1@2000-01-01, 3@2000-01-03]'), (tint '[5@2000-01-05, 7@2000-01-07]') )
+SELECT tmin(t) = tminAgg(t), tmax(t) = tmaxAgg(t), merge(t) = mergeAgg(t) FROM temp;
+WITH temp(t) AS ( VALUES (tfloat '[1@2000-01-01, 3@2000-01-03]'), (tfloat '[5@2000-01-05, 7@2000-01-07]') )
+SELECT tmin(t) = tminAgg(t), tmax(t) = tmaxAgg(t), merge(t) = mergeAgg(t) FROM temp;
+WITH temp(t) AS ( VALUES (ttext '[AAA@2000-01-01, CCC@2000-01-03]'), (ttext '[EEE@2000-01-05, GGG@2000-01-07]') )
+SELECT tmin(t) = tminAgg(t), tmax(t) = tmaxAgg(t), merge(t) = mergeAgg(t) FROM temp;
+WITH temp(inst) AS ( VALUES (tint '1@2000-01-01'), (tint '2@2000-01-02'), (tint '3@2000-01-03') )
+SELECT appendInstant(inst ORDER BY inst) = appendInstantAgg(inst ORDER BY inst) FROM temp;
+WITH temp(seq) AS ( VALUES (tint '[1@2000-01-01, 2@2000-01-02]'), (tint '[3@2000-01-03, 4@2000-01-04]') )
+SELECT appendSequence(seq ORDER BY seq) = appendSequenceAgg(seq ORDER BY seq) FROM temp;


### PR DESCRIPTION
The names tmin, tmax, merge, appendInstant and appendSequence each name both a scalar function and an aggregate. PostgreSQL keeps the two apart by argument signature, so both coexist there, but a case-insensitive host that registers each name as either a scalar or an aggregate — DuckDB and Spark among the MobilityDB bindings — cannot load a name bound to both, and so cannot expose these aggregates at all. To let every binding derive one unambiguous aggregate name, the aggregate form gains a camelCase Agg suffix: tminAgg, tmaxAgg, mergeAgg, appendInstantAgg and appendSequenceAgg. Each Agg aggregate is defined alongside the existing bare aggregate, which is kept as a PostgreSQL backward-compatibility alias so existing queries are unaffected; the bare aggregate forms are deprecated and will be removed in a future major release, at which point the scalar and aggregate name spaces are disjoint. The scalar forms keep their names: the box accessors tMin(tbox)/tMax(stbox) and the binary builder merge(T, T).

The tmin, tmax and merge aggregates carry FINALFUNC_MODIFY = READ_WRITE: their final function frees the SkipList transition state, so without this clause PostgreSQL would share one transition state between the bare and Agg forms when both appear in a query and run the state-freeing final function twice, reading freed memory. appendInstant and appendSequence keep the default because their final function does not modify the state.

The minDistance name is left out of this set: its minDistance(temporal, temporal) aggregate is the redundant cross-join restatement of the scalar set-set minDistance over arrays, so its collision is resolved by removing that aggregate rather than by adding an alias.

Regression tests assert that each Agg form equals its bare aggregate and that the two coexist in a single query, and the user manual in English and Spanish documents the Agg names as canonical and the bare aggregate forms as deprecated.