### PR TITLE
Clear cbuffer SKIP_TESTS and fix 160 LIMIT-determinism (stacked on #946)

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -77,17 +77,8 @@ jobs:
             --suppress='*:*/postgres/*' \
             --suppress='*:*/postgis/*' \
             --suppress='*:*/pgtypes/*' \
-            --suppress='*:*/h3-pg/*' \
-            --suppress='*:postgres/*' \
-            --suppress='*:postgis/*' \
-            --suppress='*:pgtypes/*' \
-            --suppress='*:h3-pg/*' \
             --suppress='missingIncludeSystem' \
             --suppress='unmatchedSuppression' \
-            --suppress='preprocessorErrorDirective:*/postgres/*' \
-            --suppress='preprocessorErrorDirective:postgres/*' \
-            -DUINT64_FORMAT='"%llu"' \
-            -DINT64_FORMAT='"%lld"' \
             --xml --xml-version=2 \
             -j "$(nproc)" \
             2> cppcheck.xml || true

--- a/meos/include/cbuffer/tcbuffer_spatialfuncs.h
+++ b/meos/include/cbuffer/tcbuffer_spatialfuncs.h
@@ -44,10 +44,12 @@
 
 /* Traversed area functions */
 
-extern GSERIALIZED *tcbufferinst_trav_area(const TInstant *inst);
-extern GSERIALIZED *tcbufferseq_trav_area(const TSequence *seq);
-extern GSERIALIZED *tcbufferseqset_trav_area(const TSequenceSet *ss);
-extern GSERIALIZED *tcbuffersegm_trav_area(const TInstant *inst1,
+extern GSERIALIZED *tcbufferinst_traversed_area(const TInstant *inst);
+extern GSERIALIZED *tcbufferseq_traversed_area(const TSequence *seq,
+  bool unary_union);
+extern GSERIALIZED *tcbufferseqset_traversed_area(const TSequenceSet *ss,
+  bool unary_union);
+extern GSERIALIZED *tcbuffersegm_traversed_area(const TInstant *inst1,
   const TInstant *inst2);
 
 /* Restriction functions */

--- a/meos/include/meos_cbuffer.h
+++ b/meos/include/meos_cbuffer.h
@@ -232,7 +232,6 @@ extern Temporal *tcbuffer_make(const Temporal *tpoint, const Temporal *tfloat);
 extern Set *tcbuffer_points(const Temporal *temp);
 extern Set *tcbuffer_radius(const Temporal *temp);
 extern GSERIALIZED *tcbuffer_traversed_area(const Temporal *temp, bool unary_union);
-extern GSERIALIZED *tcbuffer_trav_area(const Temporal *temp, bool merge_union);
 extern GSERIALIZED *tcbuffer_convex_hull(const Temporal *temp);
 
 /*****************************************************************************

--- a/meos/include/meos_cbuffer.h
+++ b/meos/include/meos_cbuffer.h
@@ -232,6 +232,8 @@ extern Temporal *tcbuffer_make(const Temporal *tpoint, const Temporal *tfloat);
 extern Set *tcbuffer_points(const Temporal *temp);
 extern Set *tcbuffer_radius(const Temporal *temp);
 extern GSERIALIZED *tcbuffer_traversed_area(const Temporal *temp, bool unary_union);
+extern GSERIALIZED *tcbuffer_trav_area(const Temporal *temp, bool merge_union);
+extern GSERIALIZED *tcbuffer_convex_hull(const Temporal *temp);
 
 /*****************************************************************************
  * Conversion functions

--- a/meos/include/meos_cbuffer.h
+++ b/meos/include/meos_cbuffer.h
@@ -231,7 +231,7 @@ extern Temporal *tcbuffer_make(const Temporal *tpoint, const Temporal *tfloat);
 
 extern Set *tcbuffer_points(const Temporal *temp);
 extern Set *tcbuffer_radius(const Temporal *temp);
-extern GSERIALIZED *tcbuffer_trav_area(const Temporal *temp, bool merge_union);
+extern GSERIALIZED *tcbuffer_traversed_area(const Temporal *temp, bool unary_union);
 
 /*****************************************************************************
  * Conversion functions

--- a/meos/include/temporal/lifting.h
+++ b/meos/include/temporal/lifting.h
@@ -64,6 +64,13 @@ typedef struct
   bool invert;                /**< True if the arguments of the function must be inverted */
   bool discont;               /**< True if the function has instantaneous discontinuities */
   bool ever;                  /**< True/false when computing the ever/always semantics */
+  bool cross_type;            /**< True if the right-hand argument's type differs from
+                                 the temporal value's basetype (e.g. trgeometry vs
+                                 geometry where basetype is Pose). When set,
+                                 segment-locate intersection finding is skipped, since
+                                 the segment-locate dispatchers (datumsegm_locate)
+                                 assume same-type comparisons and would reinterpret
+                                 the right-hand bytes through the wrong type. */
   tpfunc_base tpfn_base;      /**< Turning point function for temporal and base types*/
   tpfunc_temp tpfn_temp;      /**< Turning point function for two temporal types */
 } LiftedFunctionInfo;

--- a/meos/src/cbuffer/tcbuffer.c
+++ b/meos/src/cbuffer/tcbuffer.c
@@ -227,24 +227,35 @@ tcbuffersegm_dwithin_turnpt(Datum start1, Datum end1, Datum start2, Datum end2,
       }
     }
   }
-  if (nroots == 0)
+  /* Filter to only strictly internal timestamps: t ∈ (lower, upper).
+   * Boundary roots (t == lower or t == upper) are not "crossings" the
+   * caller needs to splice; they are handled by the surrounding sequence
+   * construction logic. Returning them causes duplicate-timestamp errors. */
+  double valid[2];
+  int nvalid = 0;
+  for (int i = 0; i < nroots; i++)
+  {
+    TimestampTz t = lower + (TimestampTz) roots[i];
+    if (t > lower && t < upper)
+    {
+      if (nvalid == 0 || fabs(roots[i] - valid[nvalid - 1]) > FP_TOLERANCE)
+        valid[nvalid++] = roots[i];
+    }
+  }
+  if (nvalid == 0)
   {
     *t1 = *t2 = (TimestampTz) 0;
     return 0;
   }
-  else if (nroots == 1)
+  else if (nvalid == 1)
   {
-    *t1 = *t2 = lower + (TimestampTz) roots[0];
+    *t1 = *t2 = lower + (TimestampTz) valid[0];
     return 1;
   }
   else
   {
-    if (roots[0] > roots[1])
-    {
-      double tmp = roots[0]; roots[0] = roots[1]; roots[1] = tmp;
-    }
-    *t1 = lower + (TimestampTz) roots[0];
-    *t2 = lower + (TimestampTz) roots[1];
+    *t1 = lower + (TimestampTz) valid[0];
+    *t2 = lower + (TimestampTz) valid[1];
     return 2;
   }
 }

--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -32,8 +32,6 @@
  * @brief Temporal distance for temporal circular buffers
  */
 
-/* C */
-#include <float.h>
 /* MEOS */
 #include <meos.h>
 #include <meos_internal.h>
@@ -521,7 +519,7 @@ nad_cbuffer_stbox(const Cbuffer *cb, const STBox *box)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_cbuffer_stbox(cb, box))
-    return DBL_MAX;
+    return -1.0;
 
   Datum geocbuf = PointerGetDatum(cbuffer_to_geom(cb));
   Datum geobox = PointerGetDatum(stbox_geo(box));
@@ -545,7 +543,7 @@ nad_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
-    return DBL_MAX;
+    return -1.0;
 
   GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
   double result = geom_distance2d(trav, gs);
@@ -566,7 +564,7 @@ nad_tcbuffer_stbox(const Temporal *temp, const STBox *box)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tcbuffer_stbox(temp, box))
-    return DBL_MAX;
+    return -1.0;
 
   GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
   GSERIALIZED *geo = stbox_geo(box);
@@ -588,7 +586,7 @@ nad_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tcbuffer_cbuffer(temp, cb))
-    return DBL_MAX;
+    return -1.0;
 
   GSERIALIZED *geom = cbuffer_to_geom(cb);
   GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
@@ -608,11 +606,11 @@ nad_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tcbuffer_tcbuffer(temp1, temp2))
-    return DBL_MAX;
+    return -1.0;
 
   Temporal *dist = tdistance_tcbuffer_tcbuffer(temp1, temp2);
   if (dist == NULL)
-    return DBL_MAX;
+    return -1.0;
   double result = DatumGetFloat8(temporal_min_value(dist));
   pfree(dist);
   return result;

--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -173,26 +173,27 @@ tcbuffer_cbuffer_distance_turnpt(Datum start, Datum end, Datum value,
       t_out = t;
     }
 
-    /* Check if the turning points are truly internal */
-    if (t_in > lower && t_out < upper)
+    /* Keep only turning points strictly inside (lower, upper) */
+    bool in_internal  = (t_in  > lower && t_in  < upper);
+    bool out_internal = (t_out > lower && t_out < upper);
+    if (in_internal && out_internal)
     {
       *t1 = t_in;
       *t2 = t_out;
       return 2;
     }
-    else if (t_in > lower && t_out >= upper)
+    else if (in_internal)
     {
       *t1 = *t2 = t_in;
       return 1;
     }
-    else if (t_in <= lower && t_out < upper)
+    else if (out_internal)
     {
       *t1 = *t2 = t_out;
       return 1;
     }
     else
     {
-      /* No true internal turning point */
       *t1 = *t2 = (TimestampTz) 0;
       return 0;
     }
@@ -284,26 +285,27 @@ cbuffersegm_distance_turnpt(const Cbuffer *start1, const Cbuffer *end1,
     TimestampTz t_out = lower + (TimestampTz)((t_rel +
       (duration - t_rel) * alpha_out));
 
-    /* Check if the turning points are truly internal */
-    if (t_in > lower && t_out < upper)
+    /* Keep only turning points strictly inside (lower, upper) */
+    bool in_internal  = (t_in  > lower && t_in  < upper);
+    bool out_internal = (t_out > lower && t_out < upper);
+    if (in_internal && out_internal)
     {
       *t1 = t_in;
       *t2 = t_out;
       return 2;
     }
-    else if (t_in > lower && t_out >= upper)
+    else if (in_internal)
     {
       *t1 = *t2 = t_in;
       return 1;
     }
-    else if (t_in <= lower && t_out < upper)
+    else if (out_internal)
     {
       *t1 = *t2 = t_out;
       return 1;
     }
     else
     {
-      /* No true internal turning point */
       *t1 = *t2 = (TimestampTz) 0;
       return 0;
     }
@@ -545,7 +547,7 @@ nad_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
   if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
     return -1.0;
 
-  GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
+  GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
   double result = geom_distance2d(trav, gs);
   pfree(trav);
   return result;
@@ -566,7 +568,7 @@ nad_tcbuffer_stbox(const Temporal *temp, const STBox *box)
   if (! ensure_valid_tcbuffer_stbox(temp, box))
     return -1.0;
 
-  GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
+  GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
   GSERIALIZED *geo = stbox_geo(box);
   double result = geom_distance2d(trav, geo);
   pfree(trav); pfree(geo);
@@ -589,7 +591,7 @@ nad_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
     return -1.0;
 
   GSERIALIZED *geom = cbuffer_to_geom(cb);
-  GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
+  GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
   double result = geom_distance2d(trav, geom);
   pfree(trav); pfree(geom);
   return result;
@@ -635,7 +637,7 @@ shortestline_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
   if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
     return NULL;
 
-  GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
+  GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
   GSERIALIZED *result = geom_shortestline2d(trav, gs);
   pfree(trav);
   return result;
@@ -657,7 +659,7 @@ shortestline_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
     return NULL;
 
   GSERIALIZED *geom = cbuffer_to_geom(cb);
-  GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
+  GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
   GSERIALIZED *result = geom_shortestline2d(trav, geom);
   pfree(geom); pfree(trav);
   return result;

--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -32,6 +32,8 @@
  * @brief Temporal distance for temporal circular buffers
  */
 
+/* C */
+#include <float.h>
 /* MEOS */
 #include <meos.h>
 #include <meos_internal.h>
@@ -173,9 +175,11 @@ tcbuffer_cbuffer_distance_turnpt(Datum start, Datum end, Datum value,
       t_out = t;
     }
 
-    /* Keep only turning points strictly inside (lower, upper) */
+    /* Only return timestamps strictly inside (lower, upper); boundary values
+     * can arise when alpha_in/alpha_out fall outside [0, 1]. */
     bool in_internal  = (t_in  > lower && t_in  < upper);
     bool out_internal = (t_out > lower && t_out < upper);
+
     if (in_internal && out_internal)
     {
       *t1 = t_in;
@@ -194,6 +198,7 @@ tcbuffer_cbuffer_distance_turnpt(Datum start, Datum end, Datum value,
     }
     else
     {
+      /* No true internal turning point */
       *t1 = *t2 = (TimestampTz) 0;
       return 0;
     }
@@ -285,9 +290,13 @@ cbuffersegm_distance_turnpt(const Cbuffer *start1, const Cbuffer *end1,
     TimestampTz t_out = lower + (TimestampTz)((t_rel +
       (duration - t_rel) * alpha_out));
 
-    /* Keep only turning points strictly inside (lower, upper) */
+    /* Only return timestamps strictly inside (lower, upper); boundary values
+     * can arise when both dist_start and dist_end are negative (circles
+     * overlap throughout the segment), causing alpha_in/alpha_out to fall
+     * outside [0, 1]. */
     bool in_internal  = (t_in  > lower && t_in  < upper);
     bool out_internal = (t_out > lower && t_out < upper);
+
     if (in_internal && out_internal)
     {
       *t1 = t_in;
@@ -306,6 +315,7 @@ cbuffersegm_distance_turnpt(const Cbuffer *start1, const Cbuffer *end1,
     }
     else
     {
+      /* No true internal turning point */
       *t1 = *t2 = (TimestampTz) 0;
       return 0;
     }
@@ -521,7 +531,7 @@ nad_cbuffer_stbox(const Cbuffer *cb, const STBox *box)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_cbuffer_stbox(cb, box))
-    return -1.0;
+    return DBL_MAX;
 
   Datum geocbuf = PointerGetDatum(cbuffer_to_geom(cb));
   Datum geobox = PointerGetDatum(stbox_geo(box));
@@ -545,9 +555,9 @@ nad_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
-    return -1.0;
+    return DBL_MAX;
 
-  GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
+  GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
   double result = geom_distance2d(trav, gs);
   pfree(trav);
   return result;
@@ -566,9 +576,9 @@ nad_tcbuffer_stbox(const Temporal *temp, const STBox *box)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tcbuffer_stbox(temp, box))
-    return -1.0;
+    return DBL_MAX;
 
-  GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
+  GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
   GSERIALIZED *geo = stbox_geo(box);
   double result = geom_distance2d(trav, geo);
   pfree(trav); pfree(geo);
@@ -588,10 +598,10 @@ nad_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tcbuffer_cbuffer(temp, cb))
-    return -1.0;
+    return DBL_MAX;
 
   GSERIALIZED *geom = cbuffer_to_geom(cb);
-  GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
+  GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
   double result = geom_distance2d(trav, geom);
   pfree(trav); pfree(geom);
   return result;
@@ -608,11 +618,11 @@ nad_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tcbuffer_tcbuffer(temp1, temp2))
-    return -1.0;
+    return DBL_MAX;
 
   Temporal *dist = tdistance_tcbuffer_tcbuffer(temp1, temp2);
   if (dist == NULL)
-    return -1.0;
+    return DBL_MAX;
   double result = DatumGetFloat8(temporal_min_value(dist));
   pfree(dist);
   return result;
@@ -637,7 +647,7 @@ shortestline_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
   if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
     return NULL;
 
-  GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
+  GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
   GSERIALIZED *result = geom_shortestline2d(trav, gs);
   pfree(trav);
   return result;
@@ -659,7 +669,7 @@ shortestline_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
     return NULL;
 
   GSERIALIZED *geom = cbuffer_to_geom(cb);
-  GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
+  GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
   GSERIALIZED *result = geom_shortestline2d(trav, geom);
   pfree(geom); pfree(trav);
   return result;

--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -557,7 +557,7 @@ nad_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
   if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
     return DBL_MAX;
 
-  GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
+  GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
   double result = geom_distance2d(trav, gs);
   pfree(trav);
   return result;
@@ -578,7 +578,7 @@ nad_tcbuffer_stbox(const Temporal *temp, const STBox *box)
   if (! ensure_valid_tcbuffer_stbox(temp, box))
     return DBL_MAX;
 
-  GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
+  GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
   GSERIALIZED *geo = stbox_geo(box);
   double result = geom_distance2d(trav, geo);
   pfree(trav); pfree(geo);
@@ -601,7 +601,7 @@ nad_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
     return DBL_MAX;
 
   GSERIALIZED *geom = cbuffer_to_geom(cb);
-  GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
+  GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
   double result = geom_distance2d(trav, geom);
   pfree(trav); pfree(geom);
   return result;
@@ -647,7 +647,7 @@ shortestline_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
   if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
     return NULL;
 
-  GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
+  GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
   GSERIALIZED *result = geom_shortestline2d(trav, gs);
   pfree(trav);
   return result;
@@ -669,7 +669,7 @@ shortestline_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
     return NULL;
 
   GSERIALIZED *geom = cbuffer_to_geom(cb);
-  GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
+  GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
   GSERIALIZED *result = geom_shortestline2d(trav, geom);
   pfree(geom); pfree(trav);
   return result;

--- a/meos/src/cbuffer/tcbuffer_spatialfuncs.c
+++ b/meos/src/cbuffer/tcbuffer_spatialfuncs.c
@@ -703,7 +703,7 @@ GSERIALIZED *
 tcbuffer_convex_hull(const Temporal *temp)
 {
   VALIDATE_TCBUFFER(temp, NULL);
-  GSERIALIZED *trav = tcbuffer_trav_area(temp, UNARY_UNION_NO);
+  GSERIALIZED *trav = tcbuffer_traversed_area(temp, UNARY_UNION_NO);
   if (! trav)
     return NULL;
   GSERIALIZED *result = geom_convex_hull(trav);

--- a/meos/src/cbuffer/tcbuffer_spatialfuncs.c
+++ b/meos/src/cbuffer/tcbuffer_spatialfuncs.c
@@ -692,4 +692,23 @@ tcbuffer_traversed_area(const Temporal *temp, bool unary_union)
   }
 }
 
+/**
+ * @ingroup meos_cbuffer_spatial_accessor
+ * @brief Return the convex hull of the traversed area of a temporal circular buffer
+ * @param[in] temp Temporal circular buffer
+ * @return On error return NULL
+ * @csqlfn #Tcbuffer_convex_hull()
+ */
+GSERIALIZED *
+tcbuffer_convex_hull(const Temporal *temp)
+{
+  VALIDATE_TCBUFFER(temp, NULL);
+  GSERIALIZED *trav = tcbuffer_trav_area(temp, UNARY_UNION_NO);
+  if (! trav)
+    return NULL;
+  GSERIALIZED *result = geom_convex_hull(trav);
+  pfree(trav);
+  return result;
+}
+
 /*****************************************************************************/

--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -240,7 +240,7 @@ ea_spatialrel_tcbufferseq_linear_geo(const TSequence *seq,
   for (int i = 1; i < seq->count; i++)
   {
     const TInstant *inst2 = TSEQUENCE_INST_N(seq, i);
-    GSERIALIZED *trav = tcbuffersegm_trav_area(inst1, inst2);
+    GSERIALIZED *trav = tcbuffersegm_traversed_area(inst1, inst2);
     int result = spatialrel_geo_geo(trav, gs, param, func, numparam, invert);
     pfree(trav);
     if (result == 1 && ever)
@@ -1501,7 +1501,7 @@ ea_dwithin_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
   lfinfo.numparam = 1;
   lfinfo.param[0] = Float8GetDatum(dist);
   lfinfo.argtype[0] = lfinfo.argtype[1] = temp1->temptype;
-  lfinfo.restype = T_TFLOAT;
+  lfinfo.restype = T_TBOOL;
   lfinfo.reslinear = false;
   lfinfo.invert = INVERT_NO;
   lfinfo.discont = MEOS_FLAGS_LINEAR_INTERP(temp1->flags) ||

--- a/meos/src/cbuffer/tcbuffer_tempspatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_tempspatialrels.c
@@ -131,7 +131,7 @@ tinterrel_tcbufferinst_geom(const TInstant *inst, const GSERIALIZED *gs,
 {
   assert(inst); assert(gs); assert(! gserialized_is_empty(gs));
   assert(inst->temptype == T_TCBUFFER);
-  GSERIALIZED *trav = tcbufferinst_trav_area(inst);
+  GSERIALIZED *trav = tcbufferinst_traversed_area(inst);
   GSERIALIZED *inter = geom_intersection2d_coll(trav, gs);
   pfree(trav);
   Datum datum_true = tinter ? BoolGetDatum(true) : BoolGetDatum(false);
@@ -160,7 +160,7 @@ tinterrel_tcbufferseq_disc_geom(const TSequence *seq, const GSERIALIZED *gs,
   assert(MEOS_FLAGS_GET_INTERP(seq->flags) == DISCRETE);
   /* Compute the intersection of the traversed area of a temporal circular
    * buffer and the geometry */
-  GSERIALIZED *trav = tcbufferseq_trav_area(seq);
+  GSERIALIZED *trav = tcbufferseq_traversed_area(seq, false);
   GSERIALIZED *inter = geom_intersection2d_coll(trav, gs);
   pfree(trav);
   /* If there is no intersection */
@@ -176,7 +176,7 @@ tinterrel_tcbufferseq_disc_geom(const TSequence *seq, const GSERIALIZED *gs,
   for (int i = 0; i < seq->count; i++)
   {
     const TInstant *inst = TSEQUENCE_INST_N(seq, i);
-    GSERIALIZED *circle = tcbufferinst_trav_area(inst);
+    GSERIALIZED *circle = tcbufferinst_traversed_area(inst);
     /* Loop for each point in the intersection */
     bool found = false;
     for (int j = 0; j < npoints; j++)
@@ -205,10 +205,10 @@ tinterrel_tcbufferseq_disc_geom(const TSequence *seq, const GSERIALIZED *gs,
   /* Compute the result */
   Datum bool_true = tinter ? BoolGetDatum(true) : BoolGetDatum(false);
   Datum bool_false = tinter ? BoolGetDatum(false) : BoolGetDatum(true);
-  /* If there is no intersection */
+  /* If no individual instant intersects */
   if (! s)
-    return (Temporal *) tsequence_from_base_temp(bool_true, T_TBOOL, seq);
-  TSequence *res_true = tsequence_from_base_tstzset(bool_false, T_TBOOL, s);
+    return (Temporal *) tsequence_from_base_temp(bool_false, T_TBOOL, seq);
+  TSequence *res_true = tsequence_from_base_tstzset(bool_true, T_TBOOL, s);
   int count;
   TimestampTz *times = tsequence_timestamps(seq, &count);
   Datum *datumarr = palloc(sizeof(Datum) * count);
@@ -249,7 +249,7 @@ tinterrel_tcbufferseq_step_geom(const TSequence *seq, const GSERIALIZED *gs,
   assert(MEOS_FLAGS_GET_INTERP(seq->flags) == STEP);
   /* Compute the intersection of the traversed area of a temporal circular
    * buffer and the geometry */
-  GSERIALIZED *trav = tcbufferseq_trav_area(seq);
+  GSERIALIZED *trav = tcbufferseq_traversed_area(seq, false);
   GSERIALIZED *inter = geom_intersection2d_coll(trav, gs);
   pfree(trav);
   /* If there is no intersection */
@@ -269,7 +269,7 @@ tinterrel_tcbufferseq_step_geom(const TSequence *seq, const GSERIALIZED *gs,
       TSEQUENCE_INST_N(seq, i + 1) : inst;
     TimestampTz mint = DT_NOEND, maxt = DT_NOBEGIN;
     bool upper_inc = (i == seq->count - 1) ? false : seq->period.upper_inc;
-    GSERIALIZED *circle = tcbufferinst_trav_area(inst);
+    GSERIALIZED *circle = tcbufferinst_traversed_area(inst);
     /* Loop for each point in the intersection */
     for (int j = 0; j < npoints; j++)
     {
@@ -360,7 +360,7 @@ tinterrel_tcbufferseq_linear_geom(const TSequence *seq, const GSERIALIZED *gs,
   assert(MEOS_FLAGS_LINEAR_INTERP(seq->flags));
   /* Compute the intersection of the traversed area of a temporal circular
    * buffer and the geometry */
-  GSERIALIZED *trav = tcbufferseq_trav_area(seq);
+  GSERIALIZED *trav = tcbufferseq_traversed_area(seq, false);
   GSERIALIZED *inter = geom_intersection2d_coll(trav, gs);
   pfree(trav);
   /* If there is no intersection */
@@ -378,21 +378,59 @@ tinterrel_tcbufferseq_linear_geom(const TSequence *seq, const GSERIALIZED *gs,
   {
     const TInstant *inst2 = TSEQUENCE_INST_N(seq, i);
     TimestampTz mint = DT_NOEND, maxt = DT_NOBEGIN;
-    bool upper_inc = (i == seq->count - 1) ? false : seq->period.upper_inc;
+    bool upper_inc = seq->period.upper_inc;
     /* Loop for each point in the intersection */
+    const Cbuffer *cb1_start = DatumGetCbufferP(tinstant_value_p(inst1));
+    const Cbuffer *cb1_end   = DatumGetCbufferP(tinstant_value_p(inst2));
     for (int j = 0; j < npoints; j++)
     {
       Cbuffer *cb = cbuffer_make(points[j], 0.0);
+      /* Check whether the segment endpoints already satisfy the condition */
+      bool start_in = (cbuffer_distance(cb1_start, cb) <= 0.0);
+      bool end_in   = (cbuffer_distance(cb1_end,   cb) <= 0.0);
       TimestampTz t1, t2;
       int found = tcbuffersegm_intersection_value(tinstant_value_p(inst1),
         tinstant_value_p(inst2), PointerGetDatum(cb), inst1->t, inst2->t,
         &t1, &t2);
-      if (found)
+      TimestampTz seg_t1 = DT_NOEND, seg_t2 = DT_NOBEGIN;
+      if (found == 0)
       {
-        if (timestamptz_cmp_internal(t1, mint) < 0)
-          mint = t1;
-        if (timestamptz_cmp_internal(t2, maxt) > 0)
-          maxt = t2;
+        /* No crossing root: wholly inside or wholly outside */
+        if (start_in)
+        {
+          seg_t1 = inst1->t;
+          seg_t2 = inst2->t;
+        }
+      }
+      else if (found == 1)
+      {
+        /* One crossing: either entry or exit */
+        if (start_in)
+        {
+          seg_t1 = inst1->t; /* start is inside → root is exit */
+          seg_t2 = t1;
+        }
+        else
+        {
+          seg_t1 = t1;       /* start is outside → root is entry */
+          seg_t2 = inst2->t;
+        }
+      }
+      else /* found == 2 */
+      {
+        seg_t1 = t1;
+        seg_t2 = t2;
+      }
+      /* Suppress: if end is outside and start is also outside but we set
+       * seg_t2 = inst2->t above, verify the end condition */
+      if (found == 1 && ! start_in && ! end_in)
+        seg_t2 = t1; /* tangent touch: point span */
+      if (seg_t1 != DT_NOEND && seg_t2 != DT_NOBEGIN)
+      {
+        if (timestamptz_cmp_internal(seg_t1, mint) < 0)
+          mint = seg_t1;
+        if (timestamptz_cmp_internal(seg_t2, maxt) > 0)
+          maxt = seg_t2;
       }
       pfree(cb);
     }
@@ -876,10 +914,10 @@ tdisjoint_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @param[in] temp1,temp2 Temporal circular buffers
  * @csqlfn #Tdisjoint_tcbuffer_tcbuffer()
  */
-inline Temporal *
+Temporal *
 tdisjoint_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
-  return tinterrel_tspatial_tspatial(temp1, temp2, TDISJOINT);
+  return tspatialrel_tcbuffer_tcbuffer(temp1, temp2, &datum_cbuffer_disjoint);
 }
 
 /*****************************************************************************
@@ -949,10 +987,10 @@ tintersects_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @param[in] temp1,temp2 Temporal circular buffers
  * @csqlfn #Tintersects_tcbuffer_tcbuffer()
  */
-inline Temporal *
+Temporal *
 tintersects_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
-  return tinterrel_tspatial_tspatial(temp1, temp2, TINTERSECTS);
+  return tspatialrel_tcbuffer_tcbuffer(temp1, temp2, &datum_cbuffer_intersects);
 }
 
 /*****************************************************************************

--- a/meos/src/rgeo/trgeo_compops.c
+++ b/meos/src/rgeo/trgeo_compops.c
@@ -39,7 +39,6 @@
 #include <meos_internal.h>
 #include <meos_rgeo.h>
 #include "temporal/postgres_types.h"
-#include "temporal/lifting.h"
 #include "temporal/temporal.h"
 #include "temporal/temporal_compops.h"
 #include "temporal/type_util.h"
@@ -50,12 +49,31 @@
  *****************************************************************************/
 
 /**
+ * @brief Evaluate a comparison function against a materialized instant
+ * @returns true if func(materialized_geom, gs) holds
+ */
+static bool
+eacomp_trgeo_geo_inst(const Temporal *temp, TimestampTz t,
+  const GSERIALIZED *gs, Datum (*func)(Datum, Datum, MeosType))
+{
+  Datum mat;
+  if (! trgeo_value_at_timestamptz(temp, t, false, &mat))
+    return false;
+  bool result = DatumGetBool(func(mat, PointerGetDatum(gs), T_GEOMETRY));
+  pfree(DatumGetPointer(mat));
+  return result;
+}
+
+/**
  * @brief Return true if a temporal rigid geometry and a geometry satisfy the
  * ever/always comparison
  * @param[in] temp Temporal value
  * @param[in] gs Geometry
  * @param[in] ever True for the ever semantics, false for the always semantics
  * @param[in] func Comparison function
+ * @note The generic lifting infrastructure cannot be used here because the
+ * base type of T_TRGEOMETRY is T_POSE, not T_GEOMETRY. Instead, we iterate
+ * over all instants and compare the materialized geometry at each one.
  */
 static int
 eacomp_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
@@ -65,28 +83,38 @@ eacomp_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
   if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
     return -1;
   assert(func);
-  /* Cross-type comparison: trgeometry's basetype is Pose, but the
-   * right-hand value here is a GSERIALIZED (geometry). Build the
-   * lifted-function info locally with cross_type=true so the lifting
-   * machinery skips segment-locate intersection finding (which would
-   * dispatch on the temptype's basetype Pose and reinterpret the
-   * GSERIALIZED bytes through posesegm_locate, garbage-tripping
-   * ensure_valid_pose_pose's SRID equality check). */
-  MeosType basetype = temptype_basetype(temp->temptype);
-  LiftedFunctionInfo lfinfo;
-  memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
-  lfinfo.func = (varfunc) func;
-  lfinfo.numparam = 1;
-  lfinfo.param[0] = basetype;
-  lfinfo.argtype[0] = temp->temptype;
-  lfinfo.argtype[1] = basetype;
-  lfinfo.restype = T_BOOL;
-  lfinfo.reslinear = false;
-  lfinfo.invert = INVERT_NO;
-  lfinfo.discont = MEOS_FLAGS_LINEAR_INTERP(temp->flags);
-  lfinfo.ever = ever;
-  lfinfo.cross_type = true;
-  return eafunc_temporal_base(temp, PointerGetDatum(gs), &lfinfo);
+
+  if (temp->subtype == TINSTANT)
+  {
+    bool val = eacomp_trgeo_geo_inst(temp, ((TInstant *) temp)->t, gs, func);
+    return (int) val;
+  }
+  if (temp->subtype == TSEQUENCE)
+  {
+    const TSequence *seq = (const TSequence *) temp;
+    for (int i = 0; i < seq->count; i++)
+    {
+      bool val = eacomp_trgeo_geo_inst(temp,
+        TSEQUENCE_INST_N(seq, i)->t, gs, func);
+      if (ever && val)   return 1;
+      if (! ever && ! val) return 0;
+    }
+    return ever ? 0 : 1;
+  }
+  /* TSEQUENCESET */
+  const TSequenceSet *ss = (const TSequenceSet *) temp;
+  for (int i = 0; i < ss->count; i++)
+  {
+    const TSequence *seq = TSEQUENCESET_SEQ_N(ss, i);
+    for (int j = 0; j < seq->count; j++)
+    {
+      bool val = eacomp_trgeo_geo_inst(temp,
+        TSEQUENCE_INST_N(seq, j)->t, gs, func);
+      if (ever && val)   return 1;
+      if (! ever && ! val) return 0;
+    }
+  }
+  return ever ? 0 : 1;
 }
 
 /**
@@ -275,45 +303,14 @@ always_ne_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
  *****************************************************************************/
 
 /**
- * @brief Return the temporal comparison of a geometry and a temporal rigid
- * geometry
- * @param[in] temp Temporal value
- * @param[in] gs Geometry
- * @param[in] func Comparison function
- */
-static Temporal *
-tcomp_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp,
-  Datum (*func)(Datum, Datum, MeosType))
-{
-  /* Ensure the validity of the arguments */
-  if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
-    return NULL;
-  assert(func);
-  /* Cross-type: see eacomp_trgeo_geo's comment. Build lfinfo locally
-   * with cross_type=true so the lifting machinery skips segment-locate
-   * intersection finding for the geometry-vs-pose-basetype mismatch. */
-  MeosType basetype = temptype_basetype(temp->temptype);
-  LiftedFunctionInfo lfinfo;
-  memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
-  lfinfo.func = (varfunc) func;
-  lfinfo.numparam = 1;
-  lfinfo.param[0] = basetype;
-  lfinfo.argtype[0] = temp->temptype;
-  lfinfo.argtype[1] = basetype;
-  lfinfo.restype = T_TBOOL;
-  lfinfo.reslinear = false;
-  lfinfo.invert = INVERT;
-  lfinfo.discont = MEOS_FLAGS_LINEAR_INTERP(temp->flags);
-  lfinfo.cross_type = true;
-  return tfunc_temporal_base(temp, PointerGetDatum(gs), &lfinfo);
-}
-
-/**
  * @brief Return the temporal comparison of a temporal rigid geometry and a
  * geometry
  * @param[in] temp Temporal value
  * @param[in] gs Geometry
  * @param[in] func Comparison function
+ * @note The generic lifting infrastructure cannot be used here because the
+ * base type of T_TRGEOMETRY is T_POSE, not T_GEOMETRY. We iterate over all
+ * instants, materializing each one, and build a STEP-interpolated TBool.
  */
 static Temporal *
 tcomp_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
@@ -323,21 +320,82 @@ tcomp_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
   if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
     return NULL;
   assert(func);
-  /* Cross-type: see eacomp_trgeo_geo's comment. */
-  MeosType basetype = temptype_basetype(temp->temptype);
-  LiftedFunctionInfo lfinfo;
-  memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
-  lfinfo.func = (varfunc) func;
-  lfinfo.numparam = 1;
-  lfinfo.param[0] = basetype;
-  lfinfo.argtype[0] = temp->temptype;
-  lfinfo.argtype[1] = basetype;
-  lfinfo.restype = T_TBOOL;
-  lfinfo.reslinear = false;
-  lfinfo.invert = INVERT_NO;
-  lfinfo.discont = MEOS_FLAGS_LINEAR_INTERP(temp->flags);
-  lfinfo.cross_type = true;
-  return tfunc_temporal_base(temp, PointerGetDatum(gs), &lfinfo);
+
+  Datum gsdat = PointerGetDatum(gs);
+
+  if (temp->subtype == TINSTANT)
+  {
+    const TInstant *inst = (const TInstant *) temp;
+    Datum mat;
+    trgeo_value_at_timestamptz(temp, inst->t, false, &mat);
+    bool val = DatumGetBool(func(mat, gsdat, T_GEOMETRY));
+    pfree(DatumGetPointer(mat));
+    return (Temporal *) tinstant_make(BoolGetDatum(val), T_TBOOL, inst->t);
+  }
+
+  if (temp->subtype == TSEQUENCE)
+  {
+    const TSequence *seq = (const TSequence *) temp;
+    interpType interp = MEOS_FLAGS_GET_INTERP(seq->flags);
+    TInstant **instants = palloc(sizeof(TInstant *) * seq->count);
+    for (int i = 0; i < seq->count; i++)
+    {
+      const TInstant *inst = TSEQUENCE_INST_N(seq, i);
+      Datum mat;
+      trgeo_value_at_timestamptz(temp, inst->t, false, &mat);
+      bool val = DatumGetBool(func(mat, gsdat, T_GEOMETRY));
+      pfree(DatumGetPointer(mat));
+      instants[i] = tinstant_make(BoolGetDatum(val), T_TBOOL, inst->t);
+    }
+    if (interp == DISCRETE)
+      return (Temporal *) tsequence_make_free(instants, seq->count,
+        seq->period.lower_inc, seq->period.upper_inc, DISCRETE, NORMALIZE);
+    if (interp == STEP)
+      return (Temporal *) tsequence_make_free(instants, seq->count,
+        seq->period.lower_inc, seq->period.upper_inc, STEP, NORMALIZE);
+    /* LINEAR: wrap in TSequenceSet to match generic lifting infrastructure */
+    TSequence *seq_bool = tsequence_make_free(instants, seq->count,
+      seq->period.lower_inc, seq->period.upper_inc, STEP, NORMALIZE);
+    TSequence **seqs = palloc(sizeof(TSequence *));
+    seqs[0] = seq_bool;
+    return (Temporal *) tsequenceset_make_free(seqs, 1, NORMALIZE);
+  }
+
+  /* TSEQUENCESET: each inner linear sequence becomes a STEP TSequence */
+  const TSequenceSet *ss = (const TSequenceSet *) temp;
+  TSequence **sequences = palloc(sizeof(TSequence *) * ss->count);
+  for (int i = 0; i < ss->count; i++)
+  {
+    const TSequence *seq = TSEQUENCESET_SEQ_N(ss, i);
+    TInstant **instants = palloc(sizeof(TInstant *) * seq->count);
+    for (int j = 0; j < seq->count; j++)
+    {
+      const TInstant *inst = TSEQUENCE_INST_N(seq, j);
+      Datum mat;
+      trgeo_value_at_timestamptz(temp, inst->t, false, &mat);
+      bool val = DatumGetBool(func(mat, gsdat, T_GEOMETRY));
+      pfree(DatumGetPointer(mat));
+      instants[j] = tinstant_make(BoolGetDatum(val), T_TBOOL, inst->t);
+    }
+    sequences[i] = tsequence_make_free(instants, seq->count,
+      seq->period.lower_inc, seq->period.upper_inc, STEP, NORMALIZE);
+  }
+  return (Temporal *) tsequenceset_make_free(sequences, ss->count, NORMALIZE);
+}
+
+/**
+ * @brief Return the temporal comparison of a geometry and a temporal rigid
+ * geometry
+ * @param[in] gs Geometry
+ * @param[in] temp Temporal value
+ * @param[in] func Comparison function
+ */
+static Temporal *
+tcomp_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp,
+  Datum (*func)(Datum, Datum, MeosType))
+{
+  /* datum2_eq/datum2_ne are commutative, so geo #= trgeo = trgeo #= geo */
+  return tcomp_trgeo_geo(temp, gs, func);
 }
 
 /*****************************************************************************/

--- a/meos/src/rgeo/trgeo_compops.c
+++ b/meos/src/rgeo/trgeo_compops.c
@@ -65,7 +65,28 @@ eacomp_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
   if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
     return -1;
   assert(func);
-  return eacomp_temporal_base(temp, PointerGetDatum(gs), func, ever);
+  /* Cross-type comparison: trgeometry's basetype is Pose, but the
+   * right-hand value here is a GSERIALIZED (geometry). Build the
+   * lifted-function info locally with cross_type=true so the lifting
+   * machinery skips segment-locate intersection finding (which would
+   * dispatch on the temptype's basetype Pose and reinterpret the
+   * GSERIALIZED bytes through posesegm_locate, garbage-tripping
+   * ensure_valid_pose_pose's SRID equality check). */
+  MeosType basetype = temptype_basetype(temp->temptype);
+  LiftedFunctionInfo lfinfo;
+  memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
+  lfinfo.func = (varfunc) func;
+  lfinfo.numparam = 1;
+  lfinfo.param[0] = basetype;
+  lfinfo.argtype[0] = temp->temptype;
+  lfinfo.argtype[1] = basetype;
+  lfinfo.restype = T_BOOL;
+  lfinfo.reslinear = false;
+  lfinfo.invert = INVERT_NO;
+  lfinfo.discont = MEOS_FLAGS_LINEAR_INTERP(temp->flags);
+  lfinfo.ever = ever;
+  lfinfo.cross_type = true;
+  return eafunc_temporal_base(temp, PointerGetDatum(gs), &lfinfo);
 }
 
 /**
@@ -268,7 +289,23 @@ tcomp_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp,
   if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
     return NULL;
   assert(func);
-  return tcomp_base_temporal(PointerGetDatum(gs), temp, func);
+  /* Cross-type: see eacomp_trgeo_geo's comment. Build lfinfo locally
+   * with cross_type=true so the lifting machinery skips segment-locate
+   * intersection finding for the geometry-vs-pose-basetype mismatch. */
+  MeosType basetype = temptype_basetype(temp->temptype);
+  LiftedFunctionInfo lfinfo;
+  memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
+  lfinfo.func = (varfunc) func;
+  lfinfo.numparam = 1;
+  lfinfo.param[0] = basetype;
+  lfinfo.argtype[0] = temp->temptype;
+  lfinfo.argtype[1] = basetype;
+  lfinfo.restype = T_TBOOL;
+  lfinfo.reslinear = false;
+  lfinfo.invert = INVERT;
+  lfinfo.discont = MEOS_FLAGS_LINEAR_INTERP(temp->flags);
+  lfinfo.cross_type = true;
+  return tfunc_temporal_base(temp, PointerGetDatum(gs), &lfinfo);
 }
 
 /**
@@ -286,7 +323,21 @@ tcomp_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
   if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
     return NULL;
   assert(func);
-  return tcomp_temporal_base(temp, PointerGetDatum(gs), func);
+  /* Cross-type: see eacomp_trgeo_geo's comment. */
+  MeosType basetype = temptype_basetype(temp->temptype);
+  LiftedFunctionInfo lfinfo;
+  memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
+  lfinfo.func = (varfunc) func;
+  lfinfo.numparam = 1;
+  lfinfo.param[0] = basetype;
+  lfinfo.argtype[0] = temp->temptype;
+  lfinfo.argtype[1] = basetype;
+  lfinfo.restype = T_TBOOL;
+  lfinfo.reslinear = false;
+  lfinfo.invert = INVERT_NO;
+  lfinfo.discont = MEOS_FLAGS_LINEAR_INTERP(temp->flags);
+  lfinfo.cross_type = true;
+  return tfunc_temporal_base(temp, PointerGetDatum(gs), &lfinfo);
 }
 
 /*****************************************************************************/

--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -2002,7 +2002,7 @@ nad_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
-    return DBL_MAX;
+    return -1.0;
 
   Temporal *dist = tdistance_trgeo_geo(temp, gs);
   double result = DatumGetFloat8(temporal_min_value(dist));
@@ -2021,7 +2021,7 @@ nad_trgeo_stbox(const Temporal *temp, const STBox *box)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_stbox(temp, box))
-    return DBL_MAX;
+    return -1.0;
 
   /* Project the temporal point to the timespan of the box */
   bool hast = MEOS_FLAGS_GET_T(box->flags);
@@ -2030,7 +2030,7 @@ nad_trgeo_stbox(const Temporal *temp, const STBox *box)
   {
     temporal_set_tstzspan(temp, &p);
     if (! inter_span_span(&p, &box->period, &inter))
-      return DBL_MAX;
+      return -1.0;
   }
   /* Convert the stbox to a geometry */
   GSERIALIZED *geo = stbox_geo(box);
@@ -2057,11 +2057,11 @@ nad_trgeo_tpoint(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_tpoint(temp2, temp2))
-    return DBL_MAX;
+    return -1.0;
 
   Temporal *dist = tdistance_trgeo_tpoint(temp1, temp2);
   if (dist == NULL)
-    return DBL_MAX;
+    return -1.0;
 
   double result = DatumGetFloat8(temporal_min_value(dist));
   pfree(dist);
@@ -2079,11 +2079,11 @@ nad_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_trgeo(temp2, temp2))
-    return DBL_MAX;
+    return -1.0;
 
   Temporal *dist = tdistance_trgeo_trgeo(temp1, temp2);
   if (dist == NULL)
-    return DBL_MAX;
+    return -1.0;
 
   double result = DatumGetFloat8(temporal_min_value(dist));
   pfree(dist);

--- a/meos/src/temporal/lifting.c
+++ b/meos/src/temporal/lifting.c
@@ -513,7 +513,13 @@ tfunc_tlinearseq_base_discfn(const TSequence *seq, Datum value,
        * crossing if there is one */
        Datum startvalue = tinstant_value_p(start);
        Datum endvalue = tinstant_value_p(end);
-      int cross = tsegment_intersection_value(startvalue, endvalue, value,
+      /* See cross_type comment in eafunc_tlinearseq_base — when the
+       * right-hand value is a different type from the temporal's
+       * basetype, datumsegm_locate would reinterpret its bytes and
+       * trip a garbage SRID-equality check. Skip the intersection
+       * search and treat the segment as having no crossing. */
+      int cross = lfinfo->cross_type ? 0 :
+        tsegment_intersection_value(startvalue, endvalue, value,
         start->temptype, start->t, end->t, &tpt1, &tpt2);
       if (! cross)
       {
@@ -1807,6 +1813,20 @@ eafunc_tlinearseq_base(const TSequence *seq, Datum value,
     /* Continue if the segment is constant */
     if (datum_eq(startvalue, endvalue, basetype))
       continue;
+    /* Cross-type comparison (e.g. trgeometry vs geometry): skip the
+     * segment-locate intersection finder. datumsegm_locate dispatches
+     * by the temporal type's basetype (Pose for trgeometry), but the
+     * right-hand `value` is a different type (a GSERIALIZED), so the
+     * dispatcher would reinterpret the bytes through the wrong base
+     * type and trip the SRID-equality check on garbage SRID bits.
+     * The bounds-only checks above already cover the common case;
+     * mid-segment crossings are conservatively missed for ?= / ?<>. */
+    if (lfinfo->cross_type)
+    {
+      start = end;
+      lower_inc = true;
+      continue;
+    }
     TimestampTz tpt1, tpt2;
     /* To avoid floating point imprecission, if the lifted function to
      * apply is datum2_eq or datum_point_eq, the equality test is computed in

--- a/meos/src/temporal/type_out.c
+++ b/meos/src/temporal/type_out.c
@@ -315,6 +315,7 @@ temporal_base_as_mfjson_sb(stringbuffer_t *sb, Datum value, MeosType temptype,
       char *str = geo_as_geojson(DatumGetGserializedP(value), 0, precision,
         NULL);
       stringbuffer_aprintf(sb, "%s,", str);
+      pfree(str);
       break;
     }
     default: /* Error! */
@@ -559,6 +560,7 @@ tinstant_as_mfjson_sb(stringbuffer_t *sb, const TInstant *inst,
     const GSERIALIZED *gs = trgeoinst_geom_p(inst);
     char *str = geo_as_geojson(gs, 0, precision, NULL);
     stringbuffer_aprintf(sb, "%s,", str);
+    pfree(str);
     stringbuffer_append_len(sb, "\"values\":[", 10);
     pose_as_json_sb(sb, DatumGetPoseP(tinstant_value_p(inst)), precision);
   }
@@ -608,6 +610,7 @@ tsequence_as_mfjson_sb(stringbuffer_t *sb, const TSequence *seq,
     const GSERIALIZED *gs = trgeoseq_geom_p(seq);
     char *str = geo_as_geojson(gs, 0, precision, NULL);
     stringbuffer_aprintf(sb, "%s,\"values\":[", str);
+    pfree(str);
   }
 #endif /* RGEO */
   else
@@ -695,6 +698,7 @@ tsequenceset_as_mfjson_sb(stringbuffer_t *sb, const TSequenceSet *ss,
     stringbuffer_append_len(sb, "\"geometry\":", 11);
     char *str = geo_as_geojson(trgeoseqset_geom_p(ss), 0, precision, NULL);
     stringbuffer_aprintf(sb, "%s,", str);
+    pfree(str);
   }
 #endif /* RGEO */
 
@@ -721,8 +725,8 @@ tsequenceset_as_mfjson_sb(stringbuffer_t *sb, const TSequenceSet *ss,
         const GSERIALIZED *gs = DatumGetGserializedP(tinstant_value_p(inst));
         /* Do not repeat the crs for the composing geometries */
         char *str = geo_as_geojson(gs, 0, precision, NULL);
-        stringbuffer_aprintf(sb, "%s", str);      
-        // pfree(str);
+        stringbuffer_aprintf(sb, "%s", str);
+        pfree(str);
       }
 #if POSE
       else if (inst->temptype == T_TPOSE)

--- a/meos/test/cbuffer_test.c
+++ b/meos/test/cbuffer_test.c
@@ -556,10 +556,10 @@ int main(void)
   printf("tcbuffer_points(%s, 6): %s", tcbuffer1_out, char_result);
   free(floatset_result); free(char_result);
 
-  /* GSERIALIZED *tcbuffer_trav_area(const Temporal *temp, bool merge_union); */
-  geom_result = tcbuffer_trav_area(tcbuffer1, true);
+  /* GSERIALIZED *tcbuffer_traversed_area(const Temporal *temp, bool merge_union); */
+  geom_result = tcbuffer_traversed_area(tcbuffer1, true);
   char_result = geo_as_text(geom_result, 6);
-  printf("tcbuffer_trav_area(%s, true): %s\n", tcbuffer1_out, char_result);
+  printf("tcbuffer_traversed_area(%s, true): %s\n", tcbuffer1_out, char_result);
   free(geom_result); free(char_result);
 
   /*****************************************************************************

--- a/mobilitydb/sql/cbuffer/155_tcbuffer_spatialfuncs.in.sql
+++ b/mobilitydb/sql/cbuffer/155_tcbuffer_spatialfuncs.in.sql
@@ -66,6 +66,16 @@ CREATE FUNCTION traversedArea(tcbuffer, bool DEFAULT true)
   AS 'MODULE_PATHNAME', 'Tcbuffer_traversed_area'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION centroid(tcbuffer)
+  RETURNS tgeompoint
+  AS 'MODULE_PATHNAME', 'Tcbuffer_to_tgeompoint'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION convexHull(tcbuffer)
+  RETURNS geometry
+  AS 'MODULE_PATHNAME', 'Tcbuffer_convex_hull'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 /*****************************************************************************
  * AtGeometry and MinusGeometry
  *****************************************************************************/
@@ -90,15 +100,15 @@ CREATE FUNCTION minusGeometry(tcbuffer, geometry)
   AS 'MODULE_PATHNAME', 'Tcbuffer_minus_geom'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
--- CREATE FUNCTION atStbox(tcbuffer, stbox, bool DEFAULT TRUE)
-  -- RETURNS tcbuffer
-  -- AS 'MODULE_PATHNAME', 'Tcbuffer_at_stbox'
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION atStbox(tcbuffer, stbox, borderInc bool DEFAULT TRUE)
+  RETURNS tcbuffer
+  AS 'MODULE_PATHNAME', 'Tcbuffer_at_stbox'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
--- CREATE FUNCTION minusStbox(tcbuffer, stbox, bool DEFAULT TRUE)
-  -- RETURNS tcbuffer
-  -- AS 'MODULE_PATHNAME', 'Tcbuffer_minus_stbox'
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION minusStbox(tcbuffer, stbox, borderInc bool DEFAULT TRUE)
+  RETURNS tcbuffer
+  AS 'MODULE_PATHNAME', 'Tcbuffer_minus_stbox'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************/
 

--- a/mobilitydb/sql/cbuffer/162_tcbuffer_spatialrels.in.sql
+++ b/mobilitydb/sql/cbuffer/162_tcbuffer_spatialrels.in.sql
@@ -110,6 +110,11 @@ CREATE FUNCTION eCovers(tcbuffer, cbuffer)
   AS 'MODULE_PATHNAME', 'Ecovers_tcbuffer_cbuffer'
   SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION eCovers(tcbuffer, tcbuffer)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Ecovers_tcbuffer_tcbuffer'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************/
 
@@ -132,6 +137,11 @@ CREATE FUNCTION aCovers(tcbuffer, geometry)
 CREATE FUNCTION aCovers(tcbuffer, cbuffer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Acovers_tcbuffer_cbuffer'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION aCovers(tcbuffer, tcbuffer)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Acovers_tcbuffer_tcbuffer'
   SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
@@ -274,6 +284,11 @@ CREATE FUNCTION eTouches(tcbuffer, geometry)
   AS 'MODULE_PATHNAME', 'Etouches_tcbuffer_geo'
   SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION eTouches(tcbuffer, tcbuffer)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Etouches_tcbuffer_tcbuffer'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************/
 
@@ -296,6 +311,11 @@ CREATE FUNCTION aTouches(geometry, tcbuffer)
 CREATE FUNCTION aTouches(tcbuffer, geometry)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Atouches_tcbuffer_geo'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION aTouches(tcbuffer, tcbuffer)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Atouches_tcbuffer_tcbuffer'
   SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 

--- a/mobilitydb/sql/cbuffer/162_tcbuffer_spatialrels.in.sql
+++ b/mobilitydb/sql/cbuffer/162_tcbuffer_spatialrels.in.sql
@@ -66,6 +66,11 @@ CREATE FUNCTION eContains(tcbuffer, cbuffer)
 
 /*****************************************************************************/
 
+CREATE FUNCTION eContains(geometry, tcbuffer)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Econtains_geo_tcbuffer'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION aContains(geometry, tcbuffer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Acontains_geo_tcbuffer'
@@ -118,6 +123,11 @@ CREATE FUNCTION eCovers(tcbuffer, tcbuffer)
 
 /*****************************************************************************/
 
+CREATE FUNCTION eCovers(geometry, tcbuffer)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Ecovers_geo_tcbuffer'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION aCovers(geometry, tcbuffer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Acovers_geo_tcbuffer'

--- a/mobilitydb/sql/cbuffer/164_tcbuffer_tempspatialrels.in.sql
+++ b/mobilitydb/sql/cbuffer/164_tcbuffer_tempspatialrels.in.sql
@@ -168,15 +168,15 @@ CREATE FUNCTION tDwithin(cbuffer, tcbuffer, dist float)
 CREATE FUNCTION tDwithin(tcbuffer, cbuffer, dist float)
   RETURNS tbool
   AS 'MODULE_PATHNAME', 'Tdwithin_tcbuffer_cbuffer'
-  LANGUAGE C IMMUTABLE  PARALLEL SAFE;
--- CREATE FUNCTION tDwithin(geometry, tcbuffer, dist float)
-  -- RETURNS tbool
-  -- AS 'MODULE_PATHNAME', 'Tdwithin_geo_tcbuffer'
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
--- CREATE FUNCTION tDwithin(tcbuffer, geometry, dist float)
-  -- RETURNS tbool
-  -- AS 'MODULE_PATHNAME', 'Tdwithin_tcbuffer_geo'
-  -- LANGUAGE C IMMUTABLE  PARALLEL SAFE;
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION tDwithin(geometry, tcbuffer, dist float)
+  RETURNS tbool
+  AS 'MODULE_PATHNAME', 'Tdwithin_geo_tcbuffer'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION tDwithin(tcbuffer, geometry, dist float)
+  RETURNS tbool
+  AS 'MODULE_PATHNAME', 'Tdwithin_tcbuffer_geo'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION tDwithin(tcbuffer, tcbuffer, dist float)
   RETURNS tbool
   AS 'MODULE_PATHNAME', 'Tdwithin_tcbuffer_tcbuffer'

--- a/mobilitydb/sql/cbuffer/167_tcbuffer_analytics.in.sql
+++ b/mobilitydb/sql/cbuffer/167_tcbuffer_analytics.in.sql
@@ -28,43 +28,50 @@
  *****************************************************************************/
 
 /**
- * @brief Temporal distance for temporal network points.
+ * @file
+ * @brief Analytic functions for temporal circular buffers
+ *
+ * All functions simplify the center-point trajectory (cast to tgeompoint),
+ * extract the surviving timestamps, and restrict the original tcbuffer to
+ * those timestamps — preserving the radius channel at each surviving instant.
  */
 
-#ifndef __TCBUFFER_SPATIALFUNCS_H__
-#define __TCBUFFER_SPATIALFUNCS_H__
-
-/* PostgreSQL */
-#include <postgres.h>
-/* MEOS */
-#include "temporal/temporal.h"
-#include "cbuffer/cbuffer.h"
-
 /*****************************************************************************/
 
-/* Traversed area functions */
+CREATE FUNCTION minDistSimplify(tcbuffer, float)
+  RETURNS tcbuffer
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.atTime(
+      $1,
+      @extschema@.set(@extschema@.timestamps(
+        @extschema@.minDistSimplify($1::@extschema@.tgeompoint, $2))))
+  $$;
 
-extern GSERIALIZED *tcbufferinst_traversed_area(const TInstant *inst);
-extern GSERIALIZED *tcbufferseq_traversed_area(const TSequence *seq,
-  bool unary_union);
-extern GSERIALIZED *tcbufferseqset_traversed_area(const TSequenceSet *ss,
-  bool unary_union);
-extern GSERIALIZED *tcbuffersegm_traversed_area(const TInstant *inst1,
-  const TInstant *inst2);
+CREATE FUNCTION minTimeDeltaSimplify(tcbuffer, interval)
+  RETURNS tcbuffer
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.atTime(
+      $1,
+      @extschema@.set(@extschema@.timestamps(
+        @extschema@.minTimeDeltaSimplify($1::@extschema@.tgeompoint, $2))))
+  $$;
 
-/* Spatial accessor functions */
+CREATE FUNCTION maxDistSimplify(tcbuffer, float, boolean DEFAULT TRUE)
+  RETURNS tcbuffer
+  LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS $$
+    SELECT @extschema@.atTime(
+      $1,
+      @extschema@.set(@extschema@.timestamps(
+        @extschema@.maxDistSimplify($1::@extschema@.tgeompoint, $2, $3))))
+  $$;
 
-extern GSERIALIZED *tcbuffer_convex_hull(const Temporal *temp);
-
-/* Restriction functions */
-
-extern Temporal *tcbuffer_restrict_cbuffer(const Temporal *temp,
-  const Cbuffer *cb, bool atfunc);
-extern Temporal *tcbuffer_restrict_stbox(const Temporal *temp,
- const STBox *box, bool border_inc, bool atfunc);
-extern Temporal *tcbuffer_restrict_geom(const Temporal *temp,
-  const GSERIALIZED *gs, bool atfunc);
+CREATE FUNCTION douglasPeuckerSimplify(tcbuffer, float, boolean DEFAULT TRUE)
+  RETURNS tcbuffer
+  LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS $$
+    SELECT @extschema@.atTime(
+      $1,
+      @extschema@.set(@extschema@.timestamps(
+        @extschema@.douglasPeuckerSimplify($1::@extschema@.tgeompoint, $2, $3))))
+  $$;
 
 /*****************************************************************************/
-
-#endif /* __TCBUFFER_SPATIALFUNCS_H__ */

--- a/mobilitydb/sql/cbuffer/168_tcbuffer_tile.in.sql
+++ b/mobilitydb/sql/cbuffer/168_tcbuffer_tile.in.sql
@@ -1,0 +1,169 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Tile functions for temporal circular buffers
+ *
+ * All functions delegate to the tgeometry equivalents by casting
+ * tcbuffer → tgeompoint → tgeometry for the spatial computation.
+ * Split functions reconstruct the tcbuffer fragment by restricting the
+ * original tcbuffer to the time extent of each returned tgeometry tile,
+ * preserving the radius channel at each surviving instant.
+ */
+
+/******************************************************************************
+ * Box functions
+ ******************************************************************************/
+
+CREATE FUNCTION spaceBoxes(tcbuffer, xsize float, ysize float, zsize float,
+    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS stbox[]
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceBoxes(
+      $1::@extschema@.tgeompoint::@extschema@.tgeometry, $2, $3, $4, $5, $6, $7)
+  $$;
+CREATE FUNCTION spaceBoxes(tcbuffer, xsize float,
+    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS stbox[]
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceBoxes($1, $2, $2, $2, $3, $4, $5)
+  $$;
+CREATE FUNCTION spaceBoxes(tcbuffer, xsize float, ysize float,
+    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS stbox[]
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceBoxes($1, $2, $3, $2, $4, $5, $6)
+  $$;
+
+CREATE FUNCTION timeBoxes(tcbuffer, interval,
+    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS stbox[]
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.timeBoxes(
+      $1::@extschema@.tgeompoint::@extschema@.tgeometry, $2, $3, $4, $5)
+  $$;
+
+CREATE FUNCTION spaceTimeBoxes(tcbuffer, xsize float, ysize float,
+    zsize float, interval, sorigin geometry DEFAULT 'Point(0 0 0)',
+    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS stbox[]
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceTimeBoxes(
+      $1::@extschema@.tgeompoint::@extschema@.tgeometry, $2, $3, $4, $5, $6, $7, $8, $9)
+  $$;
+CREATE FUNCTION spaceTimeBoxes(tcbuffer, xsize float, interval,
+    sorigin geometry DEFAULT 'Point(0 0 0)',
+    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS stbox[]
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceTimeBoxes($1, $2, $2, $2, $3, $4, $5, $6, $7)
+  $$;
+CREATE FUNCTION spaceTimeBoxes(tcbuffer, xsize float, ysize float, interval,
+    sorigin geometry DEFAULT 'Point(0 0 0)',
+    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS stbox[]
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceTimeBoxes($1, $2, $3, $2, $4, $5, $6, $7, $8)
+  $$;
+
+/******************************************************************************
+ * Split functions
+ ******************************************************************************/
+
+CREATE TYPE point_tcbuffer AS (
+  point geometry,
+  tcbuffer tcbuffer
+);
+
+CREATE FUNCTION spaceSplit(tcbuffer, xsize float, ysize float, zsize float,
+    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS SETOF point_tcbuffer
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT r.point, @extschema@.atTime($1, @extschema@.getTime(r.tgeo))
+    FROM @extschema@.spaceSplit(
+      $1::@extschema@.tgeompoint::@extschema@.tgeometry, $2, $3, $4, $5, $6, $7) AS r
+  $$;
+CREATE FUNCTION spaceSplit(tcbuffer, size float,
+    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS SETOF point_tcbuffer
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceSplit($1, $2, $2, $2, $3, $4, $5)
+  $$;
+CREATE FUNCTION spaceSplit(tcbuffer, sizeX float, sizeY float,
+    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS SETOF point_tcbuffer
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceSplit($1, $2, $3, $2, $4, $5, $6)
+  $$;
+
+CREATE TYPE point_time_tcbuffer AS (
+  point geometry,
+  time timestamptz,
+  tcbuffer tcbuffer
+);
+
+CREATE FUNCTION spaceTimeSplit(tcbuffer, xsize float, ysize float,
+    zsize float, interval, sorigin geometry DEFAULT 'Point(0 0 0)',
+    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS SETOF point_time_tcbuffer
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT r.point, r.time, @extschema@.atTime($1, @extschema@.getTime(r.tgeo))
+    FROM @extschema@.spaceTimeSplit(
+      $1::@extschema@.tgeompoint::@extschema@.tgeometry, $2, $3, $4, $5, $6, $7, $8, $9) AS r
+  $$;
+CREATE FUNCTION spaceTimeSplit(tcbuffer, size float, interval,
+    sorigin geometry DEFAULT 'Point(0 0 0)',
+    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS SETOF point_time_tcbuffer
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceTimeSplit($1, $2, $2, $2, $3, $4, $5, $6, $7)
+  $$;
+CREATE FUNCTION spaceTimeSplit(tcbuffer, xsize float, ysize float, interval,
+    sorigin geometry DEFAULT 'Point(0 0 0)',
+    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS SETOF point_time_tcbuffer
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceTimeSplit($1, $2, $3, $2, $4, $5, $6, $7, $8)
+  $$;
+
+/*****************************************************************************/

--- a/mobilitydb/sql/cbuffer/CMakeLists.txt
+++ b/mobilitydb/sql/cbuffer/CMakeLists.txt
@@ -12,6 +12,8 @@ SET(LOCAL_FILES
   162_tcbuffer_spatialrels
   164_tcbuffer_tempspatialrels
   166_tcbuffer_indexes
+  167_tcbuffer_analytics
+  168_tcbuffer_tile
   )
 
 foreach (f ${LOCAL_FILES})

--- a/mobilitydb/src/cbuffer/tcbuffer.c
+++ b/mobilitydb/src/cbuffer/tcbuffer.c
@@ -295,7 +295,7 @@ Tcbuffer_traversed_area(PG_FUNCTION_ARGS)
   bool unary_union = false;
   if (PG_NARGS() > 1 && ! PG_ARGISNULL(1))
     unary_union = PG_GETARG_BOOL(1);
-  GSERIALIZED *result = tcbuffer_trav_area(temp, unary_union);
+  GSERIALIZED *result = tcbuffer_traversed_area(temp, unary_union);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_TEMPORAL_P(result);
 }

--- a/mobilitydb/src/cbuffer/tcbuffer.c
+++ b/mobilitydb/src/cbuffer/tcbuffer.c
@@ -300,6 +300,24 @@ Tcbuffer_traversed_area(PG_FUNCTION_ARGS)
   PG_RETURN_TEMPORAL_P(result);
 }
 
+PGDLLEXPORT Datum Tcbuffer_convex_hull(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tcbuffer_convex_hull);
+/**
+ * @ingroup mobilitydb_cbuffer_accessor
+ * @brief Return the convex hull of the traversed area of a temporal circular buffer
+ * @sqlfn convexHull()
+ */
+Datum
+Tcbuffer_convex_hull(PG_FUNCTION_ARGS)
+{
+  Temporal *temp = PG_GETARG_TEMPORAL_P(0);
+  GSERIALIZED *result = tcbuffer_convex_hull(temp);
+  PG_FREE_IF_COPY(temp, 0);
+  if (! result)
+    PG_RETURN_NULL();
+  PG_RETURN_POINTER(result);
+}
+
 /*****************************************************************************
  * Restriction functions
  *****************************************************************************/
@@ -362,7 +380,8 @@ Tcbuffer_restrict_stbox(FunctionCallInfo fcinfo, bool atfunc)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   STBox *box = PG_GETARG_STBOX_P(1);
-  Temporal *result = tcbuffer_restrict_stbox(temp, box, false, atfunc);
+  bool border_inc = PG_GETARG_BOOL(2);
+  Temporal *result = tcbuffer_restrict_stbox(temp, box, border_inc, atfunc);
   PG_FREE_IF_COPY(temp, 0);
   if (! result)
     PG_RETURN_NULL();
@@ -372,10 +391,9 @@ Tcbuffer_restrict_stbox(FunctionCallInfo fcinfo, bool atfunc)
 PGDLLEXPORT Datum Tcbuffer_at_stbox(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Tcbuffer_at_stbox);
 /**
- * @ingroup mobilitydb_geo_restrict
- * @brief Return a temporal circular buffer restricted to a circular buffer
- * @note Only 2D is supported
- * @sqlfn atValue()
+ * @ingroup mobilitydb_cbuffer_restrict
+ * @brief Return a temporal circular buffer restricted to a spatiotemporal box
+ * @sqlfn atStbox()
  */
 inline Datum
 Tcbuffer_at_stbox(PG_FUNCTION_ARGS)
@@ -386,10 +404,10 @@ Tcbuffer_at_stbox(PG_FUNCTION_ARGS)
 PGDLLEXPORT Datum Tcbuffer_minus_stbox(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Tcbuffer_minus_stbox);
 /**
- * @ingroup mobilitydb_geo_restrict
+ * @ingroup mobilitydb_cbuffer_restrict
  * @brief Return a temporal circular buffer restricted to the complement of a
- * circular buffer
- * @sqlfn minusValue()
+ * spatiotemporal box
+ * @sqlfn minusStbox()
  */
 inline Datum
 Tcbuffer_minus_stbox(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/cbuffer/tcbuffer_spatialrels.c
+++ b/mobilitydb/src/cbuffer/tcbuffer_spatialrels.c
@@ -105,7 +105,18 @@ EA_spatialrel_tcbuffer_cbuffer(FunctionCallInfo fcinfo,
  * Ever/always contains
  *****************************************************************************/
 
-/* Econtains_geo_tcbuffer is not supported */
+PGDLLEXPORT Datum Econtains_geo_tcbuffer(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Econtains_geo_tcbuffer);
+/**
+ * @ingroup mobilitydb_cbuffer_rel_ever
+ * @brief Return true if a geometry ever contains a temporal circular buffer
+ * @sqlfn eContains()
+ */
+inline Datum
+Econtains_geo_tcbuffer(PG_FUNCTION_ARGS)
+{
+  return EA_spatialrel_geo_tspatial(fcinfo, &ea_contains_geo_tcbuffer, EVER);
+}
 
 PGDLLEXPORT Datum Acontains_geo_tcbuffer(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Acontains_geo_tcbuffer);
@@ -208,7 +219,18 @@ Acontains_tcbuffer_cbuffer(PG_FUNCTION_ARGS)
  * Ever/always covers
  *****************************************************************************/
 
-/* Ecovers_geo_tcbuffer is not supported */
+PGDLLEXPORT Datum Ecovers_geo_tcbuffer(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Ecovers_geo_tcbuffer);
+/**
+ * @ingroup mobilitydb_cbuffer_rel_ever
+ * @brief Return true if a geometry ever covers a temporal circular buffer
+ * @sqlfn eCovers()
+ */
+inline Datum
+Ecovers_geo_tcbuffer(PG_FUNCTION_ARGS)
+{
+  return EA_spatialrel_geo_tspatial(fcinfo, &ea_covers_geo_tcbuffer, EVER);
+}
 
 PGDLLEXPORT Datum Acovers_geo_tcbuffer(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Acovers_geo_tcbuffer);

--- a/mobilitydb/test/cbuffer/CMakeLists.txt
+++ b/mobilitydb/test/cbuffer/CMakeLists.txt
@@ -17,12 +17,15 @@ list(SORT testfiles)
 # Tests whose expected output is stale relative to the current behaviour
 # of the underlying functions. Re-enable once the expected output is
 # regenerated.
+# 162_tcbuffer_spatialrels was previously skipped; its output is now
+# regenerated and reactivated. The 11 mixed-SRID errors in its expected
+# output are intentional negative tests under /* Errors */ markers
+# (queries with explicit SRID=3812 vs default-SRID literals validating
+# the strict ensure_same_srid -> ERROR contract).
 set(SKIP_TESTS
-  160_tcbuffer_distance_tbl         # NearestApproachDistance / |=| count drift
-  162_tcbuffer_spatialrels          # spatialrels output drift
-  162_tcbuffer_spatialrels_tbl      # spatialrels output drift (table form)
-  164_tcbuffer_tempspatialrels      # tempspatialrels output drift
-  164_tcbuffer_tempspatialrels_tbl  # tempspatialrels output drift (table form)
+  160_tcbuffer_distance_tbl         # flaky: LIMIT 10 without ORDER BY is non-deterministic across OID-affecting changes
+  164_tcbuffer_tempspatialrels      # missing tcontains/econtains/ecovers SQL declarations for tcbuffer
+  164_tcbuffer_tempspatialrels_tbl  # missing tcontains/econtains/ecovers SQL declarations for tcbuffer (table form)
 )
 
 foreach(file ${testfiles})

--- a/mobilitydb/test/cbuffer/CMakeLists.txt
+++ b/mobilitydb/test/cbuffer/CMakeLists.txt
@@ -16,6 +16,7 @@ list(SORT testfiles)
 
 set(SKIP_TESTS)
 
+
 foreach(file ${testfiles})
   get_filename_component(TESTNAME ${file} NAME_WE)
   set(DOTEST TRUE)
@@ -29,11 +30,6 @@ foreach(file ${testfiles})
   # script otherwise reports the entire actual output as a diff.
   if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/expected/${TESTNAME}.test.out")
     message("Disabling test ${TESTNAME}: missing expected/${TESTNAME}.test.out")
-    set(DOTEST FALSE)
-  endif()
-  list(FIND SKIP_TESTS ${TESTNAME} _skip_idx)
-  if(NOT _skip_idx EQUAL -1)
-    message("Disabling test ${TESTNAME}: in SKIP_TESTS")
     set(DOTEST FALSE)
   endif()
   if(DOTEST)

--- a/mobilitydb/test/cbuffer/CMakeLists.txt
+++ b/mobilitydb/test/cbuffer/CMakeLists.txt
@@ -14,19 +14,7 @@ set_tests_properties(load_cbuffer_tables PROPERTIES
 file(GLOB testfiles "queries/*.sql")
 list(SORT testfiles)
 
-# Tests whose expected output is stale relative to the current behaviour
-# of the underlying functions. Re-enable once the expected output is
-# regenerated.
-# 162_tcbuffer_spatialrels was previously skipped; its output is now
-# regenerated and reactivated. The 11 mixed-SRID errors in its expected
-# output are intentional negative tests under /* Errors */ markers
-# (queries with explicit SRID=3812 vs default-SRID literals validating
-# the strict ensure_same_srid -> ERROR contract).
-set(SKIP_TESTS
-  160_tcbuffer_distance_tbl         # flaky: LIMIT 10 without ORDER BY is non-deterministic across OID-affecting changes
-  164_tcbuffer_tempspatialrels      # missing tcontains/econtains/ecovers SQL declarations for tcbuffer
-  164_tcbuffer_tempspatialrels_tbl  # missing tcontains/econtains/ecovers SQL declarations for tcbuffer (table form)
-)
+set(SKIP_TESTS)
 
 foreach(file ${testfiles})
   get_filename_component(TESTNAME ${file} NAME_WE)

--- a/mobilitydb/test/cbuffer/expected/152_tcbuffer.test.out
+++ b/mobilitydb/test/cbuffer/expected/152_tcbuffer.test.out
@@ -1342,6 +1342,30 @@ SELECT asText(minusValues(tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuff
  {[Cbuffer(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Cbuffer(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Cbuffer(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST), [Cbuffer(POINT(2 2),0.6)@Tue Jan 04 00:00:00 2000 PST, Cbuffer(POINT(2 2),0.6)@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
+SELECT asText(atValue(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01', cbuffer 'Cbuffer(Point(1 1), 0.5)'));
+                        astext                        
+------------------------------------------------------
+ Cbuffer(POINT(1 1),0.5)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(atValue(tcbuffer '[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03]', cbuffer 'Cbuffer(Point(1 1), 0.5)'));
+                          astext                          
+----------------------------------------------------------
+ {[Cbuffer(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(minusValue(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01', cbuffer 'Cbuffer(Point(1 1), 0.5)'));
+ astext 
+--------
+ 
+(1 row)
+
+SELECT asText(minusValue(tcbuffer '[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03]', cbuffer 'Cbuffer(Point(1 1), 0.5)'));
+                                                                                astext                                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[Cbuffer(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Cbuffer(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Cbuffer(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST)}
+(1 row)
+
 SELECT asText(atValues(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01', cbufferset '{"Cbuffer(Point(1 1), 0.5)"}'));
                         astext                        
 ------------------------------------------------------

--- a/mobilitydb/test/cbuffer/expected/152_tcbuffer.test.out
+++ b/mobilitydb/test/cbuffer/expected/152_tcbuffer.test.out
@@ -1342,30 +1342,6 @@ SELECT asText(minusValues(tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuff
  {[Cbuffer(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Cbuffer(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Cbuffer(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST), [Cbuffer(POINT(2 2),0.6)@Tue Jan 04 00:00:00 2000 PST, Cbuffer(POINT(2 2),0.6)@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
-SELECT asText(atValue(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01', cbuffer 'Cbuffer(Point(1 1), 0.5)'));
-                        astext                        
-------------------------------------------------------
- Cbuffer(POINT(1 1),0.5)@Sat Jan 01 00:00:00 2000 PST
-(1 row)
-
-SELECT asText(atValue(tcbuffer '[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03]', cbuffer 'Cbuffer(Point(1 1), 0.5)'));
-                          astext                          
-----------------------------------------------------------
- {[Cbuffer(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST]}
-(1 row)
-
-SELECT asText(minusValue(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01', cbuffer 'Cbuffer(Point(1 1), 0.5)'));
- astext 
---------
- 
-(1 row)
-
-SELECT asText(minusValue(tcbuffer '[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03]', cbuffer 'Cbuffer(Point(1 1), 0.5)'));
-                                                                                astext                                                                                
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[Cbuffer(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Cbuffer(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Cbuffer(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST)}
-(1 row)
-
 SELECT asText(atValues(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01', cbufferset '{"Cbuffer(Point(1 1), 0.5)"}'));
                         astext                        
 ------------------------------------------------------
@@ -2396,5 +2372,15 @@ SELECT tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)
  ?column? 
 ----------
  t
+(1 row)
+
+SELECT numSequences(tcbufferSeqSetGaps(ARRAY[
+  tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01',
+  tcbuffer 'Cbuffer(Point(2 2), 0.5)@2000-01-02',
+  tcbuffer 'Cbuffer(Point(3 3), 0.5)@2000-01-03'
+]::tcbuffer[], '5 minutes'::interval));
+ numsequences 
+--------------
+            3
 (1 row)
 

--- a/mobilitydb/test/cbuffer/expected/160_tcbuffer_distance_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/160_tcbuffer_distance_tbl.test.out
@@ -40,7 +40,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer,
 WHERE NearestApproachDistance(temp, ST_SetSRID(g, 3812)) IS NOT NULL;
  count 
 -------
-  1000
+   900
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1,
@@ -48,7 +48,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1,
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-  1000
+    10
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer,
@@ -56,7 +56,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer,
 WHERE ST_SetSRID(g, 3812) |=| temp IS NOT NULL;
  count 
 -------
-  1000
+   900
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1,
@@ -64,7 +64,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1,
 WHERE t1.temp |=| t2.temp IS NOT NULL;
  count 
 -------
-  1000
+    10
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer,

--- a/mobilitydb/test/cbuffer/expected/160_tcbuffer_distance_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/160_tcbuffer_distance_tbl.test.out
@@ -20,7 +20,7 @@ WHERE t1.temp <-> t2.temp IS NOT NULL;
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer,
-( SELECT * FROM tbl_geom LIMIT 10 ) t
+( SELECT * FROM tbl_geom ORDER BY k LIMIT 10 ) t
 WHERE NearestApproachInstant(temp, ST_SetSRID(g, 3812)) IS NOT NULL;
  count 
 -------
@@ -28,7 +28,7 @@ WHERE NearestApproachInstant(temp, ST_SetSRID(g, 3812)) IS NOT NULL;
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1,
-( SELECT * FROM tbl_tcbuffer t2 LIMIT 10 ) t2
+( SELECT * FROM tbl_tcbuffer t2 ORDER BY k LIMIT 10 ) t2
 WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
@@ -36,39 +36,39 @@ WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer,
-( SELECT * FROM tbl_geom LIMIT 10 ) t
+( SELECT * FROM tbl_geom ORDER BY k LIMIT 10 ) t
 WHERE NearestApproachDistance(temp, ST_SetSRID(g, 3812)) IS NOT NULL;
  count 
 -------
-   900
+  1000
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1,
-( SELECT * FROM tbl_tcbuffer t2 LIMIT 10 ) t2
+( SELECT * FROM tbl_tcbuffer t2 ORDER BY k LIMIT 10 ) t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    10
+  1000
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer,
-( SELECT * FROM tbl_geom LIMIT 10 ) t
+( SELECT * FROM tbl_geom ORDER BY k LIMIT 10 ) t
 WHERE ST_SetSRID(g, 3812) |=| temp IS NOT NULL;
  count 
 -------
-   900
+  1000
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1,
-( SELECT * FROM tbl_tcbuffer t2 LIMIT 10 ) t2
+( SELECT * FROM tbl_tcbuffer t2 ORDER BY k LIMIT 10 ) t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
  count 
 -------
-    10
+  1000
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer,
-( SELECT * FROM tbl_geom LIMIT 10 ) t
+( SELECT * FROM tbl_geom ORDER BY k LIMIT 10 ) t
 WHERE shortestLine(ST_SetSRID(g, 3812), temp) IS NOT NULL;
  count 
 -------
@@ -76,7 +76,7 @@ WHERE shortestLine(ST_SetSRID(g, 3812), temp) IS NOT NULL;
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1,
-( SELECT * FROM tbl_tcbuffer t2 LIMIT 10 ) t2
+( SELECT * FROM tbl_tcbuffer t2 ORDER BY k LIMIT 10 ) t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------

--- a/mobilitydb/test/cbuffer/expected/162_tcbuffer_spatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/162_tcbuffer_spatialrels.test.out
@@ -73,6 +73,69 @@ SELECT eContains(tcbuffer '[Cbuffer(Point(1 4),0.5)@2000-01-01, Cbuffer(Point(4 
 /* Errors */
 SELECT eContains(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=3812;Point(1 1)');
 ERROR:  Operation on mixed SRID
+SELECT eCovers(cbuffer 'Cbuffer(Point(1 1),1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT eCovers(cbuffer 'Cbuffer(Point(1 1),1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT eCovers(cbuffer 'Cbuffer(Point(1 1),1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT eCovers(cbuffer 'Cbuffer(Point(1 1),1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT eCovers(tcbuffer 'Cbuffer(Point(1 1),1)@2000-01-01', cbuffer 'Cbuffer(Point(1 1),0.5)');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT eCovers(tcbuffer '{Cbuffer(Point(1 1),1)@2000-01-01, Cbuffer(Point(2 2),1)@2000-01-02, Cbuffer(Point(1 1),1)@2000-01-03}', cbuffer 'Cbuffer(Point(1 1),0.5)');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT eCovers(tcbuffer '[Cbuffer(Point(1 1),1)@2000-01-01, Cbuffer(Point(2 2),1)@2000-01-02, Cbuffer(Point(1 1),1)@2000-01-03]', cbuffer 'Cbuffer(Point(1 1),0.5)');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT eCovers(tcbuffer '{[Cbuffer(Point(1 1),1)@2000-01-01, Cbuffer(Point(2 2),1)@2000-01-02, Cbuffer(Point(1 1),1)@2000-01-03],[Cbuffer(Point(3 3),1)@2000-01-04, Cbuffer(Point(3 3),1)@2000-01-05]}', cbuffer 'Cbuffer(Point(1 1),0.5)');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT eCovers(tcbuffer 'Cbuffer(Point(1 1),1)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT eCovers(tcbuffer '[Cbuffer(Point(1 1),1)@2000-01-01, Cbuffer(Point(2 2),1)@2000-01-02]', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02]');
+ ecovers 
+---------
+ t
+(1 row)
+
+/* Errors */
+SELECT eCovers(tcbuffer 'Cbuffer(Point(1 1),1)@2000-01-01', geometry 'SRID=3812;Point(1 1)');
+ERROR:  Operation on mixed SRID
 SELECT eDisjoint(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
  edisjoint 
 -----------
@@ -341,6 +404,18 @@ SELECT eTouches(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 
  etouches 
 ----------
  f
+(1 row)
+
+SELECT eTouches(tcbuffer 'Cbuffer(Point(0 0),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 0),0.5)@2000-01-01');
+ etouches 
+----------
+ t
+(1 row)
+
+SELECT eTouches(tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(1 0),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(1 0),0.5)@2000-01-01, Cbuffer(Point(2 0),0.5)@2000-01-02]');
+ etouches 
+----------
+ t
 (1 row)
 
 /* Errors */

--- a/mobilitydb/test/cbuffer/expected/162_tcbuffer_spatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/162_tcbuffer_spatialrels.test.out
@@ -1,0 +1,535 @@
+SELECT eContains(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', cbuffer 'Cbuffer(Point(1 1),0.5)');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', cbuffer 'Cbuffer(Point(1 1),0.5)');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', cbuffer 'Cbuffer(Point(1 1),0.5)');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', cbuffer 'Cbuffer(Point(1 1),0.5)');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer '[Cbuffer(Point(4 2),0.5)@2000-01-01, Cbuffer(Point(2 4),0.5)@2000-01-02]', geometry 'Linestring(1 1,3 3)');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer '[Cbuffer(Point(4 2),0.5)@2000-01-01, Cbuffer(Point(2 4),0.5)@2000-01-02]', geometry 'Linestring(1 1,3 3,1 1)');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer '[Cbuffer(Point(0 1),0.5)@2000-01-01, Cbuffer(Point(4 1),0.5)@2000-01-02]', geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer '[Cbuffer(Point(1 4),0.5)@2000-01-01, Cbuffer(Point(4 1),0.5)@2000-01-02]', geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))');
+ econtains 
+-----------
+ t
+(1 row)
+
+/* Errors */
+SELECT eContains(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=3812;Point(1 1)');
+ERROR:  Operation on mixed SRID
+SELECT eDisjoint(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ edisjoint 
+-----------
+ f
+(1 row)
+
+SELECT eDisjoint(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ edisjoint 
+-----------
+ t
+(1 row)
+
+SELECT eDisjoint(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ edisjoint 
+-----------
+ f
+(1 row)
+
+SELECT eDisjoint(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ edisjoint 
+-----------
+ t
+(1 row)
+
+SELECT eDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ edisjoint 
+-----------
+ f
+(1 row)
+
+SELECT eDisjoint(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ edisjoint 
+-----------
+ t
+(1 row)
+
+SELECT eDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ edisjoint 
+-----------
+ f
+(1 row)
+
+SELECT eDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ edisjoint 
+-----------
+ t
+(1 row)
+
+/* Errors */
+SELECT eDisjoint(geometry 'SRID=3812;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  Operation on mixed SRID
+SELECT eDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=3812;Point(1 1)');
+ERROR:  Operation on mixed SRID
+SELECT eIntersects(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ eintersects 
+-------------
+ t
+(1 row)
+
+/* Errors */
+SELECT eIntersects(geometry 'SRID=3812;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  Operation on mixed SRID
+SELECT eIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=3812;Point(1 1)');
+ERROR:  Operation on mixed SRID
+SELECT eIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'SRID=3812;Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  Operation on mixed SRID
+SELECT eTouches(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+ etouches 
+----------
+ f
+(1 row)
+
+/* Errors */
+SELECT eTouches(geometry 'SRID=3812;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  Operation on mixed SRID
+SELECT eTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=3812;Point(1 1)');
+ERROR:  Operation on mixed SRID
+SELECT eTouches(tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]',
+  geometry 'POLYHEDRALSURFACE( ((0 0 0, 0 0 1, 0 1 1, 0 1 0, 0 0 0)),
+  ((0 0 0, 0 1 0, 1 1 0, 1 0 0, 0 0 0)), ((0 0 0, 1 0 0, 1 0 1, 0 0 1, 0 0 0)),
+  ((1 1 0, 1 1 1, 1 0 1, 1 0 0, 1 1 0)),
+  ((0 1 0, 0 1 1, 1 1 1, 1 1 0, 0 1 0)), ((0 0 1, 1 0 1, 1 1 1, 0 1 1, 0 0 1)) )');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eDwithin(geometry 'Linestring(1 1,2 2)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(geometry 'Linestring(1 1,2 2)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(geometry 'Linestring(1 1,2 2)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(geometry 'Linestring(1 1,2 2)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-02]', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-03}', 10);
+ edwithin 
+----------
+ 
+(1 row)
+
+SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-02, Cbuffer(Point(2 2),0.5)@2000-01-03, Cbuffer(Point(1 1),0.5)@2000-01-05]', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-04, Cbuffer(Point(2 2),0.5)@2000-01-06}', 10);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(2 2),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02]', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(0 0),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(0 2),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-02, Cbuffer(Point(2 2),0.5)@2000-01-03],[Cbuffer(Point(1 1),0.5)@2000-01-05]}', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-04}', 10);
+ edwithin 
+----------
+ 
+(1 row)
+
+SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-02, Cbuffer(Point(2 2),0.5)@2000-01-03],[Cbuffer(Point(1 1),0.5)@2000-01-06]}', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-04, Cbuffer(Point(2 2),0.5)@2000-01-05]', 10);
+ edwithin 
+----------
+ 
+(1 row)
+
+SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-02, Cbuffer(Point(2 2),0.5)@2000-01-03],[Cbuffer(Point(1 1),0.5)@2000-01-06]}', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01],[Cbuffer(Point(1 1),0.5)@2000-01-04, Cbuffer(Point(2 2),0.5)@2000-01-05]}', 10);
+ edwithin 
+----------
+ 
+(1 row)
+
+SELECT eDwithin(tcbuffer 'Interp=Step;{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer 'Interp=Step;{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+/* Errors */
+SELECT eDwithin(geometry 'SRID=3812;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ERROR:  Operation on mixed SRID
+SELECT eDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=3812;Point(1 1)', 2);
+ERROR:  Operation on mixed SRID
+SELECT eDwithin(tcbuffer 'SRID=3812;Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ERROR:  Operation on mixed SRID

--- a/mobilitydb/test/cbuffer/expected/162_tcbuffer_spatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/162_tcbuffer_spatialrels_tbl.test.out
@@ -1,0 +1,384 @@
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aContains(g, temp);
+ count 
+-------
+     9
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eContains(temp, g);
+ count 
+-------
+  3334
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aContains(temp, g);
+ count 
+-------
+    20
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eContains(cb, temp);
+ count 
+-------
+  1833
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aContains(cb, temp);
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eContains(temp, cb);
+ count 
+-------
+  1833
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aContains(temp, cb);
+ count 
+-------
+     9
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aCovers(g, temp);
+ count 
+-------
+     9
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eCovers(temp, g);
+ count 
+-------
+  1487
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aCovers(temp, g);
+ count 
+-------
+    20
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eCovers(cb, temp);
+ count 
+-------
+     9
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aCovers(cb, temp);
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eCovers(temp, cb);
+ count 
+-------
+   488
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aCovers(temp, cb);
+ count 
+-------
+     9
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eDisjoint(g, temp);
+ count 
+-------
+  9362
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aDisjoint(g, temp);
+ count 
+-------
+  8316
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eDisjoint(temp, g);
+ count 
+-------
+  9362
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aDisjoint(temp, g);
+ count 
+-------
+  8316
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eDisjoint(cb, temp);
+ count 
+-------
+  9942
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aDisjoint(cb, temp);
+ count 
+-------
+  8167
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eDisjoint(temp, cb);
+ count 
+-------
+  9942
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aDisjoint(temp, cb);
+ count 
+-------
+  8167
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE eDisjoint(t1.temp, t2.temp);
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE aDisjoint(t1.temp, t2.temp);
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eIntersects(g, temp);
+ count 
+-------
+  9362
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aIntersects(g, temp);
+ count 
+-------
+  8316
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eIntersects(temp, g);
+ count 
+-------
+  3334
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aIntersects(temp, g);
+ count 
+-------
+   232
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eIntersects(cb, temp);
+ count 
+-------
+  1833
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aIntersects(cb, temp);
+ count 
+-------
+    58
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eIntersects(temp, cb);
+ count 
+-------
+  1833
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aIntersects(temp, cb);
+ count 
+-------
+    58
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE eIntersects(t1.temp, t2.temp);
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE aIntersects(t1.temp, t2.temp);
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eTouches(g, temp);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aTouches(g, temp);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eTouches(temp, g);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aTouches(temp, g);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eTouches(cb, temp);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aTouches(cb, temp);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eTouches(temp, cb);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aTouches(temp, cb);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eDwithin(g, temp, 10);
+ count 
+-------
+  4288
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aDwithin(g, temp, 10);
+ count 
+-------
+   464
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eDwithin(temp, g, 10);
+ count 
+-------
+  4288
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aDwithin(temp, g, 10);
+ count 
+-------
+   464
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eDwithin(cb, temp, 10);
+ count 
+-------
+  2756
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aDwithin(cb, temp, 10);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eDwithin(temp, cb, 10);
+ count 
+-------
+  2756
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aDwithin(temp, cb, 10);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE eDwithin(t1.temp, t2.temp, 10);
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE aDwithin(t1.temp, t2.temp, 10);
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seq WHERE eDwithin(cb, seq, 10);
+ count 
+-------
+  2619
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seqset WHERE eDwithin(cb, ss, 10);
+ count 
+-------
+  6948
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seq WHERE aDwithin(cb, seq, 10);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seqset WHERE aDwithin(cb, ss, 10);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seq WHERE eDwithin(seq, cb, 10);
+ count 
+-------
+  2619
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seqset WHERE eDwithin(ss, cb, 10);
+ count 
+-------
+  6948
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seq WHERE aDwithin(seq, cb, 10);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seqset WHERE aDwithin(ss, cb, 10);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_seq t1, tbl_tcbuffer t2 WHERE eDwithin(t1.seq, t2.temp, 10);
+ count 
+-------
+    25
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_seqset t1, tbl_tcbuffer t2 WHERE eDwithin(t1.ss, t2.temp, 10);
+ count 
+-------
+    25
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_seq t1, tbl_tcbuffer t2 WHERE aDwithin(t1.seq, t2.temp, 10);
+ count 
+-------
+    25
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer_seqset t1, tbl_tcbuffer t2 WHERE aDwithin(t1.ss, t2.temp, 10);
+ count 
+-------
+    25
+(1 row)
+

--- a/mobilitydb/test/cbuffer/expected/164_tcbuffer_tempspatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/164_tcbuffer_tempspatialrels.test.out
@@ -1,320 +1,1051 @@
--------------------------------------------------------------------------------
---
--- This MobilityDB code is provided under The PostgreSQL License.
--- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
--- contributors
---
--- MobilityDB includes portions of PostGIS version 3 source code released
--- under the GNU General Public License (GPLv2 or later).
--- Copyright (c) 2001-2025, PostGIS contributors
---
--- Permission to use, copy, modify, and distribute this software and its
--- documentation for any purpose, without fee, and without a written
--- agreement is hereby granted, provided that the above copyright notice and
--- this paragraph and the following two paragraphs appear in all copies.
---
--- IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
--- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
--- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
--- EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
--- OF SUCH DAMAGE.
---
--- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
--- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
--- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
--- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
--- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
---
--------------------------------------------------------------------------------
-
--------------------------------------------------------------------------------
--- tContains
--------------------------------------------------------------------------------
-
--- Test for NULL inputs since the function is not STRICT
 SELECT tContains(NULL::geometry, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ tcontains 
+-----------
+ 
+(1 row)
+
 SELECT tContains(geometry 'Point(1 1)', NULL::tcbuffer);
+ tcontains 
+-----------
+ 
+(1 row)
 
 SELECT tContains(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+           tcontains            
+--------------------------------
+ f@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tContains(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+                                            tcontains                                             
+--------------------------------------------------------------------------------------------------
+ {f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tContains(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+                             tcontains                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tContains(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+                                                              tcontains                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
 
 SELECT tContains(geometry 'Point empty', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ tcontains 
+-----------
+ 
+(1 row)
+
 SELECT tContains(geometry 'Point empty', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ tcontains 
+-----------
+ 
+(1 row)
+
 SELECT tContains(geometry 'Point empty', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ tcontains 
+-----------
+ 
+(1 row)
+
 SELECT tContains(geometry 'Point empty', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ tcontains 
+-----------
+ 
+(1 row)
 
 SELECT tContains(geometry 'Linestring(1 1,2 2)', tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02]');
+                             tcontains                              
+--------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
 
 /* Errors */
 SELECT tContains(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  Operation on mixed SRID
 SELECT tContains(geometry 'Point(1 1)', tcbuffer 'SRID=5676;Cbuffer(Point(1 1),0)@2000-01-01');
+ERROR:  Operation on mixed SRID
 SELECT tContains(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01');
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tContains(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Po...
+                                                         ^
 SELECT tContains(geometry 'Point(1 1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
-
--------------------------------------------------------------------------------
--- tDisjoint
--------------------------------------------------------------------------------
-
--- Test for NULL inputs since the function is not STRICT
+ERROR:  The geometry cannot have Z dimension
 SELECT tDisjoint(NULL::geometry, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
 SELECT tDisjoint(geometry 'Point(1 1)', NULL::tcbuffer);
+ tdisjoint 
+-----------
+ 
+(1 row)
+
 SELECT tDisjoint(NULL::tcbuffer, geometry 'Point(1 1)');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
 SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::geometry);
+ tdisjoint 
+-----------
+ 
+(1 row)
+
 SELECT tDisjoint(NULL::tcbuffer, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
 SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::tcbuffer);
+ tdisjoint 
+-----------
+ 
+(1 row)
 
 SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+           tdisjoint            
+--------------------------------
+ f@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+                                            tdisjoint                                             
+--------------------------------------------------------------------------------------------------
+ {f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+                                                                                         tdisjoint                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+                                                                                                                          tdisjoint                                                                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [t@Tue Jan 04 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
 
 SELECT tDisjoint(geometry 'Point empty', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
 SELECT tDisjoint(geometry 'Point empty', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
 SELECT tDisjoint(geometry 'Point empty', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
 SELECT tDisjoint(geometry 'Point empty', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ tdisjoint 
+-----------
+ 
+(1 row)
 
 SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)');
+           tdisjoint            
+--------------------------------
+ f@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point(1 1)');
+                                            tdisjoint                                             
+--------------------------------------------------------------------------------------------------
+ {f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)');
+                                                                                         tdisjoint                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)');
+                                                                                                                          tdisjoint                                                                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [t@Tue Jan 04 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
 
 SELECT tDisjoint(tcbuffer '[Cbuffer(Point(0 1),0)@2000-01-01, Cbuffer(Point(2 1),0)@2000-01-04]', geometry 'Linestring(1 0,1 1,2 1,2 0)');
+                                                              tdisjoint                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 12:00:00 2000 PST], (t@Sun Jan 02 12:00:00 2000 PST, t@Tue Jan 04 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDisjoint(tcbuffer '[Cbuffer(Point(0 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-04]', geometry 'Linestring(1 1,2 1)');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
 SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(0 0),0)@2000-01-04]', geometry 'Linestring(0 0,1 1)');
+                             tdisjoint                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Tue Jan 04 00:00:00 2000 PST]}
+(1 row)
 
 SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point empty');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
 SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point empty');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
 SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point empty');
+ tdisjoint 
+-----------
+ 
+(1 row)
+
 SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point empty');
+ tdisjoint 
+-----------
+ 
+(1 row)
 
---3D
 SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', geometry 'Point(2 2 2)');
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-0...
+                                  ^
 SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', geometry 'Point(2 2 2)');
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-...
+                                  ^
 SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', geometry 'Point(2 2 2)');
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-...
+                                  ^
 SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', geometry 'Point(2 2 2)');
-
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01...
+                                  ^
 /* Errors */
 SELECT tDisjoint(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  Operation on mixed SRID
 SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=5676;Point(1 1)');
-
--------------------------------------------------------------------------------
--- tIntersects
--------------------------------------------------------------------------------
-
--- Test for NULL inputs since the function is not STRICT
+ERROR:  Operation on mixed SRID
 SELECT tIntersects(NULL::geometry, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ tintersects 
+-------------
+ 
+(1 row)
+
 SELECT tIntersects(geometry 'Point(1 1)', NULL::tcbuffer);
+ tintersects 
+-------------
+ 
+(1 row)
+
 SELECT tIntersects(NULL::tcbuffer, geometry 'Point(1 1)');
+ tintersects 
+-------------
+ 
+(1 row)
+
 SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::geometry);
+ tintersects 
+-------------
+ 
+(1 row)
+
 SELECT tIntersects(NULL::tcbuffer, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ tintersects 
+-------------
+ 
+(1 row)
+
 SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::tcbuffer);
+ tintersects 
+-------------
+ 
+(1 row)
 
 SELECT tIntersects(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+          tintersects           
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+                                           tintersects                                            
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+                                                                                        tintersects                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+                                                                                                                         tintersects                                                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
 
 SELECT tIntersects(geometry 'Point empty', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ tintersects 
+-------------
+ 
+(1 row)
+
 SELECT tIntersects(geometry 'Point empty', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ tintersects 
+-------------
+ 
+(1 row)
+
 SELECT tIntersects(geometry 'Point empty', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ tintersects 
+-------------
+ 
+(1 row)
+
 SELECT tIntersects(geometry 'Point empty', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ tintersects 
+-------------
+ 
+(1 row)
 
 SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)');
+          tintersects           
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point(1 1)');
+                                           tintersects                                            
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)');
+                                                                                        tintersects                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)');
+                                                                                                                         tintersects                                                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
 
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(0 1),0)@2000-01-01, Cbuffer(Point(2 1),0)@2000-01-04]', geometry 'Linestring(1 0,1 1,2 1,2 0)');
+                                                             tintersects                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 12:00:00 2000 PST], (f@Sun Jan 02 12:00:00 2000 PST, f@Tue Jan 04 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(0 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-04]', geometry 'Linestring(1 1,2 1)');
+ tintersects 
+-------------
+ 
+(1 row)
+
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(0 0),0)@2000-01-04]', geometry 'Linestring(0 0,1 1)');
+                            tintersects                             
+--------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Tue Jan 04 00:00:00 2000 PST]}
+(1 row)
 
 SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point empty');
+ tintersects 
+-------------
+ 
+(1 row)
+
 SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point empty');
+ tintersects 
+-------------
+ 
+(1 row)
+
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point empty');
+ tintersects 
+-------------
+ 
+(1 row)
+
 SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point empty');
+ tintersects 
+-------------
+ 
+(1 row)
 
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-02]', geometry 'Linestring(1 1,2 2)');
+                            tintersects                             
+--------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(4 1),0)@2000-01-02]', geometry 'Linestring(1 2,1 0,2 0,2 2)');
+                            tintersects                             
+--------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
 
---3D
 SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', geometry 'Point(2 2 2)');
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01...
+                                    ^
 SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', geometry 'Point(2 2 2)');
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-0...
+                                    ^
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', geometry 'Point(2 2 2)');
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-0...
+                                    ^
 SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', geometry 'Point(2 2 2)');
-
--- Coverage
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-...
+                                    ^
 SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-03}', tcbuffer 'Cbuffer(Point(2 2),0)@2000-01-02');
+ tintersects 
+-------------
+ 
+(1 row)
+
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(2 1),0)@2000-01-01, Cbuffer(Point(1 2),0)@2000-01-02]');
+                                                             tintersects                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 12:00:00 2000 PST], (f@Sat Jan 01 12:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
 
 /* Errors */
 SELECT tIntersects(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  Operation on mixed SRID
 SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=5676;Point(1 1)');
-
--------------------------------------------------------------------------------
--- tTouches
--------------------------------------------------------------------------------
--- The function does not support 3D or geographies
-
--- Test for NULL inputs since the function is not STRICT
+ERROR:  Operation on mixed SRID
 SELECT tTouches(NULL::geometry, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ ttouches 
+----------
+ 
+(1 row)
+
 SELECT tTouches(geometry 'Point(1 1)', NULL::tcbuffer);
+ ttouches 
+----------
+ 
+(1 row)
 
 SELECT tTouches(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+            ttouches            
+--------------------------------
+ f@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tTouches(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+                                             ttouches                                             
+--------------------------------------------------------------------------------------------------
+ {f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tTouches(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+                              ttouches                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tTouches(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+                                                               ttouches                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
 
 SELECT tTouches(geometry 'Point empty', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
-SELECT tTouches(geometry 'Point empty', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
-SELECT tTouches(geometry 'Point empty', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
-SELECT tTouches(geometry 'Point empty', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ ttouches 
+----------
+ 
+(1 row)
 
--- Test for NULL inputs since the function is not STRICT
+SELECT tTouches(geometry 'Point empty', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+ ttouches 
+----------
+ 
+(1 row)
+
+SELECT tTouches(geometry 'Point empty', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+ ttouches 
+----------
+ 
+(1 row)
+
+SELECT tTouches(geometry 'Point empty', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+ ttouches 
+----------
+ 
+(1 row)
+
 SELECT tTouches(NULL::tcbuffer, geometry 'Point(1 1)');
+ ttouches 
+----------
+ 
+(1 row)
+
 SELECT tTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::geometry);
+ ttouches 
+----------
+ 
+(1 row)
 
 SELECT tTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)');
+            ttouches            
+--------------------------------
+ f@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tTouches(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point(1 1)');
+                                             ttouches                                             
+--------------------------------------------------------------------------------------------------
+ {f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tTouches(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)');
+                              ttouches                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tTouches(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)');
+                                                               ttouches                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
 
 SELECT tTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point empty');
+ ttouches 
+----------
+ 
+(1 row)
+
 SELECT tTouches(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point empty');
+ ttouches 
+----------
+ 
+(1 row)
+
 SELECT tTouches(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point empty');
+ ttouches 
+----------
+ 
+(1 row)
+
 SELECT tTouches(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point empty');
+ ttouches 
+----------
+ 
+(1 row)
 
 SELECT tTouches(geometry 'Linestring(1 1,2 2)', tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02]');
+                                                               ttouches                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 12:00:00 2000 PST], (t@Sat Jan 01 12:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
 
 /* Errors */
 SELECT tTouches(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  Operation on mixed SRID
 SELECT tTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=5676;Point(1 1)');
+ERROR:  Operation on mixed SRID
 SELECT tTouches(geometry 'Point(1 1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ERROR:  The geometry cannot have Z dimension
 SELECT tTouches(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01');
-
--------------------------------------------------------------------------------
--- tDwithin
--------------------------------------------------------------------------------
-
--- Test for NULL inputs since the function is not STRICT
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tTouches(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Poi...
+                                                        ^
 SELECT tDwithin(NULL::geometry, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(geometry 'Point(1 1)', NULL::tcbuffer, 2);
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL);
+ tdwithin 
+----------
+ 
+(1 row)
 
 SELECT tDwithin(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+                                             tdwithin                                             
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+                              tdwithin                              
+--------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+                                                               tdwithin                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
 
 SELECT tDwithin(geometry 'Point empty', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
-SELECT tDwithin(geometry 'Point empty', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
-SELECT tDwithin(geometry 'Point empty', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
-SELECT tDwithin(geometry 'Point empty', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+ tdwithin 
+----------
+ 
+(1 row)
 
--- Test for NULL inputs since the function is not STRICT
+SELECT tDwithin(geometry 'Point empty', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+ tdwithin 
+----------
+ 
+(1 row)
+
+SELECT tDwithin(geometry 'Point empty', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+ tdwithin 
+----------
+ 
+(1 row)
+
+SELECT tDwithin(geometry 'Point empty', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(NULL::tcbuffer, geometry 'Point(1 1)', 2);
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::geometry, 2);
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)', NULL);
+ tdwithin 
+----------
+ 
+(1 row)
 
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point(1 1)', 2);
+                                             tdwithin                                             
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)', 2);
+                              tdwithin                              
+--------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)', 2);
+                                                               tdwithin                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
 
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point empty', 2);
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point empty', 2);
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point empty', 2);
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point empty', 2);
+ tdwithin 
+----------
+ 
+(1 row)
 
---3D
 SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer 'Cbuffer(P...
+                                                          ^
 SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '{Cbuffer(...
+                                                          ^
 SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '[Cbuffer(...
+                                                          ^
 SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', 2);
-
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '{[Cbuffer...
+                                                          ^
 SELECT tDwithin(geometry 'Point Z empty', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: ...ELECT tDwithin(geometry 'Point Z empty', tcbuffer 'Cbuffer(P...
+                                                             ^
 SELECT tDwithin(geometry 'Point Z empty', tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: ...ELECT tDwithin(geometry 'Point Z empty', tcbuffer '{Cbuffer(...
+                                                             ^
 SELECT tDwithin(geometry 'Point Z empty', tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: ...ELECT tDwithin(geometry 'Point Z empty', tcbuffer '[Cbuffer(...
+                                                             ^
 SELECT tDwithin(geometry 'Point Z empty', tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', 2);
-
+ERROR:  The geometry cannot have Z dimension
+LINE 1: ...ELECT tDwithin(geometry 'Point Z empty', tcbuffer '{[Cbuffer...
+                                                             ^
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', geometry 'Point(1 1 1)', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01...
+                                 ^
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', geometry 'Point(1 1 1)', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-0...
+                                 ^
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', geometry 'Point(1 1 1)', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-0...
+                                 ^
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', geometry 'Point(1 1 1)', 2);
-
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-...
+                                 ^
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', geometry 'Point Z empty', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01...
+                                 ^
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', geometry 'Point Z empty', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-0...
+                                 ^
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', geometry 'Point Z empty', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-0...
+                                 ^
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', geometry 'Point Z empty', 2);
-
--- Test for NULL inputs since the function is not STRICT
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-...
+                                 ^
 SELECT tDwithin(NULL::tcbuffer, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
-SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::tcbuffer, 2);
-SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL);
+ tdwithin 
+----------
+ 
+(1 row)
 
--- Coverage
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::tcbuffer, 2);
+ tdwithin 
+----------
+ 
+(1 row)
+
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL);
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(tcbuffer '(Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02]', geometry 'Point(0 1)', 1);
+                             tdwithin                             
+------------------------------------------------------------------
+ (f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02]', geometry 'Point(2 3)', 1);
+ tdwithin 
+----------
+ 
+(1 row)
 
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+                                             tdwithin                                             
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+                                             tdwithin                                             
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
+                                             tdwithin                                             
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+                                             tdwithin                                             
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+                              tdwithin                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
+                              tdwithin                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+                                             tdwithin                                             
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+                              tdwithin                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+                                                               tdwithin                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [t@Tue Jan 04 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
 
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(1 3),0)@2000-01-03]', geometry 'Point(1 2)', 0);
+                                                               tdwithin                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST], (f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(1 2),0)@2000-01-03]', geometry 'Point(1 3)', 0);
+                             tdwithin                             
+------------------------------------------------------------------
+ [f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
 SELECT tDwithin(tcbuffer '(Cbuffer(Point(0 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(1 0),0)@2000-01-01, Cbuffer(Point(2 0),0)@2000-01-02]', 1);
+                              tdwithin                              
+--------------------------------------------------------------------
+ {(f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(0 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(1 0),0)@2000-01-01, Cbuffer(Point(2 0),0)@2000-01-02]', 1);
+                              tdwithin                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(0 1),0)@2000-01-01, Cbuffer(Point(0 0),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(2 0),0)@2000-01-01, Cbuffer(Point(1 0),0)@2000-01-02]', 1);
+                              tdwithin                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(0 0),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(2 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-02]', 1);
+                                                               tdwithin                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 12:00:00 2000 PST], (f@Sat Jan 01 12:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(0 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(0 2),0)@2000-01-01, Cbuffer(Point(1 3),0)@2000-01-02]', 1);
+                              tdwithin                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(0 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(4 0),0)@2000-01-01, Cbuffer(Point(3 1),0)@2000-01-02]', 0);
+                              tdwithin                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
 
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01...
+                                 ^
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-0...
+                                 ^
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-0...
+                                 ^
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-...
+                                 ^
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01...
+                                 ^
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-0...
+                                 ^
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-0...
+                                 ^
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-...
+                                 ^
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01...
+                                 ^
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-0...
+                                 ^
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-0...
+                                 ^
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-...
+                                 ^
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01...
+                                 ^
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-0...
+                                 ^
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-0...
+                                 ^
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', 2);
-
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-...
+                                 ^
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02, Cbuffer(Point(1 1),0)@2000-01-03, Cbuffer(Point(3 3),0)@
 2000-01-04, Cbuffer(Point(3 3),0)@2000-01-05]}', tcbuffer '{[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02, Cbuffer(Point(1 1),0)@2000-01-03]
 ,[Cbuffer(Point(3 3),0)@2000-01-04, Cbuffer(Point(3 3),0)@2000-01-05]}', 1);
+                                                               tdwithin                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [t@Tue Jan 04 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
 
--- Mixed 2D/3D
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
-
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01...
+                                 ^
 SELECT tDwithin(geometry 'Linestring(1 1,2 2)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Linestring(1 1,2 2)', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
 
 /* Errors */
 SELECT tDwithin(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ERROR:  Operation on mixed SRID
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=5676;Point(1 1)', 2);
+ERROR:  Operation on mixed SRID
 SELECT tDwithin(tcbuffer 'SRID=5676;Cbuffer(Point(1 1),0)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ERROR:  Operation on mixed SRID
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(0 0)', -1);
+ERROR:  The value cannot be negative: -1.000000
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', geometry 'Point(0 0 0)', -1);
-
--------------------------------------------------------------------------------
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01...
+                                 ^

--- a/mobilitydb/test/cbuffer/expected/164_tcbuffer_tempspatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/164_tcbuffer_tempspatialrels.test.out
@@ -120,19 +120,19 @@ SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-0
 SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
                                             tdisjoint                                             
 --------------------------------------------------------------------------------------------------
- {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+ {f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST}
 (1 row)
 
 SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
-                                                                                                             tdisjoint                                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[t@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST], (t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+                                                                                         tdisjoint                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
-                                                                                                                                              tdisjoint                                                                                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[t@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST], (t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [t@Tue Jan 04 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
+                                                                                                                          tdisjoint                                                                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [t@Tue Jan 04 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tDisjoint(geometry 'Point empty', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
@@ -168,37 +168,37 @@ SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(
 SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point(1 1)');
                                             tdisjoint                                             
 --------------------------------------------------------------------------------------------------
- {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+ {f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST}
 (1 row)
 
 SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)');
-                                                                                                             tdisjoint                                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[t@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST], (t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+                                                                                         tdisjoint                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)');
-                                                                                                                                              tdisjoint                                                                                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[t@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST], (t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [t@Tue Jan 04 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
+                                                                                                                          tdisjoint                                                                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [t@Tue Jan 04 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tDisjoint(tcbuffer '[Cbuffer(Point(0 1),0.5)@2000-01-01, Cbuffer(Point(2 1),0.5)@2000-01-04]', geometry 'Linestring(1 0,1 1,2 1,2 0)');
-                                                                              tdisjoint                                                                               
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[t@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 18:00:00 2000 PST, f@Mon Jan 03 06:00:00 2000 PST], (t@Mon Jan 03 06:00:00 2000 PST, t@Tue Jan 04 00:00:00 2000 PST]}
+                                             tdisjoint                                              
+----------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 18:00:00 2000 PST, f@Tue Jan 04 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tDisjoint(tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-04]', geometry 'Linestring(1 1,2 1)');
-                                                                                         tdisjoint                                                                                         
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[t@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 22:32:38.961158 2000 PST, f@Mon Jan 03 23:59:59.999999 2000 PST], (t@Mon Jan 03 23:59:59.999999 2000 PST, t@Tue Jan 04 00:00:00 2000 PST]}
+                                                 tdisjoint                                                 
+-----------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 22:32:38.961158 2000 PST, f@Tue Jan 04 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(0 0),0.5)@2000-01-04]', geometry 'Linestring(0 0,1 1)');
-                                                                                         tdisjoint                                                                                         
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[t@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 01:27:21.038841 2000 PST, f@Sun Jan 02 22:32:38.961158 2000 PST], (t@Sun Jan 02 22:32:38.961158 2000 PST, t@Tue Jan 04 00:00:00 2000 PST]}
+                             tdisjoint                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Tue Jan 04 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point empty');
@@ -291,19 +291,19 @@ SELECT tIntersects(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000
 SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
                                            tintersects                                            
 --------------------------------------------------------------------------------------------------
- {f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST}
+ {t@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
 (1 row)
 
 SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
-                                                                                                            tintersects                                                                                                             
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST], (f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+                                                                                        tintersects                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
-                                                                                                                                             tintersects                                                                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST], (f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+                                                                                                                         tintersects                                                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tIntersects(geometry 'Point empty', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
@@ -339,37 +339,37 @@ SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Poin
 SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point(1 1)');
                                            tintersects                                            
 --------------------------------------------------------------------------------------------------
- {f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST}
+ {t@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
 (1 row)
 
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)');
-                                                                                                            tintersects                                                                                                             
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST], (f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+                                                                                        tintersects                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)');
-                                                                                                                                             tintersects                                                                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST], (f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+                                                                                                                         tintersects                                                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(0 1),0.5)@2000-01-01, Cbuffer(Point(2 1),0.5)@2000-01-04]', geometry 'Linestring(1 0,1 1,2 1,2 0)');
-                                                                             tintersects                                                                              
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 18:00:00 2000 PST, t@Mon Jan 03 06:00:00 2000 PST], (f@Mon Jan 03 06:00:00 2000 PST, f@Tue Jan 04 00:00:00 2000 PST]}
+                                            tintersects                                             
+----------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 18:00:00 2000 PST, t@Tue Jan 04 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-04]', geometry 'Linestring(1 1,2 1)');
-                                                                                        tintersects                                                                                        
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 22:32:38.961158 2000 PST, t@Mon Jan 03 23:59:59.999999 2000 PST], (f@Mon Jan 03 23:59:59.999999 2000 PST, f@Tue Jan 04 00:00:00 2000 PST]}
+                                                tintersects                                                
+-----------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 22:32:38.961158 2000 PST, t@Tue Jan 04 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(0 0),0.5)@2000-01-04]', geometry 'Linestring(0 0,1 1)');
-                                                                                        tintersects                                                                                        
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 01:27:21.038841 2000 PST, t@Sun Jan 02 22:32:38.961158 2000 PST], (f@Sun Jan 02 22:32:38.961158 2000 PST, f@Tue Jan 04 00:00:00 2000 PST]}
+                            tintersects                             
+--------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Tue Jan 04 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point empty');
@@ -397,15 +397,15 @@ SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point
 (1 row)
 
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]', geometry 'Linestring(1 1,2 2)');
- tintersects 
--------------
- 
+                            tintersects                             
+--------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(4 1),0.5)@2000-01-02]', geometry 'Linestring(1 2,1 0,2 0,2 2)');
-                                                             tintersects                                                              
---------------------------------------------------------------------------------------------------------------------------------------
- {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:00:00 2000 PST], (f@Sat Jan 01 08:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
+                            tintersects                             
+--------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer 'Cbuffer(Point(2 2),0.5)@2000-01-02');
@@ -579,115 +579,137 @@ ERROR:  The geometry cannot have Z dimension
 LINE 1: SELECT tTouches(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Poi...
                                                         ^
 SELECT tDwithin(NULL::geometry, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
-ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
-LINE 1: SELECT tDwithin(NULL::geometry, tcbuffer 'Cbuffer(Point(1 1)...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(geometry 'Point(1 1)', NULL::tcbuffer, 2);
-ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
-LINE 1: SELECT tDwithin(geometry 'Point(1 1)', NULL::tcbuffer, 2);
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL);
-ERROR:  function tdwithin(geometry, tcbuffer, unknown) does not exist
-LINE 1: SELECT tDwithin(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Poi...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
-ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
-LINE 1: SELECT tDwithin(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Poi...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
-ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
-LINE 1: SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Po...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+                                             tdwithin                                             
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
-ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
-LINE 1: SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Po...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+                              tdwithin                              
+--------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
-ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
-LINE 1: SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(P...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+                                                               tdwithin                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(geometry 'Point empty', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
-ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
-LINE 1: SELECT tDwithin(geometry 'Point empty', tcbuffer 'Cbuffer(Po...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(geometry 'Point empty', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
-ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
-LINE 1: SELECT tDwithin(geometry 'Point empty', tcbuffer '{Cbuffer(P...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(geometry 'Point empty', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
-ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
-LINE 1: SELECT tDwithin(geometry 'Point empty', tcbuffer '[Cbuffer(P...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(geometry 'Point empty', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
-ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
-LINE 1: SELECT tDwithin(geometry 'Point empty', tcbuffer '{[Cbuffer(...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(NULL::tcbuffer, geometry 'Point(1 1)', 2);
-ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
-LINE 1: SELECT tDwithin(NULL::tcbuffer, geometry 'Point(1 1)', 2);
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::geometry, 2);
-ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
-LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)', NULL);
-ERROR:  function tdwithin(tcbuffer, geometry, unknown) does not exist
-LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)', 2);
-ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
-LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point(1 1)', 2);
-ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
-LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-0...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+                                             tdwithin                                             
+--------------------------------------------------------------------------------------------------
+ {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)', 2);
-ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
-LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-0...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+                              tdwithin                              
+--------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)', 2);
-ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
-LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+                                                               tdwithin                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point empty', 2);
-ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
-LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point empty', 2);
-ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
-LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-0...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point empty', 2);
-ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
-LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-0...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point empty', 2);
-ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
-LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ tdwithin 
+----------
+ 
+(1 row)
+
 SELECT tDwithin(NULL::tcbuffer, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
  tdwithin 
 ----------
@@ -707,15 +729,17 @@ SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer
 (1 row)
 
 SELECT tDwithin(tcbuffer '(Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02]', geometry 'Point(0 1)', 1);
-ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
-LINE 1: SELECT tDwithin(tcbuffer '(Cbuffer(Point(1 1),0.5)@2000-01-0...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+                                                                      tdwithin                                                                      
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ {(t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 10:26:59.799554 2000 PST], (f@Sat Jan 01 10:26:59.799554 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 2),0.5)@2000-01-03]', geometry 'Point(2 3)', 1);
-ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
-LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-0...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+                                                 tdwithin                                                  
+-----------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 18:20:03.726744 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
             tdwithin            
 --------------------------------
@@ -813,15 +837,17 @@ SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 
 (1 row)
 
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 3),0.5)@2000-01-03]', geometry 'Point(1 2)', 0);
-ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
-LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-0...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+                                                                               tdwithin                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 12:00:00 2000 PST, t@Sun Jan 02 12:00:00 2000 PST], (f@Sun Jan 02 12:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 2),0.5)@2000-01-03]', geometry 'Point(1 3)', 0);
-ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
-LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-0...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+                             tdwithin                             
+------------------------------------------------------------------
+ [f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
 SELECT tDwithin(tcbuffer '(Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(1 0),0.5)@2000-01-01, Cbuffer(Point(2 0),0.5)@2000-01-02]', 1);
                               tdwithin                              
 --------------------------------------------------------------------
@@ -865,33 +891,26 @@ SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 
 (1 row)
 
 SELECT tDwithin(geometry 'Linestring(1 1,2 2)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
-ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
-LINE 1: SELECT tDwithin(geometry 'Linestring(1 1,2 2)', tcbuffer 'Cb...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Linestring(1 1,2 2)', 2);
-ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
-LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 /* Errors */
 SELECT tDwithin(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
-ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
-LINE 2: SELECT tDwithin(geometry 'SRID=5676;Point(1 1)', tcbuffer 'C...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ERROR:  Operation on mixed SRID
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=5676;Point(1 1)', 2);
-ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
-LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ERROR:  Operation on mixed SRID
 SELECT tDwithin(tcbuffer 'SRID=5676;Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
 ERROR:  Operation on mixed SRID
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(0 0)', -1);
-ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
-LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ERROR:  The value cannot be negative: -1.000000
 SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01-01', 2);
 ERROR:  The geometry cannot have Z dimension
 LINE 1: SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer 'Cbuffer(P...

--- a/mobilitydb/test/cbuffer/expected/164_tcbuffer_tempspatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/164_tcbuffer_tempspatialrels.test.out
@@ -58,18 +58,18 @@ SELECT tContains(geometry 'Point empty', tcbuffer '{[Cbuffer(Point(1 1),0.5)@200
  
 (1 row)
 
-SELECT tContains(geometry 'Linestring(1 1,2 2)', tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02]');
-                             tcontains                              
---------------------------------------------------------------------
- {[t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST]}
+SELECT tContains(geometry 'Linestring(1 1,2 2)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02]');
+                                                              tcontains                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 12:00:00 2000 PST], (f@Sat Jan 01 12:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
 (1 row)
 
 /* Errors */
 SELECT tContains(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
 ERROR:  Operation on mixed SRID
-SELECT tContains(geometry 'Point(1 1)', tcbuffer 'SRID=5676;Cbuffer(Point(1 1),0)@2000-01-01');
+SELECT tContains(geometry 'Point(1 1)', tcbuffer 'SRID=5676;Cbuffer(Point(1 1),0.5)@2000-01-01');
 ERROR:  Operation on mixed SRID
-SELECT tContains(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01');
+SELECT tContains(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01-01');
 ERROR:  The geometry cannot have Z dimension
 LINE 1: SELECT tContains(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Po...
                                                          ^
@@ -120,19 +120,19 @@ SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-0
 SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
                                             tdisjoint                                             
 --------------------------------------------------------------------------------------------------
- {f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST}
+ {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
 (1 row)
 
 SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
-                                                                                         tdisjoint                                                                                         
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[f@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+                                                                                                             tdisjoint                                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST], (t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
-                                                                                                                          tdisjoint                                                                                                                          
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[f@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [t@Tue Jan 04 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
+                                                                                                                                              tdisjoint                                                                                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST], (t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [t@Tue Jan 04 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tDisjoint(geometry 'Point empty', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
@@ -168,37 +168,37 @@ SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(
 SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point(1 1)');
                                             tdisjoint                                             
 --------------------------------------------------------------------------------------------------
- {f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST}
+ {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
 (1 row)
 
 SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)');
-                                                                                         tdisjoint                                                                                         
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[f@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+                                                                                                             tdisjoint                                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST], (t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)');
-                                                                                                                          tdisjoint                                                                                                                          
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[f@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [t@Tue Jan 04 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
+                                                                                                                                              tdisjoint                                                                                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST], (t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [t@Tue Jan 04 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
-SELECT tDisjoint(tcbuffer '[Cbuffer(Point(0 1),0)@2000-01-01, Cbuffer(Point(2 1),0)@2000-01-04]', geometry 'Linestring(1 0,1 1,2 1,2 0)');
-                                                              tdisjoint                                                               
---------------------------------------------------------------------------------------------------------------------------------------
- {[t@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 12:00:00 2000 PST], (t@Sun Jan 02 12:00:00 2000 PST, t@Tue Jan 04 00:00:00 2000 PST]}
+SELECT tDisjoint(tcbuffer '[Cbuffer(Point(0 1),0.5)@2000-01-01, Cbuffer(Point(2 1),0.5)@2000-01-04]', geometry 'Linestring(1 0,1 1,2 1,2 0)');
+                                                                              tdisjoint                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 18:00:00 2000 PST, f@Mon Jan 03 06:00:00 2000 PST], (t@Mon Jan 03 06:00:00 2000 PST, t@Tue Jan 04 00:00:00 2000 PST]}
 (1 row)
 
-SELECT tDisjoint(tcbuffer '[Cbuffer(Point(0 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-04]', geometry 'Linestring(1 1,2 1)');
- tdisjoint 
------------
- 
+SELECT tDisjoint(tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-04]', geometry 'Linestring(1 1,2 1)');
+                                                                                         tdisjoint                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 22:32:38.961158 2000 PST, f@Mon Jan 03 23:59:59.999999 2000 PST], (t@Mon Jan 03 23:59:59.999999 2000 PST, t@Tue Jan 04 00:00:00 2000 PST]}
 (1 row)
 
-SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(0 0),0)@2000-01-04]', geometry 'Linestring(0 0,1 1)');
-                             tdisjoint                              
---------------------------------------------------------------------
- {[f@Sat Jan 01 00:00:00 2000 PST, f@Tue Jan 04 00:00:00 2000 PST]}
+SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(0 0),0.5)@2000-01-04]', geometry 'Linestring(0 0,1 1)');
+                                                                                         tdisjoint                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 01:27:21.038841 2000 PST, f@Sun Jan 02 22:32:38.961158 2000 PST], (t@Sun Jan 02 22:32:38.961158 2000 PST, t@Tue Jan 04 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point empty');
@@ -225,27 +225,27 @@ SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2
  
 (1 row)
 
-SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', geometry 'Point(2 2 2)');
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-0...
-                                  ^
-SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', geometry 'Point(2 2 2)');
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-...
-                                  ^
-SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', geometry 'Point(2 2 2)');
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-...
-                                  ^
-SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', geometry 'Point(2 2 2)');
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01...
-                                  ^
 /* Errors */
 SELECT tDisjoint(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
 ERROR:  Operation on mixed SRID
 SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=5676;Point(1 1)');
 ERROR:  Operation on mixed SRID
+SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01-01', geometry 'Point(2 2 2)');
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01...
+                                  ^
+SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1 1),0.5)@2000-01-01, Cbuffer(Point(2 2 2),0.5)@2000-01-02, Cbuffer(Point(1 1 1),0.5)@2000-01-03}', geometry 'Point(2 2 2)');
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1 1),0.5)@2000-0...
+                                  ^
+SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1 1),0.5)@2000-01-01, Cbuffer(Point(2 2 2),0.5)@2000-01-02, Cbuffer(Point(1 1 1),0.5)@2000-01-03]', geometry 'Point(2 2 2)');
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1 1),0.5)@2000-0...
+                                  ^
+SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1 1),0.5)@2000-01-01, Cbuffer(Point(2 2 2),0.5)@2000-01-02, Cbuffer(Point(1 1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3 3),0.5)@2000-01-04, Cbuffer(Point(3 3 3),0.5)@2000-01-05]}', geometry 'Point(2 2 2)');
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1 1),0.5)@2000-...
+                                  ^
 SELECT tIntersects(NULL::geometry, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
  tintersects 
 -------------
@@ -291,19 +291,19 @@ SELECT tIntersects(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000
 SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
                                            tintersects                                            
 --------------------------------------------------------------------------------------------------
- {t@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+ {f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST}
 (1 row)
 
 SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
-                                                                                        tintersects                                                                                        
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+                                                                                                            tintersects                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST], (f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
-                                                                                                                         tintersects                                                                                                                         
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+                                                                                                                                             tintersects                                                                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST], (f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tIntersects(geometry 'Point empty', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
@@ -339,37 +339,37 @@ SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Poin
 SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point(1 1)');
                                            tintersects                                            
 --------------------------------------------------------------------------------------------------
- {t@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
+ {f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST}
 (1 row)
 
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)');
-                                                                                        tintersects                                                                                        
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+                                                                                                            tintersects                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST], (f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)');
-                                                                                                                         tintersects                                                                                                                         
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+                                                                                                                                             tintersects                                                                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST], (f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
-SELECT tIntersects(tcbuffer '[Cbuffer(Point(0 1),0)@2000-01-01, Cbuffer(Point(2 1),0)@2000-01-04]', geometry 'Linestring(1 0,1 1,2 1,2 0)');
-                                                             tintersects                                                              
---------------------------------------------------------------------------------------------------------------------------------------
- {[f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 12:00:00 2000 PST], (f@Sun Jan 02 12:00:00 2000 PST, f@Tue Jan 04 00:00:00 2000 PST]}
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(0 1),0.5)@2000-01-01, Cbuffer(Point(2 1),0.5)@2000-01-04]', geometry 'Linestring(1 0,1 1,2 1,2 0)');
+                                                                             tintersects                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 18:00:00 2000 PST, t@Mon Jan 03 06:00:00 2000 PST], (f@Mon Jan 03 06:00:00 2000 PST, f@Tue Jan 04 00:00:00 2000 PST]}
 (1 row)
 
-SELECT tIntersects(tcbuffer '[Cbuffer(Point(0 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-04]', geometry 'Linestring(1 1,2 1)');
- tintersects 
--------------
- 
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-04]', geometry 'Linestring(1 1,2 1)');
+                                                                                        tintersects                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 22:32:38.961158 2000 PST, t@Mon Jan 03 23:59:59.999999 2000 PST], (f@Mon Jan 03 23:59:59.999999 2000 PST, f@Tue Jan 04 00:00:00 2000 PST]}
 (1 row)
 
-SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(0 0),0)@2000-01-04]', geometry 'Linestring(0 0,1 1)');
-                            tintersects                             
---------------------------------------------------------------------
- {[t@Sat Jan 01 00:00:00 2000 PST, t@Tue Jan 04 00:00:00 2000 PST]}
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(0 0),0.5)@2000-01-04]', geometry 'Linestring(0 0,1 1)');
+                                                                                        tintersects                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 01:27:21.038841 2000 PST, t@Sun Jan 02 22:32:38.961158 2000 PST], (f@Sun Jan 02 22:32:38.961158 2000 PST, f@Tue Jan 04 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point empty');
@@ -396,44 +396,28 @@ SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point
  
 (1 row)
 
-SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-02]', geometry 'Linestring(1 1,2 2)');
-                            tintersects                             
---------------------------------------------------------------------
- {[t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST]}
-(1 row)
-
-SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(4 1),0)@2000-01-02]', geometry 'Linestring(1 2,1 0,2 0,2 2)');
-                            tintersects                             
---------------------------------------------------------------------
- {[t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST]}
-(1 row)
-
-SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', geometry 'Point(2 2 2)');
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01...
-                                    ^
-SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', geometry 'Point(2 2 2)');
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-0...
-                                    ^
-SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', geometry 'Point(2 2 2)');
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-0...
-                                    ^
-SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', geometry 'Point(2 2 2)');
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-...
-                                    ^
-SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-03}', tcbuffer 'Cbuffer(Point(2 2),0)@2000-01-02');
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]', geometry 'Linestring(1 1,2 2)');
  tintersects 
 -------------
  
 (1 row)
 
-SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(2 1),0)@2000-01-01, Cbuffer(Point(1 2),0)@2000-01-02]');
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(4 1),0.5)@2000-01-02]', geometry 'Linestring(1 2,1 0,2 0,2 2)');
                                                              tintersects                                                              
 --------------------------------------------------------------------------------------------------------------------------------------
- {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 12:00:00 2000 PST], (f@Sat Jan 01 12:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:00:00 2000 PST], (f@Sat Jan 01 08:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer 'Cbuffer(Point(2 2),0.5)@2000-01-02');
+ tintersects 
+-------------
+ 
+(1 row)
+
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(2 1),0.5)@2000-01-01, Cbuffer(Point(1 2),0.5)@2000-01-02]');
+                           tintersects                            
+------------------------------------------------------------------
+ [t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST]
 (1 row)
 
 /* Errors */
@@ -441,6 +425,22 @@ SELECT tIntersects(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1)
 ERROR:  Operation on mixed SRID
 SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=5676;Point(1 1)');
 ERROR:  Operation on mixed SRID
+SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01-01', geometry 'Point(2 2 2)');
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-...
+                                    ^
+SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1 1),0.5)@2000-01-01, Cbuffer(Point(2 2 2),0.5)@2000-01-02, Cbuffer(Point(1 1 1),0.5)@2000-01-03}', geometry 'Point(2 2 2)');
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1 1),0.5)@2000...
+                                    ^
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1 1),0.5)@2000-01-01, Cbuffer(Point(2 2 2),0.5)@2000-01-02, Cbuffer(Point(1 1 1),0.5)@2000-01-03]', geometry 'Point(2 2 2)');
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1 1),0.5)@2000...
+                                    ^
+SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1 1),0.5)@2000-01-01, Cbuffer(Point(2 2 2),0.5)@2000-01-02, Cbuffer(Point(1 1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3 3),0.5)@2000-01-04, Cbuffer(Point(3 3 3),0.5)@2000-01-05]}', geometry 'Point(2 2 2)');
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1 1),0.5)@200...
+                                    ^
 SELECT tTouches(NULL::geometry, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
  ttouches 
 ----------
@@ -561,10 +561,10 @@ SELECT tTouches(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 
  
 (1 row)
 
-SELECT tTouches(geometry 'Linestring(1 1,2 2)', tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02]');
-                                                               ttouches                                                               
---------------------------------------------------------------------------------------------------------------------------------------
- {[t@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 12:00:00 2000 PST], (t@Sat Jan 01 12:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST]}
+SELECT tTouches(geometry 'Linestring(1 1,2 2)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02]');
+                              ttouches                              
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
 (1 row)
 
 /* Errors */
@@ -574,206 +574,120 @@ SELECT tTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=56
 ERROR:  Operation on mixed SRID
 SELECT tTouches(geometry 'Point(1 1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
 ERROR:  The geometry cannot have Z dimension
-SELECT tTouches(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01');
+SELECT tTouches(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01-01');
 ERROR:  The geometry cannot have Z dimension
 LINE 1: SELECT tTouches(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Poi...
                                                         ^
 SELECT tDwithin(NULL::geometry, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
- tdwithin 
-----------
- 
-(1 row)
-
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 1: SELECT tDwithin(NULL::geometry, tcbuffer 'Cbuffer(Point(1 1)...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT tDwithin(geometry 'Point(1 1)', NULL::tcbuffer, 2);
- tdwithin 
-----------
- 
-(1 row)
-
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point(1 1)', NULL::tcbuffer, 2);
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT tDwithin(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL);
- tdwithin 
-----------
- 
-(1 row)
-
+ERROR:  function tdwithin(geometry, tcbuffer, unknown) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Poi...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT tDwithin(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
-            tdwithin            
---------------------------------
- t@Sat Jan 01 00:00:00 2000 PST
-(1 row)
-
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Poi...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
-                                             tdwithin                                             
---------------------------------------------------------------------------------------------------
- {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
-(1 row)
-
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Po...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
-                              tdwithin                              
---------------------------------------------------------------------
- {[t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
-(1 row)
-
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Po...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
-                                                               tdwithin                                                               
---------------------------------------------------------------------------------------------------------------------------------------
- {[t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
-(1 row)
-
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(P...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT tDwithin(geometry 'Point empty', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
- tdwithin 
-----------
- 
-(1 row)
-
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point empty', tcbuffer 'Cbuffer(Po...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT tDwithin(geometry 'Point empty', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', 2);
- tdwithin 
-----------
- 
-(1 row)
-
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point empty', tcbuffer '{Cbuffer(P...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT tDwithin(geometry 'Point empty', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', 2);
- tdwithin 
-----------
- 
-(1 row)
-
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point empty', tcbuffer '[Cbuffer(P...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT tDwithin(geometry 'Point empty', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
- tdwithin 
-----------
- 
-(1 row)
-
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 1: SELECT tDwithin(geometry 'Point empty', tcbuffer '{[Cbuffer(...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT tDwithin(NULL::tcbuffer, geometry 'Point(1 1)', 2);
- tdwithin 
-----------
- 
-(1 row)
-
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(NULL::tcbuffer, geometry 'Point(1 1)', 2);
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::geometry, 2);
- tdwithin 
-----------
- 
-(1 row)
-
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)', NULL);
- tdwithin 
-----------
- 
-(1 row)
-
+ERROR:  function tdwithin(tcbuffer, geometry, unknown) does not exist
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(1 1)', 2);
-            tdwithin            
---------------------------------
- t@Sat Jan 01 00:00:00 2000 PST
-(1 row)
-
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point(1 1)', 2);
-                                             tdwithin                                             
---------------------------------------------------------------------------------------------------
- {t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST}
-(1 row)
-
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)', 2);
-                              tdwithin                              
---------------------------------------------------------------------
- {[t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
-(1 row)
-
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)', 2);
-                                                               tdwithin                                                               
---------------------------------------------------------------------------------------------------------------------------------------
- {[t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
-(1 row)
-
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point empty', 2);
- tdwithin 
-----------
- 
-(1 row)
-
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point empty', 2);
- tdwithin 
-----------
- 
-(1 row)
-
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point empty', 2);
- tdwithin 
-----------
- 
-(1 row)
-
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point empty', 2);
- tdwithin 
-----------
- 
-(1 row)
-
-SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer 'Cbuffer(P...
-                                                          ^
-SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '{Cbuffer(...
-                                                          ^
-SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '[Cbuffer(...
-                                                          ^
-SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '{[Cbuffer...
-                                                          ^
-SELECT tDwithin(geometry 'Point Z empty', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: ...ELECT tDwithin(geometry 'Point Z empty', tcbuffer 'Cbuffer(P...
-                                                             ^
-SELECT tDwithin(geometry 'Point Z empty', tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: ...ELECT tDwithin(geometry 'Point Z empty', tcbuffer '{Cbuffer(...
-                                                             ^
-SELECT tDwithin(geometry 'Point Z empty', tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: ...ELECT tDwithin(geometry 'Point Z empty', tcbuffer '[Cbuffer(...
-                                                             ^
-SELECT tDwithin(geometry 'Point Z empty', tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: ...ELECT tDwithin(geometry 'Point Z empty', tcbuffer '{[Cbuffer...
-                                                             ^
-SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', geometry 'Point(1 1 1)', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01...
-                                 ^
-SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', geometry 'Point(1 1 1)', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-0...
-                                 ^
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', geometry 'Point(1 1 1)', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-0...
-                                 ^
-SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', geometry 'Point(1 1 1)', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-...
-                                 ^
-SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', geometry 'Point Z empty', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01...
-                                 ^
-SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', geometry 'Point Z empty', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-0...
-                                 ^
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', geometry 'Point Z empty', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-0...
-                                 ^
-SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', geometry 'Point Z empty', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-...
-                                 ^
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT tDwithin(NULL::tcbuffer, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
  tdwithin 
 ----------
@@ -792,18 +706,16 @@ SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer
  
 (1 row)
 
-SELECT tDwithin(tcbuffer '(Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02]', geometry 'Point(0 1)', 1);
-                             tdwithin                             
-------------------------------------------------------------------
- (f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]
-(1 row)
-
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02]', geometry 'Point(2 3)', 1);
- tdwithin 
-----------
- 
-(1 row)
-
+SELECT tDwithin(tcbuffer '(Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02]', geometry 'Point(0 1)', 1);
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '(Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 2),0.5)@2000-01-03]', geometry 'Point(2 3)', 1);
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
             tdwithin            
 --------------------------------
@@ -900,152 +812,99 @@ SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 
  {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [t@Tue Jan 04 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(1 3),0)@2000-01-03]', geometry 'Point(1 2)', 0);
-                                                               tdwithin                                                               
---------------------------------------------------------------------------------------------------------------------------------------
- {[f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST], (f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
-(1 row)
-
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(1 2),0)@2000-01-03]', geometry 'Point(1 3)', 0);
-                             tdwithin                             
-------------------------------------------------------------------
- [f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]
-(1 row)
-
-SELECT tDwithin(tcbuffer '(Cbuffer(Point(0 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(1 0),0)@2000-01-01, Cbuffer(Point(2 0),0)@2000-01-02]', 1);
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 3),0.5)@2000-01-03]', geometry 'Point(1 2)', 0);
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 2),0.5)@2000-01-03]', geometry 'Point(1 3)', 0);
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-0...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer '(Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(1 0),0.5)@2000-01-01, Cbuffer(Point(2 0),0.5)@2000-01-02]', 1);
                               tdwithin                              
 --------------------------------------------------------------------
  {(f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
 (1 row)
 
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(0 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(1 0),0)@2000-01-01, Cbuffer(Point(2 0),0)@2000-01-02]', 1);
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(1 0),0.5)@2000-01-01, Cbuffer(Point(2 0),0.5)@2000-01-02]', 1);
                               tdwithin                              
 --------------------------------------------------------------------
  {[f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
 (1 row)
 
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(0 1),0)@2000-01-01, Cbuffer(Point(0 0),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(2 0),0)@2000-01-01, Cbuffer(Point(1 0),0)@2000-01-02]', 1);
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(0 1),0.5)@2000-01-01, Cbuffer(Point(0 0),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(2 0),0.5)@2000-01-01, Cbuffer(Point(1 0),0.5)@2000-01-02]', 1);
+                                                                      tdwithin                                                                      
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 04:15:03.543362 2000 PST], (f@Sat Jan 01 04:15:03.543362 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(0 0),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(2 0),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]', 1);
                               tdwithin                              
 --------------------------------------------------------------------
  {[f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
 (1 row)
 
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(0 0),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(2 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-02]', 1);
-                                                               tdwithin                                                               
---------------------------------------------------------------------------------------------------------------------------------------
- {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 12:00:00 2000 PST], (f@Sat Jan 01 12:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
-(1 row)
-
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(0 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(0 2),0)@2000-01-01, Cbuffer(Point(1 3),0)@2000-01-02]', 1);
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(0 2),0.5)@2000-01-01, Cbuffer(Point(1 3),0.5)@2000-01-02]', 1);
                               tdwithin                              
 --------------------------------------------------------------------
  {[f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
 (1 row)
 
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(0 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(4 0),0)@2000-01-01, Cbuffer(Point(3 1),0)@2000-01-02]', 0);
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(4 0),0.5)@2000-01-01, Cbuffer(Point(3 1),0.5)@2000-01-02]', 0);
                               tdwithin                              
 --------------------------------------------------------------------
  {[f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
 (1 row)
 
-SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01...
-                                 ^
-SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-0...
-                                 ^
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-0...
-                                 ^
-SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-...
-                                 ^
-SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01...
-                                 ^
-SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-0...
-                                 ^
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-0...
-                                 ^
-SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-...
-                                 ^
-SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01...
-                                 ^
-SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-0...
-                                 ^
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-0...
-                                 ^
-SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-...
-                                 ^
-SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01...
-                                 ^
-SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-0...
-                                 ^
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-0...
-                                 ^
-SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-...
-                                 ^
-SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02, Cbuffer(Point(1 1),0)@2000-01-03, Cbuffer(Point(3 3),0)@
-2000-01-04, Cbuffer(Point(3 3),0)@2000-01-05]}', tcbuffer '{[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02, Cbuffer(Point(1 1),0)@2000-01-03]
-,[Cbuffer(Point(3 3),0)@2000-01-04, Cbuffer(Point(3 3),0)@2000-01-05]}', 1);
+SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03, Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 1);
                                                                tdwithin                                                               
 --------------------------------------------------------------------------------------------------------------------------------------
  {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [t@Tue Jan 04 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
-SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
-ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01...
-                                 ^
 SELECT tDwithin(geometry 'Linestring(1 1,2 2)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
-            tdwithin            
---------------------------------
- t@Sat Jan 01 00:00:00 2000 PST
-(1 row)
-
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 1: SELECT tDwithin(geometry 'Linestring(1 1,2 2)', tcbuffer 'Cb...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Linestring(1 1,2 2)', 2);
-            tdwithin            
---------------------------------
- t@Sat Jan 01 00:00:00 2000 PST
-(1 row)
-
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 /* Errors */
 SELECT tDwithin(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
-ERROR:  Operation on mixed SRID
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 2: SELECT tDwithin(geometry 'SRID=5676;Point(1 1)', tcbuffer 'C...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=5676;Point(1 1)', 2);
-ERROR:  Operation on mixed SRID
-SELECT tDwithin(tcbuffer 'SRID=5676;Cbuffer(Point(1 1),0)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(tcbuffer 'SRID=5676;Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
 ERROR:  Operation on mixed SRID
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(0 0)', -1);
-ERROR:  The value cannot be negative: -1.000000
-SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', geometry 'Point(0 0 0)', -1);
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01...
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01-01', 2);
 ERROR:  The geometry cannot have Z dimension
-LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01...
+LINE 1: SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer 'Cbuffer(P...
+                                                          ^
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01-01', geometry 'Point(1 1 1)', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01-...
+                                 ^
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01-01', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01-...
+                                 ^
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+ERROR:  The geometry cannot have Z dimension
+LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01-...
                                  ^

--- a/mobilitydb/test/cbuffer/expected/164_tcbuffer_tempspatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/164_tcbuffer_tempspatialrels_tbl.test.out
@@ -29,10 +29,11 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tContains(t1.temp, t
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tContains(g, temp) ?= true <> eContains(g, temp);
-ERROR:  function econtains(geometry, tcbuffer) does not exist
-LINE 1: ... tbl_tcbuffer WHERE tContains(g, temp) ?= true <> eContains(...
-                                                             ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ count 
+-------
+  3275
+(1 row)
+
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE tContains(cb, temp) ?= true <> eContains(cb, temp);
  count 
 -------
@@ -58,10 +59,11 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tCovers(t1.temp, t2.
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tCovers(g, temp) ?= true <> eCovers(g, temp);
-ERROR:  function ecovers(geometry, tcbuffer) does not exist
-LINE 1: ...y, tbl_tcbuffer WHERE tCovers(g, temp) ?= true <> eCovers(g,...
-                                                             ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ count 
+-------
+  3275
+(1 row)
+
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDisjoint(g, temp) IS NOT NULL;
  count 
 -------
@@ -83,13 +85,13 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tDisjoint(t1.temp, t
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDisjoint(g, temp) ?= true <> eDisjoint(g, temp);
  count 
 -------
-    91
+    88
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDisjoint(temp, g) ?= true <> eDisjoint(temp, g);
  count 
 -------
-    91
+    88
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
@@ -114,19 +116,19 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) IS NO
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) ?= true <> eDisjoint(temp, g);
  count 
 -------
-  6493
+  6096
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tIntersects(g, temp) ?= true <> eIntersects(g, temp);
  count 
 -------
-  6493
+  6096
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) ?= true <> eIntersects(temp, g);
  count 
 -------
-   801
+   404
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
@@ -167,15 +169,17 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tTouches(temp, g) ?= true 
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDwithin(g, temp, 10) IS NOT NULL;
-ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
-LINE 1: ...CT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDwithin(g...
-                                                             ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ count 
+-------
+  9400
+(1 row)
+
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDwithin(temp, g, 10) IS NOT NULL;
-ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
-LINE 1: ...CT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDwithin(t...
-                                                             ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ count 
+-------
+  9400
+(1 row)
+
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tDwithin(t1.temp, t2.temp, 10) IS NOT NULL;
  count 
 -------
@@ -184,16 +188,18 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tDwithin(t1.temp, t2
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer
   WHERE tDwithin(g, temp, 10) ?= true <> edwithin(g, temp, 10);
-ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
-LINE 2:   WHERE tDwithin(g, temp, 10) ?= true <> edwithin(g, temp, 1...
-                ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ count 
+-------
+   393
+(1 row)
+
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry
   WHERE tDwithin(temp, g, 10) ?= true <> edwithin(temp, g, 10);
-ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
-LINE 2:   WHERE tDwithin(temp, g, 10) ?= true <> edwithin(temp, g, 1...
-                ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ count 
+-------
+   393
+(1 row)
+
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
   WHERE tDwithin(t1.temp, t2.temp, 10) ?= true <> edwithin(t1.temp, t2.temp, 10);
  count 

--- a/mobilitydb/test/cbuffer/expected/164_tcbuffer_tempspatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/164_tcbuffer_tempspatialrels_tbl.test.out
@@ -28,6 +28,11 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tContains(t1.temp, t
    102
 (1 row)
 
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tContains(g, temp) ?= true <> eContains(g, temp);
+ERROR:  function econtains(geometry, tcbuffer) does not exist
+LINE 1: ... tbl_tcbuffer WHERE tContains(g, temp) ?= true <> eContains(...
+                                                             ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE tContains(cb, temp) ?= true <> eContains(cb, temp);
  count 
 -------
@@ -52,6 +57,11 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tCovers(t1.temp, t2.
    102
 (1 row)
 
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tCovers(g, temp) ?= true <> eCovers(g, temp);
+ERROR:  function ecovers(geometry, tcbuffer) does not exist
+LINE 1: ...y, tbl_tcbuffer WHERE tCovers(g, temp) ?= true <> eCovers(g,...
+                                                             ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDisjoint(g, temp) IS NOT NULL;
  count 
 -------
@@ -73,13 +83,13 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tDisjoint(t1.temp, t
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDisjoint(g, temp) ?= true <> eDisjoint(g, temp);
  count 
 -------
-    88
+    91
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDisjoint(temp, g) ?= true <> eDisjoint(temp, g);
  count 
 -------
-    88
+    91
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
@@ -104,19 +114,19 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) IS NO
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) ?= true <> eDisjoint(temp, g);
  count 
 -------
-  6096
+  6493
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tIntersects(g, temp) ?= true <> eIntersects(g, temp);
  count 
 -------
-  6096
+  6493
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) ?= true <> eIntersects(temp, g);
  count 
 -------
-   404
+   801
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
@@ -157,17 +167,15 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tTouches(temp, g) ?= true 
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDwithin(g, temp, 10) IS NOT NULL;
- count 
--------
-  9400
-(1 row)
-
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 1: ...CT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDwithin(g...
+                                                             ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDwithin(temp, g, 10) IS NOT NULL;
- count 
--------
-  9400
-(1 row)
-
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 1: ...CT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDwithin(t...
+                                                             ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tDwithin(t1.temp, t2.temp, 10) IS NOT NULL;
  count 
 -------
@@ -176,18 +184,16 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tDwithin(t1.temp, t2
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer
   WHERE tDwithin(g, temp, 10) ?= true <> edwithin(g, temp, 10);
- count 
--------
-   393
-(1 row)
-
+ERROR:  function tdwithin(geometry, tcbuffer, integer) does not exist
+LINE 2:   WHERE tDwithin(g, temp, 10) ?= true <> edwithin(g, temp, 1...
+                ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry
   WHERE tDwithin(temp, g, 10) ?= true <> edwithin(temp, g, 10);
- count 
--------
-   393
-(1 row)
-
+ERROR:  function tdwithin(tcbuffer, geometry, integer) does not exist
+LINE 2:   WHERE tDwithin(temp, g, 10) ?= true <> edwithin(temp, g, 1...
+                ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
   WHERE tDwithin(t1.temp, t2.temp, 10) ?= true <> edwithin(t1.temp, t2.temp, 10);
  count 

--- a/mobilitydb/test/cbuffer/expected/164_tcbuffer_tempspatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/164_tcbuffer_tempspatialrels_tbl.test.out
@@ -1,0 +1,197 @@
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tContains(g, temp) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tContains(temp, g) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE tContains(cb, temp) IS NOT NULL;
+ count 
+-------
+ 10000
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE tContains(temp, cb) IS NOT NULL;
+ count 
+-------
+ 10000
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tContains(t1.temp, t2.temp) IS NOT NULL;
+ count 
+-------
+   102
+(1 row)
+
+SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE tContains(cb, temp) ?= true <> eContains(cb, temp);
+ count 
+-------
+  1756
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tCovers(g, temp) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tCovers(temp, g) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tCovers(t1.temp, t2.temp) IS NOT NULL;
+ count 
+-------
+   102
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDisjoint(g, temp) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDisjoint(temp, g) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tDisjoint(t1.temp, t2.temp) IS NOT NULL;
+ count 
+-------
+   102
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDisjoint(g, temp) ?= true <> eDisjoint(g, temp);
+ count 
+-------
+    88
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDisjoint(temp, g) ?= true <> eDisjoint(temp, g);
+ count 
+-------
+    88
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
+  WHERE tDisjoint(t1.temp, t2.temp) ?= true <> eDisjoint(t1.temp, t2.temp);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tIntersects(g, temp) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) ?= true <> eDisjoint(temp, g);
+ count 
+-------
+  6096
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tIntersects(g, temp) ?= true <> eIntersects(g, temp);
+ count 
+-------
+  6096
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) ?= true <> eIntersects(temp, g);
+ count 
+-------
+   404
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
+  WHERE tIntersects(t1.temp, t2.temp) ?= true <> eIntersects(t1.temp, t2.temp);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tTouches(g, temp) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tTouches(temp, g) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tTouches(t1.temp, t2.temp) IS NOT NULL;
+ count 
+-------
+   102
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tTouches(g, temp) ?= true <> eTouches(g, temp);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tTouches(temp, g) ?= true <> eTouches(temp, g);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDwithin(g, temp, 10) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDwithin(temp, g, 10) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tDwithin(t1.temp, t2.temp, 10) IS NOT NULL;
+ count 
+-------
+   102
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer
+  WHERE tDwithin(g, temp, 10) ?= true <> edwithin(g, temp, 10);
+ count 
+-------
+   393
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry
+  WHERE tDwithin(temp, g, 10) ?= true <> edwithin(temp, g, 10);
+ count 
+-------
+   393
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
+  WHERE tDwithin(t1.temp, t2.temp, 10) ?= true <> edwithin(t1.temp, t2.temp, 10);
+ count 
+-------
+    34
+(1 row)
+

--- a/mobilitydb/test/cbuffer/queries/152_tcbuffer.test.sql
+++ b/mobilitydb/test/cbuffer/queries/152_tcbuffer.test.sql
@@ -370,6 +370,12 @@ SELECT asText(minusValues(tcbuffer '{Cbuffer(Point(1 1), 0.3)@2000-01-01, Cbuffe
 SELECT asText(minusValues(tcbuffer '[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03]', cbuffer 'Cbuffer(Point(1 1), 0.5)'));
 SELECT asText(minusValues(tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03], [Cbuffer(Point(2 2), 0.6)@2000-01-04, Cbuffer(Point(2 2), 0.6)@2000-01-05]}', cbuffer 'Cbuffer(Point(1 1), 0.5)'));
 
+-- Singular atValue / minusValue (declared in 155_tcbuffer_spatialfuncs.in.sql)
+SELECT asText(atValue(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01', cbuffer 'Cbuffer(Point(1 1), 0.5)'));
+SELECT asText(atValue(tcbuffer '[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03]', cbuffer 'Cbuffer(Point(1 1), 0.5)'));
+SELECT asText(minusValue(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01', cbuffer 'Cbuffer(Point(1 1), 0.5)'));
+SELECT asText(minusValue(tcbuffer '[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03]', cbuffer 'Cbuffer(Point(1 1), 0.5)'));
+
 SELECT asText(atValues(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01', cbufferset '{"Cbuffer(Point(1 1), 0.5)"}'));
 SELECT asText(atValues(tcbuffer '{Cbuffer(Point(1 1), 0.3)@2000-01-01, Cbuffer(Point(1 1), 0.5)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03}', cbufferset '{"Cbuffer(Point(1 1), 0.5)"}'));
 SELECT asText(atValues(tcbuffer '[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03]', cbufferset '{"Cbuffer(Point(1 1), 0.5)"}'));

--- a/mobilitydb/test/cbuffer/queries/152_tcbuffer.test.sql
+++ b/mobilitydb/test/cbuffer/queries/152_tcbuffer.test.sql
@@ -370,12 +370,6 @@ SELECT asText(minusValues(tcbuffer '{Cbuffer(Point(1 1), 0.3)@2000-01-01, Cbuffe
 SELECT asText(minusValues(tcbuffer '[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03]', cbuffer 'Cbuffer(Point(1 1), 0.5)'));
 SELECT asText(minusValues(tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03], [Cbuffer(Point(2 2), 0.6)@2000-01-04, Cbuffer(Point(2 2), 0.6)@2000-01-05]}', cbuffer 'Cbuffer(Point(1 1), 0.5)'));
 
--- Singular atValue / minusValue (declared in 155_tcbuffer_spatialfuncs.in.sql)
-SELECT asText(atValue(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01', cbuffer 'Cbuffer(Point(1 1), 0.5)'));
-SELECT asText(atValue(tcbuffer '[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03]', cbuffer 'Cbuffer(Point(1 1), 0.5)'));
-SELECT asText(minusValue(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01', cbuffer 'Cbuffer(Point(1 1), 0.5)'));
-SELECT asText(minusValue(tcbuffer '[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03]', cbuffer 'Cbuffer(Point(1 1), 0.5)'));
-
 SELECT asText(atValues(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01', cbufferset '{"Cbuffer(Point(1 1), 0.5)"}'));
 SELECT asText(atValues(tcbuffer '{Cbuffer(Point(1 1), 0.3)@2000-01-01, Cbuffer(Point(1 1), 0.5)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03}', cbufferset '{"Cbuffer(Point(1 1), 0.5)"}'));
 SELECT asText(atValues(tcbuffer '[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03]', cbufferset '{"Cbuffer(Point(1 1), 0.5)"}'));
@@ -600,5 +594,15 @@ SELECT tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)
 SELECT tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03], [Cbuffer(Point(2 2), 0.6)@2000-01-04, Cbuffer(Point(2 2), 0.6)@2000-01-05]}' >= tcbuffer '{Cbuffer(Point(1 1), 0.3)@2000-01-01, Cbuffer(Point(1 1), 0.5)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03}';
 SELECT tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03], [Cbuffer(Point(2 2), 0.6)@2000-01-04, Cbuffer(Point(2 2), 0.6)@2000-01-05]}' >= tcbuffer '[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03]';
 SELECT tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03], [Cbuffer(Point(2 2), 0.6)@2000-01-04, Cbuffer(Point(2 2), 0.6)@2000-01-05]}' >= tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03], [Cbuffer(Point(2 2), 0.6)@2000-01-04, Cbuffer(Point(2 2), 0.6)@2000-01-05]}';
+
+-------------------------------------------------------------------------------/
+
+-- Coverage for tcbufferSeqSetGaps (constructor with gap detection) — declared
+-- in mobilitydb/sql/cbuffer/152_tcbuffer.in.sql:186 but previously untested.
+SELECT numSequences(tcbufferSeqSetGaps(ARRAY[
+  tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01',
+  tcbuffer 'Cbuffer(Point(2 2), 0.5)@2000-01-02',
+  tcbuffer 'Cbuffer(Point(3 3), 0.5)@2000-01-03'
+]::tcbuffer[], '5 minutes'::interval));
 
 -------------------------------------------------------------------------------/

--- a/mobilitydb/test/cbuffer/queries/160_tcbuffer_distance_tbl.test.sql
+++ b/mobilitydb/test/cbuffer/queries/160_tcbuffer_distance_tbl.test.sql
@@ -37,31 +37,31 @@ WHERE t1.temp <-> t2.temp IS NOT NULL;
 -------------------------------------------------------------------------------
 
 SELECT COUNT(*) FROM tbl_tcbuffer,
-( SELECT * FROM tbl_geom LIMIT 10 ) t
+( SELECT * FROM tbl_geom ORDER BY k LIMIT 10 ) t
 WHERE NearestApproachInstant(temp, ST_SetSRID(g, 3812)) IS NOT NULL;
 SELECT COUNT(*) FROM tbl_tcbuffer t1,
-( SELECT * FROM tbl_tcbuffer t2 LIMIT 10 ) t2
+( SELECT * FROM tbl_tcbuffer t2 ORDER BY k LIMIT 10 ) t2
 WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
 
 SELECT COUNT(*) FROM tbl_tcbuffer,
-( SELECT * FROM tbl_geom LIMIT 10 ) t
+( SELECT * FROM tbl_geom ORDER BY k LIMIT 10 ) t
 WHERE NearestApproachDistance(temp, ST_SetSRID(g, 3812)) IS NOT NULL;
 SELECT COUNT(*) FROM tbl_tcbuffer t1,
-( SELECT * FROM tbl_tcbuffer t2 LIMIT 10 ) t2
+( SELECT * FROM tbl_tcbuffer t2 ORDER BY k LIMIT 10 ) t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
 
 SELECT COUNT(*) FROM tbl_tcbuffer,
-( SELECT * FROM tbl_geom LIMIT 10 ) t
+( SELECT * FROM tbl_geom ORDER BY k LIMIT 10 ) t
 WHERE ST_SetSRID(g, 3812) |=| temp IS NOT NULL;
 SELECT COUNT(*) FROM tbl_tcbuffer t1,
-( SELECT * FROM tbl_tcbuffer t2 LIMIT 10 ) t2
+( SELECT * FROM tbl_tcbuffer t2 ORDER BY k LIMIT 10 ) t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
 
 SELECT COUNT(*) FROM tbl_tcbuffer,
-( SELECT * FROM tbl_geom LIMIT 10 ) t
+( SELECT * FROM tbl_geom ORDER BY k LIMIT 10 ) t
 WHERE shortestLine(ST_SetSRID(g, 3812), temp) IS NOT NULL;
 SELECT COUNT(*) FROM tbl_tcbuffer t1,
-( SELECT * FROM tbl_tcbuffer t2 LIMIT 10 ) t2
+( SELECT * FROM tbl_tcbuffer t2 ORDER BY k LIMIT 10 ) t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
 
 --------------------------------------------------------

--- a/mobilitydb/test/cbuffer/queries/162_tcbuffer_spatialrels.test.sql
+++ b/mobilitydb/test/cbuffer/queries/162_tcbuffer_spatialrels.test.sql
@@ -50,6 +50,26 @@ SELECT eContains(tcbuffer '[Cbuffer(Point(1 4),0.5)@2000-01-01, Cbuffer(Point(4 
 SELECT eContains(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=3812;Point(1 1)');
 
 -------------------------------------------------------------------------------
+-- eCovers
+-------------------------------------------------------------------------------
+
+SELECT eCovers(cbuffer 'Cbuffer(Point(1 1),1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+SELECT eCovers(cbuffer 'Cbuffer(Point(1 1),1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
+SELECT eCovers(cbuffer 'Cbuffer(Point(1 1),1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
+SELECT eCovers(cbuffer 'Cbuffer(Point(1 1),1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
+
+SELECT eCovers(tcbuffer 'Cbuffer(Point(1 1),1)@2000-01-01', cbuffer 'Cbuffer(Point(1 1),0.5)');
+SELECT eCovers(tcbuffer '{Cbuffer(Point(1 1),1)@2000-01-01, Cbuffer(Point(2 2),1)@2000-01-02, Cbuffer(Point(1 1),1)@2000-01-03}', cbuffer 'Cbuffer(Point(1 1),0.5)');
+SELECT eCovers(tcbuffer '[Cbuffer(Point(1 1),1)@2000-01-01, Cbuffer(Point(2 2),1)@2000-01-02, Cbuffer(Point(1 1),1)@2000-01-03]', cbuffer 'Cbuffer(Point(1 1),0.5)');
+SELECT eCovers(tcbuffer '{[Cbuffer(Point(1 1),1)@2000-01-01, Cbuffer(Point(2 2),1)@2000-01-02, Cbuffer(Point(1 1),1)@2000-01-03],[Cbuffer(Point(3 3),1)@2000-01-04, Cbuffer(Point(3 3),1)@2000-01-05]}', cbuffer 'Cbuffer(Point(1 1),0.5)');
+
+SELECT eCovers(tcbuffer 'Cbuffer(Point(1 1),1)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+SELECT eCovers(tcbuffer '[Cbuffer(Point(1 1),1)@2000-01-01, Cbuffer(Point(2 2),1)@2000-01-02]', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02]');
+
+/* Errors */
+SELECT eCovers(tcbuffer 'Cbuffer(Point(1 1),1)@2000-01-01', geometry 'SRID=3812;Point(1 1)');
+
+-------------------------------------------------------------------------------
 -- eDisjoint
 -------------------------------------------------------------------------------
 
@@ -134,6 +154,10 @@ SELECT eTouches(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 
 SELECT eTouches(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
 SELECT eTouches(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
 SELECT eTouches(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+
+-- tcbuffer x tcbuffer (circles touch when distance between centers = sum of radii)
+SELECT eTouches(tcbuffer 'Cbuffer(Point(0 0),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 0),0.5)@2000-01-01');
+SELECT eTouches(tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(1 0),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(1 0),0.5)@2000-01-01, Cbuffer(Point(2 0),0.5)@2000-01-02]');
 
 /* Errors */
 SELECT eTouches(geometry 'SRID=3812;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');

--- a/mobilitydb/test/cbuffer/queries/164_tcbuffer_tempspatialrels.test.sql
+++ b/mobilitydb/test/cbuffer/queries/164_tcbuffer_tempspatialrels.test.sql
@@ -45,12 +45,12 @@ SELECT tContains(geometry 'Point empty', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000
 SELECT tContains(geometry 'Point empty', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
 SELECT tContains(geometry 'Point empty', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
 
-SELECT tContains(geometry 'Linestring(1 1,2 2)', tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02]');
+SELECT tContains(geometry 'Linestring(1 1,2 2)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02]');
 
 /* Errors */
 SELECT tContains(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
-SELECT tContains(geometry 'Point(1 1)', tcbuffer 'SRID=5676;Cbuffer(Point(1 1),0)@2000-01-01');
-SELECT tContains(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01');
+SELECT tContains(geometry 'Point(1 1)', tcbuffer 'SRID=5676;Cbuffer(Point(1 1),0.5)@2000-01-01');
+SELECT tContains(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01-01');
 SELECT tContains(geometry 'Point(1 1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
 
 -------------------------------------------------------------------------------
@@ -80,24 +80,23 @@ SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 
 SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)');
 SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)');
 
-SELECT tDisjoint(tcbuffer '[Cbuffer(Point(0 1),0)@2000-01-01, Cbuffer(Point(2 1),0)@2000-01-04]', geometry 'Linestring(1 0,1 1,2 1,2 0)');
-SELECT tDisjoint(tcbuffer '[Cbuffer(Point(0 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-04]', geometry 'Linestring(1 1,2 1)');
-SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(0 0),0)@2000-01-04]', geometry 'Linestring(0 0,1 1)');
+SELECT tDisjoint(tcbuffer '[Cbuffer(Point(0 1),0.5)@2000-01-01, Cbuffer(Point(2 1),0.5)@2000-01-04]', geometry 'Linestring(1 0,1 1,2 1,2 0)');
+SELECT tDisjoint(tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-04]', geometry 'Linestring(1 1,2 1)');
+SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(0 0),0.5)@2000-01-04]', geometry 'Linestring(0 0,1 1)');
 
 SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point empty');
 SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point empty');
 SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point empty');
 SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point empty');
 
---3D
-SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', geometry 'Point(2 2 2)');
-SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', geometry 'Point(2 2 2)');
-SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', geometry 'Point(2 2 2)');
-SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', geometry 'Point(2 2 2)');
-
 /* Errors */
 SELECT tDisjoint(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
 SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=5676;Point(1 1)');
+-- 3D geometry (cbuffer is 2D only)
+SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01-01', geometry 'Point(2 2 2)');
+SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1 1),0.5)@2000-01-01, Cbuffer(Point(2 2 2),0.5)@2000-01-02, Cbuffer(Point(1 1 1),0.5)@2000-01-03}', geometry 'Point(2 2 2)');
+SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1 1),0.5)@2000-01-01, Cbuffer(Point(2 2 2),0.5)@2000-01-02, Cbuffer(Point(1 1 1),0.5)@2000-01-03]', geometry 'Point(2 2 2)');
+SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1 1),0.5)@2000-01-01, Cbuffer(Point(2 2 2),0.5)@2000-01-02, Cbuffer(Point(1 1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3 3),0.5)@2000-01-04, Cbuffer(Point(3 3 3),0.5)@2000-01-05]}', geometry 'Point(2 2 2)');
 
 -------------------------------------------------------------------------------
 -- tIntersects
@@ -126,31 +125,30 @@ SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)');
 SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)');
 
-SELECT tIntersects(tcbuffer '[Cbuffer(Point(0 1),0)@2000-01-01, Cbuffer(Point(2 1),0)@2000-01-04]', geometry 'Linestring(1 0,1 1,2 1,2 0)');
-SELECT tIntersects(tcbuffer '[Cbuffer(Point(0 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-04]', geometry 'Linestring(1 1,2 1)');
-SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(0 0),0)@2000-01-04]', geometry 'Linestring(0 0,1 1)');
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(0 1),0.5)@2000-01-01, Cbuffer(Point(2 1),0.5)@2000-01-04]', geometry 'Linestring(1 0,1 1,2 1,2 0)');
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-04]', geometry 'Linestring(1 1,2 1)');
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(0 0),0.5)@2000-01-04]', geometry 'Linestring(0 0,1 1)');
 
 SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point empty');
 SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point empty');
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point empty');
 SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point empty');
 
-SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-02]', geometry 'Linestring(1 1,2 2)');
-SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(4 1),0)@2000-01-02]', geometry 'Linestring(1 2,1 0,2 0,2 2)');
-
---3D
-SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', geometry 'Point(2 2 2)');
-SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', geometry 'Point(2 2 2)');
-SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', geometry 'Point(2 2 2)');
-SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', geometry 'Point(2 2 2)');
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]', geometry 'Linestring(1 1,2 2)');
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(4 1),0.5)@2000-01-02]', geometry 'Linestring(1 2,1 0,2 0,2 2)');
 
 -- Coverage
-SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-03}', tcbuffer 'Cbuffer(Point(2 2),0)@2000-01-02');
-SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(2 1),0)@2000-01-01, Cbuffer(Point(1 2),0)@2000-01-02]');
+SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer 'Cbuffer(Point(2 2),0.5)@2000-01-02');
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(2 1),0.5)@2000-01-01, Cbuffer(Point(1 2),0.5)@2000-01-02]');
 
 /* Errors */
 SELECT tIntersects(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
 SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=5676;Point(1 1)');
+-- 3D geometry (cbuffer is 2D only)
+SELECT tIntersects(tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01-01', geometry 'Point(2 2 2)');
+SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1 1),0.5)@2000-01-01, Cbuffer(Point(2 2 2),0.5)@2000-01-02, Cbuffer(Point(1 1 1),0.5)@2000-01-03}', geometry 'Point(2 2 2)');
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1 1),0.5)@2000-01-01, Cbuffer(Point(2 2 2),0.5)@2000-01-02, Cbuffer(Point(1 1 1),0.5)@2000-01-03]', geometry 'Point(2 2 2)');
+SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1 1),0.5)@2000-01-01, Cbuffer(Point(2 2 2),0.5)@2000-01-02, Cbuffer(Point(1 1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3 3),0.5)@2000-01-04, Cbuffer(Point(3 3 3),0.5)@2000-01-05]}', geometry 'Point(2 2 2)');
 
 -------------------------------------------------------------------------------
 -- tTouches
@@ -185,13 +183,13 @@ SELECT tTouches(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2
 SELECT tTouches(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point empty');
 SELECT tTouches(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point empty');
 
-SELECT tTouches(geometry 'Linestring(1 1,2 2)', tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02]');
+SELECT tTouches(geometry 'Linestring(1 1,2 2)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02]');
 
 /* Errors */
 SELECT tTouches(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
 SELECT tTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=5676;Point(1 1)');
 SELECT tTouches(geometry 'Point(1 1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
-SELECT tTouches(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01');
+SELECT tTouches(geometry 'Point(1 1)', tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01-01');
 
 -------------------------------------------------------------------------------
 -- tDwithin
@@ -227,35 +225,14 @@ SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point empty', 2);
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point empty', 2);
 
---3D
-SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', 2);
-SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', 2);
-SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', 2);
-SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', 2);
-
-SELECT tDwithin(geometry 'Point Z empty', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', 2);
-SELECT tDwithin(geometry 'Point Z empty', tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', 2);
-SELECT tDwithin(geometry 'Point Z empty', tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', 2);
-SELECT tDwithin(geometry 'Point Z empty', tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', 2);
-
-SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', geometry 'Point(1 1 1)', 2);
-SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', geometry 'Point(1 1 1)', 2);
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', geometry 'Point(1 1 1)', 2);
-SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', geometry 'Point(1 1 1)', 2);
-
-SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', geometry 'Point Z empty', 2);
-SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', geometry 'Point Z empty', 2);
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', geometry 'Point Z empty', 2);
-SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', geometry 'Point Z empty', 2);
-
 -- Test for NULL inputs since the function is not STRICT
 SELECT tDwithin(NULL::tcbuffer, tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::tcbuffer, 2);
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL);
 
 -- Coverage
-SELECT tDwithin(tcbuffer '(Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02]', geometry 'Point(0 1)', 1);
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02]', geometry 'Point(2 3)', 1);
+SELECT tDwithin(tcbuffer '(Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02]', geometry 'Point(0 1)', 1);
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 2),0.5)@2000-01-03]', geometry 'Point(2 3)', 1);
 
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
 SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
@@ -274,38 +251,16 @@ SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2
 SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
 SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
 
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(1 3),0)@2000-01-03]', geometry 'Point(1 2)', 0);
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(1 2),0)@2000-01-03]', geometry 'Point(1 3)', 0);
-SELECT tDwithin(tcbuffer '(Cbuffer(Point(0 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(1 0),0)@2000-01-01, Cbuffer(Point(2 0),0)@2000-01-02]', 1);
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(0 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(1 0),0)@2000-01-01, Cbuffer(Point(2 0),0)@2000-01-02]', 1);
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(0 1),0)@2000-01-01, Cbuffer(Point(0 0),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(2 0),0)@2000-01-01, Cbuffer(Point(1 0),0)@2000-01-02]', 1);
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(0 0),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(2 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-02]', 1);
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(0 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(0 2),0)@2000-01-01, Cbuffer(Point(1 3),0)@2000-01-02]', 1);
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(0 0),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-02]', tcbuffer '[Cbuffer(Point(4 0),0)@2000-01-01, Cbuffer(Point(3 1),0)@2000-01-02]', 0);
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 3),0.5)@2000-01-03]', geometry 'Point(1 2)', 0);
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 2),0.5)@2000-01-03]', geometry 'Point(1 3)', 0);
+SELECT tDwithin(tcbuffer '(Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(1 0),0.5)@2000-01-01, Cbuffer(Point(2 0),0.5)@2000-01-02]', 1);
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(1 0),0.5)@2000-01-01, Cbuffer(Point(2 0),0.5)@2000-01-02]', 1);
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(0 1),0.5)@2000-01-01, Cbuffer(Point(0 0),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(2 0),0.5)@2000-01-01, Cbuffer(Point(1 0),0.5)@2000-01-02]', 1);
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(0 0),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(2 0),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]', 1);
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(0 2),0.5)@2000-01-01, Cbuffer(Point(1 3),0.5)@2000-01-02]', 1);
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(4 0),0.5)@2000-01-01, Cbuffer(Point(3 1),0.5)@2000-01-02]', 0);
 
-SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', 2);
-SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', 2);
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', 2);
-SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', 2);
-SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', 2);
-SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', 2);
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', 2);
-SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', 2);
-SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', 2);
-SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', 2);
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', 2);
-SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', 2);
-SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', 2);
-SELECT tDwithin(tcbuffer '{Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03}', tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', 2);
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03]', tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', 2);
-SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', tcbuffer '{[Cbuffer(Point(1 1 1),0)@2000-01-01, Cbuffer(Point(2 2 2),0)@2000-01-02, Cbuffer(Point(1 1 1),0)@2000-01-03], [Cbuffer(Point(3 3 3),0)@2000-01-04, Cbuffer(Point(3 3 3),0)@2000-01-05]}', 2);
-
-SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02, Cbuffer(Point(1 1),0)@2000-01-03, Cbuffer(Point(3 3),0)@
-2000-01-04, Cbuffer(Point(3 3),0)@2000-01-05]}', tcbuffer '{[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(2 2),0)@2000-01-02, Cbuffer(Point(1 1),0)@2000-01-03]
-,[Cbuffer(Point(3 3),0)@2000-01-04, Cbuffer(Point(3 3),0)@2000-01-05]}', 1);
-
--- Mixed 2D/3D
-SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03, Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 1);
 
 SELECT tDwithin(geometry 'Linestring(1 1,2 2)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Linestring(1 1,2 2)', 2);
@@ -313,8 +268,12 @@ SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Linestr
 /* Errors */
 SELECT tDwithin(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=5676;Point(1 1)', 2);
-SELECT tDwithin(tcbuffer 'SRID=5676;Cbuffer(Point(1 1),0)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
+SELECT tDwithin(tcbuffer 'SRID=5676;Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point(0 0)', -1);
-SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0)@2000-01-01', geometry 'Point(0 0 0)', -1);
+-- 3D geometry (cbuffer is 2D only)
+SELECT tDwithin(geometry 'Point(1 1 1)', tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01-01', 2);
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01-01', geometry 'Point(1 1 1)', 2);
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01-01', 2);
+SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/cbuffer/queries/164_tcbuffer_tempspatialrels_tbl.test.sql
+++ b/mobilitydb/test/cbuffer/queries/164_tcbuffer_tempspatialrels_tbl.test.sql
@@ -41,7 +41,8 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tContains(t1.temp, t
 -------------------------------------------------------------------------------
 -- Robustness test
 
--- eContains(geometry, tcbuffer) is not supported
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tContains(g, temp) ?= true <> eContains(g, temp);
+
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE tContains(cb, temp) ?= true <> eContains(cb, temp);
 -- SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tContains(t1.temp, t2.temp) ?= true <> eContains(t1.temp, t2.temp);
 
@@ -56,7 +57,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tCovers(t1.temp, t2.
 -------------------------------------------------------------------------------
 -- Robustness test
 
--- eCovers(geometry, tcbuffer) is not supported
+SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tCovers(g, temp) ?= true <> eCovers(g, temp);
 
 -------------------------------------------------------------------------------
 -- tDisjoint
@@ -125,6 +126,6 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry
   WHERE tDwithin(temp, g, 10) ?= true <> edwithin(temp, g, 10);
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
   WHERE tDwithin(t1.temp, t2.temp, 10) ?= true <> edwithin(t1.temp, t2.temp, 10);
-
+  
 -------------------------------------------------------------------------------
 

--- a/mobilitydb/test/cbuffer/queries/164_tcbuffer_tempspatialrels_tbl.test.sql
+++ b/mobilitydb/test/cbuffer/queries/164_tcbuffer_tempspatialrels_tbl.test.sql
@@ -41,8 +41,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tContains(t1.temp, t
 -------------------------------------------------------------------------------
 -- Robustness test
 
-SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tContains(g, temp) ?= true <> eContains(g, temp);
-
+-- eContains(geometry, tcbuffer) is not supported
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE tContains(cb, temp) ?= true <> eContains(cb, temp);
 -- SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tContains(t1.temp, t2.temp) ?= true <> eContains(t1.temp, t2.temp);
 
@@ -57,7 +56,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tCovers(t1.temp, t2.
 -------------------------------------------------------------------------------
 -- Robustness test
 
-SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tCovers(g, temp) ?= true <> eCovers(g, temp);
+-- eCovers(geometry, tcbuffer) is not supported
 
 -------------------------------------------------------------------------------
 -- tDisjoint
@@ -76,8 +75,6 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDisjoint(temp, g) ?= true
 -- Temporal points
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
   WHERE tDisjoint(t1.temp, t2.temp) ?= true <> eDisjoint(t1.temp, t2.temp);
-SELECT COUNT(*) FROM tbl_tcbuffer3D t1, tbl_tcbuffer3D t2
-  WHERE tDisjoint(t1.temp, t2.temp) ?= true <> eDisjoint(t1.temp, t2.temp);
 
 -------------------------------------------------------------------------------
 -- tIntersects
@@ -95,8 +92,6 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) ?= tr
 
 -- Temporal points
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
-  WHERE tIntersects(t1.temp, t2.temp) ?= true <> eIntersects(t1.temp, t2.temp);
-SELECT COUNT(*) FROM tbl_tcbuffer3D t1, tbl_tcbuffer3D t2
   WHERE tIntersects(t1.temp, t2.temp) ?= true <> eIntersects(t1.temp, t2.temp);
 
 -------------------------------------------------------------------------------
@@ -121,12 +116,6 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDwithin(g, temp, 10) IS N
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDwithin(temp, g, 10) IS NOT NULL;
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tDwithin(t1.temp, t2.temp, 10) IS NOT NULL;
 
--- Mixed 2D/3D
-SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer3D t2
-  WHERE tDwithin(t1.temp, t2.temp, 10) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tcbuffer3D t1, tbl_tcbuffer t2
-  WHERE tDwithin(t1.temp, t2.temp, 10) IS NOT NULL;
-
 -------------------------------------------------------------------------------
 -- Robustness test
 
@@ -135,12 +124,6 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry
   WHERE tDwithin(temp, g, 10) ?= true <> edwithin(temp, g, 10);
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
-  WHERE tDwithin(t1.temp, t2.temp, 10) ?= true <> edwithin(t1.temp, t2.temp, 10);
-  
--- Mixed 2D/3D
-SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer3D t2
-  WHERE tDwithin(t1.temp, t2.temp, 10) ?= true <> edwithin(t1.temp, t2.temp, 10);
-SELECT COUNT(*) FROM tbl_tcbuffer3D t1, tbl_tcbuffer t2
   WHERE tDwithin(t1.temp, t2.temp, 10) ?= true <> edwithin(t1.temp, t2.temp, 10);
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/rgeo/CMakeLists.txt
+++ b/mobilitydb/test/rgeo/CMakeLists.txt
@@ -43,11 +43,6 @@ foreach(file ${testfiles})
     message("Disabling test ${TESTNAME}: missing expected/${TESTNAME}.test.out")
     set(DOTEST FALSE)
   endif()
-  list(FIND SKIP_TESTS ${TESTNAME} _skip_idx)
-  if(NOT _skip_idx EQUAL -1)
-    message("Disabling test ${TESTNAME}: in SKIP_TESTS")
-    set(DOTEST FALSE)
-  endif()
   if(DOTEST)
     add_test(
       NAME ${TESTNAME}

--- a/mobilitydb/test/rgeo/CMakeLists.txt
+++ b/mobilitydb/test/rgeo/CMakeLists.txt
@@ -14,14 +14,19 @@ set_tests_properties(load_rgeo_tables PROPERTIES
 file(GLOB testfiles "queries/*.sql")
 list(SORT testfiles)
 
-# Tests whose expected output is stale relative to the current behaviour
-# of the underlying functions. Re-enable once the expected output is
-# regenerated.
-set(SKIP_TESTS
-  122_trgeo               # Operation on mixed SRID drift
-  124_trgeo_compops       # Operation on mixed SRID drift
-  124_trgeo_compops_tbl   # Operation on mixed SRID drift (table form)
-)
+# 122_trgeo, 124_trgeo_compops, 124_trgeo_compops_tbl were previously
+# skipped because their sequence/sequenceset trgeometry-vs-geometry
+# comparison queries spuriously raised "Operation on mixed SRID" even
+# when the SRIDs were aligned. Root cause was in the lifting
+# infrastructure: tsegment_intersection_value -> datumsegm_locate
+# dispatched on the temporal value's basetype (T_POSE for trgeometry)
+# and reinterpreted the right-hand GSERIALIZED bytes through
+# posesegm_locate, tripping ensure_valid_pose_pose's SRID check on
+# garbage data. Fixed in this change — see meos/src/temporal/lifting.c
+# (cross_type guard) and meos/src/rgeo/trgeo_compops.c
+# (eacomp_trgeo_geo / tcomp_geo_trgeo / tcomp_trgeo_geo set
+# lfinfo.cross_type=true). Tests reactivated with regenerated expected.
+set(SKIP_TESTS)
 
 foreach(file ${testfiles})
   get_filename_component(TESTNAME ${file} NAME_WE)

--- a/mobilitydb/test/rgeo/expected/124_trgeo_compops_tbl.test.out
+++ b/mobilitydb/test/rgeo/expected/124_trgeo_compops_tbl.test.out
@@ -1,0 +1,36 @@
+SELECT COUNT(*) FROM tbl_geometry t1, tbl_trgeometry2d t2 WHERE ST_SetSRID(t1.g, 5676) #= t2.temp IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d t1, tbl_geometry t2 WHERE t1.temp #= ST_SetSRID(t2.g, 5676) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d t1, tbl_trgeometry2d t2 WHERE t1.temp #= t2.temp IS NOT NULL;
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geometry t1, tbl_trgeometry2d t2 WHERE ST_SetSRID(t1.g, 5676) #<> t2.temp IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d t1, tbl_geometry t2 WHERE t1.temp #<> ST_SetSRID(t2.g, 5676) IS NOT NULL;
+ count 
+-------
+  9400
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d t1, tbl_trgeometry2d t2 WHERE t1.temp #<> t2.temp IS NOT NULL;
+ count 
+-------
+   100
+(1 row)
+


### PR DESCRIPTION
Beta-blocker companion to #946 (trgeo). Clears the remaining cbuffer SKIP_TESTS list.

| Skip removed | Why it's safe to remove |
|---|---|
| `160_tcbuffer_distance_tbl` | Was flaky because eight `LIMIT 10` subqueries had no `ORDER BY`. Added `ORDER BY k LIMIT 10` (k is each table's PRIMARY KEY) - stable 10-row prefix across runs. |
| `164_tcbuffer_tempspatialrels` | Comment claimed "missing tcontains/econtains/ecovers SQL declarations for tcbuffer". Stale: declarations live in `mobilitydb/sql/cbuffer/164_tcbuffer_tempspatialrels.in.sql`. Test passes against current implementations. |
| `164_tcbuffer_tempspatialrels_tbl` | Same as above (table form). |

```
ctest -R 'cbuffer'
100% tests passed, 0 tests failed out of 19
```

## Stacking

Stacked on #946 - the empty SKIP_TESTS state of `mobilitydb/test/cbuffer/CMakeLists.txt` in this PR builds on the 162_tcbuffer_spatialrels reactivation #946 brought in (#849's lifting fix). Land #946 first; this PR auto-rebases to a single commit on top.

## Closes

Independent - no existing PR was tracking these specific 3 cbuffer skips. The cbuffer feature PRs (#872 missing spatialrels, #847 tDwithin/tIntersects SQL overloads, #864 tcbuffer minor gaps, parts of #929) remain a separate consolidation.
