### PR TITLE
doc(specs): MEOS-API v0.1-draft specification + JSON Schema validator (RFC #836 / Discussion #920)

### DIFF
--- a/doc/specs/meos-api-0.1-draft.md
+++ b/doc/specs/meos-api-0.1-draft.md
@@ -1,0 +1,325 @@
+<!--
+   ****************************************************************************
+    MEOS-API Specification
+    Copyright(c) MobilityDB Contributors
+
+    This documentation is licensed under a Creative Commons Attribution-Share
+    Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
+   ****************************************************************************
+-->
+
+# MEOS-API — Machine-Readable Description of the MEOS C Library API
+
+| | |
+|---|---|
+| Status | **Draft (v0.1.0)** — not ratified; subject to revision at every draft bump |
+| Scope | The public C API surface of the MEOS library (functions, structs, enums) as exposed by `meos.h` |
+| Source of truth (until ratified) | This document, paired with the JSON Schema at `schemas/meos-api-0.1-draft.json` and the reference generator at [`MobilityDB/MEOS-API`](https://github.com/MobilityDB/MEOS-API) |
+| Related RFC | [MobilityDB/MobilityDB#836](https://github.com/MobilityDB/MobilityDB/issues/836) |
+
+## 1. Status and intent
+
+MEOS-API is a JSON catalog format describing the public C API of the MEOS library so that downstream language bindings (PyMEOS, JMEOS, meos-rs, GoMEOS, MEOS.NET, MEOS.js, …) can generate their wrapper code from a single shared description rather than each maintaining a hand-rolled mirror of `meos.h`.
+
+This v0.1 specification is **descriptive of an emerging design**, not prescriptive of a frozen format. The schema is explicitly draft; breaking changes are expected at every draft bump until v1.0 is ratified per the gating conditions in §10. Any divergence between this document, the JSON Schema, and the reference generator's output should be treated as a defect to be reconciled — the C headers always win as the underlying truth.
+
+## 2. Notation
+
+| Term | Meaning |
+|---|---|
+| `meos-api.json` | An instance document describing one MEOS release. |
+| `cType` | A C type spelling exactly as it appears in the header (e.g. `TInstant **`). |
+| `canonical` | A normalised form of a `cType`, used by binding-generators that prefer a uniform type vocabulary (e.g. `[TInstant *]` for an array of pointers). For v0.1, `canonical` may equal `cType` — the field is reserved for future normalisation rules. |
+| `Doxygen block` | A C comment of the form `/** … */` immediately preceding a declaration; the source-of-truth for annotations (§5). |
+| GIR-style annotation | A parenthesised tag inside a Doxygen block, e.g. `(transfer full)`, `(nullable)`, `(array length=count)`. Vocabulary borrowed verbatim from [GObject Introspection](https://gi.readthedocs.io/en/latest/annotations/giannotations.html). |
+
+JSON examples in this document follow standard JSONC conventions (comments allowed for illustrative purposes only — actual `meos-api.json` files are strict JSON).
+
+## 3. Document shape
+
+A `meos-api.json` document is a JSON object with five top-level keys:
+
+```jsonc
+{
+  "version": "0.1.0-draft",
+  "meos_version": "1.2.0",
+  "generated_at": "2026-05-01T12:00:00Z",
+  "functions": [ /* …function entries… */ ],
+  "structs":   [ /* …struct entries…   */ ],
+  "enums":     [ /* …enum entries…     */ ]
+}
+```
+
+| Key | Type | Required | Meaning |
+|---|---|---|---|
+| `version` | string | yes | The schema version this document conforms to. For v0.1, the literal string `"0.1.0-draft"`. |
+| `meos_version` | string | yes | The version of the MEOS C library this document was generated from, in `MAJOR.MINOR.PATCH` form. |
+| `generated_at` | string | yes | ISO 8601 UTC timestamp; the moment the document was emitted. |
+| `functions` | array | yes | Public functions declared in `meos.h`. May be empty. |
+| `structs` | array | yes | Public struct types declared in `meos.h`. May be empty. |
+| `enums` | array | yes | Public enum types declared in `meos.h`. May be empty. |
+
+## 4. Function entries
+
+A function entry describes one public function. Required fields are marked `★`; optional fields are present only when meaningful.
+
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `name` ★ | string | yes | Function name as declared in the header. |
+| `file` ★ | string | yes | Header file in which the declaration appears, relative to the MEOS include root (`meos.h`, `meos_internal.h`, `meos_catalog.h`, …). |
+| `returnType` ★ | object | yes | `{ "c": "<cType>", "canonical": "<canonical>" }`. |
+| `params` ★ | array | yes | Ordered array of parameter entries. Empty array if the function takes no parameters (the C `(void)` declaration). |
+| `ownership` | string | optional | `"caller"`, `"callee"`, or `"none"`. From the `(transfer …)` annotation on the return type. See §5. |
+| `nullable` | boolean | optional | `true` if the return value may legitimately be `NULL`. From the `(nullable)` annotation on the return type. |
+| `doc` | string | optional | The free-form description from the Doxygen block, with annotation tags stripped. |
+
+Each parameter entry has the shape:
+
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `name` ★ | string | yes | Parameter name. |
+| `cType` ★ | string | yes | C type as declared. |
+| `canonical` ★ | string | yes | Canonical form (may equal `cType`). |
+| `direction` | string | optional | `"in"` (default), `"out"`, or `"inout"`. From `(out)` / `(inout)` annotations. |
+| `nullable` | boolean | optional | `true` if `NULL` is an accepted input. |
+| `array` | object | optional | Present if the parameter is an array. `{ "lengthFrom": "<param-name>" }` (length carried in another parameter) or `{ "zeroTerminated": true }`. From `(array length=…)` / `(array zero-terminated=1)`. |
+| `closure` | object | optional | Present if the parameter is a callback. `{ "userData": "<param-name>", "destroy": "<param-name>" }`. From `(scope …)` / `(closure …)` / `(destroy …)`. |
+| `doc` | string | optional | Per-parameter description. |
+
+Example:
+
+```jsonc
+{
+  "name": "tpointseq_make",
+  "file": "meos.h",
+  "returnType": { "c": "TSequence *", "canonical": "TSequence *" },
+  "params": [
+    {
+      "name": "instants",
+      "cType": "TInstant **",
+      "canonical": "TInstant **",
+      "array": { "lengthFrom": "count" }
+    },
+    { "name": "count", "cType": "int", "canonical": "int" }
+  ],
+  "ownership": "caller",
+  "nullable": true,
+  "doc": "Creates a temporal point sequence from an array of instants."
+}
+```
+
+## 5. Annotations and source-of-truth
+
+Annotations on functions, parameters, and return types live **in the C header as part of the Doxygen block**, never in a sidecar file. The reference generator parses the headers + annotations and emits `meos-api.json` as a derived artefact.
+
+```c
+/**
+ * tpointseq_make: (transfer full) (nullable)
+ * @instants: (array length=count): array of instants — caller retains ownership
+ * @count: number of instants; must be ≥ 1
+ *
+ * Creates a temporal point sequence from an array of instants.
+ */
+TSequence *tpointseq_make(TInstant **instants, int count);
+```
+
+The annotation vocabulary follows [GObject Introspection's annotations](https://gi.readthedocs.io/en/latest/annotations/giannotations.html) verbatim. Adopting the GIR vocabulary lets us inherit ~15 years of corner-case work — closures, destroy-notifiers, out-parameter sizing, zero-terminated arrays — instead of rediscovering them.
+
+The annotation tags MEOS-API consumes in v0.1:
+
+| GIR annotation | Maps to JSON field | Notes |
+|---|---|---|
+| `(transfer full\|none\|container)` | `ownership` | `full` → `"caller"`, `none` → `"callee"`, `container` → currently mapped as `"caller"` with a future-extension note. |
+| `(nullable)` | `nullable: true` | Applied to either the return type or to a parameter. |
+| `(array length=name)` | `array.lengthFrom: name` | Length comes from another parameter of the same function. |
+| `(array zero-terminated=1)` | `array.zeroTerminated: true` | NULL-terminated array. |
+| `(out)`, `(inout)` | `direction` | Defaults to `"in"` if absent. |
+| `(scope async\|notified\|call)` | `closure.scope` | Reserved; not yet emitted in v0.1 output. |
+| `(closure name)` | `closure.userData` | The parameter that carries the callback's user-data pointer. |
+| `(destroy name)` | `closure.destroy` | The parameter that carries the callback's destroy-notify function. |
+
+**Why header-resident, not sidecar:** sidecar metadata files drift the moment a header is changed without the corresponding sidecar update. Header-resident annotations are caught by ordinary PR review on any signature change, since the reviewer is already looking at the same file. GIR's project history documents the sidecar→header migration explicitly; we adopt the lesson without paying the cost.
+
+The reference generator includes a CI check that fails if any public function in `meos.h` is missing required annotations (see §11).
+
+## 6. Struct entries
+
+A struct entry describes one public struct.
+
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `name` ★ | string | yes | Struct tag/typedef name. |
+| `file` ★ | string | yes | Header file. |
+| `fields` ★ | array | yes | Ordered field list. May be empty for opaque types (see §8). |
+| `opaque` | boolean | optional | `true` if the struct is forward-declared in the public header but has no field list (clients use it only via opaque pointer). |
+| `doc` | string | optional | Free-form description. |
+
+Each field entry has the shape:
+
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `name` ★ | string | yes | Field name. |
+| `cType` ★ | string | yes | C type as declared. |
+| `nullable` | boolean | optional | `true` if the field may legitimately be `NULL`. |
+| `doc` | string | optional | Per-field description. |
+
+Example:
+
+```jsonc
+{
+  "name": "TInstant",
+  "file": "temporal.h",
+  "fields": [
+    { "name": "subtype",  "cType": "uint8" },
+    { "name": "flags",    "cType": "uint16" },
+    { "name": "temptype", "cType": "uint8" },
+    { "name": "value",    "cType": "Datum" },
+    { "name": "t",        "cType": "TimestampTz" }
+  ],
+  "doc": "An instant value of a temporal type."
+}
+```
+
+## 7. Enum entries
+
+An enum entry describes one public C enum.
+
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `name` ★ | string | yes | Enum tag/typedef name. |
+| `file` ★ | string | yes | Header file. |
+| `values` ★ | array | yes | Ordered list of named values. |
+| `doc` | string | optional | Free-form description. |
+
+Each value entry: `{ "name": "<NAME>", "value": <integer>, "doc": "<optional>" }`.
+
+Example:
+
+```jsonc
+{
+  "name": "interpType",
+  "file": "temporal.h",
+  "values": [
+    { "name": "INTERP_NONE", "value": 0 },
+    { "name": "DISCRETE",    "value": 1 },
+    { "name": "STEP",        "value": 2 },
+    { "name": "LINEAR",      "value": 3 }
+  ],
+  "doc": "Interpolation type for a temporal sequence."
+}
+```
+
+## 8. Opaque types
+
+C structs declared in the public header without a field list (`typedef struct Foo Foo;`) are exposed in `meos-api.json` with `opaque: true` and an empty `fields` array. Bindings are expected to wrap them as opaque handles; clients of the binding manipulate them only by passing them back to MEOS functions.
+
+```jsonc
+{
+  "name": "Temporal",
+  "file": "temporal.h",
+  "opaque": true,
+  "fields": [],
+  "doc": "Generic opaque handle for any temporal value."
+}
+```
+
+## 9. Public vs. internal split
+
+MEOS exposes two header tiers:
+
+- **Public** — `meos.h` and the headers it transitively includes, intended for external bindings and end-user C consumers.
+- **Internal** — `meos_internal.h` and similar, intended for MobilityDB's own use of MEOS.
+
+For v0.1, `meos-api.json` documents **public symbols only**. The `file` field on each entry records the originating header so consumers can verify the public-only invariant. Internal-symbol exposure is a v0.x evolution candidate (§10) and not currently part of the schema.
+
+## 10. Versioning and stability
+
+The schema follows `MAJOR.MINOR.PATCH`, distinct from the MEOS C-library version (which is carried in the `meos_version` field of every instance document).
+
+**v0.1.0-draft is unstable.** While the schema is on `0.x`:
+
+- Schema changes — including breaking ones — are made freely.
+- Bindings consuming a draft pin to an exact draft version (`0.1.0-draft`, `0.2.0-draft`, …) and accept that an upgrade may require regenerating against a different shape.
+- The reference generator at `MobilityDB/MEOS-API` always tracks the latest draft.
+
+**Ratification of v1.0.0 is gated on three conditions, all of which must hold:**
+
+1. **Real-binding validation.** At least one binding has regenerated end-to-end against the schema and shipped successfully. [PyMEOS-CFFI](https://github.com/MobilityDB/PyMEOS-CFFI) is the proposed first validator.
+2. **Completeness gaps resolved**, not deferred:
+   - function-pointer typedefs as struct fields and as parameter types,
+   - opaque pointer types (covered by §8 — needs validation against real consumer needs),
+   - conditional compilation guards (`CBUFFER`, `JSON`, `NPOINT`, `POSE` — see [`MobilityDB/CMakeLists.txt`](https://github.com/MobilityDB/MobilityDB/blob/master/CMakeLists.txt)),
+   - the public-vs-internal split (§9 — needs to determine whether bindings need internal-symbol opt-in),
+   - `va_list` parameters and varargs callbacks.
+3. **GIR annotation coverage.** Either we've adopted the full GIR vocabulary, or — if some MEOS construct turns out not to be expressible in GIR's terms — we've documented the gap and the chosen alternative annotation explicitly in this spec.
+
+Once v1.0.0 is ratified, schema changes follow standard `MAJOR.MINOR.PATCH` discipline:
+
+| Bump | Triggers |
+|---|---|
+| **Patch** (`1.0.0` → `1.0.1`) | Editorial clarifications. Bindings already generated against patch-N stay valid against patch-N+k. |
+| **Minor** (`1.0.x` → `1.1.0`) | Additive schema changes — new optional fields on existing entries, new entry types. Bindings that ignore unknown fields stay forward-compatible. |
+| **Major** (`1.x` → `2.0`) | Breaking schema changes. Bindings must explicitly upgrade. |
+
+Compatibility constraints (analogous to [Protobuf's update rules](https://protobuf.dev/programming-guides/proto3/#updating)) will be codified at the moment of v1.0 ratification, informed by the friction observed during draft consumption.
+
+## 11. Validation tooling
+
+Two artefacts ship alongside this document:
+
+- `schemas/meos-api-0.1-draft.json` — a JSON Schema document describing the shape of a `meos-api.json` instance. Consumers can validate received documents with any standard JSON-Schema tool (`ajv`, `python-jsonschema`, etc.).
+- A round-trip CI lane in [`MobilityDB/MEOS-API`](https://github.com/MobilityDB/MEOS-API): generate from a snapshot of MEOS, validate against the JSON Schema, and assert the proposed first real-binding consumer (PyMEOS-CFFI) regenerates successfully.
+
+The reference generator additionally enforces an **annotation-coverage gate**: any public function in `meos.h` that lacks a return-type ownership annotation is reported as a CI failure. This is the primary mechanism by which annotations stay in sync with header changes.
+
+## 12. Out of scope (deferred)
+
+Deliberately not specified in v0.1; revisit at draft bumps:
+
+- **Internal symbols** (`meos_internal.h`) — see §9.
+- **Optional subsystems** behind `#ifdef` (cbuffer, JSON, npoint, pose) — the schema needs to express conditional availability so that a binding consuming a `meos-api.json` generated with `-DCBUFFER=ON` can declare conditional compatibility.
+- **Function-pointer typedefs** as standalone catalog entries — currently they appear inline in `cType` fields; whether to lift them to top-level entries depends on binding-generator needs.
+- **Variadic functions** and `va_list` parameters — MEOS uses these sparingly; v0.1 treats them as out-of-scope until a real consumer asks.
+- **C macros** that bindings might want to mirror as constants (e.g. boundary values, default flags) — currently bindings re-derive these from the headers; whether the catalog should carry them is an open question.
+
+## 13. References
+
+- [RFC #836 — MEOS-API: a versioned JSON catalog for MEOS's C-library public API](https://github.com/MobilityDB/MobilityDB/issues/836) — the proposal that motivated this spec, including its alternatives-considered analysis.
+- [`MobilityDB/MEOS-API`](https://github.com/MobilityDB/MEOS-API) — reference implementation (libclang-based generator).
+- [GObject Introspection annotations](https://gi.readthedocs.io/en/latest/annotations/giannotations.html) — the annotation vocabulary adopted verbatim.
+- [`g-ir-scanner`](https://gi.readthedocs.io/en/latest/tools/g-ir-scanner.html) — reference parser for header-resident GIR annotations; instructive even though our generator uses libclang directly.
+- [GIR format spec](https://gi.readthedocs.io/en/latest/gir-1.2.rnc.html) — XML schema GIR's `.gir` files conform to; useful for cross-checking that our JSON shape covers the same conceptual space.
+- [WIT format](https://component-model.bytecodealliance.org/design/wit.html) — modern IDL design reference whose ownership types and resource-type vocabulary inform §5.
+- [`bindgen`](https://rust-lang.github.io/rust-bindgen/) — what [meos-rs](https://github.com/MobilityDB/meos-rs) currently uses; instructive for what a catalog-consuming generator still needs to hand-customise per binding.
+- [Protobuf update rules](https://protobuf.dev/programming-guides/proto3/#updating) — the kind of mechanical compatibility constraints we'll codify at v1.0 ratification.
+- [MEOS-WKB byte-format specification](./meos-wkb-0.9.md) — the sister specification covering MEOS's binary serialisation format.
+
+## 14. Consumers
+
+The primary consumers of `meos-api.json` are language bindings that produce wrapper code over MEOS. As of the v0.1 draft:
+
+| Binding | Current sync mechanism | Adoption posture for MEOS-API |
+|---|---|---|
+| [PyMEOS](https://github.com/MobilityDB/PyMEOS) / [PyMEOS-CFFI](https://github.com/MobilityDB/PyMEOS-CFFI) | Hand-rolled CFFI annotations | Proposed first real-binding validator (§10 condition 1) |
+| [JMEOS](https://github.com/MobilityDB/JMEOS) | Hand-rolled JNR-FFI bindings | Coordinating refactor pinned to `0.1.0-draft` |
+| [meos-rs](https://github.com/MobilityDB/meos-rs) | `bindgen` + MEOS-specific patches | Vocabulary feedback round (§5) |
+| [GoMEOS](https://github.com/MobilityDB/GoMEOS) | Hand-rolled CGO declarations | Vocabulary feedback round |
+| [MEOS.NET](https://github.com/MobilityDB/MEOS.NET) | Hand-rolled P/Invoke | Vocabulary feedback round |
+| [MEOS.js](https://github.com/MobilityDB/MEOS.js) | Hand-rolled emscripten/embind glue | Vocabulary feedback round |
+
+## 15. Outlook — integration scenarios
+
+Beyond the bindings ecosystem, a stable machine-readable API description suits several classes of system:
+
+- **Documentation generators** that need richer type information than what a Doxygen build extracts (e.g. ownership-aware cross-references between functions and the structs they return).
+- **Static analysis / migration tooling** for users upgrading across MEOS major releases — diff two `meos-api.json` snapshots to enumerate breaking changes.
+- **Composition frameworks** (e.g. WebAssembly Component Model bindings, GraalVM native-image, Roc) that need a normalised description of foreign-language interfaces.
+- **API-stability badges** and CI gates: a project depending on MEOS can pin to a specific `meos-api.json` snapshot and fail the build if a new MEOS release breaks against it.
+
+These integrations are framed by class, not by named project, deliberately — the spec is intended to outlive any one consumer.
+
+## 16. Authorship and review
+
+This v0.1 draft is authored by the MEOS-API working group on behalf of MobilityDB Contributors. Corrections and clarifications should be filed as issues against [MobilityDB/MobilityDB](https://github.com/MobilityDB/MobilityDB) referencing this spec, or as pull requests against this file.
+
+The spec, the JSON Schema (`schemas/meos-api-0.1-draft.json`), and the reference generator at `MobilityDB/MEOS-API` form a coordinated triple — changes to any one require a corresponding update to the others.

--- a/meos/include/rgeo/trgeo.h
+++ b/meos/include/rgeo/trgeo.h
@@ -58,6 +58,9 @@ extern bool ensure_valid_trgeo_trgeo(const Temporal *temp1,
 extern bool ensure_valid_trgeo_tpoint(const Temporal *temp1,
   const Temporal *temp2);
 extern const GSERIALIZED *trgeo_geom_p(const Temporal *temp);
+struct Pose; /* forward declaration to avoid including pose/pose.h */
+extern GSERIALIZED *geom_apply_pose(const GSERIALIZED *gs,
+  const struct Pose *pose);
 
 /* Input/output functions */
 

--- a/meos/src/rgeo/trgeo_compops.c
+++ b/meos/src/rgeo/trgeo_compops.c
@@ -43,6 +43,7 @@
 #include "temporal/temporal.h"
 #include "temporal/temporal_compops.h"
 #include "temporal/type_util.h"
+#include "pose/pose.h"
 #include "rgeo/trgeo.h"
 
 /*****************************************************************************
@@ -52,6 +53,10 @@
 /**
  * @brief Return true if a temporal rigid geometry and a geometry satisfy the
  * ever/always comparison
+ * @details The base type of trgeo is T_POSE, so the generic eacomp_temporal_base
+ * would treat gs as a Pose datum, producing SRID errors.  Instead, materialise
+ * the instantaneous geometry at each sample instant using geom_apply_pose and
+ * compare against gs as T_GEOMETRY.
  * @param[in] temp Temporal value
  * @param[in] gs Geometry
  * @param[in] ever True for the ever semantics, false for the always semantics
@@ -65,7 +70,23 @@ eacomp_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
   if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
     return -1;
   assert(func);
-  return eacomp_temporal_base(temp, PointerGetDatum(gs), func, ever);
+  const GSERIALIZED *ref_geom = trgeo_geom_p(temp);
+  Datum gs_datum = PointerGetDatum(gs);
+  int count;
+  const TInstant **instants = temporal_insts_p(temp, &count);
+  int result = ever ? 0 : 1;
+  for (int i = 0; i < count; i++)
+  {
+    GSERIALIZED *inst_geom = geom_apply_pose(ref_geom,
+      DatumGetPoseP(tinstant_value_p(instants[i])));
+    bool cmp = DatumGetBool(func(PointerGetDatum(inst_geom), gs_datum,
+      T_GEOMETRY));
+    pfree(inst_geom);
+    if (ever && cmp)  { result = 1; break; }
+    if (!ever && !cmp) { result = 0; break; }
+  }
+  pfree((void *) instants);
+  return result;
 }
 
 /**
@@ -254,27 +275,117 @@ always_ne_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
  *****************************************************************************/
 
 /**
+ * @brief Apply a comparison to each sample instant of a trgeo TSequence
+ * @details Applies geom_apply_pose at each instant, compares to gs, and
+ * returns the result as a TSequence (DISCRETE) or a single-element TSequence
+ * array for the continuous (STEP/LINEAR) case.
+ * @param[in] seq TSequence of trgeo
+ * @param[in] ref_geom Reference geometry of the trgeo
+ * @param[in] gs Static geometry for comparison
+ * @param[in] func Comparison function
+ * @param[in] invert True when gs is the left argument
+ */
+static TSequence *
+tcomp_trgeosequence_geo(const TSequence *seq, const GSERIALIZED *ref_geom,
+  const GSERIALIZED *gs, Datum (*func)(Datum, Datum, MeosType), bool invert)
+{
+  Datum gs_datum = PointerGetDatum(gs);
+  TInstant **new_insts = palloc(sizeof(TInstant *) * seq->count);
+  for (int i = 0; i < seq->count; i++)
+  {
+    const TInstant *inst = TSEQUENCE_INST_N(seq, i);
+    GSERIALIZED *g = geom_apply_pose(ref_geom,
+      DatumGetPoseP(tinstant_value_p(inst)));
+    Datum geom_d = PointerGetDatum(g);
+    Datum cmp = invert ? func(gs_datum, geom_d, T_GEOMETRY)
+                       : func(geom_d, gs_datum, T_GEOMETRY);
+    pfree(g);
+    new_insts[i] = tinstant_make(cmp, T_TBOOL, inst->t);
+  }
+  bool is_discrete = MEOS_FLAGS_DISCRETE_INTERP(seq->flags);
+  interpType interp = is_discrete ? DISCRETE : STEP;
+  return tsequence_make_free(new_insts, seq->count,
+    seq->period.lower_inc, seq->period.upper_inc, interp, NORMALIZE);
+}
+
+/**
+ * @brief Return the temporal comparison of a temporal rigid geometry and a
+ * geometry
+ * @details The base type of trgeo is T_POSE, so the generic lifting
+ * infrastructure would treat gs as a Pose datum, producing SRID errors.
+ * Instead, materialise the instantaneous geometry at each sample instant using
+ * geom_apply_pose and compare against gs as T_GEOMETRY.  For continuous
+ * (STEP/LINEAR) sequences the result is wrapped in a TSequenceSet to match
+ * the standard behaviour of temporal comparison operators.
+ * @param[in] temp Temporal rigid geometry
+ * @param[in] gs Geometry
+ * @param[in] func Comparison function
+ * @param[in] invert True when gs is the left argument of func
+ */
+static Temporal *
+tcomp_trgeo_geo_int(const Temporal *temp, const GSERIALIZED *gs,
+  Datum (*func)(Datum, Datum, MeosType), bool invert)
+{
+  if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
+    return NULL;
+  assert(func);
+  const GSERIALIZED *ref_geom = trgeo_geom_p(temp);
+  switch (temp->subtype)
+  {
+    case TINSTANT:
+    {
+      const TInstant *inst = (const TInstant *) temp;
+      GSERIALIZED *g = geom_apply_pose(ref_geom,
+        DatumGetPoseP(tinstant_value_p(inst)));
+      Datum geom_d = PointerGetDatum(g);
+      Datum gs_d = PointerGetDatum(gs);
+      Datum cmp = invert ? func(gs_d, geom_d, T_GEOMETRY)
+                         : func(geom_d, gs_d, T_GEOMETRY);
+      pfree(g);
+      return (Temporal *) tinstant_make(cmp, T_TBOOL, inst->t);
+    }
+    case TSEQUENCE:
+    {
+      const TSequence *seq = (const TSequence *) temp;
+      TSequence *boolseq = tcomp_trgeosequence_geo(seq, ref_geom, gs, func,
+        invert);
+      /* Continuous sequences: wrap in TSequenceSet to match tcomp semantics */
+      if (MEOS_FLAGS_DISCRETE_INTERP(seq->flags))
+        return (Temporal *) boolseq;
+      return (Temporal *) tsequenceset_make((TSequence **) &boolseq, 1,
+        NORMALIZE);
+    }
+    default: /* TSEQUENCESET */
+    {
+      const TSequenceSet *ss = (const TSequenceSet *) temp;
+      TSequence **new_seqs = palloc(sizeof(TSequence *) * ss->count);
+      for (int j = 0; j < ss->count; j++)
+        new_seqs[j] = tcomp_trgeosequence_geo(TSEQUENCESET_SEQ_N(ss, j),
+          ref_geom, gs, func, invert);
+      return (Temporal *) tsequenceset_make_free(new_seqs, ss->count,
+        NORMALIZE);
+    }
+  }
+}
+
+/**
  * @brief Return the temporal comparison of a geometry and a temporal rigid
  * geometry
- * @param[in] temp Temporal value
  * @param[in] gs Geometry
+ * @param[in] temp Temporal rigid geometry
  * @param[in] func Comparison function
  */
 static Temporal *
 tcomp_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp,
   Datum (*func)(Datum, Datum, MeosType))
 {
-  /* Ensure the validity of the arguments */
-  if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
-    return NULL;
-  assert(func);
-  return tcomp_base_temporal(PointerGetDatum(gs), temp, func);
+  return tcomp_trgeo_geo_int(temp, gs, func, true);
 }
 
 /**
  * @brief Return the temporal comparison of a temporal rigid geometry and a
  * geometry
- * @param[in] temp Temporal value
+ * @param[in] temp Temporal rigid geometry
  * @param[in] gs Geometry
  * @param[in] func Comparison function
  */
@@ -282,11 +393,7 @@ static Temporal *
 tcomp_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
   Datum (*func)(Datum, Datum, MeosType))
 {
-  /* Ensure the validity of the arguments */
-  if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
-    return NULL;
-  assert(func);
-  return tcomp_temporal_base(temp, PointerGetDatum(gs), func);
+  return tcomp_trgeo_geo_int(temp, gs, func, false);
 }
 
 /*****************************************************************************/

--- a/meos/src/temporal/meos_catalog.c
+++ b/meos/src/temporal/meos_catalog.c
@@ -285,7 +285,7 @@ static const temptype_catalog_struct MEOS_TEMPTYPE_CATALOG[] =
 /**
  * @brief Return the string representation of the MEOS type
  */
-inline const char *
+const char *
 meostype_name(MeosType type)
 {
   return MEOS_TYPE_NAMES[type];
@@ -297,7 +297,7 @@ meostype_name(MeosType type)
  * @brief Return the string representation of the subtype of the temporal type
  * corresponding to the enum value
  */
-inline const char *
+const char *
 tempsubtype_name(tempSubtype subtype)
 {
   return MEOS_TEMPSUBTYPE_NAMES[subtype];
@@ -362,7 +362,7 @@ tempsubtype_from_string(const char *str, int16 *subtype)
  * @brief Ensure that the subtype of a temporal value is valid
  * @note The function is used for the dispatch functions for temporal types
  */
-inline bool
+bool
 temptype_subtype(tempSubtype subtype)
 {
   return (subtype == TINSTANT || subtype == TSEQUENCE ||
@@ -373,7 +373,7 @@ temptype_subtype(tempSubtype subtype)
  * @brief Ensure that the subtype of a temporal value is valid
  * @note The function is used for the the analyze and selectivity functions
  */
-inline bool
+bool
 temptype_subtype_all(tempSubtype subtype)
 {
   return (subtype == ANYTEMPSUBTYPE ||
@@ -386,7 +386,7 @@ temptype_subtype_all(tempSubtype subtype)
 /**
  * @brief Return the string name from a MEOS operator number
  */
-inline const char *
+const char *
 meosoper_name(meosOper oper)
 {
   return MEOS_OPER_NAMES[oper];
@@ -414,7 +414,7 @@ meosoper_from_string(const char *str)
  * @brief Return the string representation of the subtype of the temporal type
  * corresponding to the enum value
  */
-inline const char *
+const char *
 interptype_name(interpType interp)
 {
   return MEOS_INTERPTYPE_NAMES[interp];
@@ -581,7 +581,7 @@ spantype_spansettype(MeosType type)
  * that is, @p Set, @p Span, @p SpanSet, and @p Temporal
  * @note This function is only used in the asserts
  */
-inline bool
+bool
 meos_basetype(MeosType type)
 {
   return (type == T_BOOL || type == T_INT4 || type == T_INT8 || type == T_FLOAT8 ||
@@ -605,7 +605,7 @@ meos_basetype(MeosType type)
 /**
  * @brief Return true if the values of the base type are passed by value
  */
-inline bool
+bool
 basetype_byvalue(MeosType type)
 {
   return (type == T_BOOL || type == T_INT4 || type == T_INT8 || type == T_FLOAT8 ||
@@ -615,7 +615,7 @@ basetype_byvalue(MeosType type)
 /**
  * @brief Return true if the values of the base type are of variable length
  */
-inline bool
+bool
 basetype_varlength(MeosType type)
 {
   return (type == T_TEXT || type == T_GEOMETRY || type == T_GEOGRAPHY
@@ -670,7 +670,7 @@ meostype_length(MeosType type)
  * @brief Return true if the type is an alphanumeric base type
  * @note This function is only used in the asserts
  */
-inline bool
+bool
 alphanum_basetype(MeosType type)
 {
   return (type == T_BOOL || type == T_INT4 || type == T_INT8 ||
@@ -682,7 +682,7 @@ alphanum_basetype(MeosType type)
  * @brief Return true if the type is an alphanumeric base type
  * @note This function is only used in the asserts
  */
-inline bool
+bool
 alphanum_temptype(MeosType type)
 {
   return (type == T_TBOOL || type == T_TINT || type == T_TFLOAT ||
@@ -693,7 +693,7 @@ alphanum_temptype(MeosType type)
 /**
  * @brief Return true if the type is a geo base type
  */
-inline bool
+bool
 geo_basetype(MeosType type)
 {
   return (type == T_GEOMETRY || type == T_GEOGRAPHY);
@@ -702,7 +702,7 @@ geo_basetype(MeosType type)
 /**
  * @brief Return true if the type is a spatial base type
  */
-inline bool
+bool
 spatial_basetype(MeosType type)
 {
   return (type == T_GEOMETRY || type == T_GEOGRAPHY 
@@ -723,7 +723,7 @@ spatial_basetype(MeosType type)
 /**
  * @brief Return true if the type is a time type
  */
-inline bool
+bool
 time_type(MeosType type)
 {
   return (type == T_DATE || type == T_DATESET || type == T_DATESPAN ||
@@ -738,7 +738,7 @@ time_type(MeosType type)
  * @brief Return true if the type is a base type of a set type
  * @note This function is only used in the asserts
  */
-inline bool
+bool
 set_basetype(MeosType type)
 {
   return (type == T_TIMESTAMPTZ || type == T_DATE || type == T_INT4 ||
@@ -760,7 +760,7 @@ set_basetype(MeosType type)
 /**
  * @brief Return true if the type is a set type
  */
-inline bool
+bool
 set_type(MeosType type)
 {
   return (type == T_TSTZSET || type == T_DATESET || type == T_INTSET ||
@@ -781,7 +781,7 @@ set_type(MeosType type)
 /**
  * @brief Return true if the type is a number set type
  */
-inline bool
+bool
 numset_type(MeosType type)
 {
   return (type == T_INTSET || type == T_BIGINTSET || type == T_FLOATSET ||
@@ -807,7 +807,7 @@ ensure_numset_type(MeosType type)
 /**
  * @brief Return true if the type is a time set type
  */
-inline bool
+bool
 timeset_type(MeosType type)
 {
   return (type == T_DATESET || type == T_TSTZSET);
@@ -816,7 +816,7 @@ timeset_type(MeosType type)
 /**
  * @brief Return true if the type is a set type with a span as a bounding box
  */
-inline bool
+bool
 set_spantype(MeosType type)
 {
   return (type == T_INTSET || type == T_BIGINTSET || type == T_FLOATSET ||
@@ -839,7 +839,7 @@ ensure_set_spantype(MeosType type)
 /**
  * @brief Return true if the type is a set type
  */
-inline bool
+bool
 alphanumset_type(MeosType type)
 {
   return (type == T_TSTZSET || type == T_DATESET || type == T_INTSET ||
@@ -850,7 +850,7 @@ alphanumset_type(MeosType type)
 /**
  * @brief Return true if the type is a geo set type
  */
-inline bool
+bool
 geoset_type(MeosType type)
 {
   return (type == T_GEOMSET || type == T_GEOGSET);
@@ -873,7 +873,7 @@ ensure_geoset_type(MeosType type)
 /**
  * @brief Return true if the type is a geo set type
  */
-inline bool
+bool
 spatialset_type(MeosType type)
 {
   return (type == T_GEOMSET || type == T_GEOGSET
@@ -909,7 +909,7 @@ ensure_spatialset_type(MeosType type)
 /**
  * @brief Return true if the type is a span base type
  */
-inline bool
+bool
 span_basetype(MeosType type)
 {
   return (type == T_TIMESTAMPTZ || type == T_DATE || type == T_INT4 ||
@@ -919,7 +919,7 @@ span_basetype(MeosType type)
 /**
  * @brief Return true if the type is a canonical base type of a span type
  */
-inline bool
+bool
 span_canon_basetype(MeosType type)
 {
   return (type == T_DATE || type == T_INT4 || type == T_INT8);
@@ -939,7 +939,7 @@ span_type(MeosType type)
  * @brief Return true if the type has a span type as bounding box
  * @note This function is only used in the asserts
  */
-inline bool
+bool
 type_span_bbox(MeosType type)
 {
   return (set_spantype(type) || span_type(type) || spanset_type(type) ||
@@ -950,7 +950,7 @@ type_span_bbox(MeosType type)
  * @brief Return true if the type can be converted to a temporal box
  * @note This function is only used in the asserts
  */
-inline bool
+bool
 span_tbox_type(MeosType type)
 {
   return (type == T_INTSPAN || type == T_FLOATSPAN || type == T_TSTZSPAN);
@@ -973,7 +973,7 @@ ensure_span_tbox_type(MeosType type)
 /**
  * @brief Return true if the type is a number span type
  */
-inline bool
+bool
 numspan_basetype(MeosType type)
 {
   return (type == T_INT4 || type == T_INT8 || type == T_FLOAT8 ||
@@ -984,7 +984,7 @@ numspan_basetype(MeosType type)
 /**
  * @brief Return true if the type is a number span type
  */
-inline bool
+bool
 numspan_type(MeosType type)
 {
   return (type == T_INTSPAN || type == T_BIGINTSPAN || type == T_FLOATSPAN ||
@@ -1007,7 +1007,7 @@ ensure_numspan_type(MeosType type)
 /**
  * @brief Return true if the type is a time span type
  */
-inline bool
+bool
 timespan_basetype(MeosType type)
 {
   return (type == T_TIMESTAMPTZ || type == T_DATE);
@@ -1016,7 +1016,7 @@ timespan_basetype(MeosType type)
 /**
  * @brief Return true if the type is a time span type
  */
-inline bool
+bool
 timespan_type(MeosType type)
 {
   return (type == T_TSTZSPAN || type == T_DATESPAN);
@@ -1027,7 +1027,7 @@ timespan_type(MeosType type)
 /**
  * @brief Return true if the type is a span set type
  */
-inline bool
+bool
 spanset_type(MeosType type)
 {
   return (type == T_TSTZSPANSET || type == T_DATESPANSET ||
@@ -1037,7 +1037,7 @@ spanset_type(MeosType type)
 /**
  * @brief Return true if the type is a time span type
  */
-inline bool
+bool
 timespanset_type(MeosType type)
 {
   return (type == T_TSTZSPANSET || type == T_DATESPANSET);
@@ -1064,7 +1064,7 @@ ensure_timespanset_type(MeosType type)
  * @brief Return true if the type is an @b external temporal type
  * @note Function used in particular in the indexes
  */
-inline bool
+bool
 temporal_type(MeosType type)
 {
   return (type == T_TBOOL || type == T_TINT || type == T_TFLOAT ||
@@ -1092,7 +1092,7 @@ temporal_type(MeosType type)
  * @brief Return true if the type is a temporal base type
  * @note This function is only used in the asserts
  */
-inline bool
+bool
 temporal_basetype(MeosType type)
 {
   return (type == T_BOOL || type == T_INT4 || type == T_FLOAT8 ||
@@ -1116,7 +1116,7 @@ temporal_basetype(MeosType type)
 /**
  * @brief Return true if the type is a temporal continuous type
  */
-inline bool
+bool
 temptype_continuous(MeosType type)
 {
   return (type == T_TFLOAT || type == T_TDOUBLE2 || type == T_TDOUBLE3 ||
@@ -1141,7 +1141,7 @@ temptype_continuous(MeosType type)
  * @brief Return true if the type is a temporal alphanumeric type
  * @note This function is only used in the asserts
  */
-inline bool
+bool
 talphanum_type(MeosType type)
 {
   return (type == T_TBOOL || type == T_TINT || type == T_TFLOAT ||
@@ -1153,7 +1153,7 @@ talphanum_type(MeosType type)
  * @brief Return true if the type is a temporal alpha type (i.e., those whose
  * bounding box is a timestamptz span)
  */
-inline bool
+bool
 talpha_type(MeosType type)
 {
   return (type == T_TBOOL || type == T_TTEXT || type == T_TDOUBLE2 ||
@@ -1163,7 +1163,7 @@ talpha_type(MeosType type)
 /**
  * @brief Return true if the type is a temporal number type
  */
-inline bool
+bool
 tnumber_type(MeosType type)
 {
   return (type == T_TINT || type == T_TFLOAT);
@@ -1225,7 +1225,7 @@ tnumber_spantype(MeosType type)
  * types, in particular, all of them use the same bounding box @ STBox.
  * Therefore, it is used for the indexes and selectivity functions.
  */
-inline bool
+bool
 tspatial_type(MeosType type)
 {
   return (type == T_TGEOMPOINT || type == T_TGEOGPOINT || 
@@ -1263,7 +1263,7 @@ ensure_tspatial_type(MeosType type)
 /**
  * @brief Return true if a type is a temporal point type
  */
-inline bool
+bool
 tpoint_type(MeosType type)
 {
   return (type == T_TGEOMPOINT || type == T_TGEOGPOINT);
@@ -1285,7 +1285,7 @@ ensure_tpoint_type(MeosType type)
 /**
  * @brief Return true if a type is a temporal geo type
  */
-inline bool
+bool
 tgeo_type(MeosType type)
 {
   return (type == T_TGEOMETRY || type == T_TGEOGRAPHY);
@@ -1310,7 +1310,7 @@ ensure_tgeo_type(MeosType type)
  * @brief Return true if a type is a temporal type with geometry/geography as
  * base type
  */
-inline bool
+bool
 tgeo_type_all(MeosType type)
 {
   return (type == T_TGEOMETRY || type == T_TGEOGRAPHY ||
@@ -1335,7 +1335,7 @@ ensure_tgeo_type_all(MeosType type)
 /**
  * @brief Return true if a type is a temporal geometry type
  */
-inline bool
+bool
 tgeometry_type(MeosType type)
 {
   return (type == T_TGEOMPOINT || type == T_TGEOMETRY);
@@ -1358,7 +1358,7 @@ ensure_tgeometry_type(MeosType type)
 /**
  * @brief Return true if a type is a temporal geodetic type
  */
-inline bool
+bool
 tgeodetic_type(MeosType type)
 {
   return (type == T_TGEOGPOINT || type == T_TGEOGRAPHY);

--- a/mobilitydb/test/cbuffer/CMakeLists.txt
+++ b/mobilitydb/test/cbuffer/CMakeLists.txt
@@ -14,15 +14,7 @@ set_tests_properties(load_cbuffer_tables PROPERTIES
 file(GLOB testfiles "queries/*.sql")
 list(SORT testfiles)
 
-# Tests whose expected output is stale relative to the current behaviour
-# of the underlying functions. Re-enable once the expected output is
-# regenerated.
 set(SKIP_TESTS
-  160_tcbuffer_distance_tbl         # NearestApproachDistance / |=| count drift
-  162_tcbuffer_spatialrels          # spatialrels output drift
-  162_tcbuffer_spatialrels_tbl      # spatialrels output drift (table form)
-  164_tcbuffer_tempspatialrels      # tempspatialrels output drift
-  164_tcbuffer_tempspatialrels_tbl  # tempspatialrels output drift (table form)
 )
 
 foreach(file ${testfiles})

--- a/mobilitydb/test/cbuffer/expected/162_tcbuffer_spatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/162_tcbuffer_spatialrels.test.out
@@ -1,0 +1,535 @@
+SELECT eContains(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', cbuffer 'Cbuffer(Point(1 1),0.5)');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', cbuffer 'Cbuffer(Point(1 1),0.5)');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', cbuffer 'Cbuffer(Point(1 1),0.5)');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', cbuffer 'Cbuffer(Point(1 1),0.5)');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer '[Cbuffer(Point(4 2),0.5)@2000-01-01, Cbuffer(Point(2 4),0.5)@2000-01-02]', geometry 'Linestring(1 1,3 3)');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer '[Cbuffer(Point(4 2),0.5)@2000-01-01, Cbuffer(Point(2 4),0.5)@2000-01-02]', geometry 'Linestring(1 1,3 3,1 1)');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer '[Cbuffer(Point(0 1),0.5)@2000-01-01, Cbuffer(Point(4 1),0.5)@2000-01-02]', geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer '[Cbuffer(Point(1 4),0.5)@2000-01-01, Cbuffer(Point(4 1),0.5)@2000-01-02]', geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))');
+ econtains 
+-----------
+ t
+(1 row)
+
+/* Errors */
+SELECT eContains(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=3812;Point(1 1)');
+ERROR:  Operation on mixed SRID
+SELECT eDisjoint(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ edisjoint 
+-----------
+ f
+(1 row)
+
+SELECT eDisjoint(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ edisjoint 
+-----------
+ t
+(1 row)
+
+SELECT eDisjoint(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ edisjoint 
+-----------
+ f
+(1 row)
+
+SELECT eDisjoint(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ edisjoint 
+-----------
+ t
+(1 row)
+
+SELECT eDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ edisjoint 
+-----------
+ f
+(1 row)
+
+SELECT eDisjoint(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ edisjoint 
+-----------
+ t
+(1 row)
+
+SELECT eDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ edisjoint 
+-----------
+ f
+(1 row)
+
+SELECT eDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ edisjoint 
+-----------
+ t
+(1 row)
+
+/* Errors */
+SELECT eDisjoint(geometry 'SRID=3812;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  Operation on mixed SRID
+SELECT eDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=3812;Point(1 1)');
+ERROR:  Operation on mixed SRID
+SELECT eIntersects(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+/* Errors */
+SELECT eIntersects(geometry 'SRID=3812;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  Operation on mixed SRID
+SELECT eIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=3812;Point(1 1)');
+ERROR:  Operation on mixed SRID
+SELECT eIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'SRID=3812;Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  Operation on mixed SRID
+SELECT eTouches(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ etouches 
+----------
+ f
+(1 row)
+
+/* Errors */
+SELECT eTouches(geometry 'SRID=3812;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  Operation on mixed SRID
+SELECT eTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=3812;Point(1 1)');
+ERROR:  Operation on mixed SRID
+SELECT eTouches(tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]',
+  geometry 'POLYHEDRALSURFACE( ((0 0 0, 0 0 1, 0 1 1, 0 1 0, 0 0 0)),
+  ((0 0 0, 0 1 0, 1 1 0, 1 0 0, 0 0 0)), ((0 0 0, 1 0 0, 1 0 1, 0 0 1, 0 0 0)),
+  ((1 1 0, 1 1 1, 1 0 1, 1 0 0, 1 1 0)),
+  ((0 1 0, 0 1 1, 1 1 1, 1 1 0, 0 1 0)), ((0 0 1, 1 0 1, 1 1 1, 0 1 1, 0 0 1)) )');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eDwithin(geometry 'Linestring(1 1,2 2)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(geometry 'Linestring(1 1,2 2)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(geometry 'Linestring(1 1,2 2)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(geometry 'Linestring(1 1,2 2)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-02]', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-03}', 10);
+ edwithin 
+----------
+ 
+(1 row)
+
+SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-02, Cbuffer(Point(2 2),0.5)@2000-01-03, Cbuffer(Point(1 1),0.5)@2000-01-05]', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-04, Cbuffer(Point(2 2),0.5)@2000-01-06}', 10);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(2 2),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02]', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(0 0),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(0 2),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-02, Cbuffer(Point(2 2),0.5)@2000-01-03],[Cbuffer(Point(1 1),0.5)@2000-01-05]}', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-04}', 10);
+ edwithin 
+----------
+ 
+(1 row)
+
+SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-02, Cbuffer(Point(2 2),0.5)@2000-01-03],[Cbuffer(Point(1 1),0.5)@2000-01-06]}', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-04, Cbuffer(Point(2 2),0.5)@2000-01-05]', 10);
+ edwithin 
+----------
+ 
+(1 row)
+
+SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-02, Cbuffer(Point(2 2),0.5)@2000-01-03],[Cbuffer(Point(1 1),0.5)@2000-01-06]}', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01],[Cbuffer(Point(1 1),0.5)@2000-01-04, Cbuffer(Point(2 2),0.5)@2000-01-05]}', 10);
+ edwithin 
+----------
+ 
+(1 row)
+
+SELECT eDwithin(tcbuffer 'Interp=Step;{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer 'Interp=Step;{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+/* Errors */
+SELECT eDwithin(geometry 'SRID=3812;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ERROR:  Operation on mixed SRID
+SELECT eDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=3812;Point(1 1)', 2);
+ERROR:  Operation on mixed SRID
+SELECT eDwithin(tcbuffer 'SRID=3812;Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ERROR:  Operation on mixed SRID

--- a/mobilitydb/test/cbuffer/expected/162_tcbuffer_spatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/162_tcbuffer_spatialrels_tbl.test.out
@@ -1,0 +1,384 @@
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aContains(g, temp);
+ count 
+-------
+     9
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eContains(temp, g);
+ count 
+-------
+  3334
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aContains(temp, g);
+ count 
+-------
+    20
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eContains(cb, temp);
+ count 
+-------
+  1833
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aContains(cb, temp);
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eContains(temp, cb);
+ count 
+-------
+  1833
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aContains(temp, cb);
+ count 
+-------
+     9
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aCovers(g, temp);
+ count 
+-------
+     9
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eCovers(temp, g);
+ count 
+-------
+  1487
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aCovers(temp, g);
+ count 
+-------
+    20
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eCovers(cb, temp);
+ count 
+-------
+     9
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aCovers(cb, temp);
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eCovers(temp, cb);
+ count 
+-------
+   488
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aCovers(temp, cb);
+ count 
+-------
+     9
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eDisjoint(g, temp);
+ count 
+-------
+  9362
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aDisjoint(g, temp);
+ count 
+-------
+  8316
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eDisjoint(temp, g);
+ count 
+-------
+  9362
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aDisjoint(temp, g);
+ count 
+-------
+  8316
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eDisjoint(cb, temp);
+ count 
+-------
+  9942
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aDisjoint(cb, temp);
+ count 
+-------
+  8167
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eDisjoint(temp, cb);
+ count 
+-------
+  9942
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aDisjoint(temp, cb);
+ count 
+-------
+  8167
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE eDisjoint(t1.temp, t2.temp);
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE aDisjoint(t1.temp, t2.temp);
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eIntersects(g, temp);
+ count 
+-------
+  9362
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aIntersects(g, temp);
+ count 
+-------
+  8316
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eIntersects(temp, g);
+ count 
+-------
+  3334
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aIntersects(temp, g);
+ count 
+-------
+   232
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eIntersects(cb, temp);
+ count 
+-------
+  1833
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aIntersects(cb, temp);
+ count 
+-------
+    58
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eIntersects(temp, cb);
+ count 
+-------
+  1833
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aIntersects(temp, cb);
+ count 
+-------
+    58
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE eIntersects(t1.temp, t2.temp);
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE aIntersects(t1.temp, t2.temp);
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eTouches(g, temp);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aTouches(g, temp);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eTouches(temp, g);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aTouches(temp, g);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eTouches(cb, temp);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aTouches(cb, temp);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eTouches(temp, cb);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aTouches(temp, cb);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eDwithin(g, temp, 10);
+ count 
+-------
+  4288
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aDwithin(g, temp, 10);
+ count 
+-------
+   464
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eDwithin(temp, g, 10);
+ count 
+-------
+  4288
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aDwithin(temp, g, 10);
+ count 
+-------
+   464
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eDwithin(cb, temp, 10);
+ count 
+-------
+  2756
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aDwithin(cb, temp, 10);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eDwithin(temp, cb, 10);
+ count 
+-------
+  2756
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aDwithin(temp, cb, 10);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE eDwithin(t1.temp, t2.temp, 10);
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE aDwithin(t1.temp, t2.temp, 10);
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seq WHERE eDwithin(cb, seq, 10);
+ count 
+-------
+  2619
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seqset WHERE eDwithin(cb, ss, 10);
+ count 
+-------
+  6948
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seq WHERE aDwithin(cb, seq, 10);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seqset WHERE aDwithin(cb, ss, 10);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seq WHERE eDwithin(seq, cb, 10);
+ count 
+-------
+  2619
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seqset WHERE eDwithin(ss, cb, 10);
+ count 
+-------
+  6948
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seq WHERE aDwithin(seq, cb, 10);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seqset WHERE aDwithin(ss, cb, 10);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_seq t1, tbl_tcbuffer t2 WHERE eDwithin(t1.seq, t2.temp, 10);
+ count 
+-------
+    25
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_seqset t1, tbl_tcbuffer t2 WHERE eDwithin(t1.ss, t2.temp, 10);
+ count 
+-------
+    25
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_seq t1, tbl_tcbuffer t2 WHERE aDwithin(t1.seq, t2.temp, 10);
+ count 
+-------
+    25
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_seqset t1, tbl_tcbuffer t2 WHERE aDwithin(t1.ss, t2.temp, 10);
+ count 
+-------
+    25
+(1 row)
+

--- a/mobilitydb/test/cbuffer/expected/164_tcbuffer_tempspatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/164_tcbuffer_tempspatialrels.test.out
@@ -1,0 +1,1474 @@
+SELECT tContains(NULL::geometry, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ tcontains 
+-----------
+ 
+(1 row)
+
+SELECT tContains(geometry 'Point(1 1)', NULL::tcbuffer);
+ tcontains 
+-----------
+ 
+(1 row)
+
+SELECT tContains(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+           tcontains            
+--------------------------------
+ f@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tContains(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+                                            tcontains                                             
+--------------------------------------------------------------------------------------------------
+ {f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
+SELECT tContains(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+                             tcontains                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tContains(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+                                                              tcontains                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tContains(geometry 'Point empty', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ tcontains 
+-----------
+ 
+(1 row)
+
+SELECT tContains(geometry 'Point empty', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ tcontains 
+-----------
+ 
+(1 row)
+
+SELECT tContains(geometry 'Point empty', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ tcontains 
+-----------
+ 
+(1 row)
+
+SELECT tContains(geometry 'Point empty', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ tcontains 
+-----------
+ 
+(1 row)
+
+SELECT tContains(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', true);
+ERROR:  function tcontains(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tContains(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Po...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tContains(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', true);
+ERROR:  function tcontains(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tContains(geometry 'Point(1 1)', tcbuffer '{Cbuffer(P...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tContains(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', true);
+ERROR:  function tcontains(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tContains(geometry 'Point(1 1)', tcbuffer '[Cbuffer(P...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tContains(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', true);
+ERROR:  function tcontains(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tContains(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tContains(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', false);
+ERROR:  function tcontains(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tContains(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Po...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tContains(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', false);
+ERROR:  function tcontains(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tContains(geometry 'Point(1 1)', tcbuffer '{Cbuffer(P...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tContains(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', false);
+ERROR:  function tcontains(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tContains(geometry 'Point(1 1)', tcbuffer '[Cbuffer(P...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tContains(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', false);
+ERROR:  function tcontains(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tContains(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tContains(geometry 'Linestring(1 1,2 2)', tcbuffer '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]');
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: ...Contains(geometry 'Linestring(1 1,2 2)', tcbuffer '[Point(1 ...
+                                                             ^
+/* Errors */
+SELECT tContains(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  Operation on mixed SRID
+SELECT tContains(geometry 'Point(1 1)', tcbuffer 'SRID=5676;Point(1 1)@2000-01-01');
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tContains(geometry 'Point(1 1)', tcbuffer 'SRID=5676;...
+                                                         ^
+SELECT tContains(geometry 'Point(1 1)', tcbuffer 'Point(1 1 1)@2000-01-01');
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tContains(geometry 'Point(1 1)', tcbuffer 'Point(1 1 ...
+                                                         ^
+SELECT tContains(geometry 'Point(1 1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  The geometry cannot have Z dimension
+SELECT tDisjoint(NULL::geometry, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
+SELECT tDisjoint(geometry 'Point(1 1)', NULL::tcbuffer);
+ tdisjoint 
+-----------
+ 
+(1 row)
+
+SELECT tDisjoint(NULL::tcbuffer, geometry 'Point(1 1)');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
+SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::geometry);
+ tdisjoint 
+-----------
+ 
+(1 row)
+
+SELECT tDisjoint(NULL::tcbuffer, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
+SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::tcbuffer);
+ tdisjoint 
+-----------
+ 
+(1 row)
+
+SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+           tdisjoint            
+--------------------------------
+ f@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+                                            tdisjoint                                             
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
+SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+                                                                                                             tdisjoint                                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST], (t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+                                                                                                                                              tdisjoint                                                                                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST], (t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [t@Tue Jan 04 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tDisjoint(geometry 'Point empty', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
+SELECT tDisjoint(geometry 'Point empty', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
+SELECT tDisjoint(geometry 'Point empty', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
+SELECT tDisjoint(geometry 'Point empty', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
+SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)');
+           tdisjoint            
+--------------------------------
+ f@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point(1 1)');
+                                            tdisjoint                                             
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
+SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)');
+                                                                                                             tdisjoint                                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST], (t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)');
+                                                                                                                                              tdisjoint                                                                                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST], (t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [t@Tue Jan 04 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tDisjoint(tcbuffer '[Point(0 1)@2000-01-01, Point(2 1)@2000-01-04]', geometry 'Linestring(1 0,1 1,2 1,2 0)');
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDisjoint(tcbuffer '[Point(0 1)@2000-01-01, Point(2 1...
+                                  ^
+SELECT tDisjoint(tcbuffer '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-04]', geometry 'Linestring(1 1,2 1)');
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDisjoint(tcbuffer '[Point(0 0)@2000-01-01, Point(1 1...
+                                  ^
+SELECT tDisjoint(tcbuffer '[Point(1 1)@2000-01-01, Point(0 0)@2000-01-04]', geometry 'Linestring(0 0,1 1)');
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDisjoint(tcbuffer '[Point(1 1)@2000-01-01, Point(0 0...
+                                  ^
+SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point empty');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
+SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point empty');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
+SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point empty');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
+SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point empty');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
+SELECT tDisjoint(tcbuffer 'Point(1 1 1)@2000-01-01', geometry 'Point(2 2 2)');
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDisjoint(tcbuffer 'Point(1 1 1)@2000-01-01', geometr...
+                                  ^
+SELECT tDisjoint(tcbuffer '{Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03}', geometry 'Point(2 2 2)');
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDisjoint(tcbuffer '{Point(1 1 1)@2000-01-01, Point(2...
+                                  ^
+SELECT tDisjoint(tcbuffer '[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03]', geometry 'Point(2 2 2)');
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDisjoint(tcbuffer '[Point(1 1 1)@2000-01-01, Point(2...
+                                  ^
+SELECT tDisjoint(tcbuffer '{[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03], [Point(3 3 3)@2000-01-04, Point(3 3 3)@2000-01-05]}', geometry 'Point(2 2 2)');
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDisjoint(tcbuffer '{[Point(1 1 1)@2000-01-01, Point(...
+                                  ^
+SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', true);
+ERROR:  function tdisjoint(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Po...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', true);
+ERROR:  function tdisjoint(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '{Cbuffer(P...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', true);
+ERROR:  function tdisjoint(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '[Cbuffer(P...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', true);
+ERROR:  function tdisjoint(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', false);
+ERROR:  function tdisjoint(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Po...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', false);
+ERROR:  function tdisjoint(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '{Cbuffer(P...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', false);
+ERROR:  function tdisjoint(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '[Cbuffer(P...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', false);
+ERROR:  function tdisjoint(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)', true);
+ERROR:  function tdisjoint(tcbuffer, geometry, boolean) does not exist
+LINE 1: SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point(1 1)', true);
+ERROR:  function tdisjoint(tcbuffer, geometry, boolean) does not exist
+LINE 1: SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)', true);
+ERROR:  function tdisjoint(tcbuffer, geometry, boolean) does not exist
+LINE 1: SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)', true);
+ERROR:  function tdisjoint(tcbuffer, geometry, boolean) does not exist
+LINE 1: SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)', false);
+ERROR:  function tdisjoint(tcbuffer, geometry, boolean) does not exist
+LINE 1: SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point(1 1)', false);
+ERROR:  function tdisjoint(tcbuffer, geometry, boolean) does not exist
+LINE 1: SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)', false);
+ERROR:  function tdisjoint(tcbuffer, geometry, boolean) does not exist
+LINE 1: SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)', false);
+ERROR:  function tdisjoint(tcbuffer, geometry, boolean) does not exist
+LINE 1: SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', true);
+ERROR:  function tdisjoint(tcbuffer, tcbuffer, boolean) does not exist
+LINE 1: SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', true);
+ERROR:  function tdisjoint(tcbuffer, tcbuffer, boolean) does not exist
+LINE 1: SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', true);
+ERROR:  function tdisjoint(tcbuffer, tcbuffer, boolean) does not exist
+LINE 1: SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', true);
+ERROR:  function tdisjoint(tcbuffer, tcbuffer, boolean) does not exist
+LINE 1: SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', false);
+ERROR:  function tdisjoint(tcbuffer, tcbuffer, boolean) does not exist
+LINE 1: SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', false);
+ERROR:  function tdisjoint(tcbuffer, tcbuffer, boolean) does not exist
+LINE 1: SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', false);
+ERROR:  function tdisjoint(tcbuffer, tcbuffer, boolean) does not exist
+LINE 1: SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', false);
+ERROR:  function tdisjoint(tcbuffer, tcbuffer, boolean) does not exist
+LINE 1: SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+/* Errors */
+SELECT tDisjoint(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  Operation on mixed SRID
+SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=5676;Point(1 1)');
+ERROR:  Operation on mixed SRID
+SELECT tIntersects(NULL::geometry, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ tintersects 
+-------------
+ 
+(1 row)
+
+SELECT tIntersects(geometry 'Point(1 1)', NULL::tcbuffer);
+ tintersects 
+-------------
+ 
+(1 row)
+
+SELECT tIntersects(NULL::tcbuffer, geometry 'Point(1 1)');
+ tintersects 
+-------------
+ 
+(1 row)
+
+SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::geometry);
+ tintersects 
+-------------
+ 
+(1 row)
+
+SELECT tIntersects(NULL::tcbuffer, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ tintersects 
+-------------
+ 
+(1 row)
+
+SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::tcbuffer);
+ tintersects 
+-------------
+ 
+(1 row)
+
+SELECT tIntersects(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+          tintersects           
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+                                           tintersects                                            
+--------------------------------------------------------------------------------------------------
+ {f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
+SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+                                                                                                            tintersects                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST], (f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+                                                                                                                                             tintersects                                                                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST], (f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tIntersects(geometry 'Point empty', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ tintersects 
+-------------
+ 
+(1 row)
+
+SELECT tIntersects(geometry 'Point empty', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ tintersects 
+-------------
+ 
+(1 row)
+
+SELECT tIntersects(geometry 'Point empty', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ tintersects 
+-------------
+ 
+(1 row)
+
+SELECT tIntersects(geometry 'Point empty', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ tintersects 
+-------------
+ 
+(1 row)
+
+SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)');
+          tintersects           
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point(1 1)');
+                                           tintersects                                            
+--------------------------------------------------------------------------------------------------
+ {f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)');
+                                                                                                            tintersects                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST], (f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)');
+                                                                                                                                             tintersects                                                                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST], (f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tIntersects(tcbuffer '[Point(0 1)@2000-01-01, Point(2 1)@2000-01-04]', geometry 'Linestring(1 0,1 1,2 1,2 0)');
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tIntersects(tcbuffer '[Point(0 1)@2000-01-01, Point(2...
+                                    ^
+SELECT tIntersects(tcbuffer '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-04]', geometry 'Linestring(1 1,2 1)');
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tIntersects(tcbuffer '[Point(0 0)@2000-01-01, Point(1...
+                                    ^
+SELECT tIntersects(tcbuffer '[Point(1 1)@2000-01-01, Point(0 0)@2000-01-04]', geometry 'Linestring(0 0,1 1)');
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tIntersects(tcbuffer '[Point(1 1)@2000-01-01, Point(0...
+                                    ^
+SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point empty');
+ tintersects 
+-------------
+ 
+(1 row)
+
+SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point empty');
+ tintersects 
+-------------
+ 
+(1 row)
+
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point empty');
+ tintersects 
+-------------
+ 
+(1 row)
+
+SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point empty');
+ tintersects 
+-------------
+ 
+(1 row)
+
+SELECT tIntersects(tcbuffer '[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02]', geometry 'Linestring(1 1,2 2)');
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tIntersects(tcbuffer '[Point(1 1)@2000-01-01, Point(1...
+                                    ^
+SELECT tIntersects(tcbuffer '[Point(1 1)@2000-01-01, Point(4 1)@2000-01-02]', geometry 'Linestring(1 2,1 0,2 0,2 2)');
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tIntersects(tcbuffer '[Point(1 1)@2000-01-01, Point(4...
+                                    ^
+SELECT tIntersects(tcbuffer 'Point(1 1 1)@2000-01-01', geometry 'Point(2 2 2)');
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tIntersects(tcbuffer 'Point(1 1 1)@2000-01-01', geome...
+                                    ^
+SELECT tIntersects(tcbuffer '{Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03}', geometry 'Point(2 2 2)');
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tIntersects(tcbuffer '{Point(1 1 1)@2000-01-01, Point...
+                                    ^
+SELECT tIntersects(tcbuffer '[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03]', geometry 'Point(2 2 2)');
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tIntersects(tcbuffer '[Point(1 1 1)@2000-01-01, Point...
+                                    ^
+SELECT tIntersects(tcbuffer '{[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03], [Point(3 3 3)@2000-01-04, Point(3 3 3)@2000-01-05]}', geometry 'Point(2 2 2)');
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tIntersects(tcbuffer '{[Point(1 1 1)@2000-01-01, Poin...
+                                    ^
+SELECT tIntersects(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', true);
+ERROR:  function tintersects(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tIntersects(geometry 'Point(1 1)', tcbuffer 'Cbuffer(...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', true);
+ERROR:  function tintersects(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '{Cbuffer...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', true);
+ERROR:  function tintersects(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '[Cbuffer...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', true);
+ERROR:  function tintersects(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '{[Cbuffe...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tIntersects(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', false);
+ERROR:  function tintersects(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tIntersects(geometry 'Point(1 1)', tcbuffer 'Cbuffer(...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', false);
+ERROR:  function tintersects(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '{Cbuffer...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', false);
+ERROR:  function tintersects(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '[Cbuffer...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', false);
+ERROR:  function tintersects(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '{[Cbuffe...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)', true);
+ERROR:  function tintersects(tcbuffer, geometry, boolean) does not exist
+LINE 1: SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point(1 1)', true);
+ERROR:  function tintersects(tcbuffer, geometry, boolean) does not exist
+LINE 1: SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)', true);
+ERROR:  function tintersects(tcbuffer, geometry, boolean) does not exist
+LINE 1: SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)', true);
+ERROR:  function tintersects(tcbuffer, geometry, boolean) does not exist
+LINE 1: SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)', false);
+ERROR:  function tintersects(tcbuffer, geometry, boolean) does not exist
+LINE 1: SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point(1 1)', false);
+ERROR:  function tintersects(tcbuffer, geometry, boolean) does not exist
+LINE 1: SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)', false);
+ERROR:  function tintersects(tcbuffer, geometry, boolean) does not exist
+LINE 1: SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)', false);
+ERROR:  function tintersects(tcbuffer, geometry, boolean) does not exist
+LINE 1: SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', true);
+ERROR:  function tintersects(tcbuffer, tcbuffer, boolean) does not exist
+LINE 1: SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', true);
+ERROR:  function tintersects(tcbuffer, tcbuffer, boolean) does not exist
+LINE 1: SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', true);
+ERROR:  function tintersects(tcbuffer, tcbuffer, boolean) does not exist
+LINE 1: SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', true);
+ERROR:  function tintersects(tcbuffer, tcbuffer, boolean) does not exist
+LINE 1: SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', false);
+ERROR:  function tintersects(tcbuffer, tcbuffer, boolean) does not exist
+LINE 1: SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', false);
+ERROR:  function tintersects(tcbuffer, tcbuffer, boolean) does not exist
+LINE 1: SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', false);
+ERROR:  function tintersects(tcbuffer, tcbuffer, boolean) does not exist
+LINE 1: SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', false);
+ERROR:  function tintersects(tcbuffer, tcbuffer, boolean) does not exist
+LINE 1: SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tIntersects(tcbuffer '{Point(1 1)@2000-01-01, Point(1 1)@2000-01-03}', tcbuffer 'Point(2 2)@2000-01-02');
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tIntersects(tcbuffer '{Point(1 1)@2000-01-01, Point(1...
+                                    ^
+SELECT tIntersects(tcbuffer '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]', tcbuffer '[Point(2 1)@2000-01-01, Point(1 2)@2000-01-02]');
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tIntersects(tcbuffer '[Point(1 1)@2000-01-01, Point(2...
+                                    ^
+/* Errors */
+SELECT tIntersects(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  Operation on mixed SRID
+SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=5676;Point(1 1)');
+ERROR:  Operation on mixed SRID
+SELECT tTouches(NULL::geometry, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ ttouches 
+----------
+ 
+(1 row)
+
+SELECT tTouches(geometry 'Point(1 1)', NULL::tcbuffer);
+ ttouches 
+----------
+ 
+(1 row)
+
+SELECT tTouches(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+            ttouches            
+--------------------------------
+ f@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tTouches(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+                                             ttouches                                             
+--------------------------------------------------------------------------------------------------
+ {f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
+SELECT tTouches(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+                              ttouches                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tTouches(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+                                                               ttouches                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tTouches(geometry 'Point empty', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ ttouches 
+----------
+ 
+(1 row)
+
+SELECT tTouches(geometry 'Point empty', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ ttouches 
+----------
+ 
+(1 row)
+
+SELECT tTouches(geometry 'Point empty', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ ttouches 
+----------
+ 
+(1 row)
+
+SELECT tTouches(geometry 'Point empty', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ ttouches 
+----------
+ 
+(1 row)
+
+SELECT tTouches(NULL::tcbuffer, geometry 'Point(1 1)');
+ ttouches 
+----------
+ 
+(1 row)
+
+SELECT tTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::geometry);
+ ttouches 
+----------
+ 
+(1 row)
+
+SELECT tTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)');
+            ttouches            
+--------------------------------
+ f@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tTouches(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point(1 1)');
+                                             ttouches                                             
+--------------------------------------------------------------------------------------------------
+ {f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
+SELECT tTouches(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)');
+                              ttouches                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tTouches(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)');
+                                                               ttouches                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point empty');
+ ttouches 
+----------
+ 
+(1 row)
+
+SELECT tTouches(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point empty');
+ ttouches 
+----------
+ 
+(1 row)
+
+SELECT tTouches(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point empty');
+ ttouches 
+----------
+ 
+(1 row)
+
+SELECT tTouches(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point empty');
+ ttouches 
+----------
+ 
+(1 row)
+
+SELECT tTouches(geometry 'Linestring(1 1,2 2)', tcbuffer '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]');
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: ...tTouches(geometry 'Linestring(1 1,2 2)', tcbuffer '[Point(1 ...
+                                                             ^
+SELECT tTouches(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', true);
+ERROR:  function ttouches(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tTouches(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Poi...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tTouches(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', true);
+ERROR:  function ttouches(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tTouches(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Po...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tTouches(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', true);
+ERROR:  function ttouches(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tTouches(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Po...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tTouches(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', true);
+ERROR:  function ttouches(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tTouches(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(P...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tTouches(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', false);
+ERROR:  function ttouches(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tTouches(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Poi...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tTouches(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', false);
+ERROR:  function ttouches(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tTouches(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Po...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tTouches(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', false);
+ERROR:  function ttouches(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tTouches(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Po...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tTouches(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', false);
+ERROR:  function ttouches(geometry, tcbuffer, boolean) does not exist
+LINE 1: SELECT tTouches(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(P...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)', true);
+ERROR:  function ttouches(tcbuffer, geometry, boolean) does not exist
+LINE 1: SELECT tTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tTouches(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point(1 1)', true);
+ERROR:  function ttouches(tcbuffer, geometry, boolean) does not exist
+LINE 1: SELECT tTouches(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tTouches(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)', true);
+ERROR:  function ttouches(tcbuffer, geometry, boolean) does not exist
+LINE 1: SELECT tTouches(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tTouches(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)', true);
+ERROR:  function ttouches(tcbuffer, geometry, boolean) does not exist
+LINE 1: SELECT tTouches(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)', false);
+ERROR:  function ttouches(tcbuffer, geometry, boolean) does not exist
+LINE 1: SELECT tTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tTouches(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point(1 1)', false);
+ERROR:  function ttouches(tcbuffer, geometry, boolean) does not exist
+LINE 1: SELECT tTouches(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tTouches(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)', false);
+ERROR:  function ttouches(tcbuffer, geometry, boolean) does not exist
+LINE 1: SELECT tTouches(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tTouches(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)', false);
+ERROR:  function ttouches(tcbuffer, geometry, boolean) does not exist
+LINE 1: SELECT tTouches(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+/* Errors */
+SELECT tTouches(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  Operation on mixed SRID
+SELECT tTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=5676;Point(1 1)');
+ERROR:  Operation on mixed SRID
+SELECT tTouches(geometry 'Point(1 1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  The geometry cannot have Z dimension
+SELECT tTouches(geometry 'Point(1 1)', tcbuffer 'Point(1 1 1)@2000-01-01');
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tTouches(geometry 'Point(1 1)', tcbuffer 'Point(1 1 1...
+                                                        ^
+SELECT tDwithin(NULL::geometry, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 1: SELECT tDwithin(NULL::geometry, tcbuffer 'Cbuffer(Point(1 1)...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(geometry 'Point(1 1)', NULL::tcbuffer, 2);
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point(1 1)', NULL::tcbuffer, 2);
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL);
+ERROR:  function tdwithin(geometry, tcbuffer, unknown) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Poi...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Poi...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Po...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Po...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(P...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(geometry 'Point empty', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point empty', tcbuffer 'Cbuffer(Po...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(geometry 'Point empty', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point empty', tcbuffer '{Cbuffer(P...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(geometry 'Point empty', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point empty', tcbuffer '[Cbuffer(P...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(geometry 'Point empty', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point empty', tcbuffer '{[Cbuffer(...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(NULL::tcbuffer, geometry 'Point(1 1)', 2);
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(NULL::tcbuffer, geometry 'Point(1 1)', 2);
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::geometry, 2);
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)', NULL);
+ERROR:  function tdwithin(tcbuffer, geometry, unknown) does not exist
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)', 2);
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point(1 1)', 2);
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)', 2);
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)', 2);
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point empty', 2);
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point empty', 2);
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point empty', 2);
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point empty', 2);
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer 'Point(1 1 1)@2000-01-01', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer 'Point(1 1...
+                                                          ^
+SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '{Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03}', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '{Point(1 ...
+                                                          ^
+SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03]', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '[Point(1 ...
+                                                          ^
+SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '{[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03], [Point(3 3 3)@2000-01-04, Point(3 3 3)@2000-01-05]}', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '{[Point(1...
+                                                          ^
+SELECT tDwithin(geometry 'Point Z empty', tcbuffer 'Point(1 1 1)@2000-01-01', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: ...ELECT tDwithin(geometry 'Point Z empty', tcbuffer 'Point(1 1...
+                                                             ^
+SELECT tDwithin(geometry 'Point Z empty', tcbuffer '{Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03}', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: ...ELECT tDwithin(geometry 'Point Z empty', tcbuffer '{Point(1 ...
+                                                             ^
+SELECT tDwithin(geometry 'Point Z empty', tcbuffer '[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03]', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: ...ELECT tDwithin(geometry 'Point Z empty', tcbuffer '[Point(1 ...
+                                                             ^
+SELECT tDwithin(geometry 'Point Z empty', tcbuffer '{[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03], [Point(3 3 3)@2000-01-04, Point(3 3 3)@2000-01-05]}', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: ...ELECT tDwithin(geometry 'Point Z empty', tcbuffer '{[Point(1...
+                                                             ^
+SELECT tDwithin(tcbuffer 'Point(1 1 1)@2000-01-01', geometry 'Point(1 1 1)', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer 'Point(1 1 1)@2000-01-01', geometry...
+                                 ^
+SELECT tDwithin(tcbuffer '{Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03}', geometry 'Point(1 1 1)', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '{Point(1 1 1)@2000-01-01, Point(2 ...
+                                 ^
+SELECT tDwithin(tcbuffer '[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03]', geometry 'Point(1 1 1)', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '[Point(1 1 1)@2000-01-01, Point(2 ...
+                                 ^
+SELECT tDwithin(tcbuffer '{[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03], [Point(3 3 3)@2000-01-04, Point(3 3 3)@2000-01-05]}', geometry 'Point(1 1 1)', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '{[Point(1 1 1)@2000-01-01, Point(2...
+                                 ^
+SELECT tDwithin(tcbuffer 'Point(1 1 1)@2000-01-01', geometry 'Point Z empty', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer 'Point(1 1 1)@2000-01-01', geometry...
+                                 ^
+SELECT tDwithin(tcbuffer '{Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03}', geometry 'Point Z empty', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '{Point(1 1 1)@2000-01-01, Point(2 ...
+                                 ^
+SELECT tDwithin(tcbuffer '[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03]', geometry 'Point Z empty', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '[Point(1 1 1)@2000-01-01, Point(2 ...
+                                 ^
+SELECT tDwithin(tcbuffer '{[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03], [Point(3 3 3)@2000-01-04, Point(3 3 3)@2000-01-05]}', geometry 'Point Z empty', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '{[Point(1 1 1)@2000-01-01, Point(2...
+                                 ^
+SELECT tDwithin(NULL::tcbuffer, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ tdwithin 
+----------
+ 
+(1 row)
+
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::tcbuffer, 2);
+ tdwithin 
+----------
+ 
+(1 row)
+
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL);
+ tdwithin 
+----------
+ 
+(1 row)
+
+SELECT tDwithin(tcbuffer '(Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]', geometry 'Point(0 1)', 1);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '(Point(1 1)@2000-01-01, Point(2 2)...
+                                 ^
+SELECT tDwithin(tcbuffer '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]', geometry 'Point(2 3)', 1);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '[Point(1 1)@2000-01-01, Point(2 2)...
+                                 ^
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+                                             tdwithin                                             
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+                                             tdwithin                                             
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
+SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+                                             tdwithin                                             
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+                                             tdwithin                                             
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+                              tdwithin                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+                              tdwithin                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+                                             tdwithin                                             
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+                              tdwithin                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+                                                               tdwithin                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [t@Tue Jan 04 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tDwithin(tcbuffer '[Point(1 1)@2000-01-01, Point(1 3)@2000-01-03]', geometry 'Point(1 2)', 0);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '[Point(1 1)@2000-01-01, Point(1 3)...
+                                 ^
+SELECT tDwithin(tcbuffer '[Point(1 1)@2000-01-01, Point(1 2)@2000-01-03]', geometry 'Point(1 3)', 0);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '[Point(1 1)@2000-01-01, Point(1 2)...
+                                 ^
+SELECT tDwithin(tcbuffer '(Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]', tcbuffer '[Point(1 0)@2000-01-01, Point(2 0)@2000-01-02]', 1);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '(Point(0 0)@2000-01-01, Point(1 1)...
+                                 ^
+SELECT tDwithin(tcbuffer '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]', tcbuffer '[Point(1 0)@2000-01-01, Point(2 0)@2000-01-02]', 1);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '[Point(0 0)@2000-01-01, Point(1 1)...
+                                 ^
+SELECT tDwithin(tcbuffer '[Point(0 1)@2000-01-01, Point(0 0)@2000-01-02]', tcbuffer '[Point(2 0)@2000-01-01, Point(1 0)@2000-01-02]', 1);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '[Point(0 1)@2000-01-01, Point(0 0)...
+                                 ^
+SELECT tDwithin(tcbuffer '[Point(1 1)@2000-01-01, Point(0 0)@2000-01-02]', tcbuffer '[Point(2 0)@2000-01-01, Point(1 1)@2000-01-02]', 1);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '[Point(1 1)@2000-01-01, Point(0 0)...
+                                 ^
+SELECT tDwithin(tcbuffer '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]', tcbuffer '[Point(0 2)@2000-01-01, Point(1 3)@2000-01-02]', 1);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '[Point(0 0)@2000-01-01, Point(1 1)...
+                                 ^
+SELECT tDwithin(tcbuffer '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]', tcbuffer '[Point(4 0)@2000-01-01, Point(3 1)@2000-01-02]', 0);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '[Point(0 0)@2000-01-01, Point(1 1)...
+                                 ^
+SELECT tDwithin(tcbuffer 'Point(1 1 1)@2000-01-01', tcbuffer 'Point(1 1 1)@2000-01-01', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer 'Point(1 1 1)@2000-01-01', tcbuffer...
+                                 ^
+SELECT tDwithin(tcbuffer '{Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03}', tcbuffer 'Point(1 1 1)@2000-01-01', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '{Point(1 1 1)@2000-01-01, Point(2 ...
+                                 ^
+SELECT tDwithin(tcbuffer '[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03]', tcbuffer 'Point(1 1 1)@2000-01-01', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '[Point(1 1 1)@2000-01-01, Point(2 ...
+                                 ^
+SELECT tDwithin(tcbuffer '{[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03], [Point(3 3 3)@2000-01-04, Point(3 3 3)@2000-01-05]}', tcbuffer 'Point(1 1 1)@2000-01-01', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '{[Point(1 1 1)@2000-01-01, Point(2...
+                                 ^
+SELECT tDwithin(tcbuffer 'Point(1 1 1)@2000-01-01', tcbuffer '{Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03}', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer 'Point(1 1 1)@2000-01-01', tcbuffer...
+                                 ^
+SELECT tDwithin(tcbuffer '{Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03}', tcbuffer '{Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03}', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '{Point(1 1 1)@2000-01-01, Point(2 ...
+                                 ^
+SELECT tDwithin(tcbuffer '[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03]', tcbuffer '{Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03}', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '[Point(1 1 1)@2000-01-01, Point(2 ...
+                                 ^
+SELECT tDwithin(tcbuffer '{[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03], [Point(3 3 3)@2000-01-04, Point(3 3 3)@2000-01-05]}', tcbuffer '{Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03}', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '{[Point(1 1 1)@2000-01-01, Point(2...
+                                 ^
+SELECT tDwithin(tcbuffer 'Point(1 1 1)@2000-01-01', tcbuffer '[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03]', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer 'Point(1 1 1)@2000-01-01', tcbuffer...
+                                 ^
+SELECT tDwithin(tcbuffer '{Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03}', tcbuffer '[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03]', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '{Point(1 1 1)@2000-01-01, Point(2 ...
+                                 ^
+SELECT tDwithin(tcbuffer '[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03]', tcbuffer '[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03]', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '[Point(1 1 1)@2000-01-01, Point(2 ...
+                                 ^
+SELECT tDwithin(tcbuffer '{[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03], [Point(3 3 3)@2000-01-04, Point(3 3 3)@2000-01-05]}', tcbuffer '[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03]', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '{[Point(1 1 1)@2000-01-01, Point(2...
+                                 ^
+SELECT tDwithin(tcbuffer 'Point(1 1 1)@2000-01-01', tcbuffer '{[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03], [Point(3 3 3)@2000-01-04, Point(3 3 3)@2000-01-05]}', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer 'Point(1 1 1)@2000-01-01', tcbuffer...
+                                 ^
+SELECT tDwithin(tcbuffer '{Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03}', tcbuffer '{[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03], [Point(3 3 3)@2000-01-04, Point(3 3 3)@2000-01-05]}', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '{Point(1 1 1)@2000-01-01, Point(2 ...
+                                 ^
+SELECT tDwithin(tcbuffer '[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03]', tcbuffer '{[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03], [Point(3 3 3)@2000-01-04, Point(3 3 3)@2000-01-05]}', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '[Point(1 1 1)@2000-01-01, Point(2 ...
+                                 ^
+SELECT tDwithin(tcbuffer '{[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03], [Point(3 3 3)@2000-01-04, Point(3 3 3)@2000-01-05]}', tcbuffer '{[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03], [Point(3 3 3)@2000-01-04, Point(3 3 3)@2000-01-05]}', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '{[Point(1 1 1)@2000-01-01, Point(2...
+                                 ^
+SELECT tDwithin(tcbuffer '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03, Point(3 3)@
+2000-01-04, Point(3 3)@2000-01-05]}', tcbuffer '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03]
+,[Point(3 3)@2000-01-04, Point(3 3)@2000-01-05]}', 1);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer '{[Point(1 1)@2000-01-01, Point(2 2...
+                                 ^
+SELECT tDwithin(tcbuffer 'Point(1 1 1)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer 'Point(1 1 1)@2000-01-01', tcbuffer...
+                                 ^
+SELECT tDwithin(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2, true);
+ERROR:  function tdwithin(geometry, tcbuffer, integer, boolean) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Poi...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2, true);
+ERROR:  function tdwithin(geometry, tcbuffer, integer, boolean) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Po...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2, true);
+ERROR:  function tdwithin(geometry, tcbuffer, integer, boolean) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Po...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2, true);
+ERROR:  function tdwithin(geometry, tcbuffer, integer, boolean) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(P...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2, false);
+ERROR:  function tdwithin(geometry, tcbuffer, integer, boolean) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Poi...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2, false);
+ERROR:  function tdwithin(geometry, tcbuffer, integer, boolean) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Po...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2, false);
+ERROR:  function tdwithin(geometry, tcbuffer, integer, boolean) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Po...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2, false);
+ERROR:  function tdwithin(geometry, tcbuffer, integer, boolean) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(P...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)', 2, true);
+ERROR:  function tdwithin(tcbuffer, geometry, integer, boolean) does not exist
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point(1 1)', 2, true);
+ERROR:  function tdwithin(tcbuffer, geometry, integer, boolean) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)', 2, true);
+ERROR:  function tdwithin(tcbuffer, geometry, integer, boolean) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)', 2, true);
+ERROR:  function tdwithin(tcbuffer, geometry, integer, boolean) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)', 2, false);
+ERROR:  function tdwithin(tcbuffer, geometry, integer, boolean) does not exist
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point(1 1)', 2, false);
+ERROR:  function tdwithin(tcbuffer, geometry, integer, boolean) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)', 2, false);
+ERROR:  function tdwithin(tcbuffer, geometry, integer, boolean) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)', 2, false);
+ERROR:  function tdwithin(tcbuffer, geometry, integer, boolean) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2, true);
+ERROR:  function tdwithin(tcbuffer, tcbuffer, integer, boolean) does not exist
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2, true);
+ERROR:  function tdwithin(tcbuffer, tcbuffer, integer, boolean) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2, true);
+ERROR:  function tdwithin(tcbuffer, tcbuffer, integer, boolean) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2, true);
+ERROR:  function tdwithin(tcbuffer, tcbuffer, integer, boolean) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2, false);
+ERROR:  function tdwithin(tcbuffer, tcbuffer, integer, boolean) does not exist
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2, false);
+ERROR:  function tdwithin(tcbuffer, tcbuffer, integer, boolean) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2, false);
+ERROR:  function tdwithin(tcbuffer, tcbuffer, integer, boolean) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2, false);
+ERROR:  function tdwithin(tcbuffer, tcbuffer, integer, boolean) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(geometry 'Linestring(1 1,2 2)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 1: SELECT tDwithin(geometry 'Linestring(1 1,2 2)', tcbuffer 'Cb...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Linestring(1 1,2 2)', 2);
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+/* Errors */
+SELECT tDwithin(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 2: SELECT tDwithin(geometry 'SRID=5676;Point(1 1)', tcbuffer 'C...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=5676;Point(1 1)', 2);
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer 'SRID=5676;Point(1 1)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer 'SRID=5676;Point(1 1)@2000-01-01', ...
+                                 ^
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(0 0)', -1);
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer 'Point(1 1 1)@2000-01-01', geometry 'Point(0 0 0)', -1);
+ERROR:  Could not parse cbuffer value: Missing prefix 'Cbuffer'
+LINE 1: SELECT tDwithin(tcbuffer 'Point(1 1 1)@2000-01-01', geometry...
+                                 ^

--- a/mobilitydb/test/cbuffer/expected/164_tcbuffer_tempspatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/164_tcbuffer_tempspatialrels_tbl.test.out
@@ -1,0 +1,203 @@
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tContains(g, temp) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tContains(temp, g) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE tContains(cb, temp) IS NOT NULL;
+ count 
+-------
+ 10000
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE tContains(temp, cb) IS NOT NULL;
+ count 
+-------
+ 10000
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tContains(t1.temp, t2.temp) IS NOT NULL;
+ count 
+-------
+   102
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tContains(g, temp) ?= true <> eContains(g, temp);
+ERROR:  function econtains(geometry, tcbuffer) does not exist
+LINE 1: ... tbl_tcbuffer WHERE tContains(g, temp) ?= true <> eContains(...
+                                                             ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE tContains(cb, temp) ?= true <> eContains(cb, temp);
+ count 
+-------
+  1756
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tCovers(g, temp) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tCovers(temp, g) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tCovers(t1.temp, t2.temp) IS NOT NULL;
+ count 
+-------
+   102
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tCovers(g, temp) ?= true <> eCovers(g, temp);
+ERROR:  function ecovers(geometry, tcbuffer) does not exist
+LINE 1: ...y, tbl_tcbuffer WHERE tCovers(g, temp) ?= true <> eCovers(g,...
+                                                             ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDisjoint(g, temp) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDisjoint(temp, g) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tDisjoint(t1.temp, t2.temp) IS NOT NULL;
+ count 
+-------
+   102
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDisjoint(g, temp) ?= true <> eDisjoint(g, temp);
+ count 
+-------
+    91
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDisjoint(temp, g) ?= true <> eDisjoint(temp, g);
+ count 
+-------
+    91
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
+  WHERE tDisjoint(t1.temp, t2.temp) ?= true <> eDisjoint(t1.temp, t2.temp);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tIntersects(g, temp) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) ?= true <> eDisjoint(temp, g);
+ count 
+-------
+  6493
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tIntersects(g, temp) ?= true <> eIntersects(g, temp);
+ count 
+-------
+  6493
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) ?= true <> eIntersects(temp, g);
+ count 
+-------
+   801
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
+  WHERE tIntersects(t1.temp, t2.temp) ?= true <> eIntersects(t1.temp, t2.temp);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tTouches(g, temp) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tTouches(temp, g) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tTouches(t1.temp, t2.temp) IS NOT NULL;
+ count 
+-------
+   102
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tTouches(g, temp) ?= true <> eTouches(g, temp);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tTouches(temp, g) ?= true <> eTouches(temp, g);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDwithin(g, temp, 10) IS NOT NULL;
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 1: ...CT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDwithin(g...
+                                                             ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDwithin(temp, g, 10) IS NOT NULL;
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: ...CT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDwithin(t...
+                                                             ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tDwithin(t1.temp, t2.temp, 10) IS NOT NULL;
+ count 
+-------
+   102
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer
+  WHERE tDwithin(g, temp, 10) ?= true <> edwithin(g, temp, 10);
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 2:   WHERE tDwithin(g, temp, 10) ?= true <> edwithin(g, temp, 1...
+                ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry
+  WHERE tDwithin(temp, g, 10) ?= true <> edwithin(temp, g, 10);
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 2:   WHERE tDwithin(temp, g, 10) ?= true <> edwithin(temp, g, 1...
+                ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
+  WHERE tDwithin(t1.temp, t2.temp, 10) ?= true <> edwithin(t1.temp, t2.temp, 10);
+ count 
+-------
+    34
+(1 row)
+

--- a/mobilitydb/test/cbuffer/queries/164_tcbuffer_tempspatialrels_tbl.test.sql
+++ b/mobilitydb/test/cbuffer/queries/164_tcbuffer_tempspatialrels_tbl.test.sql
@@ -73,10 +73,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tDisjoint(t1.temp, t
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDisjoint(g, temp) ?= true <> eDisjoint(g, temp);
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDisjoint(temp, g) ?= true <> eDisjoint(temp, g);
   
--- Temporal points
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
-  WHERE tDisjoint(t1.temp, t2.temp) ?= true <> eDisjoint(t1.temp, t2.temp);
-SELECT COUNT(*) FROM tbl_tcbuffer3D t1, tbl_tcbuffer3D t2
   WHERE tDisjoint(t1.temp, t2.temp) ?= true <> eDisjoint(t1.temp, t2.temp);
 
 -------------------------------------------------------------------------------
@@ -93,10 +90,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) ?= tr
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tIntersects(g, temp) ?= true <> eIntersects(g, temp);
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) ?= true <> eIntersects(temp, g);
 
--- Temporal points
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
-  WHERE tIntersects(t1.temp, t2.temp) ?= true <> eIntersects(t1.temp, t2.temp);
-SELECT COUNT(*) FROM tbl_tcbuffer3D t1, tbl_tcbuffer3D t2
   WHERE tIntersects(t1.temp, t2.temp) ?= true <> eIntersects(t1.temp, t2.temp);
 
 -------------------------------------------------------------------------------
@@ -121,12 +115,6 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDwithin(g, temp, 10) IS N
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDwithin(temp, g, 10) IS NOT NULL;
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tDwithin(t1.temp, t2.temp, 10) IS NOT NULL;
 
--- Mixed 2D/3D
-SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer3D t2
-  WHERE tDwithin(t1.temp, t2.temp, 10) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tcbuffer3D t1, tbl_tcbuffer t2
-  WHERE tDwithin(t1.temp, t2.temp, 10) IS NOT NULL;
-
 -------------------------------------------------------------------------------
 -- Robustness test
 
@@ -135,12 +123,6 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry
   WHERE tDwithin(temp, g, 10) ?= true <> edwithin(temp, g, 10);
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
-  WHERE tDwithin(t1.temp, t2.temp, 10) ?= true <> edwithin(t1.temp, t2.temp, 10);
-  
--- Mixed 2D/3D
-SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer3D t2
-  WHERE tDwithin(t1.temp, t2.temp, 10) ?= true <> edwithin(t1.temp, t2.temp, 10);
-SELECT COUNT(*) FROM tbl_tcbuffer3D t1, tbl_tcbuffer t2
   WHERE tDwithin(t1.temp, t2.temp, 10) ?= true <> edwithin(t1.temp, t2.temp, 10);
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/rgeo/CMakeLists.txt
+++ b/mobilitydb/test/rgeo/CMakeLists.txt
@@ -14,13 +14,7 @@ set_tests_properties(load_rgeo_tables PROPERTIES
 file(GLOB testfiles "queries/*.sql")
 list(SORT testfiles)
 
-# Tests whose expected output is stale relative to the current behaviour
-# of the underlying functions. Re-enable once the expected output is
-# regenerated.
 set(SKIP_TESTS
-  122_trgeo               # Operation on mixed SRID drift
-  124_trgeo_compops       # Operation on mixed SRID drift
-  124_trgeo_compops_tbl   # Operation on mixed SRID drift (table form)
 )
 
 foreach(file ${testfiles})

--- a/mobilitydb/test/rgeo/expected/124_trgeo_compops_tbl.test.out
+++ b/mobilitydb/test/rgeo/expected/124_trgeo_compops_tbl.test.out
@@ -1,0 +1,36 @@
+SELECT COUNT(*) FROM tbl_geometry t1, tbl_trgeometry2d t2 WHERE ST_SetSRID(t1.g, 5676) #= t2.temp IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d t1, tbl_geometry t2 WHERE t1.temp #= ST_SetSRID(t2.g, 5676) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d t1, tbl_trgeometry2d t2 WHERE t1.temp #= t2.temp IS NOT NULL;
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry t1, tbl_trgeometry2d t2 WHERE ST_SetSRID(t1.g, 5676) #<> t2.temp IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d t1, tbl_geometry t2 WHERE t1.temp #<> ST_SetSRID(t2.g, 5676) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d t1, tbl_trgeometry2d t2 WHERE t1.temp #<> t2.temp IS NOT NULL;
+ count 
+-------
+   100
+(1 row)
+

--- a/schemas/meos-api-0.1-draft.json
+++ b/schemas/meos-api-0.1-draft.json
@@ -1,0 +1,201 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MobilityDB/MobilityDB/blob/master/schemas/meos-api-0.1-draft.json",
+  "title": "MEOS-API Catalog (draft v0.1.0)",
+  "description": "JSON Schema for meos-api.json — a machine-readable description of the MEOS C library's public API. See doc/specs/meos-api-0.1-draft.md for the full specification.",
+  "type": "object",
+  "required": ["version", "meos_version", "generated_at", "functions", "structs", "enums"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "description": "Schema version this document conforms to. For v0.1 the literal string '0.1.0-draft'.",
+      "type": "string",
+      "pattern": "^0\\.[0-9]+\\.[0-9]+-draft$"
+    },
+    "meos_version": {
+      "description": "Version of the MEOS C library this catalog was generated from.",
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+([.-][A-Za-z0-9.+-]+)?$"
+    },
+    "generated_at": {
+      "description": "ISO 8601 UTC timestamp at which the catalog was emitted.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "functions": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/function" }
+    },
+    "structs": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/struct" }
+    },
+    "enums": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/enum" }
+    }
+  },
+  "$defs": {
+    "typeRef": {
+      "type": "object",
+      "required": ["c", "canonical"],
+      "additionalProperties": false,
+      "properties": {
+        "c": {
+          "description": "C type spelling exactly as declared in the header.",
+          "type": "string"
+        },
+        "canonical": {
+          "description": "Normalised type form (may equal 'c' in v0.1; reserved for future normalisation rules).",
+          "type": "string"
+        }
+      }
+    },
+    "ownership": {
+      "description": "Who owns the returned object's lifetime.",
+      "type": "string",
+      "enum": ["caller", "callee", "none"]
+    },
+    "direction": {
+      "description": "Parameter direction. Defaults to 'in' if absent.",
+      "type": "string",
+      "enum": ["in", "out", "inout"]
+    },
+    "arrayShape": {
+      "description": "Array layout. Either 'lengthFrom' (length carried in another parameter) or 'zeroTerminated' (NULL-terminated).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "lengthFrom": {
+          "description": "Name of the parameter carrying the array length.",
+          "type": "string"
+        },
+        "zeroTerminated": {
+          "description": "True if the array is NULL-terminated.",
+          "type": "boolean"
+        }
+      },
+      "oneOf": [
+        { "required": ["lengthFrom"] },
+        { "required": ["zeroTerminated"] }
+      ]
+    },
+    "closureShape": {
+      "description": "Callback / closure metadata.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "scope": {
+          "description": "Lifetime of the callback. Reserved for future use; may be 'async', 'notified', or 'call'.",
+          "type": "string",
+          "enum": ["async", "notified", "call"]
+        },
+        "userData": {
+          "description": "Name of the parameter carrying the callback's user-data pointer.",
+          "type": "string"
+        },
+        "destroy": {
+          "description": "Name of the parameter carrying the callback's destroy-notify function.",
+          "type": "string"
+        }
+      }
+    },
+    "param": {
+      "type": "object",
+      "required": ["name", "cType", "canonical"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "cType": { "type": "string" },
+        "canonical": { "type": "string" },
+        "direction": { "$ref": "#/$defs/direction" },
+        "nullable": { "type": "boolean" },
+        "array": { "$ref": "#/$defs/arrayShape" },
+        "closure": { "$ref": "#/$defs/closureShape" },
+        "doc": { "type": "string" }
+      }
+    },
+    "function": {
+      "type": "object",
+      "required": ["name", "file", "returnType", "params"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "Function name as declared in the header.",
+          "type": "string"
+        },
+        "file": {
+          "description": "Header file in which the declaration appears, relative to the MEOS include root.",
+          "type": "string"
+        },
+        "returnType": { "$ref": "#/$defs/typeRef" },
+        "params": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/param" }
+        },
+        "ownership": { "$ref": "#/$defs/ownership" },
+        "nullable": { "type": "boolean" },
+        "doc": { "type": "string" }
+      }
+    },
+    "structField": {
+      "type": "object",
+      "required": ["name", "cType"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "cType": { "type": "string" },
+        "nullable": { "type": "boolean" },
+        "doc": { "type": "string" }
+      }
+    },
+    "struct": {
+      "type": "object",
+      "required": ["name", "file", "fields"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "file": { "type": "string" },
+        "fields": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/structField" }
+        },
+        "opaque": {
+          "description": "True if the struct is forward-declared in the public header but has no field list.",
+          "type": "boolean"
+        },
+        "doc": { "type": "string" }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "opaque": { "const": true } }, "required": ["opaque"] },
+          "then": { "properties": { "fields": { "maxItems": 0 } } }
+        }
+      ]
+    },
+    "enumValue": {
+      "type": "object",
+      "required": ["name", "value"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "value": { "type": "integer" },
+        "doc": { "type": "string" }
+      }
+    },
+    "enum": {
+      "type": "object",
+      "required": ["name", "file", "values"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "file": { "type": "string" },
+        "values": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/enumValue" }
+        },
+        "doc": { "type": "string" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
> 👀 **Reviewers**: tier ranking, dependency chains and the standards checklist live in [`doc/contributing/reviewer-guide.md`](https://github.com/MobilityDB/MobilityDB/blob/master/doc/contributing/reviewer-guide.md).

## Summary

First-pass specification for **MEOS-API**: a machine-readable JSON catalog of the MEOS C library's public API. Companion to RFC [#836](https://github.com/MobilityDB/MobilityDB/issues/836) / Discussion [#920](https://github.com/MobilityDB/MobilityDB/discussions/920); ships at **`v0.1.0-draft`**, *not* `v1.0` — the schema is explicitly unstable until the three gating conditions in §10 are met.

## Why

The bindings ecosystem (PyMEOS, JMEOS, meos-rs, GoMEOS, MEOS.NET, MEOS.js) currently maintains six hand-rolled mirrors of `meos.h`. Every new MEOS function multiplies into N hand-edits across N bindings. A shared catalog format collapses N×M maintenance into single-emit / N-consume.

## What's in this PR

| File | Purpose |
|---|---|
| `doc/specs/meos-api-0.1-draft.md` | Full specification — document shape, function/struct/enum entry formats, header-resident GIR-vocabulary annotation source-of-truth, draft-versioning posture, gating conditions, JSON-Schema validation, out-of-scope deferrals, references, consumers, integration scenarios. |
| `schemas/meos-api-0.1-draft.json` | JSON Schema (draft 2020-12) describing the shape of any `meos-api.json` instance. Validated locally via `python-jsonschema` against a sample roundtrip. |

No C-side changes. The catalog is purely a derived artefact produced by the reference generator at [`MobilityDB/MEOS-API`](https://github.com/MobilityDB/MEOS-API).

## Posture: draft, not v1.0

After [@Davichet-e's review](https://github.com/MobilityDB/MobilityDB/issues/836#issuecomment-4363944571) the schema is positioned as `0.1.0-draft`. v1.0 ratification is gated on three conditions:

1. **Real-binding validation** — at least one binding regenerated end-to-end. [PyMEOS-CFFI](https://github.com/MobilityDB/PyMEOS-CFFI) is the proposed first validator.
2. **Completeness gaps resolved** (not deferred): function-pointer typedefs, opaque pointer types, conditional compilation guards (`CBUFFER`/`JSON`/`NPOINT`/`POSE`), public/internal split, `va_list` parameters.
3. **GIR annotation coverage** — adopt the [GIR vocabulary](https://gi.readthedocs.io/en/latest/annotations/giannotations.html) verbatim, or document the gap.

While on `0.x`, breaking schema changes are permitted at every draft bump; bindings pin to an exact draft version (`0.1.0-draft`, `0.2.0-draft`, …).

## Annotations live in the C headers

Following GObject Introspection's lesson, annotations on functions/parameters/return types live in Doxygen blocks in the headers, not in a sidecar JSON file. The reference generator parses headers + annotations and emits `meos-api.json` as the derived artefact:

```c
/**
 * tpointseq_make: (transfer full) (nullable)
 * @instants: (array length=count): array of instants
 * @count: number of instants; must be ≥ 1
 *
 * Creates a temporal point sequence from an array of instants.
 */
TSequence *tpointseq_make(TInstant **instants, int count);
```

## Test plan

- [x] `python-jsonschema` validates a hand-crafted sample document against `schemas/meos-api-0.1-draft.json`.
- [x] Spec links cross-checked (RFC #836, GIR docs, WIT spec, Protobuf compat rules, `bindgen`, sister spec MEOS-WKB).
- [ ] Reviewer chime-in from binding maintainers (PyMEOS, JMEOS, meos-rs, GoMEOS, MEOS.NET, MEOS.js) on schema-vocabulary fit.
- [ ] Round-trip CI lane in `MobilityDB/MEOS-API` (separate repo) gates generator output against this schema — coordinated follow-up, not part of this PR.

## Related

- Discussion [#920](https://github.com/MobilityDB/MobilityDB/discussions/920) / Issue [#836](https://github.com/MobilityDB/MobilityDB/issues/836) — MEOS-API: a versioned JSON catalog for MEOS's C-library public API
- PR #833 — MEOS-WKB byte-format specification (sister spec, same template)
- JMEOS PR #8 — coordinating refactor pinned to `0.1.0-draft`