### PR TITLE
refactor(meos): SkipListType enum prefix + tpose/trgeo function renames

### DIFF
--- a/meos/examples/ais_expand_skiplist.c
+++ b/meos/examples/ais_expand_skiplist.c
@@ -308,7 +308,7 @@ int main(void)
     if (pos < 0)
     {
       skiplist_splice(list, NULL, (void **) &newrec_p, 1, NULL, false,
-        KEYVALUE);
+        SKIPLIST_KEYVALUE);
       pos = skiplist_search(list, NULL, (void *)(&newrec));
     }
     SkipListElem *e = (SkipListElem *) &list->elems[pos];

--- a/meos/include/meos_internal.h
+++ b/meos/include/meos_internal.h
@@ -733,13 +733,23 @@ struct SkipList
 };
 
 /**
- * @brief Enumeration for the relative position of a given element into a
- * skiplist
+ * @brief Skiplist mode discriminator
+ *
+ * SKIPLIST_TEMPORAL is the legacy mode used by every production aggregate
+ * (temporal_aggfuncs.c, tgeo_aggfuncs.c, tnpoint_aggfuncs.c); elements are
+ * Temporal* values and merging routes through tsequence_tagg.
+ *
+ * SKIPLIST_KEYVALUE is the (key, value)-pair mode used by MEOS-direct
+ * streaming consumers (see meos/examples/ais_expand_skiplist.c). The
+ * supported pattern is search-then-splice-on-miss with caller-managed
+ * in-place mutation via the user-supplied merge_fn. The batch-merge code
+ * path inside keyval_skiplist_merge is unvalidated and contains known
+ * correctness bugs (1-4 in doc/drafts/keyval_skiplist_continuation_plan.md).
  */
 typedef enum
 {
-  TEMPORAL,
-  KEYVALUE
+  SKIPLIST_TEMPORAL,
+  SKIPLIST_KEYVALUE
 } SkipListType;
 
 /*****************************************************************************

--- a/meos/include/meos_pose.h
+++ b/meos/include/meos_pose.h
@@ -219,7 +219,7 @@ Temporal *tpose_in(const char *str);
  *****************************************************************************/
 
 extern Temporal *tpose_make(const Temporal *tpoint, const Temporal *tradius);
-extern Temporal *tpose_to_tpoint(const Temporal *temp);
+extern Temporal *tpose_to_tgeompoint(const Temporal *temp);
 
 /*****************************************************************************
  * Accessor functions
@@ -251,7 +251,7 @@ extern Temporal *tpose_minus_stbox(const Temporal *temp, const STBox *box, bool 
  *****************************************************************************/
 
 extern Temporal *tdistance_tpose_pose(const Temporal *temp, const Pose *pose);
-extern Temporal *tdistance_tpose_point(const Temporal *temp, const GSERIALIZED *gs);
+extern Temporal *tdistance_tpose_geo(const Temporal *temp, const GSERIALIZED *gs);
 extern Temporal *tdistance_tpose_tpose(const Temporal *temp1, const Temporal *temp2);
 extern double nad_tpose_geo(const Temporal *temp, const GSERIALIZED *gs);
 extern double nad_tpose_pose(const Temporal *temp, const Pose *pose);

--- a/meos/include/meos_rgeo.h
+++ b/meos/include/meos_rgeo.h
@@ -88,7 +88,7 @@ extern Temporal *geo_tpose_to_trgeo(const GSERIALIZED *gs, const Temporal *temp)
  *****************************************************************************/
 
 extern Temporal *trgeo_to_tpose(const Temporal *temp);
-extern Temporal *trgeo_to_tpoint(const Temporal *temp);
+extern Temporal *trgeo_to_tgeompoint(const Temporal *temp);
 
 /*****************************************************************************
  * Accessor functions

--- a/meos/src/pose/tpose.c
+++ b/meos/src/pose/tpose.c
@@ -395,11 +395,11 @@ tpose_make(const Temporal *tpoint, const Temporal *tradius)
 
 /**
  * @ingroup meos_pose_conversion
- * @brief Return a geometry point from a temporal pose
+ * @brief Return a temporal geometry point from a temporal pose
  * @param[in] temp Temporal pose
  */
 Temporal *
-tpose_to_tpoint(const Temporal *temp)
+tpose_to_tgeompoint(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TPOSE(temp, NULL);

--- a/meos/src/pose/tpose_distance.c
+++ b/meos/src/pose/tpose_distance.c
@@ -51,16 +51,16 @@
  * @brief Return the temporal distance between a geometry and a temporal pose
  * @param[in] temp Temporal pose
  * @param[in] gs Geometry
- * @csqlfn #Tdistance_tpose_point()
+ * @csqlfn #Tdistance_tpose_geo()
  */
 Temporal *
-tdistance_tpose_point(const Temporal *temp, const GSERIALIZED *gs)
+tdistance_tpose_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tpose_geo(temp, gs) || gserialized_is_empty(gs))
     return NULL;
 
-  Temporal *tpoint = tpose_to_tpoint(temp);
+  Temporal *tpoint = tpose_to_tgeompoint(temp);
   Temporal *result = tdistance_tgeo_geo((const Temporal *) tpoint, gs);
   pfree(tpoint);
   return result;
@@ -81,7 +81,7 @@ tdistance_tpose_pose(const Temporal *temp, const Pose *pose)
     return NULL;
 
   GSERIALIZED *geom = pose_to_point(pose);
-  Temporal *tpoint = tpose_to_tpoint(temp);
+  Temporal *tpoint = tpose_to_tgeompoint(temp);
   Temporal *result = tdistance_tgeo_geo(tpoint, geom);
   pfree(geom);
   return result;
@@ -100,8 +100,8 @@ tdistance_tpose_tpose(const Temporal *temp1, const Temporal *temp2)
   if (! ensure_valid_tpose_tpose(temp1, temp2))
     return NULL;
 
-  Temporal *tpoint1 = tpose_to_tpoint(temp1);
-  Temporal *tpoint2 = tpose_to_tpoint(temp2);
+  Temporal *tpoint1 = tpose_to_tgeompoint(temp1);
+  Temporal *tpoint2 = tpose_to_tgeompoint(temp2);
   Temporal *result = tdistance_tgeo_tgeo(tpoint1, tpoint2);
   pfree(tpoint1); pfree(tpoint2);
   return result;
@@ -126,7 +126,7 @@ nai_tpose_geo(const Temporal *temp, const GSERIALIZED *gs)
   if (! ensure_valid_tpose_geo(temp, gs) || gserialized_is_empty(gs))
     return NULL;
 
-  Temporal *tpoint = tpose_to_tpoint(temp);
+  Temporal *tpoint = tpose_to_tgeompoint(temp);
   TInstant *resultgeom = nai_tgeo_geo(tpoint, gs);
   /* We do not call the function tgeompointinst_tposeinst to avoid
    * roundoff errors. The closest point may be at an exclusive bound. */
@@ -152,7 +152,7 @@ nai_tpose_pose(const Temporal *temp, const Pose *pose)
     return NULL;
 
   GSERIALIZED *geom = pose_to_point(pose);
-  Temporal *tpoint = tpose_to_tpoint(temp);
+  Temporal *tpoint = tpose_to_tgeompoint(temp);
   TInstant *res = nai_tgeo_geo(tpoint, geom);
   /* We do not call the function tgeompointinst_tposeinst to avoid
    * roundoff errors. The closest point may be at an exclusive bound. */
@@ -337,8 +337,8 @@ shortestline_tpose_tpose(const Temporal *temp1, const Temporal *temp2)
   if (! ensure_valid_tpose_tpose(temp1, temp2))
     return NULL;
 
-  Temporal *tpoint1 = tpose_to_tpoint(temp1);
-  Temporal *tpoint2 = tpose_to_tpoint(temp2);
+  Temporal *tpoint1 = tpose_to_tgeompoint(temp1);
+  Temporal *tpoint2 = tpose_to_tgeompoint(temp2);
   GSERIALIZED *result = shortestline_tgeo_tgeo(tpoint1, tpoint2);
   pfree(tpoint1); pfree(tpoint2);
   return result;

--- a/meos/src/pose/tpose_spatialfuncs.c
+++ b/meos/src/pose/tpose_spatialfuncs.c
@@ -62,7 +62,7 @@ tpose_trajectory(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TPOSE(temp, NULL);
-  Temporal *tpoint = tpose_to_tpoint(temp);
+  Temporal *tpoint = tpose_to_tgeompoint(temp);
   GSERIALIZED *result = tpoint_trajectory(tpoint, UNARY_UNION_NO);
   pfree(tpoint);
   return result;
@@ -87,7 +87,7 @@ tpose_restrict_geom(const Temporal *temp, const GSERIALIZED *gs, bool atfunc)
   if (gserialized_is_empty(gs))
     return atfunc ? NULL : temporal_copy(temp);
 
-  Temporal *tpoint = tpose_to_tpoint(temp);
+  Temporal *tpoint = tpose_to_tgeompoint(temp);
   Temporal *res = tgeo_restrict_geom(tpoint, gs, atfunc);
   Temporal *result = NULL;
   if (res)
@@ -148,7 +148,7 @@ tpose_restrict_stbox(const Temporal *temp, const STBox *box, bool border_inc,
   if (! ensure_valid_tpose_stbox(temp, box))
     return NULL;
 
-  Temporal *tgeom = tpose_to_tpoint(temp);
+  Temporal *tgeom = tpose_to_tgeompoint(temp);
   Temporal *tgeomres = tgeo_restrict_stbox(tgeom, box, border_inc, atfunc);
   Temporal *result = NULL;
   if (tgeomres)

--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -267,12 +267,11 @@ trgeo_to_tpose(const Temporal *temp)
 
 /**
  * @ingroup meos_rgeo_conversion
- * @brief Return a temporal point obtained from the points of the temporal
- * pose of a temporal rigid geometry
+ * @brief Return a temporal geometry point from a temporal rigid geometry
  * @param[in] temp Temporal rigid geometry
  */
 Temporal *
-trgeo_to_tpoint(const Temporal *temp)
+trgeo_to_tgeompoint(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);

--- a/meos/src/temporal/skiplist.c
+++ b/meos/src/temporal/skiplist.c
@@ -597,7 +597,7 @@ skiplist_splice(SkipList *list, void **keys, void **values, int count,
     /* Determine the elements that will be spliced-out (if any) */
     int lower, upper;
 #if MEOS
-    spliced_count = (sktype == TEMPORAL) ?
+    spliced_count = (sktype == SKIPLIST_TEMPORAL) ?
       temporal_skiplist_common(list, values, count, &lower, &upper, update) :
       keyval_skiplist_common(list, keys, values, count, &lower, &upper, update);
 #else
@@ -645,7 +645,7 @@ skiplist_splice(SkipList *list, void **keys, void **values, int count,
       int newcount = 0;
       void **newkeys = NULL;
 #if MEOS
-      void **newvalues = (sktype == TEMPORAL) ?
+      void **newvalues = (sktype == SKIPLIST_TEMPORAL) ?
         temporal_skiplist_merge(spliced_vals, spliced_count, values, count,
           func, crossings, &newcount, &tofree, &nfree) :
         keyval_skiplist_merge(list, spliced_keys, spliced_vals, spliced_count,
@@ -696,7 +696,7 @@ skiplist_splice(SkipList *list, void **keys, void **values, int count,
 #if ! MEOS
     MemoryContext oldctx = set_aggregation_context(fetch_fcinfo());
 #endif /* ! MEOS */
-    if (sktype == TEMPORAL)
+    if (sktype == SKIPLIST_TEMPORAL)
     {
       newelem->value = temporal_copy(values[i]);
     }

--- a/meos/src/temporal/temporal_aggfuncs.c
+++ b/meos/src/temporal/temporal_aggfuncs.c
@@ -363,7 +363,8 @@ void
 temporal_skiplist_splice(SkipList *list, void **values, int count,
   datum_func2 func, bool crossings)
 {
-  return skiplist_splice(list, NULL, values, count, func, crossings, TEMPORAL);
+  return skiplist_splice(list, NULL, values, count, func, crossings,
+    SKIPLIST_TEMPORAL);
 }
 
 /*****************************************************************************

--- a/mobilitydb/sql/pose/113_tpose_distance.in.sql
+++ b/mobilitydb/sql/pose/113_tpose_distance.in.sql
@@ -42,7 +42,7 @@ CREATE FUNCTION tDistance(pose, tpose)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION tDistance(tpose, geometry(Point))
   RETURNS tfloat
-  AS 'MODULE_PATHNAME', 'Tdistance_tpose_point'
+  AS 'MODULE_PATHNAME', 'Tdistance_tpose_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION tDistance(tpose, pose)
   RETURNS tfloat

--- a/mobilitydb/sql/rgeo/122_trgeo.in.sql
+++ b/mobilitydb/sql/rgeo/122_trgeo.in.sql
@@ -207,7 +207,7 @@ CREATE FUNCTION tpose(trgeometry)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION tgeompoint(trgeometry)
   RETURNS tgeompoint
-  AS 'MODULE_PATHNAME', 'Trgeometry_to_tpoint'
+  AS 'MODULE_PATHNAME', 'Trgeometry_to_tgeompoint'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE CAST (trgeometry AS tpose) WITH FUNCTION tpose(trgeometry);

--- a/mobilitydb/src/pose/tpose.c
+++ b/mobilitydb/src/pose/tpose.c
@@ -134,7 +134,7 @@ Datum
 Tpose_to_tgeompoint(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
-  Temporal *result = tpose_to_tpoint(temp);
+  Temporal *result = tpose_to_tgeompoint(temp);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_POINTER(result);
 }

--- a/mobilitydb/src/pose/tpose_distance.c
+++ b/mobilitydb/src/pose/tpose_distance.c
@@ -61,7 +61,7 @@ Tdistance_point_tpose(PG_FUNCTION_ARGS)
 {
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(0);
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
-  Temporal *result = tdistance_tpose_point(temp, gs);
+  Temporal *result = tdistance_tpose_geo(temp, gs);
   PG_FREE_IF_COPY(gs, 0);
   PG_FREE_IF_COPY(temp, 1);
   if (! result)
@@ -69,8 +69,8 @@ Tdistance_point_tpose(PG_FUNCTION_ARGS)
   PG_RETURN_TEMPORAL_P(result);
 }
 
-PGDLLEXPORT Datum Tdistance_tpose_point(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Tdistance_tpose_point);
+PGDLLEXPORT Datum Tdistance_tpose_geo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tdistance_tpose_geo);
 /**
  * @ingroup mobilitydb_pose_dist
  * @brief Return the temporal distance between a temporal pose and a geometry
@@ -79,11 +79,11 @@ PG_FUNCTION_INFO_V1(Tdistance_tpose_point);
  * @sqlop @p <->
  */
 Datum
-Tdistance_tpose_point(PG_FUNCTION_ARGS)
+Tdistance_tpose_geo(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(1);
-  Temporal *result = tdistance_tpose_point(temp, gs);
+  Temporal *result = tdistance_tpose_geo(temp, gs);
   PG_FREE_IF_COPY(temp, 0);
   PG_FREE_IF_COPY(gs, 1);
   if (! result)

--- a/mobilitydb/src/rgeo/trgeo.c
+++ b/mobilitydb/src/rgeo/trgeo.c
@@ -416,18 +416,18 @@ Trgeometry_to_tpose(PG_FUNCTION_ARGS)
   PG_RETURN_POINTER(result);
 }
 
-PGDLLEXPORT Datum Trgeometry_to_tpoint(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Trgeometry_to_tpoint);
+PGDLLEXPORT Datum Trgeometry_to_tgeompoint(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Trgeometry_to_tgeompoint);
 /**
  * @ingroup mobilitydb_rgeo_conversion
  * @brief Convert a temporal rigid geometry into a temporal point 
  * @sqlfn tgeompoint()
  */
 Datum
-Trgeometry_to_tpoint(PG_FUNCTION_ARGS)
+Trgeometry_to_tgeompoint(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
-  Temporal *result = trgeo_to_tpoint(temp);
+  Temporal *result = trgeo_to_tgeompoint(temp);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_POINTER(result);
 }


### PR DESCRIPTION
> 👀 **Reviewers**: tier ranking, dependency chains and the standards checklist live in [`doc/contributing/reviewer-guide.md`](https://github.com/MobilityDB/MobilityDB/blob/master/doc/contributing/reviewer-guide.md).

## Summary

Two independent, pure-rename refactors with no functional changes:

**SkipListType enum prefix** (PR #896):
- Prefix all `SkipListType` enum constants with `SKIPLIST_` to avoid collision with the reserved `TEMPORAL` token
- Updates `skiplist.c`, `temporal_aggfuncs.c`, `meos_internal.h`, and the `ais_expand_skiplist.c` example

**tpose/trgeo function renames** (PR #897):
- Rename ambiguous tpose/trgeo conversion and distance functions so names precisely describe argument/return types
- Updates SQL stubs (`113_tpose_distance.in.sql`, `122_trgeo.in.sql`) and all C call sites in `pose/` and `rgeo/`

No file overlap between the two. Both source PRs are CI-green. Consolidating saves 1 review slot; close #896 and #897.

## Test plan

- [ ] Verify no compilation errors (pure renames, no logic changes)
- [ ] CI green on all PG versions