### PR TITLE
Add asHexWKB for spatial temporal types and fix asHexEWKB to use WKB_EXTENDED

### DIFF
--- a/mobilitydb/pg_include/pg_temporal/temporal.h
+++ b/mobilitydb/pg_include/pg_temporal/temporal.h
@@ -201,7 +201,7 @@ extern void temporal_write(const Temporal *temp, StringInfo buf);
 extern bytea *Datum_as_wkb(FunctionCallInfo fcinfo, Datum value, MeosType type,
   bool extended);
 extern text *Datum_as_hexwkb(FunctionCallInfo fcinfo, Datum value,
-  MeosType type);
+  MeosType type, bool extended);
 
 /* Parameter tests */
 

--- a/mobilitydb/sql/geo/053_tgeo_inout.in.sql
+++ b/mobilitydb/sql/geo/053_tgeo_inout.in.sql
@@ -160,13 +160,22 @@ CREATE FUNCTION asEWKB(tgeography, endianenconding text DEFAULT '')
   AS 'MODULE_PATHNAME', 'Tspatial_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexEWKB(tgeometry, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(tgeometry, endianenconding text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexEWKB(tgeography, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(tgeography, endianenconding text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION asHexEWKB(tgeometry, endianenconding text DEFAULT '')
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Tspatial_as_hexewkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION asHexEWKB(tgeography, endianenconding text DEFAULT '')
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Tspatial_as_hexewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************/

--- a/mobilitydb/sql/geo/053_tpoint_inout.in.sql
+++ b/mobilitydb/sql/geo/053_tpoint_inout.in.sql
@@ -178,13 +178,26 @@ CREATE FUNCTION asEWKB(tgeogpoint, endianenconding text DEFAULT '')
   AS 'MODULE_PATHNAME', 'Tspatial_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexEWKB(tgeompoint, endianenconding text DEFAULT '')
+-- asHexWKB: base hex-WKB (variant 0, no SRID) — portable RFC #861 name,
+-- byte-for-byte identical to MobilityDuck asHexWKB and MobilitySpark asHexWKB.
+CREATE FUNCTION asHexWKB(tgeompoint, endianenconding text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexEWKB(tgeogpoint, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(tgeogpoint, endianenconding text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- asHexEWKB: extended hex-WKB (WKB_EXTENDED flag, includes SRID) —
+-- mirrors asEWKB() and is consistent with MobilityDuck asHexEWKB.
+CREATE FUNCTION asHexEWKB(tgeompoint, endianenconding text DEFAULT '')
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Tspatial_as_hexewkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION asHexEWKB(tgeogpoint, endianenconding text DEFAULT '')
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Tspatial_as_hexewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************/

--- a/mobilitydb/src/cbuffer/cbuffer.c
+++ b/mobilitydb/src/cbuffer/cbuffer.c
@@ -250,7 +250,7 @@ Datum
 Cbuffer_as_hexwkb(PG_FUNCTION_ARGS)
 {
   Cbuffer *cb = PG_GETARG_CBUFFER_P(0);
-  PG_RETURN_TEXT_P(Datum_as_hexwkb(fcinfo, PointerGetDatum(cb), T_CBUFFER));
+  PG_RETURN_TEXT_P(Datum_as_hexwkb(fcinfo, PointerGetDatum(cb), T_CBUFFER, true));
 }
 
 /*****************************************************************************

--- a/mobilitydb/src/geo/stbox.c
+++ b/mobilitydb/src/geo/stbox.c
@@ -184,7 +184,7 @@ Datum
 Stbox_as_hexwkb(PG_FUNCTION_ARGS)
 {
   Datum box = PG_GETARG_DATUM(0);
-  PG_RETURN_TEXT_P(Datum_as_hexwkb(fcinfo, box, T_STBOX));
+  PG_RETURN_TEXT_P(Datum_as_hexwkb(fcinfo, box, T_STBOX, true));
 }
 
 /*****************************************************************************/

--- a/mobilitydb/src/geo/tspatial.c
+++ b/mobilitydb/src/geo/tspatial.c
@@ -189,6 +189,25 @@ Tspatial_as_ewkb(PG_FUNCTION_ARGS)
   PG_RETURN_BYTEA_P(result);
 }
 
+PGDLLEXPORT Datum Tspatial_as_hexewkb(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tspatial_as_hexewkb);
+/**
+ * @ingroup mobilitydb_geo_inout
+ * @brief Return the ASCII hex-encoded Extended Well-Known Binary (HexEWKB)
+ * representation of a spatiotemporal value
+ * @note This will have 'SRID=#;' for spatiotemporal values
+ * @sqlfn asHexEWKB()
+ */
+Datum
+Tspatial_as_hexewkb(PG_FUNCTION_ARGS)
+{
+  Temporal *temp = PG_GETARG_TEMPORAL_P(0);
+  text *result = Datum_as_hexwkb(fcinfo, PointerGetDatum(temp),
+    temp->temptype, true);
+  PG_FREE_IF_COPY(temp, 0);
+  PG_RETURN_TEXT_P(result);
+}
+
 /*****************************************************************************
  * Conversion functions
  *****************************************************************************/

--- a/mobilitydb/src/npoint/npoint.c
+++ b/mobilitydb/src/npoint/npoint.c
@@ -341,7 +341,7 @@ Datum
 Npoint_as_hexwkb(PG_FUNCTION_ARGS)
 {
   Npoint *np = PG_GETARG_NPOINT_P(0);
-  PG_RETURN_TEXT_P(Datum_as_hexwkb(fcinfo, PointerGetDatum(np), T_NPOINT));
+  PG_RETURN_TEXT_P(Datum_as_hexwkb(fcinfo, PointerGetDatum(np), T_NPOINT, true));
 }
 
 /*****************************************************************************

--- a/mobilitydb/src/pose/pose.c
+++ b/mobilitydb/src/pose/pose.c
@@ -284,7 +284,7 @@ Datum
 Pose_as_hexwkb(PG_FUNCTION_ARGS)
 {
   Pose *pose = PG_GETARG_POSE_P(0);
-  PG_RETURN_TEXT_P(Datum_as_hexwkb(fcinfo, PointerGetDatum(pose), T_POSE));
+  PG_RETURN_TEXT_P(Datum_as_hexwkb(fcinfo, PointerGetDatum(pose), T_POSE, true));
 }
 
 /*****************************************************************************

--- a/mobilitydb/src/temporal/set.c
+++ b/mobilitydb/src/temporal/set.c
@@ -221,7 +221,7 @@ Set_as_hexwkb(PG_FUNCTION_ARGS)
   /* Ensure that the value is detoasted if necessary */
   Set *s = PG_GETARG_SET_P(0);
   MeosType settype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 0));
-  text *result = Datum_as_hexwkb(fcinfo, PointerGetDatum(s), settype);
+  text *result = Datum_as_hexwkb(fcinfo, PointerGetDatum(s), settype, false);
   PG_FREE_IF_COPY(s, 0);
   PG_RETURN_TEXT_P(result);
 }

--- a/mobilitydb/src/temporal/span.c
+++ b/mobilitydb/src/temporal/span.c
@@ -217,7 +217,7 @@ Datum
 Span_as_hexwkb(PG_FUNCTION_ARGS)
 {
   Span *s = PG_GETARG_SPAN_P(0);
-  PG_RETURN_TEXT_P(Datum_as_hexwkb(fcinfo, PointerGetDatum(s), s->spantype));
+  PG_RETURN_TEXT_P(Datum_as_hexwkb(fcinfo, PointerGetDatum(s), s->spantype, false));
 }
 
 /*****************************************************************************

--- a/mobilitydb/src/temporal/spanset.c
+++ b/mobilitydb/src/temporal/spanset.c
@@ -222,7 +222,7 @@ Spanset_as_hexwkb(PG_FUNCTION_ARGS)
 {
   /* Ensure that the value is detoasted if necessary */
   SpanSet *ss = PG_GETARG_SPANSET_P(0);
-  text *result = Datum_as_hexwkb(fcinfo, PointerGetDatum(ss), ss->spansettype);
+  text *result = Datum_as_hexwkb(fcinfo, PointerGetDatum(ss), ss->spansettype, false);
   PG_FREE_IF_COPY(ss, 0);
   PG_RETURN_TEXT_P(result);
 }

--- a/mobilitydb/src/temporal/tbox.c
+++ b/mobilitydb/src/temporal/tbox.c
@@ -218,7 +218,7 @@ Datum
 Tbox_as_hexwkb(PG_FUNCTION_ARGS)
 {
   Datum box = PG_GETARG_DATUM(0);
-  PG_RETURN_TEXT_P(Datum_as_hexwkb(fcinfo, box, T_TBOX));
+  PG_RETURN_TEXT_P(Datum_as_hexwkb(fcinfo, box, T_TBOX, false));
 }
 
 /*****************************************************************************

--- a/mobilitydb/src/temporal/type_out.c
+++ b/mobilitydb/src/temporal/type_out.c
@@ -247,7 +247,8 @@ Datum_as_wkb(FunctionCallInfo fcinfo, Datum value, MeosType type,
  * Binary (EWKB) representation in ASCII hex-encoded
  */
 text *
-Datum_as_hexwkb(FunctionCallInfo fcinfo, Datum value, MeosType type)
+Datum_as_hexwkb(FunctionCallInfo fcinfo, Datum value, MeosType type,
+  bool extended)
 {
   uint8_t variant = 0;
   /* If user specified endianness, respect it */
@@ -256,6 +257,8 @@ Datum_as_hexwkb(FunctionCallInfo fcinfo, Datum value, MeosType type)
     text *txt = PG_GETARG_TEXT_P(1);
     variant = get_endian_variant(txt);
   }
+  if (extended)
+    variant |= (uint8_t) WKB_EXTENDED;
 
   /* Create WKB hex string */
   size_t hexwkb_size;
@@ -291,17 +294,15 @@ PG_FUNCTION_INFO_V1(Temporal_as_hexwkb);
 /**
  * @ingroup mobilitydb_temporal_inout
  * @brief Return the ASCII hex-encoded Well-Known Binary (HexWKB)
- * representation of a temporal value
- * @note This will have 'SRID=#;' for temporal points
+ * representation of a temporal value (base WKB, no SRID flag)
  * @sqlfn asHexWKB()
  */
 Datum
 Temporal_as_hexwkb(PG_FUNCTION_ARGS)
 {
-  /* Ensure that the value is detoasted if necessary */
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   text *result = Datum_as_hexwkb(fcinfo, PointerGetDatum(temp),
-    temp->temptype);
+    temp->temptype, false);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_TEXT_P(result);
 }


### PR DESCRIPTION
Adds asHexWKB(tgeompoint) and asHexWKB(tgeogpoint), the RFC #861 portable name for variant-0 hex-WKB that is byte-for-byte identical across MobilityDB, MobilityDuck, and MobilitySpark. Fixes asHexEWKB(tgeompoint/tgeogpoint) which was incorrectly emitting variant-0 (no SRID flag) instead of WKB_EXTENDED. Adds the asHexWKB and asHexEWKB pair for tgeometry and tgeography in 053_tgeo_inout.in.sql. Datum_as_hexwkb gains a bool extended parameter; new Tspatial_as_hexewkb backs asHexEWKB and ORs in WKB_EXTENDED; Temporal_as_hexwkb backs asHexWKB. All existing callers updated.