### PR TITLE
fix(meos): bug-audit batch — memory leaks, skiplist safety, MFJSON parser

### DIFF
--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DCMAKE_BUILD_TYPE=Debug -DMEOS=on ..
+          cmake -DCMAKE_BUILD_TYPE=Debug -DMEOS=on -DCBUFFER=on ..
           make -j $(nproc)
           sudo make install
 
@@ -65,6 +65,8 @@ jobs:
           ./geo_test
           gcc -Wall -g -I/usr/local/include -o npoint_test npoint_test.c -L/usr/local/lib -lmeos
           ./npoint_test
+          gcc -Wall -g -I/usr/local/include -o cbuffer_test cbuffer_test.c -L/usr/local/lib -lmeos
+          ./cbuffer_test
 
   threaded:
     name: Thread-safety (TSan)

--- a/meos/src/geo/tpoint_spatialfuncs.c
+++ b/meos/src/geo/tpoint_spatialfuncs.c
@@ -3301,10 +3301,12 @@ mrr_distance_geos(GEOSGeometry *geom, bool geodetic)
         GEOSGeom_destroy(pt2);
         break;
       default:
+        GEOSGeom_destroy(mrr_geom);
         meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
           "Invalid geometry type for Minimum Rotated Rectangle");
         return -1.0;
     }
+    GEOSGeom_destroy(mrr_geom);
   }
   return result;
 }

--- a/meos/src/geo/tspatial_transform_meos.c
+++ b/meos/src/geo/tspatial_transform_meos.c
@@ -174,15 +174,18 @@ void
 meos_finalize_projsrs(void)
 {
   MEOSPROJSRSCache *cache = MEOS_PROJ_CACHE;
-  if (cache)
+  /* Idempotency: bail when no cache is live, and null the global slot after
+   * release so a second finalize call (or finalize before any init) does not
+   * pfree(NULL) / double-free. */
+  if (! cache)
+    return;
+  for (uint32_t i = 0; i < cache->PROJSRSCacheCount; i++)
   {
-    for (uint32_t i = 0; i < cache->PROJSRSCacheCount; i++)
-    {
-      if (cache->MEOSPROJSRSCache[i].projection)
-        PROJSRSDestroyPJ(cache->MEOSPROJSRSCache[i].projection);
-    }
+    if (cache->MEOSPROJSRSCache[i].projection)
+      PROJSRSDestroyPJ(cache->MEOSPROJSRSCache[i].projection);
   }
   pfree(cache);
+  MEOS_PROJ_CACHE = NULL;
   return;
 }
 

--- a/meos/src/npoint/tnpoint_distance.c
+++ b/meos/src/npoint/tnpoint_distance.c
@@ -56,7 +56,9 @@ datum_npoint_distance(Datum np1, Datum np2)
 {
   Datum geom1 = PointerGetDatum(npoint_to_geompoint(DatumGetNpointP(np1)));
   Datum geom2 = PointerGetDatum(npoint_to_geompoint(DatumGetNpointP(np2)));
-  return datum_pt_distance2d(geom1, geom2);
+  Datum result = datum_pt_distance2d(geom1, geom2);
+  pfree(DatumGetPointer(geom1)); pfree(DatumGetPointer(geom2));
+  return result;
 }
 
 /*****************************************************************************

--- a/meos/src/npoint/ways_meos.c
+++ b/meos/src/npoint/ways_meos.c
@@ -150,7 +150,13 @@ GetWaysCache()
 void
 meos_finalize_ways(void)
 {
+  /* Idempotency: only destroy a live cache, and null the slot so a
+   * second finalize call does not double-free the cache and its
+   * stored geometries. */
+  if (! MEOS_WAYS_CACHE)
+    return;
   DestroyWaysCache(MEOS_WAYS_CACHE);
+  MEOS_WAYS_CACHE = NULL;
 }
 
 /**

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -1204,7 +1204,9 @@ pose_distance(Datum pose1, Datum pose2)
 {
   Datum geom1 = PosePGetDatum(pose_to_point(DatumGetPoseP(pose1)));
   Datum geom2 = PosePGetDatum(pose_to_point(DatumGetPoseP(pose2)));
-  return datum_pt_distance2d(geom1, geom2);
+  Datum result = datum_pt_distance2d(geom1, geom2);
+  pfree(DatumGetPointer(geom1)); pfree(DatumGetPointer(geom2));
+  return result;
 }
 
 /**

--- a/meos/src/pose/tpose_distance.c
+++ b/meos/src/pose/tpose_distance.c
@@ -231,7 +231,7 @@ nad_tpose_stbox(const Temporal *temp, const STBox *box)
   GSERIALIZED *traj = tpose_trajectory(temp);
   GSERIALIZED *geo = stbox_geo(box);
   double result = geom_distance2d(traj, geo);
-  pfree(traj);
+  pfree(traj); pfree(geo);
   return result;
 }
 

--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -2040,7 +2040,7 @@ nad_trgeo_stbox(const Temporal *temp, const STBox *box)
   /* Compute the result */
   Temporal *dist = tdistance_trgeo_geo(temp, geo);
   double result = DatumGetFloat8(temporal_min_value(dist));
-  pfree(geo);
+  pfree(dist); pfree(geo);
   if (hast)
     pfree(temp1);
   return result;
@@ -2106,7 +2106,7 @@ shortestline_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
     return NULL;
-  
+
   Temporal *dist = tdistance_trgeo_geo(temp, gs);
   const TInstant *inst = temporal_min_instant(dist);
   /* Timestamp t may be at an exclusive bound */
@@ -2115,6 +2115,7 @@ shortestline_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
   LWGEOM *line = (LWGEOM *) lwline_make(value, PointerGetDatum(gs));
   GSERIALIZED *result = geo_serialize(line);
   lwgeom_free(line);
+  pfree(dist);
   return result;
 }
 

--- a/meos/src/temporal/meos.c
+++ b/meos/src/temporal/meos.c
@@ -81,8 +81,18 @@ gsl_initialize(void)
 static void
 gsl_finalize(void)
 {
-  gsl_rng_free(MEOS_GENERATION_RNG);
-  gsl_rng_free(MEOS_AGGREGATION_RNG);
+  /* Idempotency: only free live generators, and null the slots so a
+   * second finalize call does not double-free. */
+  if (MEOS_GENERATION_RNG)
+  {
+    gsl_rng_free(MEOS_GENERATION_RNG);
+    MEOS_GENERATION_RNG = NULL;
+  }
+  if (MEOS_AGGREGATION_RNG)
+  {
+    gsl_rng_free(MEOS_AGGREGATION_RNG);
+    MEOS_AGGREGATION_RNG = NULL;
+  }
   MEOS_GSL_INITIALIZED = false;
   return;
 }
@@ -138,6 +148,11 @@ proj_initialize(void)
 static void
 proj_finalize(void)
 {
+  /* Idempotency: skip when the per-thread context is already gone. PROJ
+   * documents proj_context_destroy(NULL) as destroying the *default* PROJ
+   * context, which is not what we want on a second finalize call. */
+  if (! MEOS_PJ_CONTEXT)
+    return;
   proj_context_destroy(MEOS_PJ_CONTEXT);
   MEOS_PJ_CONTEXT = NULL;
   return;

--- a/meos/src/temporal/skiplist.c
+++ b/meos/src/temporal/skiplist.c
@@ -441,7 +441,7 @@ keyval_skiplist_common(SkipList *list, void **keys, void **values, int count,
   void *max_value = values[count - 1];
 
   /* Find the list values that are strictly before the span of new values */
-  memset(update, 0, sizeof(&update));
+  memset(update, 0, sizeof(int) * SKIPLIST_MAXLEVEL);
   int height = list->elems[0].height;
   SkipListElem *elem = &list->elems[0];
   int cur = 0;
@@ -490,6 +490,9 @@ keyval_skiplist_merge(SkipList *list, void **keys1, void **values1,
   int count1, void **keys2, void **values2, int count2, int *newcount,
   void ***newkeys, void ***tofree, int *nfree)
 {
+  /* Convention: result, *newkeys, and *tofree are three distinct allocations.
+   * The caller (skiplist_splice) frees the merged elements + the *tofree shell
+   * via pfree_array, then frees the result and *newkeys shells separately. */
   void **result = palloc(sizeof(void *) * (count1 + count2));
   void **newkeys1 = palloc(sizeof(void *) * (count1 + count2));
   void **tofree1 = palloc(sizeof(void *) * Max(count1, count2));
@@ -589,6 +592,12 @@ skiplist_splice(SkipList *list, void **keys, void **values, int count,
   /* Array keeping the new aggregated values that must be freed */
   void **tofree = NULL;
   int nfree = 0;
+  /* Shells returned by the merge helpers; freed after the insertion loop.
+   * The merge helpers guarantee these are distinct allocations from tofree,
+   * so we can pfree them unconditionally without double-freeing the elements
+   * (which are released via pfree_array(tofree, nfree)). */
+  void **newvalues_shell = NULL;
+  void **newkeys_shell = NULL;
 
   /* Remove from the list the elements that overlap with the new elements
    * (if any) and compute their aggregation */
@@ -671,6 +680,9 @@ skiplist_splice(SkipList *list, void **keys, void **values, int count,
       keys = newkeys;
       values = newvalues;
       count = newcount;
+      /* Stash the merge-helper shells for release after the insertion loop. */
+      newvalues_shell = newvalues;
+      newkeys_shell = newkeys;
     }
   }
 
@@ -706,6 +718,7 @@ skiplist_splice(SkipList *list, void **keys, void **values, int count,
       {
         void *newkey = palloc(list->key_size);
         memcpy(newkey, keys[i], list->key_size);
+        newelem->key = newkey;
       }
       else
         newelem->key = NULL;
@@ -732,6 +745,13 @@ skiplist_splice(SkipList *list, void **keys, void **values, int count,
   /* Free memory */
   if (spliced_count != 0)
     pfree_array((void **) tofree, nfree);
+  /* Release the merge-helper pointer-array shells. These are allocated by
+   * temporal_skiplist_merge / keyval_skiplist_merge as separate allocations
+   * from tofree, so freeing them here does not double-free the elements. */
+  if (newvalues_shell)
+    pfree(newvalues_shell);
+  if (newkeys_shell)
+    pfree(newkeys_shell);
   return;
 }
 

--- a/meos/src/temporal/temporal_aggfuncs.c
+++ b/meos/src/temporal/temporal_aggfuncs.c
@@ -103,21 +103,28 @@ datum_max_float8(Datum l, Datum r)
 }
 
 /**
- * @brief Return the minimum value of the two arguments
+ * @brief Return a fresh copy of the minimum value of the two arguments
+ * @note Returns a freshly-allocated Datum so that callers can always free the
+ * result without aliasing into one of the inputs. Required by the @p tagg
+ * paths, which free the per-element result Datum after copying it into a
+ * @p TInstant.
  */
  Datum
 datum_min_text(Datum l, Datum r)
 {
-  return text_cmp(DatumGetTextP(l), DatumGetTextP(r)) < 0 ? l : r;
+  Datum chosen = text_cmp(DatumGetTextP(l), DatumGetTextP(r)) < 0 ? l : r;
+  return datum_copy(chosen, T_TEXT);
 }
 
 /**
- * @brief Return the maximum value of the two arguments
+ * @brief Return a fresh copy of the maximum value of the two arguments
+ * @note See @ref datum_min_text for the always-fresh ownership contract.
  */
 Datum
 datum_max_text(Datum l, Datum r)
 {
-  return text_cmp(DatumGetTextP(l), DatumGetTextP(r)) > 0 ? l : r;
+  Datum chosen = text_cmp(DatumGetTextP(l), DatumGetTextP(r)) > 0 ? l : r;
+  return datum_copy(chosen, T_TEXT);
 }
 
 /**
@@ -286,7 +293,7 @@ temporal_skiplist_common(SkipList *list, void **values, int count,
   }
 
   /* Find the list values that are strictly before the span of new values */
-  memset(update, 0, sizeof(&update));
+  memset(update, 0, sizeof(int) * SKIPLIST_MAXLEVEL);
   int height = list->elems[0].height;
   SkipListElem *elem = &list->elems[0];
   int cur = 0;
@@ -339,6 +346,10 @@ temporal_skiplist_merge(void **spliced, int spliced_count, void **values,
   int count, datum_func2 func, bool crossings, int *newcount, void ***tofree,
   int *nfree)
 {
+  /* Convention: *tofree must be a distinct allocation from the returned
+   * newvalues shell. The caller (skiplist_splice) frees the elements + the
+   * tofree shell via pfree_array, then frees the newvalues shell separately.
+   * Aliasing the two would cause skiplist_splice to either leak or double-free. */
   *newcount = 0;
   void **newvalues;
   uint8 subtype = ((Temporal *) values[0])->subtype;
@@ -349,7 +360,12 @@ temporal_skiplist_merge(void **spliced, int spliced_count, void **values,
   {
     newvalues = (void **) tsequence_tagg((TSequence **) spliced, spliced_count,
       (TSequence **) values, count, func, crossings, newcount);
-    *tofree = newvalues;
+    /* Duplicate the pointer-array shell so *tofree is distinct from
+     * newvalues; both shells then hold the same TSequence* element pointers,
+     * which the elements-free pass in skiplist_splice will release exactly once. */
+    void **tofree1 = palloc(sizeof(TSequence *) * (*newcount));
+    memcpy(tofree1, newvalues, sizeof(TSequence *) * (*newcount));
+    *tofree = tofree1;
     *nfree = *newcount;
   }
   return newvalues;
@@ -388,7 +404,10 @@ tinstant_tagg(TInstant **instants1, int count1, TInstant **instants2,
   int count2, datum_func2 func, int *newcount, void ***tofree, int *nfree)
 {
   TInstant **result = palloc(sizeof(TInstant *) * (count1 + count2));
-  void **tofree1 = palloc(sizeof(TInstant *) * Max(count1, count2));
+  /* Every result entry is a freshly-allocated copy/make and is owned by this
+   * function (the skiplist insertion at the call site makes its own copy via
+   * temporal_copy). Size tofree1 to the worst case: count1 + count2. */
+  void **tofree1 = palloc(sizeof(TInstant *) * (count1 + count2));
   int i = 0, j = 0, count = 0, nfree1 = 0;
   while (i < count1 && j < count2)
   {
@@ -399,8 +418,13 @@ tinstant_tagg(TInstant **instants1, int count1, TInstant **instants2,
     {
       if (func)
       {
-        result[count++] = tinstant_make(func(tinstant_value_p(inst1),
-          tinstant_value_p(inst2)), inst1->temptype, inst1->t);
+        /* All @p datum_func2 implementations passed here return a freshly
+         * allocated Datum (or by-value); aliasing variants are wrapped at
+         * source. @p tinstant_make copies the value, so the result Datum can
+         * be released right after construction. */
+        Datum value = func(tinstant_value_p(inst1), tinstant_value_p(inst2));
+        result[count++] = tinstant_make(value, inst1->temptype, inst1->t);
+        DATUM_FREE(value, temptype_basetype(inst1->temptype));
         if (tofree)
           tofree1[nfree1++] = result[count - 1];
       }
@@ -409,6 +433,8 @@ tinstant_tagg(TInstant **instants1, int count1, TInstant **instants2,
         if (tinstant_eq(inst1, inst2))
         {
           result[count++] = tinstant_copy(inst1);
+          if (tofree)
+            tofree1[nfree1++] = result[count - 1];
         }
         else
         {
@@ -416,6 +442,22 @@ tinstant_tagg(TInstant **instants1, int count1, TInstant **instants2,
           meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
             "The temporal values have different value at their common timestamp %s",
             t1);
+          /* Mirror the caller's pfree_array teardown: when tofree was
+           * requested, every result[] entry was tracked in tofree1; otherwise
+           * walk result[] directly. Either way, release the partially built
+           * TInstants and both pointer-array shells before bailing. */
+          if (tofree)
+          {
+            for (int k = 0; k < nfree1; k++)
+              pfree(tofree1[k]);
+          }
+          else
+          {
+            for (int k = 0; k < count; k++)
+              pfree(result[k]);
+          }
+          pfree(tofree1);
+          pfree(result);
           return NULL;
         }
       }
@@ -425,6 +467,8 @@ tinstant_tagg(TInstant **instants1, int count1, TInstant **instants2,
     else if (cmp < 0)
     {
       result[count++] = tinstant_copy(inst1);
+      if (tofree)
+        tofree1[nfree1++] = result[count - 1];
       i++;
     }
     else
@@ -543,16 +587,20 @@ tsequence_tagg_iter(const TSequence *seq1, const TSequence *seq2,
   TSequence *syncseq1, *syncseq2;
   synchronize_tsequence_tsequence(seq1, seq2, &syncseq1, &syncseq2, crossings);
   TInstant **instants = palloc(sizeof(TInstant *) * syncseq1->count);
-  // MeosType basetype = temptype_basetype(seq1->temptype);
+  MeosType basetype = temptype_basetype(seq1->temptype);
   for (int i = 0; i < syncseq1->count; i++)
   {
     const TInstant *inst1 = TSEQUENCE_INST_N(syncseq1, i);
     const TInstant *inst2 = TSEQUENCE_INST_N(syncseq2, i);
     if (func)
     {
+      /* All @p datum_func2 implementations passed here return a freshly
+       * allocated Datum (or by-value); aliasing variants are wrapped at
+       * source. @p tinstant_make copies the value, so the result Datum can
+       * be released right after construction. */
       Datum value = func(tinstant_value_p(inst1), tinstant_value_p(inst2));
       instants[i] = tinstant_make(value, seq1->temptype, inst1->t);
-      // DATUM_FREE(value, basetype); // TODO
+      DATUM_FREE(value, basetype);
     }
     else
     {
@@ -564,9 +612,15 @@ tsequence_tagg_iter(const TSequence *seq1, const TSequence *seq2,
         meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
           "The temporal values have different value at their common timestamp %s",
           t1);
+        /* Free the instants built so far in this loop (j is the loop var, not
+         * i) plus the synced sequences and any "before intersection" sequence
+         * already in sequences[0..nseqs-1]. */
         for (int j = 0; j < i; j++)
-          pfree(instants[i]);
+          pfree(instants[j]);
         pfree(instants);
+        pfree(syncseq1); pfree(syncseq2);
+        for (int j = 0; j < nseqs; j++)
+          pfree(sequences[j]);
         return -1;
       }
     }
@@ -1205,14 +1259,13 @@ temporal_transform_tcount(const Temporal *temp, int *count)
 SkipList *
 timestamptz_tcount_transfn(SkipList *state, TimestampTz t)
 {
+  /* Validate the existing skiplist's subtype *before* allocating instants,
+   * otherwise the early-return on subtype mismatch leaks the transform. */
+  if (state && ! ensure_same_skiplist_subtype(state, TINSTANT))
+    return NULL;
   TInstant **instants = timestamp_transform_tcount(t);
   if (! state)
     state = temporal_skiplist_make();
-  else
-  {
-    if (! ensure_same_skiplist_subtype(state, TINSTANT))
-      return NULL;
-  }
   temporal_skiplist_splice(state, (void **) instants, 1, &datum_sum_int32,
     CROSSINGS_NO);
   pfree_array((void **) instants, 1);
@@ -1236,14 +1289,13 @@ tstzset_tcount_transfn(SkipList *state, const Set *s)
   if (! ensure_set_isof_type(s, T_TSTZSET))
     return NULL;
 
+  /* Validate the existing skiplist's subtype *before* allocating instants,
+   * otherwise the early-return on subtype mismatch leaks the transform. */
+  if (state && ! ensure_same_skiplist_subtype(state, TINSTANT))
+    return NULL;
   TInstant **instants = tstzset_transform_tcount(s);
   if (! state)
     state = temporal_skiplist_make();
-  else
-  {
-    if (! ensure_same_skiplist_subtype(state, TINSTANT))
-      return NULL;
-  }
   temporal_skiplist_splice(state, (void **) instants, s->count, &datum_sum_int32,
     CROSSINGS_NO);
   pfree_array((void **) instants, s->count);
@@ -1267,14 +1319,13 @@ tstzspan_tcount_transfn(SkipList *state, const Span *s)
   if (! ensure_span_isof_type(s, T_TSTZSPAN))
     return NULL;
 
+  /* Validate the existing skiplist's subtype *before* allocating the
+   * transform, otherwise the early-return on subtype mismatch leaks it. */
+  if (state && ! ensure_same_skiplist_subtype(state, TSEQUENCE))
+    return NULL;
   TSequence *seq = tstzspan_transform_tcount(s);
   if (! state)
     state = temporal_skiplist_make();
-  else
-  {
-    if (! ensure_same_skiplist_subtype(state, TSEQUENCE))
-      return NULL;
-  }
   temporal_skiplist_splice(state, (void **) &seq, 1, &datum_sum_int32,
     CROSSINGS_NO);
   pfree(seq);
@@ -1299,14 +1350,13 @@ tstzspanset_tcount_transfn(SkipList *state, const SpanSet *ss)
   if (! ensure_spanset_isof_type(ss, T_TSTZSPANSET))
     return NULL;
 
+  /* Validate the existing skiplist's subtype *before* allocating the
+   * transform, otherwise the early-return on subtype mismatch leaks it. */
+  if (state && ! ensure_same_skiplist_subtype(state, TSEQUENCE))
+    return NULL;
   TSequence **sequences = tstzspanset_transform_tcount(ss);
   if (! state)
     state = temporal_skiplist_make();
-  else
-  {
-    if (! ensure_same_skiplist_subtype(state, TSEQUENCE))
-      return NULL;
-  }
   for (int i = 0; i < ss->count; i++)
   {
     temporal_skiplist_splice(state, (void **) &sequences[i], 1,

--- a/meos/src/temporal/tinstant.c
+++ b/meos/src/temporal/tinstant.c
@@ -220,6 +220,7 @@ tinstant_make(Datum value, MeosType temptype, TimestampTz t)
   size_t size = value_offset;
   /* Create the temporal instant */
   size_t value_size;
+  size_t value_copy_size;
   void *value_from;
   MeosType basetype = temptype_basetype(temptype);
   bool typbyval = basetype_byvalue(basetype);
@@ -228,6 +229,7 @@ tinstant_make(Datum value, MeosType temptype, TimestampTz t)
   {
     /* For base types passed by value */
     value_size = DOUBLE_PAD(sizeof(Datum));
+    value_copy_size = sizeof(Datum);
     value_from = &value;
   }
   else
@@ -235,13 +237,24 @@ tinstant_make(Datum value, MeosType temptype, TimestampTz t)
     /* For base types passed by reference */
     int16 typlen = meostype_length(basetype);
     value_from = DatumGetPointer(value);
-    value_size = (typlen != -1) ? DOUBLE_PAD((unsigned int) typlen) :
-      DOUBLE_PAD(VARSIZE(value_from));
+    if (typlen != -1)
+    {
+      value_size = DOUBLE_PAD((unsigned int) typlen);
+      value_copy_size = (unsigned int) typlen;
+    }
+    else
+    {
+      value_copy_size = VARSIZE(value_from);
+      value_size = DOUBLE_PAD(value_copy_size);
+    }
   }
   size += value_size;
   TInstant *result = palloc0(size);
   void *value_to = ((char *) result) + value_offset;
-  memcpy(value_to, value_from, value_size);
+  /* Copy only the actual value bytes; palloc0 already zeroed any DOUBLE_PAD
+   * trailing bytes in the destination, so reading past the source object
+   * (which may be a tightly-allocated varlena) is unnecessary and unsafe. */
+  memcpy(value_to, value_from, value_copy_size);
   /* Initialize fixed-size values */
   result->temptype = temptype;
   result->subtype = TINSTANT;

--- a/meos/src/temporal/tsequenceset.c
+++ b/meos/src/temporal/tsequenceset.c
@@ -465,11 +465,17 @@ ensure_valid_tinstarr_gaps(TInstant **instants, int count, bool merge,
     if (! ensure_increasing_timestamps(instants[i - 1], instants[i], merge) ||
         ! ensure_spatial_validity((Temporal *) instants[i - 1],
           (Temporal *) instants[i]))
+    {
+      pfree(result);
       return NULL;
+    }
 #if NPOINT
     if (instants[i]->temptype == T_TNPOINT &&
         ! ensure_same_rid_tnpointinst(instants[i - 1], instants[i]))
+    {
+      pfree(result);
       return NULL;
+    }
 #endif
     /* Determine if there should be a split */
     bool split = false;

--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -347,6 +347,9 @@ parse_mfjson_values(json_object *mfjson, MeosType temptype, int *count)
     return NULL;
   }
   Datum *values = palloc(sizeof(Datum) * nvalues);
+  /* Track whether the base type is by-reference so the cleanup paths know
+   * whether to walk @p values[0..i-1] before freeing the array */
+  bool typbyref = (temptype == T_TTEXT);
   for (int i = 0; i < nvalues; ++i)
   {
     json_object *jvalue = NULL;
@@ -356,6 +359,7 @@ parse_mfjson_values(json_object *mfjson, MeosType temptype, int *count)
       case T_TBOOL:
         if (json_object_get_type(jvalue) != json_type_boolean)
         {
+          pfree(values);
           meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
             "Invalid boolean value in 'values' array in MFJSON string");
           return NULL;
@@ -365,6 +369,7 @@ parse_mfjson_values(json_object *mfjson, MeosType temptype, int *count)
       case T_TINT:
         if (json_object_get_type(jvalue) != json_type_int)
         {
+          pfree(values);
           meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
             "Invalid integer value in 'values' array in MFJSON string");
           return NULL;
@@ -377,6 +382,12 @@ parse_mfjson_values(json_object *mfjson, MeosType temptype, int *count)
       case T_TTEXT:
         if (json_object_get_type(jvalue) != json_type_string)
         {
+          if (typbyref)
+          {
+            for (int j = 0; j < i; j++)
+              pfree(DatumGetPointer(values[j]));
+          }
+          pfree(values);
           meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
             "Invalid string value in 'values' array in MFJSON string");
           return NULL;
@@ -384,6 +395,7 @@ parse_mfjson_values(json_object *mfjson, MeosType temptype, int *count)
         values[i] = PointerGetDatum(cstring2text(json_object_get_string(jvalue)));
         break;
       default: /* Error! */
+        pfree(values);
         meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
           "Unknown temporal type in MFJSON string: %s",
           meostype_name(temptype));
@@ -476,6 +488,9 @@ parse_mfjson_geos(json_object *mfjson, int32_t srid, bool geodetic, int *count)
     LWGEOM *geo = parse_geojson(geo_json, &hasz);
     if (! geo)
     {
+      /* Release previously-serialized geometries before bailing */
+      for (int j = 0; j < i; j++)
+        pfree(DatumGetPointer(values[j]));
       pfree(values);
       return NULL;
     }
@@ -679,7 +694,16 @@ parse_mfjson_poses(json_object *mfjson, int32_t srid, int *count)
   for (int i = 0; i < nposes; ++i)
   {
     json_object *pose = json_object_array_get_idx(values_json, i);
-    values[i] = PointerGetDatum(parse_mfjson_pose(pose, srid));
+    Pose *p = parse_mfjson_pose(pose, srid);
+    if (! p)
+    {
+      /* Release previously-decoded poses before bailing */
+      for (int j = 0; j < i; j++)
+        pfree(DatumGetPointer(values[j]));
+      pfree(values);
+      return NULL;
+    }
+    values[i] = PointerGetDatum(p);
   }
   *count = nposes;
   return values;
@@ -779,6 +803,13 @@ tinstant_from_mfjson(json_object *mfjson, bool spatial, int32_t srid,
   TimestampTz *times = parse_mfjson_datetimes(mfjson, &ndates);
   if (nvalues != 1 || ndates != 1)
   {
+    /* Pointer-typed Datums (text, geometry, pose, ...) are not freed by
+     * pfree(values), which only releases the array storage. */
+    if (! basetype_byvalue(temptype_basetype(temptype)))
+    {
+      for (int i = 0; i < nvalues; i++)
+        pfree(DatumGetPointer(values[i]));
+    }
     pfree(values); pfree(times);
     meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
       "Invalid number of elements in '%s' and/or 'datetimes' arrays",
@@ -826,6 +857,14 @@ tinstarr_from_mfjson(json_object *mfjson, bool isgeo, int32_t srid,
   TimestampTz *times = parse_mfjson_datetimes(mfjson, &ndates);
   if (nvalues != ndates)
   {
+    /* Pointer-typed Datums (text, geometry, pose, ...) are not freed by
+     * pfree(values), which only releases the array storage. */
+    if (! basetype_byvalue(temptype_basetype(temptype)))
+    {
+      for (int i = 0; i < nvalues; i++)
+        pfree(DatumGetPointer(values[i]));
+    }
+    pfree(values); pfree(times);
     meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
       "Distinct number of elements in '%s' and 'datetimes' arrays",
       ! isgeo ? "values" : "coordinates");
@@ -1009,7 +1048,10 @@ temporal_from_mfjson(const char *mfjson, MeosType temptype)
   const char *typestr = json_object_get_string(poObjType);
   MeosType jtemptype = T_UNKNOWN;
   if (! ensure_temptype_mfjson(typestr))
+  {
+    json_object_put(poObj);
     return NULL;
+  }
   if (strcmp(typestr, "MovingBoolean") == 0)
     jtemptype = T_TBOOL;
   else if (strcmp(typestr, "MovingInteger") == 0)
@@ -1039,6 +1081,7 @@ temporal_from_mfjson(const char *mfjson, MeosType temptype)
 
   if (temptype != T_UNKNOWN && jtemptype != temptype)
   {
+    json_object_put(poObj);
     meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
       "Invalid 'type' value in MFJSON string, expected: %s, received: %s",
       meostype_name(temptype), meostype_name(jtemptype));
@@ -1054,6 +1097,7 @@ temporal_from_mfjson(const char *mfjson, MeosType temptype)
   json_object *poObjInterp = findMemberByName(poObj, "interpolation");
   if (poObjInterp == NULL)
   {
+    json_object_put(poObj);
     meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
       "Unable to find 'interpolation' in MFJSON string");
     return NULL;
@@ -1110,6 +1154,7 @@ temporal_from_mfjson(const char *mfjson, MeosType temptype)
       gs = parse_mfjson_ref_geo(poObj, srid, false);
       if (! gs)
       {
+        json_object_put(poObj);
         meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
           "Invalid 'geometry' value in MFJSON string");
         return NULL;
@@ -1139,6 +1184,12 @@ temporal_from_mfjson(const char *mfjson, MeosType temptype)
     else
     {
       json_object_put(poObj);
+#if RGEO
+      /* Release the reference geometry parsed earlier when the dispatch
+       * fails after parse_mfjson_ref_geo succeeded */
+      if (gs)
+        pfree(gs);
+#endif /* RGEO */
       meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
         "Invalid 'interpolation' value in MFJSON string");
       return NULL;
@@ -1147,7 +1198,17 @@ temporal_from_mfjson(const char *mfjson, MeosType temptype)
   json_object_put(poObj);
 #if RGEO
   if (temptype_orig == T_TRGEOMETRY && temptype == T_TPOSE)
-    return geo_tpose_to_trgeo(gs, result);
+  {
+    /* @ref geo_tpose_to_trgeo copies @p gs and the temporal pose into the
+     * new value; release the originals here regardless of whether
+     * construction succeeded. Same pattern as the trgeo.c callers. */
+    Temporal *trgeo = geo_tpose_to_trgeo(gs, result);
+    if (gs)
+      pfree(gs);
+    if (result)
+      pfree(result);
+    return trgeo;
+  }
 #endif /* RGEO */
   return result;
 }

--- a/postgres/timezone/pgtz.c
+++ b/postgres/timezone/pgtz.c
@@ -521,10 +521,18 @@ meos_initialize_timezone(const char *tz_str)
 void
 meos_finalize_timezone(void)
 {
+  /* Idempotency: null each slot after destroying it so a second
+   * meos_finalize() call does not double-free. */
   if (session_timezone)
-    pfree(session_timezone); 
+  {
+    pfree(session_timezone);
+    session_timezone = NULL;
+  }
   if (timezone_cache)
+  {
     tzcache_my_destroy(timezone_cache);
+    timezone_cache = NULL;
+  }
   return;
 }
 /*****************************************************************************/


### PR DESCRIPTION
> 👀 **Reviewers**: tier ranking, dependency chains and the standards checklist live in [`doc/contributing/reviewer-guide.md`](https://github.com/MobilityDB/MobilityDB/blob/master/doc/contributing/reviewer-guide.md).

## Summary

Consolidates three related bug-audit fix branches into one reviewable unit:

**Distance paths and finalize functions** (PR #854):
- Make aggregate finalize functions idempotent (`pfree` intermediate results)
- Fix `pfree` of intermediate results in distance paths for geo, npoint, pose, trgeo
- Fix timezone table memory handling in `pgtz.c`

**MFJSON parser leaks** (PR #855):
- Plug memory leaks on early-return paths in `type_in.c`

**Skiplist and aggregate fixes** (PR #856):
- Fix skiplist ownership: don't `pfree` elements owned by the caller
- Fix aggregate transition-value leak in `temporal_aggfuncs.c`
- Fix heap-buffer-overflow in `tinstant_make` (off-by-one in value copy)
- Fix `TSequenceSet` iteration bounds in `tsequenceset.c`
- Fix `tpoint_spatialfuncs.c` double-free on error path
- Add `meos.yml` CI valgrind step to catch future regressions

All three source PRs are CI-green. Consolidating saves 2 review slots; close #854, #855, and #856.

## Test plan

- [ ] MEOS smoke tests pass under valgrind
- [ ] CI green on all PG versions
- [ ] No regressions in aggregate / distance query tests