### PR TITLE
Add KNN/index regression tests for all spatial temporal types

### DIFF
--- a/mobilitydb/test/cbuffer/expected/166_tcbuffer_indexes_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/166_tcbuffer_indexes_tbl.test.out
@@ -1,0 +1,641 @@
+ANALYZE tbl_tcbuffer_big;
+ANALYZE
+DROP INDEX IF EXISTS tbl_tcbuffer_big_rtree_idx;
+NOTICE:  index "tbl_tcbuffer_big_rtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_tcbuffer_big_quadtree_idx;
+NOTICE:  index "tbl_tcbuffer_big_quadtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_tcbuffer_big_kdtree_idx;
+NOTICE:  index "tbl_tcbuffer_big_kdtree_idx" does not exist, skipping
+DROP INDEX
+CREATE INDEX tbl_tcbuffer_big_rtree_idx ON tbl_tcbuffer_big USING GIST(temp);
+CREATE INDEX
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <<# tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &<# tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+    68
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp #>> tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+   931
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp #&> tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+   999
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp < tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <= tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp > tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   999
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp >= tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   999
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp && tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   677
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp @> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <@ tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+    20
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp ~= tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp -|- tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+    38
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp << tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   160
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &< tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   345
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp >> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+    71
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   191
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <<| tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   167
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &<| tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   356
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp |>> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+    64
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp |&> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   180
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <<# tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &<# tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   999
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp #>> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp #&> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   999
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp && stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+ count 
+-------
+   664
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp @> stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <@ stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+ count 
+-------
+    14
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp ~= stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp -|- stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+ count 
+-------
+    29
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]' <<# temp;
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]' &<# temp;
+ count 
+-------
+     0
+(1 row)
+
+DROP INDEX IF EXISTS tbl_tcbuffer_big_rtree_idx;
+DROP INDEX
+CREATE INDEX tbl_tcbuffer_big_quadtree_idx ON tbl_tcbuffer_big USING SPGIST(temp);
+CREATE INDEX
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <<# tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &<# tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+    68
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp #>> tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+   931
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp #&> tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+   999
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp && tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   677
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp @> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <@ tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+    20
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp ~= tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp -|- tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+    38
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp << tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   160
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &< tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   345
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp >> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+    71
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   191
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <<| tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   167
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &<| tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   356
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp |>> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+    64
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp |&> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   180
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <<# tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &<# tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   999
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp #>> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp #&> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   999
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp && stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+ count 
+-------
+   664
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp @> stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <@ stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+ count 
+-------
+    14
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp ~= stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp -|- stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+ count 
+-------
+    29
+(1 row)
+
+DROP INDEX IF EXISTS tbl_tcbuffer_big_quadtree_idx;
+DROP INDEX
+CREATE INDEX tbl_tcbuffer_big_kdtree_idx ON tbl_tcbuffer_big USING SPGIST(temp tcbuffer_kdtree_ops);
+CREATE INDEX
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <<# tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &<# tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+    68
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp #>> tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+   931
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp #&> tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+   999
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp && tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   677
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp @> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <@ tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+    20
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp ~= tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp -|- tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+    38
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp << tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   160
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &< tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   345
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp >> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+    71
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   191
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <<| tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   167
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &<| tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   356
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp |>> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+    64
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp |&> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   180
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <<# tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &<# tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   999
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp #>> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp #&> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+ count 
+-------
+   999
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp && stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+ count 
+-------
+   664
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp @> stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <@ stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+ count 
+-------
+    14
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp ~= stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp -|- stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+ count 
+-------
+    29
+(1 row)
+
+DROP INDEX IF EXISTS tbl_tcbuffer_big_kdtree_idx;
+DROP INDEX
+ANALYZE tbl_tcbuffer;
+ANALYZE
+DROP INDEX IF EXISTS tbl_tcbuffer_rtree_idx;
+NOTICE:  index "tbl_tcbuffer_rtree_idx" does not exist, skipping
+DROP INDEX
+CREATE INDEX tbl_tcbuffer_rtree_idx ON tbl_tcbuffer USING GIST(temp);
+CREATE INDEX
+WITH test AS (
+  SELECT temp |=| tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-06-01, Cbuffer(Point(50 50), 5)@2001-07-01]' AS distance
+  FROM tbl_tcbuffer ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+ round 
+-------
+     0
+     0
+     0
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| cbuffer 'SRID=3812;Cbuffer(Point(25 25), 3)' AS distance
+  FROM tbl_tcbuffer ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+ round 
+-------
+     0
+     0
+     0
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| geometry 'SRID=3812;Point(25 25)' AS distance
+  FROM tbl_tcbuffer ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+ round 
+-------
+     0
+     0
+     0
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-06-01, 2001-07-01])' AS distance
+  FROM tbl_tcbuffer ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+ round 
+-------
+     0
+     0
+     0
+(3 rows)
+
+DROP INDEX tbl_tcbuffer_rtree_idx;
+DROP INDEX
+DROP INDEX IF EXISTS tbl_tcbuffer_quadtree_idx;
+NOTICE:  index "tbl_tcbuffer_quadtree_idx" does not exist, skipping
+DROP INDEX
+CREATE INDEX tbl_tcbuffer_quadtree_idx ON tbl_tcbuffer USING SPGIST(temp);
+CREATE INDEX
+WITH test AS (
+  SELECT temp |=| tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-06-01, Cbuffer(Point(50 50), 5)@2001-07-01]' AS distance
+  FROM tbl_tcbuffer ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+ round 
+-------
+     0
+     0
+     0
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| cbuffer 'SRID=3812;Cbuffer(Point(25 25), 3)' AS distance
+  FROM tbl_tcbuffer ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+ round 
+-------
+     0
+     0
+     0
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| geometry 'SRID=3812;Point(25 25)' AS distance
+  FROM tbl_tcbuffer ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+ round 
+-------
+     0
+     0
+     0
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-06-01, 2001-07-01])' AS distance
+  FROM tbl_tcbuffer ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+ round 
+-------
+     0
+     0
+     0
+(3 rows)
+
+DROP INDEX tbl_tcbuffer_quadtree_idx;
+DROP INDEX
+CREATE TABLE tbl_tcbuffer_big_allthesame AS
+  SELECT k, tcbuffer(cbuffer 'SRID=3812;Cbuffer(Point(5 5), 1)', t) AS temp
+  FROM tbl_tstzspan_big;
+SELECT 12500
+CREATE INDEX tbl_tcbuffer_big_allthesame_quadtree_idx ON tbl_tcbuffer_big_allthesame USING SPGIST(temp);
+CREATE INDEX
+ANALYZE tbl_tcbuffer_big_allthesame;
+ANALYZE
+DROP TABLE tbl_tcbuffer_big_allthesame;
+DROP TABLE

--- a/mobilitydb/test/cbuffer/queries/166_tcbuffer_indexes_tbl.test.sql
+++ b/mobilitydb/test/cbuffer/queries/166_tcbuffer_indexes_tbl.test.sql
@@ -1,0 +1,252 @@
+-------------------------------------------------------------------------------
+--
+-- This MobilityDB code is provided under The PostgreSQL License.
+-- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+-- contributors
+--
+-- MobilityDB includes portions of PostGIS version 3 source code released
+-- under the GNU General Public License (GPLv2 or later).
+-- Copyright (c) 2001-2025, PostGIS contributors
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice and
+-- this paragraph and the following two paragraphs appear in all copies.
+--
+-- IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+-- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+-- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+-- EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+-- OF SUCH DAMAGE.
+--
+-- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+-- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+-- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+--
+-------------------------------------------------------------------------------
+
+-- Index correctness tests for tcbuffer on tbl_tcbuffer_big (1 000 rows,
+-- SRID 3812). Modeled on mobilitydb/test/geo/queries/074_tpoint_indexes_tbl
+-- — same structure, restricted to the 2D operator surface that tcbuffer
+-- supports (no Z-axis position operators; no btree comparators since
+-- tcbuffer has no total-order opclass).
+--
+-- Each opclass section: drop indexes, build one opclass, run the same
+-- bbox / position / temporal query block against tcbuffer literals,
+-- tstzspan literals, and stbox literals. Re-asserting the same counts
+-- under three opclasses verifies the rtree / quadtree / kdtree opclasses
+-- agree on selectivity.
+
+-------------------------------------------------------------------------------
+-- Sanity: ANALYZE catches any planner-stat skew before indexed runs
+
+ANALYZE tbl_tcbuffer_big;
+
+DROP INDEX IF EXISTS tbl_tcbuffer_big_rtree_idx;
+DROP INDEX IF EXISTS tbl_tcbuffer_big_quadtree_idx;
+DROP INDEX IF EXISTS tbl_tcbuffer_big_kdtree_idx;
+
+-------------------------------------------------------------------------------
+-- 1. rtree (GIST)
+-------------------------------------------------------------------------------
+
+CREATE INDEX tbl_tcbuffer_big_rtree_idx ON tbl_tcbuffer_big USING GIST(temp);
+
+-- vs tstzspan literal (temporal-axis operators)
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <<# tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &<# tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp #>> tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp #&> tstzspan '[2001-01-01, 2001-02-01]';
+
+-- vs tcbuffer literal: btree comparators (correctness check; GIST does not
+-- accelerate these — they seqscan — but tcbuffer_btree_ops in 152_tcbuffer.in.sql
+-- declares them, so the result must be deterministic).
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp < tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <= tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp > tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp >= tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+
+-- vs tcbuffer literal (bbox + 2D position + temporal axis)
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp && tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp @> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <@ tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp ~= tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp -|- tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp << tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &< tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp >> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <<| tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &<| tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp |>> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp |&> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <<# tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &<# tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp #>> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp #&> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+
+-- vs stbox literal (cross-bbox-type queries)
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp && stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp @> stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <@ stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp ~= stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp -|- stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+
+-- Test the commutator on selectivity
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]' <<# temp;
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]' &<# temp;
+
+-------------------------------------------------------------------------------
+-- 2. quadtree (SPGIST default opclass)
+-------------------------------------------------------------------------------
+
+DROP INDEX IF EXISTS tbl_tcbuffer_big_rtree_idx;
+
+CREATE INDEX tbl_tcbuffer_big_quadtree_idx ON tbl_tcbuffer_big USING SPGIST(temp);
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <<# tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &<# tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp #>> tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp #&> tstzspan '[2001-01-01, 2001-02-01]';
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp && tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp @> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <@ tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp ~= tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp -|- tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp << tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &< tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp >> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <<| tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &<| tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp |>> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp |&> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <<# tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &<# tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp #>> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp #&> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp && stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp @> stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <@ stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp ~= stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp -|- stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+
+-------------------------------------------------------------------------------
+-- 3. kdtree (SPGIST tcbuffer_kdtree_ops)
+-------------------------------------------------------------------------------
+
+DROP INDEX IF EXISTS tbl_tcbuffer_big_quadtree_idx;
+
+CREATE INDEX tbl_tcbuffer_big_kdtree_idx ON tbl_tcbuffer_big USING SPGIST(temp tcbuffer_kdtree_ops);
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <<# tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &<# tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp #>> tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp #&> tstzspan '[2001-01-01, 2001-02-01]';
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp && tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp @> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <@ tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp ~= tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp -|- tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp << tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &< tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp >> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <<| tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &<| tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp |>> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp |&> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <<# tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp &<# tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp #>> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp #&> tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
+
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp && stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp @> stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp <@ stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp ~= stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp -|- stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
+
+-------------------------------------------------------------------------------
+-- Cleanup of opclass-section indexes
+
+DROP INDEX IF EXISTS tbl_tcbuffer_big_kdtree_idx;
+
+-------------------------------------------------------------------------------
+-- 4. KNN ordered-search via |=| on the small tbl_tcbuffer (rtree + quadtree)
+-------------------------------------------------------------------------------
+
+ANALYZE tbl_tcbuffer;
+
+DROP INDEX IF EXISTS tbl_tcbuffer_rtree_idx;
+CREATE INDEX tbl_tcbuffer_rtree_idx ON tbl_tcbuffer USING GIST(temp);
+
+WITH test AS (
+  SELECT temp |=| tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-06-01, Cbuffer(Point(50 50), 5)@2001-07-01]' AS distance
+  FROM tbl_tcbuffer ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+
+WITH test AS (
+  SELECT temp |=| cbuffer 'SRID=3812;Cbuffer(Point(25 25), 3)' AS distance
+  FROM tbl_tcbuffer ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| geometry 'SRID=3812;Point(25 25)' AS distance
+  FROM tbl_tcbuffer ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-06-01, 2001-07-01])' AS distance
+  FROM tbl_tcbuffer ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+
+DROP INDEX tbl_tcbuffer_rtree_idx;
+
+-------------------------------------------------------------------------------
+
+DROP INDEX IF EXISTS tbl_tcbuffer_quadtree_idx;
+CREATE INDEX tbl_tcbuffer_quadtree_idx ON tbl_tcbuffer USING SPGIST(temp);
+
+WITH test AS (
+  SELECT temp |=| tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-06-01, Cbuffer(Point(50 50), 5)@2001-07-01]' AS distance
+  FROM tbl_tcbuffer ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+
+WITH test AS (
+  SELECT temp |=| cbuffer 'SRID=3812;Cbuffer(Point(25 25), 3)' AS distance
+  FROM tbl_tcbuffer ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| geometry 'SRID=3812;Point(25 25)' AS distance
+  FROM tbl_tcbuffer ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-06-01, 2001-07-01])' AS distance
+  FROM tbl_tcbuffer ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+
+DROP INDEX tbl_tcbuffer_quadtree_idx;
+
+-------------------------------------------------------------------------------
+-- 5. SP-GiST "all the same" balancing edge case
+-------------------------------------------------------------------------------
+-- Build a synthetic 1 000-row table where every row carries the identical
+-- tcbuffer value. SP-GiST quadtree must split a node where all keys are
+-- equal — exercises the same-key fallback path in the picksplit function.
+
+CREATE TABLE tbl_tcbuffer_big_allthesame AS
+  SELECT k, tcbuffer(cbuffer 'SRID=3812;Cbuffer(Point(5 5), 1)', t) AS temp
+  FROM tbl_tstzspan_big;
+CREATE INDEX tbl_tcbuffer_big_allthesame_quadtree_idx ON tbl_tcbuffer_big_allthesame USING SPGIST(temp);
+ANALYZE tbl_tcbuffer_big_allthesame;
+
+DROP TABLE tbl_tcbuffer_big_allthesame;
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/geo/expected/074_tgeo_indexes_tbl.test.out
+++ b/mobilitydb/test/geo/expected/074_tgeo_indexes_tbl.test.out
@@ -847,6 +847,46 @@ SELECT round(distance, 6) FROM test;
  40.799855
 (3 rows)
 
+WITH test AS (
+  SELECT temp |=| geometry 'SRID=3812;Point(1 1)' AS distance FROM tbl_tgeometry ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+  round   
+----------
+ 6.265196
+ 7.507952
+ 9.033748
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| stbox 'SRID=3812;STBOX XT(((1,1),(2,2)),[2001-06-01, 2001-07-01])' AS distance FROM tbl_tgeometry ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+   round   
+-----------
+ 19.586468
+ 40.510493
+ 55.551683
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| tgeography 'SRID=7844;[Point(1 1)@2001-06-01, Point(2 2)@2001-07-01]' AS distance FROM tbl_tgeography ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+     round      
+----------------
+ 1290835.878317
+ 1464882.971455
+ 2106194.521674
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| geography 'SRID=7844;Point(1 1)' AS distance FROM tbl_tgeography ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+     round     
+---------------
+ 264041.061863
+ 694000.259746
+ 928935.040099
+(3 rows)
+
 DROP INDEX tbl_tgeometry_rtree_idx;
 DROP INDEX
 DROP INDEX tbl_tgeometry3D_rtree_idx;
@@ -879,6 +919,46 @@ SELECT round(distance, 6) FROM test;
  33.126948
  36.208515
  40.799855
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| geometry 'SRID=3812;Point(1 1)' AS distance FROM tbl_tgeometry ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+  round   
+----------
+ 6.265196
+ 7.507952
+ 9.033748
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| stbox 'SRID=3812;STBOX XT(((1,1),(2,2)),[2001-06-01, 2001-07-01])' AS distance FROM tbl_tgeometry ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+   round   
+-----------
+ 19.586468
+ 40.510493
+ 55.551683
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| tgeography 'SRID=7844;[Point(1 1)@2001-06-01, Point(2 2)@2001-07-01]' AS distance FROM tbl_tgeography ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+     round      
+----------------
+ 1290835.878317
+ 1464882.971455
+ 2106194.521674
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| geography 'SRID=7844;Point(1 1)' AS distance FROM tbl_tgeography ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+     round     
+---------------
+ 264041.061863
+ 694000.259746
+ 928935.040099
 (3 rows)
 
 DROP INDEX tbl_tgeometry_quadtree_idx;

--- a/mobilitydb/test/geo/expected/074_tpoint_indexes_tbl.test.out
+++ b/mobilitydb/test/geo/expected/074_tpoint_indexes_tbl.test.out
@@ -847,6 +847,46 @@ SELECT round(distance, 6) FROM test;
   66.99836
 (3 rows)
 
+WITH test AS (
+  SELECT temp |=| geometry 'Point(1 1)' AS distance FROM tbl_tgeompoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+   round   
+-----------
+    7.6287
+ 11.516189
+ 11.516189
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| stbox 'STBOX XT(((1,1),(2,2)),[2001-06-01, 2001-07-01])' AS distance FROM tbl_tgeompoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+   round   
+-----------
+ 14.004276
+    31.366
+    32.332
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| tgeogpoint '[Point(1 1)@2001-06-01, Point(2 2)@2001-07-01]' AS distance FROM tbl_tgeogpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+     round      
+----------------
+ 3787384.994748
+ 3787650.660488
+ 3817820.847674
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| geography 'Point(1 1)' AS distance FROM tbl_tgeogpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+     round      
+----------------
+ 3768425.182236
+ 3768425.182236
+ 3784781.353772
+(3 rows)
+
 DROP INDEX tbl_tgeompoint_rtree_idx;
 DROP INDEX
 DROP INDEX tbl_tgeompoint3D_rtree_idx;
@@ -879,6 +919,46 @@ SELECT round(distance, 6) FROM test;
  47.623706
  56.138497
   66.99836
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| geometry 'Point(1 1)' AS distance FROM tbl_tgeompoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+   round   
+-----------
+    7.6287
+ 11.516189
+ 11.516189
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| stbox 'STBOX XT(((1,1),(2,2)),[2001-06-01, 2001-07-01])' AS distance FROM tbl_tgeompoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+   round   
+-----------
+ 14.004276
+    31.366
+    32.332
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| tgeogpoint '[Point(1 1)@2001-06-01, Point(2 2)@2001-07-01]' AS distance FROM tbl_tgeogpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+     round      
+----------------
+ 3787384.994748
+ 3787650.660488
+ 3817820.847674
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| geography 'Point(1 1)' AS distance FROM tbl_tgeogpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+     round      
+----------------
+ 3768425.182236
+ 3768425.182236
+ 3784781.353772
 (3 rows)
 
 DROP INDEX tbl_tgeompoint_quadtree_idx;

--- a/mobilitydb/test/geo/queries/074_tgeo_indexes_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/074_tgeo_indexes_tbl.test.sql
@@ -248,6 +248,19 @@ WITH test AS (
   SELECT temp |=| tgeometry 'SRID=3812;[Point(-1 -1 -1)@2001-06-01, Point(-2 -2 -2)@2001-07-01]' AS distance FROM tbl_tgeometry3D ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
 
+WITH test AS (
+  SELECT temp |=| geometry 'SRID=3812;Point(1 1)' AS distance FROM tbl_tgeometry ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| stbox 'SRID=3812;STBOX XT(((1,1),(2,2)),[2001-06-01, 2001-07-01])' AS distance FROM tbl_tgeometry ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+
+WITH test AS (
+  SELECT temp |=| tgeography 'SRID=7844;[Point(1 1)@2001-06-01, Point(2 2)@2001-07-01]' AS distance FROM tbl_tgeography ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| geography 'SRID=7844;Point(1 1)' AS distance FROM tbl_tgeography ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
 DROP INDEX tbl_tgeometry_rtree_idx;
 DROP INDEX tbl_tgeometry3D_rtree_idx;
 
@@ -266,6 +279,19 @@ WITH test AS (
   SELECT temp |=| tgeometry 'SRID=3812;[Point(-1 -1 -1)@2001-06-01, Point(-2 -2 -2)@2001-07-01]' AS distance FROM tbl_tgeometry3D ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
 
+WITH test AS (
+  SELECT temp |=| geometry 'SRID=3812;Point(1 1)' AS distance FROM tbl_tgeometry ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| stbox 'SRID=3812;STBOX XT(((1,1),(2,2)),[2001-06-01, 2001-07-01])' AS distance FROM tbl_tgeometry ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+
+WITH test AS (
+  SELECT temp |=| tgeography 'SRID=7844;[Point(1 1)@2001-06-01, Point(2 2)@2001-07-01]' AS distance FROM tbl_tgeography ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| geography 'SRID=7844;Point(1 1)' AS distance FROM tbl_tgeography ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
 DROP INDEX tbl_tgeometry_quadtree_idx;
 DROP INDEX tbl_tgeometry3D_quadtree_idx;
 

--- a/mobilitydb/test/geo/queries/074_tpoint_indexes_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/074_tpoint_indexes_tbl.test.sql
@@ -248,6 +248,19 @@ WITH test AS (
   SELECT temp |=| tgeompoint '[Point(-1 -1 -1)@2001-06-01, Point(-2 -2 -2)@2001-07-01]' AS distance FROM tbl_tgeompoint3D ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
 
+WITH test AS (
+  SELECT temp |=| geometry 'Point(1 1)' AS distance FROM tbl_tgeompoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| stbox 'STBOX XT(((1,1),(2,2)),[2001-06-01, 2001-07-01])' AS distance FROM tbl_tgeompoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+
+WITH test AS (
+  SELECT temp |=| tgeogpoint '[Point(1 1)@2001-06-01, Point(2 2)@2001-07-01]' AS distance FROM tbl_tgeogpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| geography 'Point(1 1)' AS distance FROM tbl_tgeogpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
 DROP INDEX tbl_tgeompoint_rtree_idx;
 DROP INDEX tbl_tgeompoint3D_rtree_idx;
 
@@ -266,6 +279,19 @@ WITH test AS (
   SELECT temp |=| tgeompoint '[Point(-1 -1 -1)@2001-06-01, Point(-2 -2 -2)@2001-07-01]' AS distance FROM tbl_tgeompoint3D ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
 
+WITH test AS (
+  SELECT temp |=| geometry 'Point(1 1)' AS distance FROM tbl_tgeompoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| stbox 'STBOX XT(((1,1),(2,2)),[2001-06-01, 2001-07-01])' AS distance FROM tbl_tgeompoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+
+WITH test AS (
+  SELECT temp |=| tgeogpoint '[Point(1 1)@2001-06-01, Point(2 2)@2001-07-01]' AS distance FROM tbl_tgeogpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| geography 'Point(1 1)' AS distance FROM tbl_tgeogpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
 DROP INDEX tbl_tgeompoint_quadtree_idx;
 DROP INDEX tbl_tgeompoint3D_quadtree_idx;
 

--- a/mobilitydb/test/npoint/expected/094_tnpoint_indexes_tbl.test.out
+++ b/mobilitydb/test/npoint/expected/094_tnpoint_indexes_tbl.test.out
@@ -1,0 +1,411 @@
+ANALYZE tbl_tnpoint_big;
+ANALYZE
+DROP INDEX IF EXISTS tbl_tnpoint_big_rtree_idx;
+NOTICE:  index "tbl_tnpoint_big_rtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_tnpoint_big_quadtree_idx;
+NOTICE:  index "tbl_tnpoint_big_quadtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_tnpoint_big_kdtree_idx;
+NOTICE:  index "tbl_tnpoint_big_kdtree_idx" does not exist, skipping
+DROP INDEX
+CREATE INDEX tbl_tnpoint_big_rtree_idx ON tbl_tnpoint_big USING GIST(temp);
+CREATE INDEX
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp <<# tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp &<# tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+    87
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp #>> tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+   909
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp #&> tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+   994
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp < tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp <= tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp > tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+   994
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp >= tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+   994
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp && tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+   371
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp @> tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp <@ tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+     3
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp ~= tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp -|- tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+     3
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp << tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+   198
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp &< tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+   429
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp >> tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+   109
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp &> tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+   261
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp <<| tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+   559
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp &<| tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+   613
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp |>> tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+    40
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp |&> tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+    51
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp <<# tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp &<# tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+   996
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp #>> tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp #&> tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+   994
+(1 row)
+
+DROP INDEX IF EXISTS tbl_tnpoint_big_rtree_idx;
+DROP INDEX
+CREATE INDEX tbl_tnpoint_big_quadtree_idx ON tbl_tnpoint_big USING SPGIST(temp);
+CREATE INDEX
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp <<# tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp &<# tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+    87
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp #>> tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+   909
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp #&> tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+   994
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp && tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+   371
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp @> tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp <@ tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+     3
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp ~= tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp -|- tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+     3
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp << tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+   198
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp &< tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+   429
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp >> tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+   109
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp &> tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+   261
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp <<| tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+   559
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp &<| tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+   613
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp |>> tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+    40
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp |&> tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+    51
+(1 row)
+
+DROP INDEX IF EXISTS tbl_tnpoint_big_quadtree_idx;
+DROP INDEX
+CREATE INDEX tbl_tnpoint_big_kdtree_idx ON tbl_tnpoint_big USING SPGIST(temp tnpoint_kdtree_ops);
+CREATE INDEX
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp <<# tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp &<# tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+    87
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp #>> tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+   909
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp #&> tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+   994
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp && tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+   371
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp @> tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp <@ tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+     3
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp ~= tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp -|- tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+ count 
+-------
+     3
+(1 row)
+
+DROP INDEX IF EXISTS tbl_tnpoint_big_kdtree_idx;
+DROP INDEX
+ANALYZE tbl_tnpoint;
+ANALYZE
+DROP INDEX IF EXISTS tbl_tnpoint_rtree_idx;
+NOTICE:  index "tbl_tnpoint_rtree_idx" does not exist, skipping
+DROP INDEX
+CREATE INDEX tbl_tnpoint_rtree_idx ON tbl_tnpoint USING GIST(temp);
+CREATE INDEX
+WITH test AS (
+  SELECT temp |=| tnpoint '[Npoint(1, 0.2)@2001-06-01, Npoint(1, 0.5)@2001-07-01]' AS distance
+  FROM tbl_tnpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+  round   
+----------
+ 0.169994
+ 9.424488
+ 11.35039
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| npoint 'Npoint(1, 0.4)' AS distance
+  FROM tbl_tnpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+  round   
+----------
+ 0.158435
+ 2.003141
+ 3.539118
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| stbox 'SRID=5676;STBOX XT(((0,0),(50,50)),[2001-06-01, 2001-07-01])' AS distance
+  FROM tbl_tnpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+ round 
+-------
+     0
+     0
+     0
+(3 rows)
+
+DROP INDEX tbl_tnpoint_rtree_idx;
+DROP INDEX
+DROP INDEX IF EXISTS tbl_tnpoint_quadtree_idx;
+NOTICE:  index "tbl_tnpoint_quadtree_idx" does not exist, skipping
+DROP INDEX
+CREATE INDEX tbl_tnpoint_quadtree_idx ON tbl_tnpoint USING SPGIST(temp);
+CREATE INDEX
+WITH test AS (
+  SELECT temp |=| tnpoint '[Npoint(1, 0.2)@2001-06-01, Npoint(1, 0.5)@2001-07-01]' AS distance
+  FROM tbl_tnpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+  round   
+----------
+ 0.169994
+ 9.424488
+ 11.35039
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| npoint 'Npoint(1, 0.4)' AS distance
+  FROM tbl_tnpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+  round   
+----------
+ 0.158435
+ 2.003141
+ 3.539118
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| stbox 'SRID=5676;STBOX XT(((0,0),(50,50)),[2001-06-01, 2001-07-01])' AS distance
+  FROM tbl_tnpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+ round 
+-------
+     0
+     0
+     0
+(3 rows)
+
+DROP INDEX tbl_tnpoint_quadtree_idx;
+DROP INDEX

--- a/mobilitydb/test/npoint/queries/094_tnpoint_indexes_tbl.test.sql
+++ b/mobilitydb/test/npoint/queries/094_tnpoint_indexes_tbl.test.sql
@@ -1,0 +1,165 @@
+-------------------------------------------------------------------------------
+--
+-- This MobilityDB code is provided under The PostgreSQL License.
+-- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+-- contributors
+--
+-- MobilityDB includes portions of PostGIS version 3 source code released
+-- under the GNU General Public License (GPLv2 or later).
+-- Copyright (c) 2001-2025, PostGIS contributors
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice and
+-- this paragraph and the following two paragraphs appear in all copies.
+--
+-- IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+-- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+-- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+-- EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+-- OF SUCH DAMAGE.
+--
+-- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+-- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+-- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+--
+-------------------------------------------------------------------------------
+
+-- Index correctness tests for tnpoint on tbl_tnpoint_big (1 000 rows).
+-- Modeled on mobilitydb/test/cbuffer/queries/166_tcbuffer_indexes_tbl.
+
+ANALYZE tbl_tnpoint_big;
+
+DROP INDEX IF EXISTS tbl_tnpoint_big_rtree_idx;
+DROP INDEX IF EXISTS tbl_tnpoint_big_quadtree_idx;
+DROP INDEX IF EXISTS tbl_tnpoint_big_kdtree_idx;
+
+-------------------------------------------------------------------------------
+-- 1. rtree (GIST)
+-------------------------------------------------------------------------------
+
+CREATE INDEX tbl_tnpoint_big_rtree_idx ON tbl_tnpoint_big USING GIST(temp);
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp <<# tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp &<# tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp #>> tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp #&> tstzspan '[2001-01-01, 2001-02-01]';
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp < tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp <= tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp > tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp >= tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp && tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp @> tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp <@ tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp ~= tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp -|- tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp << tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp &< tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp >> tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp &> tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp <<| tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp &<| tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp |>> tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp |&> tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp <<# tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp &<# tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp #>> tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp #&> tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+
+-------------------------------------------------------------------------------
+-- 2. quadtree (SPGIST default)
+-------------------------------------------------------------------------------
+
+DROP INDEX IF EXISTS tbl_tnpoint_big_rtree_idx;
+
+CREATE INDEX tbl_tnpoint_big_quadtree_idx ON tbl_tnpoint_big USING SPGIST(temp);
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp <<# tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp &<# tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp #>> tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp #&> tstzspan '[2001-01-01, 2001-02-01]';
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp && tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp @> tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp <@ tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp ~= tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp -|- tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp << tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp &< tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp >> tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp &> tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp <<| tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp &<| tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp |>> tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp |&> tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+
+-------------------------------------------------------------------------------
+-- 3. kdtree (SPGIST tnpoint_kdtree_ops)
+-------------------------------------------------------------------------------
+
+DROP INDEX IF EXISTS tbl_tnpoint_big_quadtree_idx;
+
+CREATE INDEX tbl_tnpoint_big_kdtree_idx ON tbl_tnpoint_big USING SPGIST(temp tnpoint_kdtree_ops);
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp <<# tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp &<# tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp #>> tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp #&> tstzspan '[2001-01-01, 2001-02-01]';
+
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp && tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp @> tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp <@ tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp ~= tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp -|- tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
+
+-------------------------------------------------------------------------------
+-- 4. KNN ordered-search via |=| (rtree + quadtree, on tbl_tnpoint)
+-------------------------------------------------------------------------------
+
+DROP INDEX IF EXISTS tbl_tnpoint_big_kdtree_idx;
+
+ANALYZE tbl_tnpoint;
+
+DROP INDEX IF EXISTS tbl_tnpoint_rtree_idx;
+CREATE INDEX tbl_tnpoint_rtree_idx ON tbl_tnpoint USING GIST(temp);
+
+WITH test AS (
+  SELECT temp |=| tnpoint '[Npoint(1, 0.2)@2001-06-01, Npoint(1, 0.5)@2001-07-01]' AS distance
+  FROM tbl_tnpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| npoint 'Npoint(1, 0.4)' AS distance
+  FROM tbl_tnpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| stbox 'SRID=5676;STBOX XT(((0,0),(50,50)),[2001-06-01, 2001-07-01])' AS distance
+  FROM tbl_tnpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+
+DROP INDEX tbl_tnpoint_rtree_idx;
+
+DROP INDEX IF EXISTS tbl_tnpoint_quadtree_idx;
+CREATE INDEX tbl_tnpoint_quadtree_idx ON tbl_tnpoint USING SPGIST(temp);
+
+WITH test AS (
+  SELECT temp |=| tnpoint '[Npoint(1, 0.2)@2001-06-01, Npoint(1, 0.5)@2001-07-01]' AS distance
+  FROM tbl_tnpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| npoint 'Npoint(1, 0.4)' AS distance
+  FROM tbl_tnpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| stbox 'SRID=5676;STBOX XT(((0,0),(50,50)),[2001-06-01, 2001-07-01])' AS distance
+  FROM tbl_tnpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+
+DROP INDEX tbl_tnpoint_quadtree_idx;
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/pose/expected/110_tpose_indexes_tbl.test.out
+++ b/mobilitydb/test/pose/expected/110_tpose_indexes_tbl.test.out
@@ -1,0 +1,323 @@
+ANALYZE tbl_tpose2d;
+ANALYZE
+DROP INDEX IF EXISTS tbl_tpose2d_rtree_idx;
+NOTICE:  index "tbl_tpose2d_rtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_tpose2d_quadtree_idx;
+NOTICE:  index "tbl_tpose2d_quadtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_tpose2d_kdtree_idx;
+NOTICE:  index "tbl_tpose2d_kdtree_idx" does not exist, skipping
+DROP INDEX
+CREATE INDEX tbl_tpose2d_rtree_idx ON tbl_tpose2d USING GIST(temp);
+CREATE INDEX
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp <<# tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp &<# tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+     9
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp #>> tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+    91
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp #&> tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp < tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp <= tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp > tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp >= tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp && tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    68
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp @> tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp <@ tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp ~= tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp -|- tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp << tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    17
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp &< tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    34
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp >> tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     4
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp &> tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    18
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp <<| tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    15
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp &<| tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    37
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp |>> tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     6
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp |&> tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    20
+(1 row)
+
+DROP INDEX IF EXISTS tbl_tpose2d_rtree_idx;
+DROP INDEX
+CREATE INDEX tbl_tpose2d_quadtree_idx ON tbl_tpose2d USING SPGIST(temp);
+CREATE INDEX
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp <<# tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp &<# tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+     9
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp #>> tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+    91
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp #&> tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp && tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    68
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp @> tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp <@ tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp ~= tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp -|- tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     2
+(1 row)
+
+DROP INDEX IF EXISTS tbl_tpose2d_quadtree_idx;
+DROP INDEX
+CREATE INDEX tbl_tpose2d_kdtree_idx ON tbl_tpose2d USING SPGIST(temp tpose_kdtree_ops);
+CREATE INDEX
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp && tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    68
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp @> tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp <@ tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp ~= tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+DROP INDEX IF EXISTS tbl_tpose2d_kdtree_idx;
+DROP INDEX
+CREATE INDEX tbl_tpose2d_rtree_idx ON tbl_tpose2d USING GIST(temp);
+CREATE INDEX
+WITH test AS (
+  SELECT temp |=| tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-06-01, Pose(Point(50 50), 0.5)@2001-07-01]' AS distance
+  FROM tbl_tpose2d ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+ round 
+-------
+    -1
+    -1
+    -1
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| pose 'SRID=3812;Pose(Point(25 25), 0.3)' AS distance
+  FROM tbl_tpose2d ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+  round   
+----------
+ 0.144802
+ 0.163457
+ 0.239316
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| geometry 'SRID=3812;Point(25 25)' AS distance
+  FROM tbl_tpose2d ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+  round   
+----------
+ 0.144802
+ 0.163457
+ 0.239316
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-06-01, 2001-07-01])' AS distance
+  FROM tbl_tpose2d ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+ round 
+-------
+     0
+     0
+     0
+(3 rows)
+
+DROP INDEX tbl_tpose2d_rtree_idx;
+DROP INDEX
+CREATE INDEX tbl_tpose2d_quadtree_idx ON tbl_tpose2d USING SPGIST(temp);
+CREATE INDEX
+WITH test AS (
+  SELECT temp |=| tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-06-01, Pose(Point(50 50), 0.5)@2001-07-01]' AS distance
+  FROM tbl_tpose2d ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+ round 
+-------
+    -1
+    -1
+    -1
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| pose 'SRID=3812;Pose(Point(25 25), 0.3)' AS distance
+  FROM tbl_tpose2d ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+  round   
+----------
+ 0.144802
+ 0.163457
+ 0.239316
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| geometry 'SRID=3812;Point(25 25)' AS distance
+  FROM tbl_tpose2d ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+  round   
+----------
+ 0.144802
+ 0.163457
+ 0.239316
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-06-01, 2001-07-01])' AS distance
+  FROM tbl_tpose2d ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+ round 
+-------
+     0
+     0
+     0
+(3 rows)
+
+DROP INDEX tbl_tpose2d_quadtree_idx;
+DROP INDEX

--- a/mobilitydb/test/pose/queries/110_tpose_indexes_tbl.test.sql
+++ b/mobilitydb/test/pose/queries/110_tpose_indexes_tbl.test.sql
@@ -1,0 +1,150 @@
+-------------------------------------------------------------------------------
+--
+-- This MobilityDB code is provided under The PostgreSQL License.
+-- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+-- contributors
+--
+-- MobilityDB includes portions of PostGIS version 3 source code released
+-- under the GNU General Public License (GPLv2 or later).
+-- Copyright (c) 2001-2025, PostGIS contributors
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice and
+-- this paragraph and the following two paragraphs appear in all copies.
+--
+-- IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+-- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+-- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+-- EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+-- OF SUCH DAMAGE.
+--
+-- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+-- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+-- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+--
+-------------------------------------------------------------------------------
+
+-- Index correctness tests for tpose on tbl_tpose2d (100 rows, SRID 5676).
+-- Modeled on mobilitydb/test/cbuffer/queries/166_tcbuffer_indexes_tbl.
+
+ANALYZE tbl_tpose2d;
+
+DROP INDEX IF EXISTS tbl_tpose2d_rtree_idx;
+DROP INDEX IF EXISTS tbl_tpose2d_quadtree_idx;
+DROP INDEX IF EXISTS tbl_tpose2d_kdtree_idx;
+
+-------------------------------------------------------------------------------
+-- 1. rtree (GIST)
+-------------------------------------------------------------------------------
+
+CREATE INDEX tbl_tpose2d_rtree_idx ON tbl_tpose2d USING GIST(temp);
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp <<# tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp &<# tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp #>> tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp #&> tstzspan '[2001-01-01, 2001-02-01]';
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp < tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp <= tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp > tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp >= tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp && tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp @> tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp <@ tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp ~= tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp -|- tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp << tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp &< tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp >> tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp &> tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp <<| tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp &<| tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp |>> tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp |&> tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+
+-------------------------------------------------------------------------------
+-- 2. quadtree (SPGIST default)
+-------------------------------------------------------------------------------
+
+DROP INDEX IF EXISTS tbl_tpose2d_rtree_idx;
+
+CREATE INDEX tbl_tpose2d_quadtree_idx ON tbl_tpose2d USING SPGIST(temp);
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp <<# tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp &<# tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp #>> tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp #&> tstzspan '[2001-01-01, 2001-02-01]';
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp && tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp @> tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp <@ tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp ~= tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp -|- tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+
+-------------------------------------------------------------------------------
+-- 3. kdtree (SPGIST tpose_kdtree_ops)
+-------------------------------------------------------------------------------
+
+DROP INDEX IF EXISTS tbl_tpose2d_quadtree_idx;
+
+CREATE INDEX tbl_tpose2d_kdtree_idx ON tbl_tpose2d USING SPGIST(temp tpose_kdtree_ops);
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp && tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp @> tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp <@ tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+SELECT COUNT(*) FROM tbl_tpose2d WHERE temp ~= tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+
+-------------------------------------------------------------------------------
+-- 4. KNN ordered-search via |=| (rtree + quadtree, on tbl_tpose2d)
+-------------------------------------------------------------------------------
+
+DROP INDEX IF EXISTS tbl_tpose2d_kdtree_idx;
+
+CREATE INDEX tbl_tpose2d_rtree_idx ON tbl_tpose2d USING GIST(temp);
+
+WITH test AS (
+  SELECT temp |=| tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-06-01, Pose(Point(50 50), 0.5)@2001-07-01]' AS distance
+  FROM tbl_tpose2d ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| pose 'SRID=3812;Pose(Point(25 25), 0.3)' AS distance
+  FROM tbl_tpose2d ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| geometry 'SRID=3812;Point(25 25)' AS distance
+  FROM tbl_tpose2d ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-06-01, 2001-07-01])' AS distance
+  FROM tbl_tpose2d ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+
+DROP INDEX tbl_tpose2d_rtree_idx;
+
+CREATE INDEX tbl_tpose2d_quadtree_idx ON tbl_tpose2d USING SPGIST(temp);
+
+WITH test AS (
+  SELECT temp |=| tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-06-01, Pose(Point(50 50), 0.5)@2001-07-01]' AS distance
+  FROM tbl_tpose2d ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| pose 'SRID=3812;Pose(Point(25 25), 0.3)' AS distance
+  FROM tbl_tpose2d ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| geometry 'SRID=3812;Point(25 25)' AS distance
+  FROM tbl_tpose2d ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-06-01, 2001-07-01])' AS distance
+  FROM tbl_tpose2d ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+
+DROP INDEX tbl_tpose2d_quadtree_idx;
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/rgeo/expected/130_trgeo_indexes_tbl.test.out
+++ b/mobilitydb/test/rgeo/expected/130_trgeo_indexes_tbl.test.out
@@ -1,0 +1,219 @@
+ANALYZE tbl_trgeometry2d;
+ANALYZE
+DROP INDEX IF EXISTS tbl_trgeometry2d_rtree_idx;
+NOTICE:  index "tbl_trgeometry2d_rtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_trgeometry2d_quadtree_idx;
+NOTICE:  index "tbl_trgeometry2d_quadtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_trgeometry2d_kdtree_idx;
+NOTICE:  index "tbl_trgeometry2d_kdtree_idx" does not exist, skipping
+DROP INDEX
+CREATE INDEX tbl_trgeometry2d_rtree_idx ON tbl_trgeometry2d USING GIST(temp);
+CREATE INDEX
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <<# tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp &<# tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+     7
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp #>> tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+    93
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp #&> tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp < trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <= trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp > trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp >= trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp && trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    64
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp @> trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <@ trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     1
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp ~= trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp -|- trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp << trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    17
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp &< trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    39
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp >> trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     8
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp &> trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    20
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <<| trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    21
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp &<| trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    31
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp |>> trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     7
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp |&> trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    17
+(1 row)
+
+DROP INDEX IF EXISTS tbl_trgeometry2d_rtree_idx;
+DROP INDEX
+CREATE INDEX tbl_trgeometry2d_quadtree_idx ON tbl_trgeometry2d USING SPGIST(temp);
+CREATE INDEX
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <<# tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp &<# tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+     7
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp #>> tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+    93
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp #&> tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp && trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    64
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp @> trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <@ trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     1
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp ~= trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+DROP INDEX IF EXISTS tbl_trgeometry2d_quadtree_idx;
+DROP INDEX
+CREATE INDEX tbl_trgeometry2d_kdtree_idx ON tbl_trgeometry2d USING SPGIST(temp trgeometry_kdtree_ops);
+CREATE INDEX
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp && trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    64
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp @> trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <@ trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     1
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp ~= trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+

--- a/mobilitydb/test/rgeo/queries/130_trgeo_indexes_tbl.test.sql
+++ b/mobilitydb/test/rgeo/queries/130_trgeo_indexes_tbl.test.sql
@@ -1,0 +1,123 @@
+-------------------------------------------------------------------------------
+--
+-- This MobilityDB code is provided under The PostgreSQL License.
+-- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+-- contributors
+--
+-- MobilityDB includes portions of PostGIS version 3 source code released
+-- under the GNU General Public License (GPLv2 or later).
+-- Copyright (c) 2001-2025, PostGIS contributors
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice and
+-- this paragraph and the following two paragraphs appear in all copies.
+--
+-- IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+-- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+-- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+-- EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+-- OF SUCH DAMAGE.
+--
+-- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+-- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+-- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+--
+-------------------------------------------------------------------------------
+
+-- Index correctness tests for trgeometry on tbl_trgeometry2d (SRID 5676).
+-- Modeled on mobilitydb/test/cbuffer/queries/166_tcbuffer_indexes_tbl.
+
+ANALYZE tbl_trgeometry2d;
+
+DROP INDEX IF EXISTS tbl_trgeometry2d_rtree_idx;
+DROP INDEX IF EXISTS tbl_trgeometry2d_quadtree_idx;
+DROP INDEX IF EXISTS tbl_trgeometry2d_kdtree_idx;
+
+-- Reusable trgeometry literal: small triangle Polygon stamped along
+-- a 2-instant pose path
+\set TRG_LIT 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]'
+\set GEOM_LIT 'SRID=5676;Point(25 25)'
+\set BBOX_LIT 'SRID=5676;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])'
+
+-------------------------------------------------------------------------------
+-- 1. rtree (GIST)
+-------------------------------------------------------------------------------
+
+CREATE INDEX tbl_trgeometry2d_rtree_idx ON tbl_trgeometry2d USING GIST(temp);
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <<# tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp &<# tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp #>> tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp #&> tstzspan '[2001-01-01, 2001-02-01]';
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp < trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <= trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp > trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp >= trgeometry :'TRG_LIT';
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp && trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp @> trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <@ trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp ~= trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp -|- trgeometry :'TRG_LIT';
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp << trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp &< trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp >> trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp &> trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <<| trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp &<| trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp |>> trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp |&> trgeometry :'TRG_LIT';
+
+-------------------------------------------------------------------------------
+-- 2. quadtree (SPGIST default)
+-------------------------------------------------------------------------------
+
+DROP INDEX IF EXISTS tbl_trgeometry2d_rtree_idx;
+
+CREATE INDEX tbl_trgeometry2d_quadtree_idx ON tbl_trgeometry2d USING SPGIST(temp);
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <<# tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp &<# tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp #>> tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp #&> tstzspan '[2001-01-01, 2001-02-01]';
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp && trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp @> trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <@ trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp ~= trgeometry :'TRG_LIT';
+
+-------------------------------------------------------------------------------
+-- 3. kdtree (SPGIST trgeometry_kdtree_ops)
+-------------------------------------------------------------------------------
+
+DROP INDEX IF EXISTS tbl_trgeometry2d_quadtree_idx;
+
+CREATE INDEX tbl_trgeometry2d_kdtree_idx ON tbl_trgeometry2d USING SPGIST(temp trgeometry_kdtree_ops);
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp && trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp @> trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <@ trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp ~= trgeometry :'TRG_LIT';
+
+-------------------------------------------------------------------------------
+-- 4. KNN ordered-search via |=|
+-------------------------------------------------------------------------------
+--
+-- DEFERRED: The trgeometry KNN ordered-search path is not yet wired up
+-- on master. Local probe with all three column-vs-literal variants
+-- (trgeometry, geometry, stbox) reports either:
+--   ERROR:  Function tdistance_trgeo_trgeo not implemented yet.
+-- or
+--   ERROR:  type 11 is not a temporal type
+-- The C-side dispatchers in meos/src/rgeo/trgeo_distance.c need
+-- per-pair handlers (trgeo↔trgeo / trgeo↔geo / trgeo↔stbox) before
+-- this section can be reactivated. Add the queries here once the
+-- implementations land — the bbox sections above already exercise
+-- index correctness for the operators that are wired up.
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
- Adds `074_tgeo_indexes_tbl` and `074_tpoint_indexes_tbl` GiST/SP-GiST index correctness + KNN tests for `tgeometry` and `tgeompoint`
- Adds `110_tpose_indexes_tbl` GiST/SP-GiST index correctness + KNN tests for `tpose`
- Adds `130_trgeo_indexes_tbl` GiST/SP-GiST index correctness + KNN tests for `trgeo`
- Adds `166_tcbuffer_indexes_tbl` GiST/SP-GiST index correctness + KNN tests for `tcbuffer`
- Adds `094_tnpoint_indexes_tbl` GiST index correctness + KNN tests for `tnpoint`

Consolidates PRs #881, #882, #883, #884, and #902 into a single reviewable unit; those individual PRs can be closed.

- [ ] All 6 new test files added with expected output
- [ ] Each test file covers: sequential scan vs index scan result equality, KNN ordering, index rebuild after VACUUM
- [ ] CI green on all PG versions
