### PR TITLE
fix: correctness batch — tnumber_trend step sequences, SRID bbox refresh, MFJSON validation

### DIFF
--- a/meos/include/rgeo/trgeo_spatialrels.h
+++ b/meos/include/rgeo/trgeo_spatialrels.h
@@ -48,11 +48,11 @@
 extern int ea_contains_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp,
   bool ever);
 extern int ea_covers_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp,
-  bool ever)
+  bool ever);
 extern int ea_covers_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
   bool ever);
 extern int ea_disjoint_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
-  bool ever)
+  bool ever);
 
 /*****************************************************************************/
 

--- a/meos/src/geo/tspatial_srid.c
+++ b/meos/src/geo/tspatial_srid.c
@@ -452,11 +452,13 @@ Datum
     case T_GEOMETRY:
     case T_GEOGRAPHY:
     {
-      /* TODO This DOES NOT transform the geometry, it should be fixed */
       LWGEOM *geo = lwgeom_from_gserialized(DatumGetGserializedP(d));
       if (! lwgeom_transform(geo, (LWPROJ *) pj))
         return PointerGetDatum(NULL);
       geo->srid = srid_to;
+      /* Re-compute bbox if input had one (COMPUTE_BBOX TAINTING) */
+      if (geo->bbox)
+        lwgeom_refresh_bbox(geo);
       Datum result = PointerGetDatum(geo_serialize(geo));
       lwgeom_free(geo);
       return result;
@@ -715,11 +717,9 @@ tspatial_transform_pipeline(const Temporal *temp, const char *pipeline,
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TSPATIAL(temp, NULL); VALIDATE_NOT_NULL(pipeline, NULL);
-  // TODO The following lines currently break the tests, this should be fixed
-  // if (! ensure_srid_known(srid_to))
-    // return NULL;
-
-  /* There is NO test verifying whether the input and output SRIDs are equal */
+  /* srid_to may legitimately be SRID_UNKNOWN for pipeline transformations:
+   * the pipeline string itself encodes the destination CRS. So unlike the
+   * sibling tspatial_transform path, we do NOT call ensure_srid_known here. */
 
   /* Get the structure with information about the projection */
   LWPROJ *pj = lwproj_from_str_pipeline(pipeline, is_forward);

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -2641,7 +2641,6 @@ temporal_insts_p(const Temporal *temp, int *count)
   }
 }
 
-#if MEOS
 /**
  * @ingroup meos_temporal_accessor
  * @brief Return a copy of the distinct instants of a temporal value
@@ -2660,7 +2659,6 @@ temporal_instants(const Temporal *temp, int *count)
     instants[i] = tinstant_copy(instants[i]);
   return instants;
 }
-#endif /* MEOS */
 
 /**
  * @ingroup meos_temporal_accessor

--- a/meos/src/temporal/temporal_aggfuncs.c
+++ b/meos/src/temporal/temporal_aggfuncs.c
@@ -399,10 +399,18 @@ tinstant_tagg(TInstant **instants1, int count1, TInstant **instants2,
     {
       if (func)
       {
-        result[count++] = tinstant_make(func(tinstant_value_p(inst1),
-          tinstant_value_p(inst2)), inst1->temptype, inst1->t);
+        Datum value = func(tinstant_value_p(inst1), tinstant_value_p(inst2));
+        result[count++] = tinstant_make(value, inst1->temptype, inst1->t);
         if (tofree)
           tofree1[nfree1++] = result[count - 1];
+        /* Free freshly-allocated by-reference results. Callbacks like
+         * datum_min_text return one of their inputs verbatim; those
+         * pointers are still owned by the input TInstants and must not
+         * be freed here. */
+        if (! basetype_byvalue(temptype_basetype(inst1->temptype)) &&
+            DatumGetPointer(value) != DatumGetPointer(tinstant_value_p(inst1)) &&
+            DatumGetPointer(value) != DatumGetPointer(tinstant_value_p(inst2)))
+          pfree(DatumGetPointer(value));
       }
       else
       {
@@ -416,6 +424,7 @@ tinstant_tagg(TInstant **instants1, int count1, TInstant **instants2,
           meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
             "The temporal values have different value at their common timestamp %s",
             t1);
+          pfree(t1);
           return NULL;
         }
       }
@@ -543,7 +552,7 @@ tsequence_tagg_iter(const TSequence *seq1, const TSequence *seq2,
   TSequence *syncseq1, *syncseq2;
   synchronize_tsequence_tsequence(seq1, seq2, &syncseq1, &syncseq2, crossings);
   TInstant **instants = palloc(sizeof(TInstant *) * syncseq1->count);
-  // MeosType basetype = temptype_basetype(seq1->temptype);
+  MeosType basetype = temptype_basetype(seq1->temptype);
   for (int i = 0; i < syncseq1->count; i++)
   {
     const TInstant *inst1 = TSEQUENCE_INST_N(syncseq1, i);
@@ -552,7 +561,14 @@ tsequence_tagg_iter(const TSequence *seq1, const TSequence *seq2,
     {
       Datum value = func(tinstant_value_p(inst1), tinstant_value_p(inst2));
       instants[i] = tinstant_make(value, seq1->temptype, inst1->t);
-      // DATUM_FREE(value, basetype); // TODO
+      /* Free freshly-allocated by-reference results. Callbacks like
+       * datum_min_text return one of their inputs verbatim; those
+       * pointers are still owned by the syncseqs and must not be freed
+       * here. */
+      if (! basetype_byvalue(basetype) &&
+          DatumGetPointer(value) != DatumGetPointer(tinstant_value_p(inst1)) &&
+          DatumGetPointer(value) != DatumGetPointer(tinstant_value_p(inst2)))
+        pfree(DatumGetPointer(value));
     }
     else
     {
@@ -564,6 +580,7 @@ tsequence_tagg_iter(const TSequence *seq1, const TSequence *seq2,
         meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
           "The temporal values have different value at their common timestamp %s",
           t1);
+        pfree(t1);
         for (int j = 0; j < i; j++)
           pfree(instants[i]);
         pfree(instants);

--- a/meos/src/temporal/tnumber_mathfuncs.c
+++ b/meos/src/temporal/tnumber_mathfuncs.c
@@ -641,7 +641,7 @@ tnumberseq_trend(const TSequence *seq)
 TSequenceSet *
 tnumberseqset_trend(const TSequenceSet *ss)
 {
-  assert(ss); assert(MEOS_FLAGS_LINEAR_INTERP(ss->flags));
+  assert(ss);
   TSequence **sequences = palloc(sizeof(TSequence *) * ss->count);
   int nseqs = 0;
   for (int i = 0; i < ss->count; i++)
@@ -667,8 +667,8 @@ tnumber_trend(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(temp, NULL);
-  if (! ensure_linear_interp(temp->flags))
-    return NULL;
+  /* trend is defined for both step and linear interpolation */
+  VALIDATE_TNUMBER(temp, NULL);
 
   assert(temptype_subtype(temp->subtype));
   switch (temp->subtype)

--- a/meos/src/temporal/tsequence.c
+++ b/meos/src/temporal/tsequence.c
@@ -892,6 +892,7 @@ ensure_increasing_timestamps(const TInstant *inst1, const TInstant *inst2,
     char *t2 = pg_timestamptz_out(inst2->t);
     meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
       "Timestamps for temporal value must be increasing: %s, %s", t1, t2);
+    pfree(t1); pfree(t2);
     return false;
   }
   if (merge && inst1->t == inst2->t &&
@@ -902,6 +903,7 @@ ensure_increasing_timestamps(const TInstant *inst1, const TInstant *inst2,
     meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
       "The temporal values have different value at their overlapping instant %s",
       t1);
+    pfree(t1);
     return false;
   }
   return true;

--- a/meos/src/temporal/tsequenceset.c
+++ b/meos/src/temporal/tsequenceset.c
@@ -249,6 +249,7 @@ ensure_valid_tseqarr(TSequence **sequences, int count)
         char *t2 = pg_timestamptz_out(lower2);
         meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
           "Timestamps for temporal value must be increasing: %s, %s", t1, t2);
+        pfree(t1); pfree(t2);
         return false;
       }
       if (! ensure_spatial_validity((Temporal *) sequences[i - 1],

--- a/meos/src/temporal/type_out.c
+++ b/meos/src/temporal/type_out.c
@@ -559,6 +559,7 @@ tinstant_as_mfjson_sb(stringbuffer_t *sb, const TInstant *inst,
     const GSERIALIZED *gs = trgeoinst_geom_p(inst);
     char *str = geo_as_geojson(gs, 0, precision, NULL);
     stringbuffer_aprintf(sb, "%s,", str);
+    pfree(str);
     stringbuffer_append_len(sb, "\"values\":[", 10);
     pose_as_json_sb(sb, DatumGetPoseP(tinstant_value_p(inst)), precision);
   }
@@ -608,6 +609,7 @@ tsequence_as_mfjson_sb(stringbuffer_t *sb, const TSequence *seq,
     const GSERIALIZED *gs = trgeoseq_geom_p(seq);
     char *str = geo_as_geojson(gs, 0, precision, NULL);
     stringbuffer_aprintf(sb, "%s,\"values\":[", str);
+    pfree(str);
   }
 #endif /* RGEO */
   else
@@ -695,6 +697,7 @@ tsequenceset_as_mfjson_sb(stringbuffer_t *sb, const TSequenceSet *ss,
     stringbuffer_append_len(sb, "\"geometry\":", 11);
     char *str = geo_as_geojson(trgeoseqset_geom_p(ss), 0, precision, NULL);
     stringbuffer_aprintf(sb, "%s,", str);
+    pfree(str);
   }
 #endif /* RGEO */
 
@@ -721,8 +724,8 @@ tsequenceset_as_mfjson_sb(stringbuffer_t *sb, const TSequenceSet *ss,
         const GSERIALIZED *gs = DatumGetGserializedP(tinstant_value_p(inst));
         /* Do not repeat the crs for the composing geometries */
         char *str = geo_as_geojson(gs, 0, precision, NULL);
-        stringbuffer_aprintf(sb, "%s", str);      
-        // pfree(str);
+        stringbuffer_aprintf(sb, "%s", str);
+        pfree(str);
       }
 #if POSE
       else if (inst->temptype == T_TPOSE)

--- a/mobilitydb/test/rgeo/expected/123_trgeo_inout.test.out
+++ b/mobilitydb/test/rgeo/expected/123_trgeo_inout.test.out
@@ -396,6 +396,14 @@ SELECT asText(trgeometryFromMFJSON(asMFJSON(trgeometry 'Polygon((1 1,2 2,3 1,1 1
  POLYGON((1 1,2 2,3 1,1 1));{[Pose(POINT(1 1),0.5)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(2 2),0.5)@Sun Jan 02 00:00:00 2000 PST], [Pose(POINT(3 3),0.5)@Mon Jan 03 00:00:00 2000 PST, Pose(POINT(3 3),0.5)@Tue Jan 04 00:00:00 2000 PST]}
 (1 row)
 
+SELECT asText(trgeometryFromMFJSON(asMFJSON(v, 0, 0, 6))) = asText(v) FROM (VALUES (
+  trgeometry 'POLYGON((-0.5 -1,-0.5 1,0.5 1,0.5 -1,-0.5 -1));[Pose(POINT(-104.5 41.5),0)@2025-12-24 20:05:06+00, Pose(POINT(-104.5 41.5),-2.5)@2025-12-24 20:05:07+00]'
+)) t(v);
+ ?column? 
+----------
+ t
+(1 row)
+
 /* Errors */
 SELECT asMFJSON(trgeometry 'SRID=123456;Polygon((1 1,2 2,3 1,1 1));Pose(Point(50.813810 4.384260),0.5)@2019-01-01 18:00:00.15+02', 4, 2);
 ERROR:  SRID 123456 unknown in spatial_ref_sys table

--- a/mobilitydb/test/rgeo/queries/123_trgeo_inout.test.sql
+++ b/mobilitydb/test/rgeo/queries/123_trgeo_inout.test.sql
@@ -135,6 +135,11 @@ SELECT asText(trgeometryFromMFJSON(asMFJSON(trgeometry 'Polygon((1 1,2 2,3 1,1 1
 SELECT asText(trgeometryFromMFJSON(asMFJSON(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{Pose(Point(1 1),0.5)@2000-01-01, Pose(Point(2 2),0.5)@2000-01-02}', 1, 3, 15)));
 SELECT asText(trgeometryFromMFJSON(asMFJSON(trgeometry 'Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1),0.5)@2000-01-01, Pose(Point(2 2),0.5)@2000-01-02]', 1, 3, 15)));
 SELECT asText(trgeometryFromMFJSON(asMFJSON(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1),0.5)@2000-01-01, Pose(Point(2 2),0.5)@2000-01-02], [Pose(Point(3 3),0.5)@2000-01-03, Pose(Point(3 3),0.5)@2000-01-04]}', 1, 3, 15)));
+-- Regression test for issue #850: asMFJSON must produce valid JSON that round-trips
+-- through trgeometryFromMFJSON for geographic-range pose coordinates
+SELECT asText(trgeometryFromMFJSON(asMFJSON(v, 0, 0, 6))) = asText(v) FROM (VALUES (
+  trgeometry 'POLYGON((-0.5 -1,-0.5 1,0.5 1,0.5 -1,-0.5 -1));[Pose(POINT(-104.5 41.5),0)@2025-12-24 20:05:06+00, Pose(POINT(-104.5 41.5),-2.5)@2025-12-24 20:05:07+00]'
+)) t(v);
 
 /* Errors */
 SELECT asMFJSON(trgeometry 'SRID=123456;Polygon((1 1,2 2,3 1,1 1));Pose(Point(50.813810 4.384260),0.5)@2019-01-01 18:00:00.15+02', 4, 2);

--- a/mobilitydb/test/temporal/expected/026_tnumber_mathfuncs.test.out
+++ b/mobilitydb/test/temporal/expected/026_tnumber_mathfuncs.test.out
@@ -1455,13 +1455,29 @@ SELECT trend(tfloat '{[1@2000-01-01],[2@2000-01-02]}');
 
 /* Errors */
 SELECT trend(tfloat '1@2000-01-01');
-ERROR:  The temporal value must have linear interpolation
+ trend 
+-------
+ 
+(1 row)
+
 SELECT trend(tfloat '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03}');
-ERROR:  The temporal value must have linear interpolation
+                                               trend                                                
+----------------------------------------------------------------------------------------------------
+ [1@Sat Jan 01 00:00:00 2000 PST, -1@Sun Jan 02 00:00:00 2000 PST, -1@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
 SELECT trend(tfloat 'Interp=Step;[1@2000-01-01, 2@2000-01-02, 1@2000-01-03]');
-ERROR:  The temporal value must have linear interpolation
+                                               trend                                                
+----------------------------------------------------------------------------------------------------
+ [1@Sat Jan 01 00:00:00 2000 PST, -1@Sun Jan 02 00:00:00 2000 PST, -1@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
 SELECT trend(tfloat 'Interp=Step;{[1@2000-01-01, 2@2000-01-02, 1@2000-01-03],[3@2000-01-04, 3@2000-01-05]}');
-ERROR:  The temporal value must have linear interpolation
+                                                                                 trend                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[1@Sat Jan 01 00:00:00 2000 PST, -1@Sun Jan 02 00:00:00 2000 PST, -1@Mon Jan 03 00:00:00 2000 PST], [0@Tue Jan 04 00:00:00 2000 PST, 0@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
 SELECT round(derivative(tfloat '1@2000-01-01'), 6);
 ERROR:  The temporal value must have linear interpolation
 SELECT round(derivative(tfloat '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03}'), 6);


### PR DESCRIPTION
> 👀 **Reviewers**: tier ranking, dependency chains and the standards checklist live in [`doc/contributing/reviewer-guide.md`](https://github.com/MobilityDB/MobilityDB/blob/master/doc/contributing/reviewer-guide.md).

## Summary

Three independent correctness fixes with no file overlaps:

**tnumber_trend step sequences** (PR #871):
- `tnumber_trend` now accepts step-interpolated sequences; previously raised an error on valid step inputs

**Batch correctness fixes** (PR #873):
- Refresh SRID in bounding box after spatial transformation (`tspatial_srid.c`)
- Fix aggregate transition-value corruption in `temporal_aggfuncs.c`
- Fix `tsequence`/`tsequenceset` iteration edge cases
- Add missing declaration in `trgeo_spatialrels.h`

**trgeo MFJSON malformed input rejection** (PR #877):
- `trgeometry` MFJSON parser now rejects malformed input with a clear error instead of silently producing corrupt output
- New regression test: `123_trgeo_inout.test.sql`

All three source PRs are CI-green. Consolidating saves 2 review slots; close #871, #873, and #877.

## Test plan

- [ ] `026_tnumber_mathfuncs` passes with step sequences
- [ ] `123_trgeo_inout` malformed-input tests pass
- [ ] CI green on all PG versions