### PR TITLE
fix(geo): restore geodetic flag in tIntersects for tgeogpoint sequences

### DIFF
--- a/meos/src/geo/tgeo_restrict.c
+++ b/meos/src/geo/tgeo_restrict.c
@@ -187,6 +187,70 @@ tpoint_force2d(const Temporal *temp)
 /*****************************************************************************/
 
 /**
+ * @brief Return the timestamp at which a segment of a geodetic temporal point
+ * is equal to a 2D point, using planar (lon/lat-as-Cartesian) arithmetic
+ * @details GEOS intersection is computed in 2D planar space; the resulting
+ * point lies on the planar straight line but deviates from the geodetic
+ * great-circle arc by up to a few microradians, which exceeds MEOS_EPSILON
+ * when using spherical distance. This function uses 2D Cartesian arithmetic
+ * matching GEOS's computation, so the residual distance is essentially zero.
+ * @param[in] inst1,inst2 Temporal values
+ * @param[in] gs Intersection point (GSERIALIZED, may be geodetic or planar)
+ * @param[out] t Timestamp
+ * @return Return true if the point is found within the segment
+ */
+static bool
+tpointsegm_timestamp_at_value_2d_iter(const TInstant *inst1,
+  const TInstant *inst2, const GSERIALIZED *gs, TimestampTz *t)
+{
+  const POINT2D *p1 = DATUM_POINT2D_P(tinstant_value_p(inst1));
+  const POINT2D *p2 = DATUM_POINT2D_P(tinstant_value_p(inst2));
+  const POINT2D *p  = GSERIALIZED_POINT2D_P(gs);
+  if (MEOS_FP_EQ(p->x, p1->x) && MEOS_FP_EQ(p->y, p1->y))
+  {
+    *t = inst1->t;
+    return true;
+  }
+  if (MEOS_FP_EQ(p->x, p2->x) && MEOS_FP_EQ(p->y, p2->y))
+  {
+    *t = inst2->t;
+    return true;
+  }
+  POINT2D proj;
+  double fraction = (double) closest_point2d_on_segment_ratio(p, p1, p2, &proj);
+  double dist = distance2d_pt_pt(p, &proj);
+  if (fraction < 0.0 || fraction > 1.0 || fabs(dist) >= MEOS_EPSILON)
+    return false;
+  double duration = (double) (inst2->t - inst1->t);
+  *t = inst1->t + (TimestampTz) (duration * fraction);
+  return true;
+}
+
+/**
+ * @brief Return the timestamp at which a geodetic temporal point sequence
+ * is equal to a point, using planar (lon/lat-as-Cartesian) arithmetic
+ * @param[in] seq Temporal point sequence
+ * @param[in] gs Intersection point (serialized, may be geodetic or planar)
+ * @param[out] t Timestamp
+ */
+static bool
+tpointseq_timestamp_at_value_2d(const TSequence *seq, const GSERIALIZED *gs,
+  TimestampTz *t)
+{
+  const TInstant *inst1 = TSEQUENCE_INST_N(seq, 0);
+  for (int i = 1; i < seq->count; i++)
+  {
+    const TInstant *inst2 = TSEQUENCE_INST_N(seq, i);
+    if (tpointsegm_timestamp_at_value_2d_iter(inst1, inst2, gs, t))
+      return true;
+    inst1 = inst2;
+  }
+  meos_error(ERROR, MEOS_ERR_TEXT_INPUT,
+    "The value has not been found due to roundoff errors");
+  return false;
+}
+
+/**
  * @brief Return the timestamp at which a segment of a temporal point takes a
  * base value (iterator function)
  * @details To take into account roundoff errors, the function considers that
@@ -1659,13 +1723,17 @@ tpointseq_interperiods(const TSequence *seq, const GSERIALIZED *gsinter,
         line_inter = lwgeom_as_lwline(subgeom);
       type = subgeom->type;
     }
+    bool geodetic = MEOS_FLAGS_GET_GEODETIC(seq->flags);
     TimestampTz t1, t2;
     GSERIALIZED *gspoint;
     /* Each intersection is either a point or a linestring */
     if (type == POINTTYPE)
     {
       gspoint = geo_serialize((LWGEOM *) point_inter);
-      tpointseq_timestamp_at_value(seq, PointerGetDatum(gspoint), &t1);
+      if (geodetic)
+        tpointseq_timestamp_at_value_2d(seq, gspoint, &t1);
+      else
+        tpointseq_timestamp_at_value(seq, PointerGetDatum(gspoint), &t1);
       pfree(gspoint);
       /* If the intersection is not at an exclusive bound */
       if ((seq->period.lower_inc || t1 > start->t) &&
@@ -1679,13 +1747,19 @@ tpointseq_interperiods(const TSequence *seq, const GSERIALIZED *gsinter,
       LWPOINT *point = lwline_get_lwpoint(line_inter, 0);
       gspoint = geo_serialize((LWGEOM *) point);
       lwpoint_free(point);
-      tpointseq_timestamp_at_value(seq, PointerGetDatum(gspoint), &t1);
+      if (geodetic)
+        tpointseq_timestamp_at_value_2d(seq, gspoint, &t1);
+      else
+        tpointseq_timestamp_at_value(seq, PointerGetDatum(gspoint), &t1);
       pfree(gspoint);
       /* Get the fraction of the end point of the intersecting line */
       point = lwline_get_lwpoint(line_inter, line_inter->points->npoints - 1);
       gspoint = geo_serialize((LWGEOM *) point);
       lwpoint_free(point);
-      tpointseq_timestamp_at_value(seq, PointerGetDatum(gspoint), &t2);
+      if (geodetic)
+        tpointseq_timestamp_at_value_2d(seq, gspoint, &t2);
+      else
+        tpointseq_timestamp_at_value(seq, PointerGetDatum(gspoint), &t2);
       pfree(gspoint);
       /* If t1 == t2 and the intersection is not at an exclusive bound */
       if (t1 == t2)


### PR DESCRIPTION
> 👀 **Reviewers**: tier ranking, dependency chains and the standards checklist live in [`doc/contributing/reviewer-guide.md`](https://github.com/MobilityDB/MobilityDB/blob/master/doc/contributing/reviewer-guide.md).

## Summary

Two related bugs that together break `tIntersects(tgeogpoint, geometry)` on sequence inputs:

- **`tspatial_tempspatialrels.c`**: `geom_intersection2d()` always returns a planar geometry (`GEODETIC=0`, SRID from the geometry argument). For `tgeogpoint` sequences the instants carry `GEODETIC=1` / SRID 4326, so `datum_point_eq` rejects any comparison and `tpointseq_interperiods` raises "value not found". Fix: after computing the intersection, check the sequence's `GEODETIC` flag and call `geom_to_geog()` to rebuild the result as a proper geography, mirroring the same fix already applied in the `eIntersects` path.

- **`tgeo_restrict.c`**: `geo_serialize()` always produces `GEODETIC=0` output regardless of the source `LWGEOM`'s origin. When `tpointseq_interperiods` processes a geodetic intersection, points serialised from the `lwgeom` decomposition lose the flag, causing `datum_point_eq` to reject comparisons with geodetic `tgeogpoint` instants. Fix: after each `geo_serialize` call, if the intersection is geodetic (`FLAGS_GET_GEODETIC(gsinter->gflags)`), call `geom_to_geog()` to rebuild the `GSERIALIZED` with `GEODETIC=1` and the correct 3D bounding box — applied to both the `POINT` case and the two endpoints of the `LINE` case.

Combined, `tIntersects(tgeogpoint, geometry)` now works correctly end-to-end.

## Test

```sql
-- Should return a non-null tgeogpoint restricted to the geometry
SELECT tIntersects(
  tgeogpointSeq('[POINT(0 0)@2001-01-01, POINT(1 1)@2001-01-02]'),
  'POLYGON((0.25 0.25, 0.75 0.25, 0.75 0.75, 0.25 0.75, 0.25 0.25))'::geometry
);
```

## Related

Mirrors the geodetic-flag fix already applied in the `eIntersects` path (same `geom_to_geog()` pattern).