### PR TITLE
fix+feat(trgeo): implement tdistance for trgeo×tgeompoint and trgeo×trgeo; fix dist2d_trgeoinst_geo pose bug

### DIFF
--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -287,8 +287,11 @@ compute_dist2(POINT4D p, POINT4D vs, POINT4D ve)
 TInstant *
 dist2d_trgeoinst_geo(const TInstant *inst, const GSERIALIZED *gs)
 {
-  double dist = geom_distance2d(trgeoinst_geom_p(inst), gs);
-  return tinstant_make(Float8GetDatum(dist), T_FLOAT8, inst->t);
+  Datum world;
+  trgeo_value_at_timestamptz((const Temporal *) inst, inst->t, true, &world);
+  double dist = geom_distance2d(DatumGetGserializedP(world), gs);
+  pfree(DatumGetPointer(world));
+  return tinstant_make(Float8GetDatum(dist), T_TFLOAT, inst->t);
 }
 
 /**
@@ -1855,23 +1858,233 @@ tdistance_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 }
 
 /**
+ * @brief Return the temporal distance between two temporal rigid geometry
+ * sequences by sampling at the union of their instant timestamps within their
+ * overlapping period.  No turning-point detection is performed.
+ * @param[in] full1,full2 Full Temporal values (with geometry) used for value
+ * lookup; may be TSequence or TSequenceSet — only their GSERIALIZED* and
+ * pose interpolation are accessed.
+ * @param[in] seq1,seq2 Component sequences used only for timestamp enumeration
+ * and period intersection; may be geometry-stripped TSequence components from
+ * a TSequenceSet.
+ */
+static TSequence *
+dist2d_trgeoseq_trgeoseq(const Temporal *full1, const Temporal *full2,
+  const TSequence *seq1, const TSequence *seq2)
+{
+  Span inter;
+  if (! inter_span_span(&seq1->period, &seq2->period, &inter))
+    return NULL;
+
+  int n1 = seq1->count, n2 = seq2->count;
+  TimestampTz *merged = palloc(sizeof(TimestampTz) * (n1 + n2));
+  int nmerged = 0;
+  for (int i = 0; i < n1; i++)
+  {
+    TimestampTz t = TSEQUENCE_INST_N(seq1, i)->t;
+    if (contains_span_timestamptz(&inter, t))
+      merged[nmerged++] = t;
+  }
+  for (int i = 0; i < n2; i++)
+  {
+    TimestampTz t = TSEQUENCE_INST_N(seq2, i)->t;
+    if (contains_span_timestamptz(&inter, t))
+      merged[nmerged++] = t;
+  }
+  if (nmerged == 0)
+  {
+    pfree(merged);
+    return NULL;
+  }
+
+  tstzarr_sort(merged, nmerged);
+  int nuniq = 0;
+  for (int i = 0; i < nmerged; i++)
+    if (i == 0 || merged[i] != merged[i - 1])
+      merged[nuniq++] = merged[i];
+
+  TInstant **instants = palloc(sizeof(TInstant *) * nuniq);
+  int k = 0;
+  for (int i = 0; i < nuniq; i++)
+  {
+    TimestampTz t = merged[i];
+    Datum val1, val2;
+    /* Use the full Temporal (with geometry) for value lookup, not the
+     * component sequence which may have its geometry stripped. */
+    if (! trgeo_value_at_timestamptz(full1, t, false, &val1))
+      continue;
+    if (! trgeo_value_at_timestamptz(full2, t, false, &val2))
+    {
+      pfree(DatumGetPointer(val1));
+      continue;
+    }
+    double dist = geom_distance2d(DatumGetGserializedP(val1),
+      DatumGetGserializedP(val2));
+    pfree(DatumGetPointer(val1));
+    pfree(DatumGetPointer(val2));
+    instants[k++] = tinstant_make(Float8GetDatum(dist), T_TFLOAT, t);
+  }
+  pfree(merged);
+
+  if (k == 0)
+  {
+    pfree(instants);
+    return NULL;
+  }
+  return tsequence_make_free(instants, k, true, true, STEP, NORMALIZE);
+}
+
+/**
+ * @brief Return the temporal distance between a temporal rigid geometry
+ * sequence and a temporal geometry point sequence.
+ * @param[in] full1 Full trgeo Temporal (with geometry) used for value lookup.
+ * @param[in] seq1 trgeo component sequence used only for timestamp enumeration
+ * and period intersection; may be geometry-stripped.
+ * @param[in] seq2 tgeompoint component sequence used for both timestamp
+ * enumeration and value lookup (tgeompoint sequences are self-contained).
+ */
+static TSequence *
+dist2d_trgeoseq_tpointseq(const Temporal *full1,
+  const TSequence *seq1, const TSequence *seq2)
+{
+  Span inter;
+  if (! inter_span_span(&seq1->period, &seq2->period, &inter))
+    return NULL;
+
+  int n1 = seq1->count, n2 = seq2->count;
+  TimestampTz *merged = palloc(sizeof(TimestampTz) * (n1 + n2));
+  int nmerged = 0;
+  for (int i = 0; i < n1; i++)
+  {
+    TimestampTz t = TSEQUENCE_INST_N(seq1, i)->t;
+    if (contains_span_timestamptz(&inter, t))
+      merged[nmerged++] = t;
+  }
+  for (int i = 0; i < n2; i++)
+  {
+    TimestampTz t = TSEQUENCE_INST_N(seq2, i)->t;
+    if (contains_span_timestamptz(&inter, t))
+      merged[nmerged++] = t;
+  }
+  if (nmerged == 0)
+  {
+    pfree(merged);
+    return NULL;
+  }
+
+  tstzarr_sort(merged, nmerged);
+  int nuniq = 0;
+  for (int i = 0; i < nmerged; i++)
+    if (i == 0 || merged[i] != merged[i - 1])
+      merged[nuniq++] = merged[i];
+
+  TInstant **instants = palloc(sizeof(TInstant *) * nuniq);
+  int k = 0;
+  for (int i = 0; i < nuniq; i++)
+  {
+    TimestampTz t = merged[i];
+    Datum val1, val2;
+    /* Use the full trgeo Temporal (with geometry) for value lookup. */
+    if (! trgeo_value_at_timestamptz(full1, t, false, &val1))
+      continue;
+    if (! temporal_value_at_timestamptz((const Temporal *) seq2, t, false, &val2))
+    {
+      pfree(DatumGetPointer(val1));
+      continue;
+    }
+    double dist = geom_distance2d(DatumGetGserializedP(val1),
+      DatumGetGserializedP(val2));
+    pfree(DatumGetPointer(val1));
+    pfree(DatumGetPointer(val2));
+    instants[k++] = tinstant_make(Float8GetDatum(dist), T_TFLOAT, t);
+  }
+  pfree(merged);
+
+  if (k == 0)
+  {
+    pfree(instants);
+    return NULL;
+  }
+  return tsequence_make_free(instants, k, true, true, STEP, NORMALIZE);
+}
+
+/**
  * @ingroup meos_rgeo_dist
- * @brief Return the temporal distance between two
- * temporal rigid geometries.
+ * @brief Return the temporal distance between a temporal rigid geometry and a
+ * temporal geometry point
  * @sqlop @p <->
  */
 Temporal *
-tdistance_trgeo_tpoint(const Temporal *temp1 UNUSED,
-  const Temporal *temp2 UNUSED)
+tdistance_trgeo_tpoint(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_tpoint(temp1, temp2))
     return NULL;
 
-  /* TODO */
-  meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
-    "Function %s not implemented yet.", __FUNCTION__);
-  return NULL;
+  if (MEOS_FLAGS_GET_Z(temp1->flags))
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Distance computation in 3D is not currently supported");
+    return NULL;
+  }
+
+  /* TInstant fast path */
+  if (temp1->subtype == TINSTANT || temp2->subtype == TINSTANT)
+  {
+    const TInstant *inst = temp1->subtype == TINSTANT
+      ? (const TInstant *) temp1 : (const TInstant *) temp2;
+    Datum val1, val2;
+    if (! trgeo_value_at_timestamptz(temp1, inst->t, false, &val1))
+      return NULL;
+    if (! temporal_value_at_timestamptz(temp2, inst->t, false, &val2))
+    {
+      pfree(DatumGetPointer(val1));
+      return NULL;
+    }
+    double dist = geom_distance2d(DatumGetGserializedP(val1),
+      DatumGetGserializedP(val2));
+    pfree(DatumGetPointer(val1));
+    pfree(DatumGetPointer(val2));
+    return (Temporal *) tinstant_make(Float8GetDatum(dist), T_TFLOAT, inst->t);
+  }
+
+  /* Both TSequence */
+  if (temp1->subtype == TSEQUENCE && temp2->subtype == TSEQUENCE)
+    return (Temporal *) dist2d_trgeoseq_tpointseq(
+      temp1, (const TSequence *) temp1, (const TSequence *) temp2);
+
+  /* At least one TSequenceSet — decompose over component sequences.
+   * Pass the full Temporal (full1/temp1) so that trgeo_value_at_timestamptz
+   * can reach the geometry; component TSequences of a TSequenceSet have their
+   * geometry stripped and must not be passed as the first argument. */
+  const TSequenceSet *ss1 = temp1->subtype == TSEQUENCESET
+    ? (const TSequenceSet *) temp1 : NULL;
+  const TSequenceSet *ss2 = temp2->subtype == TSEQUENCESET
+    ? (const TSequenceSet *) temp2 : NULL;
+  const TSequence *seq1 = ss1 ? NULL : (const TSequence *) temp1;
+  const TSequence *seq2 = ss2 ? NULL : (const TSequence *) temp2;
+
+  int outer_count = ss1 ? ss1->count : 1;
+  int inner_count = ss2 ? ss2->count : 1;
+  TSequence **seqs = palloc(sizeof(TSequence *) * outer_count * inner_count);
+  int k = 0;
+  for (int i = 0; i < outer_count; i++)
+  {
+    const TSequence *s1 = ss1 ? TSEQUENCESET_SEQ_N(ss1, i) : seq1;
+    for (int j = 0; j < inner_count; j++)
+    {
+      const TSequence *s2 = ss2 ? TSEQUENCESET_SEQ_N(ss2, j) : seq2;
+      TSequence *dist_seq = dist2d_trgeoseq_tpointseq(temp1, s1, s2);
+      if (dist_seq != NULL)
+        seqs[k++] = dist_seq;
+    }
+  }
+  if (k == 0)
+  {
+    pfree(seqs);
+    return NULL;
+  }
+  return (Temporal *) tsequenceset_make_free(seqs, k, NORMALIZE);
 }
 
 /**
@@ -1880,17 +2093,75 @@ tdistance_trgeo_tpoint(const Temporal *temp1 UNUSED,
  * @sqlop @p <->
  */
 Temporal *
-tdistance_trgeo_trgeo(const Temporal *temp1 UNUSED,
-  const Temporal *temp2 UNUSED)
+tdistance_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_trgeo(temp1, temp2))
     return NULL;
 
-  /* TODO */
-  meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
-    "Function %s not implemented yet.", __FUNCTION__);
-  return NULL;
+  if (MEOS_FLAGS_GET_Z(temp1->flags))
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Distance computation in 3D is not currently supported");
+    return NULL;
+  }
+
+  /* TInstant fast path */
+  if (temp1->subtype == TINSTANT || temp2->subtype == TINSTANT)
+  {
+    const TInstant *inst = temp1->subtype == TINSTANT
+      ? (const TInstant *) temp1 : (const TInstant *) temp2;
+    Datum val1, val2;
+    if (! trgeo_value_at_timestamptz(temp1, inst->t, false, &val1))
+      return NULL;
+    if (! trgeo_value_at_timestamptz(temp2, inst->t, false, &val2))
+    {
+      pfree(DatumGetPointer(val1));
+      return NULL;
+    }
+    double dist = geom_distance2d(DatumGetGserializedP(val1),
+      DatumGetGserializedP(val2));
+    pfree(DatumGetPointer(val1));
+    pfree(DatumGetPointer(val2));
+    return (Temporal *) tinstant_make(Float8GetDatum(dist), T_TFLOAT, inst->t);
+  }
+
+  /* Both TSequence */
+  if (temp1->subtype == TSEQUENCE && temp2->subtype == TSEQUENCE)
+    return (Temporal *) dist2d_trgeoseq_trgeoseq(
+      temp1, temp2, (const TSequence *) temp1, (const TSequence *) temp2);
+
+  /* At least one TSequenceSet — decompose over component sequences.
+   * Pass the full Temporals so that trgeo_value_at_timestamptz can reach the
+   * geometry; component TSequences from a TSequenceSet have it stripped. */
+  const TSequenceSet *ss1 = temp1->subtype == TSEQUENCESET
+    ? (const TSequenceSet *) temp1 : NULL;
+  const TSequenceSet *ss2 = temp2->subtype == TSEQUENCESET
+    ? (const TSequenceSet *) temp2 : NULL;
+  const TSequence *seq1 = ss1 ? NULL : (const TSequence *) temp1;
+  const TSequence *seq2 = ss2 ? NULL : (const TSequence *) temp2;
+
+  int outer_count = ss1 ? ss1->count : 1;
+  int inner_count = ss2 ? ss2->count : 1;
+  TSequence **seqs = palloc(sizeof(TSequence *) * outer_count * inner_count);
+  int k = 0;
+  for (int i = 0; i < outer_count; i++)
+  {
+    const TSequence *s1 = ss1 ? TSEQUENCESET_SEQ_N(ss1, i) : seq1;
+    for (int j = 0; j < inner_count; j++)
+    {
+      const TSequence *s2 = ss2 ? TSEQUENCESET_SEQ_N(ss2, j) : seq2;
+      TSequence *dist_seq = dist2d_trgeoseq_trgeoseq(temp1, temp2, s1, s2);
+      if (dist_seq != NULL)
+        seqs[k++] = dist_seq;
+    }
+  }
+  if (k == 0)
+  {
+    pfree(seqs);
+    return NULL;
+  }
+  return (Temporal *) tsequenceset_make_free(seqs, k, NORMALIZE);
 }
 
 /*****************************************************************************

--- a/mobilitydb/test/rgeo/expected/133_trgeo_distance.test.out
+++ b/mobilitydb/test/rgeo/expected/133_trgeo_distance.test.out
@@ -1,0 +1,155 @@
+SELECT round(maxValue(
+  trgeometry 'SRID=5676;Polygon((0 0,10 0,10 10,0 10,0 0));Pose(Point(0 0),0)@2000-01-01'
+  <-> ST_SetSRID(ST_MakePoint(20, 5), 5676)
+), 6);
+ round 
+-------
+    10
+(1 row)
+
+SELECT round(maxValue(
+  ST_SetSRID(ST_MakePoint(20, 5), 5676)
+  <-> trgeometry 'SRID=5676;Polygon((0 0,10 0,10 10,0 10,0 0));Pose(Point(0 0),0)@2000-01-01'
+), 6);
+ round 
+-------
+    10
+(1 row)
+
+SELECT round(maxValue(
+  trgeometry 'SRID=5676;Polygon((0 0,10 0,10 10,0 10,0 0));Pose(Point(0 0),0)@2000-01-01'
+  <-> ST_SetSRID(ST_MakePoint(5, 5), 5676)
+), 6);
+ round 
+-------
+     0
+(1 row)
+
+SELECT round(maxValue(
+  trgeometry 'SRID=5676;Polygon((0 0,10 0,10 10,0 10,0 0));[Pose(Point(0 0),0)@2000-01-01, Pose(Point(50 0),0)@2000-01-02]'
+  <-> ST_SetSRID(ST_MakePoint(25, 20), 5676)
+), 6);
+   round   
+-----------
+ 32.015621
+(1 row)
+
+SELECT round(maxValue(
+  trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));Pose(Point(0 0),0)@2000-01-01'
+  <->
+  trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));Pose(Point(20 0),0)@2000-01-01'
+), 6);
+ round 
+-------
+    15
+(1 row)
+
+SELECT trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));Pose(Point(0 0),0)@2000-01-01'
+  <-> trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));Pose(Point(20 0),0)@2000-01-02';
+ ?column? 
+----------
+ 
+(1 row)
+
+SELECT round(maxValue(
+  trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));[Pose(Point(0 0),0)@2000-01-01, Pose(Point(0 0),0)@2000-01-02]'
+  <->
+  trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));[Pose(Point(20 0),0)@2000-01-01, Pose(Point(20 0),0)@2000-01-02]'
+), 6);
+ round 
+-------
+    15
+(1 row)
+
+SELECT trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));[Pose(Point(0 0),0)@2000-01-01, Pose(Point(0 0),0)@2000-01-02]'
+  <-> trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));[Pose(Point(20 0),0)@2000-01-03, Pose(Point(20 0),0)@2000-01-04]';
+ ?column? 
+----------
+ 
+(1 row)
+
+SELECT round(
+  nearestApproachDistance(
+    trgeometry 'SRID=5676;Polygon((0 0,10 0,10 10,0 10,0 0));Pose(Point(0 0),0)@2000-01-01',
+    ST_SetSRID(ST_MakePoint(20, 5), 5676)
+  ), 6);
+ round 
+-------
+    10
+(1 row)
+
+SELECT round(
+  nearestApproachDistance(
+    trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));[Pose(Point(0 0),0)@2000-01-01, Pose(Point(0 0),0)@2000-01-02]',
+    trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));[Pose(Point(20 0),0)@2000-01-01, Pose(Point(20 0),0)@2000-01-02]'
+  ), 6);
+ round 
+-------
+    15
+(1 row)
+
+SELECT round(
+  nearestApproachDistance(
+    trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));[Pose(Point(0 0),0)@2000-01-01, Pose(Point(15 0),0)@2000-01-02]',
+    trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));[Pose(Point(20 0),0)@2000-01-01, Pose(Point(20 0),0)@2000-01-02]'
+  ), 6);
+ round 
+-------
+     0
+(1 row)
+
+SELECT asText(nearestApproachInstant(
+  trgeometry 'SRID=5676;Polygon((0 0,10 0,10 10,0 10,0 0));Pose(Point(0 0),0)@2000-01-01',
+  ST_SetSRID(ST_MakePoint(20, 5), 5676)
+));
+                                       astext                                       
+------------------------------------------------------------------------------------
+ POLYGON((0 0,10 0,10 10,0 10,0 0));Pose(POINT(0 0),0)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT getTimestamp(nearestApproachInstant(
+  trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));[Pose(Point(0 0),0)@2000-01-01, Pose(Point(0 0),0)@2000-01-02]',
+  trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));[Pose(Point(20 0),0)@2000-01-01, Pose(Point(20 0),0)@2000-01-02]'
+));
+         gettimestamp         
+------------------------------
+ Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT getTimestamp(nearestApproachInstant(
+  trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));[Pose(Point(0 0),0)@2000-01-01, Pose(Point(15 0),0)@2000-01-02]',
+  trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));[Pose(Point(20 0),0)@2000-01-01, Pose(Point(20 0),0)@2000-01-02]'
+));
+         gettimestamp         
+------------------------------
+ Sun Jan 02 00:00:00 2000 PST
+(1 row)
+
+SELECT round(maxValue(
+  trgeometry 'SRID=5676;Polygon((0 0,10 0,10 10,0 10,0 0));Pose(Point(0 0),0)@2000-01-01'
+  <-> setSRID(tgeompoint 'Point(20 5)@2000-01-01', 5676)
+), 6);
+ round 
+-------
+    10
+(1 row)
+
+SELECT asText(
+  trgeometry 'SRID=5676;Polygon((0 0,10 0,10 10,0 10,0 0));[Pose(Point(0 0),0)@2000-01-01, Pose(Point(50 0),0)@2000-01-02]'
+  <-> setSRID(tgeompoint '[Point(25 20)@2000-01-01 12:00, Point(25 5)@2000-01-02]', 5676)
+);
+                                     astext                                     
+--------------------------------------------------------------------------------
+ Interp=Step;[10@Sat Jan 01 12:00:00 2000 PST, 25@Sun Jan 02 00:00:00 2000 PST]
+(1 row)
+
+SELECT round(nearestApproachDistance(
+  trgeometry 'SRID=5676;Polygon((0 0,10 0,10 10,0 10,0 0));Pose(Point(0 0),0)@2000-01-01',
+  setSRID(tgeompoint 'Point(20 5)@2000-01-01', 5676)
+), 6);
+ round 
+-------
+    10
+(1 row)
+
+/*****************************************************************************/

--- a/mobilitydb/test/rgeo/expected/133_trgeo_distance_tbl.test.out
+++ b/mobilitydb/test/rgeo/expected/133_trgeo_distance_tbl.test.out
@@ -1,0 +1,47 @@
+SELECT round(MAX(maxValue(t1.temp <-> setSRID(t2.temp, 5676))), 6)
+FROM tbl_trgeometry2d t1, tbl_tgeompoint t2
+WHERE t1.temp <-> setSRID(t2.temp, 5676) IS NOT NULL;
+   round   
+-----------
+ 187.42017
+(1 row)
+
+SELECT round(MAX(nearestApproachDistance(t1.temp, setSRID(t2.temp, 5676))), 6)
+FROM tbl_trgeometry2d t1, tbl_tgeompoint t2;
+   round   
+-----------
+ 17.620953
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d t1,
+  (SELECT * FROM tbl_tgeompoint LIMIT 10) t2
+WHERE nearestApproachInstant(t1.temp, setSRID(t2.temp, 5676)) IS NOT NULL;
+ count 
+-------
+     0
+(1 row)
+
+SELECT round(MAX(maxValue(t1.temp <-> t2.temp)), 6)
+FROM tbl_trgeometry2d t1, tbl_trgeometry2d t2
+WHERE t1.temp <-> t2.temp IS NOT NULL;
+ round 
+-------
+     0
+(1 row)
+
+SELECT round(MAX(nearestApproachDistance(t1.temp, t2.temp)), 6)
+FROM tbl_trgeometry2d t1, tbl_trgeometry2d t2;
+ round 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d t1,
+  (SELECT * FROM tbl_trgeometry2d LIMIT 10) t2
+WHERE nearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
+ count 
+-------
+    10
+(1 row)
+
+/*****************************************************************************/

--- a/mobilitydb/test/rgeo/queries/133_trgeo_distance.test.sql
+++ b/mobilitydb/test/rgeo/queries/133_trgeo_distance.test.sql
@@ -1,0 +1,148 @@
+-------------------------------------------------------------------------------
+--
+-- This MobilityDB code is provided under The PostgreSQL License.
+-- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+-- contributors
+--
+-- MobilityDB includes portions of PostGIS version 3 source code released
+-- under the GNU General Public License (GPLv2 or later).
+-- Copyright (c) 2001-2025, PostGIS contributors
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice and
+-- this paragraph and the following two paragraphs appear in all copies.
+--
+-- IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+-- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+-- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+-- EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+-- OF SUCH DAMAGE.
+--
+-- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+-- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+-- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+--
+-------------------------------------------------------------------------------
+
+-- Polygon at origin (no pose transform) — world shape equals reference body
+-- Distance from TInstant to static geometry
+SELECT round(maxValue(
+  trgeometry 'SRID=5676;Polygon((0 0,10 0,10 10,0 10,0 0));Pose(Point(0 0),0)@2000-01-01'
+  <-> ST_SetSRID(ST_MakePoint(20, 5), 5676)
+), 6);
+
+-- Same as above reversed (geometry <-> trgeometry)
+SELECT round(maxValue(
+  ST_SetSRID(ST_MakePoint(20, 5), 5676)
+  <-> trgeometry 'SRID=5676;Polygon((0 0,10 0,10 10,0 10,0 0));Pose(Point(0 0),0)@2000-01-01'
+), 6);
+
+-- Distance zero: point inside polygon
+SELECT round(maxValue(
+  trgeometry 'SRID=5676;Polygon((0 0,10 0,10 10,0 10,0 0));Pose(Point(0 0),0)@2000-01-01'
+  <-> ST_SetSRID(ST_MakePoint(5, 5), 5676)
+), 6);
+
+-- TSequence <-> geometry: polygon moves from (0,0) to (50,0), point at (25,20)
+-- At t=2000-01-01 12:00: polygon center ~(25,0), closest edge point (25,10), dist=10
+SELECT round(maxValue(
+  trgeometry 'SRID=5676;Polygon((0 0,10 0,10 10,0 10,0 0));[Pose(Point(0 0),0)@2000-01-01, Pose(Point(50 0),0)@2000-01-02]'
+  <-> ST_SetSRID(ST_MakePoint(25, 20), 5676)
+), 6);
+
+-------------------------------------------------------------------------------
+-- TInstant × TInstant same timestamp — distance equals static distance
+SELECT round(maxValue(
+  trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));Pose(Point(0 0),0)@2000-01-01'
+  <->
+  trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));Pose(Point(20 0),0)@2000-01-01'
+), 6);
+
+-- TInstant × TInstant different timestamps — no time overlap, result NULL
+SELECT trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));Pose(Point(0 0),0)@2000-01-01'
+  <-> trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));Pose(Point(20 0),0)@2000-01-02';
+
+-- TSequence × TSequence overlapping: two stationary polygons 15 units apart
+SELECT round(maxValue(
+  trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));[Pose(Point(0 0),0)@2000-01-01, Pose(Point(0 0),0)@2000-01-02]'
+  <->
+  trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));[Pose(Point(20 0),0)@2000-01-01, Pose(Point(20 0),0)@2000-01-02]'
+), 6);
+
+-- TSequence × TSequence non-overlapping time spans — result NULL
+SELECT trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));[Pose(Point(0 0),0)@2000-01-01, Pose(Point(0 0),0)@2000-01-02]'
+  <-> trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));[Pose(Point(20 0),0)@2000-01-03, Pose(Point(20 0),0)@2000-01-04]';
+
+-------------------------------------------------------------------------------
+-- nearestApproachDistance
+
+-- TInstant: same as distance for a single instant
+SELECT round(
+  nearestApproachDistance(
+    trgeometry 'SRID=5676;Polygon((0 0,10 0,10 10,0 10,0 0));Pose(Point(0 0),0)@2000-01-01',
+    ST_SetSRID(ST_MakePoint(20, 5), 5676)
+  ), 6);
+
+-- TSequence × TSequence stationary 15 apart
+SELECT round(
+  nearestApproachDistance(
+    trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));[Pose(Point(0 0),0)@2000-01-01, Pose(Point(0 0),0)@2000-01-02]',
+    trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));[Pose(Point(20 0),0)@2000-01-01, Pose(Point(20 0),0)@2000-01-02]'
+  ), 6);
+
+-- Two approaching polygons: p1 moves from (0,0) to (15,0), p2 stays at (20,0)
+-- At t=start: gap=15; at t=end: gap=0
+SELECT round(
+  nearestApproachDistance(
+    trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));[Pose(Point(0 0),0)@2000-01-01, Pose(Point(15 0),0)@2000-01-02]',
+    trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));[Pose(Point(20 0),0)@2000-01-01, Pose(Point(20 0),0)@2000-01-02]'
+  ), 6);
+
+-------------------------------------------------------------------------------
+-- nearestApproachInstant
+
+-- TInstant: returns the single instant
+SELECT asText(nearestApproachInstant(
+  trgeometry 'SRID=5676;Polygon((0 0,10 0,10 10,0 10,0 0));Pose(Point(0 0),0)@2000-01-01',
+  ST_SetSRID(ST_MakePoint(20, 5), 5676)
+));
+
+-- TSequence × TSequence stationary: returns the first instant (all equal)
+SELECT getTimestamp(nearestApproachInstant(
+  trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));[Pose(Point(0 0),0)@2000-01-01, Pose(Point(0 0),0)@2000-01-02]',
+  trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));[Pose(Point(20 0),0)@2000-01-01, Pose(Point(20 0),0)@2000-01-02]'
+));
+
+-- Approaching polygons: minimum distance at the last instant
+SELECT getTimestamp(nearestApproachInstant(
+  trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));[Pose(Point(0 0),0)@2000-01-01, Pose(Point(15 0),0)@2000-01-02]',
+  trgeometry 'SRID=5676;Polygon((0 0,5 0,5 5,0 5,0 0));[Pose(Point(20 0),0)@2000-01-01, Pose(Point(20 0),0)@2000-01-02]'
+));
+
+-------------------------------------------------------------------------------
+-- tdistance(trgeo, tgeompoint)
+
+-- TInstant trgeo <-> TInstant tgeompoint (same timestamp)
+SELECT round(maxValue(
+  trgeometry 'SRID=5676;Polygon((0 0,10 0,10 10,0 10,0 0));Pose(Point(0 0),0)@2000-01-01'
+  <-> setSRID(tgeompoint 'Point(20 5)@2000-01-01', 5676)
+), 6);
+
+-- TSequence trgeo <-> TSequence tgeompoint, overlapping
+-- trgeo: polygon (0,0)-(10,10) moving from (0,0) to (50,0) over 2 days
+-- tgeompoint: point moving from (25,20) to (25,5) over the second day only
+SELECT asText(
+  trgeometry 'SRID=5676;Polygon((0 0,10 0,10 10,0 10,0 0));[Pose(Point(0 0),0)@2000-01-01, Pose(Point(50 0),0)@2000-01-02]'
+  <-> setSRID(tgeompoint '[Point(25 20)@2000-01-01 12:00, Point(25 5)@2000-01-02]', 5676)
+);
+
+-- nearestApproachDistance(trgeo, tgeompoint)
+SELECT round(nearestApproachDistance(
+  trgeometry 'SRID=5676;Polygon((0 0,10 0,10 10,0 10,0 0));Pose(Point(0 0),0)@2000-01-01',
+  setSRID(tgeompoint 'Point(20 5)@2000-01-01', 5676)
+), 6);
+
+/*****************************************************************************/

--- a/mobilitydb/test/rgeo/queries/133_trgeo_distance_tbl.test.sql
+++ b/mobilitydb/test/rgeo/queries/133_trgeo_distance_tbl.test.sql
@@ -1,0 +1,61 @@
+-------------------------------------------------------------------------------
+--
+-- This MobilityDB code is provided under The PostgreSQL License.
+-- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+-- contributors
+--
+-- MobilityDB includes portions of PostGIS version 3 source code released
+-- under the GNU General Public License (GPLv2 or later).
+-- Copyright (c) 2001-2025, PostGIS contributors
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice and
+-- this paragraph and the following two paragraphs appear in all copies.
+--
+-- IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+-- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+-- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+-- EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+-- OF SUCH DAMAGE.
+--
+-- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+-- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+-- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+--
+-------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- tdistance(trgeometry, tgeompoint) / nearestApproachDistance
+-- setSRID sets the coordinate reference system without reprojecting
+-------------------------------------------------------------------------------
+
+SELECT round(MAX(maxValue(t1.temp <-> setSRID(t2.temp, 5676))), 6)
+FROM tbl_trgeometry2d t1, tbl_tgeompoint t2
+WHERE t1.temp <-> setSRID(t2.temp, 5676) IS NOT NULL;
+
+SELECT round(MAX(nearestApproachDistance(t1.temp, setSRID(t2.temp, 5676))), 6)
+FROM tbl_trgeometry2d t1, tbl_tgeompoint t2;
+
+SELECT COUNT(*) FROM tbl_trgeometry2d t1,
+  (SELECT * FROM tbl_tgeompoint LIMIT 10) t2
+WHERE nearestApproachInstant(t1.temp, setSRID(t2.temp, 5676)) IS NOT NULL;
+
+-------------------------------------------------------------------------------
+-- tdistance(trgeometry, trgeometry) / nearestApproachDistance / NAI
+-------------------------------------------------------------------------------
+
+SELECT round(MAX(maxValue(t1.temp <-> t2.temp)), 6)
+FROM tbl_trgeometry2d t1, tbl_trgeometry2d t2
+WHERE t1.temp <-> t2.temp IS NOT NULL;
+
+SELECT round(MAX(nearestApproachDistance(t1.temp, t2.temp)), 6)
+FROM tbl_trgeometry2d t1, tbl_trgeometry2d t2;
+
+SELECT COUNT(*) FROM tbl_trgeometry2d t1,
+  (SELECT * FROM tbl_trgeometry2d LIMIT 10) t2
+WHERE nearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
+
+/*****************************************************************************/


### PR DESCRIPTION
> 👀 **Reviewers**: tier ranking, dependency chains and the standards checklist live in [`doc/contributing/reviewer-guide.md`](https://github.com/MobilityDB/MobilityDB/blob/master/doc/contributing/reviewer-guide.md).

## Summary

Implements the `tdistance` family of functions for trgeometry that were declared in SQL but returning a \"not implemented\" error.

### Bug fixes

- **`dist2d_trgeoinst_geo`**: was computing distance against the raw reference body instead of the world geometry at the instant's pose (missing `trgeo_value_at_timestamptz` call). Also returned `T_FLOAT8` instead of `T_TFLOAT`, causing type confusion downstream.
- **TSequenceSet crash**: component TSequences returned by `TSEQUENCESET_SEQ_N(ss, i)` have their reference geometry stripped (stored once in the parent TSequenceSet, not per-component). Passing them directly to `trgeo_value_at_timestamptz` triggered `assert(MEOS_FLAGS_GET_GEOM(seq->flags))`, crashing the server on any full cross-join of `tbl_trgeometry2d`. The fix passes the full `Temporal*` (which owns the geometry) to value-lookup calls, using the component sequence only for timestamp enumeration and period intersection.

### New implementations

Both use a synchronized-timestamp approach: merge the instant timestamps from both temporals within their time intersection, evaluate the world geometry at each via `trgeo_value_at_timestamptz`, compute `geom_distance2d`, and return a STEP `TSequence`/`TSequenceSet` of distances.

- `tdistance(trgeometry, tgeompoint)` / `tdistance(tgeompoint, trgeometry)`
- `tdistance(trgeometry, trgeometry)`
- `nearestApproachDistance(trgeometry, tgeompoint)` / `nearestApproachDistance(trgeometry, trgeometry)` (delegates to `tdistance`, already wired)
- `nearestApproachInstant(trgeometry, tgeompoint)` / `nearestApproachInstant(trgeometry, trgeometry)` (same)
- `<->` operator overloads (already wired through `tdistance`)

### Tests

- `mobilitydb/test/rgeo/queries/133_trgeo_distance.test.sql` — unit tests: TInstant×geometry, TInstant×TInstant (same/different timestamps), TSequence×TSequence, NAD, NAI, trgeo×tgeompoint
- `mobilitydb/test/rgeo/queries/133_trgeo_distance_tbl.test.sql` — cross-table tests over `tbl_trgeometry2d` and `tbl_tgeompoint`

## Test plan

- [x] Full 100×100 `tbl_trgeometry2d × tbl_trgeometry2d` cross join completes without crash
- [x] `133_trgeo_distance` and `133_trgeo_distance_tbl` pass via CTest
- [x] Unit tests verify known geometry values (distance 10, 15, 0, NAD=0 for approaching polygons)