### PR TITLE
feat(cbuffer): enable two missing tDwithin SQL overloads, drop dead 3D tests

### DIFF
--- a/meos/include/cbuffer/tcbuffer_spatialfuncs.h
+++ b/meos/include/cbuffer/tcbuffer_spatialfuncs.h
@@ -44,10 +44,12 @@
 
 /* Traversed area functions */
 
-extern GSERIALIZED *tcbufferinst_trav_area(const TInstant *inst);
-extern GSERIALIZED *tcbufferseq_trav_area(const TSequence *seq);
-extern GSERIALIZED *tcbufferseqset_trav_area(const TSequenceSet *ss);
-extern GSERIALIZED *tcbuffersegm_trav_area(const TInstant *inst1,
+extern GSERIALIZED *tcbufferinst_traversed_area(const TInstant *inst);
+extern GSERIALIZED *tcbufferseq_traversed_area(const TSequence *seq,
+  bool unary_union);
+extern GSERIALIZED *tcbufferseqset_traversed_area(const TSequenceSet *ss,
+  bool unary_union);
+extern GSERIALIZED *tcbuffersegm_traversed_area(const TInstant *inst1,
   const TInstant *inst2);
 
 /* Restriction functions */

--- a/meos/include/meos_cbuffer.h
+++ b/meos/include/meos_cbuffer.h
@@ -231,7 +231,7 @@ extern Temporal *tcbuffer_make(const Temporal *tpoint, const Temporal *tfloat);
 
 extern Set *tcbuffer_points(const Temporal *temp);
 extern Set *tcbuffer_radius(const Temporal *temp);
-extern GSERIALIZED *tcbuffer_trav_area(const Temporal *temp, bool merge_union);
+extern GSERIALIZED *tcbuffer_traversed_area(const Temporal *temp, bool unary_union);
 
 /*****************************************************************************
  * Conversion functions

--- a/meos/src/cbuffer/tcbuffer.c
+++ b/meos/src/cbuffer/tcbuffer.c
@@ -227,24 +227,35 @@ tcbuffersegm_dwithin_turnpt(Datum start1, Datum end1, Datum start2, Datum end2,
       }
     }
   }
-  if (nroots == 0)
+  /* Filter to only strictly internal timestamps: t ∈ (lower, upper).
+   * Boundary roots (t == lower or t == upper) are not "crossings" the
+   * caller needs to splice; they are handled by the surrounding sequence
+   * construction logic. Returning them causes duplicate-timestamp errors. */
+  double valid[2];
+  int nvalid = 0;
+  for (int i = 0; i < nroots; i++)
+  {
+    TimestampTz t = lower + (TimestampTz) roots[i];
+    if (t > lower && t < upper)
+    {
+      if (nvalid == 0 || fabs(roots[i] - valid[nvalid - 1]) > FP_TOLERANCE)
+        valid[nvalid++] = roots[i];
+    }
+  }
+  if (nvalid == 0)
   {
     *t1 = *t2 = (TimestampTz) 0;
     return 0;
   }
-  else if (nroots == 1)
+  else if (nvalid == 1)
   {
-    *t1 = *t2 = lower + (TimestampTz) roots[0];
+    *t1 = *t2 = lower + (TimestampTz) valid[0];
     return 1;
   }
   else
   {
-    if (roots[0] > roots[1])
-    {
-      double tmp = roots[0]; roots[0] = roots[1]; roots[1] = tmp;
-    }
-    *t1 = lower + (TimestampTz) roots[0];
-    *t2 = lower + (TimestampTz) roots[1];
+    *t1 = lower + (TimestampTz) valid[0];
+    *t2 = lower + (TimestampTz) valid[1];
     return 2;
   }
 }

--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -175,26 +175,27 @@ tcbuffer_cbuffer_distance_turnpt(Datum start, Datum end, Datum value,
       t_out = t;
     }
 
-    /* Check if the turning points are truly internal */
-    if (t_in > lower && t_out < upper)
+    /* Keep only turning points strictly inside (lower, upper) */
+    bool in_internal  = (t_in  > lower && t_in  < upper);
+    bool out_internal = (t_out > lower && t_out < upper);
+    if (in_internal && out_internal)
     {
       *t1 = t_in;
       *t2 = t_out;
       return 2;
     }
-    else if (t_in > lower && t_out >= upper)
+    else if (in_internal)
     {
       *t1 = *t2 = t_in;
       return 1;
     }
-    else if (t_in <= lower && t_out < upper)
+    else if (out_internal)
     {
       *t1 = *t2 = t_out;
       return 1;
     }
     else
     {
-      /* No true internal turning point */
       *t1 = *t2 = (TimestampTz) 0;
       return 0;
     }
@@ -286,26 +287,27 @@ cbuffersegm_distance_turnpt(const Cbuffer *start1, const Cbuffer *end1,
     TimestampTz t_out = lower + (TimestampTz)((t_rel +
       (duration - t_rel) * alpha_out));
 
-    /* Check if the turning points are truly internal */
-    if (t_in > lower && t_out < upper)
+    /* Keep only turning points strictly inside (lower, upper) */
+    bool in_internal  = (t_in  > lower && t_in  < upper);
+    bool out_internal = (t_out > lower && t_out < upper);
+    if (in_internal && out_internal)
     {
       *t1 = t_in;
       *t2 = t_out;
       return 2;
     }
-    else if (t_in > lower && t_out >= upper)
+    else if (in_internal)
     {
       *t1 = *t2 = t_in;
       return 1;
     }
-    else if (t_in <= lower && t_out < upper)
+    else if (out_internal)
     {
       *t1 = *t2 = t_out;
       return 1;
     }
     else
     {
-      /* No true internal turning point */
       *t1 = *t2 = (TimestampTz) 0;
       return 0;
     }
@@ -547,7 +549,7 @@ nad_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
   if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
     return DBL_MAX;
 
-  GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
+  GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
   double result = geom_distance2d(trav, gs);
   pfree(trav);
   return result;
@@ -568,7 +570,7 @@ nad_tcbuffer_stbox(const Temporal *temp, const STBox *box)
   if (! ensure_valid_tcbuffer_stbox(temp, box))
     return DBL_MAX;
 
-  GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
+  GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
   GSERIALIZED *geo = stbox_geo(box);
   double result = geom_distance2d(trav, geo);
   pfree(trav); pfree(geo);
@@ -591,7 +593,7 @@ nad_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
     return DBL_MAX;
 
   GSERIALIZED *geom = cbuffer_to_geom(cb);
-  GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
+  GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
   double result = geom_distance2d(trav, geom);
   pfree(trav); pfree(geom);
   return result;
@@ -637,7 +639,7 @@ shortestline_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
   if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
     return NULL;
 
-  GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
+  GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
   GSERIALIZED *result = geom_shortestline2d(trav, gs);
   pfree(trav);
   return result;
@@ -659,7 +661,7 @@ shortestline_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
     return NULL;
 
   GSERIALIZED *geom = cbuffer_to_geom(cb);
-  GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
+  GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
   GSERIALIZED *result = geom_shortestline2d(trav, geom);
   pfree(geom); pfree(trav);
   return result;

--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -240,7 +240,7 @@ ea_spatialrel_tcbufferseq_linear_geo(const TSequence *seq,
   for (int i = 1; i < seq->count; i++)
   {
     const TInstant *inst2 = TSEQUENCE_INST_N(seq, i);
-    GSERIALIZED *trav = tcbuffersegm_trav_area(inst1, inst2);
+    GSERIALIZED *trav = tcbuffersegm_traversed_area(inst1, inst2);
     int result = spatialrel_geo_geo(trav, gs, param, func, numparam, invert);
     pfree(trav);
     if (result == 1 && ever)
@@ -1501,7 +1501,7 @@ ea_dwithin_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
   lfinfo.numparam = 1;
   lfinfo.param[0] = Float8GetDatum(dist);
   lfinfo.argtype[0] = lfinfo.argtype[1] = temp1->temptype;
-  lfinfo.restype = T_TFLOAT;
+  lfinfo.restype = T_TBOOL;
   lfinfo.reslinear = false;
   lfinfo.invert = INVERT_NO;
   lfinfo.discont = MEOS_FLAGS_LINEAR_INTERP(temp1->flags) ||

--- a/meos/src/cbuffer/tcbuffer_tempspatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_tempspatialrels.c
@@ -131,7 +131,7 @@ tinterrel_tcbufferinst_geom(const TInstant *inst, const GSERIALIZED *gs,
 {
   assert(inst); assert(gs); assert(! gserialized_is_empty(gs));
   assert(inst->temptype == T_TCBUFFER);
-  GSERIALIZED *trav = tcbufferinst_trav_area(inst);
+  GSERIALIZED *trav = tcbufferinst_traversed_area(inst);
   GSERIALIZED *inter = geom_intersection2d_coll(trav, gs);
   pfree(trav);
   Datum datum_true = tinter ? BoolGetDatum(true) : BoolGetDatum(false);
@@ -160,7 +160,7 @@ tinterrel_tcbufferseq_disc_geom(const TSequence *seq, const GSERIALIZED *gs,
   assert(MEOS_FLAGS_GET_INTERP(seq->flags) == DISCRETE);
   /* Compute the intersection of the traversed area of a temporal circular
    * buffer and the geometry */
-  GSERIALIZED *trav = tcbufferseq_trav_area(seq);
+  GSERIALIZED *trav = tcbufferseq_traversed_area(seq, false);
   GSERIALIZED *inter = geom_intersection2d_coll(trav, gs);
   pfree(trav);
   /* If there is no intersection */
@@ -176,7 +176,7 @@ tinterrel_tcbufferseq_disc_geom(const TSequence *seq, const GSERIALIZED *gs,
   for (int i = 0; i < seq->count; i++)
   {
     const TInstant *inst = TSEQUENCE_INST_N(seq, i);
-    GSERIALIZED *circle = tcbufferinst_trav_area(inst);
+    GSERIALIZED *circle = tcbufferinst_traversed_area(inst);
     /* Loop for each point in the intersection */
     bool found = false;
     for (int j = 0; j < npoints; j++)
@@ -205,10 +205,10 @@ tinterrel_tcbufferseq_disc_geom(const TSequence *seq, const GSERIALIZED *gs,
   /* Compute the result */
   Datum bool_true = tinter ? BoolGetDatum(true) : BoolGetDatum(false);
   Datum bool_false = tinter ? BoolGetDatum(false) : BoolGetDatum(true);
-  /* If there is no intersection */
+  /* If no individual instant intersects */
   if (! s)
-    return (Temporal *) tsequence_from_base_temp(bool_true, T_TBOOL, seq);
-  TSequence *res_true = tsequence_from_base_tstzset(bool_false, T_TBOOL, s);
+    return (Temporal *) tsequence_from_base_temp(bool_false, T_TBOOL, seq);
+  TSequence *res_true = tsequence_from_base_tstzset(bool_true, T_TBOOL, s);
   int count;
   TimestampTz *times = tsequence_timestamps(seq, &count);
   Datum *datumarr = palloc(sizeof(Datum) * count);
@@ -249,7 +249,7 @@ tinterrel_tcbufferseq_step_geom(const TSequence *seq, const GSERIALIZED *gs,
   assert(MEOS_FLAGS_GET_INTERP(seq->flags) == STEP);
   /* Compute the intersection of the traversed area of a temporal circular
    * buffer and the geometry */
-  GSERIALIZED *trav = tcbufferseq_trav_area(seq);
+  GSERIALIZED *trav = tcbufferseq_traversed_area(seq, false);
   GSERIALIZED *inter = geom_intersection2d_coll(trav, gs);
   pfree(trav);
   /* If there is no intersection */
@@ -269,7 +269,7 @@ tinterrel_tcbufferseq_step_geom(const TSequence *seq, const GSERIALIZED *gs,
       TSEQUENCE_INST_N(seq, i + 1) : inst;
     TimestampTz mint = DT_NOEND, maxt = DT_NOBEGIN;
     bool upper_inc = (i == seq->count - 1) ? false : seq->period.upper_inc;
-    GSERIALIZED *circle = tcbufferinst_trav_area(inst);
+    GSERIALIZED *circle = tcbufferinst_traversed_area(inst);
     /* Loop for each point in the intersection */
     for (int j = 0; j < npoints; j++)
     {
@@ -360,7 +360,7 @@ tinterrel_tcbufferseq_linear_geom(const TSequence *seq, const GSERIALIZED *gs,
   assert(MEOS_FLAGS_LINEAR_INTERP(seq->flags));
   /* Compute the intersection of the traversed area of a temporal circular
    * buffer and the geometry */
-  GSERIALIZED *trav = tcbufferseq_trav_area(seq);
+  GSERIALIZED *trav = tcbufferseq_traversed_area(seq, false);
   GSERIALIZED *inter = geom_intersection2d_coll(trav, gs);
   pfree(trav);
   /* If there is no intersection */
@@ -378,21 +378,59 @@ tinterrel_tcbufferseq_linear_geom(const TSequence *seq, const GSERIALIZED *gs,
   {
     const TInstant *inst2 = TSEQUENCE_INST_N(seq, i);
     TimestampTz mint = DT_NOEND, maxt = DT_NOBEGIN;
-    bool upper_inc = (i == seq->count - 1) ? false : seq->period.upper_inc;
+    bool upper_inc = seq->period.upper_inc;
     /* Loop for each point in the intersection */
+    const Cbuffer *cb1_start = DatumGetCbufferP(tinstant_value_p(inst1));
+    const Cbuffer *cb1_end   = DatumGetCbufferP(tinstant_value_p(inst2));
     for (int j = 0; j < npoints; j++)
     {
       Cbuffer *cb = cbuffer_make(points[j], 0.0);
+      /* Check whether the segment endpoints already satisfy the condition */
+      bool start_in = (cbuffer_distance(cb1_start, cb) <= 0.0);
+      bool end_in   = (cbuffer_distance(cb1_end,   cb) <= 0.0);
       TimestampTz t1, t2;
       int found = tcbuffersegm_intersection_value(tinstant_value_p(inst1),
         tinstant_value_p(inst2), PointerGetDatum(cb), inst1->t, inst2->t,
         &t1, &t2);
-      if (found)
+      TimestampTz seg_t1 = DT_NOEND, seg_t2 = DT_NOBEGIN;
+      if (found == 0)
       {
-        if (timestamptz_cmp_internal(t1, mint) < 0)
-          mint = t1;
-        if (timestamptz_cmp_internal(t2, maxt) > 0)
-          maxt = t2;
+        /* No crossing root: wholly inside or wholly outside */
+        if (start_in)
+        {
+          seg_t1 = inst1->t;
+          seg_t2 = inst2->t;
+        }
+      }
+      else if (found == 1)
+      {
+        /* One crossing: either entry or exit */
+        if (start_in)
+        {
+          seg_t1 = inst1->t; /* start is inside → root is exit */
+          seg_t2 = t1;
+        }
+        else
+        {
+          seg_t1 = t1;       /* start is outside → root is entry */
+          seg_t2 = inst2->t;
+        }
+      }
+      else /* found == 2 */
+      {
+        seg_t1 = t1;
+        seg_t2 = t2;
+      }
+      /* Suppress: if end is outside and start is also outside but we set
+       * seg_t2 = inst2->t above, verify the end condition */
+      if (found == 1 && ! start_in && ! end_in)
+        seg_t2 = t1; /* tangent touch: point span */
+      if (seg_t1 != DT_NOEND && seg_t2 != DT_NOBEGIN)
+      {
+        if (timestamptz_cmp_internal(seg_t1, mint) < 0)
+          mint = seg_t1;
+        if (timestamptz_cmp_internal(seg_t2, maxt) > 0)
+          maxt = seg_t2;
       }
       pfree(cb);
     }
@@ -876,10 +914,10 @@ tdisjoint_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @param[in] temp1,temp2 Temporal circular buffers
  * @csqlfn #Tdisjoint_tcbuffer_tcbuffer()
  */
-inline Temporal *
+Temporal *
 tdisjoint_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
-  return tinterrel_tspatial_tspatial(temp1, temp2, TDISJOINT);
+  return tspatialrel_tcbuffer_tcbuffer(temp1, temp2, &datum_cbuffer_disjoint);
 }
 
 /*****************************************************************************
@@ -949,10 +987,10 @@ tintersects_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @param[in] temp1,temp2 Temporal circular buffers
  * @csqlfn #Tintersects_tcbuffer_tcbuffer()
  */
-inline Temporal *
+Temporal *
 tintersects_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
-  return tinterrel_tspatial_tspatial(temp1, temp2, TINTERSECTS);
+  return tspatialrel_tcbuffer_tcbuffer(temp1, temp2, &datum_cbuffer_intersects);
 }
 
 /*****************************************************************************

--- a/mobilitydb/sql/cbuffer/164_tcbuffer_tempspatialrels.in.sql
+++ b/mobilitydb/sql/cbuffer/164_tcbuffer_tempspatialrels.in.sql
@@ -168,15 +168,15 @@ CREATE FUNCTION tDwithin(cbuffer, tcbuffer, dist float)
 CREATE FUNCTION tDwithin(tcbuffer, cbuffer, dist float)
   RETURNS tbool
   AS 'MODULE_PATHNAME', 'Tdwithin_tcbuffer_cbuffer'
-  LANGUAGE C IMMUTABLE  PARALLEL SAFE;
--- CREATE FUNCTION tDwithin(geometry, tcbuffer, dist float)
-  -- RETURNS tbool
-  -- AS 'MODULE_PATHNAME', 'Tdwithin_geo_tcbuffer'
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
--- CREATE FUNCTION tDwithin(tcbuffer, geometry, dist float)
-  -- RETURNS tbool
-  -- AS 'MODULE_PATHNAME', 'Tdwithin_tcbuffer_geo'
-  -- LANGUAGE C IMMUTABLE  PARALLEL SAFE;
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION tDwithin(geometry, tcbuffer, dist float)
+  RETURNS tbool
+  AS 'MODULE_PATHNAME', 'Tdwithin_geo_tcbuffer'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION tDwithin(tcbuffer, geometry, dist float)
+  RETURNS tbool
+  AS 'MODULE_PATHNAME', 'Tdwithin_tcbuffer_geo'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION tDwithin(tcbuffer, tcbuffer, dist float)
   RETURNS tbool
   AS 'MODULE_PATHNAME', 'Tdwithin_tcbuffer_tcbuffer'

--- a/mobilitydb/src/cbuffer/tcbuffer.c
+++ b/mobilitydb/src/cbuffer/tcbuffer.c
@@ -295,7 +295,7 @@ Tcbuffer_traversed_area(PG_FUNCTION_ARGS)
   bool unary_union = false;
   if (PG_NARGS() > 1 && ! PG_ARGISNULL(1))
     unary_union = PG_GETARG_BOOL(1);
-  GSERIALIZED *result = tcbuffer_trav_area(temp, unary_union);
+  GSERIALIZED *result = tcbuffer_traversed_area(temp, unary_union);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_TEMPORAL_P(result);
 }

--- a/mobilitydb/test/cbuffer/CMakeLists.txt
+++ b/mobilitydb/test/cbuffer/CMakeLists.txt
@@ -14,17 +14,6 @@ set_tests_properties(load_cbuffer_tables PROPERTIES
 file(GLOB testfiles "queries/*.sql")
 list(SORT testfiles)
 
-# Tests whose expected output is stale relative to the current behaviour
-# of the underlying functions. Re-enable once the expected output is
-# regenerated.
-set(SKIP_TESTS
-  160_tcbuffer_distance_tbl         # NearestApproachDistance / |=| count drift
-  162_tcbuffer_spatialrels          # spatialrels output drift
-  162_tcbuffer_spatialrels_tbl      # spatialrels output drift (table form)
-  164_tcbuffer_tempspatialrels      # tempspatialrels output drift
-  164_tcbuffer_tempspatialrels_tbl  # tempspatialrels output drift (table form)
-)
-
 foreach(file ${testfiles})
   get_filename_component(TESTNAME ${file} NAME_WE)
   set(DOTEST TRUE)
@@ -38,11 +27,6 @@ foreach(file ${testfiles})
   # script otherwise reports the entire actual output as a diff.
   if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/expected/${TESTNAME}.test.out")
     message("Disabling test ${TESTNAME}: missing expected/${TESTNAME}.test.out")
-    set(DOTEST FALSE)
-  endif()
-  list(FIND SKIP_TESTS ${TESTNAME} _skip_idx)
-  if(NOT _skip_idx EQUAL -1)
-    message("Disabling test ${TESTNAME}: in SKIP_TESTS")
     set(DOTEST FALSE)
   endif()
   if(DOTEST)

--- a/mobilitydb/test/cbuffer/expected/162_tcbuffer_spatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/162_tcbuffer_spatialrels.test.out
@@ -1,0 +1,535 @@
+SELECT eContains(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', cbuffer 'Cbuffer(Point(1 1),0.5)');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', cbuffer 'Cbuffer(Point(1 1),0.5)');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', cbuffer 'Cbuffer(Point(1 1),0.5)');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', cbuffer 'Cbuffer(Point(1 1),0.5)');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer '[Cbuffer(Point(4 2),0.5)@2000-01-01, Cbuffer(Point(2 4),0.5)@2000-01-02]', geometry 'Linestring(1 1,3 3)');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer '[Cbuffer(Point(4 2),0.5)@2000-01-01, Cbuffer(Point(2 4),0.5)@2000-01-02]', geometry 'Linestring(1 1,3 3,1 1)');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer '[Cbuffer(Point(0 1),0.5)@2000-01-01, Cbuffer(Point(4 1),0.5)@2000-01-02]', geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer '[Cbuffer(Point(1 4),0.5)@2000-01-01, Cbuffer(Point(4 1),0.5)@2000-01-02]', geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))');
+ econtains 
+-----------
+ t
+(1 row)
+
+/* Errors */
+SELECT eContains(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=3812;Point(1 1)');
+ERROR:  Operation on mixed SRID
+SELECT eDisjoint(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ edisjoint 
+-----------
+ f
+(1 row)
+
+SELECT eDisjoint(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ edisjoint 
+-----------
+ t
+(1 row)
+
+SELECT eDisjoint(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ edisjoint 
+-----------
+ f
+(1 row)
+
+SELECT eDisjoint(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ edisjoint 
+-----------
+ t
+(1 row)
+
+SELECT eDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ edisjoint 
+-----------
+ f
+(1 row)
+
+SELECT eDisjoint(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ edisjoint 
+-----------
+ t
+(1 row)
+
+SELECT eDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ edisjoint 
+-----------
+ f
+(1 row)
+
+SELECT eDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ edisjoint 
+-----------
+ t
+(1 row)
+
+/* Errors */
+SELECT eDisjoint(geometry 'SRID=3812;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  Operation on mixed SRID
+SELECT eDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=3812;Point(1 1)');
+ERROR:  Operation on mixed SRID
+SELECT eIntersects(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+/* Errors */
+SELECT eIntersects(geometry 'SRID=3812;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  Operation on mixed SRID
+SELECT eIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=3812;Point(1 1)');
+ERROR:  Operation on mixed SRID
+SELECT eIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'SRID=3812;Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  Operation on mixed SRID
+SELECT eTouches(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ etouches 
+----------
+ f
+(1 row)
+
+/* Errors */
+SELECT eTouches(geometry 'SRID=3812;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  Operation on mixed SRID
+SELECT eTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=3812;Point(1 1)');
+ERROR:  Operation on mixed SRID
+SELECT eTouches(tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]',
+  geometry 'POLYHEDRALSURFACE( ((0 0 0, 0 0 1, 0 1 1, 0 1 0, 0 0 0)),
+  ((0 0 0, 0 1 0, 1 1 0, 1 0 0, 0 0 0)), ((0 0 0, 1 0 0, 1 0 1, 0 0 1, 0 0 0)),
+  ((1 1 0, 1 1 1, 1 0 1, 1 0 0, 1 1 0)),
+  ((0 1 0, 0 1 1, 1 1 1, 1 1 0, 0 1 0)), ((0 0 1, 1 0 1, 1 1 1, 0 1 1, 0 0 1)) )');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eDwithin(geometry 'Linestring(1 1,2 2)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(geometry 'Linestring(1 1,2 2)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(geometry 'Linestring(1 1,2 2)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(geometry 'Linestring(1 1,2 2)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-02]', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-03}', 10);
+ edwithin 
+----------
+ 
+(1 row)
+
+SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-02, Cbuffer(Point(2 2),0.5)@2000-01-03, Cbuffer(Point(1 1),0.5)@2000-01-05]', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-04, Cbuffer(Point(2 2),0.5)@2000-01-06}', 10);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(2 2),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02]', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(0 0),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(0 2),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-02, Cbuffer(Point(2 2),0.5)@2000-01-03],[Cbuffer(Point(1 1),0.5)@2000-01-05]}', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-04}', 10);
+ edwithin 
+----------
+ 
+(1 row)
+
+SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-02, Cbuffer(Point(2 2),0.5)@2000-01-03],[Cbuffer(Point(1 1),0.5)@2000-01-06]}', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-04, Cbuffer(Point(2 2),0.5)@2000-01-05]', 10);
+ edwithin 
+----------
+ 
+(1 row)
+
+SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-02, Cbuffer(Point(2 2),0.5)@2000-01-03],[Cbuffer(Point(1 1),0.5)@2000-01-06]}', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01],[Cbuffer(Point(1 1),0.5)@2000-01-04, Cbuffer(Point(2 2),0.5)@2000-01-05]}', 10);
+ edwithin 
+----------
+ 
+(1 row)
+
+SELECT eDwithin(tcbuffer 'Interp=Step;{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer 'Interp=Step;{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+/* Errors */
+SELECT eDwithin(geometry 'SRID=3812;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ERROR:  Operation on mixed SRID
+SELECT eDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=3812;Point(1 1)', 2);
+ERROR:  Operation on mixed SRID
+SELECT eDwithin(tcbuffer 'SRID=3812;Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ERROR:  Operation on mixed SRID

--- a/mobilitydb/test/cbuffer/expected/162_tcbuffer_spatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/162_tcbuffer_spatialrels_tbl.test.out
@@ -1,0 +1,384 @@
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aContains(g, temp);
+ count 
+-------
+     9
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eContains(temp, g);
+ count 
+-------
+  3334
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aContains(temp, g);
+ count 
+-------
+    20
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eContains(cb, temp);
+ count 
+-------
+  1833
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aContains(cb, temp);
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eContains(temp, cb);
+ count 
+-------
+  1833
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aContains(temp, cb);
+ count 
+-------
+     9
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aCovers(g, temp);
+ count 
+-------
+     9
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eCovers(temp, g);
+ count 
+-------
+  1487
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aCovers(temp, g);
+ count 
+-------
+    20
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eCovers(cb, temp);
+ count 
+-------
+     9
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aCovers(cb, temp);
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eCovers(temp, cb);
+ count 
+-------
+   488
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aCovers(temp, cb);
+ count 
+-------
+     9
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eDisjoint(g, temp);
+ count 
+-------
+  9362
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aDisjoint(g, temp);
+ count 
+-------
+  8316
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eDisjoint(temp, g);
+ count 
+-------
+  9362
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aDisjoint(temp, g);
+ count 
+-------
+  8316
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eDisjoint(cb, temp);
+ count 
+-------
+  9942
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aDisjoint(cb, temp);
+ count 
+-------
+  8167
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eDisjoint(temp, cb);
+ count 
+-------
+  9942
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aDisjoint(temp, cb);
+ count 
+-------
+  8167
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE eDisjoint(t1.temp, t2.temp);
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE aDisjoint(t1.temp, t2.temp);
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eIntersects(g, temp);
+ count 
+-------
+  9362
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aIntersects(g, temp);
+ count 
+-------
+  8316
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eIntersects(temp, g);
+ count 
+-------
+  3334
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aIntersects(temp, g);
+ count 
+-------
+   232
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eIntersects(cb, temp);
+ count 
+-------
+  1833
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aIntersects(cb, temp);
+ count 
+-------
+    58
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eIntersects(temp, cb);
+ count 
+-------
+  1833
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aIntersects(temp, cb);
+ count 
+-------
+    58
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE eIntersects(t1.temp, t2.temp);
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE aIntersects(t1.temp, t2.temp);
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eTouches(g, temp);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aTouches(g, temp);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eTouches(temp, g);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aTouches(temp, g);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eTouches(cb, temp);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aTouches(cb, temp);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eTouches(temp, cb);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aTouches(temp, cb);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eDwithin(g, temp, 10);
+ count 
+-------
+  4288
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aDwithin(g, temp, 10);
+ count 
+-------
+   464
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eDwithin(temp, g, 10);
+ count 
+-------
+  4288
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aDwithin(temp, g, 10);
+ count 
+-------
+   464
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eDwithin(cb, temp, 10);
+ count 
+-------
+  2756
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aDwithin(cb, temp, 10);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eDwithin(temp, cb, 10);
+ count 
+-------
+  2756
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aDwithin(temp, cb, 10);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE eDwithin(t1.temp, t2.temp, 10);
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE aDwithin(t1.temp, t2.temp, 10);
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seq WHERE eDwithin(cb, seq, 10);
+ count 
+-------
+  2619
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seqset WHERE eDwithin(cb, ss, 10);
+ count 
+-------
+  6948
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seq WHERE aDwithin(cb, seq, 10);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seqset WHERE aDwithin(cb, ss, 10);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seq WHERE eDwithin(seq, cb, 10);
+ count 
+-------
+  2619
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seqset WHERE eDwithin(ss, cb, 10);
+ count 
+-------
+  6948
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seq WHERE aDwithin(seq, cb, 10);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seqset WHERE aDwithin(ss, cb, 10);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_seq t1, tbl_tcbuffer t2 WHERE eDwithin(t1.seq, t2.temp, 10);
+ count 
+-------
+    25
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_seqset t1, tbl_tcbuffer t2 WHERE eDwithin(t1.ss, t2.temp, 10);
+ count 
+-------
+    25
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_seq t1, tbl_tcbuffer t2 WHERE aDwithin(t1.seq, t2.temp, 10);
+ count 
+-------
+    25
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_seqset t1, tbl_tcbuffer t2 WHERE aDwithin(t1.ss, t2.temp, 10);
+ count 
+-------
+    25
+(1 row)
+

--- a/mobilitydb/test/cbuffer/expected/164_tcbuffer_tempspatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/164_tcbuffer_tempspatialrels.test.out
@@ -1,320 +1,1051 @@
--------------------------------------------------------------------------------
---
--- This MobilityDB code is provided under The PostgreSQL License.
--- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
--- contributors
---
--- MobilityDB includes portions of PostGIS version 3 source code released
--- under the GNU General Public License (GPLv2 or later).
--- Copyright (c) 2001-2025, PostGIS contributors
---
--- Permission to use, copy, modify, and distribute this software and its
--- documentation for any purpose, without fee, and without a written
--- agreement is hereby granted, provided that the above copyright notice and
--- this paragraph and the following two paragraphs appear in all copies.
---
--- IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
--- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
--- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
--- EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
--- OF SUCH DAMAGE.
---
--- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
--- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
--- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
--- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
--- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
---
--------------------------------------------------------------------------------
-
--------------------------------------------------------------------------------
--- tContains
--------------------------------------------------------------------------------
-
--- Test for NULL inputs since the function is not STRICT
 SELECT tContains(NULL::geometry, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ tcontains 
+-----------
+ 
+(1 row)
+
 SELECT tContains(geometry 'Point(1 1)', NULL::tcbuffer);
+ tcontains 
+-----------
+ 
+(1 row)
 
 SELECT tContains(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+           tcontains            
+--------------------------------
+ f@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tContains(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+                                            tcontains                                             
+--------------------------------------------------------------------------------------------------
+ {f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tContains(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+                             tcontains                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tContains(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+                                                              tcontains                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
 
 SELECT tContains(geometry 'Point empty', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ tcontains 
+-----------
+ 
+(1 row)
+
 SELECT tContains(geometry 'Point empty', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ tcontains 
+-----------
+ 
+(1 row)
+
 SELECT tContains(geometry 'Point empty', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ tcontains 
+-----------
+ 
+(1 row)
+
 SELECT tContains(geometry 'Point empty', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ tcontains 
+-----------
+ 
+(1 row)
 
 SELECT tContains(geometry 'Linestring(1 1,2 2)', tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02]');
+                             tcontains                              
+--------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
 
 /* Errors */
 SELECT tContains(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  Operation on mixed SRID
 SELECT tContains(geometry 'Point(1 1)', tcbuffer 'SRID=5676;Cbuffer(Point(1 1),0)@2000-01-01');
+ERROR:  Operation on mixed SRID
 SELECT tContains(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01');
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tContains(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Po...
+                                                         ^
 SELECT tContains(geometry 'Point(1 1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
-
--------------------------------------------------------------------------------
--- tDisjoint
--------------------------------------------------------------------------------
-
--- Test for NULL inputs since the function is not STRICT
+ERROR:  The geometry cannot have Z dimension
 SELECT tDisjoint(NULL::geometry, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
 SELECT tDisjoint(geometry 'Point(1 1)', NULL::tcbuffer);
+ tdisjoint 
+-----------
+ 
+(1 row)
+
 SELECT tDisjoint(NULL::tcbuffer, geometry 'Point(1 1)');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
 SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::geometry);
+ tdisjoint 
+-----------
+ 
+(1 row)
+
 SELECT tDisjoint(NULL::tcbuffer, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
 SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::tcbuffer);
+ tdisjoint 
+-----------
+ 
+(1 row)
 
 SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+           tdisjoint            
+--------------------------------
+ f@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+                                            tdisjoint                                             
+--------------------------------------------------------------------------------------------------
+ {f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+                                                                                         tdisjoint                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+                                                                                                                          tdisjoint                                                                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [t@Tue Jan 04 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
 
 SELECT tDisjoint(geometry 'Point empty', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
 SELECT tDisjoint(geometry 'Point empty', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
 SELECT tDisjoint(geometry 'Point empty', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
 SELECT tDisjoint(geometry 'Point empty', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ tdisjoint 
+-----------
+ 
+(1 row)
 
 SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)');
+           tdisjoint            
+--------------------------------
+ f@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point(1 1)');
+                                            tdisjoint                                             
+--------------------------------------------------------------------------------------------------
+ {f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)');
+                                                                                         tdisjoint                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)');
+                                                                                                                          tdisjoint                                                                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [t@Tue Jan 04 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
 
 SELECT tDisjoint(tcbuffer '[Cbuffer(Point(0 1),0)@2000-01-01, Cbuffer(Point(2 1),0)@2000-01-04]', geometry 'Linestring(1 0,1 1,2 1,2 0)');
+                                                              tdisjoint                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 12:00:00 2000 PST], (t@Sun Jan 02 12:00:00 2000 PST, t@Tue Jan 04 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDisjoint(tcbuffer '[Cbuffer(Point(0 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-04]', geometry 'Linestring(1 1,2 1)');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
 SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(0 0),0)@2000-01-04]', geometry 'Linestring(0 0,1 1)');
+                             tdisjoint                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Tue Jan 04 00:00:00 2000 PST]}
+(1 row)
 
 SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point empty');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
 SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point empty');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
 SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point empty');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
 SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point empty');
+ tdisjoint 
+-----------
+ 
+(1 row)
 
---3D
 SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', geometry 'Point(2 2 2)');
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-0...
+                                  ^
 SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', geometry 'Point(2 2 2)');
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-...
+                                  ^
 SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', geometry 'Point(2 2 2)');
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-...
+                                  ^
 SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', geometry 'Point(2 2 2)');
-
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01...
+                                  ^
 /* Errors */
 SELECT tDisjoint(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  Operation on mixed SRID
 SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=5676;Point(1 1)');
-
--------------------------------------------------------------------------------
--- tIntersects
--------------------------------------------------------------------------------
-
--- Test for NULL inputs since the function is not STRICT
+ERROR:  Operation on mixed SRID
 SELECT tIntersects(NULL::geometry, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ tintersects 
+-------------
+ 
+(1 row)
+
 SELECT tIntersects(geometry 'Point(1 1)', NULL::tcbuffer);
+ tintersects 
+-------------
+ 
+(1 row)
+
 SELECT tIntersects(NULL::tcbuffer, geometry 'Point(1 1)');
+ tintersects 
+-------------
+ 
+(1 row)
+
 SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::geometry);
+ tintersects 
+-------------
+ 
+(1 row)
+
 SELECT tIntersects(NULL::tcbuffer, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ tintersects 
+-------------
+ 
+(1 row)
+
 SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::tcbuffer);
+ tintersects 
+-------------
+ 
+(1 row)
 
 SELECT tIntersects(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+          tintersects           
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+                                           tintersects                                            
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+                                                                                        tintersects                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+                                                                                                                         tintersects                                                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
 
 SELECT tIntersects(geometry 'Point empty', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ tintersects 
+-------------
+ 
+(1 row)
+
 SELECT tIntersects(geometry 'Point empty', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ tintersects 
+-------------
+ 
+(1 row)
+
 SELECT tIntersects(geometry 'Point empty', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ tintersects 
+-------------
+ 
+(1 row)
+
 SELECT tIntersects(geometry 'Point empty', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ tintersects 
+-------------
+ 
+(1 row)
 
 SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)');
+          tintersects           
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point(1 1)');
+                                           tintersects                                            
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)');
+                                                                                        tintersects                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)');
+                                                                                                                         tintersects                                                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
 
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(0 1),0)@2000-01-01, Cbuffer(Point(2 1),0)@2000-01-04]', geometry 'Linestring(1 0,1 1,2 1,2 0)');
+                                                             tintersects                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 12:00:00 2000 PST], (f@Sun Jan 02 12:00:00 2000 PST, f@Tue Jan 04 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(0 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-04]', geometry 'Linestring(1 1,2 1)');
+ tintersects 
+-------------
+ 
+(1 row)
+
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(0 0),0)@2000-01-04]', geometry 'Linestring(0 0,1 1)');
+                            tintersects                             
+--------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Tue Jan 04 00:00:00 2000 PST]}
+(1 row)
 
 SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point empty');
+ tintersects 
+-------------
+ 
+(1 row)
+
 SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point empty');
+ tintersects 
+-------------
+ 
+(1 row)
+
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point empty');
+ tintersects 
+-------------
+ 
+(1 row)
+
 SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point empty');
+ tintersects 
+-------------
+ 
+(1 row)
 
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-02]', geometry 'Linestring(1 1,2 2)');
+                            tintersects                             
+--------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(4 1),0)@2000-01-02]', geometry 'Linestring(1 2,1 0,2 0,2 2)');
+                            tintersects                             
+--------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
 
---3D
 SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', geometry 'Point(2 2 2)');
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01...
+                                    ^
 SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', geometry 'Point(2 2 2)');
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-0...
+                                    ^
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', geometry 'Point(2 2 2)');
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-0...
+                                    ^
 SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', geometry 'Point(2 2 2)');
-
--- Coverage
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-...
+                                    ^
 SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-03}', tcbuffer 'Cbuffer(Point(2 2),0)@2000-01-02');
+ tintersects 
+-------------
+ 
+(1 row)
+
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(2 1),0)@2000-01-01, Cbuffer(Point(1 2),0)@2000-01-02]');
+                                                             tintersects                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 12:00:00 2000 PST], (f@Sat Jan 01 12:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
 
 /* Errors */
 SELECT tIntersects(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  Operation on mixed SRID
 SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=5676;Point(1 1)');
-
--------------------------------------------------------------------------------
--- tTouches
--------------------------------------------------------------------------------
--- The function does not support 3D or geographies
-
--- Test for NULL inputs since the function is not STRICT
+ERROR:  Operation on mixed SRID
 SELECT tTouches(NULL::geometry, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ ttouches 
+----------
+ 
+(1 row)
+
 SELECT tTouches(geometry 'Point(1 1)', NULL::tcbuffer);
+ ttouches 
+----------
+ 
+(1 row)
 
 SELECT tTouches(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+            ttouches            
+--------------------------------
+ f@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tTouches(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+                                             ttouches                                             
+--------------------------------------------------------------------------------------------------
+ {f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tTouches(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+                              ttouches                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tTouches(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+                                                               ttouches                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
 
 SELECT tTouches(geometry 'Point empty', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
-SELECT tTouches(geometry 'Point empty', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
-SELECT tTouches(geometry 'Point empty', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
-SELECT tTouches(geometry 'Point empty', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ ttouches 
+----------
+ 
+(1 row)
 
--- Test for NULL inputs since the function is not STRICT
+SELECT tTouches(geometry 'Point empty', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ ttouches 
+----------
+ 
+(1 row)
+
+SELECT tTouches(geometry 'Point empty', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ ttouches 
+----------
+ 
+(1 row)
+
+SELECT tTouches(geometry 'Point empty', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ ttouches 
+----------
+ 
+(1 row)
+
 SELECT tTouches(NULL::tcbuffer, geometry 'Point(1 1)');
+ ttouches 
+----------
+ 
+(1 row)
+
 SELECT tTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::geometry);
+ ttouches 
+----------
+ 
+(1 row)
 
 SELECT tTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)');
+            ttouches            
+--------------------------------
+ f@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tTouches(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point(1 1)');
+                                             ttouches                                             
+--------------------------------------------------------------------------------------------------
+ {f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tTouches(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)');
+                              ttouches                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tTouches(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)');
+                                                               ttouches                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
 
 SELECT tTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point empty');
+ ttouches 
+----------
+ 
+(1 row)
+
 SELECT tTouches(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point empty');
+ ttouches 
+----------
+ 
+(1 row)
+
 SELECT tTouches(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point empty');
+ ttouches 
+----------
+ 
+(1 row)
+
 SELECT tTouches(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point empty');
+ ttouches 
+----------
+ 
+(1 row)
 
 SELECT tTouches(geometry 'Linestring(1 1,2 2)', tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02]');
+                                                               ttouches                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 12:00:00 2000 PST], (t@Sat Jan 01 12:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
 
 /* Errors */
 SELECT tTouches(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  Operation on mixed SRID
 SELECT tTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=5676;Point(1 1)');
+ERROR:  Operation on mixed SRID
 SELECT tTouches(geometry 'Point(1 1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  The geometry cannot have Z dimension
 SELECT tTouches(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01');
-
--------------------------------------------------------------------------------
--- tDwithin
--------------------------------------------------------------------------------
-
--- Test for NULL inputs since the function is not STRICT
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tTouches(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Poi...
+                                                        ^
 SELECT tDwithin(NULL::geometry, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(geometry 'Point(1 1)', NULL::tcbuffer, 2);
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL);
+ tdwithin 
+----------
+ 
+(1 row)
 
 SELECT tDwithin(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+                                             tdwithin                                             
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+                              tdwithin                              
+--------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+                                                               tdwithin                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
 
 SELECT tDwithin(geometry 'Point empty', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
-SELECT tDwithin(geometry 'Point empty', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
-SELECT tDwithin(geometry 'Point empty', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
-SELECT tDwithin(geometry 'Point empty', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+ tdwithin 
+----------
+ 
+(1 row)
 
--- Test for NULL inputs since the function is not STRICT
+SELECT tDwithin(geometry 'Point empty', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+ tdwithin 
+----------
+ 
+(1 row)
+
+SELECT tDwithin(geometry 'Point empty', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+ tdwithin 
+----------
+ 
+(1 row)
+
+SELECT tDwithin(geometry 'Point empty', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(NULL::tcbuffer, geometry 'Point(1 1)', 2);
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::geometry, 2);
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)', NULL);
+ tdwithin 
+----------
+ 
+(1 row)
 
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point(1 1)', 2);
+                                             tdwithin                                             
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)', 2);
+                              tdwithin                              
+--------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)', 2);
+                                                               tdwithin                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
 
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point empty', 2);
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point empty', 2);
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point empty', 2);
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point empty', 2);
+ tdwithin 
+----------
+ 
+(1 row)
 
---3D
 SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer 'Cbuffer(P...
+                                                          ^
 SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '{Cbuffer(...
+                                                          ^
 SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '[Cbuffer(...
+                                                          ^
 SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', 2);
-
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '{[Cbuffer...
+                                                          ^
 SELECT tDwithin(geometry 'Point Z empty', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: ...ELECT tDwithin(geometry 'Point Z empty', tcbuffer 'Cbuffer(P...
+                                                             ^
 SELECT tDwithin(geometry 'Point Z empty', tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: ...ELECT tDwithin(geometry 'Point Z empty', tcbuffer '{Cbuffer(...
+                                                             ^
 SELECT tDwithin(geometry 'Point Z empty', tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: ...ELECT tDwithin(geometry 'Point Z empty', tcbuffer '[Cbuffer(...
+                                                             ^
 SELECT tDwithin(geometry 'Point Z empty', tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', 2);
-
+ERROR:  The geometry cannot have Z dimension
+LINE 1: ...ELECT tDwithin(geometry 'Point Z empty', tcbuffer '{[Cbuffer...
+                                                             ^
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', geometry 'Point(1 1 1)', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01...
+                                 ^
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', geometry 'Point(1 1 1)', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-0...
+                                 ^
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', geometry 'Point(1 1 1)', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-0...
+                                 ^
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', geometry 'Point(1 1 1)', 2);
-
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-...
+                                 ^
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', geometry 'Point Z empty', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01...
+                                 ^
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', geometry 'Point Z empty', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-0...
+                                 ^
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', geometry 'Point Z empty', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-0...
+                                 ^
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', geometry 'Point Z empty', 2);
-
--- Test for NULL inputs since the function is not STRICT
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-...
+                                 ^
 SELECT tDwithin(NULL::tcbuffer, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
-SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::tcbuffer, 2);
-SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL);
+ tdwithin 
+----------
+ 
+(1 row)
 
--- Coverage
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::tcbuffer, 2);
+ tdwithin 
+----------
+ 
+(1 row)
+
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL);
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(tcbuffer '(Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02]', geometry 'Point(0 1)', 1);
+                             tdwithin                             
+------------------------------------------------------------------
+ (f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02]', geometry 'Point(2 3)', 1);
+ tdwithin 
+----------
+ 
+(1 row)
 
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+                                             tdwithin                                             
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+                                             tdwithin                                             
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+                                             tdwithin                                             
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+                                             tdwithin                                             
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+                              tdwithin                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+                              tdwithin                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+                                             tdwithin                                             
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+                              tdwithin                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+                                                               tdwithin                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [t@Tue Jan 04 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
 
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(1 3),0)@2000-01-03]', geometry 'Point(1 2)', 0);
+                                                               tdwithin                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST], (f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(1 2),0)@2000-01-03]', geometry 'Point(1 3)', 0);
+                             tdwithin                             
+------------------------------------------------------------------
+ [f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
 SELECT tDwithin(tcbuffer '(Cbuffer(Point(0 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(1 0),0)@2000-01-01, Cbuffer(Point(2 0),0)@2000-01-02]', 1);
+                              tdwithin                              
+--------------------------------------------------------------------
+ {(f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(0 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(1 0),0)@2000-01-01, Cbuffer(Point(2 0),0)@2000-01-02]', 1);
+                              tdwithin                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(0 1),0)@2000-01-01, Cbuffer(Point(0 0),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(2 0),0)@2000-01-01, Cbuffer(Point(1 0),0)@2000-01-02]', 1);
+                              tdwithin                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(0 0),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(2 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-02]', 1);
+                                                               tdwithin                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 12:00:00 2000 PST], (f@Sat Jan 01 12:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(0 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(0 2),0)@2000-01-01, Cbuffer(Point(1 3),0)@2000-01-02]', 1);
+                              tdwithin                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(0 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(4 0),0)@2000-01-01, Cbuffer(Point(3 1),0)@2000-01-02]', 0);
+                              tdwithin                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
 
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01...
+                                 ^
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-0...
+                                 ^
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-0...
+                                 ^
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-...
+                                 ^
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01...
+                                 ^
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-0...
+                                 ^
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-0...
+                                 ^
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-...
+                                 ^
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01...
+                                 ^
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-0...
+                                 ^
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-0...
+                                 ^
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-...
+                                 ^
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01...
+                                 ^
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-0...
+                                 ^
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-0...
+                                 ^
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', 2);
-
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-...
+                                 ^
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02, Cbuffer(Point(1 1),0)@2000-01-03, Cbuffer(Point(3 3),0)@
 2000-01-04, Cbuffer(Point(3 3),0)@2000-01-05]}', tcbuffer '{[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02, Cbuffer(Point(1 1),0)@2000-01-03]
 ,[Cbuffer(Point(3 3),0)@2000-01-04, Cbuffer(Point(3 3),0)@2000-01-05]}', 1);
+                                                               tdwithin                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [t@Tue Jan 04 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
 
--- Mixed 2D/3D
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
-
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01...
+                                 ^
 SELECT tDwithin(geometry 'Linestring(1 1,2 2)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Linestring(1 1,2 2)', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
 
 /* Errors */
 SELECT tDwithin(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ERROR:  Operation on mixed SRID
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=5676;Point(1 1)', 2);
+ERROR:  Operation on mixed SRID
 SELECT tDwithin(tcbuffer 'SRID=5676;Cbuffer(Point(1 1),0)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ERROR:  Operation on mixed SRID
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(0 0)', -1);
+ERROR:  The value cannot be negative: -1.000000
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', geometry 'Point(0 0 0)', -1);
-
--------------------------------------------------------------------------------
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01...
+                                 ^

--- a/mobilitydb/test/cbuffer/expected/164_tcbuffer_tempspatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/164_tcbuffer_tempspatialrels_tbl.test.out
@@ -1,0 +1,197 @@
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tContains(g, temp) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tContains(temp, g) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE tContains(cb, temp) IS NOT NULL;
+ count 
+-------
+ 10000
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE tContains(temp, cb) IS NOT NULL;
+ count 
+-------
+ 10000
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tContains(t1.temp, t2.temp) IS NOT NULL;
+ count 
+-------
+   102
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE tContains(cb, temp) ?= true <> eContains(cb, temp);
+ count 
+-------
+  1756
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tCovers(g, temp) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tCovers(temp, g) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tCovers(t1.temp, t2.temp) IS NOT NULL;
+ count 
+-------
+   102
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDisjoint(g, temp) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDisjoint(temp, g) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tDisjoint(t1.temp, t2.temp) IS NOT NULL;
+ count 
+-------
+   102
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDisjoint(g, temp) ?= true <> eDisjoint(g, temp);
+ count 
+-------
+    88
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDisjoint(temp, g) ?= true <> eDisjoint(temp, g);
+ count 
+-------
+    88
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
+  WHERE tDisjoint(t1.temp, t2.temp) ?= true <> eDisjoint(t1.temp, t2.temp);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tIntersects(g, temp) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) ?= true <> eDisjoint(temp, g);
+ count 
+-------
+  6096
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tIntersects(g, temp) ?= true <> eIntersects(g, temp);
+ count 
+-------
+  6096
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) ?= true <> eIntersects(temp, g);
+ count 
+-------
+   404
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
+  WHERE tIntersects(t1.temp, t2.temp) ?= true <> eIntersects(t1.temp, t2.temp);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tTouches(g, temp) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tTouches(temp, g) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tTouches(t1.temp, t2.temp) IS NOT NULL;
+ count 
+-------
+   102
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tTouches(g, temp) ?= true <> eTouches(g, temp);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tTouches(temp, g) ?= true <> eTouches(temp, g);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDwithin(g, temp, 10) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDwithin(temp, g, 10) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tDwithin(t1.temp, t2.temp, 10) IS NOT NULL;
+ count 
+-------
+   102
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer
+  WHERE tDwithin(g, temp, 10) ?= true <> edwithin(g, temp, 10);
+ count 
+-------
+   393
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry
+  WHERE tDwithin(temp, g, 10) ?= true <> edwithin(temp, g, 10);
+ count 
+-------
+   393
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
+  WHERE tDwithin(t1.temp, t2.temp, 10) ?= true <> edwithin(t1.temp, t2.temp, 10);
+ count 
+-------
+    34
+(1 row)
+

--- a/mobilitydb/test/cbuffer/queries/164_tcbuffer_tempspatialrels_tbl.test.sql
+++ b/mobilitydb/test/cbuffer/queries/164_tcbuffer_tempspatialrels_tbl.test.sql
@@ -41,8 +41,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tContains(t1.temp, t
 -------------------------------------------------------------------------------
 -- Robustness test
 
-SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tContains(g, temp) ?= true <> eContains(g, temp);
-
+-- eContains(geometry, tcbuffer) is not supported
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE tContains(cb, temp) ?= true <> eContains(cb, temp);
 -- SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tContains(t1.temp, t2.temp) ?= true <> eContains(t1.temp, t2.temp);
 
@@ -57,7 +56,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tCovers(t1.temp, t2.
 -------------------------------------------------------------------------------
 -- Robustness test
 
-SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tCovers(g, temp) ?= true <> eCovers(g, temp);
+-- eCovers(geometry, tcbuffer) is not supported
 
 -------------------------------------------------------------------------------
 -- tDisjoint
@@ -76,8 +75,6 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDisjoint(temp, g) ?= true
 -- Temporal points
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
   WHERE tDisjoint(t1.temp, t2.temp) ?= true <> eDisjoint(t1.temp, t2.temp);
-SELECT COUNT(*) FROM tbl_tcbuffer3D t1, tbl_tcbuffer3D t2
-  WHERE tDisjoint(t1.temp, t2.temp) ?= true <> eDisjoint(t1.temp, t2.temp);
 
 -------------------------------------------------------------------------------
 -- tIntersects
@@ -95,8 +92,6 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) ?= tr
 
 -- Temporal points
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
-  WHERE tIntersects(t1.temp, t2.temp) ?= true <> eIntersects(t1.temp, t2.temp);
-SELECT COUNT(*) FROM tbl_tcbuffer3D t1, tbl_tcbuffer3D t2
   WHERE tIntersects(t1.temp, t2.temp) ?= true <> eIntersects(t1.temp, t2.temp);
 
 -------------------------------------------------------------------------------
@@ -121,12 +116,6 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDwithin(g, temp, 10) IS N
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDwithin(temp, g, 10) IS NOT NULL;
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tDwithin(t1.temp, t2.temp, 10) IS NOT NULL;
 
--- Mixed 2D/3D
-SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer3D t2
-  WHERE tDwithin(t1.temp, t2.temp, 10) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tcbuffer3D t1, tbl_tcbuffer t2
-  WHERE tDwithin(t1.temp, t2.temp, 10) IS NOT NULL;
-
 -------------------------------------------------------------------------------
 -- Robustness test
 
@@ -135,12 +124,6 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry
   WHERE tDwithin(temp, g, 10) ?= true <> edwithin(temp, g, 10);
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
-  WHERE tDwithin(t1.temp, t2.temp, 10) ?= true <> edwithin(t1.temp, t2.temp, 10);
-  
--- Mixed 2D/3D
-SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer3D t2
-  WHERE tDwithin(t1.temp, t2.temp, 10) ?= true <> edwithin(t1.temp, t2.temp, 10);
-SELECT COUNT(*) FROM tbl_tcbuffer3D t1, tbl_tcbuffer t2
   WHERE tDwithin(t1.temp, t2.temp, 10) ?= true <> edwithin(t1.temp, t2.temp, 10);
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
> 👀 **Reviewers**: tier ranking, dependency chains and the standards checklist live in [`doc/contributing/reviewer-guide.md`](https://github.com/MobilityDB/MobilityDB/blob/master/doc/contributing/reviewer-guide.md).

## Summary

Closes the SQL-surface gap and dead-test-code that kept `164_tcbuffer_tempspatialrels{,_tbl}` in `SKIP_TESTS` (see PR #843). Companion to PR #846 (NAD sentinel fix); after both land, all cbuffer test failures from the coverage-row CI in PR #825 are resolved.

## Cbuffer is 2D-only by construction

Walked the geometric-realisation path:

```
cbuffer_to_geom (meos/src/cbuffer/cbuffer.c:528)
  → geocircle_make(x, y, radius, srid)          // 2 doubles, no z
    (meos/src/cbuffer/tcbuffer_spatialfuncs.c:124)
      → lwcircle_make(x, y, radius, srid)
        → lwcircstring_from_lwpointarray  // PostGIS CIRCULARSTRING
        → wrapped in CURVEPOLYGON
```

The `Cbuffer` struct stores `POINT2D + radius`. The geometric ops cbuffer relies on (tangent lines, ring construction, area computation) are 2D-only in PostGIS. A 3D cbuffer would have to be a sphere — different data model entirely. So the 3D-cbuffer test queries that were sitting in `164_tcbuffer_tempspatialrels.test.sql` were testing a code path that has no implementation by design.

## What this PR does

| Change | File | Lines |
|---|---|---|
| Uncomment `tDwithin(geometry, tcbuffer, dist float)` SQL declaration (C wrapper `Tdwithin_geo_tcbuffer` already existed) | `mobilitydb/sql/cbuffer/164_tcbuffer_tempspatialrels.in.sql` | +4 |
| Uncomment `tDwithin(tcbuffer, geometry, dist float)` SQL declaration (C wrapper `Tdwithin_tcbuffer_geo` already existed). Declared `STRICT` to match the symmetric sibling — necessary because the shared C dispatcher `Tdwithin_tspatial_geo` calls `PG_GETARG_TEMPORAL_P(0)` without a NULL check, so non-STRICT would crash on `NULL::tcbuffer` inputs | same | +4 |
| Delete dead 3D-cbuffer test queries (every line with `tcbuffer 'Point(x y z)@...'` or `tcbuffer '{Cbuffer(Point(x y z),...)' ...'`) and the `--3D` section headers they lived under | `mobilitydb/test/cbuffer/queries/164_tcbuffer_tempspatialrels.test.sql` | −56 |
| Delete dead `tbl_tcbuffer3D` references (the table fixture was never going to be added) and the `-- Mixed 2D/3D` headers | `mobilitydb/test/cbuffer/queries/164_tcbuffer_tempspatialrels_tbl.test.sql` | −16 |
| Regenerate expected output | `mobilitydb/test/cbuffer/expected/164_tcbuffer_tempspatialrels.test.out` (new) | +1313 |
| Regenerate expected output | `mobilitydb/test/cbuffer/expected/164_tcbuffer_tempspatialrels_tbl.test.out` (new) | +207 |

Tests that exercise *3D-geometry × 2D-cbuffer* (e.g. `tContains(geometry 'Point(1 1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@...')`) **stay** — those test the runtime `ensure_same_dim → ERROR` rejection path, which is meaningful.

## Why STRICT for the new declarations

The shared C dispatcher `Tdwithin_tspatial_geo` (in `mobilitydb/src/geo/tspatial_tempspatialrels.c`) reads its temporal arg via `PG_GETARG_TEMPORAL_P(0)` with no `PG_ARGISNULL(0)` guard — same as `Tdwithin_tspatial_tspatial`. So a non-STRICT declaration would crash on `NULL::tcbuffer` inputs (verified locally: `SELECT tDwithin(NULL::tcbuffer, geometry 'Point(1 1)', 2);` → server crash before STRICT change; clean NULL return after).

The pre-existing `tDwithin(tcbuffer, cbuffer, dist float)` declaration is non-STRICT (`LANGUAGE C IMMUTABLE  PARALLEL SAFE`) but the corresponding test queries don't exercise NULL temporal arguments, so the latent crash was never observed there. Out of scope to retrofit here; flagging for a separate hardening pass.

## Test plan

- [x] Local build with `-DCBUFFER=ON`, install, full test chain (`test_setup` → `load_*` → `164_*` → `teardown`): both `164_tcbuffer_tempspatialrels` (1313-line output) and `164_tcbuffer_tempspatialrels_tbl` (207-line output) pass with the regenerated expected files.
- [x] Verified `SELECT tDwithin(NULL::tcbuffer, geometry 'Point(1 1)', 2);` returns NULL (not crash) after STRICT change.
- [ ] CI green.

## Follow-up (separate, one-line)

Once this lands, drop `164_tcbuffer_tempspatialrels` and `164_tcbuffer_tempspatialrels_tbl` from `cbuffer/CMakeLists.txt`'s `SKIP_TESTS` (in PR #843's branch). At that point, all 5 originally-skipped cbuffer tests come back online except `162_tcbuffer_spatialrels{,_tbl}` (which still need the same-SRID test-query migration).