### PR TITLE
Expose acovers_geo_tgeo, acovers_tgeo_geo, and acovers_tgeo_tgeo in MEOS

### DIFF
--- a/meos/include/meos_geo.h
+++ b/meos/include/meos_geo.h
@@ -807,6 +807,9 @@ extern bool right_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2
 extern int acontains_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp);
 extern int acontains_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs);
 extern int acontains_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2);
+extern int acovers_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp);
+extern int acovers_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs);
+extern int acovers_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2);
 extern int adisjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs);
 extern int adisjoint_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2);
 extern int adwithin_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist);


### PR DESCRIPTION
The implementations already exist under `#if MEOS` in meos/src/geo/tgeo_spatialrels.c (alongside ecovers_*), but the public header meos_geo.h only declared the ever-semantics variants (ecovers_*). External MEOS consumers (PyMEOS, JMEOS, meos-rs, MobilityDuck) couldn't reach the always-semantics variants without duplicating the prototypes.

This adds the three missing extern declarations next to the acontains_* / adisjoint_* / atouches_* siblings so the always-covers predicates are part of the public surface, mirroring the layout already used for the other ever/always pairs.

No implementation change.
