### PR TITLE
ci: ban int64_t in public headers + remove stale GEOS version guards

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -24,3 +24,12 @@ jobs:
           sudo apt install -y licensecheck
       - name: Run License Check
         run: ./tools/scripts/test_license.sh
+
+  int64_check:
+    name: int64 vs int64_t header convention
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Reject int64_t / uint64_t in MobilityDB public headers
+        run: ./tools/scripts/check_int64_in_headers.sh

--- a/mobilitydb/test/geo/expected/058_tgeo_tile_tbl.test.out
+++ b/mobilitydb/test/geo/expected/058_tgeo_tile_tbl.test.out
@@ -59,48 +59,48 @@ SELECT extent(getSpaceTile(g, 2.5, geometry 'Point(10 10 10)')) FROM
 (1 row)
 
 SELECT extent(getStboxTimeTile(t, interval '2 days')) FROM
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
                                 extent                                 
 -----------------------------------------------------------------------
- STBOX T([Sat Jan 27 00:00:00 2001 PST, Tue Dec 11 00:00:00 2001 PST))
+ STBOX T([Sat Dec 30 00:00:00 2000 PST, Thu Dec 27 00:00:00 2001 PST))
 (1 row)
 
 SELECT extent(getStboxTimeTile(t, interval '2 days', '2001-06-01')) FROM
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
                                 extent                                 
 -----------------------------------------------------------------------
- STBOX T([Sat Jan 27 23:00:00 2001 PST, Sun Dec 09 23:00:00 2001 PST))
+ STBOX T([Sat Dec 30 23:00:00 2000 PST, Thu Dec 27 23:00:00 2001 PST))
 (1 row)
 
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days')) FROM
 (SELECT * FROM tbl_geom_point WHERE g IS NOT NULL AND NOT ST_IsEmpty(g) LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
                                             extent                                            
 ----------------------------------------------------------------------------------------------
- STBOX XT(((17.5,5),(100,97.5)),[Sat Jan 27 00:00:00 2001 PST, Tue Dec 11 00:00:00 2001 PST))
+ STBOX XT(((17.5,5),(100,97.5)),[Sat Dec 30 00:00:00 2000 PST, Thu Dec 27 00:00:00 2001 PST))
 (1 row)
 
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days', geometry 'Point(10 10)', '2001-06-01')) FROM
 (SELECT * FROM tbl_geom_point WHERE g IS NOT NULL AND NOT ST_IsEmpty(g) LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
                                             extent                                            
 ----------------------------------------------------------------------------------------------
- STBOX XT(((17.5,5),(100,97.5)),[Sat Jan 27 23:00:00 2001 PST, Sun Dec 09 23:00:00 2001 PST))
+ STBOX XT(((17.5,5),(100,97.5)),[Sat Dec 30 23:00:00 2000 PST, Thu Dec 27 23:00:00 2001 PST))
 (1 row)
 
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days')) FROM
 (SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL AND NOT ST_IsEmpty(g) LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
                                                 extent                                                
 ------------------------------------------------------------------------------------------------------
- STBOX ZT(((10,2.5,2.5),(80,97.5,67.5)),[Sat Jan 27 00:00:00 2001 PST, Tue Dec 11 00:00:00 2001 PST))
+ STBOX ZT(((10,2.5,2.5),(80,97.5,67.5)),[Sat Dec 30 00:00:00 2000 PST, Thu Dec 27 00:00:00 2001 PST))
 (1 row)
 
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days', geometry 'Point(10 10 10)', '2001-06-01')) FROM
 (SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL AND NOT ST_IsEmpty(g) LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
                                                 extent                                                
 ------------------------------------------------------------------------------------------------------
- STBOX ZT(((10,2.5,2.5),(80,97.5,67.5)),[Sat Jan 27 23:00:00 2001 PST, Sun Dec 09 23:00:00 2001 PST))
+ STBOX ZT(((10,2.5,2.5),(80,97.5,67.5)),[Sat Dec 30 23:00:00 2000 PST, Thu Dec 27 23:00:00 2001 PST))
 (1 row)
 

--- a/mobilitydb/test/geo/expected/058_tpoint_tile_tbl.test.out
+++ b/mobilitydb/test/geo/expected/058_tpoint_tile_tbl.test.out
@@ -31,76 +31,76 @@ SELECT spaceTimeTiles(b, 2.5, interval '1 week', 'Point(10 10)', '2001-06-01'), 
 (3 rows)
 
 SELECT extent(getSpaceTile(g, 2.5)) FROM
-(SELECT * FROM tbl_geom_point WHERE g IS NOT NULL LIMIT 10) t1;
-             extent             
---------------------------------
- STBOX X((2.5,2.5),(92.5,92.5))
+(SELECT * FROM tbl_geom_point WHERE g IS NOT NULL) t1;
+          extent          
+--------------------------
+ STBOX X((0,0),(100,100))
 (1 row)
 
 SELECT extent(getSpaceTile(g, 2.5, geometry 'Point(10 10)')) FROM
-(SELECT * FROM tbl_geom_point WHERE g IS NOT NULL LIMIT 10) t1;
-             extent             
---------------------------------
- STBOX X((2.5,2.5),(92.5,92.5))
+(SELECT * FROM tbl_geom_point WHERE g IS NOT NULL) t1;
+          extent          
+--------------------------
+ STBOX X((0,0),(100,100))
 (1 row)
 
 SELECT extent(getSpaceTile(g, 2.5)) FROM
-(SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL LIMIT 10) t1;
-                extent                
---------------------------------------
- STBOX Z((2.5,10,0),(72.5,92.5,97.5))
+(SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL) t1;
+             extent             
+--------------------------------
+ STBOX Z((0,0,0),(100,100,100))
 (1 row)
 
 SELECT extent(getSpaceTile(g, 2.5, geometry 'Point(10 10 10)')) FROM
-(SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL LIMIT 10) t1;
-                extent                
---------------------------------------
- STBOX Z((2.5,10,0),(72.5,92.5,97.5))
+(SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL) t1;
+             extent             
+--------------------------------
+ STBOX Z((0,0,0),(100,100,100))
 (1 row)
 
 SELECT extent(getStboxTimeTile(t, interval '2 days')) FROM
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
                                 extent                                 
 -----------------------------------------------------------------------
- STBOX T([Sat Jan 27 00:00:00 2001 PST, Tue Dec 11 00:00:00 2001 PST))
+ STBOX T([Sat Dec 30 00:00:00 2000 PST, Thu Dec 27 00:00:00 2001 PST))
 (1 row)
 
 SELECT extent(getStboxTimeTile(t, interval '2 days', '2001-06-01')) FROM
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
                                 extent                                 
 -----------------------------------------------------------------------
- STBOX T([Sat Jan 27 23:00:00 2001 PST, Sun Dec 09 23:00:00 2001 PST))
+ STBOX T([Sat Dec 30 23:00:00 2000 PST, Thu Dec 27 23:00:00 2001 PST))
 (1 row)
 
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days')) FROM
 (SELECT * FROM tbl_geom_point WHERE g IS NOT NULL LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
                                             extent                                            
 ----------------------------------------------------------------------------------------------
- STBOX XT(((17.5,5),(100,97.5)),[Sat Jan 27 00:00:00 2001 PST, Tue Dec 11 00:00:00 2001 PST))
+ STBOX XT(((17.5,5),(100,97.5)),[Sat Dec 30 00:00:00 2000 PST, Thu Dec 27 00:00:00 2001 PST))
 (1 row)
 
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days', geometry 'Point(10 10)', '2001-06-01')) FROM
 (SELECT * FROM tbl_geom_point WHERE g IS NOT NULL LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
                                             extent                                            
 ----------------------------------------------------------------------------------------------
- STBOX XT(((17.5,5),(100,97.5)),[Sat Jan 27 23:00:00 2001 PST, Sun Dec 09 23:00:00 2001 PST))
+ STBOX XT(((17.5,5),(100,97.5)),[Sat Dec 30 23:00:00 2000 PST, Thu Dec 27 23:00:00 2001 PST))
 (1 row)
 
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days')) FROM
 (SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
                                                 extent                                                
 ------------------------------------------------------------------------------------------------------
- STBOX ZT(((10,2.5,2.5),(80,97.5,67.5)),[Sat Jan 27 00:00:00 2001 PST, Tue Dec 11 00:00:00 2001 PST))
+ STBOX ZT(((10,2.5,2.5),(80,97.5,67.5)),[Sat Dec 30 00:00:00 2000 PST, Thu Dec 27 00:00:00 2001 PST))
 (1 row)
 
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days', geometry 'Point(10 10 10)', '2001-06-01')) FROM
 (SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
                                                 extent                                                
 ------------------------------------------------------------------------------------------------------
- STBOX ZT(((10,2.5,2.5),(80,97.5,67.5)),[Sat Jan 27 23:00:00 2001 PST, Sun Dec 09 23:00:00 2001 PST))
+ STBOX ZT(((10,2.5,2.5),(80,97.5,67.5)),[Sat Dec 30 23:00:00 2000 PST, Thu Dec 27 23:00:00 2001 PST))
 (1 row)
 

--- a/mobilitydb/test/geo/expected/064_tgeo_distance_tbl.test.out
+++ b/mobilitydb/test/geo/expected/064_tgeo_distance_tbl.test.out
@@ -82,20 +82,18 @@ WHERE t1.temp <-> t2.temp IS NOT NULL ORDER BY 1 LIMIT 10;
      0
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry,
-( SELECT * FROM tbl_geometry LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry t
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry t1,
-( SELECT * FROM tbl_tgeometry t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2
 WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    10
+   104
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry3D, tbl_geometry3D
@@ -112,20 +110,18 @@ WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
    102
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeography,
-( SELECT * FROM tbl_geography LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeography, tbl_geography t
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
  count 
 -------
-  1000
+ 10000
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeography t1,
-( SELECT * FROM tbl_tgeography t2  LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography t1, tbl_tgeography t2
 WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    10
+   104
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeography3D, tbl_geography3D
@@ -142,187 +138,164 @@ WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
    100
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry,
-( SELECT * FROM tbl_geometry LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry t1,
-( SELECT * FROM tbl_tgeometry t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    10
+   104
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry3D,
-( SELECT * FROM tbl_geometry3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry3D, tbl_geometry3D t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry3D t1,
-( SELECT * FROM tbl_tgeometry3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry3D t1, tbl_tgeometry3D t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    10
+   102
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeography,
-( SELECT * FROM tbl_geography LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeography, tbl_geography t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
  count 
 -------
-  1000
+ 10000
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeography t1,
-( SELECT * FROM tbl_tgeography t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography t1, tbl_tgeography t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    10
+   104
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeography3D,
-( SELECT * FROM tbl_geography3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeography3D, tbl_geography3D t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
  count 
 -------
-  1000
+ 10000
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeography3D t1,
-( SELECT * FROM tbl_tgeography3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography3D t1, tbl_tgeography3D t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    10
+   100
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry,
-( SELECT * FROM tbl_geometry LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry t
 WHERE g |=| temp IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry t1,
-( SELECT * FROM tbl_tgeometry t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
  count 
 -------
-    10
+   104
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry3D,
-( SELECT * FROM tbl_geometry3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry3D, tbl_geometry3D t
 WHERE g |=| temp IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry3D t1,
-(SELECT * FROM tbl_tgeometry3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry3D t1, tbl_tgeometry3D t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
  count 
 -------
-    10
+   102
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeography,
-( SELECT * FROM tbl_geography LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeography, tbl_geography t
 WHERE g |=| temp IS NOT NULL;
  count 
 -------
-  1000
+ 10000
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeography t1,
-( SELECT * FROM tbl_tgeography t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography t1, tbl_tgeography t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
  count 
 -------
-    10
+   104
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeography3D,
-( SELECT * FROM tbl_geography3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeography3D, tbl_geography3D t
 WHERE g |=| temp IS NOT NULL;
  count 
 -------
-  1000
+ 10000
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeography3D t1,
-(SELECT * FROM tbl_tgeography3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography3D t1, tbl_tgeography3D t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
  count 
 -------
-    10
+   100
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry,
-( SELECT * FROM tbl_geometry LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry t
 WHERE shortestLine(g, temp) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry t1,
-( SELECT * FROM tbl_tgeometry t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    10
+   104
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry3D,
-( SELECT * FROM tbl_geometry3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry3D, tbl_geometry3D t
 WHERE shortestLine(g, temp) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry3D t1,
-( SELECT * FROM tbl_tgeometry3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry3D t1, tbl_tgeometry3D t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    10
+   102
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeography,
-( SELECT * FROM tbl_geography LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeography, tbl_geography t
 WHERE shortestLine(g, temp) IS NOT NULL;
  count 
 -------
-  1000
+ 10000
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeography t1,
-( SELECT * FROM tbl_tgeography t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography t1, tbl_tgeography t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    10
+   104
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeography3D t1,
-( SELECT * FROM tbl_tgeography3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography3D t1, tbl_tgeography3D t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    10
+   100
 (1 row)
 

--- a/mobilitydb/test/geo/expected/064_tpoint_distance_tbl.test.out
+++ b/mobilitydb/test/geo/expected/064_tpoint_distance_tbl.test.out
@@ -82,20 +82,18 @@ WHERE t1.temp <-> t2.temp IS NOT NULL ORDER BY 1 LIMIT 10;
  3731547.354944
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint,
-( SELECT * FROM tbl_geom LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint t1,
-( SELECT * FROM tbl_tgeompoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2
 WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    18
+   152
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint3D, tbl_geom3D
@@ -112,20 +110,18 @@ WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
    150
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeogpoint,
-( SELECT * FROM tbl_geog LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeogpoint, tbl_geog t
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeogpoint t1,
-( SELECT * FROM tbl_tgeogpoint t2  LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_tgeogpoint t2
 WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    18
+   148
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeogpoint3D, tbl_geog3D
@@ -142,187 +138,164 @@ WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
    150
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint,
-( SELECT * FROM tbl_geom LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint t1,
-( SELECT * FROM tbl_tgeompoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    18
+   152
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint3D,
-( SELECT * FROM tbl_geom3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint3D, tbl_geom3D t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint3D t1,
-( SELECT * FROM tbl_tgeompoint3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    18
+   150
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeogpoint,
-( SELECT * FROM tbl_geog LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeogpoint, tbl_geog t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeogpoint t1,
-( SELECT * FROM tbl_tgeogpoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_tgeogpoint t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    18
+   148
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeogpoint3D,
-( SELECT * FROM tbl_geog3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeogpoint3D, tbl_geog3D t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeogpoint3D t1,
-( SELECT * FROM tbl_tgeogpoint3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    18
+   150
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint,
-( SELECT * FROM tbl_geom LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE g |=| temp IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint t1,
-( SELECT * FROM tbl_tgeompoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
  count 
 -------
-    18
+   152
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint3D,
-( SELECT * FROM tbl_geom3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint3D, tbl_geom3D t
 WHERE g |=| temp IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint3D t1,
-(SELECT * FROM tbl_tgeompoint3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
  count 
 -------
-    18
+   150
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeogpoint,
-( SELECT * FROM tbl_geog LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeogpoint, tbl_geog t
 WHERE g |=| temp IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeogpoint t1,
-( SELECT * FROM tbl_tgeogpoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_tgeogpoint t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
  count 
 -------
-    18
+   148
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeogpoint3D,
-( SELECT * FROM tbl_geog3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeogpoint3D, tbl_geog3D t
 WHERE g |=| temp IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeogpoint3D t1,
-(SELECT * FROM tbl_tgeogpoint3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
  count 
 -------
-    18
+   150
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint,
-( SELECT * FROM tbl_geom LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE shortestLine(g, temp) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint t1,
-( SELECT * FROM tbl_tgeompoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    18
+   152
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint3D,
-( SELECT * FROM tbl_geom3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint3D, tbl_geom3D t
 WHERE shortestLine(g, temp) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint3D t1,
-( SELECT * FROM tbl_tgeompoint3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    18
+   150
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeogpoint,
-( SELECT * FROM tbl_geog LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeogpoint, tbl_geog t
 WHERE shortestLine(g, temp) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeogpoint t1,
-( SELECT * FROM tbl_tgeogpoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_tgeogpoint t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    18
+   148
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeogpoint3D t1,
-( SELECT * FROM tbl_tgeogpoint3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    18
+   150
 (1 row)
 

--- a/mobilitydb/test/geo/queries/058_tgeo_tile_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/058_tgeo_tile_tbl.test.sql
@@ -49,24 +49,24 @@ SELECT extent(getSpaceTile(g, 2.5, geometry 'Point(10 10 10)')) FROM
 
 -- Time
 SELECT extent(getStboxTimeTile(t, interval '2 days')) FROM
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
 SELECT extent(getStboxTimeTile(t, interval '2 days', '2001-06-01')) FROM
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
 
 -- 2D
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days')) FROM
 (SELECT * FROM tbl_geom_point WHERE g IS NOT NULL AND NOT ST_IsEmpty(g) LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days', geometry 'Point(10 10)', '2001-06-01')) FROM
 (SELECT * FROM tbl_geom_point WHERE g IS NOT NULL AND NOT ST_IsEmpty(g) LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
 -- 3D
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days')) FROM
 (SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL AND NOT ST_IsEmpty(g) LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days', geometry 'Point(10 10 10)', '2001-06-01')) FROM
 (SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL AND NOT ST_IsEmpty(g) LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
 
 -------------------------------------------------------------------------------
 

--- a/mobilitydb/test/geo/queries/058_tpoint_tile_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/058_tpoint_tile_tbl.test.sql
@@ -38,35 +38,35 @@ SELECT spaceTimeTiles(b, 2.5, interval '1 week', 'Point(10 10)', '2001-06-01'), 
 
 -- 2D
 SELECT extent(getSpaceTile(g, 2.5)) FROM
-(SELECT * FROM tbl_geom_point WHERE g IS NOT NULL LIMIT 10) t1;
+(SELECT * FROM tbl_geom_point WHERE g IS NOT NULL) t1;
 SELECT extent(getSpaceTile(g, 2.5, geometry 'Point(10 10)')) FROM
-(SELECT * FROM tbl_geom_point WHERE g IS NOT NULL LIMIT 10) t1;
+(SELECT * FROM tbl_geom_point WHERE g IS NOT NULL) t1;
 -- 3D
 SELECT extent(getSpaceTile(g, 2.5)) FROM
-(SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL LIMIT 10) t1;
+(SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL) t1;
 SELECT extent(getSpaceTile(g, 2.5, geometry 'Point(10 10 10)')) FROM
-(SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL LIMIT 10) t1;
+(SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL) t1;
 
 -- Time
 SELECT extent(getStboxTimeTile(t, interval '2 days')) FROM
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
 SELECT extent(getStboxTimeTile(t, interval '2 days', '2001-06-01')) FROM
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
 
 -- 2D
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days')) FROM
 (SELECT * FROM tbl_geom_point WHERE g IS NOT NULL LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days', geometry 'Point(10 10)', '2001-06-01')) FROM
 (SELECT * FROM tbl_geom_point WHERE g IS NOT NULL LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
 -- 3D
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days')) FROM
 (SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days', geometry 'Point(10 10 10)', '2001-06-01')) FROM
 (SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
 
 -------------------------------------------------------------------------------
 

--- a/mobilitydb/test/geo/queries/064_tgeo_distance_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/064_tgeo_distance_tbl.test.sql
@@ -61,104 +61,77 @@ WHERE t1.temp <-> t2.temp IS NOT NULL ORDER BY 1 LIMIT 10;
 
 -------------------------------------------------------------------------------
 
-SELECT COUNT(*) FROM tbl_tgeometry,
-( SELECT * FROM tbl_geometry LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry t
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeometry t1,
-( SELECT * FROM tbl_tgeometry t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2
 WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
 SELECT COUNT(*) FROM tbl_tgeometry3D, tbl_geometry3D
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
 SELECT COUNT(*) FROM tbl_tgeometry3D t1, tbl_tgeometry3D t2
 WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeography,
-( SELECT * FROM tbl_geography LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeography, tbl_geography t
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeography t1,
-( SELECT * FROM tbl_tgeography t2  LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography t1, tbl_tgeography t2
 WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
 SELECT COUNT(*) FROM tbl_tgeography3D, tbl_geography3D
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
 SELECT COUNT(*) FROM tbl_tgeography3D t1, tbl_tgeography3D t2
 WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeometry,
-( SELECT * FROM tbl_geometry LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeometry t1,
-( SELECT * FROM tbl_tgeometry t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeometry3D,
-( SELECT * FROM tbl_geometry3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry3D, tbl_geometry3D t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeometry3D t1,
-( SELECT * FROM tbl_tgeometry3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry3D t1, tbl_tgeometry3D t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeography,
-( SELECT * FROM tbl_geography LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeography, tbl_geography t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeography t1,
-( SELECT * FROM tbl_tgeography t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography t1, tbl_tgeography t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeography3D,
-( SELECT * FROM tbl_geography3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeography3D, tbl_geography3D t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeography3D t1,
-( SELECT * FROM tbl_tgeography3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography3D t1, tbl_tgeography3D t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeometry,
-( SELECT * FROM tbl_geometry LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry t
 WHERE g |=| temp IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeometry t1,
-( SELECT * FROM tbl_tgeometry t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeometry3D,
-( SELECT * FROM tbl_geometry3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry3D, tbl_geometry3D t
 WHERE g |=| temp IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeometry3D t1,
-(SELECT * FROM tbl_tgeometry3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry3D t1, tbl_tgeometry3D t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeography,
-( SELECT * FROM tbl_geography LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeography, tbl_geography t
 WHERE g |=| temp IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeography t1,
-( SELECT * FROM tbl_tgeography t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography t1, tbl_tgeography t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeography3D,
-( SELECT * FROM tbl_geography3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeography3D, tbl_geography3D t
 WHERE g |=| temp IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeography3D t1,
-(SELECT * FROM tbl_tgeography3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography3D t1, tbl_tgeography3D t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeometry,
-( SELECT * FROM tbl_geometry LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry t
 WHERE shortestLine(g, temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeometry t1,
-( SELECT * FROM tbl_tgeometry t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeometry3D,
-( SELECT * FROM tbl_geometry3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry3D, tbl_geometry3D t
 WHERE shortestLine(g, temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeometry3D t1,
-( SELECT * FROM tbl_tgeometry3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry3D t1, tbl_tgeometry3D t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeography,
-( SELECT * FROM tbl_geography LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeography, tbl_geography t
 WHERE shortestLine(g, temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeography t1,
-( SELECT * FROM tbl_tgeography t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography t1, tbl_tgeography t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
 -- SELECT COUNT(*) FROM tbl_tgeography3D,
 -- ( SELECT * FROM tbl_geography3D LIMIT 10 ) t
 -- WHERE shortestLine(g, temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeography3D t1,
-( SELECT * FROM tbl_tgeography3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography3D t1, tbl_tgeography3D t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/geo/queries/064_tpoint_distance_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/064_tpoint_distance_tbl.test.sql
@@ -59,104 +59,77 @@ WHERE t1.temp <-> t2.temp IS NOT NULL ORDER BY 1 LIMIT 10;
 
 -------------------------------------------------------------------------------
 
-SELECT COUNT(*) FROM tbl_tgeompoint,
-( SELECT * FROM tbl_geom LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeompoint t1,
-( SELECT * FROM tbl_tgeompoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2
 WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
 SELECT COUNT(*) FROM tbl_tgeompoint3D, tbl_geom3D
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
 SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2
 WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeogpoint,
-( SELECT * FROM tbl_geog LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeogpoint, tbl_geog t
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeogpoint t1,
-( SELECT * FROM tbl_tgeogpoint t2  LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_tgeogpoint t2
 WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
 SELECT COUNT(*) FROM tbl_tgeogpoint3D, tbl_geog3D
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
 SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2
 WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeompoint,
-( SELECT * FROM tbl_geom LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeompoint t1,
-( SELECT * FROM tbl_tgeompoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeompoint3D,
-( SELECT * FROM tbl_geom3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint3D, tbl_geom3D t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeompoint3D t1,
-( SELECT * FROM tbl_tgeompoint3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeogpoint,
-( SELECT * FROM tbl_geog LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeogpoint, tbl_geog t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeogpoint t1,
-( SELECT * FROM tbl_tgeogpoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_tgeogpoint t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeogpoint3D,
-( SELECT * FROM tbl_geog3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeogpoint3D, tbl_geog3D t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeogpoint3D t1,
-( SELECT * FROM tbl_tgeogpoint3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeompoint,
-( SELECT * FROM tbl_geom LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE g |=| temp IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeompoint t1,
-( SELECT * FROM tbl_tgeompoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeompoint3D,
-( SELECT * FROM tbl_geom3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint3D, tbl_geom3D t
 WHERE g |=| temp IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeompoint3D t1,
-(SELECT * FROM tbl_tgeompoint3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeogpoint,
-( SELECT * FROM tbl_geog LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeogpoint, tbl_geog t
 WHERE g |=| temp IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeogpoint t1,
-( SELECT * FROM tbl_tgeogpoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_tgeogpoint t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeogpoint3D,
-( SELECT * FROM tbl_geog3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeogpoint3D, tbl_geog3D t
 WHERE g |=| temp IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeogpoint3D t1,
-(SELECT * FROM tbl_tgeogpoint3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeompoint,
-( SELECT * FROM tbl_geom LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE shortestLine(g, temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeompoint t1,
-( SELECT * FROM tbl_tgeompoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeompoint3D,
-( SELECT * FROM tbl_geom3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint3D, tbl_geom3D t
 WHERE shortestLine(g, temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeompoint3D t1,
-( SELECT * FROM tbl_tgeompoint3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeogpoint,
-( SELECT * FROM tbl_geog LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeogpoint, tbl_geog t
 WHERE shortestLine(g, temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeogpoint t1,
-( SELECT * FROM tbl_tgeogpoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_tgeogpoint t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
 -- SELECT COUNT(*) FROM tbl_tgeogpoint3D,
 -- ( SELECT * FROM tbl_geog3D LIMIT 10 ) t
 -- WHERE shortestLine(g, temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeogpoint3D t1,
-( SELECT * FROM tbl_tgeogpoint3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
 
 --------------------------------------------------------

--- a/tools/scripts/check_int64_in_headers.sh
+++ b/tools/scripts/check_int64_in_headers.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Reject int64_t / uint64_t in MobilityDB public-facing headers.
+#
+# Why
+# ---
+# PostgreSQL's c.h provides int64 / uint64 typedefs that the rest of
+# the codebase uses uniformly. The C99 stdint.h spellings happen to
+# resolve to the same underlying types as PG's aliases on every
+# supported platform for 8 / 16 / 32 bits, so int8_t / int16_t /
+# int32_t and their unsigned variants are interchangeable with the PG
+# aliases there and may legitimately appear in headers (WKB byte
+# arrays, SRIDs, hash codes).
+#
+# The 64-bit case is different. On Linux glibc (LP64) int64_t is
+# typed as 'long int' which matches PG's int64. On macOS Darwin libc
+# (also LP64) int64_t is typed as 'long long int' while PG's int64
+# stays 'long int'. Both are 64 bits and ABI-identical on the wire,
+# but the C type system considers 'long int' and 'long long int' as
+# distinct on macOS, so a function declared with int64_t in a header
+# and defined with int64 in the implementation emits 'conflicting
+# types' on macOS / Clang -- silently fine on Linux because the
+# spellings resolve to the same type there.
+#
+# This rule exists because that exact mix produced a build break on
+# macOS PG 17 in PR #803 after a portability sweep changed 82
+# function signatures in meos.h to int64_t while leaving the
+# implementations on int64. Keeping the 64-bit spellings consistent
+# at the header / implementation boundary is what prevents the
+# regression from recurring.
+#
+# Scope
+# -----
+# Headers under:
+#   meos/include/          -- MEOS standalone API surface
+#   mobilitydb/pg_include/ -- MobilityDB extension internal headers
+#
+# Vendored trees (mobilitydb/postgis, pgtypes) are intentionally
+# excluded -- those follow upstream conventions and are touched only
+# when syncing from upstream PostGIS / PostgreSQL.
+#
+# Implementation files (meos/src, mobilitydb/src) are not scanned --
+# stdint types may legitimately appear in printf format specifiers,
+# hash seeds, and isolated locals where they are well-contained.
+
+set -euo pipefail
+
+violations=$(grep -rEn '\bu?int64_t\b' \
+  meos/include \
+  mobilitydb/pg_include \
+  2>/dev/null || true)
+
+if [ -n "$violations" ]; then
+  cat >&2 <<'EOF'
+ERROR: int64_t / uint64_t found in MobilityDB public headers.
+
+Use int64 / uint64 (PostgreSQL convention) instead. Reason: macOS
+toolchains type int64_t as 'long long int' while PG types int64 as
+'long int' -- both are 64 bits but the C type system treats them as
+distinct, producing 'conflicting types' diagnostics when a header
+declaration and an implementation disagree on which spelling to use.
+
+Offending lines:
+EOF
+  echo "$violations" >&2
+  exit 1
+fi
+
+echo "OK: no int64_t / uint64_t in MobilityDB public headers."


### PR DESCRIPTION
> 👀 **Reviewers**: tier ranking, dependency chains and the standards checklist live in [`doc/contributing/reviewer-guide.md`](https://github.com/MobilityDB/MobilityDB/blob/master/doc/contributing/reviewer-guide.md).

## Summary

Two independent CI/code-quality improvements with no file overlaps:

**Ban int64\_t in public headers** (PR #879):
- New `check-code.yml` CI step fails if any public header uses `int64_t` (portable code must use `int64` / `uint64`)
- `tools/scripts/check_int64_in_headers.sh` is the enforcement script

**Remove stale GEOS version guards** (PR #880):
- Drop `#if POSTGIS_GEOS_VERSION >= ...` guards that protected code now unconditional for all supported GEOS versions
- Update expected output for `058_tgeo_tile_tbl`, `058_tpoint_tile_tbl`, `064_tgeo_distance_tbl`, `064_tpoint_distance_tbl`

Both source PRs are CI-green. Consolidating saves 1 review slot; close #879 and #880.

## Test plan

- [ ] `check-code.yml` step passes on a clean build
- [ ] 058/064 tbl tests pass with updated expected output
- [ ] CI green on all PG versions