### PR TITLE
docs(trgeo): production-readiness pass for ttrgeo

### DIFF
--- a/doc/mobilitydb-manual.xml
+++ b/doc/mobilitydb-manual.xml
@@ -23,6 +23,7 @@
 <!ENTITY temporal_types_analytics SYSTEM "temporal_types_analytics.xml">
 <!ENTITY temporal_types_aggregation SYSTEM "temporal_types_aggregation.xml">
 <!ENTITY temporal_poses SYSTEM "temporal_poses.xml">
+<!ENTITY temporal_rigid_geometries SYSTEM "temporal_rigid_geometries.xml">
 <!ENTITY temporal_network_points SYSTEM "temporal_network_points.xml">
 <!ENTITY temporal_circular_buffers SYSTEM "temporal_circular_buffers.xml">
 <!ENTITY reference SYSTEM "reference.xml">
@@ -125,6 +126,7 @@
 	&temporal_types_analytics;
 	&temporal_types_aggregation;
 	&temporal_poses;
+	&temporal_rigid_geometries;
 	&temporal_network_points;
 	&temporal_circular_buffers;
 	&reference;

--- a/doc/temporal_rigid_geometries.xml
+++ b/doc/temporal_rigid_geometries.xml
@@ -1,0 +1,610 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   ****************************************************************************
+    MobilityDB Manual
+    Copyright(c) MobilityDB Contributors
+
+    This documentation is licensed under a Creative Commons Attribution-Share
+    Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
+   ****************************************************************************
+-->
+<chapter xml:id="trgeometry">
+	<title>Temporal Rigid Geometries</title>
+
+	<para>A temporal rigid geometry (<varname>trgeometry</varname>) is a static 2D reference geometry — typically a polygon describing the shape of a moving body — paired with a temporal pose (<varname>tpose</varname>) describing how that geometry translates and rotates over time. The materialised geometry at time <varname>t</varname> is the reference geometry rotated and translated according to the pose interpolated at <varname>t</varname>.</para>
+
+	<para>This is the natural representation for moving objects whose <emphasis>shape</emphasis> matters, not just their position. The motivating example is AIS maritime traffic, where each ship's hull (a pentagon derived from the antenna offsets <varname>A</varname>, <varname>B</varname>, <varname>C</varname>, <varname>D</varname>) follows a pose path defined by lat/lon and heading reports. The materialised geometry at any instant is the actual ship outline at that moment.</para>
+
+	<para>The <varname>trgeometry</varname> type builds on <xref linkend="temporal_poses"/>. Most accessor, comparison, topological, position, and indexing operators have the same shape as the corresponding <varname>tpose</varname> functions; this chapter covers the trgeometry-specific surface — pose-to-shape materialisation, traversed area, materialised distance, and spatial restrictions on the centroid trajectory.</para>
+
+	<para>Operational guidance on choosing between <varname>trgeometry</varname>, <varname>tpose</varname>, and <varname>tgeometry</varname>; the frame conventions the implementation enforces (2D-only reference shape, single shared reference geometry per row, same-SRID requirement, centroid-based spatial-restriction semantics); the numerical hazards production workloads should anticipate (sampling caveat for <varname>traversedArea</varname> over rotation segments, adaptive sub-sampling tolerance in materialised distance, mixed-SRID rejection); and the durability and storage conventions are collected in <xref linkend="trgeometry_production_guidance"/>.</para>
+
+	<sect1 xml:id="trgeometry_inout">
+		<title>Input and Output</title>
+
+		<para>A <varname>trgeometry</varname> literal pairs a reference geometry with a temporal pose. The reference geometry comes first, separated from the pose by a semicolon; the pose follows the standard <varname>tpose</varname> syntax (instant, sequence, or sequence set).</para>
+
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0), 0.5)@2001-01-01';
+SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(5 0), 0.5)@2001-01-02, Pose(Point(0 0), 0.0)@2001-01-03}';
+SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 1.5)@2001-01-02]';
+SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(5 0), 0.0)@2001-01-02], [Pose(Point(0 0), 0.0)@2001-01-04, Pose(Point(2 0), 0.0)@2001-01-05]}';
+</programlisting>
+
+		<para>The reference geometry can be any 2D polygon or polyhedral surface. The pose interpolation is linear in translation and angular-shortest-path in rotation. SRIDs are inherited from the reference geometry and the pose; they must agree.</para>
+
+		<para>An SRID can be specified for a trgeometry either at the begining of the literal or before the reference geometry as shown below.</para>
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT trgeometry 'SRID=25832;Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0), 0.5)@2001-01-01';
+SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));SRID=25832;Pose(Point(0 0), 0.5)@2001-01-01';
+</programlisting>
+
+		<para>Step interpolation can also be specified in the same way as for other temporal types:</para>
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT trgeometry 'Interp=Step;Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]';
+</programlisting>
+
+		<para>The standard wire formats are supported.</para>
+
+		<itemizedlist>
+			<listitem xml:id="trgeometry_asText">
+				<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
+				<para>Return the Well-Known Text (WKT) representation</para>
+				<para><varname>asText({trgeometry,trgeometry[]} [, maxdecimaldigits int=15]) → text</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1.123456789 1.123456789), 0.5)@2000-01-01', 6);
+-- POLYGON((1 1,2 2,3 1,1 1));Pose(POINT(1.123457 1.123457),0.5)@Sat Jan 01 00:00:00 2000 PST
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="trgeometry_asEWKT">
+				<indexterm significance="normal"><primary><varname>asEWKT</varname></primary></indexterm>
+				<para>Return the Extended Well-Known Text (EWKT) representation, prefixed with the SRID</para>
+				<para><varname>asEWKT({trgeometry,trgeometry[]} [, maxdecimaldigits int=15]) → text</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asEWKT(trgeometry 'SRID=25832;Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1),0.5)@2000-01-01');
+-- SRID=25832;POLYGON((1 1,2 2,3 1,1 1));Pose(POINT(1 1),0.5)@Sat Jan 01 00:00:00 2000 PST
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="trgeometry_asMFJSON">
+				<indexterm significance="normal"><primary><varname>asMFJSON</varname></primary></indexterm>
+				<para>Return the Moving Features JSON representation</para>
+				<para><varname>asMFJSON(trgeometry [, options int=0 [, flags int=0 [, maxdecimaldigits int=15]]]) → text</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asMFJSON(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0),0)@2001-01-01');
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="trgeometry_asEWKB">
+				<indexterm significance="normal"><primary><varname>asEWKB</varname></primary></indexterm>
+				<para>Return the Extended Well-Known Binary (EWKB) representation</para>
+				<para><varname>asEWKB(trgeometry [, endian text]) → bytea</varname></para>
+				<para>Companion <varname>asHexEWKB</varname> returns the same bytes as a hex-encoded text.</para>
+			</listitem>
+
+			<listitem xml:id="trgeometry_fromText">
+				<indexterm significance="normal"><primary><varname>trgeometryFromText</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>trgeometryFromMFJSON</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>trgeometryFromEWKB</varname></primary></indexterm>
+				<para>Each output format has a companion parser:</para>
+				<para><varname>trgeometryFromText(text) → trgeometry</varname></para>
+				<para><varname>trgeometryFromEWKT(text) → trgeometry</varname></para>
+				<para><varname>trgeometryFromMFJSON(text) → trgeometry</varname></para>
+				<para><varname>trgeometryFromEWKB(bytea) → trgeometry</varname></para>
+				<para><varname>trgeometryFromHexEWKB(text) → trgeometry</varname></para>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
+	<sect1 xml:id="trgeometry_constructors">
+		<title>Constructors</title>
+
+		<para>A <varname>trgeometry</varname> can be built directly from its component types — a reference geometry plus a temporal pose:</para>
+
+		<itemizedlist>
+			<listitem xml:id="trgeometry_constructor">
+				<indexterm significance="normal"><primary><varname>trgeometry</varname></primary></indexterm>
+				<para>Construct a temporal rigid geometry from a reference geometry and a temporal pose</para>
+				<para><varname>trgeometry(geometry, tpose) → trgeometry</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT trgeometry(
+  geometry 'Polygon((0 0,1 0,1 1,0 1,0 0))',
+  tpose 'Pose(Point(0 0), 0.0)@2001-01-01');
+-- POLYGON((0 0,1 0,1 1,0 1,0 0));Pose(POINT(0 0),0)@Mon Jan 01 00:00:00 2001 PST
+</programlisting>
+				<para>Both arguments must share the same SRID. The reference geometry may be a polygon or a polyhedral surface; the pose may be of any temporal subtype.</para>
+			</listitem>
+
+			<listitem xml:id="trgeometry_appendInstant">
+				<indexterm significance="normal"><primary><varname>appendInstant</varname></primary></indexterm>
+				<para>Append a single instant to an existing trgeometry, growing the underlying pose path</para>
+				<para><varname>appendInstant(trgeometry, trgeometry [, maxdist float [, maxt interval]]) → trgeometry</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT appendInstant(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01]',
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(5 0), 0.0)@2001-01-02');
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="trgeometry_appendSequence">
+				<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
+				<para>Append an entire sequence to an existing trgeometry</para>
+				<para><varname>appendSequence(trgeometry, trgeometry) → trgeometry</varname></para>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
+	<sect1 xml:id="trgeometry_conversions">
+		<title>Conversions</title>
+
+		<para>The <varname>trgeometry</varname> can be projected to its component types or to a pure-point trajectory.</para>
+
+		<itemizedlist>
+			<listitem xml:id="trgeometry_to_tpose">
+				<indexterm significance="normal"><primary><varname>tpose</varname></primary></indexterm>
+				<para>Return the underlying temporal pose</para>
+				<para><varname>tpose(trgeometry) → tpose</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(tpose(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.5)@2001-01-02]'));
+-- [Pose(POINT(0 0),0)@..., Pose(POINT(10 0),0.5)@...]
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="trgeometry_to_tgeompoint">
+				<indexterm significance="normal"><primary><varname>tgeompoint</varname></primary></indexterm>
+				<para>Return the centroid (antenna) trajectory as a temporal point</para>
+				<para><varname>tgeompoint(trgeometry) → tgeompoint</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(tgeompoint(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]'));
+-- [POINT(0 0)@..., POINT(10 0)@...]
+</programlisting>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
+	<sect1 xml:id="trgeometry_accessors">
+		<title>Accessors</title>
+
+		<para>The standard temporal-type accessors apply: each returns the materialised geometry at the requested timestamp (the reference shape rotated and translated according to the interpolated pose), or a metadata value derived from the pose path.</para>
+
+		<itemizedlist>
+			<listitem xml:id="trgeometry_startValue">
+				<indexterm significance="normal"><primary><varname>startValue</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>endValue</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
+				<para>Return the materialised geometry at the start, end, or a chosen timestamp</para>
+				<para><varname>startValue(trgeometry) → geometry</varname></para>
+				<para><varname>endValue(trgeometry) → geometry</varname></para>
+				<para><varname>valueAtTimestamp(trgeometry, timestamptz) → geometry</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(startValue(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]'));
+-- POLYGON((0 0,1 0,1 1,0 1,0 0))
+
+SELECT asText(valueAtTimestamp(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]',
+  timestamptz '2001-01-01 12:00:00'));
+-- POLYGON((5 0,6 0,6 1,5 1,5 0))
+</programlisting>
+				<para>Note that the rotation interpolates linearly along the angular shortest path; a 90° rotation between two instants placed one day apart returns a 45°-rotated polygon at the midpoint.</para>
+			</listitem>
+
+			<listitem xml:id="trgeometry_numInstants">
+				<indexterm significance="normal"><primary><varname>numInstants</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>numSequences</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>numTimestamps</varname></primary></indexterm>
+				<para>Return the number of distinct instants, sequences, or timestamps</para>
+				<para><varname>numInstants(trgeometry) → integer</varname></para>
+				<para><varname>numSequences(trgeometry) → integer</varname></para>
+				<para><varname>numTimestamps(trgeometry) → integer</varname></para>
+			</listitem>
+
+			<listitem xml:id="trgeometry_instants">
+				<indexterm significance="normal"><primary><varname>instants</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>sequences</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>segments</varname></primary></indexterm>
+				<para>Return the array of constituent instants, sequences, or inter-instant segments</para>
+				<para><varname>instants(trgeometry) → trgeometry[]</varname></para>
+				<para><varname>sequences(trgeometry) → trgeometry[]</varname></para>
+				<para><varname>segments(trgeometry) → trgeometry[]</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT array_length(
+  instants(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(5 0), 0.5)@2001-01-02, Pose(Point(0 0), 0.0)@2001-01-03}'),
+  1);
+-- 3
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="trgeometry_points">
+				<indexterm significance="normal"><primary><varname>points</varname></primary></indexterm>
+				<para>Return the set of distinct centroid (antenna) points seen along the trgeometry</para>
+				<para><varname>points(trgeometry) → geomset</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(points(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(5 5), 0.0)@2001-01-02, Pose(Point(0 0), 0.0)@2001-01-03}'));
+-- {"POINT(0 0)", "POINT(5 5)"}
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="trgeometry_rotation">
+				<indexterm significance="normal"><primary><varname>rotation</varname></primary></indexterm>
+				<para>Return the rotation angle as a temporal float</para>
+				<para><varname>rotation(trgeometry) → tfloat</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(rotation(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(0 0), 1.5)@2001-01-02]'));
+-- [0@..., 1.5@...]
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="trgeometry_geom">
+				<indexterm significance="normal"><primary><varname>geom</varname></primary></indexterm>
+				<para>Return the static reference geometry</para>
+				<para><varname>geom(trgeometry) → geometry</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_AsText(geom(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(5 0), 0.5)@2001-01-01'));
+-- POLYGON((0 0,1 0,1 1,0 1,0 0))
+</programlisting>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
+	<sect1 xml:id="trgeometry_traversed_area">
+		<title>Traversed Area</title>
+
+		<para>The <varname>traversedArea</varname> function returns the union of every materialised geometry over the trgeometry's time domain — the spatial footprint of the moving body.</para>
+
+		<itemizedlist>
+			<listitem xml:id="trgeometry_traversedArea_func">
+				<indexterm significance="normal"><primary><varname>traversedArea</varname></primary></indexterm>
+				<para>Return the union of the materialised polygons across the trgeometry's time domain</para>
+				<para><varname>traversedArea(trgeometry [, unary_union boolean = true]) → geometry</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_AsText(traversedArea(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]'));
+-- POLYGON((0 0, 11 0, 11 1, 0 1, 0 0))
+</programlisting>
+				<para>With <varname>unary_union = false</varname> the function returns a GeometryCollection of the per-instant materialised polygons without dissolving them — useful when the caller wants to do its own post-processing.</para>
+				<para><emphasis>Sampling caveat:</emphasis> the implementation samples at the input instants, so pure-translation segments are exact but the swept ribbon between two instants where a rotation happens is approximated by the convex hull of the two endpoint polygons. Adding intermediate sub-samples is a documented future refinement.</para>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
+	<sect1 xml:id="trgeometry_modifications">
+		<title>Modifications</title>
+
+		<para>The standard sequence-modifying functions apply: <varname>round</varname>, <varname>setInterp</varname>, <varname>shiftTime</varname>, <varname>scaleTime</varname>, <varname>shiftScaleTime</varname>, <varname>deleteTimestamp</varname>, etc.</para>
+
+		<itemizedlist>
+			<listitem xml:id="trgeometry_round">
+				<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
+				<para>Round all numeric components to a given number of decimal places</para>
+				<para><varname>round(trgeometry, integer) → trgeometry</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(round(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(1.123456789 1.123456789), 0.123456)@2001-01-01',
+  3));
+-- POLYGON((0 0,1 0,1 1,0 1,0 0));Pose(POINT(1.123 1.123),0.123)@...
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="trgeometry_setInterp">
+				<indexterm significance="normal"><primary><varname>setInterp</varname></primary></indexterm>
+				<para>Convert between linear and step interpolations</para>
+				<para><varname>setInterp(trgeometry, text) → trgeometry</varname></para>
+			</listitem>
+
+			<listitem xml:id="trgeometry_shiftTime">
+				<indexterm significance="normal"><primary><varname>shiftTime</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>scaleTime</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>shiftScaleTime</varname></primary></indexterm>
+				<para>Shift, scale, or both shift and scale the time domain of a trgeometry</para>
+				<para><varname>shiftTime(trgeometry, interval) → trgeometry</varname></para>
+				<para><varname>scaleTime(trgeometry, interval) → trgeometry</varname></para>
+				<para><varname>shiftScaleTime(trgeometry, interval, interval) → trgeometry</varname></para>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
+	<sect1 xml:id="trgeometry_restrictions">
+		<title>Spatial Restrictions</title>
+
+		<para>The <varname>atGeometry</varname>, <varname>minusGeometry</varname>, <varname>atStbox</varname>, and <varname>minusStbox</varname> functions restrict a trgeometry to (the complement of) a geometry or a spatiotemporal box. The semantic mirrors <varname>tpose</varname>: a temporal rigid geometry is "in" a region at time <varname>t</varname> iff its centroid (antenna) at <varname>t</varname> lies in that region.</para>
+
+		<itemizedlist>
+			<listitem xml:id="trgeometry_atGeometry">
+				<indexterm significance="normal"><primary><varname>atGeometry</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>minusGeometry</varname></primary></indexterm>
+				<para>Restrict a trgeometry to (the complement of) a geometry</para>
+				<para><varname>atGeometry(trgeometry, geometry) → trgeometry</varname></para>
+				<para><varname>minusGeometry(trgeometry, geometry) → trgeometry</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT temporalTime(atGeometry(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(4 0), 0.0)@2001-01-05]',
+  geometry 'Polygon((1 -1,3 -1,3 1,1 1,1 -1))'));
+-- {[2001-01-02, 2001-01-04]}
+
+SELECT temporalTime(minusGeometry(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(4 0), 0.0)@2001-01-05]',
+  geometry 'Polygon((1 -1,3 -1,3 1,1 1,1 -1))'));
+-- {[2001-01-01, 2001-01-02), (2001-01-04, 2001-01-05]}
+</programlisting>
+				<para>Restriction against an empty geometry returns NULL for <varname>atGeometry</varname> and the original input for <varname>minusGeometry</varname>.</para>
+			</listitem>
+
+			<listitem xml:id="trgeometry_atStbox">
+				<indexterm significance="normal"><primary><varname>atStbox</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>minusStbox</varname></primary></indexterm>
+				<para>Restrict a trgeometry to (the complement of) a spatiotemporal box</para>
+				<para><varname>atStbox(trgeometry, stbox [, border_inc boolean = true]) → trgeometry</varname></para>
+				<para><varname>minusStbox(trgeometry, stbox [, border_inc boolean = true]) → trgeometry</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT temporalTime(atStbox(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(4 0), 0.0)@2001-01-05]',
+  stbox 'STBOX X((1, -1), (3, 1))'));
+-- {[2001-01-02, 2001-01-04]}
+
+SELECT temporalTime(atStbox(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(4 0), 0.0)@2001-01-05]',
+  stbox 'STBOX T([2001-01-02, 2001-01-04])'));
+-- {[2001-01-02, 2001-01-04]}
+</programlisting>
+				<para>If the STBox has only a temporal component the call collapses to the standard <varname>atTime</varname>; if it has only a spatial component the temporal domain is preserved.</para>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
+	<sect1 xml:id="trgeometry_distance">
+		<title>Distance Operations</title>
+
+		<para>Distance between a trgeometry and a geometry / pose / spatiotemporal box / another trgeometry is computed on the <emphasis>materialised</emphasis> geometry — the reference shape rotated and translated according to the pose. Distance is exact at every shared timestamp; for sequence inputs an adaptive recursive bisection emits intermediate marks where the distance trajectory deviates from a straight line.</para>
+
+		<itemizedlist>
+			<listitem xml:id="trgeometry_tdistance">
+				<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tdistance</varname></primary></indexterm>
+				<para>Return the temporal distance between two trgeometries</para>
+				<para><varname>{geometry,trgeometry} &lt;-&gt; {geometry,trgeometry} → tfloat</varname></para>
+				<para><varname>tdistance({geometry,trgeometry}, {geometry,trgeometry}) → tfloat</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT round(maxValue(tdistance(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0), 0.0)@2001-01-01',
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(5 0), 0.0)@2001-01-01')), 6);
+-- 4
+
+SELECT asText(tdistance(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(0 0), 0.0)@2001-01-02]',
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(2 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]'));
+-- [1@2001-01-01 ..., 9@2001-01-02 ...]
+</programlisting>
+				<para>The dispatcher covers every subtype combination — TINSTANT × TINSTANT, TINSTANT × TSEQUENCE asymmetric, TSEQUENCE × TSEQUENCE, TSEQUENCE × TSEQUENCESET, TSEQUENCESET × TSEQUENCESET. The adaptive sub-sampling kernel underlies every continuous combo; instant combos materialise once. Pure-translation segments converge at depth 0 (two endpoint marks); rotation-heavy segments emit up to 32 marks per inter-instant gap. The bound on the LINEAR-interpolated approximation between marks is <varname>1e-3</varname> by construction.</para>
+			</listitem>
+
+			<listitem xml:id="trgeometry_nad">
+				<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>nearestApproachDistance</varname></primary></indexterm>
+				<para>Return the smallest distance between two trgeometries over their shared time domain</para>
+				<para><varname>{geometry,trgeometry,stbox} |=| {geometry,trgeometry,stbox} → float</varname></para>
+				<para><varname>nearestApproachDistance({geometry,trgeometry,stbox}, {geometry,trgeometry,stbox}) → float</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]'
+       |=|
+       trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(50 0), 0.0)@2001-01-01, Pose(Point(50 0), 0.0)@2001-01-02]';
+-- 39
+</programlisting>
+				<para>The <varname>|=|</varname> operator can be used for nearest-neighbour searches against GiST or SP-GiST indexes (see <xref linkend="trgeometry_indexing"/>).</para>
+			</listitem>
+
+			<listitem xml:id="trgeometry_nai">
+				<indexterm significance="normal"><primary><varname>nearestApproachInstant</varname></primary></indexterm>
+				<para>Return the instant at which the two arguments are at their smallest mutual distance</para>
+				<para><varname>nearestApproachInstant({geometry,trgeometry}, {geometry,trgeometry}) → trgeometry</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(nearestApproachInstant(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]',
+  geometry 'Point(5 5)'));
+-- POLYGON((5 0,6 0,6 1,5 1,5 0));Pose(POINT(5 0),0)@2001-01-01 12:00:00+00
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="trgeometry_shortestLine">
+				<indexterm significance="normal"><primary><varname>shortestLine</varname></primary></indexterm>
+				<para>Return the line connecting the two arguments at their nearest approach</para>
+				<para><varname>shortestLine({geometry,trgeometry}, {geometry,trgeometry}) → geometry</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_AsText(shortestLine(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0), 0.0)@2001-01-01',
+  geometry 'Point(10 0)'));
+-- LINESTRING(1 0,10 0)
+</programlisting>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
+	<sect1 xml:id="trgeometry_comparisons">
+		<title>Comparisons</title>
+
+		<para>Equality and ever / always operators compare two trgeometries on the materialised geometry — both the reference shape and the pose path must agree at every shared instant.</para>
+
+		<itemizedlist>
+			<listitem xml:id="trgeometry_eq">
+				<indexterm significance="normal"><primary><varname>=</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>&lt;&gt;</varname></primary></indexterm>
+				<para>Test exact (in)equality of two trgeometries</para>
+				<para><varname>trgeometry = trgeometry → boolean</varname></para>
+				<para><varname>trgeometry &lt;&gt; trgeometry → boolean</varname></para>
+			</listitem>
+
+			<listitem xml:id="trgeometry_evereq">
+				<indexterm significance="normal"><primary><varname>?=</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>?&lt;&gt;</varname></primary></indexterm>
+				<para>Test whether the materialised geometry is ever (not) equal to the operand at any time</para>
+				<para><varname>{geometry,trgeometry} ?= {geometry,trgeometry} → boolean</varname></para>
+				<para><varname>{geometry,trgeometry} ?&lt;&gt; {geometry,trgeometry} → boolean</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(5 0), 0.0)@2001-01-02]'
+       ?= geometry 'Polygon((5 0,6 0,6 1,5 1,5 0))';
+-- t
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="trgeometry_alwayseq">
+				<indexterm significance="normal"><primary><varname>%=</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>%&lt;&gt;</varname></primary></indexterm>
+				<para>Test whether the materialised geometry is always (not) equal to the operand</para>
+				<para><varname>{geometry,trgeometry} %= {geometry,trgeometry} → boolean</varname></para>
+				<para><varname>{geometry,trgeometry} %&lt;&gt; {geometry,trgeometry} → boolean</varname></para>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
+	<sect1 xml:id="trgeometry_bbox_ops">
+		<title>Bounding-Box Operators</title>
+
+		<para>Topological and position operators compare the spatiotemporal bounding boxes of the operands; both can be a <varname>trgeometry</varname>, an <varname>stbox</varname>, a <varname>geometry</varname>, or a <varname>tstzspan</varname>.</para>
+
+		<itemizedlist>
+			<listitem xml:id="trgeometry_topops">
+				<indexterm significance="normal"><primary><varname>&amp;&amp;</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>@&gt;</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>&lt;@</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>-|-</varname></primary></indexterm>
+				<para>Standard topological operators on bounding boxes</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]'
+       &amp;&amp;
+       stbox 'STBOX X((5, -1), (15, 1))';
+-- t
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="trgeometry_posops">
+				<indexterm significance="normal"><primary><varname>&lt;&lt;</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>&gt;&gt;</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>&amp;&lt;</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>&amp;&gt;</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>&lt;&lt;#</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>#&gt;&gt;</varname></primary></indexterm>
+				<para>Spatial and temporal position operators</para>
+				<para>The full set <varname>&lt;&lt;</varname>, <varname>&gt;&gt;</varname>, <varname>&amp;&lt;</varname>, <varname>&amp;&gt;</varname>, <varname>&lt;&lt;|</varname>, <varname>&amp;&lt;|</varname>, <varname>|&gt;&gt;</varname>, <varname>|&amp;&gt;</varname>, <varname>&lt;&lt;#</varname>, <varname>&amp;&lt;#</varname>, <varname>#&gt;&gt;</varname>, <varname>#&amp;&gt;</varname> all accept <varname>trgeometry</varname> on either side.</para>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
+	<sect1 xml:id="trgeometry_aggregations">
+		<title>Aggregations</title>
+
+		<itemizedlist>
+			<listitem xml:id="trgeometry_tcount">
+				<indexterm significance="normal"><primary><varname>tcount</varname></primary></indexterm>
+				<para>Number of overlapping trgeometries at each instant — equivalent to <varname>tcount</varname> on the underlying tpose</para>
+				<para><varname>tcount(trgeometry) → tint</varname></para>
+			</listitem>
+
+			<listitem xml:id="trgeometry_extent">
+				<indexterm significance="normal"><primary><varname>extent</varname></primary></indexterm>
+				<para>Aggregate bounding box of a column of trgeometries</para>
+				<para><varname>extent(trgeometry) → stbox</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT extent(temp) FROM tbl_trgeometry;
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="trgeometry_merge">
+				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
+				<para>Combine two trgeometries with the same reference geometry into a single sequence-set</para>
+				<para><varname>merge(trgeometry, trgeometry) → trgeometry</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(merge(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(5 0), 0.0)@2001-01-02]',
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-04, Pose(Point(5 0), 0.0)@2001-01-05]'));
+</programlisting>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
+	<sect1 xml:id="trgeometry_indexing">
+		<title>Indexing</title>
+
+		<para>Three index types are available on <varname>trgeometry</varname> columns. Each uses the spatiotemporal bounding box of the materialised geometry and supports topological, position, and KNN distance queries.</para>
+
+		<itemizedlist>
+			<listitem><para><varname>GIST(temp)</varname> — R-tree GiST.</para></listitem>
+			<listitem><para><varname>SPGIST(temp trgeometry_quadtree_ops)</varname> — quad-tree SP-GiST.</para></listitem>
+			<listitem><para><varname>SPGIST(temp trgeometry_kdtree_ops)</varname> — kd-tree SP-GiST.</para></listitem>
+		</itemizedlist>
+
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
+CREATE INDEX tbl_trgeometry_gist_idx
+  ON tbl_trgeometry
+  USING GIST(temp);
+
+-- topological lookup
+SELECT count(*) FROM tbl_trgeometry
+WHERE temp &amp;&amp; stbox 'STBOX XT(((0, 0), (10, 10)),[2001-01-01, 2001-01-02])';
+
+-- KNN (ordered scan)
+SELECT mmsi
+FROM tbl_trgeometry
+ORDER BY temp &lt;-&gt; trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(100 100), 0.0)@2001-01-01'
+LIMIT 10;
+</programlisting>
+
+		<para>The kd-tree variant typically wins on workloads dominated by KNN queries with a tight ordering bound; the quad-tree variant is more uniform. The R-tree GiST is the safe default for mixed read/write workloads.</para>
+	</sect1>
+
+	<sect1 xml:id="trgeometry_production_guidance">
+		<title>Production guidance</title>
+		<para>This section captures the operational knowledge production workloads need on top of the function reference: when <varname>trgeometry</varname> is the right type relative to its neighbours (<varname>tpose</varname> and <varname>tgeometry</varname>), the frame conventions the implementation enforces, and the numerical hazards real rigid-body workloads hit. Most of these are surfaced separately throughout the chapter; the goal here is one place a new contributor can read end-to-end before instrumenting an application.</para>
+
+		<sect2 xml:id="trgeometry_when_to_use">
+			<title>When to use trgeometry vs tpose vs tgeometry</title>
+			<para>Three temporal types span the rigid-body / arbitrary-shape design space. Pick the narrowest type that fits the workload — narrower types pay less storage and produce sharper bounding boxes for the spatial index.</para>
+			<itemizedlist>
+				<listitem><para><varname>tpose</varname> — temporal position and orientation only; the body is treated as a point with a heading. Use when the shape is irrelevant to the query (kinematic tracking, heading-only collision proxies).</para></listitem>
+				<listitem><para><varname>trgeometry</varname> — a single static reference shape that translates and rotates over time per a temporal pose. Use when the shape <emphasis>matters</emphasis> but is rigid: ships, vehicles, drones with fixed geometry, body-conforming exclusion zones. The reference geometry is stored once per row, not per instant, so storage is dominated by the underlying <varname>tpose</varname>.</para></listitem>
+				<listitem><para><varname>tgeometry</varname> — temporal arbitrary geometry whose shape itself varies over time. Use when the shape is non-rigid: storm wind swaths, expanding plumes, evolving polygons.</para></listitem>
+			</itemizedlist>
+			<para>A <varname>trgeometry</varname> can be projected to its underlying <varname>tpose</varname> (centroid trajectory) or to a fully-materialised <varname>tgeometry</varname> via the conversions in <xref linkend="trgeometry_conversions"/>. The reverse direction (lifting a <varname>tgeometry</varname> back to a <varname>trgeometry</varname>) is not generally well-defined since arbitrary shape changes do not factor cleanly into rotation + translation of a fixed reference.</para>
+		</sect2>
+
+		<sect2 xml:id="trgeometry_frame_conventions">
+			<title>Frame conventions</title>
+			<itemizedlist>
+				<listitem><para><emphasis>2D-only reference geometry</emphasis>. The reference shape is a 2D polygon or polyhedral surface; the pose's rotation component is the 2D yaw angle from <xref linkend="temporal_poses"/>. There is no 3D rigid-body representation in this type — workloads needing full 3D orientation (quaternion) on a 3D shape should compose <varname>tpose</varname> with the materialisation step explicitly.</para></listitem>
+				<listitem><para><emphasis>Single shared reference geometry</emphasis>. Every instant of a <varname>trgeometry</varname> shares the same reference shape; only the pose varies. The shape is stored once per row, not per instant.</para></listitem>
+				<listitem><para><emphasis>Same-SRID requirement</emphasis>. The reference geometry and the temporal pose must share an SRID; the constructor rejects mismatches with the standard MEOS <varname>ensure_same_srid</varname> error. The materialised geometry inherits this SRID.</para></listitem>
+				<listitem><para><emphasis>Centroid-based spatial-restriction semantics</emphasis>. <varname>atGeometry</varname>, <varname>minusGeometry</varname>, <varname>atStbox</varname>, and <varname>minusStbox</varname> test the centroid of the materialised shape against the region — not the materialised shape itself. A trgeometry whose centroid lies outside a region but whose body extends into the region is <emphasis>excluded</emphasis>. This mirrors the underlying <varname>tpose</varname> semantics (a pose is a point) and is a deliberate design choice; workloads needing whole-shape containment must materialise to <varname>tgeometry</varname> first.</para></listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2 xml:id="trgeometry_hazards">
+			<title>Numerical hazards</title>
+			<para>Four hazards reliably bite real rigid-body workloads. The implementation mitigates each as follows:</para>
+			<itemizedlist>
+				<listitem>
+					<para><emphasis>Mixed-SRID inputs</emphasis>. Constructing a <varname>trgeometry</varname> from a reference geometry and a <varname>tpose</varname> in different SRIDs would silently produce wrong materialised positions if the SRIDs were not checked.</para>
+					<para><emphasis>Mitigation</emphasis>: the constructor and every cross-type operator route through <varname>ensure_same_srid</varname>, which raises an error naming both SRIDs. The error path is loud and explicit; there is no implicit transform.</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>traversedArea sampling caveat</emphasis>. The <varname>traversedArea</varname> function samples at the input instants and connects them with the convex hull of the two endpoint polygons. Pure-translation segments are exact, but inter-instant rotations are approximated — for a 90° rotation between two instants, the swept ribbon is wider than the convex hull captures.</para>
+					<para><emphasis>Mitigation</emphasis>: documented in <xref linkend="trgeometry_traversed_area"/>. Workloads needing tight swept-area bounds must up-sample the input <varname>tpose</varname> before constructing the <varname>trgeometry</varname>; the <varname>setInterp</varname> + sub-instant insertion pattern from the <varname>tpose</varname> chapter is the standard approach. Adaptive sub-sampling within <varname>traversedArea</varname> is a documented future refinement.</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>Adaptive sub-sampling tolerance in materialised distance</emphasis>. Continuous-distance kernels (<varname>tdistance</varname>, <varname>nearestApproachDistance</varname>) materialise the rigid shape per inter-instant gap and emit intermediate marks where the distance trajectory deviates from a straight line. The depth-cap is 32 marks per gap and the LINEAR-interpolated approximation between marks is bounded by <varname>1e-3</varname> (in CRS units).</para>
+					<para><emphasis>Mitigation</emphasis>: the <varname>1e-3</varname> bound is a documented design choice. Pure-translation segments converge at depth 0; rotation-heavy segments use the full 32-mark budget. Workloads that need sharper precision on a specific operator should pre-process the input poses to denser instants rather than rely on tighter recursion.</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>Centroid-based spatial restriction surprise</emphasis>. <varname>atGeometry(trgeometry, geometry)</varname> tests the pose centroid against the region, not the materialised shape. A long ship whose stern is in a harbour but whose bow has crossed the harbour boundary will be reported as inside the harbour as long as its centroid is inside.</para>
+					<para><emphasis>Mitigation</emphasis>: documented as a tier-D design choice in <xref linkend="trgeometry_restrictions"/>. Workloads needing whole-shape semantics must convert via <varname>trgeometry::tgeometry</varname> before applying the spatial restriction. The conversion materialises one polygon per instant and is correspondingly more expensive.</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2 xml:id="trgeometry_durability">
+			<title>Durability and storage</title>
+			<para>The on-disk representation of a <varname>trgeometry</varname> is the reference <varname>GSERIALIZED</varname> followed by the temporal-pose payload. The byte layout is stable: <varname>asBinary(trgeometry)</varname> / <varname>trgeometryFromBinary(bytea)</varname> round-trip preserves the value bit-for-bit (including the reference shape's SRID, Z and M flags, and the underlying <varname>tpose</varname> subtype), and the WKB / EWKB / HexEWKB serialisations follow the standard PostGIS endian-flag-then-payload pattern.</para>
+			<para>The <varname>asMFJSON(trgeometry)</varname> / <varname>trgeometryFromMFJSON(text)</varname> pair is bidirectional. Each instant renders as <varname>{"geometry":&lt;reference-geojson&gt;,"values":[&lt;pose-payload&gt;]}</varname>: the reference geometry uses the standard PostGIS GeoJSON shape and the pose payload follows the OGC GeoPose Basic-YPR conformance class layout (<varname>{"position":...,"quaternion":...}</varname> for 3D / <varname>{"position":...,"rotation":...}</varname> for 2D). The reference geometry is emitted once per instant in the current schema; future schema work could elevate it to a chapter-level header to avoid the per-instant repetition for long sequences.</para>
+			<para>The <varname>pg_dump</varname> output of a table containing <varname>trgeometry</varname> columns uses the WKT representation by default; <varname>pg_dump --binary-upgrade</varname> uses the WKB representation. Both are round-trip-stable across PostgreSQL major-version upgrades.</para>
+		</sect2>
+	</sect1>
+</chapter>


### PR DESCRIPTION
> 👀 **Reviewers**: tier ranking, dependency chains and the standards checklist live in [`doc/contributing/reviewer-guide.md`](https://github.com/MobilityDB/MobilityDB/blob/master/doc/contributing/reviewer-guide.md).

## Summary

Extends \`doc/temporal_rigid_geometries.xml\` with four sections covering the SQL surface added in #862 (stacked on that PR — open as draft until #862 merges):

- **\`trgeometry_spatialrels\`**: \`eContains\`/\`aContains\`, \`eCovers\`/\`aCovers\`, \`eDisjoint\`/\`aDisjoint\`, \`eIntersects\`/\`aIntersects\`, \`eTouches\`/\`aTouches\`, \`eDwithin\`/\`aDwithin\` — 36 SQL overloads.
- **\`trgeometry_tempspatialrels\`**: \`tContains\`, \`tCovers\`, \`tDisjoint\`, \`tIntersects\`, \`tTouches\`, \`tDwithin\` — 18 SQL overloads.
- **\`trgeometry_tiling\`**: \`spaceBoxes\`, \`timeBoxes\`, \`spaceTimeBoxes\`, \`spaceSplit\`, \`spaceTimeSplit\`.
- **\`trgeometry_analytics\`**: \`minTimeDeltaSimplify\`, \`minDistSimplify\`, \`maxDistSimplify\`, \`douglasPeuckerSimplify\`.

Also removes \`mobilitydb/sql/rgeo/130_trgeo_boxops.in.sql\` — dead duplicate of \`266_trgeo_bbox_split.in.sql\`, never wired into \`CMakeLists.txt\`.

## Stacking dependency

Stacked on #862. Base will be changed to \`master\` once #862 merges.

## Test plan

- [x] DocBook builds cleanly.
- [x] No SQL or C changes — documentation only (plus dead-file removal).
- [x] Linux gcc + clang + macOS + Windows CI green.