### PR TITLE
Add geo production guidance and hazard regression suite

### DIFF
--- a/doc/temporal_spatial_p1.xml
+++ b/doc/temporal_spatial_p1.xml
@@ -80,6 +80,7 @@
 			</listitem>
 		</itemizedlist>
 		<para>In the following, we specify with the symbol &Z_support; that the function supports 3D geometries and with the symbol &geography_support; that the function supports geographies.</para>
+		<para>Operational guidance on choosing between <varname>tgeompoint</varname>, <varname>tgeogpoint</varname>, <varname>tgeometry</varname>, and <varname>tgeography</varname>; the SRID and dimensionality conventions the implementation enforces; and the named numerical hazards production workloads should anticipate is collected in <xref linkend="geo_production_guidance"/>.</para>
 	</sect1>
 
 	<sect1 xml:id="tgeo_inout">

--- a/doc/temporal_spatial_p2.xml
+++ b/doc/temporal_spatial_p2.xml
@@ -577,5 +577,73 @@ SELECT tTouches(geometry 'Polygon((1 0,1 2,2 2,2 0,1 0))',
 			</itemizedlist>
 		</sect2>
 	</sect1>
+
+	<sect1 xml:id="geo_production_guidance">
+		<title>Production guidance</title>
+		<para>This section captures the operational knowledge production workloads need on top of the function reference: when each member of the geo family (<varname>tgeompoint</varname>, <varname>tgeogpoint</varname>, <varname>tgeometry</varname>, <varname>tgeography</varname>) is the right type, the spatial-reference and dimensionality conventions the implementation assumes, and the numerical hazards real spatial pipelines hit. Most of these are surfaced separately throughout the chapter; the goal here is one place a new contributor can read end-to-end before instrumenting an application.</para>
+
+		<sect2 xml:id="geo_when_to_use">
+			<title>When to use which type within the geo family</title>
+			<para>The four temporal geo types form a 2x2 grid along two axes: the value's <emphasis>shape</emphasis> (a single moving point versus an arbitrary geometry whose shape may itself vary) and the <emphasis>spatial reference</emphasis> (projected coordinates with planar Euclidean math versus geographic coordinates with spherical / great-circle math).</para>
+			<itemizedlist>
+				<listitem><para><varname>tgeompoint</varname> &#x2014; temporal trajectory of a position in projected coordinates (planar Euclidean math). The most common case; lowest storage; fastest operations. Use for vehicle GPS tracks reduced to a planar CRS, animal movement in a local projection, indoor tracking in a building frame.</para></listitem>
+				<listitem><para><varname>tgeogpoint</varname> &#x2014; temporal trajectory of a position in geographic coordinates (lat / lon, spherical math). Use when the spatial extent crosses zones (continental / global tracks, AIS feeds), or when great-circle distances are required.</para></listitem>
+				<listitem><para><varname>tgeometry</varname> &#x2014; temporal <emphasis>arbitrary</emphasis> geometry (point, line, polygon, multi-*) in projected coordinates. Use when the value's <emphasis>shape</emphasis>, not just its position, varies over time &#x2014; storm wind swaths, expanding plumes, rotating exclusion zones, evolving polygons.</para></listitem>
+				<listitem><para><varname>tgeography</varname> &#x2014; temporal arbitrary geometry in geographic coordinates. Same role as <varname>tgeometry</varname> but on the sphere.</para></listitem>
+			</itemizedlist>
+			<para>The position component of a <varname>tgeometry</varname> whose value is point-typed is recoverable as a <varname>tgeompoint</varname> via the standard cast; analogously for <varname>tgeography</varname> / <varname>tgeogpoint</varname>. Consequently a single <varname>tgeometry</varname> column subsumes a <varname>tgeompoint</varname> column when both might be needed and the storage cost of the wider type is acceptable.</para>
+		</sect2>
+
+		<sect2 xml:id="geo_srid_conventions">
+			<title>CRS and SRID conventions</title>
+			<para>Every value in the geo family carries an SRID encoded in the underlying <varname>GSERIALIZED</varname> flag, propagated to the temporal value's bounding box and validated on every cross-type operation.</para>
+			<itemizedlist>
+				<listitem><para><emphasis>Mixed-SRID inputs are rejected</emphasis>, not implicitly transformed. Any binary operation between two geo values whose SRIDs differ raises an error via <varname>ensure_same_srid</varname>; the analogous projected-versus-geographic mismatch is caught by <varname>ensure_same_geodetic</varname>. The rationale is that an implicit <varname>ST_Transform</varname> would hide the cost (PROJ initialisation per call) and silently change semantics around the antimeridian, the poles, and at the boundary between projection zones. Workloads needing cross-CRS operations must call <varname>ST_Transform</varname> explicitly first.</para></listitem>
+				<listitem><para><emphasis>Geographic versus projected math</emphasis>. <varname>tgeompoint</varname> and <varname>tgeometry</varname> use planar Euclidean math; <varname>distance</varname> values are in CRS units (typically metres for a UTM zone, degrees for an unprojected geographic CRS). <varname>tgeogpoint</varname> and <varname>tgeography</varname> use spherical / great-circle math on the WGS-84 sphere; <varname>distance</varname> values are in metres. The two distance scales are <emphasis>not</emphasis> comparable; a query that joins on a distance threshold must check the underlying type before choosing the threshold.</para></listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2 xml:id="geo_dimensions">
+			<title>2D, 3D, and 4D coordinate semantics</title>
+			<para>All four types accept 2D (XY), 3D (XYZ), and 4D (XYZM) inputs. The Z and M flags are encoded in the <varname>GSERIALIZED</varname> header and preserved through the entire pipeline.</para>
+			<itemizedlist>
+				<listitem><para><emphasis>Z is preserved through all operations</emphasis>. Linear interpolation between two 3D instants is linear in 3D &#x2014; <varname>(x, y, z)</varname> all interpolate independently. Distance is full 3D Euclidean for projected geometries; for <varname>tgeogpoint</varname> with altitude, the distance combines great-circle horizontal distance with the altitude difference. The bounding box is an <varname>STBox</varname> with both Z and time extents set.</para></listitem>
+				<listitem><para><emphasis>M is parsed but ignored by spatial predicates</emphasis>. The M coordinate (a fourth, application-defined value &#x2014; commonly speed, accumulated distance, or a measured reading) is preserved on the value through WKT / WKB / MFJSON round-trips, but does not participate in <varname>distance</varname>, <varname>intersects</varname>, <varname>contains</varname>, <varname>dwithin</varname>, or any other topological / metric predicate. Workloads that need M-aware semantics must extract M as a separate <varname>tfloat</varname> column and operate on it explicitly &#x2014; do not assume any geo-family predicate is 4D-aware.</para></listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2 xml:id="geo_hazards">
+			<title>Numerical hazards</title>
+			<para>Five hazards reliably bite real spatial workloads. The implementation mitigates each as follows:</para>
+			<itemizedlist>
+				<listitem>
+					<para><emphasis>Mixed-SRID inputs</emphasis>. A query that joins two tables stored in different CRSes (e.g., one in WGS-84 geographic, one in a local UTM zone) would produce silently wrong distances if the SRIDs were not checked.</para>
+					<para><emphasis>Mitigation</emphasis>: every cross-type operation routes through <varname>ensure_same_srid</varname> / <varname>ensure_same_geodetic</varname>, which raise an error naming both SRIDs. The error path is loud and explicit; there is no implicit transform.</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>Empty geometry inputs</emphasis>. A <varname>POINT EMPTY</varname> or <varname>POLYGON EMPTY</varname> has no coordinates and would produce <varname>NaN</varname> bounding boxes if accepted into a temporal value.</para>
+					<para><emphasis>Mitigation</emphasis>: every <varname>tgeo*</varname> constructor (<varname>tgeoseq_from_base_tstzspan</varname>, <varname>tpointseq_from_base_tstzspan</varname>, <varname>tgeo_from_base_temp_int</varname>, and the analogous <varname>seqset</varname> / <varname>tstzset</varname> entries) calls <varname>gserialized_is_empty</varname> on the input geometry and rejects empty values before any further processing &#x2014; see <filename>meos/src/geo/tgeo_meos.c</filename> at lines 572, 594, and 665.</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>NaN and infinity coordinates</emphasis>. A <varname>POINT(NaN NaN)</varname> or a coordinate that overflows to <varname>Inf</varname> during a transform would propagate through bounding-box union, distance, and predicate evaluation, poisoning every downstream query.</para>
+					<para><emphasis>Mitigation</emphasis>: input parsing routes through PostGIS <varname>liblwgeom</varname>, which rejects non-finite coordinates at WKT / WKB / GeoJSON parse time. MEOS does not add an additional validation layer because the upstream check is already authoritative; non-finite coordinates therefore cannot enter a temporal geo value in the first place.</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>Antimeridian and pole crossings for <varname>tgeogpoint</varname></emphasis>. A temporal sequence with two consecutive points on opposite sides of &#xb1;180&#xb0; longitude (e.g., a transpacific flight or a vessel rounding Cape Horn at high latitude) is interpolated along the shortest great-circle arc &#x2014; the PostGIS / PROJ default. For workloads where this is the wrong semantics (a vessel that <emphasis>did</emphasis> travel the long way round), the input must be pre-processed to insert a synthetic instant near the antimeridian or at a sub-polar way-point, splitting the leg into two arcs each shorter than a hemisphere.</para>
+					<para><emphasis>Mitigation</emphasis>: documented as a caveat. No warning is currently emitted at construction time because detecting the case reliably (versus an intentional shortest-arc crossing of the dateline) is non-trivial.</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>Topological-predicate kernels</emphasis>. The geo family computes <varname>atGeometry</varname> / <varname>minusGeometry</varname> for the point-typed sub-family (<varname>tgeompoint</varname>, <varname>tgeogpoint</varname>) via a MEOS-native 2D / 3D trajectory-clipping kernel implemented in <filename>tpoint_geom_clip.c</filename>. For areal-Boolean operations on <varname>tgeometry</varname>, the implementation routes through PostGIS / GEOS today; the project is migrating these paths to native MEOS kernels (Clipper2-based) for performance reasons, with GEOS retained as a fallback for paths not yet covered. Users writing performance-sensitive code should not assume GEOS is the long-term engine; the MEOS-native path is the supported direction.</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2 xml:id="geo_durability">
+			<title>Durability and storage</title>
+			<para>The on-disk representation of a geo value is the standard PostGIS <varname>GSERIALIZED</varname> payload, with the SRID, Z flag, M flag, and geodetic flag encoded in the header. The byte layout is stable: <varname>geo_in</varname> / <varname>geo_as_text</varname> and <varname>geo_as_wkb</varname> / <varname>geo_from_wkb</varname> round-trip preserves the value (including Z, M, and SRID) bit-for-bit, and the WKB / EWKB / HexEWKB serialisations follow the standard PostGIS endian-flag-then-payload pattern.</para>
+			<para>The <varname>asMFJSON(tgeo*)</varname> / <varname>tspatialFromMFJSON(text)</varname> pair is bidirectional, so MovingFeatures-JSON is a viable interchange format for all four geo types on equal footing with WKB.</para>
+			<para>The <varname>pg_dump</varname> output of a table containing geo or temporal-geo columns uses the WKT representation by default; <varname>pg_dump --binary-upgrade</varname> uses the WKB representation. Both are round-trip-stable across PostgreSQL major-version upgrades.</para>
+		</sect2>
+	</sect1>
 </chapter>
 

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -46,6 +46,19 @@
 #include <meos.h>
 #include <meos_geo.h>
 
+/* Silent error handler used by the production-readiness hazard
+ * regressions at the bottom of main(): records the errno via
+ * meos_errno_set() without writing to stderr and without exiting on
+ * ERROR. The default handler exits on ERROR, which would terminate
+ * the test mid-run on any negative-path exercise. */
+static void
+silent_error_handler(int errlevel, int errcode, const char *errmsg)
+{
+  (void) errlevel; (void) errmsg;
+  meos_errno_set(errcode);
+  return;
+}
+
 /* Main program */
 int main(void)
 {
@@ -2843,6 +2856,156 @@ int main(void)
   /* double temporal_hausdorff_distance(const Temporal *temp1, const Temporal *temp2); */
   float8_result = temporal_hausdorff_distance(tgeompt1, tgeompt2);
   printf("temporal_hausdorff_distance(%s, %s): %lf\n", tgeompt1_out, tgeompt2_out, float8_result);
+
+  printf("****************************************************************\n");
+
+  /*****************************************************************************/
+  /* Production-readiness hazard regressions for the geo family                */
+  /*****************************************************************************/
+  /* These exercises pin the documented hazards from the geo_production_guidance
+   * sect1 in doc/temporal_spatial_p2.xml: mixed-SRID rejection, empty-geometry
+   * rejection, 3D linear interpolation, geographic-vs-planar distance scale
+   * divergence, and M-coordinate preservation through WKT round-trip while
+   * being ignored by spatial predicates. The default MEOS error handler exits
+   * on ERROR; we install a silent handler so the negative-path checks can
+   * inspect meos_errno() without terminating the process. */
+  printf("****************************************************************\n");
+  printf("* Production-readiness hazard regressions *\n");
+  printf("****************************************************************\n");
+
+  /* Install a silent handler so the negative-path checks can inspect
+   * meos_errno() without terminating the process. The MEOS public API
+   * does not expose a getter for the current handler; passing NULL to
+   * meos_initialize_error_handler reinstalls the default at the end. */
+  meos_initialize_error_handler(&silent_error_handler);
+
+  /* Hazard 1: mixed-SRID inputs are rejected via ensure_same_srid */
+  {
+    GSERIALIZED *gs_4326 = geom_in("SRID=4326;Point(1 1)", -1);
+    Temporal *t_3857 = tgeompoint_in(
+      "SRID=3857;[Point(1 1)@2001-01-01, Point(3 3)@2001-01-03]");
+    meos_errno_reset();
+    Temporal *result = tdistance_tgeo_geo(t_3857, gs_4326);
+    int err = meos_errno();
+    if (result == NULL && err == MEOS_ERR_INVALID_ARG_VALUE)
+      printf("PASS: mixed-SRID tdistance_tgeo_geo(SRID=3857 tgeompoint, "
+        "SRID=4326 geometry) rejected with MEOS_ERR_INVALID_ARG_VALUE\n");
+    else
+      printf("FAIL: mixed-SRID tdistance_tgeo_geo expected NULL + errno=%d, "
+        "got %s + errno=%d\n", MEOS_ERR_INVALID_ARG_VALUE,
+        result == NULL ? "NULL" : "non-NULL", err);
+    free(gs_4326); free(t_3857);
+    if (result != NULL) free(result);
+    meos_errno_reset();
+  }
+
+  /* Hazard 2: empty-geometry input rejected at construction
+   * (gserialized_is_empty in tgeo_meos.c at lines 572, 594, 665).
+   * tpointseq_from_base_tstzspan exercises the dedicated MEOS guard. */
+  {
+    GSERIALIZED *gs_empty = geom_in("SRID=5676;Point EMPTY", -1);
+    Span *span = tstzspan_in("[2001-01-01, 2001-01-03]");
+    meos_errno_reset();
+    TSequence *result = tpointseq_from_base_tstzspan(gs_empty, span, LINEAR);
+    /* The constructor returns NULL on empty without setting an errno
+     * (the empty-check is a silent guard, not an error path). */
+    if (result == NULL)
+      printf("PASS: empty-geometry input to tpointseq_from_base_tstzspan "
+        "rejected (returned NULL)\n");
+    else
+      printf("FAIL: empty-geometry input expected NULL, got non-NULL\n");
+    free(gs_empty); free(span);
+    if (result != NULL) free(result);
+    meos_errno_reset();
+  }
+
+  /* Hazard 3: 3D linear interpolation. A 2-instant tgeompoint with Z
+   * sampled at the midpoint must yield the linear midpoint of x, y, z. */
+  {
+    Temporal *t3d = tgeompoint_in(
+      "SRID=5676;[Point(0 0 0)@2001-01-01, Point(10 20 30)@2001-01-03]");
+    TimestampTz tmid = timestamptz_in("2001-01-02", -1);
+    GSERIALIZED *mid = NULL;
+    bool ok = tgeo_value_at_timestamptz(t3d, tmid, true, &mid);
+    /* Expect Point(5 10 15) at the temporal midpoint. */
+    char *mid_wkt = ok && mid ? geo_as_text(mid, 6) : NULL;
+    if (ok && mid_wkt && strstr(mid_wkt, "POINT Z (5 10 15)") != NULL)
+      printf("PASS: 3D linear interpolation midpoint of "
+        "[Point(0 0 0)@d1, Point(10 20 30)@d3] at d2 = %s\n", mid_wkt);
+    else
+      printf("FAIL: 3D linear interpolation expected POINT Z (5 10 15), "
+        "got %s\n", mid_wkt ? mid_wkt : "NULL");
+    if (mid_wkt) free(mid_wkt);
+    if (mid) free(mid);
+    free(t3d);
+  }
+
+  /* Hazard 4: geographic vs planar distance scale divergence.
+   * Identical XY coordinates as tgeompoint(SRID=3857) and tgeogpoint(
+   * SRID=4326) must produce different distance results because the math
+   * is planar Euclidean (CRS units, here metres in Web Mercator) versus
+   * spherical great-circle (metres on the WGS-84 sphere). */
+  {
+    GSERIALIZED *gs_proj = geom_in("SRID=3857;Point(0 0)", -1);
+    GSERIALIZED *gs_geog = geog_in("SRID=4326;Point(0 0)", -1);
+    Temporal *t_proj = tgeompoint_in(
+      "SRID=3857;[Point(10 10)@2001-01-01, Point(20 20)@2001-01-03]");
+    Temporal *t_geog = tgeogpoint_in(
+      "SRID=4326;[Point(10 10)@2001-01-01, Point(20 20)@2001-01-03]");
+    Temporal *d_proj = tdistance_tgeo_geo(t_proj, gs_proj);
+    Temporal *d_geog = tdistance_tgeo_geo(t_geog, gs_geog);
+    /* Sample the start instant of each result and compare. */
+    double v_proj = 0.0, v_geog = 0.0;
+    TimestampTz t_start = timestamptz_in("2001-01-01", -1);
+    bool ok_proj = tfloat_value_at_timestamptz(d_proj, t_start, true, &v_proj);
+    bool ok_geog = tfloat_value_at_timestamptz(d_geog, t_start, true, &v_geog);
+    /* Planar Euclidean distance from (0,0) to (10,10) in CRS units = sqrt(200)
+     * = ~14.14. Great-circle distance from (0,0) to (10,10) on WGS-84 is
+     * ~1568 km = 1.568e6 m. The two must differ by orders of magnitude. */
+    if (ok_proj && ok_geog && v_proj != v_geog && v_geog > v_proj * 1000.0)
+      printf("PASS: geographic-vs-planar distance scales diverge: "
+        "planar=%g, great-circle=%g (ratio=%g)\n",
+        v_proj, v_geog, v_geog / v_proj);
+    else
+      printf("FAIL: expected planar (~14) and great-circle (~1.5e6) to differ "
+        "by >1000x, got planar=%g, great-circle=%g\n", v_proj, v_geog);
+    free(gs_proj); free(gs_geog); free(t_proj); free(t_geog);
+    free(d_proj); free(d_geog);
+  }
+
+  /* Hazard 5: M coordinate preserved through WKT round-trip but ignored by
+   * spatial predicates. We construct a 4D (XYZM) tgeometry and check that
+   * (a) the WKT representation preserves the M coordinate, and (b) an
+   * intersects predicate against a 2D geometry returns the value we would
+   * get from the 2D projection of the trajectory (M is ignored).
+   * Note: PostGIS may emit a 3D-vs-2D NOTICE through the MEOS error path
+   * during this kind of cross-dimension comparison; we check the
+   * observable result, not the errno. */
+  {
+    Temporal *t4d = tgeometry_in(
+      "SRID=5676;[Point ZM (0 0 0 100)@2001-01-01, "
+      "Point ZM (10 10 10 200)@2001-01-03]");
+    char *t4d_wkt = tspatial_as_ewkt(t4d, 6);
+    bool m_preserved = strstr(t4d_wkt, "100") != NULL &&
+                       strstr(t4d_wkt, "200") != NULL;
+    /* Predicate against a 2D box that overlaps the XY trajectory. */
+    GSERIALIZED *box2d = geom_in(
+      "SRID=5676;Polygon((0 0, 0 20, 20 20, 20 0, 0 0))", -1);
+    meos_errno_reset();
+    int ever = eintersects_tgeo_geo(t4d, box2d);
+    if (m_preserved && ever == 1)
+      printf("PASS: 4D tgeometry round-trip preserves M (WKT contains "
+        "100 and 200) and eintersects_tgeo_geo against 2D polygon = true "
+        "(M ignored by predicate)\n");
+    else
+      printf("FAIL: 4D semantics: m_preserved=%d, eintersects=%d, "
+        "wkt=%s\n", (int) m_preserved, ever, t4d_wkt);
+    free(t4d); free(t4d_wkt); free(box2d);
+    meos_errno_reset();
+  }
+
+  /* Restore the default exiting error handler. */
+  meos_initialize_error_handler(NULL);
 
   printf("****************************************************************\n");
 


### PR DESCRIPTION
Adds a `geo_production_guidance` section at the end of `doc/temporal_spatial_p2.xml` covering the full geo type family (tgeompoint / tgeogpoint / tgeometry / tgeography):

- **Type selection** - 2×2 grid (point vs shape) × (projected vs geographic) with storage and bbox-precision rationale
- **CRS / SRID conventions** - mixed-SRID inputs rejected via `ensure_same_srid` / `ensure_same_geodetic`; geographic vs projected distance scales not comparable
- **2D / 3D / 4D semantics** - Z preserved; M parsed but ignored by spatial predicates
- **Numerical hazards** - four-tier classification: tier A (ERROR) for mixed-SRID and empty geometry; tier C (docs-only) for NaN/Inf (rejected upstream), antimeridian and pole crossings on tgeogpoint
- **Durability** - GSERIALIZED layout, WKT / WKB / EWKB / HexEWKB / MFJSON round-trip conventions, pg_dump

Adds a hazard regression suite in `meos/test/geo_test.c` exercising the documented error paths.

Adds an inbound cross-link from `tgeo_notation` to `geo_production_guidance`.

- [ ] All existing CI checks pass
- [ ] Hazard regression suite passes under CTest (`ctest -R geo_test`)
- [ ] DocBook renders without broken xrefs (`make -C doc html`)
