### PR TITLE
fix(geo): NULL-guard the shared Tspatialrel/Tdwithin dispatchers

### DIFF
--- a/mobilitydb/src/geo/tspatial_tempspatialrels.c
+++ b/mobilitydb/src/geo/tspatial_tempspatialrels.c
@@ -65,6 +65,8 @@ Datum
 Tspatialrel_geo_tspatial(FunctionCallInfo fcinfo,
   Temporal * (*func)(const GSERIALIZED *, const Temporal *))
 {
+  if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
+    PG_RETURN_NULL();
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(0);
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
   Temporal *result = func(gs, temp);
@@ -83,6 +85,8 @@ Datum
 Tspatialrel_tspatial_geo(FunctionCallInfo fcinfo,
   Temporal * (*func)(const Temporal *, const GSERIALIZED *))
 {
+  if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
+    PG_RETURN_NULL();
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(1);
   Temporal *result = func(temp, gs);
@@ -101,6 +105,8 @@ Datum
 Tspatialrel_tspatial_tspatial(FunctionCallInfo fcinfo,
   Temporal * (*func)(const Temporal *, const Temporal *))
 {
+  if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
+    PG_RETURN_NULL();
   Temporal *temp1 = PG_GETARG_TEMPORAL_P(0);
   Temporal *temp2 = PG_GETARG_TEMPORAL_P(1);
   /* Result depends on whether we are computing tintersects or tdisjoint */
@@ -122,6 +128,8 @@ Datum
 Tdwithin_geo_tspatial(FunctionCallInfo fcinfo,
   Temporal * (*func)(const GSERIALIZED *, const Temporal *, double))
 {
+  if (PG_ARGISNULL(0) || PG_ARGISNULL(1) || PG_ARGISNULL(2))
+    PG_RETURN_NULL();
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(0);
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
   double dist = PG_GETARG_FLOAT8(2);
@@ -141,6 +149,8 @@ Datum
 Tdwithin_tspatial_geo(FunctionCallInfo fcinfo,
   Temporal * (*func)(const Temporal *, const GSERIALIZED *, double))
 {
+  if (PG_ARGISNULL(0) || PG_ARGISNULL(1) || PG_ARGISNULL(2))
+    PG_RETURN_NULL();
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(1);
   double dist = PG_GETARG_FLOAT8(2);
@@ -160,6 +170,8 @@ Datum
 Tdwithin_tspatial_tspatial(FunctionCallInfo fcinfo,
   Temporal * (*func)(const Temporal *, const Temporal *, double))
 {
+  if (PG_ARGISNULL(0) || PG_ARGISNULL(1) || PG_ARGISNULL(2))
+    PG_RETURN_NULL();
   Temporal *temp1 = PG_GETARG_TEMPORAL_P(0);
   Temporal *temp2 = PG_GETARG_TEMPORAL_P(1);
   double dist = PG_GETARG_FLOAT8(2);


### PR DESCRIPTION
## Summary

Defensive hardening for six shared dispatchers in `mobilitydb/src/geo/tspatial_tempspatialrels.c`. Surfaced during PR #847's local-build verification: a non-STRICT SQL declaration mapping to `Tdwithin_tcbuffer_geo` (which delegates to `Tdwithin_tspatial_geo`) crashed the server on `NULL::tcbuffer` input. The dispatchers read their args via `PG_GETARG_TEMPORAL_P` / `PG_GETARG_GSERIALIZED_P` / `PG_GETARG_FLOAT8` with no `PG_ARGISNULL` guard.

## What this PR changes

Adds a `PG_ARGISNULL` guard at the top of each dispatcher:

| Dispatcher | Args guarded |
|---|---|
| `Tspatialrel_geo_tspatial` | (0, 1) |
| `Tspatialrel_tspatial_geo` | (0, 1) |
| `Tspatialrel_tspatial_tspatial` | (0, 1) |
| `Tdwithin_geo_tspatial` | (0, 1, 2) |
| `Tdwithin_tspatial_geo` | (0, 1, 2) |
| `Tdwithin_tspatial_tspatial` | (0, 1, 2) |

```c
if (PG_ARGISNULL(0) || PG_ARGISNULL(1))   // or || PG_ARGISNULL(2) for Tdwithin_*
  PG_RETURN_NULL();
```

## Why this is the right fix

The pre-existing invariant — *"every SQL declaration that maps here must be STRICT"* — is fragile. PR #847 surfaced exactly that fragility: when uncommenting a previously-non-STRICT `tDwithin(tcbuffer, geometry, dist)` declaration, the server crashed on `NULL::tcbuffer` until the SQL was changed to `STRICT`. Adding the C-level guards means non-STRICT declarations are now safe in depth, not by-convention.

Behaviour for STRICT callers is unchanged — PG never dispatches to C with a NULL arg, so the guard is a no-op on the common path.

## What this PR does *not* change

- The other ~100 shared dispatchers across the codebase (`compops`, `boxops`, `tile`, `routeops`, `aggfuncs`, `restrict`, `temporal_compops`, etc.) follow the same fragile pattern. They're out of scope here. A separate sweep audit would cover them.
- No SQL declaration changes — the SQL surface keeps its current STRICT/non-STRICT decisions. The point is that the C-side is now robust to either choice.

## Test plan

- [x] Local build with `-DCBUFFER=ON`, install, smoke-test:
  - `tContains(NULL::geometry, NULL::tgeompoint)` → NULL (no crash)
  - `tDwithin(NULL::tcbuffer, geometry 'Point(1 1)', 2)` via a deliberately non-STRICT declaration → NULL (no crash)
  - Non-NULL calls (`tDwithin(tcbuffer 'Cbuffer(...)', geometry 'Point(1 1)', 2)`) → expected temporal result.
- [ ] CI green.

## Related

- PR #847 — `feat(cbuffer): enable two missing tDwithin SQL overloads, drop dead 3D tests` — surfaced this issue; uses `STRICT` to avoid the crash. After this PR lands, the STRICT discipline becomes a style choice rather than a correctness requirement.