### PR TITLE
doc(edge-to-cloud): RFC — portable named-function SQL dialect for MobilityDB ecosystem

### DIFF
--- a/doc/edge-to-cloud/README.md
+++ b/doc/edge-to-cloud/README.md
@@ -1,0 +1,177 @@
+# RFC: Edge-to-Cloud SQL Portability for the MobilityDB Ecosystem
+
+> **Discussion [#861](https://github.com/MobilityDB/MobilityDB/discussions/861)** — community discussion and sign-off
+
+## The Problem
+
+The MobilityDB ecosystem now spans three execution platforms:
+
+| Platform | Engine | Implementation |
+|---|---|---|
+| **[MobilityDB](https://github.com/MobilityDB/MobilityDB)** | PostgreSQL | Native C + PostGIS |
+| **[MobilityDuck](https://github.com/MobilityDB/MobilityDuck)** | DuckDB | C++ extension (MEOS-backed) |
+| **[MobilitySpark](https://github.com/MobilityDB/MobilitySpark)** | Apache Spark | JVM UDFs via [JMEOS 1.3](https://github.com/MobilityDB/JMEOS/pull/9) |
+
+Each platform understands the same temporal and spatial types — `tgeompoint`, `tgeometry`,
+`tstzspan`, `tbox`, `stbox` — because all three are backed by the same
+[MEOS](https://github.com/MobilityDB/MEOS-API) C library (either directly or through JMEOS).
+
+Yet today **you cannot take the same SQL query and run it unchanged on all three platforms**,
+because MobilityDB's richest interface uses PostgreSQL custom operators (`&&`, `@>`, `<<#`,
+`?=`, `<->`, …) that neither DuckDB nor Spark SQL can register.
+
+## Why Now
+
+Three things are now true at once:
+
+- **[MobilityDuck](https://github.com/MobilityDB/MobilityDuck)** has reached **100% parity**
+  with MobilityDB within the temporal and geo scope (35 test files, 1186 assertions, all passing)
+  and exposes every MobilityDB operator as a named function (`before()`,
+  `eIntersects()`, `nearestApproachDistance()`, …).
+- **[JMEOS 1.3](https://github.com/MobilityDB/JMEOS/pull/9)** is complete: code-generated
+  from [`meos-api.json`](https://github.com/MobilityDB/MEOS-API), full Java 21, ready to
+  back MobilitySpark UDFs.
+- **[MobilityPySpark](https://github.com/MobilityDB/MobilityPySpark)** has BerlinMOD Q1–Q12
+  running end-to-end on PyMEOS, proving the query pattern works on Spark SQL.
+
+All three platforms already support a **named-function form** for every MobilityDB operation.
+The gap is not new engineering — it is agreement on canonical function names and one BerlinMOD
+benchmark run to prove it.
+
+## Proposal
+
+A portable query uses **only named functions, no operator symbols**.  MobilityDB already
+registers named aliases for every operator.  MobilityDuck uses the same names.  MobilitySpark
+needs UDFs with matching names.
+
+### Operator → Function mapping
+
+The table below maps each MobilityDB operator to the corresponding portable named function.
+
+| Category | MobilityDB operator | Portable function |
+|---|---|---|
+| **Time position** | `<<#` | `before(a, b)` |
+| | `#>>` | `after(a, b)` |
+| | `&<#` | `overbefore(a, b)` |
+| | `#&>` | `overafter(a, b)` |
+| **Space — X axis** | `<<` | `left(a, b)` |
+| | `>>` | `right(a, b)` |
+| | `&<` | `overleft(a, b)` |
+| | `&>` | `overright(a, b)` |
+| **Space — Y axis** | `<<`&#124; | `below(a, b)` |
+| | &#124;`>>` | `above(a, b)` |
+| | `&<`&#124; | `overbelow(a, b)` |
+| | &#124;`&>` | `overabove(a, b)` |
+| **Space — Z axis** _(3D types only)_ | `<</` | `front(a, b)` |
+| | `/>>` | `back(a, b)` |
+| | `&</` | `overfront(a, b)` |
+| | `/&>` | `overback(a, b)` |
+| **Ever** | `?=` | `ever_eq(v, t)` |
+| | `?<>` | `ever_ne(v, t)` |
+| | `?<` | `ever_lt(v, t)` |
+| | `?<=` | `ever_le(v, t)` |
+| | `?>` | `ever_gt(v, t)` |
+| | `?>=` | `ever_ge(v, t)` |
+| **Always** | `%=` | `always_eq(v, t)` |
+| | `%<>` | `always_ne(v, t)` |
+| | `%<` | `always_lt(v, t)` |
+| | `%<=` | `always_le(v, t)` |
+| | `%>` | `always_gt(v, t)` |
+| | `%>=` | `always_ge(v, t)` |
+| **Topology** | `&&` | `overlaps(a, b)` |
+| | `@>` | `contains(a, b)` |
+| | `<@` | `contained(a, b)` |
+| | `-`&#124;`-` | `adjacent(a, b)` |
+| **Distance** | `<->` | `tdistance(a, b)` |
+| | &#124;`=`&#124; | `nearestApproachDistance(a, b)` |
+
+Spatial relationship functions (`eIntersects`, `aIntersects`, `tIntersects`, `eTouches`,
+`eContains`, `eDwithin`, …) and restriction functions (`atTime`, `atGeometry`, `atValue`, …)
+already use named-function syntax in MobilityDB and require no mapping — write them the same
+way on all three platforms.
+
+### Serialization interchange
+
+Objects must round-trip between platforms unchanged.  The canonical interchange format is
+**MF-JSON** (OGC Moving Features JSON), already supported by `asMFJSON()` / `fromMFJSON()`
+in MobilityDB and MEOS.  For bulk transfer, MEOS binary (hex-encoded WKB extension) is the
+efficient alternative.
+
+> **Important discrepancy to resolve:** [MobilityPySpark](https://github.com/MobilityDB/MobilityPySpark)
+> currently uses `-1.0` as the `nearestApproachDistance` failure sentinel. MEOS and MobilityDB
+> use `DBL_MAX` ([PR #846](https://github.com/MobilityDB/MobilityDB/pull/846)).
+> The canonical value is `NULL` at the SQL level; the dialect must hide the C sentinel.
+
+## BerlinMOD Reference Queries (Portable)
+
+The [`berlinmod/`](berlinmod/) subdirectory contains the first five BerlinMOD benchmark
+queries written in the portable dialect.  These are the POC acceptance criteria: **the same
+`.sql` file must produce the same result on all three platforms without modification**.
+
+| Query | Temporal operations used | File |
+|---|---|---|
+| Q1 | None (relational join) | [berlinmod/q01.sql](berlinmod/q01.sql) |
+| Q3 | `atTime()` | [berlinmod/q03.sql](berlinmod/q03.sql) |
+| Q4 | `eIntersects()` | [berlinmod/q04.sql](berlinmod/q04.sql) |
+| Q5 | `nearestApproachDistance()` + `MIN()` | [berlinmod/q05.sql](berlinmod/q05.sql) |
+| Q6 | `eDwithin()` | [berlinmod/q06.sql](berlinmod/q06.sql) |
+
+## Six-Phase Implementation Plan
+
+### Phase 1 — [JMEOS 1.3](https://github.com/MobilityDB/JMEOS/pull/9) integration into [MobilitySpark](https://github.com/MobilityDB/MobilitySpark)
+Wire JMEOS 1.3 (PR [MobilityDB/JMEOS#9](https://github.com/MobilityDB/JMEOS/pull/9)) into
+MobilitySpark, replacing the placeholder 1-UDF POC.  Register `tgeompoint`, `tgeometry`,
+`tint`, `tfloat`, `ttext`, `tbool` as Spark SQL types backed by MEOS binary representation.
+
+### Phase 2 — Canonical function name registry
+Publish a machine-readable table ([`meos-api.json`](https://github.com/MobilityDB/MEOS-API)
+extension or a companion `portable-sql.json`) that maps each MEOS function to its canonical
+SQL name.  Each platform validates against this registry rather than maintaining its own
+ad-hoc mapping.
+
+### Phase 3 — [MobilitySpark](https://github.com/MobilityDB/MobilitySpark) function surface (generated)
+Use the `NewFunctionsGenerator` already in
+[JMEOS](https://github.com/MobilityDB/JMEOS/pull/9) to produce Spark UDF registrations for
+all MEOS functions, analogous to what `meos-api.json` drives for JMEOS itself.
+Target: BerlinMOD Q1–Q12 all passing.
+
+### Phase 4 — Serialization alignment
+Replace [MobilityPySpark](https://github.com/MobilityDB/MobilityPySpark)'s WKT string
+interchange with MEOS binary hex.  Establish a shared test fixture (small BerlinMOD dataset
+in MF-JSON) runnable on all three platforms from the same file.
+
+### Phase 5 — BerlinMOD Q1–Q20 parity suite
+Complete Q13–Q20 on all three platforms.  Surface any remaining name or semantic mismatches.
+All 20 queries return identical results on all three platforms with the portable SQL files
+in [`berlinmod/`](berlinmod/).
+
+### Phase 6 — Catalyst extensions for [MobilitySpark](https://github.com/MobilityDB/MobilitySpark)
+Implement Spark Catalyst planning rules for predicate push-down on `eIntersects` / `before`
+/ `after`, leveraging the spatial index primitives exposed by
+[PR #740](https://github.com/MobilityDB/MobilityDB/pull/740) (SP-GiST in MEOS).
+
+## Open Questions
+
+1. **[MobilityDB](https://github.com/MobilityDB/MobilityDB) maintainers**: review the
+   [operator → function mapping table](#operator--function-mapping) and flag any name that
+   should differ from the MEOS canonical.
+2. **[JMEOS](https://github.com/MobilityDB/JMEOS) contributors**: confirm that
+   [JMEOS 1.3 (PR #9)](https://github.com/MobilityDB/JMEOS/pull/9) exposes all functions
+   referenced in the [table above](#operator--function-mapping), or note the gaps.
+3. **[MobilitySpark](https://github.com/MobilityDB/MobilitySpark) contributors**: wire JMEOS
+   1.3 and register UDFs using the canonical names.
+4. **[MobilityPySpark](https://github.com/MobilityDB/MobilityPySpark) contributors**: rename
+   UDFs to canonical names and switch serialization to MEOS binary / MF-JSON.
+5. **Anyone**: run the queries in [`berlinmod/`](berlinmod/) on whichever platform you have
+   available and report results.
+
+The goal is **one SQL file, three platforms, same answer**.
+
+## Related
+
+- [MobilityDB](https://github.com/MobilityDB/MobilityDB) — PostgreSQL extension
+- [MobilityDuck](https://github.com/MobilityDB/MobilityDuck) — DuckDB extension
+- [MobilitySpark](https://github.com/MobilityDB/MobilitySpark) — Apache Spark UDFs (Java/JMEOS)
+- [MobilityPySpark](https://github.com/MobilityDB/MobilityPySpark) — Apache Spark UDFs (Python/PyMEOS)
+- [JMEOS](https://github.com/MobilityDB/JMEOS) — Java bindings for MEOS ([PR #9 = 1.3](https://github.com/MobilityDB/JMEOS/pull/9))
+- [MEOS-API](https://github.com/MobilityDB/MEOS-API) — canonical function registry (meos-api.json)

--- a/doc/edge-to-cloud/README.md
+++ b/doc/edge-to-cloud/README.md
@@ -1,3 +1,10 @@
+<!--
+Copyright(c) MobilityDB Contributors
+
+This documentation is provided under Creative Commons Attribution 4.0
+International License (CC BY 4.0): https://creativecommons.org/licenses/by/4.0/
+-->
+
 # RFC: Edge-to-Cloud SQL Portability for the MobilityDB Ecosystem
 
 > **Discussion [#861](https://github.com/MobilityDB/MobilityDB/discussions/861)** — community discussion and sign-off

--- a/doc/edge-to-cloud/berlinmod/q01.sql
+++ b/doc/edge-to-cloud/berlinmod/q01.sql
@@ -1,0 +1,11 @@
+-- BerlinMOD Q1: Models of vehicles with licences from QueryLicences.
+--
+-- Portable: works unchanged on MobilityDB/PostgreSQL, MobilityDuck/DuckDB,
+-- and MobilitySpark/Spark SQL.
+--
+-- Temporal operations used: none (pure relational join — baseline portability test).
+
+SELECT l.licence, v.model
+FROM   QueryLicences l
+JOIN   Vehicles v ON v.licence = l.licence
+ORDER  BY l.licence;

--- a/doc/edge-to-cloud/berlinmod/q01.sql
+++ b/doc/edge-to-cloud/berlinmod/q01.sql
@@ -1,3 +1,7 @@
+-- Copyright(c) MobilityDB Contributors
+-- This file is part of MobilityDB documentation.
+-- Licensed under Creative Commons Attribution 4.0 International (CC BY 4.0).
+--
 -- BerlinMOD Q1: Models of vehicles with licences from QueryLicences.
 --
 -- Portable: works unchanged on MobilityDB/PostgreSQL, MobilityDuck/DuckDB,

--- a/doc/edge-to-cloud/berlinmod/q03.sql
+++ b/doc/edge-to-cloud/berlinmod/q03.sql
@@ -1,0 +1,19 @@
+-- BerlinMOD Q3: Position of query-licence vehicles at each query instant.
+--
+-- Portable: works unchanged on MobilityDB/PostgreSQL, MobilityDuck/DuckDB,
+-- and MobilitySpark/Spark SQL.
+--
+-- Temporal operations used:
+--   atTime(tgeompoint, timestamptz) → tgeompoint restricted to that instant
+--   (NULL when the trip was not active at the given instant)
+
+SELECT v.vehId,
+       v.licence,
+       i.instantId,
+       atTime(t.trip, i.instant) AS pos
+FROM   QueryLicences l
+JOIN   Vehicles v  ON  v.licence = l.licence
+JOIN   Trips    t  ON  t.vehId   = v.vehId
+JOIN   QueryInstants i ON true
+WHERE  atTime(t.trip, i.instant) IS NOT NULL
+ORDER  BY v.vehId, i.instantId;

--- a/doc/edge-to-cloud/berlinmod/q03.sql
+++ b/doc/edge-to-cloud/berlinmod/q03.sql
@@ -1,3 +1,7 @@
+-- Copyright(c) MobilityDB Contributors
+-- This file is part of MobilityDB documentation.
+-- Licensed under Creative Commons Attribution 4.0 International (CC BY 4.0).
+--
 -- BerlinMOD Q3: Position of query-licence vehicles at each query instant.
 --
 -- Portable: works unchanged on MobilityDB/PostgreSQL, MobilityDuck/DuckDB,

--- a/doc/edge-to-cloud/berlinmod/q04.sql
+++ b/doc/edge-to-cloud/berlinmod/q04.sql
@@ -1,0 +1,15 @@
+-- BerlinMOD Q4: Licence plates of vehicles that ever passed a query point.
+--
+-- Portable: works unchanged on MobilityDB/PostgreSQL, MobilityDuck/DuckDB,
+-- and MobilitySpark/Spark SQL.
+--
+-- Temporal operations used:
+--   eIntersects(tgeompoint, geometry) → boolean, true if the trip ever intersects geom
+--
+-- MobilityDB operator equivalent:  t.trip && p.geom  (ever-intersects shorthand)
+
+SELECT DISTINCT v.licence
+FROM   Vehicles v
+JOIN   Trips t      ON t.vehId  = v.vehId
+JOIN   QueryPoints p ON eIntersects(t.trip, p.geom)
+ORDER  BY v.licence;

--- a/doc/edge-to-cloud/berlinmod/q04.sql
+++ b/doc/edge-to-cloud/berlinmod/q04.sql
@@ -1,3 +1,7 @@
+-- Copyright(c) MobilityDB Contributors
+-- This file is part of MobilityDB documentation.
+-- Licensed under Creative Commons Attribution 4.0 International (CC BY 4.0).
+--
 -- BerlinMOD Q4: Licence plates of vehicles that ever passed a query point.
 --
 -- Portable: works unchanged on MobilityDB/PostgreSQL, MobilityDuck/DuckDB,

--- a/doc/edge-to-cloud/berlinmod/q05.sql
+++ b/doc/edge-to-cloud/berlinmod/q05.sql
@@ -1,0 +1,27 @@
+-- BerlinMOD Q5: For each pair of query-licence vehicles, the minimum distance
+-- ever reached between their trips.
+--
+-- Portable: works unchanged on MobilityDB/PostgreSQL, MobilityDuck/DuckDB,
+-- and MobilitySpark/Spark SQL.
+--
+-- Temporal operations used:
+--   nearestApproachDistance(tgeompoint, tgeompoint) → float8
+--     Returns the minimum Euclidean distance reached at any common instant.
+--     Returns NULL when the trips have no overlapping time extent.
+--
+-- MobilityDB operator equivalent:  t1.trip |=| t2.trip
+-- NOTE: MobilityPySpark called this min_distance() / nearest_approach_distance();
+--       the canonical portable name is nearestApproachDistance() (MEOS convention).
+
+SELECT l1.licence AS licence1,
+       l2.licence AS licence2,
+       MIN(nearestApproachDistance(t1.trip, t2.trip)) AS min_dist
+FROM   QueryLicences l1
+JOIN   Vehicles v1  ON  v1.licence = l1.licence
+JOIN   Trips    t1  ON  t1.vehId   = v1.vehId
+JOIN   QueryLicences l2 ON l1.licenceId < l2.licenceId
+JOIN   Vehicles v2  ON  v2.licence = l2.licence
+JOIN   Trips    t2  ON  t2.vehId   = v2.vehId
+WHERE  nearestApproachDistance(t1.trip, t2.trip) IS NOT NULL
+GROUP  BY l1.licence, l2.licence
+ORDER  BY l1.licence, l2.licence;

--- a/doc/edge-to-cloud/berlinmod/q05.sql
+++ b/doc/edge-to-cloud/berlinmod/q05.sql
@@ -1,3 +1,7 @@
+-- Copyright(c) MobilityDB Contributors
+-- This file is part of MobilityDB documentation.
+-- Licensed under Creative Commons Attribution 4.0 International (CC BY 4.0).
+--
 -- BerlinMOD Q5: For each pair of query-licence vehicles, the minimum distance
 -- ever reached between their trips.
 --

--- a/doc/edge-to-cloud/berlinmod/q06.sql
+++ b/doc/edge-to-cloud/berlinmod/q06.sql
@@ -1,3 +1,7 @@
+-- Copyright(c) MobilityDB Contributors
+-- This file is part of MobilityDB documentation.
+-- Licensed under Creative Commons Attribution 4.0 International (CC BY 4.0).
+--
 -- BerlinMOD Q6: Pairs of trucks that ever came within 10 m of each other.
 --
 -- Portable: works unchanged on MobilityDB/PostgreSQL, MobilityDuck/DuckDB,

--- a/doc/edge-to-cloud/berlinmod/q06.sql
+++ b/doc/edge-to-cloud/berlinmod/q06.sql
@@ -1,0 +1,22 @@
+-- BerlinMOD Q6: Pairs of trucks that ever came within 10 m of each other.
+--
+-- Portable: works unchanged on MobilityDB/PostgreSQL, MobilityDuck/DuckDB,
+-- and MobilitySpark/Spark SQL.
+--
+-- Temporal operations used:
+--   eDwithin(tgeompoint, tgeompoint, float8) → boolean
+--     True if the two trips ever came within the given distance of each other.
+--
+-- MobilityDB operator equivalent: t1.trip |=| t2.trip <= 10.0
+-- (|=| is nearest-approach-distance; eDwithin is the efficient index-friendly form)
+
+SELECT v1.licence AS licence1,
+       v2.licence AS licence2
+FROM   Vehicles v1
+JOIN   Trips t1 ON t1.vehId = v1.vehId
+JOIN   Vehicles v2 ON v1.vehId < v2.vehId
+JOIN   Trips t2 ON t2.vehId = v2.vehId
+WHERE  v1.type  = 'truck'
+  AND  v2.type  = 'truck'
+  AND  eDwithin(t1.trip, t2.trip, 10.0)
+ORDER  BY v1.licence, v2.licence;

--- a/doc/edge-to-cloud/berlinmod/schema.sql
+++ b/doc/edge-to-cloud/berlinmod/schema.sql
@@ -1,3 +1,7 @@
+-- Copyright(c) MobilityDB Contributors
+-- This file is part of MobilityDB documentation.
+-- Licensed under Creative Commons Attribution 4.0 International (CC BY 4.0).
+--
 -- BerlinMOD schema — portable across MobilityDB/PostgreSQL, MobilityDuck/DuckDB,
 -- and MobilitySpark/Spark SQL.
 --

--- a/doc/edge-to-cloud/berlinmod/schema.sql
+++ b/doc/edge-to-cloud/berlinmod/schema.sql
@@ -1,0 +1,45 @@
+-- BerlinMOD schema — portable across MobilityDB/PostgreSQL, MobilityDuck/DuckDB,
+-- and MobilitySpark/Spark SQL.
+--
+-- Type names (tgeompoint, tstzspan, …) are registered identically on all three platforms.
+-- The geometry type uses the platform's native geometry type (PostGIS / DuckDB Spatial /
+-- Spark JTS — all store EWKB-compatible hex strings in the portable interchange format).
+
+CREATE TABLE IF NOT EXISTS Vehicles (
+    vehId   integer  PRIMARY KEY,
+    licence text     NOT NULL,
+    type    text     NOT NULL,
+    model   text     NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS Trips (
+    tripId  integer     PRIMARY KEY,
+    vehId   integer     NOT NULL REFERENCES Vehicles(vehId),
+    trip    tgeompoint  NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS QueryLicences (
+    licenceId integer PRIMARY KEY,
+    licence   text    NOT NULL,
+    vehId     integer
+);
+
+CREATE TABLE IF NOT EXISTS QueryInstants (
+    instantId integer     PRIMARY KEY,
+    instant   timestamptz NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS QueryPoints (
+    pointId integer  PRIMARY KEY,
+    geom    geometry NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS QueryRegions (
+    regionId integer  PRIMARY KEY,
+    geom     geometry NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS QueryPeriods (
+    periodId integer   PRIMARY KEY,
+    period   tstzspan  NOT NULL
+);

--- a/meos/src/geo/tgeo_restrict.c
+++ b/meos/src/geo/tgeo_restrict.c
@@ -1661,10 +1661,18 @@ tpointseq_interperiods(const TSequence *seq, const GSERIALIZED *gsinter,
     }
     TimestampTz t1, t2;
     GSERIALIZED *gspoint;
+    bool geodetic = FLAGS_GET_GEODETIC(gsinter->gflags);
     /* Each intersection is either a point or a linestring */
     if (type == POINTTYPE)
     {
       gspoint = geo_serialize((LWGEOM *) point_inter);
+      /* geo_serialize strips the geodetic flag; restore it for geodetic seqs */
+      if (geodetic)
+      {
+        GSERIALIZED *tmp = geom_to_geog(gspoint);
+        pfree(gspoint);
+        gspoint = tmp;
+      }
       tpointseq_timestamp_at_value(seq, PointerGetDatum(gspoint), &t1);
       pfree(gspoint);
       /* If the intersection is not at an exclusive bound */
@@ -1679,12 +1687,24 @@ tpointseq_interperiods(const TSequence *seq, const GSERIALIZED *gsinter,
       LWPOINT *point = lwline_get_lwpoint(line_inter, 0);
       gspoint = geo_serialize((LWGEOM *) point);
       lwpoint_free(point);
+      if (geodetic)
+      {
+        GSERIALIZED *tmp = geom_to_geog(gspoint);
+        pfree(gspoint);
+        gspoint = tmp;
+      }
       tpointseq_timestamp_at_value(seq, PointerGetDatum(gspoint), &t1);
       pfree(gspoint);
       /* Get the fraction of the end point of the intersecting line */
       point = lwline_get_lwpoint(line_inter, line_inter->points->npoints - 1);
       gspoint = geo_serialize((LWGEOM *) point);
       lwpoint_free(point);
+      if (geodetic)
+      {
+        GSERIALIZED *tmp = geom_to_geog(gspoint);
+        pfree(gspoint);
+        gspoint = tmp;
+      }
       tpointseq_timestamp_at_value(seq, PointerGetDatum(gspoint), &t2);
       pfree(gspoint);
       /* If t1 == t2 and the intersection is not at an exclusive bound */

--- a/meos/src/geo/tspatial_tempspatialrels.c
+++ b/meos/src/geo/tspatial_tempspatialrels.c
@@ -199,6 +199,16 @@ tinterrel_tpointseq_simple_geo(const TSequence *seq, const GSERIALIZED *gs,
   GSERIALIZED *traj = tpointseq_linear_trajectory(seq, UNARY_UNION_NO);
   GSERIALIZED *inter = geom_intersection2d(traj, gs);
   pfree(traj);
+  /* geom_intersection2d returns a planar geometry (GEODETIC=0, SRID from gs).
+   * For geodetic sequences the instants carry GEODETIC=1 and SRID=4326, so
+   * datum_point_eq rejects any comparison. Promote the intersection result to
+   * geography here so that tpointseq_interperiods can locate timestamps. */
+  if (! gserialized_is_empty(inter) && MEOS_FLAGS_GET_GEODETIC(seq->flags))
+  {
+    GSERIALIZED *inter_geog = geom_to_geog(inter);
+    pfree(inter);
+    inter = inter_geog;
+  }
   if (gserialized_is_empty(inter))
   {
     result = palloc(sizeof(TSequence *));


### PR DESCRIPTION
## Summary

Proposes a **portable named-function SQL dialect** that lets the same `.sql` query run
unchanged on MobilityDB (PostgreSQL), MobilityDuck (DuckDB), and MobilitySpark (Spark).

- Maps every PostgreSQL-specific MobilityDB operator to a canonical named function
  (`&&` → `overlaps`, `<<#` → `before`, `<->` → `tdistance`, …)
- Shows that no new engineering is required — MobilityDB and MobilityDuck already expose
  all named forms; MobilitySpark needs UDFs with matching names
- Includes BerlinMOD Q1/Q3/Q4/Q5/Q6 in the portable dialect as acceptance criteria
- Lays out a six-phase implementation roadmap (JMEOS 1.3 wiring → name registry →
  MobilitySpark UDF generation → serialisation → full BerlinMOD → Catalyst push-down)
- Poses five open questions for community sign-off

Community Discussion: https://github.com/MobilityDB/MobilityDB/discussions/861

**Companion RFCs** (same batch):
- PR #911 — TemporalParquet wire format
- PR #912 — Temporal Data Lake architecture

## Test plan

- [ ] Review `doc/edge-to-cloud/README.md` — problem statement, operator table, open questions
- [ ] Review `doc/edge-to-cloud/berlinmod/q*.sql` — portable dialect correctness
- [ ] Verify the operator mapping table covers all MobilityDB operators that have no
      named alias today
- [ ] Comment on Discussion #861 with any name disagreements or additions