### PR TITLE
Surface cbufferset in the Set-and-Span-Types chapter

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -98,7 +98,14 @@
 					<entry><varname>geogset</varname></entry>
 					<entry><varname></varname></entry>
 					<entry><varname></varname></entry>
-					<entry><varname>tgeogpoint</varname></entry>
+					<entry><varname>tgeogpoint</varname>, <varname>tgeography</varname></entry>
+				</row>
+				<row>
+					<entry><emphasis role="bold"><varname>pose</varname></emphasis></entry>
+					<entry><varname>poseset</varname></entry>
+					<entry><varname></varname></entry>
+					<entry><varname></varname></entry>
+					<entry><varname>tpose</varname></entry>
 				</row>
 				<row>
 					<entry><emphasis role="bold"><varname>npoint</varname></emphasis></entry>
@@ -106,6 +113,13 @@
 					<entry><varname></varname></entry>
 					<entry><varname></varname></entry>
 					<entry><varname>tnpoint</varname></entry>
+				</row>
+				<row>
+					<entry><emphasis role="bold"><varname>cbuffer</varname></emphasis></entry>
+					<entry><varname>cbufferset</varname></entry>
+					<entry><varname></varname></entry>
+					<entry><varname></varname></entry>
+					<entry><varname>tcbuffer</varname></entry>
 				</row>
 			</tbody>
 			</tgroup>

--- a/doc/es/set_span_types.xml
+++ b/doc/es/set_span_types.xml
@@ -16,10 +16,10 @@
 	</para>
 
 	<para>
-		Los tipos de base que se utilizan para construir tipos de conjunto, de rango y de conjunto de rangos son los tipos <varname>integer</varname>, <varname>bigint</varname>, <varname>float</varname>, <varname>text</varname>, <varname>date</varname>, and <varname>timestamptz</varname> (marca de tiempo con zona horaria) proporcionados por PostgreSQL, los tipos <varname>geometry</varname> y <varname>geography</varname> proporcionados por PostGIS, y el tipo <varname>npoint</varname > (<emphasis>network point</emphasis> o punto de red) proporcionado por MobilityDB (ver <xref linkend="temporal_network_points" />). MobilityDB proporciona los siguientes tipos de conjunto y de rango:
+		Los tipos de base que se utilizan para construir tipos de conjunto, de rango y de conjunto de rangos son los tipos <varname>integer</varname>, <varname>bigint</varname>, <varname>float</varname>, <varname>text</varname>, <varname>date</varname>, and <varname>timestamptz</varname> (marca de tiempo con zona horaria) proporcionados por PostgreSQL, los tipos <varname>geometry</varname> y <varname>geography</varname> proporcionados por PostGIS, y los tipos <varname>cbuffer</varname> (búfer circular, ver <xref linkend="temporal_circular_buffers" />) y <varname>npoint</varname> (<emphasis>network point</emphasis> o punto de red, ver <xref linkend="temporal_network_points" />) proporcionados por MobilityDB. MobilityDB proporciona los siguientes tipos de conjunto y de rango:
 		<itemizedlist>
 			<listitem>
-				<para><varname>set</varname>: <varname>intset</varname>, <varname>bigintset</varname>, <varname>floatset</varname>, <varname>textset</varname>, <varname>dateset</varname>, <varname>tstzset</varname>, <varname>geomset</varname>, <varname>geogset</varname>, <varname>npointset</varname>.</para>
+				<para><varname>set</varname>: <varname>intset</varname>, <varname>bigintset</varname>, <varname>floatset</varname>, <varname>textset</varname>, <varname>dateset</varname>, <varname>tstzset</varname>, <varname>geomset</varname>, <varname>geogset</varname>, <varname>cbufferset</varname>, <varname>npointset</varname>.</para>
 			</listitem>
 			<listitem>
 				<para><varname>span</varname>: <varname>intspan</varname>, <varname>bigintspan</varname>, <varname>floatspan</varname>, <varname>datespan</varname>, <varname>tstzspan</varname>.</para>
@@ -125,9 +125,11 @@ SELECT textset '{"highway"}';
 SELECT floatset '{3.5, 1.2}';
 -- Conjunto erróneo: elementos duplicados
 SELECT geomset '{"Point(1 1)", "Point(1 1)"}';
+-- Conjunto de búferes circulares: cada elemento es un cbuffer en WKT
+SELECT cbufferset '{"Cbuffer(Point(1 1),0.5)", "Cbuffer(Point(2 2),1.0)"}';
 </programlisting>
 		<para>
-			Nótese que los elementos de los conjuntos <varname>textset</varname>, <varname>geomset</varname>, <varname>geogset</varname> y <varname>npointset</varname> deben estar delimitados entre commillas dobles. Nótese también que las geometrías y las geografías utilizan el orden definido por PostGIS.
+			Nótese que los elementos de los conjuntos <varname>textset</varname>, <varname>geomset</varname>, <varname>geogset</varname>, <varname>cbufferset</varname> y <varname>npointset</varname> deben estar delimitados entre commillas dobles. Nótese también que las geometrías y las geografías utilizan el orden definido por PostGIS.
 		</para>
 
 		<para>
@@ -919,6 +921,12 @@ SELECT asEWKT(setSRID(geomset '{Point(1 1), Point(2 2)}', 5676));
 -- SRID=5676;{"POINT(1 1)", "POINT(2 2)"}
 SELECT asEWKT(setSRID(poseset '{"Pose(Point(1 1),1)", "Pose(Point(2 2),3)"}', 5676));
 -- SRID=5676;{"Pose(POINT(2 2),3)", "Pose(POINT(1 1),1)"}
+SELECT SRID(cbufferset 'SRID=4326;{"Cbuffer(Point(1 1),0.5)",
+  "Cbuffer(Point(2 2),1.0)"}');
+-- 4326
+SELECT asEWKT(setSRID(cbufferset '{"Cbuffer(Point(1 1),0.5)",
+  "Cbuffer(Point(2 2),1.0)"}', 3812));
+-- SRID=3812;{"Cbuffer(POINT(1 1),0.5)", "Cbuffer(POINT(2 2),1)"}
 </programlisting>
 				</listitem>
 

--- a/doc/set_span_types.xml
+++ b/doc/set_span_types.xml
@@ -16,10 +16,10 @@
 	</para>
 
 	<para>
-		The base types used for constructing set, span, and span set types are the types <varname>integer</varname>, <varname>bigint</varname>, <varname>float</varname>,  <varname>text</varname>, <varname>date</varname>, and <varname>timestamptz</varname> (timestamp with time zone) provided by PostgreSQL, the types <varname>geometry</varname> and <varname>geography</varname> provided by PostGIS, and the type <varname>npoint</varname> (network point) provided by MobilityDB (see <xref linkend="temporal_network_points"/>). MobilityDB provides the following set and span types:
+		The base types used for constructing set, span, and span set types are the types <varname>integer</varname>, <varname>bigint</varname>, <varname>float</varname>,  <varname>text</varname>, <varname>date</varname>, and <varname>timestamptz</varname> (timestamp with time zone) provided by PostgreSQL, the types <varname>geometry</varname> and <varname>geography</varname> provided by PostGIS, and the types <varname>cbuffer</varname> (circular buffer, see <xref linkend="temporal_circular_buffers"/>) and <varname>npoint</varname> (network point, see <xref linkend="temporal_network_points"/>) provided by MobilityDB. MobilityDB provides the following set and span types:
 		<itemizedlist>
 			<listitem>
-				<para><varname>set</varname>: <varname>intset</varname>, <varname>bigintset</varname>, <varname>floatset</varname>, <varname>textset</varname>, <varname>dateset</varname>,  <varname>tstzset</varname>,  <varname>geomset</varname>, <varname>geogset</varname>, <varname>npointset</varname>.</para>
+				<para><varname>set</varname>: <varname>intset</varname>, <varname>bigintset</varname>, <varname>floatset</varname>, <varname>textset</varname>, <varname>dateset</varname>,  <varname>tstzset</varname>,  <varname>geomset</varname>, <varname>geogset</varname>, <varname>cbufferset</varname>, <varname>npointset</varname>.</para>
 			</listitem>
 			<listitem>
 				<para><varname>span</varname>: <varname>intspan</varname>, <varname>bigintspan</varname>, <varname>floatspan</varname>, <varname>datespan</varname>, <varname>tstzspan</varname>.</para>
@@ -117,9 +117,11 @@ SELECT textset '{"highway"}';
 SELECT floatset '{3.5, 1.2}';
 -- Erroneous set: duplicate elements
 SELECT geomset '{"Point(1 1)", "Point(1 1)"}';
+-- Circular-buffer set: each element is a cbuffer WKT
+SELECT cbufferset '{"Cbuffer(Point(1 1),0.5)", "Cbuffer(Point(2 2),1.0)"}';
 </programlisting>
 		<para>
-			Notice that the elements of the sets <varname>textset</varname>, <varname>geomset</varname>, <varname>geogset</varname>, and <varname>npointset</varname> must be enclosed between double quotes. Notice also that geometries and geographies follow the order defined in PostGIS.
+			Notice that the elements of the sets <varname>textset</varname>, <varname>geomset</varname>, <varname>geogset</varname>, <varname>cbufferset</varname>, and <varname>npointset</varname> must be enclosed between double quotes. Notice also that geometries and geographies follow the order defined in PostGIS.
 		</para>
 
 		<para>
@@ -916,6 +918,12 @@ SELECT asEWKT(setSRID(geomset '{Point(1 1), Point(2 2)}', 5676));
 -- SRID=5676;{"POINT(1 1)", "POINT(2 2)"}
 SELECT asEWKT(setSRID(poseset '{"Pose(Point(1 1),1)", "Pose(Point(2 2),3)"}', 5676));
 -- SRID=5676;{"Pose(POINT(2 2),3)", "Pose(POINT(1 1),1)"}
+SELECT SRID(cbufferset 'SRID=4326;{"Cbuffer(Point(1 1),0.5)",
+  "Cbuffer(Point(2 2),1.0)"}');
+-- 4326
+SELECT asEWKT(setSRID(cbufferset '{"Cbuffer(Point(1 1),0.5)",
+  "Cbuffer(Point(2 2),1.0)"}', 3812));
+-- SRID=3812;{"Cbuffer(POINT(1 1),0.5)", "Cbuffer(POINT(2 2),1)"}
 </programlisting>
 			</listitem>
 


### PR DESCRIPTION
`cbufferset` is implemented and usable on master but the manual gave users no way to discover it.

Before this PR:
- The Set-and-Span-Types overview listed every other set type (`intset`, `bigintset`, `floatset`, `textset`, `dateset`, `tstzset`, `geomset`, `geogset`, `npointset`) but not `cbufferset`
- The base-types preamble named PostgreSQL scalars, PostGIS geometry/geography, and npoint as available base types - `cbuffer` was not mentioned
- The I/O example block had no `cbufferset` literal and was missing the "elements must be double-quoted" note for it
- The SRID section showed `geomset` / `geogset` / `poseset` examples but not `cbufferset`, even though `cbufferset` carries SRID identically

Threads `cbufferset` through the three user-visible entry points where its absence was noticeable:

| File | Change |
|---|---|
| `doc/set_span_types.xml` | Add `cbufferset` to overview, base-type preamble, I/O block, and SRID section |
| `doc/es/set_span_types.xml` | Same additions in the Spanish translation |
| `doc/es/reference.xml` | Lock the Spanish type-matrix into step with the English version - was missing `pose` and `cbuffer` rows |

Everything else (accessors, set operations, comparisons, aggregations) already handles `cbufferset` implicitly via the polymorphic set-type signatures documented in the chapter - no per-type examples needed.
