### PR TITLE
feat(sql): add Pascal-cased *Agg aliases for SkipList aggregates (RFC #827)

### DIFF
--- a/mobilitydb/sql/cbuffer/167_aggregate_renames.in.sql
+++ b/mobilitydb/sql/cbuffer/167_aggregate_renames.in.sql
@@ -1,0 +1,124 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS
+ * TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Forward-compatible aggregate aliases per RFC #827.
+ *
+ * Each aggregate registered by the previous SQL files is exposed under a
+ * Pascal-cased *Agg name in addition to its original lowercase or
+ * camelCase name. This eliminates the case-folding collision between the
+ * scalar accessors `Tmin(tbox|stbox)` / `Tmax(tbox|stbox)` and the
+ * temporal-min / temporal-max aggregates, which previously differed only
+ * in the casing of their first letter and so collapsed to the same
+ * canonical name in catalogs that are case-insensitive but key on
+ * `(name, kind)` rather than `(name, argtypes, kind)` (DuckDB, BigQuery,
+ * Snowflake, Trino, ...).
+ *
+ * The original names remain valid for backward compatibility. Once
+ * downstream tools have migrated, a future major version may drop the
+ * un-suffixed aliases.
+ *
+ * The new aggregates share the same internal C transition functions as
+ * the originals, so the only runtime cost is one extra row in
+ * `pg_aggregate` per aggregate.
+ */
+
+-- From 151_cbufferset.in.sql
+CREATE AGGREGATE SetUnionAgg(cbuffer) (
+  SFUNC = set_union_transfn,
+  STYPE = internal,
+  FINALFUNC = cbufferset_union_finalfn
+);
+
+CREATE AGGREGATE SetUnionAgg(cbufferset) (
+  SFUNC = set_union_transfn,
+  STYPE = internal,
+  FINALFUNC = cbufferset_union_finalfn
+);
+
+-- From 161_tcbuffer_aggfuncs.in.sql
+CREATE AGGREGATE TcountAgg(tcbuffer) (
+  SFUNC = tcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tcount_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE WcountAgg(tcbuffer, interval) (
+  SFUNC = wcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tint_tsum_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE MergeAgg(tcbuffer) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tcbuffer_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tcbuffer) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tcbuffer,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tcbuffer, text) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tcbuffer,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tcbuffer, text, float, interval) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tcbuffer,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendSequenceAgg(tcbuffer) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tcbuffer,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+

--- a/mobilitydb/sql/cbuffer/CMakeLists.txt
+++ b/mobilitydb/sql/cbuffer/CMakeLists.txt
@@ -12,6 +12,7 @@ SET(LOCAL_FILES
   162_tcbuffer_spatialrels
   164_tcbuffer_tempspatialrels
   166_tcbuffer_indexes
+  167_aggregate_renames
   )
 
 foreach (f ${LOCAL_FILES})

--- a/mobilitydb/sql/geo/069_aggregate_renames.in.sql
+++ b/mobilitydb/sql/geo/069_aggregate_renames.in.sql
@@ -1,0 +1,321 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS
+ * TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Forward-compatible aggregate aliases per RFC #827.
+ *
+ * Each aggregate registered by the previous SQL files is exposed under a
+ * Pascal-cased *Agg name in addition to its original lowercase or
+ * camelCase name. This eliminates the case-folding collision between the
+ * scalar accessors `Tmin(tbox|stbox)` / `Tmax(tbox|stbox)` and the
+ * temporal-min / temporal-max aggregates, which previously differed only
+ * in the casing of their first letter and so collapsed to the same
+ * canonical name in catalogs that are case-insensitive but key on
+ * `(name, kind)` rather than `(name, argtypes, kind)` (DuckDB, BigQuery,
+ * Snowflake, Trino, ...).
+ *
+ * The original names remain valid for backward compatibility. Once
+ * downstream tools have migrated, a future major version may drop the
+ * un-suffixed aliases.
+ *
+ * The new aggregates share the same internal C transition functions as
+ * the originals, so the only runtime cost is one extra row in
+ * `pg_aggregate` per aggregate.
+ */
+
+-- From 050_geoset.in.sql
+CREATE AGGREGATE SetUnionAgg(geometry) (
+  SFUNC = set_union_transfn,
+  STYPE = internal,
+  FINALFUNC = geomset_union_finalfn
+);
+
+CREATE AGGREGATE SetUnionAgg(geography) (
+  SFUNC = set_union_transfn,
+  STYPE = internal,
+  FINALFUNC = geogset_union_finalfn
+);
+
+CREATE AGGREGATE SetUnionAgg(geomset) (
+  SFUNC = set_union_transfn,
+  STYPE = internal,
+  FINALFUNC = geomset_union_finalfn
+);
+
+CREATE AGGREGATE SetUnionAgg(geogset) (
+  SFUNC = set_union_transfn,
+  STYPE = internal,
+  FINALFUNC = geogset_union_finalfn
+);
+
+-- From 068_tpoint_aggfuncs.in.sql
+CREATE AGGREGATE TcountAgg(tgeompoint) (
+  SFUNC = tcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tcount_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE TcountAgg(tgeogpoint) (
+  SFUNC = tcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tcount_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE WcountAgg(tgeompoint, interval) (
+  SFUNC = wcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tint_tsum_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE WcountAgg(tgeogpoint, interval) (
+  SFUNC = wcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tint_tsum_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE TcentroidAgg(tgeompoint) (
+  SFUNC = tcentroid_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tcentroid_combinefn,
+  FINALFUNC = tcentroid_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE MergeAgg(tgeompoint) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tgeompoint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE MergeAgg(tgeogpoint) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tgeogpoint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tgeompoint) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeompoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tgeogpoint) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeogpoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tgeompoint, text) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeompoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tgeogpoint, text) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeogpoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tgeompoint, text, float, interval) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeompoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tgeogpoint, text, float, interval) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeogpoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendSequenceAgg(tgeompoint) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tgeompoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendSequenceAgg(tgeogpoint) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tgeogpoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+-- From 068_tgeo_aggfuncs.in.sql
+CREATE AGGREGATE TcountAgg(tgeometry) (
+  SFUNC = tcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tcount_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE TcountAgg(tgeography) (
+  SFUNC = tcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tcount_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE WcountAgg(tgeometry, interval) (
+  SFUNC = wcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tint_tsum_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE WcountAgg(tgeography, interval) (
+  SFUNC = wcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tint_tsum_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE MergeAgg(tgeometry) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tgeometry_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE MergeAgg(tgeography) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tgeography_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tgeometry) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeometry,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tgeography) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeography,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tgeometry, text) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeometry,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tgeography, text) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeography,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tgeometry, text, float, interval) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeometry,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tgeography, text, float, interval) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeography,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendSequenceAgg(tgeometry) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tgeometry,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendSequenceAgg(tgeography) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tgeography,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+

--- a/mobilitydb/sql/geo/CMakeLists.txt
+++ b/mobilitydb/sql/geo/CMakeLists.txt
@@ -36,6 +36,7 @@ list(APPEND LOCAL_FILES
   073_tgeo_gist
   074_tgeo_spgist
   076_tgeo_analytics
+  069_aggregate_renames
   )
 
 foreach (f ${LOCAL_FILES})

--- a/mobilitydb/sql/npoint/096_aggregate_renames.in.sql
+++ b/mobilitydb/sql/npoint/096_aggregate_renames.in.sql
@@ -1,0 +1,134 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS
+ * TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Forward-compatible aggregate aliases per RFC #827.
+ *
+ * Each aggregate registered by the previous SQL files is exposed under a
+ * Pascal-cased *Agg name in addition to its original lowercase or
+ * camelCase name. This eliminates the case-folding collision between the
+ * scalar accessors `Tmin(tbox|stbox)` / `Tmax(tbox|stbox)` and the
+ * temporal-min / temporal-max aggregates, which previously differed only
+ * in the casing of their first letter and so collapsed to the same
+ * canonical name in catalogs that are case-insensitive but key on
+ * `(name, kind)` rather than `(name, argtypes, kind)` (DuckDB, BigQuery,
+ * Snowflake, Trino, ...).
+ *
+ * The original names remain valid for backward compatibility. Once
+ * downstream tools have migrated, a future major version may drop the
+ * un-suffixed aliases.
+ *
+ * The new aggregates share the same internal C transition functions as
+ * the originals, so the only runtime cost is one extra row in
+ * `pg_aggregate` per aggregate.
+ */
+
+-- From 082_npointset.in.sql
+CREATE AGGREGATE SetUnionAgg(npoint) (
+  SFUNC = set_union_transfn,
+  STYPE = internal,
+  FINALFUNC = npointset_union_finalfn
+);
+
+CREATE AGGREGATE SetUnionAgg(npointset) (
+  SFUNC = set_union_transfn,
+  STYPE = internal,
+  FINALFUNC = npointset_union_finalfn
+);
+
+-- From 095_tnpoint_aggfuncs.in.sql
+CREATE AGGREGATE TcountAgg(tnpoint) (
+  SFUNC = tcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tcount_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE WcountAgg(tnpoint, interval) (
+  SFUNC = wcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tint_tsum_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE TcentroidAgg(tnpoint) (
+  SFUNC = tcentroid_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tcentroid_combinefn,
+  FINALFUNC = tcentroid_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE MergeAgg(tnpoint) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tnpoint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tnpoint) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tnpoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tnpoint, text) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tnpoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tnpoint, text, float, interval) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tnpoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendSequenceAgg(tnpoint) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tnpoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+

--- a/mobilitydb/sql/npoint/CMakeLists.txt
+++ b/mobilitydb/sql/npoint/CMakeLists.txt
@@ -13,6 +13,7 @@ SET(LOCAL_FILES
   093_tnpoint_distance
   095_tnpoint_aggfuncs
   098_tnpoint_indexes
+  096_aggregate_renames
   )
 
 foreach (f ${LOCAL_FILES})

--- a/mobilitydb/sql/pose/112_aggregate_renames.in.sql
+++ b/mobilitydb/sql/pose/112_aggregate_renames.in.sql
@@ -1,0 +1,124 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS
+ * TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Forward-compatible aggregate aliases per RFC #827.
+ *
+ * Each aggregate registered by the previous SQL files is exposed under a
+ * Pascal-cased *Agg name in addition to its original lowercase or
+ * camelCase name. This eliminates the case-folding collision between the
+ * scalar accessors `Tmin(tbox|stbox)` / `Tmax(tbox|stbox)` and the
+ * temporal-min / temporal-max aggregates, which previously differed only
+ * in the casing of their first letter and so collapsed to the same
+ * canonical name in catalogs that are case-insensitive but key on
+ * `(name, kind)` rather than `(name, argtypes, kind)` (DuckDB, BigQuery,
+ * Snowflake, Trino, ...).
+ *
+ * The original names remain valid for backward compatibility. Once
+ * downstream tools have migrated, a future major version may drop the
+ * un-suffixed aliases.
+ *
+ * The new aggregates share the same internal C transition functions as
+ * the originals, so the only runtime cost is one extra row in
+ * `pg_aggregate` per aggregate.
+ */
+
+-- From 101_poseset.in.sql
+CREATE AGGREGATE SetUnionAgg(pose) (
+  SFUNC = set_union_transfn,
+  STYPE = internal,
+  FINALFUNC = poseset_union_finalfn
+);
+
+CREATE AGGREGATE SetUnionAgg(poseset) (
+  SFUNC = set_union_transfn,
+  STYPE = internal,
+  FINALFUNC = poseset_union_finalfn
+);
+
+-- From 111_tpose_aggfuncs.in.sql
+CREATE AGGREGATE TcountAgg(tpose) (
+  SFUNC = tcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tcount_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE WcountAgg(tpose, interval) (
+  SFUNC = wcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tint_tsum_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE MergeAgg(tpose) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tpose_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tpose) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tpose,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tpose, text) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tpose,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tpose, text, float, interval) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tpose,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendSequenceAgg(tpose) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tpose,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+

--- a/mobilitydb/sql/pose/CMakeLists.txt
+++ b/mobilitydb/sql/pose/CMakeLists.txt
@@ -9,6 +9,7 @@ SET(LOCAL_FILES
   111_tpose_aggfuncs
   113_tpose_distance
   114_tpose_indexes
+  112_aggregate_renames
   )
 
 foreach (f ${LOCAL_FILES})

--- a/mobilitydb/sql/temporal/045_aggregate_renames.in.sql
+++ b/mobilitydb/sql/temporal/045_aggregate_renames.in.sql
@@ -1,0 +1,714 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS
+ * TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Forward-compatible aggregate aliases per RFC #827.
+ *
+ * Each aggregate registered by the previous SQL files is exposed under a
+ * Pascal-cased *Agg name in addition to its original lowercase or
+ * camelCase name. This eliminates the case-folding collision between the
+ * scalar accessors `Tmin(tbox|stbox)` / `Tmax(tbox|stbox)` and the
+ * temporal-min / temporal-max aggregates, which previously differed only
+ * in the casing of their first letter and so collapsed to the same
+ * canonical name in catalogs that are case-insensitive but key on
+ * `(name, kind)` rather than `(name, argtypes, kind)` (DuckDB, BigQuery,
+ * Snowflake, Trino, ...).
+ *
+ * The original names remain valid for backward compatibility. Once
+ * downstream tools have migrated, a future major version may drop the
+ * un-suffixed aliases.
+ *
+ * The new aggregates share the same internal C transition functions as
+ * the originals, so the only runtime cost is one extra row in
+ * `pg_aggregate` per aggregate.
+ */
+
+-- From 015_span_aggfuncs.in.sql
+CREATE AGGREGATE SpanUnionAgg(intspan) (
+  SFUNC = array_agg_transfn,
+  STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
+  FINALFUNC = intspan_union_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE SpanUnionAgg(bigintspan) (
+  SFUNC = array_agg_transfn,
+  STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
+  FINALFUNC = bigintspan_union_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE SpanUnionAgg(floatspan) (
+  SFUNC = array_agg_transfn,
+  STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
+  FINALFUNC = floatspan_union_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE SpanUnionAgg(datespan) (
+  SFUNC = array_agg_transfn,
+  STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
+  FINALFUNC = datespan_union_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE SpanUnionAgg(tstzspan) (
+  SFUNC = array_agg_transfn,
+  STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
+  FINALFUNC = tstzspan_union_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE SpanUnionAgg(intspanset) (
+  SFUNC = spanset_union_transfn,
+  STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
+  FINALFUNC = intspan_union_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE SpanUnionAgg(bigintspanset) (
+  SFUNC = spanset_union_transfn,
+  STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
+  FINALFUNC = bigintspan_union_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE SpanUnionAgg(floatspanset) (
+  SFUNC = spanset_union_transfn,
+  STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
+  FINALFUNC = floatspan_union_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE SpanUnionAgg(datespanset) (
+  SFUNC = spanset_union_transfn,
+  STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
+  FINALFUNC = datespan_union_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE SpanUnionAgg(tstzspanset) (
+  SFUNC = spanset_union_transfn,
+  STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
+  FINALFUNC = tstzspan_union_finalfn,
+  PARALLEL = safe
+);
+
+-- From 001_set.in.sql
+CREATE AGGREGATE SetUnionAgg(integer) (
+  SFUNC = set_union_transfn,
+  STYPE = internal,
+  FINALFUNC = intset_union_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE SetUnionAgg(bigint) (
+  SFUNC = set_union_transfn,
+  STYPE = internal,
+  FINALFUNC = bigintset_union_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE SetUnionAgg(float) (
+  SFUNC = set_union_transfn,
+  STYPE = internal,
+  FINALFUNC = floatset_union_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE SetUnionAgg(text) (
+  SFUNC = set_union_transfn,
+  STYPE = internal,
+  FINALFUNC = textset_union_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE SetUnionAgg(date) (
+  SFUNC = set_union_transfn,
+  STYPE = internal,
+  FINALFUNC = dateset_union_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE SetUnionAgg(timestamptz) (
+  SFUNC = set_union_transfn,
+  STYPE = internal,
+  FINALFUNC = tstzset_union_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE SetUnionAgg(intset) (
+  SFUNC = set_union_transfn,
+  STYPE = internal,
+  FINALFUNC = intset_union_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE SetUnionAgg(bigintset) (
+  SFUNC = set_union_transfn,
+  STYPE = internal,
+  FINALFUNC = bigintset_union_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE SetUnionAgg(floatset) (
+  SFUNC = set_union_transfn,
+  STYPE = internal,
+  FINALFUNC = floatset_union_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE SetUnionAgg(textset) (
+  SFUNC = set_union_transfn,
+  STYPE = internal,
+  FINALFUNC = textset_union_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE SetUnionAgg(dateset) (
+  SFUNC = set_union_transfn,
+  STYPE = internal,
+  FINALFUNC = dateset_union_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE SetUnionAgg(tstzset) (
+  SFUNC = set_union_transfn,
+  STYPE = internal,
+  FINALFUNC = tstzset_union_finalfn,
+  PARALLEL = safe
+);
+
+-- From 040_temporal_aggfuncs.in.sql
+CREATE AGGREGATE TcountAgg(timestamptz) (
+  SFUNC = tcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tcount_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE TcountAgg(tstzset) (
+  SFUNC = tcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tcount_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE TcountAgg(tstzspan) (
+  SFUNC = tcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tcount_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE TcountAgg(tstzspanset) (
+  SFUNC = tcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tcount_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE TcountAgg(tbool) (
+  SFUNC = tcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tcount_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE TandAgg(tbool) (
+  SFUNC = tbool_tand_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tbool_tand_combinefn,
+  FINALFUNC = tbool_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE TorAgg(tbool) (
+  SFUNC = tbool_tor_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tbool_tor_combinefn,
+  FINALFUNC = tbool_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE TcountAgg(tint) (
+  SFUNC = tcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tcount_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE TminAgg(tint) (
+  SFUNC = tint_tmin_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tint_tmin_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE TmaxAgg(tint) (
+  SFUNC = tint_tmax_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tint_tmax_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE TsumAgg(tint) (
+  SFUNC = tint_tsum_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tint_tsum_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE TavgAgg(tint) (
+  SFUNC = tavg_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tavg_combinefn,
+  FINALFUNC = tavg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE TcountAgg(tfloat) (
+  SFUNC = tcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tcount_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE TminAgg(tfloat) (
+  SFUNC = tfloat_tmin_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tfloat_tmin_combinefn,
+  FINALFUNC = tfloat_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE TmaxAgg(tfloat) (
+  SFUNC = tfloat_tmax_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tfloat_tmax_combinefn,
+  FINALFUNC = tfloat_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE TsumAgg(tfloat) (
+  SFUNC = tfloat_tsum_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tfloat_tsum_combinefn,
+  FINALFUNC = tfloat_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE TavgAgg(tfloat) (
+  SFUNC = tavg_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tavg_combinefn,
+  FINALFUNC = tavg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE TcountAgg(ttext) (
+  SFUNC = tcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tcount_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE TminAgg(ttext) (
+  SFUNC = ttext_tmin_transfn,
+  STYPE = internal,
+  COMBINEFUNC = ttext_tmin_combinefn,
+  FINALFUNC = ttext_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE TmaxAgg(ttext) (
+  SFUNC = ttext_tmax_transfn,
+  STYPE = internal,
+  COMBINEFUNC = ttext_tmax_combinefn,
+  FINALFUNC = ttext_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE MergeAgg(tbool) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tbool_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE MergeAgg(tint) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE MergeAgg(tfloat) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tfloat_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE MergeAgg(ttext) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = ttext_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tbool) (
+  SFUNC = temporal_app_tinst_transfn(tbool, tbool),
+  STYPE = tbool,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tbool, interp text) (
+  SFUNC = temporal_app_tinst_transfn(tbool, tbool, text),
+  STYPE = tbool,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tbool, interp text, maxt interval) (
+  SFUNC = temporal_app_tinst_transfn(tbool, tbool, text, maxt),
+  STYPE = tbool,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tint) (
+  SFUNC = temporal_app_tinst_transfn(tint, tint),
+  STYPE = tint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tint, interp text) (
+  SFUNC = temporal_app_tinst_transfn(tint, tint, text),
+  STYPE = tint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tint, interp text, maxdist float, 
+    maxt interval) (
+  SFUNC = temporal_app_tinst_transfn(tint, tint, text, maxdist, maxt),
+  STYPE = tint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tfloat) (
+  SFUNC = temporal_app_tinst_transfn(tfloat, tfloat),
+  STYPE = tfloat,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tfloat, interp text) (
+  SFUNC = temporal_app_tinst_transfn(tfloat, tfloat, text),
+  STYPE = tfloat,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(tfloat, interp text, maxdist float, 
+    maxt interval) (
+  SFUNC = temporal_app_tinst_transfn(tfloat, tfloat, text, maxdist, maxt),
+  STYPE = tfloat,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(ttext) (
+  SFUNC = temporal_app_tinst_transfn(ttext, ttext),
+  STYPE = ttext,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(ttext, interp text) (
+  SFUNC = temporal_app_tinst_transfn(ttext, ttext, text),
+  STYPE = ttext,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendInstantAgg(ttext, interp text, maxt interval) (
+  SFUNC = temporal_app_tinst_transfn(ttext, ttext, text, maxt),
+  STYPE = ttext,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendSequenceAgg(tbool) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tbool,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendSequenceAgg(tint) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendSequenceAgg(tfloat) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tfloat,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE AppendSequenceAgg(ttext) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = ttext,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+-- From 042_temporal_waggfuncs.in.sql
+CREATE AGGREGATE WminAgg(tint, interval) (
+  SFUNC = tint_wmin_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tint_tmin_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE WmaxAgg(tint, interval) (
+  SFUNC = tint_wmax_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tint_tmax_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE WsumAgg(tint, interval) (
+  SFUNC = tint_wsum_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tint_tsum_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE WcountAgg(tint, interval) (
+  SFUNC = wcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tint_tsum_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE WavgAgg(tint, interval) (
+  SFUNC = wavg_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tavg_combinefn,
+  FINALFUNC = tavg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE WminAgg(tfloat, interval) (
+  SFUNC = tfloat_wmin_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tfloat_tmin_combinefn,
+  FINALFUNC = tfloat_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE WmaxAgg(tfloat, interval) (
+  SFUNC = tfloat_wmax_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tfloat_tmax_combinefn,
+  FINALFUNC = tfloat_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE WsumAgg(tfloat, interval) (
+  SFUNC = tfloat_wsum_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tfloat_tsum_combinefn,
+  FINALFUNC = tfloat_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE WcountAgg(tfloat, interval) (
+  SFUNC = wcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tint_tsum_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE AGGREGATE WavgAgg(tfloat, interval) (
+  SFUNC = wavg_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tavg_combinefn,
+  FINALFUNC = tavg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+

--- a/mobilitydb/sql/temporal/CMakeLists.txt
+++ b/mobilitydb/sql/temporal/CMakeLists.txt
@@ -27,6 +27,7 @@ SET(LOCAL_FILES
   043_temporal_gist
   044_temporal_spgist
   046_temporal_analytics
+  045_aggregate_renames
   999_oid_cache
   )
 


### PR DESCRIPTION
Adds Pascal-cased `*Agg` aliases for the SkipList aggregate functions per RFC #827 (portable SQL naming).

## Summary
- 1 commit, ahead of `master` by 1, no merge conflicts
- Single-purpose: SQL alias additions

## Test plan
- [ ] CI green on the PR