### PR TITLE
fix(lifting): demote LINEAR to STEP when result type is not continuous

### DIFF
--- a/meos/src/temporal/lifting.c
+++ b/meos/src/temporal/lifting.c
@@ -181,11 +181,34 @@
 /* MEOS */
 #include <meos.h>
 #include <meos_internal.h>
+#include "temporal/meos_catalog.h"
 #include "temporal/temporal_restrict.h"
 #include "temporal/tsequence.h"
 #include "temporal/tsequenceset.h"
 #include "temporal/type_util.h"
 #include "geo/tgeo_spatialfuncs.h"
+
+/*****************************************************************************
+ * Local helpers
+ *****************************************************************************/
+
+/**
+ * @brief Return the output interpolation for a lift operation
+ *
+ * The output sequence's interpolation matches the input's, demoted to
+ * STEP when the result type does not support LINEAR
+ * (`temptype_continuous(restype)` is false).  Using the catalog
+ * predicate keeps the interpolation contract enforceable at the lift
+ * level for every result type.
+ */
+static interpType
+lift_result_interp(const TSequence *seq, MeosType restype)
+{
+  interpType interp = MEOS_FLAGS_GET_INTERP(seq->flags);
+  if (interp == LINEAR && ! temptype_continuous(restype))
+    interp = STEP;
+  return interp;
+}
 
 /*****************************************************************************
  * Functions where the argument is a temporal type.
@@ -240,7 +263,8 @@ tfunc_tsequence(const TSequence *seq, LiftedFunctionInfo *lfinfo)
   for (int i = 0; i < seq->count; i++)
     instants[i] = tfunc_tinstant(TSEQUENCE_INST_N(seq, i), lfinfo);
   return tsequence_make_free(instants, seq->count, seq->period.lower_inc,
-    seq->period.upper_inc, MEOS_FLAGS_GET_INTERP(seq->flags), NORMALIZE);
+    seq->period.upper_inc, lift_result_interp(seq, lfinfo->restype),
+    NORMALIZE);
 }
 
 /**
@@ -335,11 +359,7 @@ tfunc_tsequence_base(const TSequence *seq, Datum value,
   TInstant **instants = palloc(sizeof(TInstant *) * seq->count);
   for (int i = 0; i < seq->count; i++)
     instants[i] = tfunc_tinstant_base(TSEQUENCE_INST_N(seq, i), value, lfinfo);
-  /* Set the interpolation depending on the one of the sequence and the result
-   * as stated in the `lfinfo` structure */
-  interpType interp = MEOS_FLAGS_GET_INTERP(seq->flags);
-  if (interp == LINEAR && ! lfinfo->reslinear)
-    interp = STEP;
+  interpType interp = lift_result_interp(seq, lfinfo->restype);
   /* The last two values of sequences with step interpolation and exclusive
      upper bound must be equal */
   if (! seq->period.upper_inc && interp == STEP)


### PR DESCRIPTION
## Why

The generic `tfunc_tsequence` lift in `meos/src/temporal/lifting.c` used the
input sequence's interpolation verbatim when constructing the output
sequence.  When a LINEAR sequence is lifted to a result type that does not
support LINEAR — i.e. any STEP-only type, concretely `th3index` which
materialises a discrete H3 cell at each instant — `tsequence_make_free` saw
`interp=LINEAR` on a STEP-only `temptype` and `ensure_valid_interp` correctly
errored:

```
ERROR:  The temporal type cannot have linear interpolation
```

The sibling `tfunc_tsequence_base` already carried an ad-hoc demotion of the
form `if (interp == LINEAR && ! lfinfo->reslinear) interp = STEP;`, but the
plain `tfunc_tsequence` had no such correction.  Any non-base-value lift
(the entire `tfunc_temporal(temp, lfinfo)` family) hit the error path for
STEP-only result types.

This was surfaced while running the BerlinMOD chapter 1 + th3index
benchmark on `feat/h3-static-geo-coverage` (PR #938).  The fix is
generic so it lands on master rather than stacked on the th3index
branch.

## What

Centralise the demotion in a single helper:

```c
static interpType
lift_result_interp(const TSequence *seq, MeosType restype)
{
  interpType interp = MEOS_FLAGS_GET_INTERP(seq->flags);
  if (interp == LINEAR && ! temptype_continuous(restype))
    interp = STEP;
  return interp;
}
```

Both `tfunc_tsequence` and `tfunc_tsequence_base` route through it,
removing the duplicated correction in the latter.  The helper uses
`temptype_continuous(restype)` — the catalog truth — instead of
`lfinfo->reslinear`, which is a per-caller flag each lift caller must
remember to set consistently with the result type.

## Behaviour change

- For callers where `reslinear` was set consistently with the result
  type (every caller in the current codebase, since `tfunc_tsequence_base`
  already had the demotion): behaviour is preserved — the helper returns
  the same answer either way.
- For the previously broken path (`tgeompoint_to_th3index` and any
  future lift to a STEP-only result type): now succeeds instead of
  erroring.  This is the bug fix.

## Test plan

- [ ] CI builds clean (master, no H3) — verified locally with
      `cmake -DCMAKE_BUILD_TYPE=Release .. && make -j16`.
- [ ] Stacked manual test on `feat/h3-static-geo-coverage`:
      `SELECT temporal_out(h3_latlng_to_cell(trip4326, 7)) FROM trips LIMIT 1`
      succeeds instead of erroring.
- [ ] Existing test suite continues to pass (the helper preserves the
      previous answer for every caller in the catalog today).

## References

- BerlinMOD bench report that surfaced the bug:
  `MobilityDB-BerlinMOD/doc/benchmarks/MobilityDB_BerlinMOD_th3index_bench.md`
  (in the PR being filed in parallel).
- Related PR: #938 `feat(h3): static-geometry → H3 cell set public API`
  (open).