### PR TITLE
fix(meos): export missing public symbols + restore JVM-safe error handler

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -380,6 +380,7 @@ typedef void (*error_handler_fn)(int, int, const char *);
 
 extern void meos_initialize_timezone(const char *name);
 extern void meos_initialize_error_handler(error_handler_fn err_handler);
+extern void meos_initialize_noexit_error_handler(void);
 extern void meos_finalize_timezone(void);
 extern void meos_finalize_projsrs(void);
 extern void meos_finalize_ways(void);

--- a/meos/src/cbuffer/cbuffer.c
+++ b/meos/src/cbuffer/cbuffer.c
@@ -1367,7 +1367,7 @@ cbuffer_eq(const Cbuffer *cb1, const Cbuffer *cb2)
  * @param[in] cb1,cb2 Circular buffers
  * @csqlfn #Cbuffer_ne()
  */
-inline bool
+bool
 cbuffer_ne(const Cbuffer *cb1, const Cbuffer *cb2)
 {
   return (! cbuffer_eq(cb1, cb2));
@@ -1397,7 +1397,7 @@ cbuffer_same(const Cbuffer *cb1, const Cbuffer *cb2)
  * @brief Return true if two circular buffers are approximately equal with
  * respect to an epsilon value
  */
-inline bool
+bool
 cbuffer_nsame(const Cbuffer *cb1, const Cbuffer *cb2)
 {
   return ! cbuffer_same(cb1, cb2);
@@ -1450,7 +1450,7 @@ cbuffer_cmp(const Cbuffer *cb1, const Cbuffer *cb2)
  * @param[in] cb1,cb2 Circular buffers
  * @csqlfn #Cbuffer_lt()
  */
-inline bool
+bool
 cbuffer_lt(const Cbuffer *cb1, const Cbuffer *cb2)
 {
   return cbuffer_cmp(cb1, cb2) < 0;
@@ -1463,7 +1463,7 @@ cbuffer_lt(const Cbuffer *cb1, const Cbuffer *cb2)
  * @param[in] cb1,cb2 Circular buffers
  * @csqlfn #Cbuffer_le()
  */
-inline bool
+bool
 cbuffer_le(const Cbuffer *cb1, const Cbuffer *cb2)
 {
   return cbuffer_cmp(cb1, cb2) <= 0;
@@ -1475,7 +1475,7 @@ cbuffer_le(const Cbuffer *cb1, const Cbuffer *cb2)
  * @param[in] cb1,cb2 Circular buffers
  * @csqlfn #Cbuffer_gt()
  */
-inline bool
+bool
 cbuffer_gt(const Cbuffer *cb1, const Cbuffer *cb2)
 {
   return cbuffer_cmp(cb1, cb2) > 0;
@@ -1488,7 +1488,7 @@ cbuffer_gt(const Cbuffer *cb1, const Cbuffer *cb2)
  * @param[in] cb1,cb2 Circular buffers
  * @csqlfn #Cbuffer_ge()
  */
-inline bool
+bool
 cbuffer_ge(const Cbuffer *cb1, const Cbuffer *cb2)
 {
   return cbuffer_cmp(cb1, cb2) >= 0;

--- a/meos/src/cbuffer/tcbuffer.c
+++ b/meos/src/cbuffer/tcbuffer.c
@@ -870,7 +870,7 @@ tcbuffer_members(const Temporal *temp, bool point)
  * @brief Return the array of points or radius of a temporal circular buffer
  * @csqlfn #Tcbuffer_points()
  */
-inline Set *
+Set *
 tcbuffer_points(const Temporal *temp)
 {
   return tcbuffer_members(temp, true);
@@ -881,7 +881,7 @@ tcbuffer_points(const Temporal *temp)
  * @brief Return the array of radii of a temporal circular buffer
  * @csqlfn #Tcbuffer_points()
  */
-inline Set *
+Set *
 tcbuffer_radius(const Temporal *temp)
 {
   return tcbuffer_members(temp, false);

--- a/meos/src/cbuffer/tcbuffer_compops.c
+++ b/meos/src/cbuffer/tcbuffer_compops.c
@@ -91,7 +91,7 @@ eacomp_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
  * @param[in] temp Temporal value
  * @csqlfn #Ever_eq_cbuffer_tcbuffer()
  */
-inline int
+int
 ever_eq_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 {
   return eacomp_tcbuffer_cbuffer(temp, cb, &datum2_eq, EVER);
@@ -105,7 +105,7 @@ ever_eq_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
  * @param[in] cb Circular buffer
  * @csqlfn #Ever_eq_tcbuffer_cbuffer()
  */
-inline int
+int
 ever_eq_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return eacomp_tcbuffer_cbuffer(temp, cb, &datum2_eq, EVER);
@@ -119,7 +119,7 @@ ever_eq_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @param[in] temp Temporal value
  * @csqlfn #Ever_ne_cbuffer_tcbuffer()
  */
-inline int
+int
 ever_ne_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 {
   return eacomp_tcbuffer_cbuffer(temp, cb, &datum2_ne, EVER);
@@ -133,7 +133,7 @@ ever_ne_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
  * @param[in] cb Circular buffer
  * @csqlfn #Ever_ne_tcbuffer_cbuffer()
  */
-inline int
+int
 ever_ne_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return eacomp_tcbuffer_cbuffer(temp, cb, &datum2_ne, EVER);
@@ -147,7 +147,7 @@ ever_ne_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @param[in] temp Temporal value
  * @csqlfn #Always_eq_cbuffer_tcbuffer()
  */
-inline int
+int
 always_eq_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 {
   return eacomp_tcbuffer_cbuffer(temp, cb, &datum2_eq, ALWAYS);
@@ -161,7 +161,7 @@ always_eq_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
  * @param[in] cb Circular buffer
  * @csqlfn #Always_eq_tcbuffer_cbuffer()
  */
-inline int
+int
 always_eq_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return eacomp_tcbuffer_cbuffer(temp, cb, &datum2_eq, ALWAYS);
@@ -175,7 +175,7 @@ always_eq_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @param[in] temp Temporal value
  * @csqlfn #Always_ne_cbuffer_tcbuffer()
  */
-inline int
+int
 always_ne_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 {
   return eacomp_tcbuffer_cbuffer(temp, cb, &datum2_ne, ALWAYS);
@@ -189,7 +189,7 @@ always_ne_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
  * @param[in] cb Circular buffer
  * @csqlfn #Always_ne_tcbuffer_cbuffer()
  */
-inline int
+int
 always_ne_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return eacomp_tcbuffer_cbuffer(temp, cb, &datum2_ne, ALWAYS);
@@ -203,7 +203,7 @@ always_ne_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @param[in] temp1,temp2 Temporal circular buffers
  * @csqlfn #Ever_eq_tcbuffer_tcbuffer()
  */
-inline int
+int
 ever_eq_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tcbuffer_tcbuffer(temp1, temp2, &datum2_eq, EVER);
@@ -215,7 +215,7 @@ ever_eq_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal circular buffers
  * @csqlfn #Ever_ne_tcbuffer_tcbuffer()
  */
-inline int
+int
 ever_ne_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tcbuffer_tcbuffer(temp1, temp2, &datum2_ne, EVER);
@@ -227,7 +227,7 @@ ever_ne_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal circular buffers
  * @csqlfn #Always_eq_tcbuffer_tcbuffer()
  */
-inline int
+int
 always_eq_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tcbuffer_tcbuffer(temp1, temp2, &datum2_eq, ALWAYS);
@@ -239,7 +239,7 @@ always_eq_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal circular buffers
  * @csqlfn #Always_ne_tcbuffer_tcbuffer()
  */
-inline int
+int
 always_ne_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tcbuffer_tcbuffer(temp1, temp2, &datum2_ne, ALWAYS);
@@ -293,7 +293,7 @@ tcomp_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb,
  * @param[in] temp Temporal value
  * @csqlfn #Teq_cbuffer_tcbuffer()
  */
-inline Temporal *
+Temporal *
 teq_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 {
   return tcomp_cbuffer_tcbuffer(cb, temp, &datum2_eq);
@@ -307,7 +307,7 @@ teq_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
  * @param[in] temp Temporal value
  * @csqlfn #Tne_cbuffer_tcbuffer()
  */
-inline Temporal *
+Temporal *
 tne_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 {
   return tcomp_cbuffer_tcbuffer(cb, temp, &datum2_ne);
@@ -323,7 +323,7 @@ tne_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
  * @param[in] cb Circular buffer
  * @csqlfn #Teq_tcbuffer_cbuffer()
  */
-inline Temporal *
+Temporal *
 teq_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return tcomp_tcbuffer_cbuffer(temp, cb, &datum2_eq);
@@ -337,7 +337,7 @@ teq_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @param[in] cb Circular buffer
  * @csqlfn #Tne_tcbuffer_cbuffer()
  */
-inline Temporal *
+Temporal *
 tne_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return tcomp_tcbuffer_cbuffer(temp, cb, &datum2_ne);

--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -453,7 +453,7 @@ ea_contains_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp,
  * geometry
  * @csqlfn #Acontains_geo_tcbuffer()
  */
-inline int
+int
 acontains_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp)
 {
   return ea_contains_geo_tcbuffer(gs, temp, ALWAYS);
@@ -492,7 +492,7 @@ ea_contains_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs,
  * geometry
  * @csqlfn #Econtains_tcbuffer_geo()
  */
-inline int
+int
 econtains_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_contains_tcbuffer_geo(temp, gs, EVER);
@@ -508,7 +508,7 @@ econtains_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
  * geometry
  * @csqlfn #Acontains_tcbuffer_geo()
  */
-inline int
+int
 acontains_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_contains_tcbuffer_geo(temp, gs, ALWAYS);
@@ -544,7 +544,7 @@ ea_contains_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp,
  * @param[in] temp Temporal circular buffer
  * @csqlfn #Econtains_cbuffer_tcbuffer()
  */
-inline int
+int
 econtains_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 {
   return ea_contains_cbuffer_tcbuffer(cb, temp, EVER);
@@ -558,7 +558,7 @@ econtains_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
  * @param[in] temp Temporal circular buffer
  * @csqlfn #Acontains_cbuffer_tcbuffer()
  */
-inline int
+int
 acontains_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 {
   return ea_contains_cbuffer_tcbuffer(cb, temp, ALWAYS);
@@ -594,7 +594,7 @@ ea_contains_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb,
  * @param[in] cb Circular buffer
  * @csqlfn #Econtains_tcbuffer_cbuffer()
  */
-inline int
+int
 econtains_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return ea_contains_tcbuffer_cbuffer(temp, cb, EVER);
@@ -608,7 +608,7 @@ econtains_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @param[in] cb Circular buffer
  * @csqlfn #Acontains_tcbuffer_cbuffer()
  */
-inline int
+int
 acontains_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return ea_contains_tcbuffer_cbuffer(temp, cb, ALWAYS);
@@ -646,7 +646,7 @@ ea_covers_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp, bool ever)
  * geometry
  * @csqlfn #Acovers_geo_tcbuffer()
  */
-inline int
+int
 acovers_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp)
 {
   return ea_covers_geo_tcbuffer(gs, temp, ALWAYS);
@@ -681,7 +681,7 @@ ea_covers_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
  * geometry
  * @csqlfn #Ecovers_tcbuffer_geo()
  */
-inline int
+int
 ecovers_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_covers_tcbuffer_geo(temp, gs, EVER);
@@ -697,7 +697,7 @@ ecovers_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
  * geometry
  * @csqlfn #Acovers_tcbuffer_geo()
  */
-inline int
+int
 acovers_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_covers_tcbuffer_geo(temp, gs, ALWAYS);
@@ -728,7 +728,7 @@ ea_covers_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp,
  * @param[in] temp Temporal circular buffer
  * @csqlfn #Ecovers_cbuffer_tcbuffer()
  */
-inline int
+int
 ecovers_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 {
   return ea_covers_cbuffer_tcbuffer(cb, temp, EVER);
@@ -742,7 +742,7 @@ ecovers_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
  * @param[in] temp Temporal circular buffer
  * @csqlfn #Acovers_cbuffer_tcbuffer()
  */
-inline int
+int
 acovers_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 {
   return ea_covers_cbuffer_tcbuffer(cb, temp, ALWAYS);
@@ -773,7 +773,7 @@ ea_covers_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb,
  * @param[in] cb Circular buffer
  * @csqlfn #Ecovers_tcbuffer_cbuffer()
  */
-inline int
+int
 ecovers_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return ea_covers_tcbuffer_cbuffer(temp, cb, EVER);
@@ -787,7 +787,7 @@ ecovers_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @param[in] cb Circular buffer
  * @csqlfn #Acovers_tcbuffer_cbuffer()
  */
-inline int
+int
 acovers_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return ea_covers_tcbuffer_cbuffer(temp, cb, ALWAYS);
@@ -897,7 +897,7 @@ edisjoint_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @note aDisjoint(a, b) is equivalent to NOT eIntersects(a, b)
  * @csqlfn #Adisjoint_tcbuffer_geo()
  */
-inline int
+int
 adisjoint_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_disjoint_tcbuffer_geo(temp, gs, ALWAYS);
@@ -959,7 +959,7 @@ edisjoint_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @note aDisjoint(a, b) is equivalent to NOT eIntersects(a, b)
  * @csqlfn #Adisjoint_tcbuffer_geo()
  */
-inline int
+int
 adisjoint_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return ea_disjoint_tcbuffer_cbuffer(temp, cb, ALWAYS);
@@ -992,7 +992,7 @@ ea_disjoint_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
  * @param[in] temp1,temp2 Temporal circular buffers
  * @csqlfn #Edisjoint_tcbuffer_tcbuffer()
  */
-inline int
+int
 edisjoint_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_disjoint_tcbuffer_tcbuffer(temp1, temp2, EVER);
@@ -1006,7 +1006,7 @@ edisjoint_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal circular buffers
  * @csqlfn #Adisjoint_tcbuffer_tcbuffer()
  */
-inline int
+int
 adisjoint_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_disjoint_tcbuffer_tcbuffer(temp1, temp2, ALWAYS);
@@ -1073,7 +1073,7 @@ eintersects_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @note aIntersects(tcbuffer, geo) is equivalent to NOT eDisjoint(tcbuffer, geo)
  * @csqlfn #Aintersects_tcbuffer_geo()
  */
-inline int
+int
 aintersects_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_intersects_tcbuffer_geo(temp, gs, ALWAYS);
@@ -1122,7 +1122,7 @@ ea_intersects_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp,
  * @param[in] cb Circular buffer
  * @csqlfn #Eintersects_tcbuffer_cbuffer()
  */
-inline int
+int
 eintersects_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return ea_intersects_tcbuffer_cbuffer(temp, cb, EVER);
@@ -1138,7 +1138,7 @@ eintersects_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * NOT eDisjoint(tcbuffer, cbuffer)
  * @csqlfn #Aintersects_tcbuffer_cbuffer()
  */
-inline int
+int
 aintersects_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return ea_intersects_tcbuffer_cbuffer(temp, cb, ALWAYS);
@@ -1171,7 +1171,7 @@ ea_intersects_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
  * @param[in] temp1,temp2 Temporal circular buffers
  * @csqlfn #Eintersects_tcbuffer_tcbuffer()
  */
-inline int
+int
 eintersects_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_intersects_tcbuffer_tcbuffer(temp1, temp2, EVER);
@@ -1184,7 +1184,7 @@ eintersects_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal circular buffers
  * @csqlfn #Aintersects_tcbuffer_tcbuffer()
  */
-inline int
+int
 aintersects_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_intersects_tcbuffer_tcbuffer(temp1, temp2, ALWAYS);
@@ -1296,7 +1296,7 @@ ea_touches_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp, bool ever)
  * @param[in] cb Circular buffer
  * @csqlfn #Atouches_tcbuffer_cbuffer()
  */
-inline int
+int
 etouches_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return ea_touches_tcbuffer_cbuffer(temp, cb, EVER); 
@@ -1310,7 +1310,7 @@ etouches_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @param[in] cb Circular buffer
  * @csqlfn #Atouches_tcbuffer_cbuffer()
  */
-inline int
+int
 atouches_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return ea_touches_tcbuffer_cbuffer(temp, cb, ALWAYS); 
@@ -1520,7 +1520,7 @@ ea_dwithin_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
  * @param[in] dist Distance
  * @csqlfn #Edwithin_tcbuffer_tcbuffer()
  */
-inline int
+int
 edwithin_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
   double dist)
 {
@@ -1536,7 +1536,7 @@ edwithin_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
  * @param[in] dist Distance
  * @csqlfn #Adwithin_tcbuffer_tcbuffer()
  */
-inline int
+int
 adwithin_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
   double dist)
 {

--- a/meos/src/cbuffer/tcbuffer_tempspatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_tempspatialrels.c
@@ -821,7 +821,7 @@ tcovers_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
  * @param[in] gs Geometry
  * @csqlfn #Tdisjoint_tcbuffer_geo()
  */
-inline Temporal *
+Temporal *
 tdisjoint_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp)
 {
   return tinterrel_tcbuffer_geo(temp, gs, TDISJOINT);
@@ -835,7 +835,7 @@ tdisjoint_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp)
  * @param[in] gs Geometry
  * @csqlfn #Tdisjoint_tcbuffer_geo()
  */
-inline Temporal *
+Temporal *
 tdisjoint_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tinterrel_tcbuffer_geo(temp, gs, TDISJOINT);
@@ -849,7 +849,7 @@ tdisjoint_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] cb Circular buffer
  * @csqlfn #Tdisjoint_tcbuffer_geo()
  */
-inline Temporal *
+Temporal *
 tdisjoint_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 {
   return tinterrel_tcbuffer_cbuffer(temp, cb, TDISJOINT);
@@ -863,7 +863,7 @@ tdisjoint_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
  * @param[in] cb Circular buffer
  * @csqlfn #Tdisjoint_tcbuffer_geo()
  */
-inline Temporal *
+Temporal *
 tdisjoint_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return tinterrel_tcbuffer_cbuffer(temp, cb, TDISJOINT);
@@ -876,7 +876,7 @@ tdisjoint_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @param[in] temp1,temp2 Temporal circular buffers
  * @csqlfn #Tdisjoint_tcbuffer_tcbuffer()
  */
-inline Temporal *
+Temporal *
 tdisjoint_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
   return tinterrel_tspatial_tspatial(temp1, temp2, TDISJOINT);
@@ -894,7 +894,7 @@ tdisjoint_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
  * @param[in] gs Geometry
  * @csqlfn #Tintersects_tcbuffer_geo()
  */
-inline Temporal *
+Temporal *
 tintersects_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tinterrel_tcbuffer_geo(temp, gs, TINTERSECTS);
@@ -908,7 +908,7 @@ tintersects_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] gs Geometry
  * @csqlfn #Tintersects_tcbuffer_geo()
  */
-inline Temporal *
+Temporal *
 tintersects_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp)
 {
   return tinterrel_tcbuffer_geo(temp, gs, TINTERSECTS);
@@ -922,7 +922,7 @@ tintersects_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp)
  * @param[in] cb Circular buffer
  * @csqlfn #Tdisjoint_tcbuffer_geo()
  */
-inline Temporal *
+Temporal *
 tintersects_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 {
   return tinterrel_tcbuffer_cbuffer(temp, cb, TDISJOINT);
@@ -936,7 +936,7 @@ tintersects_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
  * @param[in] cb Circular buffer
  * @csqlfn #Tdisjoint_tcbuffer_geo()
  */
-inline Temporal *
+Temporal *
 tintersects_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return tinterrel_tcbuffer_cbuffer(temp, cb, TDISJOINT);
@@ -949,7 +949,7 @@ tintersects_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @param[in] temp1,temp2 Temporal circular buffers
  * @csqlfn #Tintersects_tcbuffer_tcbuffer()
  */
-inline Temporal *
+Temporal *
 tintersects_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
   return tinterrel_tspatial_tspatial(temp1, temp2, TINTERSECTS);

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -1534,7 +1534,7 @@ geom_spatialrel(const GSERIALIZED *gs1, const GSERIALIZED *gs2, spatialRel rel)
  * @param[in] gs1,gs2 Geometries
  * @note PostGIS functions: @p ST_Intersects(PG_FUNCTION_ARGS)
  */
-inline bool
+bool
 geom_intersects2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 {
   return geom_spatialrel(gs1, gs2, INTERSECTS);
@@ -1547,7 +1547,7 @@ geom_intersects2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
  * @param[in] gs1,gs2 Geometries
  * @note PostGIS functions: @p contains(PG_FUNCTION_ARGS)
  */
-inline bool
+bool
 geom_contains(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 {
   return geom_spatialrel(gs1, gs2, CONTAINS);
@@ -1560,7 +1560,7 @@ geom_contains(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
  * @param[in] gs1,gs2 Geometries
  * @note PostGIS function: @p touches(PG_FUNCTION_ARGS)
  */
-inline bool
+bool
 geom_touches(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 {
   return geom_spatialrel(gs1, gs2, TOUCHES);
@@ -1573,7 +1573,7 @@ geom_touches(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
  * @param[in] gs1,gs2 Geometries
  * @note PostGIS function: @p ST_Covers(PG_FUNCTION_ARGS)
  */
-inline bool
+bool
 geom_covers(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 {
   return geom_spatialrel(gs1, gs2, COVERS);
@@ -1585,7 +1585,7 @@ geom_covers(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
  * @param[in] gs1,gs2 Geometries
  * @note PostGIS function: @p ST_Disjoint(PG_FUNCTION_ARGS)
  */
-inline bool
+bool
 geom_disjoint2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 {
   return ! geom_spatialrel(gs1, gs2, INTERSECTS);
@@ -2964,7 +2964,7 @@ geog_dwithin(const GSERIALIZED *gs1, const GSERIALIZED *gs2, double tolerance,
  * @param[in] use_spheroid True when using a spheroid
  * @note PostGIS function: @p geography_intersects(PG_FUNCTION_ARGS)
  */
-inline bool
+bool
 geog_intersects(const GSERIALIZED *gs1, const GSERIALIZED *gs2,
   bool use_spheroid)
 {
@@ -3354,7 +3354,7 @@ geo_as_wkt(const GSERIALIZED *gs, int precision, bool extended)
  * @param[in] precision Maximum number of decimal digits
  * @note PostGIS function: @p LWGEOM_asText(PG_FUNCTION_ARGS)
  */
-inline char *
+char *
 geo_as_text(const GSERIALIZED *gs, int precision)
 {
   return geo_as_wkt(gs, precision, false);
@@ -3371,7 +3371,7 @@ geo_as_text(const GSERIALIZED *gs, int precision)
  * accept (HEX)WKB or EWKT.
  * @note PostGIS function: @p LWGEOM_asEWKT(PG_FUNCTION_ARGS)
  */
-inline char *
+char *
 geo_as_ewkt(const GSERIALIZED *gs, int precision)
 {
   return geo_as_wkt(gs, precision, true);
@@ -3388,7 +3388,7 @@ geo_as_ewkt(const GSERIALIZED *gs, int precision)
  * accept (HEX)WKB or EWKT.
  * @note PostGIS function: @p LWGEOM_from_text(PG_FUNCTION_ARGS)
  */
-inline GSERIALIZED *
+GSERIALIZED *
 geom_from_hexewkb(const char *wkt)
 {
   return geom_in(wkt, -1);
@@ -3403,7 +3403,7 @@ geom_from_hexewkb(const char *wkt)
  * accept (HEX)WKB or EWKT.
  * @note PostGIS function: @p LWGEOM_from_text(PG_FUNCTION_ARGS)
  */
-inline GSERIALIZED *
+GSERIALIZED *
 geog_from_hexewkb(const char *wkt)
 {
   return geog_in(wkt, -1);

--- a/meos/src/geo/stbox.c
+++ b/meos/src/geo/stbox.c
@@ -1804,7 +1804,7 @@ contains_stbox_stbox(const STBox *box1, const STBox *box2)
  * @param[in] box1,box2 Spatiotemporal boxes
  * @csqlfn #Contained_stbox_stbox()
  */
-inline bool
+bool
 contained_stbox_stbox(const STBox *box1, const STBox *box2)
 {
   return contains_stbox_stbox(box2, box1);
@@ -2435,7 +2435,7 @@ stbox_eq(const STBox *box1, const STBox *box2)
  * @param[in] box1,box2 Spatiotemporal boxes
  * @csqlfn #Stbox_ne()
  */
-inline bool
+bool
 stbox_ne(const STBox *box1, const STBox *box2)
 {
   return ! stbox_eq(box1, box2);
@@ -2520,7 +2520,7 @@ stbox_cmp(const STBox *box1, const STBox *box2)
  * @param[in] box1,box2 Spatiotemporal boxes
  * @csqlfn #Stbox_lt()
  */
-inline bool
+bool
 stbox_lt(const STBox *box1, const STBox *box2)
 {
   return stbox_cmp(box1, box2) < 0;
@@ -2533,7 +2533,7 @@ stbox_lt(const STBox *box1, const STBox *box2)
  * @param[in] box1,box2 Spatiotemporal boxes
  * @csqlfn #Stbox_le()
  */
-inline bool
+bool
 stbox_le(const STBox *box1, const STBox *box2)
 {
   return stbox_cmp(box1, box2) <= 0;
@@ -2546,7 +2546,7 @@ stbox_le(const STBox *box1, const STBox *box2)
  * @param[in] box1,box2 Spatiotemporal boxes
  * @csqlfn #Stbox_ge()
  */
-inline bool
+bool
 stbox_ge(const STBox *box1, const STBox *box2)
 {
   return stbox_cmp(box1, box2) >= 0;
@@ -2559,7 +2559,7 @@ stbox_ge(const STBox *box1, const STBox *box2)
  * @param[in] box1,box2 Spatiotemporal boxes
  * @csqlfn #Stbox_gt()
  */
-inline bool
+bool
 stbox_gt(const STBox *box1, const STBox *box2)
 {
   return stbox_cmp(box1, box2) > 0;

--- a/meos/src/geo/tgeo_compops.c
+++ b/meos/src/geo/tgeo_compops.c
@@ -95,7 +95,7 @@ eacomp_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2,
  * @param[in] temp Temporal geo
  * @csqlfn #Ever_eq_geo_tgeo()
  */
-inline int
+int
 ever_eq_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   return eacomp_tgeo_geo(temp, gs, &datum2_eq, EVER);
@@ -108,7 +108,7 @@ ever_eq_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
  * @param[in] gs Geo
  * @csqlfn #Ever_eq_tgeo_geo()
  */
-inline int
+int
 ever_eq_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return eacomp_tgeo_geo(temp, gs, &datum2_eq, EVER);
@@ -121,7 +121,7 @@ ever_eq_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] temp Temporal geo
  * @csqlfn #Ever_ne_geo_tgeo()
  */
-inline int
+int
 ever_ne_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   return eacomp_tgeo_geo(temp, gs, &datum2_ne, EVER);
@@ -134,7 +134,7 @@ ever_ne_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
  * @param[in] gs Geo
  * @csqlfn #Ever_ne_tgeo_geo()
  */
-inline int
+int
 ever_ne_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return eacomp_tgeo_geo(temp, gs, &datum2_ne, EVER);
@@ -147,7 +147,7 @@ ever_ne_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] temp Temporal geo
  * @csqlfn #Always_eq_geo_tgeo()
  */
-inline int
+int
 always_eq_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   return eacomp_tgeo_geo(temp, gs, &datum2_eq, ALWAYS);
@@ -160,7 +160,7 @@ always_eq_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
  * @param[in] gs Geo
  * @csqlfn #Always_eq_tgeo_geo()
  */
-inline int
+int
 always_eq_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return eacomp_tgeo_geo(temp, gs, &datum2_eq, ALWAYS);
@@ -173,7 +173,7 @@ always_eq_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] temp Temporal geo
  * @csqlfn #Always_ne_geo_tgeo()
  */
-inline int
+int
 always_ne_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   return eacomp_tgeo_geo(temp, gs, &datum2_ne, ALWAYS);
@@ -186,7 +186,7 @@ always_ne_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
  * @param[in] gs Geo
  * @csqlfn #Always_ne_tgeo_geo()
  */
-inline int
+int
 always_ne_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return eacomp_tgeo_geo(temp, gs, &datum2_ne, ALWAYS);
@@ -200,7 +200,7 @@ always_ne_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Ever_eq_tgeo_tgeo()
  */
-inline int
+int
 ever_eq_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tgeo_tgeo(temp1, temp2, &datum2_eq, EVER);
@@ -212,7 +212,7 @@ ever_eq_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Ever_ne_tgeo_tgeo()
  */
-inline int
+int
 ever_ne_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tgeo_tgeo(temp1, temp2, &datum2_ne, EVER);
@@ -224,7 +224,7 @@ ever_ne_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Always_eq_tgeo_tgeo()
  */
-inline int
+int
 always_eq_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tgeo_tgeo(temp1, temp2, &datum2_eq, ALWAYS);
@@ -236,7 +236,7 @@ always_eq_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Always_ne_tgeo_tgeo()
  */
-inline int
+int
 always_ne_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tgeo_tgeo(temp1, temp2, &datum2_ne, ALWAYS);
@@ -291,7 +291,7 @@ tcomp_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
  * @param[in] temp Temporal geo
  * @csqlfn #Teq_geo_tgeo()
  */
-inline Temporal *
+Temporal *
 teq_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   return tcomp_geo_tgeo(gs, temp, &datum2_eq);
@@ -304,7 +304,7 @@ teq_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
  * @param[in] temp Temporal geo
  * @csqlfn #Tne_geo_tgeo()
  */
-inline Temporal *
+Temporal *
 tne_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   return tcomp_geo_tgeo(gs, temp, &datum2_ne);
@@ -319,7 +319,7 @@ tne_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
  * @param[in] gs Geo
  * @csqlfn #Teq_tgeo_geo()
  */
-inline Temporal *
+Temporal *
 teq_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tcomp_tgeo_geo(temp, gs, &datum2_eq);
@@ -332,7 +332,7 @@ teq_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] gs Geo
  * @csqlfn #Tne_tgeo_geo()
  */
-inline Temporal *
+Temporal *
 tne_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tcomp_tgeo_geo(temp, gs, &datum2_ne);

--- a/meos/src/geo/tgeo_meos.c
+++ b/meos/src/geo/tgeo_meos.c
@@ -271,7 +271,7 @@ tgeographyseqset_in(const char *str)
  * @param[in] srid SRID
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TInstant *
+TInstant *
 tgeompointinst_from_mfjson(json_object *mfjson, int32_t srid)
 {
   return tinstant_from_mfjson(mfjson, true, srid, T_TGEOMPOINT);
@@ -285,7 +285,7 @@ tgeompointinst_from_mfjson(json_object *mfjson, int32_t srid)
  * @param[in] srid SRID
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TInstant *
+TInstant *
 tgeogpointinst_from_mfjson(json_object *mfjson, int32_t srid)
 {
   return tinstant_from_mfjson(mfjson, true, srid, T_TGEOGPOINT);
@@ -298,7 +298,7 @@ tgeogpointinst_from_mfjson(json_object *mfjson, int32_t srid)
  * @param[in] srid SRID
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TInstant *
+TInstant *
 tgeometryinst_from_mfjson(json_object *mfjson, int32_t srid)
 {
   return tinstant_from_mfjson(mfjson, true, srid, T_TGEOMETRY);
@@ -311,7 +311,7 @@ tgeometryinst_from_mfjson(json_object *mfjson, int32_t srid)
  * @param[in] srid SRID
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TInstant *
+TInstant *
 tgeographyinst_from_mfjson(json_object *mfjson, int32_t srid)
 {
   return tinstant_from_mfjson(mfjson, true, srid, T_TGEOGRAPHY);
@@ -328,7 +328,7 @@ tgeographyinst_from_mfjson(json_object *mfjson, int32_t srid)
  * @param[in] interp Interpolation
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequence *
+TSequence *
 tgeompointseq_from_mfjson(json_object *mfjson, int32_t srid, interpType interp)
 {
   return tsequence_from_mfjson(mfjson, true, srid, T_TGEOMPOINT, interp);
@@ -343,7 +343,7 @@ tgeompointseq_from_mfjson(json_object *mfjson, int32_t srid, interpType interp)
  * @param[in] interp Interpolation
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequence *
+TSequence *
 tgeogpointseq_from_mfjson(json_object *mfjson, int32_t srid, interpType interp)
 {
   return tsequence_from_mfjson(mfjson, true, srid, T_TGEOGPOINT, interp);
@@ -357,7 +357,7 @@ tgeogpointseq_from_mfjson(json_object *mfjson, int32_t srid, interpType interp)
  * @param[in] interp Interpolation
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequence *
+TSequence *
 tgeometryseq_from_mfjson(json_object *mfjson, int32_t srid, interpType interp)
 {
   return tsequence_from_mfjson(mfjson, true, srid, T_TGEOMETRY, interp);
@@ -371,7 +371,7 @@ tgeometryseq_from_mfjson(json_object *mfjson, int32_t srid, interpType interp)
  * @param[in] interp Interpolation
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequence *
+TSequence *
 tgeographyseq_from_mfjson(json_object *mfjson, int32_t srid, interpType interp)
 {
   return tsequence_from_mfjson(mfjson, true, srid, T_TGEOGRAPHY, interp);
@@ -388,7 +388,7 @@ tgeographyseq_from_mfjson(json_object *mfjson, int32_t srid, interpType interp)
  * @param[in] interp Interpolation
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequenceSet *
+TSequenceSet *
 tgeompointseqset_from_mfjson(json_object *mfjson, int32_t srid, interpType interp)
 {
   return tsequenceset_from_mfjson(mfjson, true, srid, T_TGEOMPOINT, interp);
@@ -403,7 +403,7 @@ tgeompointseqset_from_mfjson(json_object *mfjson, int32_t srid, interpType inter
  * @param[in] interp Interpolation
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequenceSet *
+TSequenceSet *
 tgeogpointseqset_from_mfjson(json_object *mfjson, int32_t srid, interpType interp)
 {
   return tsequenceset_from_mfjson(mfjson, true, srid, T_TGEOGPOINT, interp);
@@ -418,7 +418,7 @@ tgeogpointseqset_from_mfjson(json_object *mfjson, int32_t srid, interpType inter
  * @param[in] interp Interpolation
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequenceSet *
+TSequenceSet *
 tgeometryseqset_from_mfjson(json_object *mfjson, int32_t srid, interpType interp)
 {
   return tsequenceset_from_mfjson(mfjson, true, srid, T_TGEOMETRY, interp);
@@ -433,7 +433,7 @@ tgeometryseqset_from_mfjson(json_object *mfjson, int32_t srid, interpType interp
  * @param[in] interp Interpolation
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequenceSet *
+TSequenceSet *
 tgeographyseqset_from_mfjson(json_object *mfjson, int32_t srid, interpType interp)
 {
   return tsequenceset_from_mfjson(mfjson, true, srid, T_TGEOGRAPHY, interp);
@@ -448,7 +448,7 @@ tgeographyseqset_from_mfjson(json_object *mfjson, int32_t srid, interpType inter
  * @return On error return @p NULL
  * @see #temporal_from_mfjson()
  */
-inline Temporal *
+Temporal *
 tgeompoint_from_mfjson(const char *mfjson)
 {
   return temporal_from_mfjson(mfjson, T_TGEOMPOINT);
@@ -461,7 +461,7 @@ tgeompoint_from_mfjson(const char *mfjson)
  * @return On error return @p NULL
  * @see #temporal_from_mfjson()
  */
-inline Temporal *
+Temporal *
 tgeogpoint_from_mfjson(const char *mfjson)
 {
   return temporal_from_mfjson(mfjson, T_TGEOGPOINT);
@@ -473,7 +473,7 @@ tgeogpoint_from_mfjson(const char *mfjson)
  * @return On error return @p NULL
  * @see #temporal_from_mfjson()
  */
-inline Temporal *
+Temporal *
 tgeometry_from_mfjson(const char *mfjson)
 {
   return temporal_from_mfjson(mfjson, T_TGEOMETRY);
@@ -486,7 +486,7 @@ tgeometry_from_mfjson(const char *mfjson)
  * @return On error return @p NULL
  * @see #temporal_from_mfjson()
  */
-inline Temporal *
+Temporal *
 tgeography_from_mfjson(const char *mfjson)
 {
   return temporal_from_mfjson(mfjson, T_TGEOGRAPHY);
@@ -679,7 +679,7 @@ tgeo_from_base_temp_int(const GSERIALIZED *gs, const Temporal *temp,
  * @param[in] gs Value
  * @param[in] temp Temporal value
  */
-inline Temporal *
+Temporal *
 tpoint_from_base_temp(const GSERIALIZED *gs, const Temporal *temp)
 {
   return tgeo_from_base_temp_int(gs, temp, true);
@@ -692,7 +692,7 @@ tpoint_from_base_temp(const GSERIALIZED *gs, const Temporal *temp)
  * @param[in] gs Value
  * @param[in] temp Temporal value
  */
-inline Temporal *
+Temporal *
 tgeo_from_base_temp(const GSERIALIZED *gs, const Temporal *temp)
 {
   return tgeo_from_base_temp_int(gs, temp, false);

--- a/meos/src/geo/tgeo_restrict.c
+++ b/meos/src/geo/tgeo_restrict.c
@@ -1175,7 +1175,7 @@ tgeo_restrict_stbox(const Temporal *temp, const STBox *box, bool border_inc,
  * @param[in] border_inc True when the box contains the upper border
  * @csqlfn #Tgeo_at_stbox()
  */
-inline Temporal *
+Temporal *
 tgeo_at_stbox(const Temporal *temp, const STBox *box, bool border_inc)
 {
   return tgeo_restrict_stbox(temp, box, border_inc, REST_AT);
@@ -1190,7 +1190,7 @@ tgeo_at_stbox(const Temporal *temp, const STBox *box, bool border_inc)
  * @param[in] border_inc True when the box contains the upper border
  * @csqlfn #Tgeo_minus_stbox()
  */
-inline Temporal *
+Temporal *
 tgeo_minus_stbox(const Temporal *temp, const STBox *box, bool border_inc)
 {
   return tgeo_restrict_stbox(temp, box, border_inc, REST_MINUS);
@@ -2049,7 +2049,7 @@ tgeo_restrict_geom(const Temporal *temp, const GSERIALIZED *gs,
  * @note This function has a last parameter for the Z dimension which is not
  * available for temporal geometries
  */
-inline Temporal *
+Temporal *
 tpoint_at_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tgeo_restrict_geom(temp, gs, REST_AT);
@@ -2062,7 +2062,7 @@ tpoint_at_geom(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] gs Geometry
  * @csqlfn #Tgeo_at_geom()
  */
-inline Temporal *
+Temporal *
 tgeo_at_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tgeo_restrict_geom(temp, gs, REST_AT);
@@ -2077,7 +2077,7 @@ tgeo_at_geom(const Temporal *temp, const GSERIALIZED *gs)
  * @note This function has a last parameter for the Z dimension which is not
  * available for temporal geometries
  */
-inline Temporal *
+Temporal *
 tpoint_minus_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tgeo_restrict_geom(temp, gs, REST_MINUS);
@@ -2090,7 +2090,7 @@ tpoint_minus_geom(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] gs Geometry
  * @csqlfn #Tgeo_minus_geom()
  */
-inline Temporal *
+Temporal *
 tgeo_minus_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tgeo_restrict_geom(temp, gs, REST_MINUS);
@@ -2152,7 +2152,7 @@ tgeo_restrict_elevation(const Temporal *temp, const Span *s, bool atfunc)
  * @param[in] s Elevation span
  * @csqlfn #Tgeo_at_elevation()
  */
-inline Temporal *
+Temporal *
 tpoint_at_elevation(const Temporal *temp, const Span *s)
 {
   return tgeo_restrict_elevation(temp, s, REST_AT);
@@ -2165,7 +2165,7 @@ tpoint_at_elevation(const Temporal *temp, const Span *s)
  * @param[in] s Elevation span
  * @csqlfn #Tgeo_at_elevation()
  */
-inline Temporal *
+Temporal *
 tgeo_at_elevation(const Temporal *temp, const Span *s)
 {
   return tgeo_restrict_elevation(temp, s, REST_AT);
@@ -2180,7 +2180,7 @@ tgeo_at_elevation(const Temporal *temp, const Span *s)
  * @note This function has a last parameter for the Z dimension which is not
  * available for temporal geometries
  */
-inline Temporal *
+Temporal *
 tpoint_minus_elevation(const Temporal *temp, const Span *s)
 {
   return tgeo_restrict_elevation(temp, s, REST_MINUS);
@@ -2193,7 +2193,7 @@ tpoint_minus_elevation(const Temporal *temp, const Span *s)
  * @param[in] s Elevation span
  * @csqlfn #Tgeo_minus_elevation()
  */
-inline Temporal *
+Temporal *
 tgeo_minus_elevation(const Temporal *temp, const Span *s)
 {
   return tgeo_restrict_elevation(temp, s, REST_MINUS);

--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -604,7 +604,7 @@ ea_contains_tgeo_geo_common(const Temporal *temp, const GSERIALIZED *gs, bool ev
  * @brief Return 1 if a temporal geometry ever/always contains a geo, 0 if not,
  * and -1 on error or if the geometry is empty
  */
-inline int
+int
 ea_contains_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
 {
   return ea_contains_tgeo_geo_common(temp, gs, ever, INVERT);
@@ -615,7 +615,7 @@ ea_contains_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
  * @brief Return 1 if a temporal geometry ever/always contains a geo, 0 if not,
  * and -1 on error or if the geometry is empty
  */
-inline int
+int
 ea_contains_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 {
   return ea_contains_tgeo_geo_common(temp, gs, ever, INVERT_NO);
@@ -713,7 +713,7 @@ ea_contains_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2, bool ever)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Econtains_tgeo_tgeo()
  */
-inline int
+int
 econtains_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_contains_tgeo_tgeo(temp1, temp2, EVER);
@@ -726,7 +726,7 @@ econtains_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Acontains_tgeo_tgeo()
  */
-inline int
+int
 acontains_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_contains_tgeo_tgeo(temp1, temp2, ALWAYS);
@@ -780,7 +780,7 @@ ea_covers_tgeo_geo_int(const Temporal *temp, const GSERIALIZED *gs, bool ever,
  * @brief Return 1 if a temporal geometry ever/always covers a geo, 0 if not,
  * and -1 on error or if the geometry is empty
  */
-inline int
+int
 ea_covers_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
 {
   return ea_covers_tgeo_geo_int(temp, gs, ever, INVERT);
@@ -791,7 +791,7 @@ ea_covers_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
  * @brief Return 1 if a temporal geometry ever/always covers a geo, 0 if not,
  * and -1 on error or if the geometry is empty
  */
-inline int
+int
 ea_covers_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 {
   return ea_covers_tgeo_geo_int(temp, gs, ever, INVERT_NO);
@@ -889,7 +889,7 @@ ea_covers_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2, bool ever)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Ecovers_tgeo_tgeo()
  */
-inline int
+int
 ecovers_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_covers_tgeo_tgeo(temp1, temp2, EVER);
@@ -902,7 +902,7 @@ ecovers_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Acovers_tgeo_tgeo()
  */
-inline int
+int
 acovers_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_covers_tgeo_tgeo(temp1, temp2, ALWAYS);
@@ -978,7 +978,7 @@ ea_disjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
  * @brief Return 1 if a temporal geometry and a geometry are ever disjoint,
  * 0 if not, and -1 on error or if the geometry is empty
  */
-inline int
+int
 ea_disjoint_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
 {
   return ea_disjoint_tgeo_geo(temp, gs, ever);
@@ -993,7 +993,7 @@ ea_disjoint_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
  * @param[in] gs Geometry
  * @csqlfn #Edisjoint_tgeo_geo()
  */
-inline int
+int
 edisjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_disjoint_tgeo_geo(temp, gs, EVER);
@@ -1007,7 +1007,7 @@ edisjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] gs Geometry
  * @csqlfn #Adisjoint_tgeo_geo()
  */
-inline int
+int
 adisjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_disjoint_tgeo_geo(temp, gs, ALWAYS);
@@ -1044,7 +1044,7 @@ ea_disjoint_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2, bool ever)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Edisjoint_tgeo_tgeo()
  */
-inline int
+int
 edisjoint_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_disjoint_tgeo_tgeo(temp1, temp2, EVER);
@@ -1057,7 +1057,7 @@ edisjoint_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Adisjoint_tgeo_tgeo()
  */
-inline int
+int
 adisjoint_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_disjoint_tgeo_tgeo(temp1, temp2, ALWAYS);
@@ -1106,7 +1106,7 @@ ea_intersects_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
  * @brief Return 1 if a geometry intersects a temporal geometry, 0 if not,
  * and -1 on error or if the geometry is empty
  */
-inline int
+int
 ea_intersects_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
 {
   return ea_intersects_tgeo_geo(temp, gs, ever);
@@ -1121,7 +1121,7 @@ ea_intersects_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
  * @param[in] gs Geometry
  * @csqlfn #Aintersects_tgeo_geo()
  */
-inline int
+int
 eintersects_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_intersects_tgeo_geo(temp, gs, EVER);
@@ -1135,7 +1135,7 @@ eintersects_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] gs Geometry
  * @csqlfn #Aintersects_tgeo_geo()
  */
-inline int
+int
 aintersects_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_intersects_tgeo_geo(temp, gs, ALWAYS);
@@ -1173,7 +1173,7 @@ ea_intersects_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2,
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Eintersects_tgeo_tgeo()
  */
-inline int
+int
 eintersects_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_intersects_tgeo_tgeo(temp1, temp2, EVER);
@@ -1186,7 +1186,7 @@ eintersects_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Aintersects_tgeo_tgeo()
  */
-inline int
+int
 aintersects_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_intersects_tgeo_tgeo(temp1, temp2, ALWAYS);
@@ -1721,7 +1721,7 @@ ea_dwithin_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2, double dist,
  * @param[in] dist Distance
  * @csqlfn #Edwithin_tgeo_tgeo()
  */
-inline int
+int
 edwithin_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2, double dist)
 {
   return ea_dwithin_tgeo_tgeo(temp1, temp2, dist, EVER);
@@ -1735,7 +1735,7 @@ edwithin_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2, double dist)
  * @param[in] dist Distance
  * @csqlfn #Adwithin_tgeo_tgeo()
  */
-inline int
+int
 adwithin_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2, double dist)
 {
   return ea_dwithin_tgeo_tgeo(temp1, temp2, dist, ALWAYS);

--- a/meos/src/geo/tgeo_tile.c
+++ b/meos/src/geo/tgeo_tile.c
@@ -770,7 +770,7 @@ stbox_space_time_tiles(const STBox *bounds, double xsize, double ysize,
  * @param[out] count Number of values in the output array
  * @csqlfn #Stbox_space_tiles()
  */
-inline STBox *
+STBox *
 stbox_space_tiles(const STBox *bounds, double xsize, double ysize, double zsize,
   const GSERIALIZED *sorigin,  bool border_inc, int *count)
 {
@@ -789,7 +789,7 @@ stbox_space_tiles(const STBox *bounds, double xsize, double ysize, double zsize,
  * @param[out] count Number of values in the output array
  * @csqlfn #Stbox_time_tiles()
  */
-inline STBox *
+STBox *
 stbox_time_tiles(const STBox *bounds, const Interval *duration,
   TimestampTz torigin, bool border_inc, int *count)
 {
@@ -890,7 +890,7 @@ stbox_space_time_tile(const GSERIALIZED *point, TimestampTz t,
  * @param[in] torigin Origin for the time dimension
  * @csqlfn Stbox_get_space_time_tile()
  */
-inline STBox *
+STBox *
 stbox_get_space_time_tile(const GSERIALIZED *point, TimestampTz t,
   double xsize, double ysize, double zsize, const Interval *duration,
   const GSERIALIZED *sorigin, TimestampTz torigin)
@@ -907,7 +907,7 @@ stbox_get_space_time_tile(const GSERIALIZED *point, TimestampTz t,
  * @param[in] sorigin Origin for the space dimension
  * @csqlfn Stbox_get_space_tile()
  */
-inline STBox *
+STBox *
 stbox_get_space_tile(const GSERIALIZED *point, double xsize, double ysize,
   double zsize, const GSERIALIZED *sorigin)
 {
@@ -923,7 +923,7 @@ stbox_get_space_tile(const GSERIALIZED *point, double xsize, double ysize,
  * @param[in] torigin Origin for the time dimension
  * @csqlfn Stbox_get_time_tile()
  */
-inline STBox *
+STBox *
 stbox_get_time_tile(TimestampTz t, const Interval *duration,
   TimestampTz torigin)
 {
@@ -1034,7 +1034,7 @@ tgeo_space_time_boxes(const Temporal *temp, double xsize, double ysize,
  * the upper border is assumed as outside of the box.
  * @param[out] count Number of elements in the output array
  */
-inline STBox *
+STBox *
 tgeo_space_boxes(const Temporal *temp, double xsize, double ysize,
   double zsize, const GSERIALIZED *sorigin, bool bitmatrix, bool border_inc,
   int *count)
@@ -1458,7 +1458,7 @@ tgeo_space_time_split(const Temporal *temp, double xsize, double ysize,
  * @param[out] space_bins Array of space bins
  * @param[out] count Number of elements in the output arrays
  */
-inline Temporal **
+Temporal **
 tgeo_space_split(const Temporal *temp, double xsize, double ysize,
   double zsize, const GSERIALIZED *sorigin, bool bitmatrix, bool border_inc,
   GSERIALIZED ***space_bins, int *count)

--- a/meos/src/geo/tspatial.c
+++ b/meos/src/geo/tspatial.c
@@ -180,7 +180,7 @@ spatialset_out_fn(const Set *s, int maxdd, outfunc wkt_out, bool extended)
  * @brief Return the Well-Known Text (WKT) representation of a spatial set
  * @csqlfn #Spatialset_as_text()
  */
-inline char *
+char *
 spatialset_as_text(const Set *s, int maxdd)
 {
   return spatialset_out_fn(s, maxdd, &spatialbase_as_text, false);
@@ -193,7 +193,7 @@ spatialset_as_text(const Set *s, int maxdd)
  * @param[in] maxdd Maximum number of decimal digits
  * @csqlfn #Spatialset_as_ewkt()
  */
-inline char *
+char *
 spatialset_as_ewkt(const Set *s, int maxdd)
 {
   /* The SRID will be output as prefix, the elements will output the SRID*/
@@ -353,7 +353,7 @@ spatialarr_wkt_out(const Datum *spatialarr, MeosType elemtype, int count,
  * @param[in] count Number of elements in the input array
  * @param[in] maxdd Maximum number of decimal digits to output
  */
-inline char **
+char **
 spatialarr_as_text(const Datum *spatialarr, MeosType elemtype, int count, 
   int maxdd)
 {
@@ -369,7 +369,7 @@ spatialarr_as_text(const Datum *spatialarr, MeosType elemtype, int count,
  * @param[in] count Number of elements in the input array
  * @param[in] maxdd Maximum number of decimal digits to output
  */
-inline char **
+char **
 spatialarr_as_ewkt(const Datum *spatialarr, MeosType elemtype, int count, 
   int maxdd)
 {

--- a/meos/src/geo/tspatial_posops_meos.c
+++ b/meos/src/geo/tspatial_posops_meos.c
@@ -60,7 +60,7 @@
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Left_stbox_tspatial()
  */
-inline bool
+bool
 left_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &left_stbox_stbox, INVERT);
@@ -74,7 +74,7 @@ left_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Overleft_stbox_tspatial()
  */
-inline bool
+bool
 overleft_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &overleft_stbox_stbox, INVERT);
@@ -88,7 +88,7 @@ overleft_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Right_stbox_tspatial()
  */
-inline bool
+bool
 right_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &right_stbox_stbox, INVERT);
@@ -102,7 +102,7 @@ right_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Overright_stbox_tspatial()
  */
-inline bool
+bool
 overright_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &overright_stbox_stbox, INVERT);
@@ -115,7 +115,7 @@ overright_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Below_stbox_tspatial()
  */
-inline bool
+bool
 below_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &below_stbox_stbox, INVERT);
@@ -129,7 +129,7 @@ below_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Overbelow_stbox_tspatial()
  */
-inline bool
+bool
 overbelow_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &overbelow_stbox_stbox, INVERT);
@@ -142,7 +142,7 @@ overbelow_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Above_stbox_tspatial()
  */
-inline bool
+bool
 above_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &above_stbox_stbox, INVERT);
@@ -156,7 +156,7 @@ above_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Overabove_stbox_tspatial()
  */
-inline bool
+bool
 overabove_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &overabove_stbox_stbox, INVERT);
@@ -170,7 +170,7 @@ overabove_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Front_stbox_tspatial()
  */
-inline bool
+bool
 front_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &front_stbox_stbox, INVERT);
@@ -184,7 +184,7 @@ front_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Overfront_stbox_tspatial()
  */
-inline bool
+bool
 overfront_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &overfront_stbox_stbox, INVERT);
@@ -198,7 +198,7 @@ overfront_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Back_stbox_tspatial()
  */
-inline bool
+bool
 back_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &back_stbox_stbox, INVERT);
@@ -212,7 +212,7 @@ back_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Overback_stbox_tspatial()
  */
-inline bool
+bool
 overback_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &overback_stbox_stbox, INVERT);
@@ -226,7 +226,7 @@ overback_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Before_stbox_tspatial()
  */
-inline bool
+bool
 before_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &before_stbox_stbox, INVERT);
@@ -240,7 +240,7 @@ before_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Overbefore_stbox_tspatial()
  */
-inline bool
+bool
 overbefore_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &overbefore_stbox_stbox, INVERT);
@@ -253,7 +253,7 @@ overbefore_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #After_stbox_tspatial()
  */
-inline bool
+bool
 after_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &after_stbox_stbox, INVERT);
@@ -267,7 +267,7 @@ after_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Overafter_stbox_tspatial()
  */
-inline bool
+bool
 overafter_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &overafter_stbox_stbox, INVERT);
@@ -285,7 +285,7 @@ overafter_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] box Spatiotemporal box
 box * @csqlfn #Left_tspatial_stbox()
  */
-inline bool
+bool
 left_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &left_stbox_stbox, INVERT_NO);
@@ -299,7 +299,7 @@ left_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Overleft_tspatial_stbox()
  */
-inline bool
+bool
 overleft_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &overleft_stbox_stbox, INVERT_NO);
@@ -313,7 +313,7 @@ overleft_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Right_tspatial_stbox()
  */
-inline bool
+bool
 right_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &right_stbox_stbox, INVERT_NO);
@@ -327,7 +327,7 @@ right_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Overright_tspatial_stbox()
  */
-inline bool
+bool
 overright_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &overright_stbox_stbox, INVERT_NO);
@@ -340,7 +340,7 @@ overright_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Below_tspatial_stbox()
  */
-inline bool
+bool
 below_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &below_stbox_stbox, INVERT_NO);
@@ -354,7 +354,7 @@ below_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Overbelow_tspatial_stbox()
  */
-inline bool
+bool
 overbelow_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &overbelow_stbox_stbox, INVERT_NO);
@@ -367,7 +367,7 @@ overbelow_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Above_tspatial_stbox()
  */
-inline bool
+bool
 above_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &above_stbox_stbox, INVERT_NO);
@@ -381,7 +381,7 @@ above_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Overabove_tspatial_stbox()
  */
-inline bool
+bool
 overabove_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &overabove_stbox_stbox, INVERT_NO);
@@ -395,7 +395,7 @@ overabove_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Front_tspatial_stbox()
  */
-inline bool
+bool
 front_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &front_stbox_stbox, INVERT_NO);
@@ -409,7 +409,7 @@ front_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Overfront_tspatial_stbox()
  */
-inline bool
+bool
 overfront_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &overfront_stbox_stbox, INVERT_NO);
@@ -423,7 +423,7 @@ overfront_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Back_tspatial_stbox()
  */
-inline bool
+bool
 back_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &back_stbox_stbox, INVERT_NO);
@@ -437,7 +437,7 @@ back_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Overback_tspatial_stbox()
  */
-inline bool
+bool
 overback_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &overback_stbox_stbox, INVERT_NO);
@@ -451,7 +451,7 @@ overback_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Before_tspatial_stbox()
  */
-inline bool
+bool
 before_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &before_stbox_stbox, INVERT_NO);
@@ -465,7 +465,7 @@ before_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Overbefore_tspatial_stbox()
  */
-inline bool
+bool
 overbefore_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &overbefore_stbox_stbox, INVERT_NO);
@@ -478,7 +478,7 @@ overbefore_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #After_tspatial_stbox()
  */
-inline bool
+bool
 after_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &after_stbox_stbox, INVERT_NO);
@@ -492,7 +492,7 @@ after_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Overafter_tspatial_stbox()
  */
-inline bool
+bool
 overafter_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &overafter_stbox_stbox, INVERT_NO);
@@ -508,7 +508,7 @@ overafter_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Left_tspatial_tspatial()
  */
-inline bool
+bool
 left_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &left_stbox_stbox);
@@ -521,7 +521,7 @@ left_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Overleft_tspatial_tspatial()
  */
-inline bool
+bool
 overleft_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &overleft_stbox_stbox);
@@ -534,7 +534,7 @@ overleft_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Right_tspatial_tspatial()
  */
-inline bool
+bool
 right_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &right_stbox_stbox);
@@ -547,7 +547,7 @@ right_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Overright_tspatial_tspatial()
  */
-inline bool
+bool
 overright_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &overright_stbox_stbox);
@@ -560,7 +560,7 @@ overright_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Below_tspatial_tspatial()
  */
-inline bool
+bool
 below_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &below_stbox_stbox);
@@ -573,7 +573,7 @@ below_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Overbelow_tspatial_tspatial()
  */
-inline bool
+bool
 overbelow_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &overbelow_stbox_stbox);
@@ -586,7 +586,7 @@ overbelow_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Above_tspatial_tspatial()
  */
-inline bool
+bool
 above_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &above_stbox_stbox);
@@ -600,7 +600,7 @@ above_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Overabove_tspatial_tspatial()
  */
-inline bool
+bool
 overabove_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &overabove_stbox_stbox);
@@ -613,7 +613,7 @@ overabove_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Front_tspatial_tspatial()
  */
-inline bool
+bool
 front_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &front_stbox_stbox);
@@ -626,7 +626,7 @@ front_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Overfront_tspatial_tspatial()
  */
-inline bool
+bool
 overfront_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &overfront_stbox_stbox);
@@ -639,7 +639,7 @@ overfront_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Back_tspatial_tspatial()
  */
-inline bool
+bool
 back_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &back_stbox_stbox);
@@ -652,7 +652,7 @@ back_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Overback_tspatial_tspatial()
  */
-inline bool
+bool
 overback_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &overback_stbox_stbox);
@@ -665,7 +665,7 @@ overback_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Before_tspatial_tspatial()
  */
-inline bool
+bool
 before_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &before_stbox_stbox);
@@ -678,7 +678,7 @@ before_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Overbefore_tspatial_tspatial()
  */
-inline bool
+bool
 overbefore_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &overbefore_stbox_stbox);
@@ -691,7 +691,7 @@ overbefore_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #After_tspatial_tspatial()
  */
-inline bool
+bool
 after_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &after_stbox_stbox);
@@ -704,7 +704,7 @@ after_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Overafter_tspatial_tspatial()
  */
-inline bool
+bool
 overafter_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &overafter_stbox_stbox);

--- a/meos/src/geo/tspatial_tempspatialrels.c
+++ b/meos/src/geo/tspatial_tempspatialrels.c
@@ -812,7 +812,7 @@ tdisjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Tdisjoint_tgeo_tgeo()
  */
-inline Temporal *
+Temporal *
 tdisjoint_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return tinterrel_tspatial_tspatial(temp1, temp2, TDISJOINT);
@@ -857,7 +857,7 @@ tintersects_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Tintersects_tgeo_tgeo()
  */
-inline Temporal *
+Temporal *
 tintersects_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return tinterrel_tspatial_tspatial(temp1, temp2, TINTERSECTS);

--- a/meos/src/geo/tspatial_topops_meos.c
+++ b/meos/src/geo/tspatial_topops_meos.c
@@ -61,7 +61,7 @@
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Overlaps_stbox_tspatial()
  */
-inline bool
+bool
 overlaps_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &overlaps_stbox_stbox, INVERT);
@@ -75,7 +75,7 @@ overlaps_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Overlaps_tspatial_stbox()
  */
-inline bool
+bool
 overlaps_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &overlaps_stbox_stbox, INVERT_NO);
@@ -88,7 +88,7 @@ overlaps_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Overlaps_tspatial_tspatial()
  */
-inline bool
+bool
 overlaps_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &overlaps_stbox_stbox);
@@ -106,7 +106,7 @@ overlaps_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Contains_stbox_tspatial()
  */
-inline bool
+bool
 contains_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &contains_stbox_stbox, INVERT);
@@ -120,7 +120,7 @@ contains_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Contains_tspatial_stbox()
  */
-inline bool
+bool
 contains_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &contains_stbox_stbox, INVERT_NO);
@@ -133,7 +133,7 @@ contains_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Contains_tspatial_tspatial()
  */
-inline bool
+bool
 contains_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &contains_stbox_stbox);
@@ -151,7 +151,7 @@ contains_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Contained_stbox_tspatial()
  */
-inline bool
+bool
 contained_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &contained_stbox_stbox, INVERT);
@@ -165,7 +165,7 @@ contained_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Contained_tspatial_stbox()
  */
-inline bool
+bool
 contained_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &contained_stbox_stbox, INVERT_NO);
@@ -178,7 +178,7 @@ contained_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Contained_tspatial_tspatial()
  */
-inline bool
+bool
 contained_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &contained_stbox_stbox);
@@ -196,7 +196,7 @@ contained_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Same_stbox_tspatial()
  */
-inline bool
+bool
 same_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &same_stbox_stbox, INVERT);
@@ -210,7 +210,7 @@ same_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Same_tspatial_stbox()
  */
-inline bool
+bool
 same_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &same_stbox_stbox, INVERT_NO);
@@ -223,7 +223,7 @@ same_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Same_tspatial_tspatial()
  */
-inline bool
+bool
 same_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &same_stbox_stbox);
@@ -241,7 +241,7 @@ same_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Adjacent_stbox_tspatial()
  */
-inline bool
+bool
 adjacent_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &adjacent_stbox_stbox, INVERT);
@@ -255,7 +255,7 @@ adjacent_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Adjacent_tspatial_stbox()
  */
-inline bool
+bool
 adjacent_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &adjacent_stbox_stbox, INVERT_NO);
@@ -268,7 +268,7 @@ adjacent_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Adjacent_tspatial_tspatial()
  */
-inline bool
+bool
 adjacent_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &adjacent_stbox_stbox);

--- a/meos/src/npoint/npoint.c
+++ b/meos/src/npoint/npoint.c
@@ -1143,7 +1143,7 @@ nsegment_end_position(const Nsegment *ns)
  * is the one from the @p ways table, for performance reasons we simply get
  * the SRID of the table
  */
-inline int32_t
+int32_t
 npoint_srid(const Npoint *np UNUSED)
 {
   return get_srid_ways();
@@ -1158,7 +1158,7 @@ npoint_srid(const Npoint *np UNUSED)
  * is the one from the @p ways table, for performance reasons we simply get
  * the SRID of the table
  */
-inline int32_t
+int32_t
 nsegment_srid(const Nsegment *ns UNUSED)
 {
   return get_srid_ways();
@@ -1188,7 +1188,7 @@ npoint_eq(const Npoint *np1, const Npoint *np2)
  * @param[in] np1,np2 Network points
  * @csqlfn #Npoint_ne()
  */
-inline bool
+bool
 npoint_ne(const Npoint *np1, const Npoint *np2)
 {
   return ! npoint_eq(np1, np2);
@@ -1225,7 +1225,7 @@ npoint_cmp(const Npoint *np1, const Npoint *np2)
  * @param[in] np1,np2 Network points
  * @csqlfn #Npoint_lt()
  */
-inline bool
+bool
 npoint_lt(const Npoint *np1, const Npoint *np2)
 {
   return npoint_cmp(np1, np2) < 0;
@@ -1238,7 +1238,7 @@ npoint_lt(const Npoint *np1, const Npoint *np2)
  * @param[in] np1,np2 Network points
  * @csqlfn #Npoint_le()
  */
-inline bool
+bool
 npoint_le(const Npoint *np1, const Npoint *np2)
 {
   return npoint_cmp(np1, np2) <= 0;
@@ -1250,7 +1250,7 @@ npoint_le(const Npoint *np1, const Npoint *np2)
  * @param[in] np1,np2 Network points
  * @csqlfn #Npoint_gt()
  */
-inline bool
+bool
 npoint_gt(const Npoint *np1, const Npoint *np2)
 {
   return npoint_cmp(np1, np2) > 0;
@@ -1263,7 +1263,7 @@ npoint_gt(const Npoint *np1, const Npoint *np2)
  * @param[in] np1,np2 Network points
  * @csqlfn #Npoint_ge()
  */
-inline bool
+bool
 npoint_ge(const Npoint *np1, const Npoint *np2)
 {
   return npoint_cmp(np1, np2) >= 0;
@@ -1293,7 +1293,7 @@ nsegment_eq(const Nsegment *ns1, const Nsegment *ns2)
  * @param[in] ns1,ns2 Network segments
  * @csqlfn #Nsegment_ne()
  */
-inline bool
+bool
 nsegment_ne(const Nsegment *ns1, const Nsegment *ns2)
 {
   return ! nsegment_eq(ns1, ns2);
@@ -1335,7 +1335,7 @@ nsegment_cmp(const Nsegment *ns1, const Nsegment *ns2)
  * @param[in] ns1,ns2 Network segments
  * @csqlfn #Nsegment_lt()
  */
-inline bool
+bool
 nsegment_lt(const Nsegment *ns1, const Nsegment *ns2)
 {
   return nsegment_cmp(ns1, ns2) < 0;
@@ -1348,7 +1348,7 @@ nsegment_lt(const Nsegment *ns1, const Nsegment *ns2)
  * @param[in] ns1,ns2 Network segments
  * @csqlfn #Nsegment_le()
  */
-inline bool
+bool
 nsegment_le(const Nsegment *ns1, const Nsegment *ns2)
 {
   return nsegment_cmp(ns1, ns2) <= 0;
@@ -1361,7 +1361,7 @@ nsegment_le(const Nsegment *ns1, const Nsegment *ns2)
  * @param[in] ns1,ns2 Network segments
  * @csqlfn #Nsegment_gt()
  */
-inline bool
+bool
 nsegment_gt(const Nsegment *ns1, const Nsegment *ns2)
 {
   return nsegment_cmp(ns1, ns2) > 0;
@@ -1374,7 +1374,7 @@ nsegment_gt(const Nsegment *ns1, const Nsegment *ns2)
  * @param[in] ns1,ns2 Network segments
  * @csqlfn #Nsegment_ge()
  */
-inline bool
+bool
 nsegment_ge(const Nsegment *ns1, const Nsegment *ns2)
 {
   return nsegment_cmp(ns1, ns2) >= 0;

--- a/meos/src/npoint/tnpoint.c
+++ b/meos/src/npoint/tnpoint.c
@@ -810,7 +810,7 @@ tnpoint_restrict_npoint(const Temporal *temp, const Npoint *np, bool atfunc)
  * @param[in] np Network point
  * @csqlfn #Tnpoint_at_npoint()
  */
-inline Temporal *
+Temporal *
 tnpoint_at_npoint(const Temporal *temp, const Npoint *np)
 {
   return tnpoint_restrict_npoint(temp, np, REST_AT);
@@ -823,7 +823,7 @@ tnpoint_at_npoint(const Temporal *temp, const Npoint *np)
  * @param[in] np Network point
  * @csqlfn #Tnpoint_minus_npoint()
  */
-inline Temporal *
+Temporal *
 tnpoint_minus_npoint(const Temporal *temp, const Npoint *np)
 {
   return tnpoint_restrict_npoint(temp, np, REST_MINUS);
@@ -860,7 +860,7 @@ tnpoint_restrict_npointset(const Temporal *temp, const Set *s, bool atfunc)
  * @param[in] s Set of network points
  * @csqlfn #Tnpoint_at_npointset()
  */
-inline Temporal *
+Temporal *
 tnpoint_at_npointset(const Temporal *temp, const Set *s)
 {
   return tnpoint_restrict_npointset(temp, s, REST_AT);
@@ -874,7 +874,7 @@ tnpoint_at_npointset(const Temporal *temp, const Set *s)
  * @param[in] s Set of network points
  * @csqlfn #Tnpoint_minus_npointset()
  */
-inline Temporal *
+Temporal *
 tnpoint_minus_npointset(const Temporal *temp, const Set *s)
 {
   return tnpoint_restrict_npointset(temp, s, REST_MINUS);

--- a/meos/src/npoint/tnpoint_compops.c
+++ b/meos/src/npoint/tnpoint_compops.c
@@ -92,7 +92,7 @@ eacomp_tnpoint_tnpoint(const Temporal *temp1, const Temporal *temp2,
  * @param[in] temp Temporal network point
  * @csqlfn #Ever_eq_npoint_tnpoint()
  */
-inline int
+int
 ever_eq_npoint_tnpoint(const Npoint *np, const Temporal *temp)
 {
   return eacomp_tnpoint_npoint(temp, np, &datum2_eq, EVER);
@@ -107,7 +107,7 @@ ever_eq_npoint_tnpoint(const Npoint *np, const Temporal *temp)
  * @param[in] np Network point
  * @csqlfn #Ever_eq_tnpoint_npoint()
  */
-inline int
+int
 ever_eq_tnpoint_npoint(const Temporal *temp, const Npoint *np)
 {
   return eacomp_tnpoint_npoint(temp, np, &datum2_eq, EVER);
@@ -122,7 +122,7 @@ ever_eq_tnpoint_npoint(const Temporal *temp, const Npoint *np)
  * @param[in] temp Temporal network point
  * @csqlfn #Ever_ne_npoint_tnpoint()
  */
-inline int
+int
 ever_ne_npoint_tnpoint(const Npoint *np, const Temporal *temp)
 {
   return eacomp_tnpoint_npoint(temp, np, &datum2_ne, EVER);
@@ -137,7 +137,7 @@ ever_ne_npoint_tnpoint(const Npoint *np, const Temporal *temp)
  * @param[in] np Network point
  * @csqlfn #Ever_ne_tnpoint_npoint()
  */
-inline int
+int
 ever_ne_tnpoint_npoint(const Temporal *temp, const Npoint *np)
 {
   return eacomp_tnpoint_npoint(temp, np, &datum2_ne, EVER);
@@ -152,7 +152,7 @@ ever_ne_tnpoint_npoint(const Temporal *temp, const Npoint *np)
  * @param[in] temp Temporal network point
  * @csqlfn #Always_eq_npoint_tnpoint()
  */
-inline int
+int
 always_eq_npoint_tnpoint(const Npoint *np, const Temporal *temp)
 {
   return eacomp_tnpoint_npoint(temp, np, &datum2_eq, ALWAYS);
@@ -167,7 +167,7 @@ always_eq_npoint_tnpoint(const Npoint *np, const Temporal *temp)
  * @param[in] np Network point
  * @csqlfn #Always_eq_tnpoint_npoint()
  */
-inline int
+int
 always_eq_tnpoint_npoint(const Temporal *temp, const Npoint *np)
 {
   return eacomp_tnpoint_npoint(temp, np, &datum2_eq, ALWAYS);
@@ -182,7 +182,7 @@ always_eq_tnpoint_npoint(const Temporal *temp, const Npoint *np)
  * @param[in] temp Temporal network point
  * @csqlfn #Always_ne_npoint_tnpoint()
  */
-inline int
+int
 always_ne_npoint_tnpoint(const Npoint *np, const Temporal *temp)
 {
   return eacomp_tnpoint_npoint(temp, np, &datum2_ne, ALWAYS);
@@ -197,7 +197,7 @@ always_ne_npoint_tnpoint(const Npoint *np, const Temporal *temp)
  * @param[in] np Network point
  * @csqlfn #Always_ne_tnpoint_npoint()
  */
-inline int
+int
 always_ne_tnpoint_npoint(const Temporal *temp, const Npoint *np)
 {
   return eacomp_tnpoint_npoint(temp, np, &datum2_ne, ALWAYS);
@@ -211,7 +211,7 @@ always_ne_tnpoint_npoint(const Temporal *temp, const Npoint *np)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Ever_eq_tnpoint_tnpoint()
  */
-inline int
+int
 ever_eq_tnpoint_tnpoint(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tnpoint_tnpoint(temp1, temp2, &datum2_eq, EVER);
@@ -223,7 +223,7 @@ ever_eq_tnpoint_tnpoint(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Ever_ne_tnpoint_tnpoint()
  */
-inline int
+int
 ever_ne_tnpoint_tnpoint(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tnpoint_tnpoint(temp1, temp2, &datum2_ne, EVER);
@@ -235,7 +235,7 @@ ever_ne_tnpoint_tnpoint(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Always_eq_tnpoint_tnpoint()
  */
-inline int
+int
 always_eq_tnpoint_tnpoint(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tnpoint_tnpoint(temp1, temp2, &datum2_eq, ALWAYS);
@@ -247,7 +247,7 @@ always_eq_tnpoint_tnpoint(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Always_ne_tnpoint_tnpoint()
  */
-inline int
+int
 always_ne_tnpoint_tnpoint(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tnpoint_tnpoint(temp1, temp2, &datum2_ne, ALWAYS);
@@ -285,7 +285,7 @@ tcomp_tnpoint_npoint(const Temporal *temp, const Npoint *np,
  * @param[in] np Network point
  * @csqlfn #Teq_tnpoint_npoint()
  */
-inline Temporal *
+Temporal *
 teq_tnpoint_npoint(const Temporal *temp, const Npoint *np)
 {
   return tcomp_tnpoint_npoint(temp, np, &datum2_eq);
@@ -299,7 +299,7 @@ teq_tnpoint_npoint(const Temporal *temp, const Npoint *np)
  * @param[in] np Network point
  * @csqlfn #Tne_tnpoint_npoint()
  */
-inline Temporal *
+Temporal *
 tne_tnpoint_npoint(const Temporal *temp, const Npoint *np)
 {
   return tcomp_tnpoint_npoint(temp, np, &datum2_ne);

--- a/meos/src/npoint/tnpoint_routeops.c
+++ b/meos/src/npoint/tnpoint_routeops.c
@@ -73,7 +73,7 @@ contains_rid_tnpoint_bigint(const Temporal *temp, int64 rid,
  * @brief Return true if a temporal network point and a route satisfy the
  * function
  */
-inline bool
+bool
 contained_rid_tnpoint_bigint(const Temporal *temp, int64 rid,
   bool invert)
 {
@@ -136,7 +136,7 @@ contains_rid_tnpoint_bigintset(const Temporal *temp, const Set *s,
  * @brief Return true if a temporal network point and a big integer set
  * satisfy the function
  */
-inline bool
+bool
 contained_rid_tnpoint_bigintset(const Temporal *temp, const Set *s,
   bool invert)
 {
@@ -181,7 +181,7 @@ contains_rid_tnpoint_npoint(const Temporal *temp, const Npoint *np,
  * @brief Return true if a temporal network point and a network point
  * satisfy the function
  */
-inline bool
+bool
 contained_rid_npoint_tnpoint(const Temporal *temp, const Npoint *np,
   bool invert)
 {

--- a/meos/src/npoint/tnpoint_spatialfuncs.c
+++ b/meos/src/npoint/tnpoint_spatialfuncs.c
@@ -511,7 +511,7 @@ tnpoint_restrict_geom(const Temporal *temp, const GSERIALIZED *gs, bool atfunc)
  * @param[in] gs Geometry
  * @csqlfn #Tnpoint_at_geom()
  */
-inline Temporal *
+Temporal *
 tnpoint_at_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tnpoint_restrict_geom(temp, gs, REST_AT);
@@ -524,7 +524,7 @@ tnpoint_at_geom(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] gs Geometry
  * @csqlfn #Tnpoint_minus_geom()
  */
-inline Temporal *
+Temporal *
 tnpoint_minus_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tnpoint_restrict_geom(temp, gs, REST_MINUS);
@@ -569,7 +569,7 @@ tnpoint_restrict_stbox(const Temporal *temp, const STBox *box, bool border_inc,
  * @param[in] border_inc True when the box contains the upper border
  * @sqlfn #Tnpoint_at_stbox()
  */
-inline Temporal *
+Temporal *
 tnpoint_at_stbox(const Temporal *temp, const STBox *box, bool border_inc)
 {
   return tnpoint_restrict_stbox(temp, box, border_inc, REST_AT);
@@ -583,7 +583,7 @@ tnpoint_at_stbox(const Temporal *temp, const STBox *box, bool border_inc)
  * @param[in] border_inc True when the box contains the upper border
  * @sqlfn #Tnpoint_minus_stbox()
  */
-inline Temporal *
+Temporal *
 tnpoint_minus_stbox(const Temporal *temp, const STBox *box, bool border_inc)
 {
   return tnpoint_restrict_stbox(temp, box, border_inc, REST_MINUS);

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -590,7 +590,7 @@ pose_wkt_out(const Pose *pose, bool extended, int maxdd)
  * @param[in] maxdd Maximum number of decimal digits
  * @csqlfn #Pose_as_text()
  */
-inline char *
+char *
 pose_as_text(const Pose *pose, int maxdd)
 {
   return pose_wkt_out(pose, false, maxdd);
@@ -1317,7 +1317,7 @@ pose_eq(const Pose *pose1, const Pose *pose2)
  * @brief Return true if the first pose is not equal to the second one
  * @param[in] pose1,pose2 Poses
  */
-inline bool
+bool
 pose_ne(const Pose *pose1, const Pose *pose2)
 {
   return ! pose_eq(pose1, pose2);
@@ -1357,7 +1357,7 @@ pose_same(const Pose *pose1, const Pose *pose2)
  * @brief Return true if the first pose is not equal to the second one
  * @param[in] pose1,pose2 Poses
  */
-inline bool
+bool
 pose_nsame(const Pose *pose1, const Pose *pose2)
 {
   return ! pose_same(pose1, pose2);
@@ -1400,7 +1400,7 @@ pose_cmp(const Pose *pose1, const Pose *pose2)
  * @brief Return true if the first pose is less than the second one
  * @param[in] pose1,pose2 Poses
  */
-inline bool
+bool
 pose_lt(const Pose *pose1, const Pose *pose2)
 {
   return pose_cmp(pose1, pose2) < 0;
@@ -1411,7 +1411,7 @@ pose_lt(const Pose *pose1, const Pose *pose2)
  * @brief Return true if the first pose is less than or equal to the second one
  * @param[in] pose1,pose2 Poses
  */
-inline bool
+bool
 pose_le(const Pose *pose1, const Pose *pose2)
 {
   return pose_cmp(pose1, pose2) <= 0;
@@ -1422,7 +1422,7 @@ pose_le(const Pose *pose1, const Pose *pose2)
  * @brief Return true if the first pose is greater than the second one
  * @param[in] pose1,pose2 Poses
  */
-inline bool
+bool
 pose_gt(const Pose *pose1, const Pose *pose2)
 {
   return pose_cmp(pose1, pose2) > 0;
@@ -1434,7 +1434,7 @@ pose_gt(const Pose *pose1, const Pose *pose2)
  * one
  * @param[in] pose1,pose2 Poses
  */
-inline bool
+bool
 pose_ge(const Pose *pose1, const Pose *pose2)
 {
   return pose_cmp(pose1, pose2) >= 0;

--- a/meos/src/pose/tpose_compops.c
+++ b/meos/src/pose/tpose_compops.c
@@ -97,7 +97,7 @@ eacomp_tpose_tpose(const Temporal *temp1, const Temporal *temp2,
  * @param[in] temp Temporal value
  * @csqlfn #Ever_eq_pose_tpose()
  */
-inline int
+int
 ever_eq_pose_tpose(const Pose *pose, const Temporal *temp)
 {
   return eacomp_tpose_pose(temp, pose, &datum2_eq, EVER);
@@ -111,7 +111,7 @@ ever_eq_pose_tpose(const Pose *pose, const Temporal *temp)
  * @param[in] pose Pose
  * @csqlfn #Ever_eq_tpose_pose()
  */
-inline int
+int
 ever_eq_tpose_pose(const Temporal *temp, const Pose *pose)
 {
   return eacomp_tpose_pose(temp, pose, &datum2_eq, EVER);
@@ -124,7 +124,7 @@ ever_eq_tpose_pose(const Temporal *temp, const Pose *pose)
  * @param[in] temp Temporal value
  * @csqlfn #Ever_ne_pose_tpose()
  */
-inline int
+int
 ever_ne_pose_tpose(const Pose *pose, const Temporal *temp)
 {
   return eacomp_tpose_pose(temp, pose, &datum2_ne, EVER);
@@ -138,7 +138,7 @@ ever_ne_pose_tpose(const Pose *pose, const Temporal *temp)
  * @param[in] pose Pose
  * @csqlfn #Ever_ne_tpose_pose()
  */
-inline int
+int
 ever_ne_tpose_pose(const Temporal *temp, const Pose *pose)
 {
   return eacomp_tpose_pose(temp, pose, &datum2_ne, EVER);
@@ -151,7 +151,7 @@ ever_ne_tpose_pose(const Temporal *temp, const Pose *pose)
  * @param[in] temp Temporal value
  * @csqlfn #Always_eq_pose_tpose()
  */
-inline int
+int
 always_eq_pose_tpose(const Pose *pose, const Temporal *temp)
 {
   return eacomp_tpose_pose(temp, pose, &datum2_eq, ALWAYS);
@@ -165,7 +165,7 @@ always_eq_pose_tpose(const Pose *pose, const Temporal *temp)
  * @param[in] pose Pose
  * @csqlfn #Always_eq_tpose_pose()
  */
-inline int
+int
 always_eq_tpose_pose(const Temporal *temp, const Pose *pose)
 {
   return eacomp_tpose_pose(temp, pose, &datum2_eq, ALWAYS);
@@ -178,7 +178,7 @@ always_eq_tpose_pose(const Temporal *temp, const Pose *pose)
  * @param[in] temp Temporal value
  * @csqlfn #Always_ne_pose_tpose()
  */
-inline int
+int
 always_ne_pose_tpose(const Pose *pose, const Temporal *temp)
 {
   return eacomp_tpose_pose(temp, pose, &datum2_ne, ALWAYS);
@@ -192,7 +192,7 @@ always_ne_pose_tpose(const Pose *pose, const Temporal *temp)
  * @param[in] pose Pose
  * @csqlfn #Always_ne_tpose_pose()
  */
-inline int
+int
 always_ne_tpose_pose(const Temporal *temp, const Pose *pose)
 {
   return eacomp_tpose_pose(temp, pose, &datum2_ne, ALWAYS);
@@ -206,7 +206,7 @@ always_ne_tpose_pose(const Temporal *temp, const Pose *pose)
  * @param[in] temp1,temp2 Temporal poses
  * @csqlfn #Ever_eq_tpose_tpose()
  */
-inline int
+int
 ever_eq_tpose_tpose(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tpose_tpose(temp1, temp2, &datum2_eq, EVER);
@@ -218,7 +218,7 @@ ever_eq_tpose_tpose(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal poses
  * @csqlfn #Ever_ne_tpose_tpose()
  */
-inline int
+int
 ever_ne_tpose_tpose(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tpose_tpose(temp1, temp2, &datum2_ne, EVER);
@@ -230,7 +230,7 @@ ever_ne_tpose_tpose(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal poses
  * @csqlfn #Always_eq_tpose_tpose()
  */
-inline int
+int
 always_eq_tpose_tpose(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tpose_tpose(temp1, temp2, &datum2_eq, ALWAYS);
@@ -242,7 +242,7 @@ always_eq_tpose_tpose(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal poses
  * @csqlfn #Always_ne_tpose_tpose()
  */
-inline int
+int
 always_ne_tpose_tpose(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tpose_tpose(temp1, temp2, &datum2_ne, ALWAYS);
@@ -298,7 +298,7 @@ tcomp_tpose_pose(const Temporal *temp, const Pose *pose,
  * @param[in] temp Temporal value
  * @csqlfn #Teq_pose_tpose()
  */
-inline Temporal *
+Temporal *
 teq_pose_tpose(const Pose *pose, const Temporal *temp)
 {
   return tcomp_pose_tpose(pose, temp, &datum2_eq);
@@ -311,7 +311,7 @@ teq_pose_tpose(const Pose *pose, const Temporal *temp)
  * @param[in] temp Temporal value
  * @csqlfn #Tne_pose_tpose()
  */
-inline Temporal *
+Temporal *
 tne_pose_tpose(const Pose *pose, const Temporal *temp)
 {
   return tcomp_pose_tpose(pose, temp, &datum2_ne);
@@ -327,7 +327,7 @@ tne_pose_tpose(const Pose *pose, const Temporal *temp)
  * @param[in] pose Pose
  * @csqlfn #Teq_tpose_pose()
  */
-inline Temporal *
+Temporal *
 teq_tpose_pose(const Temporal *temp, const Pose *pose)
 {
   return tcomp_tpose_pose(temp, pose, &datum2_eq);
@@ -341,7 +341,7 @@ teq_tpose_pose(const Temporal *temp, const Pose *pose)
  * @param[in] pose Pose
  * @csqlfn #Tne_tpose_pose()
  */
-inline Temporal *
+Temporal *
 tne_tpose_pose(const Temporal *temp, const Pose *pose)
 {
   return tcomp_tpose_pose(temp, pose, &datum2_ne);

--- a/meos/src/pose/tpose_spatialfuncs.c
+++ b/meos/src/pose/tpose_spatialfuncs.c
@@ -109,7 +109,7 @@ tpose_restrict_geom(const Temporal *temp, const GSERIALIZED *gs, bool atfunc)
  * @param[in] gs Geometry
  * @csqlfn #Tpose_at_geom()
  */
-inline Temporal *
+Temporal *
 tpose_at_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tpose_restrict_geom(temp, gs, REST_AT);
@@ -122,7 +122,7 @@ tpose_at_geom(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] gs Geometry
  * @csqlfn #Tpose_minus_geom()
  */
-inline Temporal *
+Temporal *
 tpose_minus_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tpose_restrict_geom(temp, gs, REST_MINUS);
@@ -173,7 +173,7 @@ tpose_restrict_stbox(const Temporal *temp, const STBox *box, bool border_inc,
  * @param[in] border_inc True when the box contains the upper border
  * @sqlfn #Tpose_at_stbox()
  */
-inline Temporal *
+Temporal *
 tpose_at_stbox(const Temporal *temp, const STBox *box, bool border_inc)
 {
   return tpose_restrict_stbox(temp, box, border_inc, REST_AT);
@@ -187,7 +187,7 @@ tpose_at_stbox(const Temporal *temp, const STBox *box, bool border_inc)
  * @param[in] border_inc True when the box contains the upper border
  * @sqlfn #Tpose_minus_stbox()
  */
-inline Temporal *
+Temporal *
 tpose_minus_stbox(const Temporal *temp, const STBox *box, bool border_inc)
 {
   return tpose_restrict_stbox(temp, box, border_inc, REST_MINUS);

--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -137,7 +137,7 @@ ensure_valid_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
  * representation
  * @param[in] str String
  */
-inline Temporal *
+Temporal *
 trgeo_in(const char *str)
 {
   /* Ensure the validity of the arguments */
@@ -152,7 +152,7 @@ trgeo_in(const char *str)
  * @return On error return @p NULL
  * @see #temporal_from_mfjson()
  */
-inline Temporal *
+Temporal *
 trgeo_from_mfjson(const char *mfjson)
 {
   /* Ensure the validity of the arguments */
@@ -219,7 +219,7 @@ trgeo_wkt_out(const Temporal *temp, int maxdd, bool extended)
  * @param[in] temp Temporal rigid geometry
  * @param[in] maxdd Maximum number of decimal digits
  */
-inline char *
+char *
 trgeo_as_text(const Temporal *temp, int maxdd)
 {
   return trgeo_wkt_out(temp, maxdd, false);
@@ -232,7 +232,7 @@ trgeo_as_text(const Temporal *temp, int maxdd)
  * @param[in] temp Temporal rigid geometry
  * @param[in] maxdd Maximum number of decimal digits
  */
-inline char *
+char *
 trgeo_as_ewkt(const Temporal *temp, int maxdd)
 {
   return trgeo_wkt_out(temp, maxdd, true);
@@ -999,7 +999,7 @@ trgeo_restrict_values(const Temporal *temp, const Set *s, bool atfunc)
  * @param[in] s Set of values
  * @csqlfn #Temporal_at_values()
  */
-inline Temporal *
+Temporal *
 trgeo_at_values(const Temporal *temp, const Set *s)
 {
   return trgeo_restrict_values(temp, s, REST_AT);
@@ -1013,7 +1013,7 @@ trgeo_at_values(const Temporal *temp, const Set *s)
  * @csqlfn #Temporal_minus_values()
  * @param[in] s Set of values
  */
-inline Temporal *
+Temporal *
 trgeo_minus_values(const Temporal *temp, const Set *s)
 {
   return trgeo_restrict_values(temp, s, REST_MINUS);
@@ -1053,7 +1053,7 @@ trgeo_restrict_timestamptz(const Temporal *temp, TimestampTz t, bool atfunc)
  * @param[in] t Timestamptz
  * @csqlfn #Temporal_at_timestamptz()
  */
-inline Temporal *
+Temporal *
 trgeo_at_timestamptz(const Temporal *temp, TimestampTz t)
 {
   return trgeo_restrict_timestamptz(temp, t, REST_AT);
@@ -1067,7 +1067,7 @@ trgeo_at_timestamptz(const Temporal *temp, TimestampTz t)
  * @param[in] t Timestamptz
  * @csqlfn #Temporal_minus_timestamptz()
  */
-inline Temporal *
+Temporal *
 trgeo_minus_timestamptz(const Temporal *temp, TimestampTz t)
 {
   return trgeo_restrict_timestamptz(temp, t, REST_MINUS);
@@ -1106,7 +1106,7 @@ trgeo_restrict_tstzset(const Temporal *temp, const Set *s, bool atfunc)
  * @param[in] s Set
  * @csqlfn #Temporal_at_tstzspanset()
  */
-inline Temporal *
+Temporal *
 trgeo_at_tstzset(const Temporal *temp, const Set *s)
 {
   return trgeo_restrict_tstzset(temp, s, REST_AT);
@@ -1120,7 +1120,7 @@ trgeo_at_tstzset(const Temporal *temp, const Set *s)
  * @param[in] s Set
  * @csqlfn #Temporal_minus_tstzspanset()
  */
-inline Temporal *
+Temporal *
 trgeo_minus_tstzset(const Temporal *temp, const Set *s)
 {
   return trgeo_restrict_tstzset(temp, s, REST_MINUS);
@@ -1159,7 +1159,7 @@ trgeo_restrict_tstzspan(const Temporal *temp, const Span *s, bool atfunc)
  * @param[in] s Span
  * @csqlfn #Temporal_at_tstzspan()
  */
-inline Temporal *
+Temporal *
 trgeo_at_tstzspan(const Temporal *temp, const Span *s)
 {
   return trgeo_restrict_tstzspan(temp, s, REST_AT);
@@ -1173,7 +1173,7 @@ trgeo_at_tstzspan(const Temporal *temp, const Span *s)
  * @param[in] s Span
  * @csqlfn #Temporal_minus_tstzspan()
  */
-inline Temporal *
+Temporal *
 trgeo_minus_tstzspan(const Temporal *temp, const Span *s)
 {
   return trgeo_restrict_tstzspan(temp, s, REST_MINUS);
@@ -1213,7 +1213,7 @@ trgeo_restrict_tstzspanset(const Temporal *temp, const SpanSet *ss,
  * @param[in] ss Span set
  * @csqlfn #Temporal_at_tstzspanset()
  */
-inline Temporal *
+Temporal *
 trgeo_at_tstzspanset(const Temporal *temp, const SpanSet *ss)
 {
   return trgeo_restrict_tstzspanset(temp, ss, REST_AT);
@@ -1227,7 +1227,7 @@ trgeo_at_tstzspanset(const Temporal *temp, const SpanSet *ss)
  * @param[in] ss Span set
  * @csqlfn #Temporal_minus_tstzspanset()
  */
-inline Temporal *
+Temporal *
 trgeo_minus_tstzspanset(const Temporal *temp, const SpanSet *ss)
 {
   return trgeo_restrict_tstzspanset(temp, ss, REST_MINUS);

--- a/meos/src/rgeo/trgeo_compops.c
+++ b/meos/src/rgeo/trgeo_compops.c
@@ -95,7 +95,7 @@ eacomp_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2,
  * @param[in] temp Temporal value
  * @csqlfn #Ever_eq_geo_trgeo()
  */
-inline int
+int
 ever_eq_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   return eacomp_trgeo_geo(temp, gs, &datum2_eq, EVER);
@@ -109,7 +109,7 @@ ever_eq_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
  * @param[in] gs Geometry
  * @csqlfn #Ever_eq_trgeo_geo()
  */
-inline int
+int
 ever_eq_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return eacomp_trgeo_geo(temp, gs, &datum2_eq, EVER);
@@ -123,7 +123,7 @@ ever_eq_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] temp Temporal value
  * @csqlfn #Ever_ne_geo_trgeo()
  */
-inline int
+int
 ever_ne_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   return eacomp_trgeo_geo(temp, gs, &datum2_ne, EVER);
@@ -137,7 +137,7 @@ ever_ne_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
  * @param[in] gs Geometry
  * @csqlfn #Ever_ne_trgeo_geo()
  */
-inline int
+int
 ever_ne_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return eacomp_trgeo_geo(temp, gs, &datum2_ne, EVER);
@@ -151,7 +151,7 @@ ever_ne_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] temp Temporal value
  * @csqlfn #Always_eq_geo_trgeo()
  */
-inline int
+int
 always_eq_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   return eacomp_trgeo_geo(temp, gs, &datum2_eq, ALWAYS);
@@ -165,7 +165,7 @@ always_eq_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
  * @param[in] gs Geometry
  * @csqlfn #Always_eq_trgeo_geo()
  */
-inline int
+int
 always_eq_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return eacomp_trgeo_geo(temp, gs, &datum2_eq, ALWAYS);
@@ -179,7 +179,7 @@ always_eq_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] temp Temporal value
  * @csqlfn #Always_ne_geo_trgeo()
  */
-inline int
+int
 always_ne_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   return eacomp_trgeo_geo(temp, gs, &datum2_ne, ALWAYS);
@@ -193,7 +193,7 @@ always_ne_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
  * @param[in] gs Geometry
  * @csqlfn #Always_ne_trgeo_geo()
  */
-inline int
+int
 always_ne_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return eacomp_trgeo_geo(temp, gs, &datum2_ne, ALWAYS);
@@ -207,7 +207,7 @@ always_ne_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] temp1,temp2 Temporal rigid geometries
  * @csqlfn #Ever_eq_trgeo_trgeo()
  */
-inline int
+int
 ever_eq_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_trgeo_trgeo(temp1, temp2, &datum2_eq, EVER);
@@ -219,7 +219,7 @@ ever_eq_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal rigid geometries
  * @csqlfn #Ever_ne_trgeo_trgeo()
  */
-inline int
+int
 ever_ne_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_trgeo_trgeo(temp1, temp2, &datum2_ne, EVER);
@@ -231,7 +231,7 @@ ever_ne_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal rigid geometries
  * @csqlfn #Always_eq_trgeo_trgeo()
  */
-inline int
+int
 always_eq_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_trgeo_trgeo(temp1, temp2, &datum2_eq, ALWAYS);
@@ -243,7 +243,7 @@ always_eq_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal rigid geometries
  * @csqlfn #Always_ne_trgeo_trgeo()
  */
-inline int
+int
 always_ne_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_trgeo_trgeo(temp1, temp2, &datum2_ne, ALWAYS);
@@ -299,7 +299,7 @@ tcomp_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
  * @param[in] temp Temporal value
  * @csqlfn #Teq_geo_trgeo()
  */
-inline Temporal *
+Temporal *
 teq_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   return tcomp_geo_trgeo(gs, temp, &datum2_eq);
@@ -313,7 +313,7 @@ teq_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
  * @param[in] temp Temporal value
  * @csqlfn #Tne_geo_trgeo()
  */
-inline Temporal *
+Temporal *
 tne_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   return tcomp_geo_trgeo(gs, temp, &datum2_ne);
@@ -329,7 +329,7 @@ tne_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
  * @param[in] gs Geometry
  * @csqlfn #Teq_trgeo_geo()
  */
-inline Temporal *
+Temporal *
 teq_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tcomp_trgeo_geo(temp, gs, &datum2_eq);
@@ -343,7 +343,7 @@ teq_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] gs Geometry
  * @csqlfn #Tne_trgeo_geo()
  */
-inline Temporal *
+Temporal *
 tne_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tcomp_trgeo_geo(temp, gs, &datum2_ne);

--- a/meos/src/rgeo/trgeo_seq.c
+++ b/meos/src/rgeo/trgeo_seq.c
@@ -235,7 +235,7 @@ trgeoseq_make1_exp(const GSERIALIZED *geom, TInstant **instants,
  * @brief Construct a temporal sequence from an array of temporal instants
  * @pre The validity of the arguments has been tested before
  */
-inline TSequence *
+TSequence *
 trgeoseq_make1(const GSERIALIZED *geom, TInstant **instants, int count,
   bool lower_inc, bool upper_inc, interpType interp, bool normalize)
 {
@@ -278,7 +278,7 @@ trgeoseq_make_exp(const GSERIALIZED *geom, TInstant **instants,
  * @param[in] interp Interpolation
  * @param[in] normalize True if the resulting value should be normalized
  */
-inline TSequence *
+TSequence *
 trgeoseq_make(const GSERIALIZED *geom, TInstant **instants, int count,
   bool lower_inc, bool upper_inc, interpType interp, bool normalize)
 {
@@ -333,7 +333,7 @@ trgeoseq_make_free_exp(const GSERIALIZED *geom, TInstant **instants, int count,
  * @note Does not free the reference geometry
  * @see tsequence_make
  */
-inline TSequence *
+TSequence *
 trgeoseq_make_free(const GSERIALIZED *geom, TInstant **instants, int count,
   bool lower_inc, bool upper_inc, interpType interp, bool normalize)
 {

--- a/meos/src/rgeo/trgeo_seqset.c
+++ b/meos/src/rgeo/trgeo_seqset.c
@@ -241,7 +241,7 @@ trgeoseqset_make_exp(const GSERIALIZED *geom, TSequence **sequences,
  * temporal sequence sets before applying an operation to them.
  * @sqlfn tbool_seqset(), tint_seqset(), tfloat_seqset(), ttext_seqset(), etc.
  */
-inline TSequenceSet *
+TSequenceSet *
 trgeoseqset_make(const GSERIALIZED *geom, TSequence **sequences, int count,
   bool normalize)
 {

--- a/meos/src/rgeo/trgeo_spatialrels.c
+++ b/meos/src/rgeo/trgeo_spatialrels.c
@@ -173,7 +173,7 @@ ea_contains_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
  * https://postgis.net/docs/ST_Contains.html
  * @csqlfn #Acontains_geo_trgeo()
  */
-inline int
+int
 econtains_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   return ea_contains_geo_trgeo(gs, temp, EVER);
@@ -191,7 +191,7 @@ econtains_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
  * https://postgis.net/docs/ST_Contains.html
  * @csqlfn #Acontains_geo_trgeo()
  */
-inline int
+int
 acontains_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   return ea_contains_geo_trgeo(gs, temp, ALWAYS);
@@ -239,7 +239,7 @@ ea_covers_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
  * https://postgis.net/docs/ST_Contains.html
  * @csqlfn #Ecovers_geo_trgeo()
  */
-inline int
+int
 ecovers_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   return ea_covers_geo_trgeo(gs, temp, EVER);
@@ -257,7 +257,7 @@ ecovers_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
  * https://postgis.net/docs/ST_Contains.html
  * @csqlfn #Acovers_geo_trgeo()
  */
-inline int
+int
 acovers_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   return ea_covers_geo_trgeo(gs, temp, ALWAYS);
@@ -303,7 +303,7 @@ ea_covers_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
  * https://postgis.net/docs/ST_Contains.html
  * @csqlfn #Ecovers_trgeo_geo()
  */
-inline int
+int
 ecovers_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_covers_trgeo_geo(temp, gs, EVER);
@@ -321,7 +321,7 @@ ecovers_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * https://postgis.net/docs/ST_Contains.html
  * @csqlfn #Acovers_trgeo_geo()
  */
-inline int
+int
 acovers_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_covers_trgeo_geo(temp, gs, ALWAYS);
@@ -358,7 +358,7 @@ ea_disjoint_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
  * @param[in] gs Geometry
  * @csqlfn #Edisjoint_trgeo_geo()
  */
-inline int
+int
 edisjoint_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_disjoint_trgeo_geo(temp, gs, EVER);
@@ -373,7 +373,7 @@ edisjoint_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @note aDisjoint(a, b) is equivalent to NOT eIntersects(a, b)
  * @csqlfn #Adisjoint_trgeo_geo()
  */
-inline int
+int
 adisjoint_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_disjoint_trgeo_geo(temp, gs, ALWAYS);
@@ -387,7 +387,7 @@ adisjoint_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] temp1,temp2 Temporal rigid geometries
  * @csqlfn #Edisjoint_trgeo_trgeo()
  */
-inline int
+int
 edisjoint_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_spatialrel_tspatial_tspatial(temp1, temp2, &datum2_point_ne, EVER);
@@ -401,7 +401,7 @@ edisjoint_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal rigid geometries
  * @csqlfn #Adisjoint_trgeo_trgeo()
  */
-inline int
+int
 adisjoint_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_spatialrel_tspatial_tspatial(temp1, temp2, &datum2_point_ne,
@@ -421,7 +421,7 @@ adisjoint_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
  * @param[in] gs Geometry
  * @csqlfn #Eintersects_trgeo_geo()
  */
-inline int
+int
 eintersects_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return spatialrel_trgeo_trav_geo(temp, gs, (Datum) NULL, 
@@ -437,7 +437,7 @@ eintersects_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @note aIntersects(trgeo, gs) is equivalent to NOT eDisjoint(trgeo, gs)
  * @csqlfn #Aintersects_trgeo_geo()
  */
-inline int
+int
 aintersects_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return INVERT_RESULT(edisjoint_trgeo_geo(temp, gs));
@@ -451,7 +451,7 @@ aintersects_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] temp1,temp2 Temporal rigid geometries
  * @csqlfn #Eintersects_trgeo_trgeo()
  */
-inline int
+int
 eintersects_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_spatialrel_tspatial_tspatial(temp1, temp2, &datum2_point_eq, EVER);
@@ -464,7 +464,7 @@ eintersects_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal rigid geometries
  * @csqlfn #Aintersects_trgeo_trgeo()
  */
-inline int
+int
 aintersects_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_spatialrel_tspatial_tspatial(temp1, temp2, &datum2_point_eq,
@@ -842,7 +842,7 @@ ea_dwithin_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2,
  * @param[in] dist Distance
  * @csqlfn #EA_dwithin_trgeo_trgeo()
  */
-inline int
+int
 edwithin_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2, double dist)
 {
   return ea_dwithin_trgeo_trgeo(temp1, temp2, dist, EVER);
@@ -857,7 +857,7 @@ edwithin_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2, double dist)
  * @param[in] dist Distance
  * @csqlfn #Adwithin_trgeo_trgeo()
  */
-inline int
+int
 adwithin_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2, double dist)
 {
   return ea_dwithin_trgeo_trgeo(temp1, temp2, dist, ALWAYS);

--- a/meos/src/temporal/error.c
+++ b/meos/src/temporal/error.c
@@ -190,6 +190,37 @@ meos_initialize_error_handler(error_handler_fn err_handler)
   __atomic_store_n(&MEOS_ERROR_HANDLER, h, __ATOMIC_RELEASE);
   return;
 }
+
+/**
+ * @brief Error handler that records the errno but does NOT call exit()
+ * @details The default_error_handler in MEOS calls exit() on every error,
+ * which is fatal in embedded contexts (notably JNR-FFI threads in JVM
+ * processes — exit() from a foreign thread tears the entire JVM down with
+ * SIGSEGV in libc, with no recovery path). Install this handler once at
+ * startup via meos_initialize_noexit_error_handler() so MEOS errors are
+ * reported via meos_errno() instead of process termination.
+ */
+static void
+noexit_error_handler(int errlevel __attribute__((__unused__)), int errcode,
+  const char *errmsg)
+{
+  fprintf(stderr, "%s\n", errmsg);
+  meos_errno_set(errcode);
+  return;
+}
+
+/**
+ * @brief Install the no-exit error handler
+ * @details Safe to call from multiple threads — the underlying atomic
+ * store is idempotent and always sets the same function pointer.
+ */
+void
+meos_initialize_noexit_error_handler(void)
+{
+  __atomic_store_n(&MEOS_ERROR_HANDLER,
+    (meos_error_handler_t) noexit_error_handler, __ATOMIC_RELEASE);
+  return;
+}
 #endif /* MEOS */
 
 /*****************************************************************************/

--- a/meos/src/temporal/meos_catalog.c
+++ b/meos/src/temporal/meos_catalog.c
@@ -285,7 +285,7 @@ static const temptype_catalog_struct MEOS_TEMPTYPE_CATALOG[] =
 /**
  * @brief Return the string representation of the MEOS type
  */
-inline const char *
+const char *
 meostype_name(MeosType type)
 {
   return MEOS_TYPE_NAMES[type];
@@ -297,7 +297,7 @@ meostype_name(MeosType type)
  * @brief Return the string representation of the subtype of the temporal type
  * corresponding to the enum value
  */
-inline const char *
+const char *
 tempsubtype_name(tempSubtype subtype)
 {
   return MEOS_TEMPSUBTYPE_NAMES[subtype];
@@ -362,7 +362,7 @@ tempsubtype_from_string(const char *str, int16 *subtype)
  * @brief Ensure that the subtype of a temporal value is valid
  * @note The function is used for the dispatch functions for temporal types
  */
-inline bool
+bool
 temptype_subtype(tempSubtype subtype)
 {
   return (subtype == TINSTANT || subtype == TSEQUENCE ||
@@ -373,7 +373,7 @@ temptype_subtype(tempSubtype subtype)
  * @brief Ensure that the subtype of a temporal value is valid
  * @note The function is used for the the analyze and selectivity functions
  */
-inline bool
+bool
 temptype_subtype_all(tempSubtype subtype)
 {
   return (subtype == ANYTEMPSUBTYPE ||
@@ -386,7 +386,7 @@ temptype_subtype_all(tempSubtype subtype)
 /**
  * @brief Return the string name from a MEOS operator number
  */
-inline const char *
+const char *
 meosoper_name(meosOper oper)
 {
   return MEOS_OPER_NAMES[oper];
@@ -414,7 +414,7 @@ meosoper_from_string(const char *str)
  * @brief Return the string representation of the subtype of the temporal type
  * corresponding to the enum value
  */
-inline const char *
+const char *
 interptype_name(interpType interp)
 {
   return MEOS_INTERPTYPE_NAMES[interp];
@@ -581,7 +581,7 @@ spantype_spansettype(MeosType type)
  * that is, @p Set, @p Span, @p SpanSet, and @p Temporal
  * @note This function is only used in the asserts
  */
-inline bool
+bool
 meos_basetype(MeosType type)
 {
   return (type == T_BOOL || type == T_INT4 || type == T_INT8 || type == T_FLOAT8 ||
@@ -605,7 +605,7 @@ meos_basetype(MeosType type)
 /**
  * @brief Return true if the values of the base type are passed by value
  */
-inline bool
+bool
 basetype_byvalue(MeosType type)
 {
   return (type == T_BOOL || type == T_INT4 || type == T_INT8 || type == T_FLOAT8 ||
@@ -615,7 +615,7 @@ basetype_byvalue(MeosType type)
 /**
  * @brief Return true if the values of the base type are of variable length
  */
-inline bool
+bool
 basetype_varlength(MeosType type)
 {
   return (type == T_TEXT || type == T_GEOMETRY || type == T_GEOGRAPHY
@@ -670,7 +670,7 @@ meostype_length(MeosType type)
  * @brief Return true if the type is an alphanumeric base type
  * @note This function is only used in the asserts
  */
-inline bool
+bool
 alphanum_basetype(MeosType type)
 {
   return (type == T_BOOL || type == T_INT4 || type == T_INT8 ||
@@ -682,7 +682,7 @@ alphanum_basetype(MeosType type)
  * @brief Return true if the type is an alphanumeric base type
  * @note This function is only used in the asserts
  */
-inline bool
+bool
 alphanum_temptype(MeosType type)
 {
   return (type == T_TBOOL || type == T_TINT || type == T_TFLOAT ||
@@ -693,7 +693,7 @@ alphanum_temptype(MeosType type)
 /**
  * @brief Return true if the type is a geo base type
  */
-inline bool
+bool
 geo_basetype(MeosType type)
 {
   return (type == T_GEOMETRY || type == T_GEOGRAPHY);
@@ -702,7 +702,7 @@ geo_basetype(MeosType type)
 /**
  * @brief Return true if the type is a spatial base type
  */
-inline bool
+bool
 spatial_basetype(MeosType type)
 {
   return (type == T_GEOMETRY || type == T_GEOGRAPHY 
@@ -723,7 +723,7 @@ spatial_basetype(MeosType type)
 /**
  * @brief Return true if the type is a time type
  */
-inline bool
+bool
 time_type(MeosType type)
 {
   return (type == T_DATE || type == T_DATESET || type == T_DATESPAN ||
@@ -738,7 +738,7 @@ time_type(MeosType type)
  * @brief Return true if the type is a base type of a set type
  * @note This function is only used in the asserts
  */
-inline bool
+bool
 set_basetype(MeosType type)
 {
   return (type == T_TIMESTAMPTZ || type == T_DATE || type == T_INT4 ||
@@ -760,7 +760,7 @@ set_basetype(MeosType type)
 /**
  * @brief Return true if the type is a set type
  */
-inline bool
+bool
 set_type(MeosType type)
 {
   return (type == T_TSTZSET || type == T_DATESET || type == T_INTSET ||
@@ -781,7 +781,7 @@ set_type(MeosType type)
 /**
  * @brief Return true if the type is a number set type
  */
-inline bool
+bool
 numset_type(MeosType type)
 {
   return (type == T_INTSET || type == T_BIGINTSET || type == T_FLOATSET ||
@@ -807,7 +807,7 @@ ensure_numset_type(MeosType type)
 /**
  * @brief Return true if the type is a time set type
  */
-inline bool
+bool
 timeset_type(MeosType type)
 {
   return (type == T_DATESET || type == T_TSTZSET);
@@ -816,7 +816,7 @@ timeset_type(MeosType type)
 /**
  * @brief Return true if the type is a set type with a span as a bounding box
  */
-inline bool
+bool
 set_spantype(MeosType type)
 {
   return (type == T_INTSET || type == T_BIGINTSET || type == T_FLOATSET ||
@@ -839,7 +839,7 @@ ensure_set_spantype(MeosType type)
 /**
  * @brief Return true if the type is a set type
  */
-inline bool
+bool
 alphanumset_type(MeosType type)
 {
   return (type == T_TSTZSET || type == T_DATESET || type == T_INTSET ||
@@ -850,7 +850,7 @@ alphanumset_type(MeosType type)
 /**
  * @brief Return true if the type is a geo set type
  */
-inline bool
+bool
 geoset_type(MeosType type)
 {
   return (type == T_GEOMSET || type == T_GEOGSET);
@@ -873,7 +873,7 @@ ensure_geoset_type(MeosType type)
 /**
  * @brief Return true if the type is a geo set type
  */
-inline bool
+bool
 spatialset_type(MeosType type)
 {
   return (type == T_GEOMSET || type == T_GEOGSET
@@ -909,7 +909,7 @@ ensure_spatialset_type(MeosType type)
 /**
  * @brief Return true if the type is a span base type
  */
-inline bool
+bool
 span_basetype(MeosType type)
 {
   return (type == T_TIMESTAMPTZ || type == T_DATE || type == T_INT4 ||
@@ -919,7 +919,7 @@ span_basetype(MeosType type)
 /**
  * @brief Return true if the type is a canonical base type of a span type
  */
-inline bool
+bool
 span_canon_basetype(MeosType type)
 {
   return (type == T_DATE || type == T_INT4 || type == T_INT8);
@@ -939,7 +939,7 @@ span_type(MeosType type)
  * @brief Return true if the type has a span type as bounding box
  * @note This function is only used in the asserts
  */
-inline bool
+bool
 type_span_bbox(MeosType type)
 {
   return (set_spantype(type) || span_type(type) || spanset_type(type) ||
@@ -950,7 +950,7 @@ type_span_bbox(MeosType type)
  * @brief Return true if the type can be converted to a temporal box
  * @note This function is only used in the asserts
  */
-inline bool
+bool
 span_tbox_type(MeosType type)
 {
   return (type == T_INTSPAN || type == T_FLOATSPAN || type == T_TSTZSPAN);
@@ -973,7 +973,7 @@ ensure_span_tbox_type(MeosType type)
 /**
  * @brief Return true if the type is a number span type
  */
-inline bool
+bool
 numspan_basetype(MeosType type)
 {
   return (type == T_INT4 || type == T_INT8 || type == T_FLOAT8 ||
@@ -984,7 +984,7 @@ numspan_basetype(MeosType type)
 /**
  * @brief Return true if the type is a number span type
  */
-inline bool
+bool
 numspan_type(MeosType type)
 {
   return (type == T_INTSPAN || type == T_BIGINTSPAN || type == T_FLOATSPAN ||
@@ -1007,7 +1007,7 @@ ensure_numspan_type(MeosType type)
 /**
  * @brief Return true if the type is a time span type
  */
-inline bool
+bool
 timespan_basetype(MeosType type)
 {
   return (type == T_TIMESTAMPTZ || type == T_DATE);
@@ -1016,7 +1016,7 @@ timespan_basetype(MeosType type)
 /**
  * @brief Return true if the type is a time span type
  */
-inline bool
+bool
 timespan_type(MeosType type)
 {
   return (type == T_TSTZSPAN || type == T_DATESPAN);
@@ -1027,7 +1027,7 @@ timespan_type(MeosType type)
 /**
  * @brief Return true if the type is a span set type
  */
-inline bool
+bool
 spanset_type(MeosType type)
 {
   return (type == T_TSTZSPANSET || type == T_DATESPANSET ||
@@ -1037,7 +1037,7 @@ spanset_type(MeosType type)
 /**
  * @brief Return true if the type is a time span type
  */
-inline bool
+bool
 timespanset_type(MeosType type)
 {
   return (type == T_TSTZSPANSET || type == T_DATESPANSET);
@@ -1064,7 +1064,7 @@ ensure_timespanset_type(MeosType type)
  * @brief Return true if the type is an @b external temporal type
  * @note Function used in particular in the indexes
  */
-inline bool
+bool
 temporal_type(MeosType type)
 {
   return (type == T_TBOOL || type == T_TINT || type == T_TFLOAT ||
@@ -1092,7 +1092,7 @@ temporal_type(MeosType type)
  * @brief Return true if the type is a temporal base type
  * @note This function is only used in the asserts
  */
-inline bool
+bool
 temporal_basetype(MeosType type)
 {
   return (type == T_BOOL || type == T_INT4 || type == T_FLOAT8 ||
@@ -1116,7 +1116,7 @@ temporal_basetype(MeosType type)
 /**
  * @brief Return true if the type is a temporal continuous type
  */
-inline bool
+bool
 temptype_continuous(MeosType type)
 {
   return (type == T_TFLOAT || type == T_TDOUBLE2 || type == T_TDOUBLE3 ||
@@ -1141,7 +1141,7 @@ temptype_continuous(MeosType type)
  * @brief Return true if the type is a temporal alphanumeric type
  * @note This function is only used in the asserts
  */
-inline bool
+bool
 talphanum_type(MeosType type)
 {
   return (type == T_TBOOL || type == T_TINT || type == T_TFLOAT ||
@@ -1153,7 +1153,7 @@ talphanum_type(MeosType type)
  * @brief Return true if the type is a temporal alpha type (i.e., those whose
  * bounding box is a timestamptz span)
  */
-inline bool
+bool
 talpha_type(MeosType type)
 {
   return (type == T_TBOOL || type == T_TTEXT || type == T_TDOUBLE2 ||
@@ -1163,7 +1163,7 @@ talpha_type(MeosType type)
 /**
  * @brief Return true if the type is a temporal number type
  */
-inline bool
+bool
 tnumber_type(MeosType type)
 {
   return (type == T_TINT || type == T_TFLOAT);
@@ -1225,7 +1225,7 @@ tnumber_spantype(MeosType type)
  * types, in particular, all of them use the same bounding box @ STBox.
  * Therefore, it is used for the indexes and selectivity functions.
  */
-inline bool
+bool
 tspatial_type(MeosType type)
 {
   return (type == T_TGEOMPOINT || type == T_TGEOGPOINT || 
@@ -1263,7 +1263,7 @@ ensure_tspatial_type(MeosType type)
 /**
  * @brief Return true if a type is a temporal point type
  */
-inline bool
+bool
 tpoint_type(MeosType type)
 {
   return (type == T_TGEOMPOINT || type == T_TGEOGPOINT);
@@ -1285,7 +1285,7 @@ ensure_tpoint_type(MeosType type)
 /**
  * @brief Return true if a type is a temporal geo type
  */
-inline bool
+bool
 tgeo_type(MeosType type)
 {
   return (type == T_TGEOMETRY || type == T_TGEOGRAPHY);
@@ -1310,7 +1310,7 @@ ensure_tgeo_type(MeosType type)
  * @brief Return true if a type is a temporal type with geometry/geography as
  * base type
  */
-inline bool
+bool
 tgeo_type_all(MeosType type)
 {
   return (type == T_TGEOMETRY || type == T_TGEOGRAPHY ||
@@ -1335,7 +1335,7 @@ ensure_tgeo_type_all(MeosType type)
 /**
  * @brief Return true if a type is a temporal geometry type
  */
-inline bool
+bool
 tgeometry_type(MeosType type)
 {
   return (type == T_TGEOMPOINT || type == T_TGEOMETRY);
@@ -1358,7 +1358,7 @@ ensure_tgeometry_type(MeosType type)
 /**
  * @brief Return true if a type is a temporal geodetic type
  */
-inline bool
+bool
 tgeodetic_type(MeosType type)
 {
   return (type == T_TGEOGPOINT || type == T_TGEOGRAPHY);

--- a/meos/src/temporal/postgres_types.c
+++ b/meos/src/temporal/postgres_types.c
@@ -825,7 +825,7 @@ date2timestamptz_opt_overflow(DateADT dateVal, int *overflow)
  * @param[in] d Date
  * @note PostgreSQL function: @p date_timestamptz(PG_FUNCTION_ARGS)
  */
-inline TimestampTz
+TimestampTz
 date_to_timestamptz(DateADT d)
 {
   return date2timestamptz_opt_overflow(d, NULL);
@@ -1426,7 +1426,7 @@ timestamptz_out(TimestampTz t)
 {
   return timestamp_out_common(t, true);
 }
-inline char *
+char *
 pg_timestamptz_out(TimestampTz t)
 {
   return timestamp_out_common(t, true);

--- a/meos/src/temporal/set.c
+++ b/meos/src/temporal/set.c
@@ -1086,7 +1086,7 @@ set_eq(const Set *s1, const Set *s2)
  * @param[in] s1,s2 Sets
  * @csqlfn #Set_ne()
  */
-inline bool
+bool
 set_ne(const Set *s1, const Set *s2)
 {
   return ! set_eq(s1, s2);
@@ -1134,7 +1134,7 @@ set_cmp(const Set *s1, const Set *s2)
  * @param[in] s1,s2 Sets
  * @csqlfn #Set_lt()
  */
-inline bool
+bool
 set_lt(const Set *s1, const Set *s2)
 {
   return set_cmp(s1, s2) < 0;
@@ -1146,7 +1146,7 @@ set_lt(const Set *s1, const Set *s2)
  * @param[in] s1,s2 Sets
  * @csqlfn #Set_le()
  */
-inline bool
+bool
 set_le(const Set *s1, const Set *s2)
 {
   return set_cmp(s1, s2) <= 0;
@@ -1158,7 +1158,7 @@ set_le(const Set *s1, const Set *s2)
  * @param[in] s1,s2 Sets
  * @csqlfn #Set_gt()
  */
-inline bool
+bool
 set_gt(const Set *s1, const Set *s2)
 {
   return set_cmp(s1, s2) > 0;
@@ -1170,7 +1170,7 @@ set_gt(const Set *s1, const Set *s2)
  * @param[in] s1,s2 Sets
  * @csqlfn #Set_ge()
  */
-inline bool
+bool
 set_ge(const Set *s1, const Set *s2)
 {
   return set_cmp(s1, s2) >= 0;

--- a/meos/src/temporal/set_ops.c
+++ b/meos/src/temporal/set_ops.c
@@ -237,7 +237,7 @@ contains_set_set(const Set *s1, const Set *s2)
  * @param[in] value Value
  * @param[in] s Set
  */
-inline bool
+bool
 contained_value_set(Datum value, const Set *s)
 {
   return contains_set_value(s, value);
@@ -249,7 +249,7 @@ contained_value_set(Datum value, const Set *s)
  * @param[in] s1,s2 Sets
  * @csqlfn #Contained_set_set()
  */
-inline bool
+bool
 contained_set_set(const Set *s1, const Set *s2)
 {
   return contains_set_set(s2, s1);
@@ -346,7 +346,7 @@ left_set_set(const Set *s1, const Set *s2)
  * @param[in] value Value
  * @param[in] s Set
  */
-inline bool
+bool
 right_value_set(Datum value, const Set *s)
 {
   return left_set_value(s, value);
@@ -358,7 +358,7 @@ right_value_set(Datum value, const Set *s)
  * @param[in] s Set
  * @param[in] value Value
  */
-inline bool
+bool
 right_set_value(const Set *s, Datum value)
 {
   return left_value_set(value, s);
@@ -370,7 +370,7 @@ right_set_value(const Set *s, Datum value)
  * @param[in] s1,s2 Sets
  * @csqlfn #Right_set_set()
  */
-inline bool
+bool
 right_set_set(const Set *s1, const Set *s2)
 {
   return left_set_set(s2, s1);
@@ -513,7 +513,7 @@ union_set_value(const Set *s, Datum value)
  * @param[in] value Value
  * @param[in] s Set
  */
-inline Set *
+Set *
 union_value_set(Datum value, const Set *s)
 {
   return union_set_value(s, value);
@@ -559,7 +559,7 @@ intersection_set_value(const Set *s, Datum value)
  * @param[in] value Value
  * @param[in] s Set
  */
-inline Set *
+Set *
 intersection_value_set(Datum value, const Set *s)
 {
   return intersection_set_value(s, value);

--- a/meos/src/temporal/set_ops_meos.c
+++ b/meos/src/temporal/set_ops_meos.c
@@ -1087,7 +1087,7 @@ union_set_timestamptz(const Set *s, const TimestampTz t)
  * @param[in] i Value
  * @csqlfn #Union_set_value()
  */
-inline Set *
+Set *
 union_int_set(int i, const Set *s)
 {
   return union_set_int(s, i);
@@ -1100,7 +1100,7 @@ union_int_set(int i, const Set *s)
  * @param[in] i Value
  * @csqlfn #Union_set_value()
  */
-inline Set *
+Set *
 union_bigint_set(int64 i, const Set *s)
 {
   return union_set_bigint(s, i);
@@ -1113,7 +1113,7 @@ union_bigint_set(int64 i, const Set *s)
  * @param[in] d Value
  * @csqlfn #Union_set_value()
  */
-inline Set *
+Set *
 union_float_set(double d, const Set *s)
 {
   return union_set_float(s, d);
@@ -1126,7 +1126,7 @@ union_float_set(double d, const Set *s)
  * @param[in] txt Value
  * @csqlfn #Union_set_value()
  */
-inline Set *
+Set *
 union_text_set(const text *txt, const Set *s)
 {
   return union_set_text(s, txt);
@@ -1139,7 +1139,7 @@ union_text_set(const text *txt, const Set *s)
  * @param[in] d Value
  * @csqlfn #Union_set_value()
  */
-inline Set *
+Set *
 union_date_set(const DateADT d, const Set *s)
 {
   return union_set_date(s, d);
@@ -1152,7 +1152,7 @@ union_date_set(const DateADT d, const Set *s)
  * @param[in] t Value
  * @csqlfn #Union_set_value()
  */
-inline Set *
+Set *
 union_timestamptz_set(const TimestampTz t, const Set *s)
 {
   return union_set_timestamptz(s, t);
@@ -1261,7 +1261,7 @@ intersection_set_timestamptz(const Set *s, TimestampTz t)
  * @param[in] i Value
  * @csqlfn #Union_set_value()
  */
-inline Set *
+Set *
 intersection_int_set(int i, const Set *s)
 {
   return intersection_set_int(s, i);
@@ -1274,7 +1274,7 @@ intersection_int_set(int i, const Set *s)
  * @param[in] i Value
  * @csqlfn #Union_set_value()
  */
-inline Set *
+Set *
 intersection_bigint_set(int64 i, const Set *s)
 {
   return intersection_set_bigint(s, i);
@@ -1287,7 +1287,7 @@ intersection_bigint_set(int64 i, const Set *s)
  * @param[in] d Value
  * @csqlfn #Union_set_value()
  */
-inline Set *
+Set *
 intersection_float_set(double d, const Set *s)
 {
   return intersection_set_float(s, d);
@@ -1300,7 +1300,7 @@ intersection_float_set(double d, const Set *s)
  * @param[in] txt Value
  * @csqlfn #Union_set_value()
  */
-inline Set *
+Set *
 intersection_text_set(const text *txt, const Set *s)
 {
   return intersection_set_text(s, txt);
@@ -1313,7 +1313,7 @@ intersection_text_set(const text *txt, const Set *s)
  * @param[in] d Value
  * @csqlfn #Union_set_value()
  */
-inline Set *
+Set *
 intersection_date_set(const DateADT d, const Set *s)
 {
   return intersection_set_date(s, d);
@@ -1326,7 +1326,7 @@ intersection_date_set(const DateADT d, const Set *s)
  * @param[in] t Value
  * @csqlfn #Union_set_value()
  */
-inline Set *
+Set *
 intersection_timestamptz_set(const TimestampTz t, const Set *s)
 {
   return intersection_set_timestamptz(s, t);

--- a/meos/src/temporal/span.c
+++ b/meos/src/temporal/span.c
@@ -1504,7 +1504,7 @@ span_eq(const Span *s1, const Span *s2)
  * @param[in] s1,s2 Sets
  * @csqlfn #Span_ne()
  */
-inline bool
+bool
 span_ne(const Span *s1, const Span *s2)
 {
   return (! span_eq(s1, s2));
@@ -1547,7 +1547,7 @@ span_cmp(const Span *s1, const Span *s2)
  * @param[in] s1,s2 Sets
  * @csqlfn #Span_lt()
  */
-inline bool
+bool
 span_lt(const Span *s1, const Span *s2)
 {
   return span_cmp(s1, s2) < 0;
@@ -1559,7 +1559,7 @@ span_lt(const Span *s1, const Span *s2)
  * @param[in] s1,s2 Sets
  * @csqlfn #Span_le()
  */
-inline bool
+bool
 span_le(const Span *s1, const Span *s2)
 {
   return span_cmp(s1, s2) <= 0;
@@ -1572,7 +1572,7 @@ span_le(const Span *s1, const Span *s2)
  * @param[in] s1,s2 Sets
  * @csqlfn #Span_gt()
  */
-inline bool
+bool
 span_ge(const Span *s1, const Span *s2)
 {
   return span_cmp(s1, s2) >= 0;
@@ -1584,7 +1584,7 @@ span_ge(const Span *s1, const Span *s2)
  * @param[in] s1,s2 Sets
  * @csqlfn #Span_ge()
  */
-inline bool
+bool
 span_gt(const Span *s1, const Span *s2)
 {
   return span_cmp(s1, s2) > 0;

--- a/meos/src/temporal/span_ops.c
+++ b/meos/src/temporal/span_ops.c
@@ -177,7 +177,7 @@ contains_span_span(const Span *s1, const Span *s2)
  * @param[in] value Value
  * @param[in] s Span
  */
-inline bool
+bool
 contained_value_span(Datum value, const Span *s)
 {
   return contains_span_value(s, value);
@@ -189,7 +189,7 @@ contained_value_span(Datum value, const Span *s)
  * @param[in] s1,s2 Spans
  * @csqlfn #Contained_value_span()
  */
-inline bool
+bool
 contained_span_span(const Span *s1, const Span *s2)
 {
   return contains_span_span(s2, s1);
@@ -358,7 +358,7 @@ lfnadj_span_span(const Span *s1, const Span *s2)
  * @param[in] value Value
  * @param[in] s Span
  */
-inline bool
+bool
 right_value_span(Datum value, const Span *s)
 {
   return left_span_value(s, value);
@@ -370,7 +370,7 @@ right_value_span(Datum value, const Span *s)
  * @param[in] s Span
  * @param[in] value Value
  */
-inline bool
+bool
 right_span_value(const Span *s, Datum value)
 {
   return left_value_span(value, s);
@@ -382,7 +382,7 @@ right_span_value(const Span *s, Datum value)
  * @param[in] s1,s2 Spans
  * @csqlfn #Right_span_span()
  */
-inline bool
+bool
 right_span_span(const Span *s1, const Span *s2)
 {
   return left_span_span(s2, s1);

--- a/meos/src/temporal/spanset.c
+++ b/meos/src/temporal/spanset.c
@@ -178,7 +178,7 @@ spanset_find_value(const SpanSet *ss, Datum v, int *loc)
 }
 
 #if MEOS
-inline bool
+bool
 tstzspanset_find_timestamptz(const SpanSet *ss, TimestampTz t, int *loc)
 {
   return spanset_find_value(ss, TimestampTzGetDatum(t), loc);
@@ -1445,7 +1445,7 @@ spanset_eq(const SpanSet *ss1, const SpanSet *ss2)
  * @param[in] ss1,ss2 Span sets
  * @csqlfn #Spanset_ne()
  */
-inline bool
+bool
 spanset_ne(const SpanSet *ss1, const SpanSet *ss2)
 {
   return ! spanset_eq(ss1, ss2);
@@ -1496,7 +1496,7 @@ spanset_cmp(const SpanSet *ss1, const SpanSet *ss2)
  * @param[in] ss1,ss2 Span sets
  * @csqlfn #Spanset_lt()
  */
-inline bool
+bool
 spanset_lt(const SpanSet *ss1, const SpanSet *ss2)
 {
   return spanset_cmp(ss1, ss2) < 0;
@@ -1509,7 +1509,7 @@ spanset_lt(const SpanSet *ss1, const SpanSet *ss2)
  * @param[in] ss1,ss2 Span sets
  * @csqlfn #Spanset_le()
  */
-inline bool
+bool
 spanset_le(const SpanSet *ss1, const SpanSet *ss2)
 {
   return spanset_cmp(ss1, ss2) <= 0;
@@ -1522,7 +1522,7 @@ spanset_le(const SpanSet *ss1, const SpanSet *ss2)
  * @param[in] ss1,ss2 Span sets
  * @csqlfn #Spanset_ge()
  */
-inline bool
+bool
 spanset_ge(const SpanSet *ss1, const SpanSet *ss2)
 {
   return spanset_cmp(ss1, ss2) >= 0;
@@ -1534,7 +1534,7 @@ spanset_ge(const SpanSet *ss1, const SpanSet *ss2)
  * @param[in] ss1,ss2 Span sets
  * @csqlfn #Spanset_gt()
  */
-inline bool
+bool
 spanset_gt(const SpanSet *ss1, const SpanSet *ss2)
 {
   return spanset_cmp(ss1, ss2) > 0;

--- a/meos/src/temporal/spanset_ops.c
+++ b/meos/src/temporal/spanset_ops.c
@@ -190,7 +190,7 @@ contains_spanset_spanset(const SpanSet *ss1, const SpanSet *ss2)
  * @param[in] value Value
  * @param[in] ss Span set
  */
-inline bool
+bool
 contained_value_spanset(Datum value, const SpanSet *ss)
 {
   return contains_spanset_value(ss, value);
@@ -203,7 +203,7 @@ contained_value_spanset(Datum value, const SpanSet *ss)
  * @param[in] ss Span set
  * @csqlfn #Contained_span_spanset()
  */
-inline bool
+bool
 contained_span_spanset(const Span *s, const SpanSet *ss)
 {
   return contains_spanset_span(ss, s);
@@ -216,7 +216,7 @@ contained_span_spanset(const Span *s, const SpanSet *ss)
  * @param[in] s Span
  * @csqlfn #Contained_spanset_span()
  */
-inline bool
+bool
 contained_spanset_span(const SpanSet *ss, const Span *s)
 {
   return contains_span_spanset(s, ss);
@@ -228,7 +228,7 @@ contained_spanset_span(const SpanSet *ss, const Span *s)
  * @param[in] ss1,ss2 Span sets
  * @csqlfn #Contained_spanset_spanset()
  */
-inline bool
+bool
 contained_spanset_spanset(const SpanSet *ss1, const SpanSet *ss2)
 {
   return contains_spanset_spanset(ss2, ss1);
@@ -281,7 +281,7 @@ overlaps_spanset_span(const SpanSet *ss, const Span *s)
  * @param[in] ss Span set
  * @csqlfn #Overlaps_span_spanset()
  */
-inline bool
+bool
 overlaps_span_spanset(const Span *s, const SpanSet *ss)
 {
   return overlaps_spanset_span(ss, s);
@@ -341,7 +341,7 @@ overlaps_spanset_spanset(const SpanSet *ss1, const SpanSet *ss2)
  * @param[in] value Value
  * @csqlfn #Adjacent_spanset_value()
  */
-inline bool
+bool
 adjacent_spanset_value(const SpanSet *ss, Datum value)
 {
   /* A span set and a value are adjacent if and only if the first or the last
@@ -357,7 +357,7 @@ adjacent_spanset_value(const SpanSet *ss, Datum value)
  * @param[in] value Value
  * @csqlfn #Adjacent_spanset_value()
  */
-inline bool
+bool
 adjacent_value_spanset(Datum value, const SpanSet *ss)
 {
   return adjacent_spanset_value(ss, value);
@@ -398,7 +398,7 @@ adjacent_spanset_span(const SpanSet *ss, const Span *s)
  * @param[in] ss Span set
  * @csqlfn #Adjacent_span_spanset()
  */
-inline bool
+bool
 adjacent_span_spanset(const Span *s, const SpanSet *ss)
 {
   return adjacent_spanset_span(ss, s);
@@ -445,7 +445,7 @@ adjacent_spanset_spanset(const SpanSet *ss1, const SpanSet *ss2)
  * @param[in] value Value
  * @param[in] ss Span set
  */
-inline bool
+bool
 left_value_spanset(Datum value, const SpanSet *ss)
 {
   return left_value_span(value, SPANSET_SP_N(ss, 0));
@@ -473,7 +473,7 @@ left_span_spanset(const Span *s, const SpanSet *ss)
  * @param[in] ss Span set
  * @param[in] value Value
  */
-inline bool
+bool
 left_spanset_value(const SpanSet *ss, Datum value)
 {
   return left_span_value(SPANSET_SP_N(ss, ss->count - 1), value);
@@ -521,7 +521,7 @@ left_spanset_spanset(const SpanSet *ss1, const SpanSet *ss2)
  * @param[in] value Value
  * @param[in] ss Span set
  */
-inline bool
+bool
 right_value_spanset(Datum value, const SpanSet *ss)
 {
   return left_spanset_value(ss, value);
@@ -534,7 +534,7 @@ right_value_spanset(Datum value, const SpanSet *ss)
  * @param[in] ss Span set
  * @csqlfn #Right_span_spanset()
  */
-inline bool
+bool
 right_span_spanset(const Span *s, const SpanSet *ss)
 {
   return left_spanset_span(ss, s);
@@ -546,7 +546,7 @@ right_span_spanset(const Span *s, const SpanSet *ss)
  * @param[in] ss Span set
  * @param[in] value Value
  */
-inline bool
+bool
 right_spanset_value(const SpanSet *ss, Datum value)
 {
   return left_value_spanset(value, ss);
@@ -559,7 +559,7 @@ right_spanset_value(const SpanSet *ss, Datum value)
  * @param[in] s Span
  * @csqlfn #Right_spanset_span()
  */
-inline bool
+bool
 right_spanset_span(const SpanSet *ss, const Span *s)
 {
   return left_span_spanset(s, ss);
@@ -571,7 +571,7 @@ right_spanset_span(const SpanSet *ss, const Span *s)
  * @param[in] ss1,ss2 Span sets
  * @csqlfn #Right_spanset_spanset()
  */
-inline bool
+bool
 right_spanset_spanset(const SpanSet *ss1, const SpanSet *ss2)
 {
   return left_spanset_spanset(ss2, ss1);
@@ -587,7 +587,7 @@ right_spanset_spanset(const SpanSet *ss1, const SpanSet *ss2)
  * @param[in] ss Span set
  * @param[in] value Value
  */
-inline bool
+bool
 overleft_spanset_value(const SpanSet *ss, Datum value)
 {
   assert(ss);
@@ -1026,7 +1026,7 @@ intersection_spanset_span(const SpanSet *ss, const Span *s)
  * @param[in] ss Span set
  * @csqlfn #Intersection_span_spanset()
  */
-inline SpanSet *
+SpanSet *
 intersection_span_spanset(const Span *s, const SpanSet *ss)
 {
   return intersection_spanset_span(ss, s);

--- a/meos/src/temporal/tbox.c
+++ b/meos/src/temporal/tbox.c
@@ -249,7 +249,7 @@ number_timestamptz_to_tbox(Datum value, MeosType basetype, TimestampTz t)
  * @param[in] t Timestamp
  * @csqlfn #Number_timestamptz_to_tbox()
  */
-inline TBox *
+TBox *
 int_timestamptz_to_tbox(int i, TimestampTz t)
 {
   return number_timestamptz_to_tbox(Int32GetDatum(i), T_INT4, t);
@@ -262,7 +262,7 @@ int_timestamptz_to_tbox(int i, TimestampTz t)
  * @param[in] t Timestamp
  * @csqlfn #Number_timestamptz_to_tbox()
  */
-inline TBox *
+TBox *
 float_timestamptz_to_tbox(double d, TimestampTz t)
 {
   return number_timestamptz_to_tbox(Float8GetDatum(d), T_FLOAT8, t);
@@ -1368,7 +1368,7 @@ contains_tbox_tbox(const TBox *box1, const TBox *box2)
  * @param[in] box1,box2 Temporal boxes
  * @csqlfn #Contained_tbox_tbox()
  */
-inline bool
+bool
 contained_tbox_tbox(const TBox *box1, const TBox *box2)
 {
   return contains_tbox_tbox(box2, box1);
@@ -1714,7 +1714,7 @@ tbox_eq(const TBox *box1, const TBox *box2)
  * @param[in] box1,box2 Temporal boxes
  * @csqlfn #Tbox_ne()
  */
-inline bool
+bool
 tbox_ne(const TBox *box1, const TBox *box2)
 {
   return ! tbox_eq(box1, box2);
@@ -1766,7 +1766,7 @@ tbox_cmp(const TBox *box1, const TBox *box2)
  * @param[in] box1,box2 Temporal boxes
  * @csqlfn #Tbox_lt()
  */
-inline bool
+bool
 tbox_lt(const TBox *box1, const TBox *box2)
 {
   return tbox_cmp(box1, box2) < 0;
@@ -1779,7 +1779,7 @@ tbox_lt(const TBox *box1, const TBox *box2)
  * @param[in] box1,box2 Temporal boxes
  * @csqlfn #Tbox_le()
  */
-inline bool
+bool
 tbox_le(const TBox *box1, const TBox *box2)
 {
   return tbox_cmp(box1, box2) <= 0;
@@ -1792,7 +1792,7 @@ tbox_le(const TBox *box1, const TBox *box2)
  * @param[in] box1,box2 Temporal boxes
  * @csqlfn #Tbox_ge()
  */
-inline bool
+bool
 tbox_ge(const TBox *box1, const TBox *box2)
 {
   int cmp = tbox_cmp(box1, box2);
@@ -1805,7 +1805,7 @@ tbox_ge(const TBox *box1, const TBox *box2)
  * @param[in] box1,box2 Temporal boxes
  * @csqlfn #Tbox_gt()
  */
-inline bool
+bool
 tbox_gt(const TBox *box1, const TBox *box2)
 {
   return tbox_cmp(box1, box2) > 0;

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -3378,7 +3378,7 @@ temporal_eq(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal values
  * @csqlfn #Temporal_ne()
  */
-inline bool
+bool
 temporal_ne(const Temporal *temp1, const Temporal *temp2)
 {
   return ! temporal_eq(temp1, temp2);
@@ -3468,7 +3468,7 @@ temporal_cmp(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal values
  * @csqlfn #Temporal_lt()
  */
-inline bool
+bool
 temporal_lt(const Temporal *temp1, const Temporal *temp2)
 {
   return temporal_cmp(temp1, temp2) < 0;
@@ -3481,7 +3481,7 @@ temporal_lt(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal values
  * @csqlfn #Temporal_le()
  */
-inline bool
+bool
 temporal_le(const Temporal *temp1, const Temporal *temp2)
 {
   return temporal_cmp(temp1, temp2) <= 0;
@@ -3494,7 +3494,7 @@ temporal_le(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal values
  * @csqlfn #Temporal_gt()
  */
-inline bool
+bool
 temporal_ge(const Temporal *temp1, const Temporal *temp2)
 {
   return temporal_cmp(temp1, temp2) >= 0;
@@ -3506,7 +3506,7 @@ temporal_ge(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal values
  * @csqlfn #Temporal_ge()
  */
-inline bool
+bool
 temporal_gt(const Temporal *temp1, const Temporal *temp2)
 {
   return temporal_cmp(temp1, temp2) > 0;

--- a/meos/src/temporal/temporal_tile.c
+++ b/meos/src/temporal/temporal_tile.c
@@ -206,7 +206,7 @@ float_get_bin(double value, double size, double origin)
 /**
  * @brief Return the interval in the same representation as Postgres timestamps
  */
-inline int64
+int64
 interval_units(const Interval *interval)
 {
   return interval->time + (interval->day * USECS_PER_DAY);

--- a/meos/src/temporal/tinstant.c
+++ b/meos/src/temporal/tinstant.c
@@ -170,7 +170,7 @@ tinstant_to_string(const TInstant *inst, int maxdd, outfunc value_out)
  * @param[in] inst Temporal instant
  * @param[in] maxdd Maximum number of decimal digits
  */
-inline char *
+char *
 tinstant_out(const TInstant *inst, int maxdd)
 {
   return tinstant_to_string(inst, maxdd, &basetype_out);

--- a/meos/src/temporal/tsequence.c
+++ b/meos/src/temporal/tsequence.c
@@ -1075,7 +1075,7 @@ tsequence_make(TInstant **instants, int count, bool lower_inc, bool upper_inc,
  * @param[in] normalize True if the resulting value should be normalized
  * @see #tsequence_make
  */
-inline TSequence *
+TSequence *
 tsequence_make_free(TInstant **instants, int count, bool lower_inc,
   bool upper_inc, interpType interp, bool normalize)
 {
@@ -2476,7 +2476,7 @@ intersection_tcontseq_tdiscseq(const TSequence *seq1, const TSequence *seq2,
  * @param[out] inter1,inter2 Output values
  * @return Return false if the input values do not overlap on time.
  */
-inline bool
+bool
 intersection_tdiscseq_tcontseq(const TSequence *seq1, const TSequence *seq2,
   TSequence **inter1, TSequence **inter2)
 {
@@ -2738,7 +2738,7 @@ intersection_tsequence_tinstant(const TSequence *seq, const TInstant *inst,
  * @param[out] inter1, inter2 Output values
  * @return Return false if the input values do not overlap on time.
  */
-inline bool
+bool
 intersection_tinstant_tsequence(const TInstant *inst, const TSequence *seq,
   TInstant **inter1, TInstant **inter2)
 {

--- a/meos/src/temporal/tsequence_meos.c
+++ b/meos/src/temporal/tsequence_meos.c
@@ -69,7 +69,7 @@
  * @param[in] str String
  * @param[in] interp Interpolation
  */
-inline TSequence *
+TSequence *
 tboolseq_in(const char *str, interpType interp)
 {
   return tsequence_in(str, T_TBOOL, interp);
@@ -82,7 +82,7 @@ tboolseq_in(const char *str, interpType interp)
  * @param[in] str String
  * @param[in] interp Interpolation
  */
-inline TSequence *
+TSequence *
 tintseq_in(const char *str, interpType interp)
 {
   return tsequence_in(str, T_TINT, interp);
@@ -95,7 +95,7 @@ tintseq_in(const char *str, interpType interp)
  * @param[in] str String
  * @param[in] interp Interpolation
  */
-inline TSequence *
+TSequence *
 tfloatseq_in(const char *str, interpType interp)
 {
   return tsequence_in(str, T_TFLOAT, interp);
@@ -108,7 +108,7 @@ tfloatseq_in(const char *str, interpType interp)
  * @param[in] str String
  * @param[in] interp Interpolation
  */
-inline TSequence *
+TSequence *
 ttextseq_in(const char *str, interpType interp)
 {
   return tsequence_in(str, T_TTEXT, interp);

--- a/meos/src/temporal/type_in_meos.c
+++ b/meos/src/temporal/type_in_meos.c
@@ -57,7 +57,7 @@
  * @param[in] mfjson MFJSON object
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TInstant *
+TInstant *
 tboolinst_from_mfjson(json_object *mfjson)
 {
   return tinstant_from_mfjson(mfjson, false, 0, T_TBOOL);
@@ -69,7 +69,7 @@ tboolinst_from_mfjson(json_object *mfjson)
  * @param[in] mfjson MFJSON object
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TInstant *
+TInstant *
 tintinst_from_mfjson(json_object *mfjson)
 {
   return tinstant_from_mfjson(mfjson, false, 0, T_TINT);
@@ -81,7 +81,7 @@ tintinst_from_mfjson(json_object *mfjson)
  * @param[in] mfjson MFJSON object
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TInstant *
+TInstant *
 tfloatinst_from_mfjson(json_object *mfjson)
 {
   return tinstant_from_mfjson(mfjson, false, 0, T_TFLOAT);
@@ -93,7 +93,7 @@ tfloatinst_from_mfjson(json_object *mfjson)
  * @param[in] mfjson MFJSON object
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TInstant *
+TInstant *
 ttextinst_from_mfjson(json_object *mfjson)
 {
   return tinstant_from_mfjson(mfjson, false, 0, T_TTEXT);
@@ -107,7 +107,7 @@ ttextinst_from_mfjson(json_object *mfjson)
  * @param[in] mfjson MFJSON object
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequence *
+TSequence *
 tboolseq_from_mfjson(json_object *mfjson)
 {
   return tsequence_from_mfjson(mfjson, false, 0, T_TBOOL, STEP);
@@ -119,7 +119,7 @@ tboolseq_from_mfjson(json_object *mfjson)
  * @param[in] mfjson MFJSON object
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequence *
+TSequence *
 tintseq_from_mfjson(json_object *mfjson)
 {
   return tsequence_from_mfjson(mfjson, false, 0, T_TINT, STEP);
@@ -132,7 +132,7 @@ tintseq_from_mfjson(json_object *mfjson)
  * @param[in] interp Interpolation
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequence *
+TSequence *
 tfloatseq_from_mfjson(json_object *mfjson, interpType interp)
 {
   return tsequence_from_mfjson(mfjson, false, 0, T_TFLOAT, interp);
@@ -144,7 +144,7 @@ tfloatseq_from_mfjson(json_object *mfjson, interpType interp)
  * @param[in] mfjson MFJSON object
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequence *
+TSequence *
 ttextseq_from_mfjson(json_object *mfjson)
 {
   return tsequence_from_mfjson(mfjson, false, 0, T_TTEXT, STEP);
@@ -159,7 +159,7 @@ ttextseq_from_mfjson(json_object *mfjson)
  * @param[in] mfjson MFJSON object
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequenceSet *
+TSequenceSet *
 tboolseqset_from_mfjson(json_object *mfjson)
 {
   return tsequenceset_from_mfjson(mfjson, false, 0, T_TBOOL, STEP);
@@ -172,7 +172,7 @@ tboolseqset_from_mfjson(json_object *mfjson)
  * @param[in] mfjson MFJSON object
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequenceSet *
+TSequenceSet *
 tintseqset_from_mfjson(json_object *mfjson)
 {
   return tsequenceset_from_mfjson(mfjson, false, 0, T_TINT, STEP);
@@ -185,7 +185,7 @@ tintseqset_from_mfjson(json_object *mfjson)
  * @param[in] interp Interpolation
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequenceSet *
+TSequenceSet *
 tfloatseqset_from_mfjson(json_object *mfjson, interpType interp)
 {
   return tsequenceset_from_mfjson(mfjson, false, 0, T_TFLOAT, interp);
@@ -197,7 +197,7 @@ tfloatseqset_from_mfjson(json_object *mfjson, interpType interp)
  * @param[in] mfjson MFJSON object
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequenceSet *
+TSequenceSet *
 ttextseqset_from_mfjson(json_object *mfjson)
 {
   return tsequenceset_from_mfjson(mfjson, false, 0, T_TTEXT, STEP);
@@ -212,7 +212,7 @@ ttextseqset_from_mfjson(json_object *mfjson)
  * @return On error return @p NULL
  * @see #temporal_from_mfjson()
  */
-inline Temporal *
+Temporal *
 tbool_from_mfjson(const char *mfjson)
 {
   return temporal_from_mfjson(mfjson, T_TBOOL);
@@ -225,7 +225,7 @@ tbool_from_mfjson(const char *mfjson)
  * @return On error return @p NULL
  * @see #temporal_from_mfjson()
  */
-inline Temporal *
+Temporal *
 tint_from_mfjson(const char *mfjson)
 {
   return temporal_from_mfjson(mfjson, T_TINT);


### PR DESCRIPTION
## Summary

Two fixes that together let JNR-FFI / cffi consumers (JMEOS, PyMEOS,
MEOS-rs) bind the full public MEOS API without resorting to private-
header symbol-stub workarounds. Both are scoped to MEOS shared-library
exports — no behavioural change to any function's semantics.

### 1. Restore `meos_initialize_noexit_error_handler`

The default MEOS error handler calls `exit()` on every error, which
tears down the entire JVM/Python process — fatal for embedded contexts
where MEOS is loaded as a shared library. The noexit handler installs in
its place a function that records the errno (so callers can inspect via
`meos_errno()`) and writes to stderr instead of terminating the process.

This was previously added on a fork branch (commit `9ee6cf721`) but
never landed in mainline; consumers (notably MobilitySpark via JMEOS)
depend on it for crash safety. Without it, ~62 MobilitySpark tests
crash the JVM via the trigger-MEOS-error code paths.

Implementation reuses the existing thread-safe `MEOS_ERROR_HANDLER`
atomic from PR #815 — the new exporter is a one-liner
`__atomic_store_n`.

### 2. Drop unguarded `inline` from public C-SQL functions

446 functions across 44 files were declared `inline TYPE name(...)`
at top-level (not `static inline`). Per C99 semantics, an unguarded
`inline` definition has external linkage but the compiler MAY choose
to inline-only without emitting an external definition, leaving the
symbol absent from libmeos.so.

Real-world breakage: `acovers_tgeo_tgeo()` is a documented public
C-SQL entry point (`@csqlfn #Acovers_tgeo_tgeo()`) but was missing
from libmeos.so because of the `inline` qualifier. JMEOS could not
bind it; MobilitySpark's `aCoversTgeoTgeo` UDF therefore failed at
runtime.

Mechanical fix: `inline TYPE` at start-of-line becomes `TYPE`.
`static inline` (correct usage for translation-unit-private helpers)
is preserved unchanged.

Symbol count in libmeos.so increases from ~3070 to 3237 T-defined
symbols. All previously-callable functions remain callable — removing
`inline` never breaks correctness, only defeats an optimization hint
that was already unreliable for cross-TU use.

## Cross-platform impact

- **JMEOS PR #15** (regen against MEOS 1.4): drops the manual
  `extern int acovers_tgeo_tgeo(...)` workaround from its amalgamated
  meos.h once this lands; the symbol is then picked up automatically.
  Drops the `meos_initialize_noexit_error_handler` reflective fallback
  in MobilitySpark's `MeosThread`.
- **PyMEOS** / **MEOS-rs**: same regen pipeline benefits — any binding
  generator that walks the public meos.h surface gets the additional
  167 newly-exported symbols + the noexit safety helper.

## Test plan

- [x] `make meos` produces libmeos.so with `meos_initialize_noexit_error_handler`
      (`nm -D /usr/local/lib/libmeos.so | grep noexit`)
- [x] `make meos` produces libmeos.so with `acovers_tgeo_tgeo`
      (`nm -D /usr/local/lib/libmeos.so | grep acovers_tgeo_tgeo`)
- [x] MobilitySpark recovers from 845 / 907 (with reflective fallback,
      no noexit installed) to 906 / 907 (with this PR + JMEOS PR #15
      bumping the jar). The remaining 1 test failure
      (`MathUDFsExtTest.tnumberTrend_tint_returns_nonnull`) is a
      MobilitySpark fixture bug (passing tint/STEP to a function that
      requires linear interpolation) — unrelated; tracked separately.
- [ ] `mvn test` against PyMEOS — sanity check that no PyMEOS-bound
      symbol relied on a name that the inline-cleanup happens to rename
      (none expected; rename is mechanical, no symbol names change).