### PR TITLE
docs: align visualization-adapter links with renamed repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ These projects push the boundaries of MobilityDB and connect it with the Postgre
 
 ### Visualization
 
-*   [MobilityDB-Deck](https://github.com/MobilityDB/MobilityDB-Deck): Integration of MobilityDB with [deck.gl](https://deck.gl/)
+*   [MobilityDeck](https://github.com/MobilityDB/MobilityDeck): Integration of MobilityDB with [deck.gl](https://deck.gl/)
 *   [MobilityDB-Leaflet](https://github.com/MobilityDB/MobilityDB-Leaflet): Integration of MobilityDB with [Leaflet](https://leafletjs.com/)
-*   [MobilityDB-OpenLayers](https://github.com/MobilityDB/MobilityDB-OpenLayers): Integration of MobilityDB with [OpenLayers](https://openlayers.org/)
-*   [MobilityDB-QGIS](https://github.com/MobilityDB/MobilityDB-QGIS): Integration of MobilityDB with [QGIS](https://qgis.org/)
+*   [MobilityOpenLayers](https://github.com/MobilityDB/MobilityOpenLayers): Integration of MobilityDB with [OpenLayers](https://openlayers.org/)
+*   [MobilityQGIS](https://github.com/MobilityDB/MobilityQGIS): Integration of MobilityDB with [QGIS](https://qgis.org/)
 
 ### Public Transport
 


### PR DESCRIPTION
Renames `MobilityDB-Deck` → `MobilityDeck`, `MobilityDB-OpenLayers` → `MobilityOpenLayers`, and `MobilityDB-QGIS` → `MobilityQGIS` in this README's link block, following the corresponding GitHub repo renames on 2026-05-01.

Naming taxonomy: `MobilityDB-X` is for repos bound to MobilityDB (admin tooling, build artefacts, benchmarks, drivers tied to the SQL surface). Compound `Mobility…` names go to independent projects that use MobilityDB / MEOS as one possible backend (peer family of MobilityDuck, PyMEOS, JMEOS, MobilityPandas). The renamed visualization-adapter repos have their own release cadence and don't depend on a specific MobilityDB version.

GitHub redirects the old URLs permanently — this is cosmetic.