### PR TITLE
ci(cppcheck): suppress vendored-relative paths and define INT64/UINT64 macros

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -77,8 +77,17 @@ jobs:
             --suppress='*:*/postgres/*' \
             --suppress='*:*/postgis/*' \
             --suppress='*:*/pgtypes/*' \
+            --suppress='*:*/h3-pg/*' \
+            --suppress='*:postgres/*' \
+            --suppress='*:postgis/*' \
+            --suppress='*:pgtypes/*' \
+            --suppress='*:h3-pg/*' \
             --suppress='missingIncludeSystem' \
             --suppress='unmatchedSuppression' \
+            --suppress='preprocessorErrorDirective:*/postgres/*' \
+            --suppress='preprocessorErrorDirective:postgres/*' \
+            -DUINT64_FORMAT='"%llu"' \
+            -DINT64_FORMAT='"%lld"' \
             --xml --xml-version=2 \
             -j "$(nproc)" \
             2> cppcheck.xml || true


### PR DESCRIPTION
## Why

The GHAS-side `Cppcheck` check_run has been going red on most PRs after the recent squashes — the published SARIF includes alerts the project's own gate already filters, but the upload step doesn't apply the same filter, so GHAS shows them as failures on the PR rollup.

The two error-level alerts that consistently show:

1. `postgres/timezone/findtimezone.c:158` — vendored postgres `#error` directive
2. `meos/src/temporal/type_out.c:2291` — `unknownMacro: UINT64_FORMAT`

Both are noise.

## What

Two fixes to `.github/workflows/cppcheck.yml`:

1. **Vendored suppress globs were absolute-only** (`*:*/postgres/*`). Cppcheck emits relative paths under `--project=compile_commands.json`, so the absolute-form glob misses them. Add relative-form globs belt-and-braces, plus `h3-pg/` (was already in the post-process Python filter but missing from the suppress list). Also explicitly suppress `preprocessorErrorDirective` in vendored postgres so the `#error No way to determine TZ?` alert stops surfacing.

2. **Define UINT64_FORMAT / INT64_FORMAT** on the cppcheck command line. PostgreSQL defines them in `pg_config.h` but cppcheck doesn't pick them up. Values match the standard glibc/macOS resolution (`%lld` / `%llu`).

## Effect

- The project's own gate (Python critical-pattern filter) is unchanged — same blocking semantics.
- The SARIF uploaded to GHAS no longer carries the vendored-postgres `#error` and unknown-macro alerts.
- GHAS-side `Cppcheck` check_run stops going red on every squashed PR.

## Test plan

- [ ] CI green on this PR's own Cppcheck workflow run
- [ ] After merge, rebase a couple of currently-red PRs (#813, #814) onto the new master and verify the GHAS Cppcheck check_run turns green