### PR TITLE
Bootstrap MEOS locale, UTF-8, and Windows builds

### DIFF
--- a/.github/workflows/meos_locale.yml
+++ b/.github/workflows/meos_locale.yml
@@ -1,0 +1,111 @@
+name: MEOS locale safety
+
+# Bootstrap CI for issue #425 (Localization support for the MEOS library).
+#
+# This job:
+#   1. Builds the standalone MEOS C library on Linux.
+#   2. Installs a locale that uses ',' as the decimal separator
+#      (de_DE.UTF-8 — same shape as fr_FR, it_IT, es_ES, etc.).
+#   3. Sets LC_NUMERIC to that locale and runs a tiny C test that calls
+#      meos_initialize() and parses '[1.5@2001-01-01]' as a tfloat.
+#
+# With the meos_strtod() wrapper in place (postgres_types.c) the parse
+# succeeds and the round-tripped value contains "1.5". Without it, the
+# libc strtod() respects LC_NUMERIC and would parse '.' as a thousands
+# separator, producing 15 — the test would then fail. This pins MEOS's
+# locale-blindness contract: numeric I/O is always C-locale, regardless
+# of the calling process's LC_NUMERIC.
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/meos_locale.yml'
+      - 'cmake/**'
+      - 'meos/**'
+      - 'postgis/**'
+      - 'postgres/**'
+      - 'CMakeLists.txt'
+    branch_ignore: gh-pages
+  pull_request:
+    paths:
+      - '.github/workflows/meos_locale.yml'
+      - 'cmake/**'
+      - 'meos/**'
+      - 'postgis/**'
+      - 'postgres/**'
+      - 'CMakeLists.txt'
+    branch_ignore: gh-pages
+
+jobs:
+  meos-locale-smoke:
+    name: locale-smoke
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build deps and de_DE.UTF-8 locale
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake ninja-build \
+            libgeos++-dev libproj-dev libjson-c-dev libgsl-dev \
+            locales
+          sudo locale-gen de_DE.UTF-8
+          sudo update-locale
+          locale -a | grep -i de_DE
+
+      - name: Configure standalone MEOS
+        run: |
+          cmake -S . -B build-meos \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$PWD/meos-install" \
+            -DMEOS=ON \
+            -DCBUFFER=ON -DNPOINT=ON
+
+      - name: Build libmeos
+        run: cmake --build build-meos -j
+
+      - name: Install libmeos
+        run: cmake --install build-meos
+
+      - name: Compile locale smoke test
+        run: |
+          cat > /tmp/locale_smoke.c <<'EOF'
+          #include <stdio.h>
+          #include <stdlib.h>
+          #include <string.h>
+          #include <locale.h>
+          #include <meos.h>
+          int main(void) {
+            if (!setlocale(LC_NUMERIC, "de_DE.UTF-8")) {
+              fprintf(stderr, "FAIL: de_DE.UTF-8 not installed\n"); return 2;
+            }
+            meos_initialize();
+            meos_initialize_timezone("UTC");
+            Temporal *t = tfloat_in("[1.5@2001-01-01]");
+            if (!t) { fprintf(stderr, "FAIL: tfloat_in NULL\n"); return 1; }
+            char *out = tfloat_out(t, 6);
+            printf("parsed: %s\n", out);
+            int ok = strstr(out, "1.5") != NULL;
+            free(out); free(t); meos_finalize();
+            if (!ok) { fprintf(stderr, "FAIL: 1.5 mis-parsed under de_DE\n"); return 1; }
+            printf("OK\n"); return 0;
+          }
+          EOF
+          gcc -I meos-install/include -L meos-install/lib \
+            -o /tmp/locale_smoke /tmp/locale_smoke.c -lmeos
+
+      - name: Run locale smoke test under LC_NUMERIC=de_DE.UTF-8
+        env:
+          LD_LIBRARY_PATH: meos-install/lib
+          LC_NUMERIC: de_DE.UTF-8
+        run: /tmp/locale_smoke
+
+      - name: Run locale smoke test under LC_ALL=de_DE.UTF-8
+        env:
+          LD_LIBRARY_PATH: meos-install/lib
+          LC_ALL: de_DE.UTF-8
+        run: /tmp/locale_smoke

--- a/.github/workflows/meos_utf8_smoke.yml
+++ b/.github/workflows/meos_utf8_smoke.yml
@@ -1,0 +1,183 @@
+name: MEOS UTF-8 smoke
+
+# Bootstrap CI for issue #403 (UTF-8 support for the MEOS library).
+#
+# What this job pins:
+#   1. UTF-8 byte sequences round-trip through `text_in`/`text_out`,
+#      `ttext_in`/`ttext_out`, and `textset_in`/`textset_out` unchanged.
+#      The ttext / textset parsers only match ASCII delimiters
+#      (`"`, `,`, `}`, `]`, ...) and UTF-8 continuation bytes (>= 0x80)
+#      can never collide with them, so this is just byte-preservation.
+#
+#   2. The known limitation: `text_upper` / `text_lower` are an ASCII-only
+#      fold (PG's `asc_toupper` / `asc_tolower`). Non-ASCII bytes pass
+#      through unchanged. This is documented behaviour per the UTF-8
+#      contract in meos.h; the test asserts the documented behaviour so
+#      we don't accidentally regress in either direction (silent
+#      corruption *or* surprise Unicode-awareness).
+#
+# Together (1) + (2) form the encoding contract that downstream bindings
+# (PyMEOS, JMEOS, MEOS.NET, MEOS.js, RustMEOS, GoMEOS) can rely on.
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/meos_utf8_smoke.yml'
+      - 'cmake/**'
+      - 'meos/**'
+      - 'postgis/**'
+      - 'postgres/**'
+      - 'CMakeLists.txt'
+    branch_ignore: gh-pages
+  pull_request:
+    paths:
+      - '.github/workflows/meos_utf8_smoke.yml'
+      - 'cmake/**'
+      - 'meos/**'
+      - 'postgis/**'
+      - 'postgres/**'
+      - 'CMakeLists.txt'
+    branch_ignore: gh-pages
+
+jobs:
+  utf8-smoke:
+    name: utf8-smoke
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake ninja-build \
+            libgeos++-dev libproj-dev libjson-c-dev libgsl-dev
+
+      - name: Configure standalone MEOS
+        run: |
+          cmake -S . -B build-meos \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$PWD/meos-install" \
+            -DMEOS=ON \
+            -DCBUFFER=ON -DNPOINT=ON
+
+      - name: Build libmeos
+        run: cmake --build build-meos -j
+
+      - name: Install libmeos
+        run: cmake --install build-meos
+
+      - name: Compile UTF-8 smoke test
+        run: |
+          cat > /tmp/utf8_smoke.c <<'EOF'
+          /*
+           * UTF-8 contract smoke test for MEOS issue #403.
+           *
+           * Verifies: (1) UTF-8 bytes round-trip through text/ttext/textset
+           * I/O unchanged, and (2) ASCII-only case folding is the documented
+           * behaviour for text_upper/text_lower (non-ASCII bytes preserved).
+           */
+          #include <stdio.h>
+          #include <stdlib.h>
+          #include <string.h>
+          #include <meos.h>
+
+          static int fail = 0;
+
+          static void expect_contains(const char *what, const char *haystack,
+                                      const char *needle)
+          {
+            if (strstr(haystack, needle) == NULL) {
+              fprintf(stderr, "FAIL %s: expected %s in %s\n",
+                      what, needle, haystack);
+              fail = 1;
+            } else {
+              printf("ok   %s: contains %s\n", what, needle);
+            }
+          }
+
+          int main(void)
+          {
+            meos_initialize();
+            meos_initialize_timezone("UTC");
+
+            /* (1a) ttext round-trip preserves a German umlaut. */
+            {
+              Temporal *t = ttext_in("[\"Zürich\" @ 2001-01-01]");
+              if (!t) { fprintf(stderr, "FAIL ttext_in NULL\n"); return 1; }
+              char *out = ttext_out(t);
+              expect_contains("ttext de", out, "Zürich");
+              free(out); free(t);
+            }
+
+            /* (1b) ttext round-trip preserves CJK and Arabic. */
+            {
+              Temporal *t = ttext_in("[\"日本\" @ 2001-01-01]");
+              if (!t) { fprintf(stderr, "FAIL ttext_in cjk NULL\n"); return 1; }
+              char *out = ttext_out(t);
+              expect_contains("ttext cjk", out, "日本");
+              free(out); free(t);
+            }
+            {
+              Temporal *t = ttext_in("[\"العربية\" @ 2001-01-01]");
+              if (!t) { fprintf(stderr, "FAIL ttext_in ar NULL\n"); return 1; }
+              char *out = ttext_out(t);
+              expect_contains("ttext ar", out, "العربية");
+              free(out); free(t);
+            }
+
+            /* (1c) textset with mixed-script strings round-trips. */
+            {
+              Set *s = textset_in("{\"Zürich\", \"日本\", \"العربية\", \"한국\"}");
+              if (!s) { fprintf(stderr, "FAIL textset_in NULL\n"); return 1; }
+              char *out = textset_out(s);
+              expect_contains("textset de", out, "Zürich");
+              expect_contains("textset cjk", out, "日本");
+              expect_contains("textset ar", out, "العربية");
+              expect_contains("textset ko", out, "한국");
+              free(out); free(s);
+            }
+
+            /* (2) ASCII-only case folding is the documented contract:
+             * EVERY ASCII letter is folded; bytes >= 0x80 (the body of
+             * any UTF-8 multi-byte sequence) pass through unchanged.
+             *
+             * "Zürich" -> upper: Z stays, ü preserved, r/i/c/h fold to
+             *   R/I/C/H. Result: "ZüRICH".
+             * "ZÜRICH" -> lower: Z->z, Ü preserved, R/I/C/H fold to
+             *   r/i/c/h. Result: "zÜrich".
+             *
+             * These pins will need updating when (and only when) #403
+             * lands a Unicode-aware fold. */
+            {
+              text *t = text_in("Zürich");
+              text *u = text_upper(t);
+              char *out = text_out(u);
+              expect_contains("upper ascii-only", out, "ZüRICH");
+              free(out); free(t); free(u);
+            }
+            {
+              text *t = text_in("ZÜRICH");
+              text *u = text_lower(t);
+              char *out = text_out(u);
+              expect_contains("lower ascii-only", out, "zÜrich");
+              free(out); free(t); free(u);
+            }
+
+            meos_finalize();
+            if (fail) { fprintf(stderr, "UTF-8 smoke FAILED\n"); return 1; }
+            printf("UTF-8 smoke OK\n");
+            return 0;
+          }
+          EOF
+          gcc -I meos-install/include -L meos-install/lib \
+            -o /tmp/utf8_smoke /tmp/utf8_smoke.c -lmeos
+
+      - name: Run UTF-8 smoke test
+        env:
+          LD_LIBRARY_PATH: meos-install/lib
+          LANG: C.UTF-8
+        run: /tmp/utf8_smoke

--- a/.github/workflows/windows_msys2_meos.yml
+++ b/.github/workflows/windows_msys2_meos.yml
@@ -104,5 +104,5 @@ jobs:
             -o meos-install/temporal_test.exe \
             meos/test/temporal_test.c \
             -lmeos
-          PATH="$PWD/meos-install/bin:$PWD/build-meos:$PATH" ./meos-install/temporal_test.exe \
+          PATH="$PWD/meos-install/bin:$PWD/meos-install/lib:$PWD/build-meos:$PATH" ./meos-install/temporal_test.exe \
             || (echo "temporal_test.exe failed at runtime"; exit 1)

--- a/.github/workflows/windows_msys2_meos.yml
+++ b/.github/workflows/windows_msys2_meos.yml
@@ -95,7 +95,7 @@ jobs:
           ls -la meos-install/bin meos-install/lib meos-install/include 2>/dev/null || true
           # CMake on MSYS2/MinGW puts the .dll in the install bin/ dir and
           # the .dll.a import lib in lib/. Confirm both exist.
-          test -f build-meos/libmeos.dll || (echo "libmeos.dll not produced"; exit 1)
+          test -f build-meos/meos/libmeos.dll || (echo "libmeos.dll not produced"; exit 1)
 
       - name: Smoke test (build temporal_test against installed libmeos)
         run: |

--- a/.github/workflows/windows_msys2_meos.yml
+++ b/.github/workflows/windows_msys2_meos.yml
@@ -1,0 +1,108 @@
+name: Build MEOS on Windows (MSYS2/UCRT64)
+
+# Builds the standalone MEOS C library natively on Windows under MSYS2's
+# UCRT64 runtime.  This workflow gates issue #513 (native Windows MEOS support).
+#
+# What this job verifies:
+#   * cmake -DMEOS=ON resolves all dependencies under MSYS2 mingw-w64
+#     (json-c, geos, proj, gsl, tzdata).
+#   * The standalone libmeos.dll links cleanly.
+#   * A minimal smoke test (meos/test/temporal_test) builds and runs.
+#
+# Note: full MSVC support requires sweeping PGDLLEXPORT onto every public
+# extern declaration in meos.h / meos_*.h.  That is intentionally left as
+# a follow-up; MinGW-GCC under MSYS2 exports symbols by default
+# (--export-all-symbols) so this CI runs without that sweep.
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/windows_msys2_meos.yml'
+      - 'cmake/**'
+      - 'meos/**'
+      - 'postgis/**'
+      - 'postgres/**'
+      - 'CMakeLists.txt'
+    branch_ignore: gh-pages
+  pull_request:
+    paths:
+      - '.github/workflows/windows_msys2_meos.yml'
+      - 'cmake/**'
+      - 'meos/**'
+      - 'postgis/**'
+      - 'postgres/**'
+      - 'CMakeLists.txt'
+    branch_ignore: gh-pages
+
+jobs:
+  build-meos:
+    name: meos-windows
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup MSYS2 (UCRT64)
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-ninja
+            mingw-w64-ucrt-x86_64-json-c
+            mingw-w64-ucrt-x86_64-geos
+            mingw-w64-ucrt-x86_64-proj
+            mingw-w64-ucrt-x86_64-gsl
+            mingw-w64-ucrt-x86_64-tzdata
+
+      - name: Resolve native timezone data path
+        run: |
+          # cygpath -m converts the MSYS2 POSIX path to a Windows-native path
+          # (forward slashes, e.g. C:/msys64/ucrt64/share/zoneinfo) that fopen()
+          # inside the compiled DLL can open at runtime.
+          TZDATA_WIN=$(cygpath -m "$MSYSTEM_PREFIX/share/zoneinfo")
+          echo "MEOS_TZDATA_WIN=$TZDATA_WIN" >> "$GITHUB_ENV"
+
+      - name: Configure (MEOS=ON, no PostgreSQL extension)
+        run: |
+          # POSE pulls in RGEO via CMAKE_DEPENDENT_OPTION; we leave RGEO off
+          # for now because rgeo's compilation on Windows depends on PostGIS
+          # build-tree generated headers that have not been verified there.
+          cmake -S . -B build-meos \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$PWD/meos-install" \
+            -DMEOS=ON \
+            -DCBUFFER=ON -DNPOINT=ON -DPOSE=OFF -DRGEO=OFF \
+            -DMEOS_TZDATA_DIR="$MEOS_TZDATA_WIN"
+
+      - name: Build libmeos
+        run: cmake --build build-meos -j
+
+      - name: Install libmeos
+        run: cmake --install build-meos
+
+      - name: Show built artifacts
+        run: |
+          ls -la build-meos/
+          ls -la meos-install/bin meos-install/lib meos-install/include 2>/dev/null || true
+          # CMake on MSYS2/MinGW puts the .dll in the install bin/ dir and
+          # the .dll.a import lib in lib/. Confirm both exist.
+          test -f build-meos/libmeos.dll || (echo "libmeos.dll not produced"; exit 1)
+
+      - name: Smoke test (build temporal_test against installed libmeos)
+        run: |
+          gcc -I meos-install/include \
+            -L meos-install/lib \
+            -o meos-install/temporal_test.exe \
+            meos/test/temporal_test.c \
+            -lmeos
+          PATH="$PWD/meos-install/bin:$PWD/build-meos:$PATH" ./meos-install/temporal_test.exe \
+            || (echo "temporal_test.exe failed at runtime"; exit 1)

--- a/cmake/ConfigurePgConfig.cmake
+++ b/cmake/ConfigurePgConfig.cmake
@@ -24,6 +24,8 @@ check_type_size("void *"          SIZEOF_VOID_P           BUILTIN_TYPES_ONLY)
 check_type_size("long"            SIZEOF_LONG             BUILTIN_TYPES_ONLY)
 check_type_size("size_t"          SIZEOF_SIZE_T)
 check_type_size("long long int"   SIZEOF_LONG_LONG_INT    BUILTIN_TYPES_ONLY)
+# pg_bitutils.h uses SIZEOF_LONG_LONG (no _INT suffix); alias the detected value.
+set(SIZEOF_LONG_LONG ${SIZEOF_LONG_LONG_INT})
 
 #-----------------------------------------------------------------------
 # 2. Alignment (no native CMake check; use offsetof trick via CHECK_C_SOURCE_RUNS)

--- a/meos/CMakeLists.txt
+++ b/meos/CMakeLists.txt
@@ -19,9 +19,44 @@ set(MEOS_LIB_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}")
 set(MEOS_LIB_NAME "meos")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
-# Set the location of the directory of the time zone database
-add_definitions(-DSYSTEMTZDIR="/usr/share/zoneinfo")
-message(STATUS "Directory of the time zone database: /usr/share/zoneinfo")
+# Set the location of the IANA timezone database directory.  pgtz.c uses the
+# SYSTEMTZDIR macro to avoid calling get_share_path() (a PostgreSQL-internal
+# function not available in the MEOS standalone build).
+#
+# Override at cmake time with -DMEOS_TZDATA_DIR=<path>.  The path must be a
+# native OS path that fopen() can open (i.e. a Windows path such as
+# C:/msys64/ucrt64/share/zoneinfo on Windows, not an MSYS2 POSIX path).
+if(NOT DEFINED MEOS_TZDATA_DIR)
+  if(NOT WIN32)
+    set(MEOS_TZDATA_DIR "/usr/share/zoneinfo")
+  else()
+    # Auto-discover from the MSYS2 environment: MSYSTEM_PREFIX is set by the
+    # MSYS2 shell (e.g. /ucrt64).  cygpath -m converts the POSIX path to a
+    # Windows-native path (e.g. C:/msys64/ucrt64/share/zoneinfo) that the
+    # compiled DLL — a native Windows binary — can open with fopen().
+    if(DEFINED ENV{MSYSTEM_PREFIX})
+      execute_process(
+        COMMAND cygpath -m "$ENV{MSYSTEM_PREFIX}/share/zoneinfo"
+        OUTPUT_VARIABLE MEOS_TZDATA_DIR
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        RESULT_VARIABLE _cygpath_rc
+      )
+      if(NOT _cygpath_rc EQUAL 0 OR NOT MEOS_TZDATA_DIR)
+        set(MEOS_TZDATA_DIR "C:/msys64/ucrt64/share/zoneinfo")
+        message(WARNING "cygpath failed; falling back to ${MEOS_TZDATA_DIR}")
+      endif()
+    else()
+      # Outside MSYS2 (e.g. MSVC developer command prompt): caller must pass
+      # -DMEOS_TZDATA_DIR=... or install tzdata to this default location.
+      set(MEOS_TZDATA_DIR "C:/msys64/ucrt64/share/zoneinfo")
+      message(WARNING "MEOS_TZDATA_DIR not set and MSYSTEM_PREFIX not found; "
+                      "defaulting to ${MEOS_TZDATA_DIR}")
+    endif()
+  endif()
+endif()
+add_definitions(-DSYSTEMTZDIR="${MEOS_TZDATA_DIR}")
+message(STATUS "Directory of the time zone database: ${MEOS_TZDATA_DIR}")
 
 # Option to build MEOS as a shared or static library
 option(BUILD_SHARED_LIBS

--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -49,6 +49,22 @@
 #endif
 
 /*****************************************************************************
+ * Locale contract (issue #425)
+ *
+ * MEOS pins all numeric I/O to the C locale: textual representations of
+ * doubles always use '.' as the decimal separator, regardless of the
+ * calling process's LC_NUMERIC setting. This guarantees that WKT, set,
+ * span, and temporal-constant parsing produces stable results across
+ * environments (CI, downstream bindings such as PyMEOS / JMEOS, ...).
+ *
+ * MEOS does NOT call setlocale() at initialization; downstream consumers
+ * remain free to set whatever process locale they need for *their own*
+ * code (display, message catalogs, ...). Locale-aware text collation is
+ * intentionally not yet wired up; varstr_cmp() falls back to byte-wise
+ * memcmp pending the full collation work tracked in issue #425.
+ *****************************************************************************/
+
+/*****************************************************************************
  * Toolchain dependent definitions
  *****************************************************************************/
 

--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -65,6 +65,36 @@
  *****************************************************************************/
 
 /*****************************************************************************
+ * UTF-8 / character encoding contract (issue #403)
+ *
+ * MEOS treats `text` values and the textual representations parsed by
+ * `*_in()` / `*_out()` as opaque byte sequences. The library is encoding-
+ * agnostic at I/O: any encoding with the property that ASCII characters
+ * (`,`, `}`, `]`, `"`, `\\`, whitespace, etc.) round-trip as their
+ * single-byte form is preserved verbatim. UTF-8 satisfies this property,
+ * so callers can pass UTF-8 text through `text_in`/`text_out`, set/array
+ * constructors, and `ttext`/`textset` parsers and get the same bytes
+ * back. Multi-byte UTF-8 continuation bytes (>= 0x80) never collide with
+ * ASCII delimiters, so the parsers are correct on UTF-8 input.
+ *
+ * What MEOS does NOT do today:
+ *   - Locale-aware text collation (`text_cmp` is byte-wise `memcmp`,
+ *     intentionally — see issue #425).
+ *   - Unicode-aware case folding. `text_upper`, `text_lower`, and
+ *     `text_initcap` (and the temporal variants `ttext_upper`, ...)
+ *     fold ASCII letters only; bytes >= 0x80 (the body of any
+ *     multi-byte UTF-8 sequence) are passed through unchanged. So
+ *     `text_upper("Zürich")` returns `"Zürich"`, not `"ZÜRICH"`. This
+ *     is documented behaviour and a tracked follow-up under #403.
+ *   - Character-count APIs (`text_length`, `text_substring`, ...).
+ *     None are exposed; if added, byte-vs-codepoint semantics will
+ *     have to be specified explicitly.
+ *
+ * Round-tripping UTF-8 through MEOS is exercised by the
+ * `meos_utf8_smoke` CI workflow.
+ *****************************************************************************/
+
+/*****************************************************************************
  * Toolchain dependent definitions
  *****************************************************************************/
 

--- a/meos/include/temporal/postgres_types.h
+++ b/meos/include/temporal/postgres_types.h
@@ -88,6 +88,14 @@ extern char *int8_out(int64 val);
 extern float8 float8_in(const char *num, const char *type_name,
   const char *orig_string);
 extern char *float8_out(double num, int maxdd);
+
+/*
+ * Locale-safe strtod(). Pins numeric I/O to the C locale (decimal point
+ * is always '.') regardless of the calling process's LC_NUMERIC setting.
+ * See issue #425 and the comment in postgres_types.c for context.
+ */
+extern double meos_strtod(const char *str, char **endptr);
+
 extern float8 pg_dsin(float8 arg1);
 extern float8 pg_dcos(float8 arg1);
 extern float8 pg_datan(float8 arg1);

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -392,13 +392,13 @@ pose_parse(const char **str, bool end)
   /* Determine whether the pose has a geometry */
   int32_t srid_geo;
   GSERIALIZED *geo = NULL;
-  if (strncasecmp(*str,"POSE",4) != 0)
+  if (pg_strncasecmp(*str, "POSE", 4) != 0)
   {
     if (! geo_parse(str, T_GEOMETRY, ',', &srid_geo, &geo))
       return NULL;
   }
 
-  if (strncasecmp(*str, "POSE", 4) == 0)
+  if (pg_strncasecmp(*str, "POSE", 4) == 0)
   {
     *str += 4;
     p_whitespace(str);

--- a/meos/src/rgeo/trgeo_parser.c
+++ b/meos/src/rgeo/trgeo_parser.c
@@ -318,7 +318,7 @@ trgeo_parse(const char **str, MeosType temptype)
 
   interpType interp = temptype_continuous(temptype) ? LINEAR : STEP;
   /* Starts with "Interp=Step" */
-  if (strncasecmp(*str, "Interp=Step;", 12) == 0)
+  if (pg_strncasecmp(*str, "Interp=Step;", 12) == 0)
   {
     /* Move str after the semicolon */
     *str += 12;

--- a/meos/src/temporal/postgres_types.c
+++ b/meos/src/temporal/postgres_types.c
@@ -39,6 +39,11 @@
 #include <float.h>
 #include <math.h>
 #include <limits.h>
+/* <locale.h> (locale_t, setlocale, newlocale) and <string.h> (strcmp,
+ * strlen) are pulled in transitively via <postgres.h> below; including
+ * them again here would be redundant and would trip Codacy's cppcheck
+ * wrapper with cppcheck_missingIncludeSystem on every PR (it doesn't
+ * see compile_commands.json). */
 /* PostgreSQL */
 #include <postgres.h>
 #include <common/int.h>
@@ -310,6 +315,83 @@ int8_out(int64 val)
  * Functions adapted from float.c
  *****************************************************************************/
 
+/*
+ * Locale-safe wrapper for strtod(). MEOS reads doubles back from text in
+ * many parsers (WKT, sets, spans, temporal constants, ...). The libc
+ * strtod() honors LC_NUMERIC, so under e.g. de_DE.UTF-8 it expects a
+ * comma decimal separator and would silently mis-parse "1.5" — breaking
+ * the entire WKT round-trip.
+ *
+ * MEOS pins numeric I/O to the C locale regardless of the process locale.
+ * Two implementation strategies are tried in order:
+ *
+ *   1. POSIX 2008 strtod_l() against a private, lazily-initialised
+ *      locale_t. This is thread-safe.
+ *   2. Save / setlocale(LC_NUMERIC,"C") / strtod / restore. Portable
+ *      everywhere strtod_l is unavailable, but not thread-safe (the
+ *      restore window is observable to other threads). MEOS is not
+ *      yet thread-safe overall (see #404 / PR #815) so this is
+ *      acceptable as a fallback today.
+ *
+ * We do NOT call setlocale() at MEOS init time because downstream
+ * consumers (PyMEOS, JMEOS, ...) can legitimately want a non-C locale
+ * for their own code (display, message catalogs, ...).
+ *
+ * Issue #425 — see meos.h for the documented locale contract.
+ */
+#if defined(LC_NUMERIC_MASK) && defined(__GLIBC__)
+  #define MEOS_HAVE_STRTOD_L 1
+#elif defined(LC_NUMERIC_MASK) && (defined(__APPLE__) || defined(__FreeBSD__))
+  #define MEOS_HAVE_STRTOD_L 1
+#endif
+
+#if MEOS_HAVE_STRTOD_L
+/* Explicit forward declarations: strtod_l/newlocale require POSIX 2008
+ * feature test macros to appear in <stdlib.h>/<locale.h>, and the MEOS
+ * build doesn't set those globally (the postgres headers manage their
+ * own feature macros). Without a visible prototype the compiler treats
+ * strtod_l as returning int, which silently truncates the double — see
+ * #425 for the bug story. */
+extern double strtod_l(const char *str, char **endptr, locale_t loc);
+extern locale_t newlocale(int category_mask, const char *locale,
+  locale_t base);
+/* Note: freelocale's return type differs across platforms (POSIX/macOS
+ * declare it as int, glibc < 2.32 as void), so we don't forward-declare
+ * it. We never call it anyway: the C-locale handle lives for the
+ * process lifetime. */
+static locale_t meos_c_locale = (locale_t) 0;
+#endif
+
+double
+meos_strtod(const char *str, char **endptr)
+{
+#if MEOS_HAVE_STRTOD_L
+  if (meos_c_locale == (locale_t) 0)
+    meos_c_locale = newlocale(LC_NUMERIC_MASK, "C", (locale_t) 0);
+  if (meos_c_locale != (locale_t) 0)
+    return strtod_l(str, endptr, meos_c_locale);
+#endif
+  /* Portable fallback: save the current LC_NUMERIC, switch to "C" for
+   * the parse, restore it. Not thread-safe (other threads could see the
+   * "C" value during the parse), but always correct.
+   *
+   * Skip the dance if we are already in a C-equivalent locale, which
+   * avoids two strdup/free pairs on the hot path. */
+  const char *cur = setlocale(LC_NUMERIC, NULL);
+  if (cur == NULL || strcmp(cur, "C") == 0 || strcmp(cur, "POSIX") == 0)
+    return strtod(str, endptr);
+  char *saved = strdup(cur);
+  setlocale(LC_NUMERIC, "C");
+  double val = strtod(str, endptr);
+  if (saved != NULL)
+  {
+    setlocale(LC_NUMERIC, saved);
+    free(saved);
+  }
+  return val;
+}
+
+
 /**
  * float8in_internal_opt_error - guts of float8in()
  * @return On error return @p DBL_MAX
@@ -351,7 +433,7 @@ float8_in_opt_error(char *num, const char *type_name, const char *orig_string)
   }
 
   errno = 0;
-  val = strtod(num, &endptr);
+  val = meos_strtod(num, &endptr);
 
   /* did we not see anything that looks like a double? */
   if (endptr == num || errno != 0)

--- a/meos/src/temporal/postgres_types.c
+++ b/meos/src/temporal/postgres_types.c
@@ -68,6 +68,20 @@
 #include <meos_internal.h>
 #include "temporal/temporal.h"
 
+/* On Windows, <postgres.h> transitively pulls in port/win32_port.h
+ * which redefines setlocale() to pgwin32_setlocale() — a PostgreSQL-
+ * internal helper provided by libpgport. MEOS standalone builds do
+ * not link libpgport, so the macro causes an undefined-reference link
+ * error in meos_strtod(). Undefine it so the libc setlocale prototype
+ * pulled in transitively via <locale.h> remains the call target. The
+ * non-MEOS in-extension build keeps the macro and its libpgport
+ * linkage (the server backend statically links libpgport). */
+#if defined(_WIN32) && defined(MEOS)
+  #ifdef setlocale
+    #undef setlocale
+  #endif
+#endif
+
 #if ! MEOS
   extern Datum call_function1(PGFunction func, Datum arg1);
   extern Datum call_function3(PGFunction func, Datum arg1, Datum arg2, Datum arg3);

--- a/meos/src/temporal/postgres_types.c
+++ b/meos/src/temporal/postgres_types.c
@@ -2502,7 +2502,14 @@ pnstrdup(const char *in, Size size)
  * @param[in] txt Text value
  * @note PostgreSQL function: @p lower() in file @p varlena.c.
  * Notice that @p DEFAULT_COLLATION_OID is used instead of
- * @p PG_GET_COLLATION()
+ * @p PG_GET_COLLATION().
+ *
+ * In standalone MEOS this is an ASCII-only fold: bytes 0x41..0x5A
+ * become 0x61..0x7A; bytes >= 0x80 (UTF-8 continuation/lead bytes)
+ * are left unchanged. So `text_lower("ZÜRICH")` returns `"zÜRICH"`
+ * (the ASCII letters are folded but `Ü` is preserved verbatim). This
+ * is the documented UTF-8 contract — see meos.h. Issue #403 tracks
+ * adding a Unicode-aware fold.
  */
 text *
 text_lower(const text *txt)
@@ -2534,7 +2541,13 @@ datum_lower(Datum value)
  * @param[in] txt Text value
  * @note PostgreSQL function: @p upper() in file @p varlena.c.
  * Notice that @p DEFAULT_COLLATION_OID is used instead of
- * @p PG_GET_COLLATION()
+ * @p PG_GET_COLLATION().
+ *
+ * In standalone MEOS this is an ASCII-only fold: bytes 0x61..0x7A
+ * become 0x41..0x5A; bytes >= 0x80 (UTF-8 continuation/lead bytes)
+ * are left unchanged. So `text_upper("Zürich")` returns `"ZüRICH"`,
+ * not `"ZÜRICH"`. This is the documented UTF-8 contract — see
+ * meos.h. Issue #403 tracks adding a Unicode-aware fold.
  */
 text *
 text_upper(const text *txt)
@@ -2566,7 +2579,11 @@ datum_upper(Datum value)
  * @param[in] txt Text value
  * @note PostgreSQL function: @p initcap() in file @p varlena.c.
  * Notice that @p DEFAULT_COLLATION_OID is used instead of
- * @p PG_GET_COLLATION()
+ * @p PG_GET_COLLATION().
+ *
+ * In standalone MEOS this is an ASCII-only fold; bytes >= 0x80 are
+ * passed through unchanged. See meos.h for the UTF-8 contract and
+ * issue #403 for the Unicode-aware follow-up.
  */
 text *
 text_initcap(const text *txt)

--- a/meos/src/temporal/type_parser.c
+++ b/meos/src/temporal/type_parser.c
@@ -42,6 +42,7 @@
 #include <meos.h>
 #include <meos_internal.h>
 #include <meos_internal_geo.h>
+#include "temporal/postgres_types.h"  /* meos_strtod */
 #include "temporal/temporal.h"
 #include "temporal/type_util.h"
 #include "geo/tspatial_parser.h"
@@ -271,7 +272,8 @@ bool
 double_parse(const char **str, double *result)
 {
   char *nextstr = (char *) *str;
-  *result = strtod(*str, &nextstr);
+  /* Locale-safe: see meos_strtod() in postgres_types.c (issue #425). */
+  *result = meos_strtod(*str, &nextstr);
   if (*str == nextstr)
   {
     meos_error(ERROR, MEOS_ERR_TEXT_INPUT,

--- a/postgres/pg_config.h.in
+++ b/postgres/pg_config.h.in
@@ -20,6 +20,7 @@
  */
 #define SIZEOF_VOID_P         @SIZEOF_VOID_P@
 #define SIZEOF_LONG           @SIZEOF_LONG@
+#define SIZEOF_LONG_LONG      @SIZEOF_LONG_LONG@
 #define SIZEOF_SIZE_T         @SIZEOF_SIZE_T@
 
 /*


### PR DESCRIPTION
Rolling-topic MEOS bootstrap PR per the ecosystem PR consolidation policy. Three orthogonal concerns about MEOS's I/O / build behaviour, each one feature commit:

- **`fix(meos): bootstrap MEOS locale safety`** (was [PR #813](https://github.com/MobilityDB/MobilityDB/pull/813))
  Pins all numeric I/O to the C locale so WKT, set, span, and temporal-constant parsing produce stable results regardless of the calling process's `LC_NUMERIC`.  Adds a portable `strtod_l` wrapper (POSIX 2008 thread-safe path with setlocale fallback) and the public locale contract in `meos.h`.  Closes #425.

- **`fix(meos): bootstrap MEOS UTF-8 contract`** (was [PR #814](https://github.com/MobilityDB/MobilityDB/pull/814))
  Documents and enforces MEOS's encoding-agnostic byte-pass-through I/O.  Adds `meos_utf8_smoke` CI workflow that round-trips UTF-8 through `text_in`/`text_out`, set/array constructors, and `ttext`/`textset` parsers.  ASCII-only case folding is documented as intentional.  Closes #403.

- **`feat(meos): bootstrap native Windows MEOS build`** (was [PR #812](https://github.com/MobilityDB/MobilityDB/pull/812), 3-commit iterative fix squashed to 1)
  Adds `.github/workflows/windows_msys2_meos.yml` building the standalone MEOS library on Windows via MSYS2 UCRT64 + CMake/Ninja.  Includes the SYSTEMTZDIR fix (MSYS2 tzdata location) and the `SIZEOF_LONG_LONG` `pg_config.h.in` alias for GCC 16/LLP64.  Non-blocking (`continue-on-error: true`) - surfaces Windows issues without gating master.  Closes #513.

The three concerns are orthogonal - locale is about numeric formatting, UTF-8 is about byte-pass-through text, Windows is about build/CI surfaces.  No file overlap except `meos/include/meos.h` (locale + UTF-8 contract blocks coexist as separate sections).

## Closes

- Closes #813
- Closes #814
- Closes #812

- [ ] `meos_locale` workflow passes - strtod produces "1.5" → 1.5 under de_DE.UTF-8
- [ ] `meos_utf8_smoke` workflow passes - UTF-8 round-trips byte-identical
- [ ] `windows_msys2_meos` workflow runs (non-blocking, expected to surface issues until JMEOS/JNR-FFI Windows path is fully wired)
- [ ] No regressions on Linux x86 / ARM64
