### PR TITLE
fix(rgeo): pfree geo_as_geojson strings in asMFJSON output functions (closes #850)

### DIFF
--- a/meos/src/temporal/type_out.c
+++ b/meos/src/temporal/type_out.c
@@ -315,6 +315,7 @@ temporal_base_as_mfjson_sb(stringbuffer_t *sb, Datum value, MeosType temptype,
       char *str = geo_as_geojson(DatumGetGserializedP(value), 0, precision,
         NULL);
       stringbuffer_aprintf(sb, "%s,", str);
+      pfree(str);
       break;
     }
     default: /* Error! */
@@ -559,6 +560,7 @@ tinstant_as_mfjson_sb(stringbuffer_t *sb, const TInstant *inst,
     const GSERIALIZED *gs = trgeoinst_geom_p(inst);
     char *str = geo_as_geojson(gs, 0, precision, NULL);
     stringbuffer_aprintf(sb, "%s,", str);
+    pfree(str);
     stringbuffer_append_len(sb, "\"values\":[", 10);
     pose_as_json_sb(sb, DatumGetPoseP(tinstant_value_p(inst)), precision);
   }
@@ -608,6 +610,7 @@ tsequence_as_mfjson_sb(stringbuffer_t *sb, const TSequence *seq,
     const GSERIALIZED *gs = trgeoseq_geom_p(seq);
     char *str = geo_as_geojson(gs, 0, precision, NULL);
     stringbuffer_aprintf(sb, "%s,\"values\":[", str);
+    pfree(str);
   }
 #endif /* RGEO */
   else
@@ -695,6 +698,7 @@ tsequenceset_as_mfjson_sb(stringbuffer_t *sb, const TSequenceSet *ss,
     stringbuffer_append_len(sb, "\"geometry\":", 11);
     char *str = geo_as_geojson(trgeoseqset_geom_p(ss), 0, precision, NULL);
     stringbuffer_aprintf(sb, "%s,", str);
+    pfree(str);
   }
 #endif /* RGEO */
 
@@ -721,8 +725,8 @@ tsequenceset_as_mfjson_sb(stringbuffer_t *sb, const TSequenceSet *ss,
         const GSERIALIZED *gs = DatumGetGserializedP(tinstant_value_p(inst));
         /* Do not repeat the crs for the composing geometries */
         char *str = geo_as_geojson(gs, 0, precision, NULL);
-        stringbuffer_aprintf(sb, "%s", str);      
-        // pfree(str);
+        stringbuffer_aprintf(sb, "%s", str);
+        pfree(str);
       }
 #if POSE
       else if (inst->temptype == T_TPOSE)


### PR DESCRIPTION
> 👀 **Reviewers**: tier ranking, dependency chains and the standards checklist live in [`doc/contributing/reviewer-guide.md`](https://github.com/MobilityDB/MobilityDB/blob/master/doc/contributing/reviewer-guide.md).

## Summary

- `geo_as_geojson` returns a `palloc`'d / `lwalloc`'d string that must be `pfree`'d after it is appended to the `stringbuffer`. Five call sites in `meos/src/temporal/type_out.c` were missing this `pfree`, causing a memory leak on every `asMFJSON` call on a `trgeo` value.

## Fixes

| Function | Location | Fix |
|---|---|---|
| `temporal_base_as_mfjson_sb` | T_TGEOMETRY / T_TGEOGRAPHY switch case | add `pfree(str)` |
| `tinstant_as_mfjson_sb` | trgeo branch (`trgeoinst_geom_p`) | add `pfree(str)` |
| `tsequence_as_mfjson_sb` | trgeo branch (`trgeoseq_geom_p`) | add `pfree(str)` |
| `tsequenceset_as_mfjson_sb` | trgeo branch | add `pfree(str)` |
| `tsequenceset_as_mfjson_sb` | tgeo_type branch | uncomment existing (commented-out) `pfree(str)` |

## Test

Reproduction from issue #850:

```sql
SELECT asMFJSON(trgeo 'Pose(Point(1 2),0.5)@2020-01-01');
SELECT asMFJSON(trgeo '[Pose(Point(1 2),0.5)@2020-01-01, Pose(Point(3 4),1.0)@2020-01-02]');
SELECT asMFJSON(trgeo '{[Pose(Point(1 2),0.5)@2020-01-01, Pose(Point(3 4),1.0)@2020-01-02],[Pose(Point(5 6),0.0)@2020-01-03]}');
```

All three now return valid, well-formed MFJSON. Previously the output was truncated / corrupted.

## CI

All checks green (Ubuntu, clang, Windows, CodeQL, Cppcheck, MEOS compile). macOS runner queued.