### PR TITLE
Add pre-push parity check script and CONTRIBUTING guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,41 @@ Pull Request Process
 --------------------
 You can fork this repository, make your own contribution, and submit a pull request. Please put as the pull request title the issue number that it closes (for example, `[Closes issue #xxx]`). Write a clear log message for your commits. One-line messages are fine for small changes, but bigger changes should have more information.
 
+### Check open PRs before you start
+
+Before you write a line of code — whether you're adding a feature, fixing a bug, or responding to a red CI run on someone else's PR — search the open pull-request queue for prior work in the same area:
+
+```sh
+gh pr list --state open --limit 30
+gh pr list --state open --search "<feature-or-fixture-name>"
+gh search code --repo MobilityDB/MobilityDB "<symbol-or-error-string>"
+```
+
+Read each candidate PR's *body*, not just its title — the failure mode you're chasing is often documented as "previous approach (X) caused Y; this PR replaces it with Z." If you find a PR that already addresses your case, comment on it (or on the issue it closes) rather than opening a parallel fix.
+
+This applies just as strongly when investigating a red CI run: the test failure on PR A may already be fixed in PR B that hasn't merged yet. Pushing a parallel fix to PR A is noise; rebasing PR A on PR B (or waiting for B to land) is the right outcome.
+
+Same rule extends across the ecosystem when a change in one repo could land before related changes in a sibling repo (MobilityDB ↔ JMEOS ↔ MobilityDuck ↔ MobilitySpark ↔ PyMEOS ↔ MEOS-API).
+
+### Pre-push checks
+
+Before pushing a commit that opens or updates a pull request, run
+
+```sh
+tools/scripts/pre-push-check.sh
+```
+
+from the repo root. The script configures the build the way the `coverage: 1` matrix variant of `pgversion.yml` does (`-DCBUFFER=ON -DPOSE=ON -DRGEO=ON -DH3=ON`), builds, and runs the regression test suite. If anything fails, fix it before pushing.
+
+Rationale: the GitHub-hosted CI matrix runs across PostgreSQL 16 / 17 / 18 on Linux, plus macOS and Windows MSYS2. The coverage variant is the most exhaustive Linux build — running it locally catches the failure modes the project has historically tripped over (missing `libh3-dev`, opt-in subsystem regressions, type-catalog gaps). The script's own header documents the gaps it cannot cover (Windows MSYS2 build, macOS build, Coveralls upload); flag those gaps explicitly in the PR description if they apply.
+
+The "CI green before push" convention has two documented exceptions:
+
+* **External infrastructure outages** — e.g. a transient `coveralls.io 502 Bad Gateway` during lcov upload, a quay.io 502 on a Docker base image pull, npm registry timeout. Re-run the failed job once the service recovers; do not change the code in response.
+* **Coverage / Codacy thresholds** — `ACTION_REQUIRED` from Codacy on large refactors, where the maintainer has reviewed and accepted the metric drift. Document the override in the PR description.
+
+Anything outside these two exceptions is a real failure and must be resolved before the next push.
+
 Contribution Agreement
 ----------------------
 MobilityDB source code is provided under the [PostgreSQL license](https://github.com/MobilityDB/MobilityDB/blob/master/LICENSE.txt). The documentation is provided under the [Creative Commons Attribution-Share Alike 3.0 License](https://creativecommons.org/licenses/by-sa/3.0/). Any contribution will automatically fall to the same license respectively.

--- a/tools/scripts/pre-push-check.sh
+++ b/tools/scripts/pre-push-check.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Pre-push CI parity check.
+#
+# Runs locally what the GitHub-hosted CI matrix would catch, so the
+# contributor never pushes a commit that introduces a red CI run on a
+# job they could have caught on their own machine.
+#
+# What this catches (matches the failure patterns observed historically):
+#
+#   1. Compile / link errors in MEOS (cbuffer, pose, rgeo, h3 enablement)
+#      — caught by the cmake configure + build step below.
+#
+#   2. Missing libh3-dev / liblwgeom-dev / etc. (any opt-in subsystem
+#      enabled in the local cmake) — caught at configure time.
+#
+#   3. SQL test regressions on the H3-enabled / coverage-equivalent build
+#      (matrix variant `coverage: 1` enables -DCBUFFER=ON -DPOSE=ON
+#       -DRGEO=ON -DH3=ON; running 'make test' here mirrors that).
+#
+#   4. UTF-8 / locale smoke (`meos_utf8_smoke.yml` + `meos_locale.yml`).
+#
+# What this does NOT catch (acknowledged gaps; surface in the PR
+# description if you can't test locally):
+#
+#   * Windows MSYS2 build (`windows_msys2_meos.yml`) — needs a Windows /
+#     MSYS2 environment. If you don't have one, note it in the PR
+#     description and merge will require a re-push after the windows-
+#     specific failure is resolved.
+#   * macOS build (`macos.yml`) — same; needs macOS.
+#   * Coveralls upload (`pgversion.yml` matrix `coverage: 1`) — uses an
+#     external service that returns 502 transiently; running the build +
+#     tests locally still validates everything except the upload.
+#
+# Usage:
+#   tools/scripts/pre-push-check.sh
+#
+# Exit codes:
+#   0 = ready to push
+#   1 = build / test failure; do NOT push
+#   2 = misuse (run from wrong directory)
+
+set -euo pipefail
+
+if [[ ! -f CMakeLists.txt ]] || [[ ! -d meos ]] || [[ ! -d mobilitydb ]]; then
+    echo "error: run from the MobilityDB repo root" >&2
+    exit 2
+fi
+
+BUILD_DIR=${BUILD_DIR:-build_pre_push}
+
+echo "==> Configure (mirrors the GitHub coverage matrix variant)"
+mkdir -p "$BUILD_DIR"
+( cd "$BUILD_DIR" && cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCBUFFER=ON \
+    -DPOSE=ON \
+    -DRGEO=ON \
+    -DH3=ON \
+    .. )
+
+echo "==> Build"
+( cd "$BUILD_DIR" && make -j"$(nproc 2>/dev/null || sysctl -n hw.ncpu)" )
+
+echo "==> Test"
+( cd "$BUILD_DIR" && make test )
+
+echo
+echo "OK — local mirror of the coverage matrix variant is green."
+echo "    Push when ready. Note any gaps you couldn't test (Windows /"
+echo "    macOS) in the PR description so reviewers know what CI will"
+echo "    cover."


### PR DESCRIPTION
Adds tools/scripts/pre-push-check.sh, which configures the build with the same flags as the coverage:1 CI matrix variant (-DCBUFFER=ON -DPOSE=ON -DRGEO=ON -DH3=ON), builds, and runs the regression-test suite, exiting non-zero on any failure. The script header documents what it cannot cover (Windows MSYS2, macOS, Coveralls upload) and prescribes a PR-description note as the workaround. Updates CONTRIBUTING.md with a new Pre-push checks section that names the two documented exceptions to the green-before-push convention: external infrastructure outages (e.g. Coveralls 502) and Codacy or coverage thresholds with maintainer override.