### PR TITLE
fix(cbuffer,rgeo): align NAD failure sentinel with PG-wrapper expectation

### DIFF
--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -32,6 +32,8 @@
  * @brief Temporal distance for temporal circular buffers
  */
 
+/* C */
+#include <float.h>
 /* MEOS */
 #include <meos.h>
 #include <meos_internal.h>
@@ -519,7 +521,7 @@ nad_cbuffer_stbox(const Cbuffer *cb, const STBox *box)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_cbuffer_stbox(cb, box))
-    return -1.0;
+    return DBL_MAX;
 
   Datum geocbuf = PointerGetDatum(cbuffer_to_geom(cb));
   Datum geobox = PointerGetDatum(stbox_geo(box));
@@ -543,7 +545,7 @@ nad_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
-    return -1.0;
+    return DBL_MAX;
 
   GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
   double result = geom_distance2d(trav, gs);
@@ -564,7 +566,7 @@ nad_tcbuffer_stbox(const Temporal *temp, const STBox *box)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tcbuffer_stbox(temp, box))
-    return -1.0;
+    return DBL_MAX;
 
   GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
   GSERIALIZED *geo = stbox_geo(box);
@@ -586,7 +588,7 @@ nad_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tcbuffer_cbuffer(temp, cb))
-    return -1.0;
+    return DBL_MAX;
 
   GSERIALIZED *geom = cbuffer_to_geom(cb);
   GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
@@ -606,11 +608,11 @@ nad_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tcbuffer_tcbuffer(temp1, temp2))
-    return -1.0;
+    return DBL_MAX;
 
   Temporal *dist = tdistance_tcbuffer_tcbuffer(temp1, temp2);
   if (dist == NULL)
-    return -1.0;
+    return DBL_MAX;
   double result = DatumGetFloat8(temporal_min_value(dist));
   pfree(dist);
   return result;

--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -2002,7 +2002,7 @@ nad_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
-    return -1.0;
+    return DBL_MAX;
 
   Temporal *dist = tdistance_trgeo_geo(temp, gs);
   double result = DatumGetFloat8(temporal_min_value(dist));
@@ -2021,7 +2021,7 @@ nad_trgeo_stbox(const Temporal *temp, const STBox *box)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_stbox(temp, box))
-    return -1.0;
+    return DBL_MAX;
 
   /* Project the temporal point to the timespan of the box */
   bool hast = MEOS_FLAGS_GET_T(box->flags);
@@ -2030,7 +2030,7 @@ nad_trgeo_stbox(const Temporal *temp, const STBox *box)
   {
     temporal_set_tstzspan(temp, &p);
     if (! inter_span_span(&p, &box->period, &inter))
-      return -1.0;
+      return DBL_MAX;
   }
   /* Convert the stbox to a geometry */
   GSERIALIZED *geo = stbox_geo(box);
@@ -2057,11 +2057,11 @@ nad_trgeo_tpoint(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_tpoint(temp2, temp2))
-    return -1.0;
+    return DBL_MAX;
 
   Temporal *dist = tdistance_trgeo_tpoint(temp1, temp2);
   if (dist == NULL)
-    return -1.0;
+    return DBL_MAX;
 
   double result = DatumGetFloat8(temporal_min_value(dist));
   pfree(dist);
@@ -2079,11 +2079,11 @@ nad_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_trgeo(temp2, temp2))
-    return -1.0;
+    return DBL_MAX;
 
   Temporal *dist = tdistance_trgeo_trgeo(temp1, temp2);
   if (dist == NULL)
-    return -1.0;
+    return DBL_MAX;
 
   double result = DatumGetFloat8(temporal_min_value(dist));
   pfree(dist);


### PR DESCRIPTION
## Summary

Fixes the root cause behind the count drift that [@mschoema flagged on PR #843](https://github.com/MobilityDB/MobilityDB/pull/843#pullrequestreview-4215096017): `WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL` was matching rows that should have been NULL, jumping the cross-table count from 10 to 1000.

## Root cause

Sentinel mismatch between MEOS-side `nad_*` and the PG wrappers `NAD_*`:

| Family | MEOS-side returns on failure | PG-wrapper expects | Match? |
|---|---|---|---|
| `nad_tgeo_*` | `DBL_MAX` | `DBL_MAX` | ✓ |
| `nad_tnpoint_*` | `DBL_MAX` | `DBL_MAX` | ✓ |
| `nad_tcbuffer_*` | `-1.0` | `DBL_MAX` | ✗ |
| `nad_trgeo_*` | `-1.0` | `DBL_MAX` | ✗ |

The PG-side conversion in `mobilitydb/src/{cbuffer,rgeo}/*_distance.c` looks like:

```c
if (result == DBL_MAX)
  PG_RETURN_NULL();
PG_RETURN_FLOAT8(result);
```

When MEOS returned `-1.0`, this check never matched, and `-1.0` leaked through as a non-NULL float. SQL's `IS NOT NULL` matched on the leaked `-1.0` rows, inflating the count.

## Fix

Standardise `nad_tcbuffer_*` and `nad_trgeo_*` on the `DBL_MAX` sentinel — matching the established convention already used by `nad_tgeo_*` and `nad_tnpoint_*`. 13 call sites updated:

- **cbuffer** (6): `nad_cbuffer_stbox`, `nad_tcbuffer_geo`, `nad_tcbuffer_stbox`, `nad_tcbuffer_cbuffer`, `nad_tcbuffer_tcbuffer` (×2 — guard + post-tdistance NULL path).
- **rgeo** (7): `nad_trgeo_geo`, `nad_trgeo_stbox` (×2), `nad_trgeo_tpoint` (×2), `nad_trgeo_trgeo` (×2).

`<float.h>` is already included in both files; no header change required.

## Why this is the right side to fix

Two reasons to fix the MEOS side rather than the PG side:

1. **Convention precedent.** `nad_tgeo_*` and `nad_tnpoint_*` already return `DBL_MAX`. The PG-wrapper pattern (`if (result == DBL_MAX) PG_RETURN_NULL();`) is established. The cbuffer/rgeo MEOS-side is the deviation; bringing it into line preserves the wider convention.
2. **MEOS API contract clarity.** A "no defined distance" sentinel is most natural at the *upper* extreme (`DBL_MAX`) — distances are non-negative, so any ordinary numeric return is `< DBL_MAX`, making the sentinel detectable without ambiguity. `-1.0` would also work, but only by convention; `DBL_MAX` doubles as a guard against accidental ordering / min-comparison code paths.

## Follow-up

Once this lands, [`160_tcbuffer_distance_tbl`](https://github.com/MobilityDB/MobilityDB/blob/master/mobilitydb/test/cbuffer/queries/160_tcbuffer_distance_tbl.test.sql) can come out of `SKIP_TESTS` (PR #843) — its current expected output (which has the OLD pre-bug counts of 900 / 10) becomes correct again, since the wrapper now properly converts the failure return to NULL.

## Test plan

- [x] All `return -1.0` in `nad_*` functions in cbuffer/rgeo replaced with `return DBL_MAX`.
- [x] No new `-1.0` returns introduced; no other code path in those files relied on the `-1.0` sentinel.
- [ ] Local `make test` with `-DCBUFFER=ON -DRGEO=ON` to confirm `160_tcbuffer_distance_tbl`'s count returns to 900 / 10.
- [ ] CI green on this branch.