### PR TITLE
Make MEOS thread-safe for JVM/multi-threaded hosts (GEOS reentrant + JVM-safe error handler)

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -380,6 +380,7 @@ typedef void (*error_handler_fn)(int, int, const char *);
 
 extern void meos_initialize_timezone(const char *name);
 extern void meos_initialize_error_handler(error_handler_fn err_handler);
+extern void meos_initialize_noexit_error_handler(void);
 extern void meos_finalize_timezone(void);
 extern void meos_finalize_projsrs(void);
 extern void meos_finalize_ways(void);

--- a/meos/include/meos_internal_geo.h
+++ b/meos/include/meos_internal_geo.h
@@ -40,6 +40,8 @@
 #include <json-c/json.h>
 /* PROJ */
 #include <proj.h>
+/* GEOS */
+#include <geos_c.h>
 /* PostgreSQL */
 /* MEOS */
 #include <meos.h>
@@ -98,6 +100,12 @@
  *****************************************************************************/
 
 extern PJ_CONTEXT *proj_get_context(void);
+
+/*****************************************************************************
+ * Internal function accessing the GEOS library
+ *****************************************************************************/
+
+extern GEOSContextHandle_t geos_get_context(void);
 
 /*****************************************************************************
  * Round functions

--- a/meos/src/cbuffer/cbuffer.c
+++ b/meos/src/cbuffer/cbuffer.c
@@ -1367,7 +1367,7 @@ cbuffer_eq(const Cbuffer *cb1, const Cbuffer *cb2)
  * @param[in] cb1,cb2 Circular buffers
  * @csqlfn #Cbuffer_ne()
  */
-inline bool
+bool
 cbuffer_ne(const Cbuffer *cb1, const Cbuffer *cb2)
 {
   return (! cbuffer_eq(cb1, cb2));
@@ -1397,7 +1397,7 @@ cbuffer_same(const Cbuffer *cb1, const Cbuffer *cb2)
  * @brief Return true if two circular buffers are approximately equal with
  * respect to an epsilon value
  */
-inline bool
+bool
 cbuffer_nsame(const Cbuffer *cb1, const Cbuffer *cb2)
 {
   return ! cbuffer_same(cb1, cb2);
@@ -1450,7 +1450,7 @@ cbuffer_cmp(const Cbuffer *cb1, const Cbuffer *cb2)
  * @param[in] cb1,cb2 Circular buffers
  * @csqlfn #Cbuffer_lt()
  */
-inline bool
+bool
 cbuffer_lt(const Cbuffer *cb1, const Cbuffer *cb2)
 {
   return cbuffer_cmp(cb1, cb2) < 0;
@@ -1463,7 +1463,7 @@ cbuffer_lt(const Cbuffer *cb1, const Cbuffer *cb2)
  * @param[in] cb1,cb2 Circular buffers
  * @csqlfn #Cbuffer_le()
  */
-inline bool
+bool
 cbuffer_le(const Cbuffer *cb1, const Cbuffer *cb2)
 {
   return cbuffer_cmp(cb1, cb2) <= 0;
@@ -1475,7 +1475,7 @@ cbuffer_le(const Cbuffer *cb1, const Cbuffer *cb2)
  * @param[in] cb1,cb2 Circular buffers
  * @csqlfn #Cbuffer_gt()
  */
-inline bool
+bool
 cbuffer_gt(const Cbuffer *cb1, const Cbuffer *cb2)
 {
   return cbuffer_cmp(cb1, cb2) > 0;
@@ -1488,7 +1488,7 @@ cbuffer_gt(const Cbuffer *cb1, const Cbuffer *cb2)
  * @param[in] cb1,cb2 Circular buffers
  * @csqlfn #Cbuffer_ge()
  */
-inline bool
+bool
 cbuffer_ge(const Cbuffer *cb1, const Cbuffer *cb2)
 {
   return cbuffer_cmp(cb1, cb2) >= 0;

--- a/meos/src/cbuffer/tcbuffer.c
+++ b/meos/src/cbuffer/tcbuffer.c
@@ -870,7 +870,7 @@ tcbuffer_members(const Temporal *temp, bool point)
  * @brief Return the array of points or radius of a temporal circular buffer
  * @csqlfn #Tcbuffer_points()
  */
-inline Set *
+Set *
 tcbuffer_points(const Temporal *temp)
 {
   return tcbuffer_members(temp, true);
@@ -881,7 +881,7 @@ tcbuffer_points(const Temporal *temp)
  * @brief Return the array of radii of a temporal circular buffer
  * @csqlfn #Tcbuffer_points()
  */
-inline Set *
+Set *
 tcbuffer_radius(const Temporal *temp)
 {
   return tcbuffer_members(temp, false);

--- a/meos/src/cbuffer/tcbuffer_compops.c
+++ b/meos/src/cbuffer/tcbuffer_compops.c
@@ -91,7 +91,7 @@ eacomp_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
  * @param[in] temp Temporal value
  * @csqlfn #Ever_eq_cbuffer_tcbuffer()
  */
-inline int
+int
 ever_eq_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 {
   return eacomp_tcbuffer_cbuffer(temp, cb, &datum2_eq, EVER);
@@ -105,7 +105,7 @@ ever_eq_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
  * @param[in] cb Circular buffer
  * @csqlfn #Ever_eq_tcbuffer_cbuffer()
  */
-inline int
+int
 ever_eq_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return eacomp_tcbuffer_cbuffer(temp, cb, &datum2_eq, EVER);
@@ -119,7 +119,7 @@ ever_eq_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @param[in] temp Temporal value
  * @csqlfn #Ever_ne_cbuffer_tcbuffer()
  */
-inline int
+int
 ever_ne_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 {
   return eacomp_tcbuffer_cbuffer(temp, cb, &datum2_ne, EVER);
@@ -133,7 +133,7 @@ ever_ne_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
  * @param[in] cb Circular buffer
  * @csqlfn #Ever_ne_tcbuffer_cbuffer()
  */
-inline int
+int
 ever_ne_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return eacomp_tcbuffer_cbuffer(temp, cb, &datum2_ne, EVER);
@@ -147,7 +147,7 @@ ever_ne_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @param[in] temp Temporal value
  * @csqlfn #Always_eq_cbuffer_tcbuffer()
  */
-inline int
+int
 always_eq_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 {
   return eacomp_tcbuffer_cbuffer(temp, cb, &datum2_eq, ALWAYS);
@@ -161,7 +161,7 @@ always_eq_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
  * @param[in] cb Circular buffer
  * @csqlfn #Always_eq_tcbuffer_cbuffer()
  */
-inline int
+int
 always_eq_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return eacomp_tcbuffer_cbuffer(temp, cb, &datum2_eq, ALWAYS);
@@ -175,7 +175,7 @@ always_eq_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @param[in] temp Temporal value
  * @csqlfn #Always_ne_cbuffer_tcbuffer()
  */
-inline int
+int
 always_ne_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 {
   return eacomp_tcbuffer_cbuffer(temp, cb, &datum2_ne, ALWAYS);
@@ -189,7 +189,7 @@ always_ne_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
  * @param[in] cb Circular buffer
  * @csqlfn #Always_ne_tcbuffer_cbuffer()
  */
-inline int
+int
 always_ne_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return eacomp_tcbuffer_cbuffer(temp, cb, &datum2_ne, ALWAYS);
@@ -203,7 +203,7 @@ always_ne_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @param[in] temp1,temp2 Temporal circular buffers
  * @csqlfn #Ever_eq_tcbuffer_tcbuffer()
  */
-inline int
+int
 ever_eq_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tcbuffer_tcbuffer(temp1, temp2, &datum2_eq, EVER);
@@ -215,7 +215,7 @@ ever_eq_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal circular buffers
  * @csqlfn #Ever_ne_tcbuffer_tcbuffer()
  */
-inline int
+int
 ever_ne_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tcbuffer_tcbuffer(temp1, temp2, &datum2_ne, EVER);
@@ -227,7 +227,7 @@ ever_ne_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal circular buffers
  * @csqlfn #Always_eq_tcbuffer_tcbuffer()
  */
-inline int
+int
 always_eq_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tcbuffer_tcbuffer(temp1, temp2, &datum2_eq, ALWAYS);
@@ -239,7 +239,7 @@ always_eq_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal circular buffers
  * @csqlfn #Always_ne_tcbuffer_tcbuffer()
  */
-inline int
+int
 always_ne_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tcbuffer_tcbuffer(temp1, temp2, &datum2_ne, ALWAYS);
@@ -293,7 +293,7 @@ tcomp_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb,
  * @param[in] temp Temporal value
  * @csqlfn #Teq_cbuffer_tcbuffer()
  */
-inline Temporal *
+Temporal *
 teq_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 {
   return tcomp_cbuffer_tcbuffer(cb, temp, &datum2_eq);
@@ -307,7 +307,7 @@ teq_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
  * @param[in] temp Temporal value
  * @csqlfn #Tne_cbuffer_tcbuffer()
  */
-inline Temporal *
+Temporal *
 tne_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 {
   return tcomp_cbuffer_tcbuffer(cb, temp, &datum2_ne);
@@ -323,7 +323,7 @@ tne_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
  * @param[in] cb Circular buffer
  * @csqlfn #Teq_tcbuffer_cbuffer()
  */
-inline Temporal *
+Temporal *
 teq_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return tcomp_tcbuffer_cbuffer(temp, cb, &datum2_eq);
@@ -337,7 +337,7 @@ teq_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @param[in] cb Circular buffer
  * @csqlfn #Tne_tcbuffer_cbuffer()
  */
-inline Temporal *
+Temporal *
 tne_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return tcomp_tcbuffer_cbuffer(temp, cb, &datum2_ne);

--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -453,7 +453,7 @@ ea_contains_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp,
  * geometry
  * @csqlfn #Acontains_geo_tcbuffer()
  */
-inline int
+int
 acontains_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp)
 {
   return ea_contains_geo_tcbuffer(gs, temp, ALWAYS);
@@ -492,7 +492,7 @@ ea_contains_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs,
  * geometry
  * @csqlfn #Econtains_tcbuffer_geo()
  */
-inline int
+int
 econtains_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_contains_tcbuffer_geo(temp, gs, EVER);
@@ -508,7 +508,7 @@ econtains_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
  * geometry
  * @csqlfn #Acontains_tcbuffer_geo()
  */
-inline int
+int
 acontains_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_contains_tcbuffer_geo(temp, gs, ALWAYS);
@@ -544,7 +544,7 @@ ea_contains_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp,
  * @param[in] temp Temporal circular buffer
  * @csqlfn #Econtains_cbuffer_tcbuffer()
  */
-inline int
+int
 econtains_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 {
   return ea_contains_cbuffer_tcbuffer(cb, temp, EVER);
@@ -558,7 +558,7 @@ econtains_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
  * @param[in] temp Temporal circular buffer
  * @csqlfn #Acontains_cbuffer_tcbuffer()
  */
-inline int
+int
 acontains_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 {
   return ea_contains_cbuffer_tcbuffer(cb, temp, ALWAYS);
@@ -594,7 +594,7 @@ ea_contains_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb,
  * @param[in] cb Circular buffer
  * @csqlfn #Econtains_tcbuffer_cbuffer()
  */
-inline int
+int
 econtains_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return ea_contains_tcbuffer_cbuffer(temp, cb, EVER);
@@ -608,7 +608,7 @@ econtains_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @param[in] cb Circular buffer
  * @csqlfn #Acontains_tcbuffer_cbuffer()
  */
-inline int
+int
 acontains_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return ea_contains_tcbuffer_cbuffer(temp, cb, ALWAYS);
@@ -646,7 +646,7 @@ ea_covers_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp, bool ever)
  * geometry
  * @csqlfn #Acovers_geo_tcbuffer()
  */
-inline int
+int
 acovers_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp)
 {
   return ea_covers_geo_tcbuffer(gs, temp, ALWAYS);
@@ -681,7 +681,7 @@ ea_covers_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
  * geometry
  * @csqlfn #Ecovers_tcbuffer_geo()
  */
-inline int
+int
 ecovers_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_covers_tcbuffer_geo(temp, gs, EVER);
@@ -697,7 +697,7 @@ ecovers_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
  * geometry
  * @csqlfn #Acovers_tcbuffer_geo()
  */
-inline int
+int
 acovers_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_covers_tcbuffer_geo(temp, gs, ALWAYS);
@@ -728,7 +728,7 @@ ea_covers_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp,
  * @param[in] temp Temporal circular buffer
  * @csqlfn #Ecovers_cbuffer_tcbuffer()
  */
-inline int
+int
 ecovers_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 {
   return ea_covers_cbuffer_tcbuffer(cb, temp, EVER);
@@ -742,7 +742,7 @@ ecovers_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
  * @param[in] temp Temporal circular buffer
  * @csqlfn #Acovers_cbuffer_tcbuffer()
  */
-inline int
+int
 acovers_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 {
   return ea_covers_cbuffer_tcbuffer(cb, temp, ALWAYS);
@@ -773,7 +773,7 @@ ea_covers_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb,
  * @param[in] cb Circular buffer
  * @csqlfn #Ecovers_tcbuffer_cbuffer()
  */
-inline int
+int
 ecovers_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return ea_covers_tcbuffer_cbuffer(temp, cb, EVER);
@@ -787,7 +787,7 @@ ecovers_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @param[in] cb Circular buffer
  * @csqlfn #Acovers_tcbuffer_cbuffer()
  */
-inline int
+int
 acovers_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return ea_covers_tcbuffer_cbuffer(temp, cb, ALWAYS);
@@ -897,7 +897,7 @@ edisjoint_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @note aDisjoint(a, b) is equivalent to NOT eIntersects(a, b)
  * @csqlfn #Adisjoint_tcbuffer_geo()
  */
-inline int
+int
 adisjoint_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_disjoint_tcbuffer_geo(temp, gs, ALWAYS);
@@ -959,7 +959,7 @@ edisjoint_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @note aDisjoint(a, b) is equivalent to NOT eIntersects(a, b)
  * @csqlfn #Adisjoint_tcbuffer_geo()
  */
-inline int
+int
 adisjoint_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return ea_disjoint_tcbuffer_cbuffer(temp, cb, ALWAYS);
@@ -992,7 +992,7 @@ ea_disjoint_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
  * @param[in] temp1,temp2 Temporal circular buffers
  * @csqlfn #Edisjoint_tcbuffer_tcbuffer()
  */
-inline int
+int
 edisjoint_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_disjoint_tcbuffer_tcbuffer(temp1, temp2, EVER);
@@ -1006,7 +1006,7 @@ edisjoint_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal circular buffers
  * @csqlfn #Adisjoint_tcbuffer_tcbuffer()
  */
-inline int
+int
 adisjoint_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_disjoint_tcbuffer_tcbuffer(temp1, temp2, ALWAYS);
@@ -1073,7 +1073,7 @@ eintersects_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @note aIntersects(tcbuffer, geo) is equivalent to NOT eDisjoint(tcbuffer, geo)
  * @csqlfn #Aintersects_tcbuffer_geo()
  */
-inline int
+int
 aintersects_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_intersects_tcbuffer_geo(temp, gs, ALWAYS);
@@ -1122,7 +1122,7 @@ ea_intersects_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp,
  * @param[in] cb Circular buffer
  * @csqlfn #Eintersects_tcbuffer_cbuffer()
  */
-inline int
+int
 eintersects_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return ea_intersects_tcbuffer_cbuffer(temp, cb, EVER);
@@ -1138,7 +1138,7 @@ eintersects_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * NOT eDisjoint(tcbuffer, cbuffer)
  * @csqlfn #Aintersects_tcbuffer_cbuffer()
  */
-inline int
+int
 aintersects_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return ea_intersects_tcbuffer_cbuffer(temp, cb, ALWAYS);
@@ -1171,7 +1171,7 @@ ea_intersects_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
  * @param[in] temp1,temp2 Temporal circular buffers
  * @csqlfn #Eintersects_tcbuffer_tcbuffer()
  */
-inline int
+int
 eintersects_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_intersects_tcbuffer_tcbuffer(temp1, temp2, EVER);
@@ -1184,7 +1184,7 @@ eintersects_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal circular buffers
  * @csqlfn #Aintersects_tcbuffer_tcbuffer()
  */
-inline int
+int
 aintersects_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_intersects_tcbuffer_tcbuffer(temp1, temp2, ALWAYS);
@@ -1296,7 +1296,7 @@ ea_touches_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp, bool ever)
  * @param[in] cb Circular buffer
  * @csqlfn #Atouches_tcbuffer_cbuffer()
  */
-inline int
+int
 etouches_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return ea_touches_tcbuffer_cbuffer(temp, cb, EVER); 
@@ -1310,7 +1310,7 @@ etouches_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @param[in] cb Circular buffer
  * @csqlfn #Atouches_tcbuffer_cbuffer()
  */
-inline int
+int
 atouches_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return ea_touches_tcbuffer_cbuffer(temp, cb, ALWAYS); 
@@ -1519,7 +1519,7 @@ ea_dwithin_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
  * @param[in] dist Distance
  * @csqlfn #Edwithin_tcbuffer_tcbuffer()
  */
-inline int
+int
 edwithin_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
   double dist)
 {
@@ -1535,7 +1535,7 @@ edwithin_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
  * @param[in] dist Distance
  * @csqlfn #Adwithin_tcbuffer_tcbuffer()
  */
-inline int
+int
 adwithin_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
   double dist)
 {

--- a/meos/src/cbuffer/tcbuffer_tempspatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_tempspatialrels.c
@@ -820,7 +820,7 @@ tcovers_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
  * @param[in] gs Geometry
  * @csqlfn #Tdisjoint_tcbuffer_geo()
  */
-inline Temporal *
+Temporal *
 tdisjoint_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp)
 {
   return tinterrel_tcbuffer_geo(temp, gs, TDISJOINT);
@@ -834,7 +834,7 @@ tdisjoint_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp)
  * @param[in] gs Geometry
  * @csqlfn #Tdisjoint_tcbuffer_geo()
  */
-inline Temporal *
+Temporal *
 tdisjoint_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tinterrel_tcbuffer_geo(temp, gs, TDISJOINT);
@@ -848,7 +848,7 @@ tdisjoint_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] cb Circular buffer
  * @csqlfn #Tdisjoint_tcbuffer_geo()
  */
-inline Temporal *
+Temporal *
 tdisjoint_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 {
   return tinterrel_tcbuffer_cbuffer(temp, cb, TDISJOINT);
@@ -862,7 +862,7 @@ tdisjoint_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
  * @param[in] cb Circular buffer
  * @csqlfn #Tdisjoint_tcbuffer_geo()
  */
-inline Temporal *
+Temporal *
 tdisjoint_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return tinterrel_tcbuffer_cbuffer(temp, cb, TDISJOINT);
@@ -875,7 +875,7 @@ tdisjoint_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @param[in] temp1,temp2 Temporal circular buffers
  * @csqlfn #Tdisjoint_tcbuffer_tcbuffer()
  */
-inline Temporal *
+Temporal *
 tdisjoint_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
   return tinterrel_tspatial_tspatial(temp1, temp2, TDISJOINT);
@@ -893,7 +893,7 @@ tdisjoint_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
  * @param[in] gs Geometry
  * @csqlfn #Tintersects_tcbuffer_geo()
  */
-inline Temporal *
+Temporal *
 tintersects_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tinterrel_tcbuffer_geo(temp, gs, TINTERSECTS);
@@ -907,7 +907,7 @@ tintersects_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] gs Geometry
  * @csqlfn #Tintersects_tcbuffer_geo()
  */
-inline Temporal *
+Temporal *
 tintersects_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp)
 {
   return tinterrel_tcbuffer_geo(temp, gs, TINTERSECTS);
@@ -921,7 +921,7 @@ tintersects_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp)
  * @param[in] cb Circular buffer
  * @csqlfn #Tdisjoint_tcbuffer_geo()
  */
-inline Temporal *
+Temporal *
 tintersects_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 {
   return tinterrel_tcbuffer_cbuffer(temp, cb, TDISJOINT);
@@ -935,7 +935,7 @@ tintersects_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
  * @param[in] cb Circular buffer
  * @csqlfn #Tdisjoint_tcbuffer_geo()
  */
-inline Temporal *
+Temporal *
 tintersects_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   return tinterrel_tcbuffer_cbuffer(temp, cb, TDISJOINT);
@@ -948,7 +948,7 @@ tintersects_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @param[in] temp1,temp2 Temporal circular buffers
  * @csqlfn #Tintersects_tcbuffer_tcbuffer()
  */
-inline Temporal *
+Temporal *
 tintersects_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
   return tinterrel_tspatial_tspatial(temp1, temp2, TINTERSECTS);

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -1533,7 +1533,7 @@ geom_spatialrel(const GSERIALIZED *gs1, const GSERIALIZED *gs2, spatialRel rel)
  * @param[in] gs1,gs2 Geometries
  * @note PostGIS functions: @p ST_Intersects(PG_FUNCTION_ARGS)
  */
-inline bool
+bool
 geom_intersects2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 {
   return geom_spatialrel(gs1, gs2, INTERSECTS);
@@ -1546,7 +1546,7 @@ geom_intersects2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
  * @param[in] gs1,gs2 Geometries
  * @note PostGIS functions: @p contains(PG_FUNCTION_ARGS)
  */
-inline bool
+bool
 geom_contains(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 {
   return geom_spatialrel(gs1, gs2, CONTAINS);
@@ -1559,7 +1559,7 @@ geom_contains(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
  * @param[in] gs1,gs2 Geometries
  * @note PostGIS function: @p touches(PG_FUNCTION_ARGS)
  */
-inline bool
+bool
 geom_touches(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 {
   return geom_spatialrel(gs1, gs2, TOUCHES);
@@ -1572,7 +1572,7 @@ geom_touches(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
  * @param[in] gs1,gs2 Geometries
  * @note PostGIS function: @p ST_Covers(PG_FUNCTION_ARGS)
  */
-inline bool
+bool
 geom_covers(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 {
   return geom_spatialrel(gs1, gs2, COVERS);
@@ -1584,7 +1584,7 @@ geom_covers(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
  * @param[in] gs1,gs2 Geometries
  * @note PostGIS function: @p ST_Disjoint(PG_FUNCTION_ARGS)
  */
-inline bool
+bool
 geom_disjoint2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 {
   return ! geom_spatialrel(gs1, gs2, INTERSECTS);
@@ -2944,7 +2944,7 @@ geog_dwithin(const GSERIALIZED *gs1, const GSERIALIZED *gs2, double tolerance,
  * @param[in] use_spheroid True when using a spheroid
  * @note PostGIS function: @p geography_intersects(PG_FUNCTION_ARGS)
  */
-inline bool
+bool
 geog_intersects(const GSERIALIZED *gs1, const GSERIALIZED *gs2,
   bool use_spheroid)
 {
@@ -3280,7 +3280,10 @@ geo_from_text(const char *wkt, int32_t srid)
 
   if (lwgeom_parse_wkt(&lwg_parser_result, (char *) wkt,
       LW_PARSER_CHECK_ALL) == LW_FAILURE )
+  {
     PG_PARSER_ERROR(lwg_parser_result);
+    return NULL;
+  }
 
   lwgeom = lwg_parser_result.geom;
 
@@ -3334,7 +3337,7 @@ geo_as_wkt(const GSERIALIZED *gs, int precision, bool extended)
  * @param[in] precision Maximum number of decimal digits
  * @note PostGIS function: @p LWGEOM_asText(PG_FUNCTION_ARGS)
  */
-inline char *
+char *
 geo_as_text(const GSERIALIZED *gs, int precision)
 {
   return geo_as_wkt(gs, precision, false);
@@ -3351,7 +3354,7 @@ geo_as_text(const GSERIALIZED *gs, int precision)
  * accept (HEX)WKB or EWKT.
  * @note PostGIS function: @p LWGEOM_asEWKT(PG_FUNCTION_ARGS)
  */
-inline char *
+char *
 geo_as_ewkt(const GSERIALIZED *gs, int precision)
 {
   return geo_as_wkt(gs, precision, true);
@@ -3368,7 +3371,7 @@ geo_as_ewkt(const GSERIALIZED *gs, int precision)
  * accept (HEX)WKB or EWKT.
  * @note PostGIS function: @p LWGEOM_from_text(PG_FUNCTION_ARGS)
  */
-inline GSERIALIZED *
+GSERIALIZED *
 geom_from_hexewkb(const char *wkt)
 {
   return geom_in(wkt, -1);
@@ -3383,7 +3386,7 @@ geom_from_hexewkb(const char *wkt)
  * accept (HEX)WKB or EWKT.
  * @note PostGIS function: @p LWGEOM_from_text(PG_FUNCTION_ARGS)
  */
-inline GSERIALIZED *
+GSERIALIZED *
 geog_from_hexewkb(const char *wkt)
 {
   return geog_in(wkt, -1);
@@ -3710,10 +3713,13 @@ geog_in(const char *str, int32 typmod)
   /* WKT then. */
   else
   {
-    if ( lwgeom_parse_wkt(&lwg_parser_result, (char *) str, 
+    if ( lwgeom_parse_wkt(&lwg_parser_result, (char *) str,
         LW_PARSER_CHECK_ALL) == LW_FAILURE )
+    {
       PG_PARSER_ERROR(lwg_parser_result);
-      lwgeom = lwg_parser_result.geom;
+      return NULL;
+    }
+    lwgeom = lwg_parser_result.geom;
   }
 
   GSERIALIZED *result = NULL;

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -52,6 +52,7 @@
 /* MEOS */
 #include <meos.h>
 #include <meos_internal.h>
+#include <meos_internal_geo.h>
 #include "temporal/postgres_types.h"
 #include "temporal/type_util.h"
 #include "geo/meos_transform.h"
@@ -1438,35 +1439,33 @@ GEOS2POSTGIS(GEOSGeom geom, char want3d)
  */
 static char
 meos_call_geos2(const GSERIALIZED *gs1, const GSERIALIZED *gs2,
-  char (*func)(const GEOSGeometry *geos1, const GEOSGeometry *geos2))
+  char (*func)(GEOSContextHandle_t ctx, const GEOSGeometry *geos1,
+    const GEOSGeometry *geos2))
 {
-  initGEOS(lwnotice, lwgeom_geos_error);
+  GEOSContextHandle_t ctx = geos_get_context();
 
   GEOSGeometry *geos1 = POSTGIS2GEOS(gs1);
   if (! geos1)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "First argument geometry could not be converted to GEOS");
-    finishGEOS();
     return 2;
   }
   GEOSGeometry *geos2 = POSTGIS2GEOS(gs2);
   if (! geos2)
   {
-    GEOSGeom_destroy(geos1);
+    GEOSGeom_destroy_r(ctx, geos1);
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "Second argument geometry could not be converted to GEOS");
-    finishGEOS();
     return 2;
   }
 
-  char result = func(geos1, geos2);
+  char result = func(ctx, geos1, geos2);
 
-  GEOSGeom_destroy(geos1); GEOSGeom_destroy(geos2);
+  GEOSGeom_destroy_r(ctx, geos1); GEOSGeom_destroy_r(ctx, geos2);
   if (result == 2)
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "GEOS returned error");
-  finishGEOS();
   return result;
 }
 
@@ -1515,13 +1514,13 @@ geom_spatialrel(const GSERIALIZED *gs1, const GSERIALIZED *gs2, spatialRel rel)
   switch (rel)
   {
     case INTERSECTS:
-      return (bool) meos_call_geos2(gs1, gs2, &GEOSIntersects);
+      return (bool) meos_call_geos2(gs1, gs2, &GEOSIntersects_r);
     case CONTAINS:
-      return (bool) meos_call_geos2(gs1, gs2, &GEOSContains);
+      return (bool) meos_call_geos2(gs1, gs2, &GEOSContains_r);
     case TOUCHES:
-      return (bool) meos_call_geos2(gs1, gs2, &GEOSTouches);
+      return (bool) meos_call_geos2(gs1, gs2, &GEOSTouches_r);
     case COVERS:
-      return (bool) meos_call_geos2(gs1, gs2, &GEOSCovers);
+      return (bool) meos_call_geos2(gs1, gs2, &GEOSCovers_r);
     default:
       /* keep compiler quiet */
       return false;
@@ -1609,23 +1608,21 @@ geom_relate_pattern(const GSERIALIZED *gs1, const GSERIALIZED *gs2, char *p)
 
   /* TODO handle empty */
 
-  initGEOS(lwnotice, lwgeom_geos_error);
+  GEOSContextHandle_t ctx = geos_get_context();
 
   GEOSGeometry *geos1 = POSTGIS2GEOS(gs1);
   if (!geos1)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "First argument geometry could not be converted to GEOS");
-    finishGEOS();
     return false;
   }
   GEOSGeometry *geos2 = POSTGIS2GEOS(gs2);
   if (!geos2)
   {
-    GEOSGeom_destroy(geos1);
+    GEOSGeom_destroy_r(ctx, geos1);
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "Second argument geometry could not be converted to GEOS");
-    finishGEOS();
     return false;
   }
 
@@ -1638,14 +1635,13 @@ geom_relate_pattern(const GSERIALIZED *gs1, const GSERIALIZED *gs2, char *p)
     if ( p[i] == 'f' ) p[i] = 'F';
   }
 
-  char result = GEOSRelatePattern(geos1, geos2, p);
-  GEOSGeom_destroy(geos1);
-  GEOSGeom_destroy(geos2);
+  char result = GEOSRelatePattern_r(ctx, geos1, geos2, p);
+  GEOSGeom_destroy_r(ctx, geos1);
+  GEOSGeom_destroy_r(ctx, geos2);
 
   if (result == 2)
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "GEOSRelatePattern returned error");
-  finishGEOS();
   return (bool) result;
 }
 
@@ -1716,7 +1712,7 @@ geom_array_union(GSERIALIZED **gsarr, int count)
   GEOSGeometry *g = NULL;
   GEOSGeometry *g_union = NULL;
 
-  initGEOS(lwnotice, lwgeom_geos_error);
+  GEOSContextHandle_t ctx = geos_get_context();
 
   /* Collect the non-empty inputs and stuff them into a GEOS collection */
   GEOSGeometry **geoms = palloc(sizeof(GEOSGeometry *) * count);
@@ -1754,7 +1750,6 @@ geom_array_union(GSERIALIZED **gsarr, int count)
       {
         meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
           "One of the geometries in the set could not be converted to GEOS");
-        finishGEOS();
         return NULL;
       }
 
@@ -1768,34 +1763,31 @@ geom_array_union(GSERIALIZED **gsarr, int count)
   */
   if (curgeom > 0)
   {
-    g = GEOSGeom_createCollection(GEOS_GEOMETRYCOLLECTION, geoms, curgeom);
+    g = GEOSGeom_createCollection_r(ctx, GEOS_GEOMETRYCOLLECTION, geoms, curgeom);
     if (! g)
     {
       meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
         "Could not create GEOS COLLECTION from geometry array");
-      finishGEOS();
       return NULL;
     }
 
-    g_union = GEOSUnaryUnion(g);
-    GEOSGeom_destroy(g);
+    g_union = GEOSUnaryUnion_r(ctx, g);
+    GEOSGeom_destroy_r(ctx, g);
     if (! g_union)
     {
       meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR, "GEOSUnaryUnion");
-      finishGEOS();
       return NULL;
     }
 
-    GEOSSetSRID(g_union, srid);
+    GEOSSetSRID_r(ctx, g_union, srid);
     result = GEOS2POSTGIS(g_union, is3d);
     /* MEOS: GEOS DOES NOT SET THE GEODETIC FLAG */
     FLAGS_SET_GEODETIC(result->gflags, FLAGS_GET_GEODETIC(gsarr[0]->gflags));
-    GEOSGeom_destroy(g_union);
+    GEOSGeom_destroy_r(ctx, g_union);
   }
   /* No real geometries in our array, any empties? */
   else
   {
-    finishGEOS();
     /* If it was only empties, we'll return the largest type number */
     if (empty_type > 0)
     {
@@ -1810,7 +1802,6 @@ geom_array_union(GSERIALIZED **gsarr, int count)
   }
 
   pfree(geoms);
-  finishGEOS();
   if (! result)
     /* Union returned a NULL geometry */
     return NULL;
@@ -1852,38 +1843,35 @@ geom_convex_hull(const GSERIALIZED *gs)
 
   int32_t srid = gserialized_get_srid(gs);
 
-  initGEOS(lwnotice, lwgeom_geos_error);
+  GEOSContextHandle_t ctx = geos_get_context();
 
   GEOSGeometry *geos1 = POSTGIS2GEOS(gs);
   if (!geos1)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "First argument geometry could not be converted to GEOS");
-    finishGEOS();
     return NULL;
   }
 
-  GEOSGeometry *geos2 = GEOSConvexHull(geos1);
-  GEOSGeom_destroy(geos1);
+  GEOSGeometry *geos2 = GEOSConvexHull_r(ctx, geos1);
+  GEOSGeom_destroy_r(ctx, geos1);
 
   if (! geos2)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "GEOS convexhull() threw an error !");
-    finishGEOS();
     return NULL;
   }
 
-  GEOSSetSRID(geos2, srid);
+  GEOSSetSRID_r(ctx, geos2, srid);
 
   LWGEOM *lwout = GEOS2LWGEOM(geos2, (uint8_t) gserialized_has_z(gs));
-  GEOSGeom_destroy(geos2);
+  GEOSGeom_destroy_r(ctx, geos2);
 
   if (!lwout)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "convexhull() failed to convert GEOS geometry to LWGEOM");
-    finishGEOS();
     return NULL;
   }
 
@@ -1898,7 +1886,6 @@ geom_convex_hull(const GSERIALIZED *gs)
 
   GSERIALIZED *result = geo_serialize(lwout);
   lwgeom_free(lwout);
-  finishGEOS();
   if (! result)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
@@ -2060,34 +2047,33 @@ geom_buffer(const GSERIALIZED *gs, double size, const char *params)
 
   lwgeom_free(lwg);
 
-  initGEOS(lwnotice, lwgeom_geos_error);
+  GEOSContextHandle_t ctx = geos_get_context();
 
   g1 = POSTGIS2GEOS(gs);
   if (! g1)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "First argument geometry could not be converted to GEOS");
-    finishGEOS();
     return NULL;
   }
 
-  bufferparams = GEOSBufferParams_create();
+  bufferparams = GEOSBufferParams_create_r(ctx);
   if (bufferparams)
   {
-    if (GEOSBufferParams_setEndCapStyle(bufferparams, endCapStyle) &&
-      GEOSBufferParams_setJoinStyle(bufferparams, joinStyle) &&
-      GEOSBufferParams_setMitreLimit(bufferparams, mitreLimit) &&
-      GEOSBufferParams_setQuadrantSegments(bufferparams, quadsegs) &&
-      GEOSBufferParams_setSingleSided(bufferparams, singleside))
+    if (GEOSBufferParams_setEndCapStyle_r(ctx, bufferparams, endCapStyle) &&
+      GEOSBufferParams_setJoinStyle_r(ctx, bufferparams, joinStyle) &&
+      GEOSBufferParams_setMitreLimit_r(ctx, bufferparams, mitreLimit) &&
+      GEOSBufferParams_setQuadrantSegments_r(ctx, bufferparams, quadsegs) &&
+      GEOSBufferParams_setSingleSided_r(ctx, bufferparams, singleside))
     {
-      g3 = GEOSBufferWithParams(g1, bufferparams, size);
+      g3 = GEOSBufferWithParams_r(ctx, g1, bufferparams, size);
     }
     else
     {
       meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
         "Error setting buffer parameters.");
     }
-    GEOSBufferParams_destroy(bufferparams);
+    GEOSBufferParams_destroy_r(ctx, bufferparams);
   }
   else
   {
@@ -2095,21 +2081,19 @@ geom_buffer(const GSERIALIZED *gs, double size, const char *params)
       "Error setting buffer parameters.");
   }
 
-  GEOSGeom_destroy(g1);
+  GEOSGeom_destroy_r(ctx, g1);
 
   if (! g3)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "GEOSBuffer returned error");
-    finishGEOS();
     return NULL;
   }
 
-  GEOSSetSRID(g3, gserialized_get_srid(gs));
+  GEOSSetSRID_r(ctx, g3, gserialized_get_srid(gs));
 
   GSERIALIZED *result = GEOS2POSTGIS(g3, gserialized_has_z(gs));
-  GEOSGeom_destroy(g3);
-  finishGEOS();
+  GEOSGeom_destroy_r(ctx, g3);
   if (! result)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
@@ -2240,7 +2224,7 @@ geo_equals(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   if (VARSIZE(gs1) == VARSIZE(gs2) && ! memcmp(gs1, gs2, VARSIZE(gs1)))
       return 1;
 
-  initGEOS(lwnotice, lwgeom_geos_error);
+  GEOSContextHandle_t ctx = geos_get_context();
 
   GEOSGeometry *geos1 = POSTGIS2GEOS(gs1);
   if (! geos1)
@@ -2248,7 +2232,6 @@ geo_equals(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "First argument geometry could not be converted to GEOS");
     /* Clean up the global context */
-    finishGEOS();
     return -1;
   }
 
@@ -2257,24 +2240,21 @@ geo_equals(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "First argument geometry could not be converted to GEOS");
-    GEOSGeom_destroy(geos1);
-    finishGEOS();
+    GEOSGeom_destroy_r(ctx, geos1);
     return -1;
   }
 
-  int result = GEOSEquals(geos1, geos2);
-  GEOSGeom_destroy(geos1);
-  GEOSGeom_destroy(geos2);
+  int result = GEOSEquals_r(ctx, geos1, geos2);
+  GEOSGeom_destroy_r(ctx, geos1);
+  GEOSGeom_destroy_r(ctx, geos2);
 
   if (result == 2)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "GEOS equals() threw an error !");
-    finishGEOS();
     return -1;
   }
 
-  finishGEOS();
   return result;
 }
 

--- a/meos/src/geo/stbox.c
+++ b/meos/src/geo/stbox.c
@@ -1804,7 +1804,7 @@ contains_stbox_stbox(const STBox *box1, const STBox *box2)
  * @param[in] box1,box2 Spatiotemporal boxes
  * @csqlfn #Contained_stbox_stbox()
  */
-inline bool
+bool
 contained_stbox_stbox(const STBox *box1, const STBox *box2)
 {
   return contains_stbox_stbox(box2, box1);
@@ -2435,7 +2435,7 @@ stbox_eq(const STBox *box1, const STBox *box2)
  * @param[in] box1,box2 Spatiotemporal boxes
  * @csqlfn #Stbox_ne()
  */
-inline bool
+bool
 stbox_ne(const STBox *box1, const STBox *box2)
 {
   return ! stbox_eq(box1, box2);
@@ -2520,7 +2520,7 @@ stbox_cmp(const STBox *box1, const STBox *box2)
  * @param[in] box1,box2 Spatiotemporal boxes
  * @csqlfn #Stbox_lt()
  */
-inline bool
+bool
 stbox_lt(const STBox *box1, const STBox *box2)
 {
   return stbox_cmp(box1, box2) < 0;
@@ -2533,7 +2533,7 @@ stbox_lt(const STBox *box1, const STBox *box2)
  * @param[in] box1,box2 Spatiotemporal boxes
  * @csqlfn #Stbox_le()
  */
-inline bool
+bool
 stbox_le(const STBox *box1, const STBox *box2)
 {
   return stbox_cmp(box1, box2) <= 0;
@@ -2546,7 +2546,7 @@ stbox_le(const STBox *box1, const STBox *box2)
  * @param[in] box1,box2 Spatiotemporal boxes
  * @csqlfn #Stbox_ge()
  */
-inline bool
+bool
 stbox_ge(const STBox *box1, const STBox *box2)
 {
   return stbox_cmp(box1, box2) >= 0;
@@ -2559,7 +2559,7 @@ stbox_ge(const STBox *box1, const STBox *box2)
  * @param[in] box1,box2 Spatiotemporal boxes
  * @csqlfn #Stbox_gt()
  */
-inline bool
+bool
 stbox_gt(const STBox *box1, const STBox *box2)
 {
   return stbox_cmp(box1, box2) > 0;

--- a/meos/src/geo/tgeo_compops.c
+++ b/meos/src/geo/tgeo_compops.c
@@ -95,7 +95,7 @@ eacomp_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2,
  * @param[in] temp Temporal geo
  * @csqlfn #Ever_eq_geo_tgeo()
  */
-inline int
+int
 ever_eq_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   return eacomp_tgeo_geo(temp, gs, &datum2_eq, EVER);
@@ -108,7 +108,7 @@ ever_eq_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
  * @param[in] gs Geo
  * @csqlfn #Ever_eq_tgeo_geo()
  */
-inline int
+int
 ever_eq_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return eacomp_tgeo_geo(temp, gs, &datum2_eq, EVER);
@@ -121,7 +121,7 @@ ever_eq_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] temp Temporal geo
  * @csqlfn #Ever_ne_geo_tgeo()
  */
-inline int
+int
 ever_ne_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   return eacomp_tgeo_geo(temp, gs, &datum2_ne, EVER);
@@ -134,7 +134,7 @@ ever_ne_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
  * @param[in] gs Geo
  * @csqlfn #Ever_ne_tgeo_geo()
  */
-inline int
+int
 ever_ne_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return eacomp_tgeo_geo(temp, gs, &datum2_ne, EVER);
@@ -147,7 +147,7 @@ ever_ne_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] temp Temporal geo
  * @csqlfn #Always_eq_geo_tgeo()
  */
-inline int
+int
 always_eq_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   return eacomp_tgeo_geo(temp, gs, &datum2_eq, ALWAYS);
@@ -160,7 +160,7 @@ always_eq_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
  * @param[in] gs Geo
  * @csqlfn #Always_eq_tgeo_geo()
  */
-inline int
+int
 always_eq_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return eacomp_tgeo_geo(temp, gs, &datum2_eq, ALWAYS);
@@ -173,7 +173,7 @@ always_eq_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] temp Temporal geo
  * @csqlfn #Always_ne_geo_tgeo()
  */
-inline int
+int
 always_ne_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   return eacomp_tgeo_geo(temp, gs, &datum2_ne, ALWAYS);
@@ -186,7 +186,7 @@ always_ne_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
  * @param[in] gs Geo
  * @csqlfn #Always_ne_tgeo_geo()
  */
-inline int
+int
 always_ne_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return eacomp_tgeo_geo(temp, gs, &datum2_ne, ALWAYS);
@@ -200,7 +200,7 @@ always_ne_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Ever_eq_tgeo_tgeo()
  */
-inline int
+int
 ever_eq_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tgeo_tgeo(temp1, temp2, &datum2_eq, EVER);
@@ -212,7 +212,7 @@ ever_eq_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Ever_ne_tgeo_tgeo()
  */
-inline int
+int
 ever_ne_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tgeo_tgeo(temp1, temp2, &datum2_ne, EVER);
@@ -224,7 +224,7 @@ ever_ne_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Always_eq_tgeo_tgeo()
  */
-inline int
+int
 always_eq_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tgeo_tgeo(temp1, temp2, &datum2_eq, ALWAYS);
@@ -236,7 +236,7 @@ always_eq_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Always_ne_tgeo_tgeo()
  */
-inline int
+int
 always_ne_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tgeo_tgeo(temp1, temp2, &datum2_ne, ALWAYS);
@@ -291,7 +291,7 @@ tcomp_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
  * @param[in] temp Temporal geo
  * @csqlfn #Teq_geo_tgeo()
  */
-inline Temporal *
+Temporal *
 teq_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   return tcomp_geo_tgeo(gs, temp, &datum2_eq);
@@ -304,7 +304,7 @@ teq_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
  * @param[in] temp Temporal geo
  * @csqlfn #Tne_geo_tgeo()
  */
-inline Temporal *
+Temporal *
 tne_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   return tcomp_geo_tgeo(gs, temp, &datum2_ne);
@@ -319,7 +319,7 @@ tne_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
  * @param[in] gs Geo
  * @csqlfn #Teq_tgeo_geo()
  */
-inline Temporal *
+Temporal *
 teq_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tcomp_tgeo_geo(temp, gs, &datum2_eq);
@@ -332,7 +332,7 @@ teq_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] gs Geo
  * @csqlfn #Tne_tgeo_geo()
  */
-inline Temporal *
+Temporal *
 tne_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tcomp_tgeo_geo(temp, gs, &datum2_ne);

--- a/meos/src/geo/tgeo_meos.c
+++ b/meos/src/geo/tgeo_meos.c
@@ -271,7 +271,7 @@ tgeographyseqset_in(const char *str)
  * @param[in] srid SRID
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TInstant *
+TInstant *
 tgeompointinst_from_mfjson(json_object *mfjson, int32_t srid)
 {
   return tinstant_from_mfjson(mfjson, true, srid, T_TGEOMPOINT);
@@ -285,7 +285,7 @@ tgeompointinst_from_mfjson(json_object *mfjson, int32_t srid)
  * @param[in] srid SRID
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TInstant *
+TInstant *
 tgeogpointinst_from_mfjson(json_object *mfjson, int32_t srid)
 {
   return tinstant_from_mfjson(mfjson, true, srid, T_TGEOGPOINT);
@@ -298,7 +298,7 @@ tgeogpointinst_from_mfjson(json_object *mfjson, int32_t srid)
  * @param[in] srid SRID
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TInstant *
+TInstant *
 tgeometryinst_from_mfjson(json_object *mfjson, int32_t srid)
 {
   return tinstant_from_mfjson(mfjson, true, srid, T_TGEOMETRY);
@@ -311,7 +311,7 @@ tgeometryinst_from_mfjson(json_object *mfjson, int32_t srid)
  * @param[in] srid SRID
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TInstant *
+TInstant *
 tgeographyinst_from_mfjson(json_object *mfjson, int32_t srid)
 {
   return tinstant_from_mfjson(mfjson, true, srid, T_TGEOGRAPHY);
@@ -328,7 +328,7 @@ tgeographyinst_from_mfjson(json_object *mfjson, int32_t srid)
  * @param[in] interp Interpolation
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequence *
+TSequence *
 tgeompointseq_from_mfjson(json_object *mfjson, int32_t srid, interpType interp)
 {
   return tsequence_from_mfjson(mfjson, true, srid, T_TGEOMPOINT, interp);
@@ -343,7 +343,7 @@ tgeompointseq_from_mfjson(json_object *mfjson, int32_t srid, interpType interp)
  * @param[in] interp Interpolation
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequence *
+TSequence *
 tgeogpointseq_from_mfjson(json_object *mfjson, int32_t srid, interpType interp)
 {
   return tsequence_from_mfjson(mfjson, true, srid, T_TGEOGPOINT, interp);
@@ -357,7 +357,7 @@ tgeogpointseq_from_mfjson(json_object *mfjson, int32_t srid, interpType interp)
  * @param[in] interp Interpolation
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequence *
+TSequence *
 tgeometryseq_from_mfjson(json_object *mfjson, int32_t srid, interpType interp)
 {
   return tsequence_from_mfjson(mfjson, true, srid, T_TGEOMETRY, interp);
@@ -371,7 +371,7 @@ tgeometryseq_from_mfjson(json_object *mfjson, int32_t srid, interpType interp)
  * @param[in] interp Interpolation
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequence *
+TSequence *
 tgeographyseq_from_mfjson(json_object *mfjson, int32_t srid, interpType interp)
 {
   return tsequence_from_mfjson(mfjson, true, srid, T_TGEOGRAPHY, interp);
@@ -388,7 +388,7 @@ tgeographyseq_from_mfjson(json_object *mfjson, int32_t srid, interpType interp)
  * @param[in] interp Interpolation
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequenceSet *
+TSequenceSet *
 tgeompointseqset_from_mfjson(json_object *mfjson, int32_t srid, interpType interp)
 {
   return tsequenceset_from_mfjson(mfjson, true, srid, T_TGEOMPOINT, interp);
@@ -403,7 +403,7 @@ tgeompointseqset_from_mfjson(json_object *mfjson, int32_t srid, interpType inter
  * @param[in] interp Interpolation
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequenceSet *
+TSequenceSet *
 tgeogpointseqset_from_mfjson(json_object *mfjson, int32_t srid, interpType interp)
 {
   return tsequenceset_from_mfjson(mfjson, true, srid, T_TGEOGPOINT, interp);
@@ -418,7 +418,7 @@ tgeogpointseqset_from_mfjson(json_object *mfjson, int32_t srid, interpType inter
  * @param[in] interp Interpolation
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequenceSet *
+TSequenceSet *
 tgeometryseqset_from_mfjson(json_object *mfjson, int32_t srid, interpType interp)
 {
   return tsequenceset_from_mfjson(mfjson, true, srid, T_TGEOMETRY, interp);
@@ -433,7 +433,7 @@ tgeometryseqset_from_mfjson(json_object *mfjson, int32_t srid, interpType interp
  * @param[in] interp Interpolation
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequenceSet *
+TSequenceSet *
 tgeographyseqset_from_mfjson(json_object *mfjson, int32_t srid, interpType interp)
 {
   return tsequenceset_from_mfjson(mfjson, true, srid, T_TGEOGRAPHY, interp);
@@ -448,7 +448,7 @@ tgeographyseqset_from_mfjson(json_object *mfjson, int32_t srid, interpType inter
  * @return On error return @p NULL
  * @see #temporal_from_mfjson()
  */
-inline Temporal *
+Temporal *
 tgeompoint_from_mfjson(const char *mfjson)
 {
   return temporal_from_mfjson(mfjson, T_TGEOMPOINT);
@@ -461,7 +461,7 @@ tgeompoint_from_mfjson(const char *mfjson)
  * @return On error return @p NULL
  * @see #temporal_from_mfjson()
  */
-inline Temporal *
+Temporal *
 tgeogpoint_from_mfjson(const char *mfjson)
 {
   return temporal_from_mfjson(mfjson, T_TGEOGPOINT);
@@ -473,7 +473,7 @@ tgeogpoint_from_mfjson(const char *mfjson)
  * @return On error return @p NULL
  * @see #temporal_from_mfjson()
  */
-inline Temporal *
+Temporal *
 tgeometry_from_mfjson(const char *mfjson)
 {
   return temporal_from_mfjson(mfjson, T_TGEOMETRY);
@@ -486,7 +486,7 @@ tgeometry_from_mfjson(const char *mfjson)
  * @return On error return @p NULL
  * @see #temporal_from_mfjson()
  */
-inline Temporal *
+Temporal *
 tgeography_from_mfjson(const char *mfjson)
 {
   return temporal_from_mfjson(mfjson, T_TGEOGRAPHY);
@@ -679,7 +679,7 @@ tgeo_from_base_temp_int(const GSERIALIZED *gs, const Temporal *temp,
  * @param[in] gs Value
  * @param[in] temp Temporal value
  */
-inline Temporal *
+Temporal *
 tpoint_from_base_temp(const GSERIALIZED *gs, const Temporal *temp)
 {
   return tgeo_from_base_temp_int(gs, temp, true);
@@ -692,7 +692,7 @@ tpoint_from_base_temp(const GSERIALIZED *gs, const Temporal *temp)
  * @param[in] gs Value
  * @param[in] temp Temporal value
  */
-inline Temporal *
+Temporal *
 tgeo_from_base_temp(const GSERIALIZED *gs, const Temporal *temp)
 {
   return tgeo_from_base_temp_int(gs, temp, false);

--- a/meos/src/geo/tgeo_restrict.c
+++ b/meos/src/geo/tgeo_restrict.c
@@ -1177,7 +1177,7 @@ tgeo_restrict_stbox(const Temporal *temp, const STBox *box, bool border_inc,
  * @param[in] border_inc True when the box contains the upper border
  * @csqlfn #Tgeo_at_stbox()
  */
-inline Temporal *
+Temporal *
 tgeo_at_stbox(const Temporal *temp, const STBox *box, bool border_inc)
 {
   return tgeo_restrict_stbox(temp, box, border_inc, REST_AT);
@@ -1192,7 +1192,7 @@ tgeo_at_stbox(const Temporal *temp, const STBox *box, bool border_inc)
  * @param[in] border_inc True when the box contains the upper border
  * @csqlfn #Tgeo_minus_stbox()
  */
-inline Temporal *
+Temporal *
 tgeo_minus_stbox(const Temporal *temp, const STBox *box, bool border_inc)
 {
   return tgeo_restrict_stbox(temp, box, border_inc, REST_MINUS);
@@ -2051,7 +2051,7 @@ tgeo_restrict_geom(const Temporal *temp, const GSERIALIZED *gs,
  * @note This function has a last parameter for the Z dimension which is not
  * available for temporal geometries
  */
-inline Temporal *
+Temporal *
 tpoint_at_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tgeo_restrict_geom(temp, gs, REST_AT);
@@ -2064,7 +2064,7 @@ tpoint_at_geom(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] gs Geometry
  * @csqlfn #Tgeo_at_geom()
  */
-inline Temporal *
+Temporal *
 tgeo_at_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tgeo_restrict_geom(temp, gs, REST_AT);
@@ -2079,7 +2079,7 @@ tgeo_at_geom(const Temporal *temp, const GSERIALIZED *gs)
  * @note This function has a last parameter for the Z dimension which is not
  * available for temporal geometries
  */
-inline Temporal *
+Temporal *
 tpoint_minus_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tgeo_restrict_geom(temp, gs, REST_MINUS);
@@ -2092,7 +2092,7 @@ tpoint_minus_geom(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] gs Geometry
  * @csqlfn #Tgeo_minus_geom()
  */
-inline Temporal *
+Temporal *
 tgeo_minus_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tgeo_restrict_geom(temp, gs, REST_MINUS);
@@ -2154,7 +2154,7 @@ tgeo_restrict_elevation(const Temporal *temp, const Span *s, bool atfunc)
  * @param[in] s Elevation span
  * @csqlfn #Tgeo_at_elevation()
  */
-inline Temporal *
+Temporal *
 tpoint_at_elevation(const Temporal *temp, const Span *s)
 {
   return tgeo_restrict_elevation(temp, s, REST_AT);
@@ -2167,7 +2167,7 @@ tpoint_at_elevation(const Temporal *temp, const Span *s)
  * @param[in] s Elevation span
  * @csqlfn #Tgeo_at_elevation()
  */
-inline Temporal *
+Temporal *
 tgeo_at_elevation(const Temporal *temp, const Span *s)
 {
   return tgeo_restrict_elevation(temp, s, REST_AT);
@@ -2182,7 +2182,7 @@ tgeo_at_elevation(const Temporal *temp, const Span *s)
  * @note This function has a last parameter for the Z dimension which is not
  * available for temporal geometries
  */
-inline Temporal *
+Temporal *
 tpoint_minus_elevation(const Temporal *temp, const Span *s)
 {
   return tgeo_restrict_elevation(temp, s, REST_MINUS);
@@ -2195,7 +2195,7 @@ tpoint_minus_elevation(const Temporal *temp, const Span *s)
  * @param[in] s Elevation span
  * @csqlfn #Tgeo_minus_elevation()
  */
-inline Temporal *
+Temporal *
 tgeo_minus_elevation(const Temporal *temp, const Span *s)
 {
   return tgeo_restrict_elevation(temp, s, REST_MINUS);

--- a/meos/src/geo/tgeo_spatialfuncs.c
+++ b/meos/src/geo/tgeo_spatialfuncs.c
@@ -1733,7 +1733,6 @@ geo_cluster_dbscan(const GSERIALIZED **geoms, uint32_t ngeoms,
 
   uint32_t i;
   char *is_in_cluster = NULL;
-  initGEOS(lwnotice, lwgeom_geos_error);
   LWGEOM **lwgeoms = lwalloc(ngeoms * sizeof(LWGEOM *));
   UNIONFIND *uf = UF_create(ngeoms);
   for (i = 0; i < ngeoms; i++)
@@ -1757,7 +1756,6 @@ geo_cluster_dbscan(const GSERIALIZED **geoms, uint32_t ngeoms,
 
   uint32_t *result_ids = UF_get_collapsed_cluster_ids(uf, is_in_cluster);
   *count = uf->N;
-  finishGEOS();
   UF_destroy(uf);
   if (is_in_cluster)
     lwfree(is_in_cluster);
@@ -1791,7 +1789,7 @@ geo_cluster_intersecting(const GSERIALIZED **geoms, uint32_t ngeoms,
   /* TODO short-circuit for one element? */
 
   /* Ok, we really need geos now ;) */
-  initGEOS(lwnotice, lwgeom_geos_error);
+  GEOSContextHandle_t ctx = geos_get_context();
   GEOSGeometry **geos_inputs = palloc(ngeoms * sizeof(GEOSGeometry *));
   for (i = 0; i < ngeoms; i++)
   {
@@ -1801,7 +1799,7 @@ geo_cluster_intersecting(const GSERIALIZED **geoms, uint32_t ngeoms,
     {
       lwerror("Geometry could not be converted to GEOS");
       for (j = 0; j < i; j++)
-        GEOSGeom_destroy(geos_inputs[j]);
+        GEOSGeom_destroy_r(ctx, geos_inputs[j]);
       return NULL;
     }
 
@@ -1813,7 +1811,7 @@ geo_cluster_intersecting(const GSERIALIZED **geoms, uint32_t ngeoms,
     else if (! ensure_same_srid(srid, gserialized_get_srid(geoms[i])))
     {
       for (j = 0; j <= i; j++)
-        GEOSGeom_destroy(geos_inputs[j]);
+        GEOSGeom_destroy_r(ctx, geos_inputs[j]);
       return NULL;
     }
   }
@@ -1837,11 +1835,10 @@ geo_cluster_intersecting(const GSERIALIZED **geoms, uint32_t ngeoms,
   for (i = 0; i < nclusters; ++i)
   {
     result[i] = GEOS2POSTGIS(geos_results[i], is3d);
-    GEOSGeom_destroy(geos_results[i]);
+    GEOSGeom_destroy_r(ctx, geos_results[i]);
   }
   lwfree(geos_results);
   *count = nclusters;
-  finishGEOS();
   return result;
 }
 
@@ -1872,7 +1869,6 @@ geo_cluster_within(const GSERIALIZED **geoms, uint32_t ngeoms,
   }
 
   uint32_t i;
-  initGEOS(lwnotice, lwgeom_geos_error);
   LWGEOM **lwgeoms = lwalloc(ngeoms * sizeof(LWGEOM *));
   for (i = 0; i < ngeoms; i++)
     lwgeoms[i] = lwgeom_from_gserialized(geoms[i]);
@@ -1899,7 +1895,6 @@ geo_cluster_within(const GSERIALIZED **geoms, uint32_t ngeoms,
     lwgeom_free(lw_results[i]);
   }
   lwfree(lw_results);
-  finishGEOS();
   *count = nclusters;
   return result;
 }

--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -602,7 +602,7 @@ ea_contains_tgeo_geo_common(const Temporal *temp, const GSERIALIZED *gs, bool ev
  * @brief Return 1 if a temporal geometry ever/always contains a geo, 0 if not,
  * and -1 on error or if the geometry is empty
  */
-inline int
+int
 ea_contains_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
 {
   return ea_contains_tgeo_geo_common(temp, gs, ever, INVERT);
@@ -613,7 +613,7 @@ ea_contains_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
  * @brief Return 1 if a temporal geometry ever/always contains a geo, 0 if not,
  * and -1 on error or if the geometry is empty
  */
-inline int
+int
 ea_contains_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 {
   return ea_contains_tgeo_geo_common(temp, gs, ever, INVERT_NO);
@@ -711,7 +711,7 @@ ea_contains_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2, bool ever)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Econtains_tgeo_tgeo()
  */
-inline int
+int
 econtains_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_contains_tgeo_tgeo(temp1, temp2, EVER);
@@ -724,7 +724,7 @@ econtains_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Acontains_tgeo_tgeo()
  */
-inline int
+int
 acontains_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_contains_tgeo_tgeo(temp1, temp2, ALWAYS);
@@ -778,7 +778,7 @@ ea_covers_tgeo_geo_int(const Temporal *temp, const GSERIALIZED *gs, bool ever,
  * @brief Return 1 if a temporal geometry ever/always covers a geo, 0 if not,
  * and -1 on error or if the geometry is empty
  */
-inline int
+int
 ea_covers_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
 {
   return ea_covers_tgeo_geo_int(temp, gs, ever, INVERT);
@@ -789,7 +789,7 @@ ea_covers_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
  * @brief Return 1 if a temporal geometry ever/always covers a geo, 0 if not,
  * and -1 on error or if the geometry is empty
  */
-inline int
+int
 ea_covers_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 {
   return ea_covers_tgeo_geo_int(temp, gs, ever, INVERT_NO);
@@ -887,7 +887,7 @@ ea_covers_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2, bool ever)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Ecovers_tgeo_tgeo()
  */
-inline int
+int
 ecovers_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_covers_tgeo_tgeo(temp1, temp2, EVER);
@@ -900,7 +900,7 @@ ecovers_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Acovers_tgeo_tgeo()
  */
-inline int
+int
 acovers_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_covers_tgeo_tgeo(temp1, temp2, ALWAYS);
@@ -976,7 +976,7 @@ ea_disjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
  * @brief Return 1 if a temporal geometry and a geometry are ever disjoint,
  * 0 if not, and -1 on error or if the geometry is empty
  */
-inline int
+int
 ea_disjoint_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
 {
   return ea_disjoint_tgeo_geo(temp, gs, ever);
@@ -991,7 +991,7 @@ ea_disjoint_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
  * @param[in] gs Geometry
  * @csqlfn #Edisjoint_tgeo_geo()
  */
-inline int
+int
 edisjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_disjoint_tgeo_geo(temp, gs, EVER);
@@ -1005,7 +1005,7 @@ edisjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] gs Geometry
  * @csqlfn #Adisjoint_tgeo_geo()
  */
-inline int
+int
 adisjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_disjoint_tgeo_geo(temp, gs, ALWAYS);
@@ -1042,7 +1042,7 @@ ea_disjoint_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2, bool ever)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Edisjoint_tgeo_tgeo()
  */
-inline int
+int
 edisjoint_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_disjoint_tgeo_tgeo(temp1, temp2, EVER);
@@ -1055,7 +1055,7 @@ edisjoint_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Adisjoint_tgeo_tgeo()
  */
-inline int
+int
 adisjoint_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_disjoint_tgeo_tgeo(temp1, temp2, ALWAYS);
@@ -1104,7 +1104,7 @@ ea_intersects_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
  * @brief Return 1 if a geometry intersects a temporal geometry, 0 if not,
  * and -1 on error or if the geometry is empty
  */
-inline int
+int
 ea_intersects_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
 {
   return ea_intersects_tgeo_geo(temp, gs, ever);
@@ -1119,7 +1119,7 @@ ea_intersects_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
  * @param[in] gs Geometry
  * @csqlfn #Aintersects_tgeo_geo()
  */
-inline int
+int
 eintersects_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_intersects_tgeo_geo(temp, gs, EVER);
@@ -1133,7 +1133,7 @@ eintersects_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] gs Geometry
  * @csqlfn #Aintersects_tgeo_geo()
  */
-inline int
+int
 aintersects_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_intersects_tgeo_geo(temp, gs, ALWAYS);
@@ -1171,7 +1171,7 @@ ea_intersects_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2,
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Eintersects_tgeo_tgeo()
  */
-inline int
+int
 eintersects_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_intersects_tgeo_tgeo(temp1, temp2, EVER);
@@ -1184,7 +1184,7 @@ eintersects_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Aintersects_tgeo_tgeo()
  */
-inline int
+int
 aintersects_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_intersects_tgeo_tgeo(temp1, temp2, ALWAYS);
@@ -1718,7 +1718,7 @@ ea_dwithin_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2, double dist,
  * @param[in] dist Distance
  * @csqlfn #Edwithin_tgeo_tgeo()
  */
-inline int
+int
 edwithin_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2, double dist)
 {
   return ea_dwithin_tgeo_tgeo(temp1, temp2, dist, EVER);
@@ -1732,7 +1732,7 @@ edwithin_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2, double dist)
  * @param[in] dist Distance
  * @csqlfn #Adwithin_tgeo_tgeo()
  */
-inline int
+int
 adwithin_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2, double dist)
 {
   return ea_dwithin_tgeo_tgeo(temp1, temp2, dist, ALWAYS);

--- a/meos/src/geo/tgeo_tile.c
+++ b/meos/src/geo/tgeo_tile.c
@@ -770,7 +770,7 @@ stbox_space_time_tiles(const STBox *bounds, double xsize, double ysize,
  * @param[out] count Number of values in the output array
  * @csqlfn #Stbox_space_tiles()
  */
-inline STBox *
+STBox *
 stbox_space_tiles(const STBox *bounds, double xsize, double ysize, double zsize,
   const GSERIALIZED *sorigin,  bool border_inc, int *count)
 {
@@ -789,7 +789,7 @@ stbox_space_tiles(const STBox *bounds, double xsize, double ysize, double zsize,
  * @param[out] count Number of values in the output array
  * @csqlfn #Stbox_time_tiles()
  */
-inline STBox *
+STBox *
 stbox_time_tiles(const STBox *bounds, const Interval *duration,
   TimestampTz torigin, bool border_inc, int *count)
 {
@@ -890,7 +890,7 @@ stbox_space_time_tile(const GSERIALIZED *point, TimestampTz t,
  * @param[in] torigin Origin for the time dimension
  * @csqlfn Stbox_get_space_time_tile()
  */
-inline STBox *
+STBox *
 stbox_get_space_time_tile(const GSERIALIZED *point, TimestampTz t,
   double xsize, double ysize, double zsize, const Interval *duration,
   const GSERIALIZED *sorigin, TimestampTz torigin)
@@ -907,7 +907,7 @@ stbox_get_space_time_tile(const GSERIALIZED *point, TimestampTz t,
  * @param[in] sorigin Origin for the space dimension
  * @csqlfn Stbox_get_space_tile()
  */
-inline STBox *
+STBox *
 stbox_get_space_tile(const GSERIALIZED *point, double xsize, double ysize,
   double zsize, const GSERIALIZED *sorigin)
 {
@@ -923,7 +923,7 @@ stbox_get_space_tile(const GSERIALIZED *point, double xsize, double ysize,
  * @param[in] torigin Origin for the time dimension
  * @csqlfn Stbox_get_time_tile()
  */
-inline STBox *
+STBox *
 stbox_get_time_tile(TimestampTz t, const Interval *duration,
   TimestampTz torigin)
 {
@@ -1034,7 +1034,7 @@ tgeo_space_time_boxes(const Temporal *temp, double xsize, double ysize,
  * the upper border is assumed as outside of the box.
  * @param[out] count Number of elements in the output array
  */
-inline STBox *
+STBox *
 tgeo_space_boxes(const Temporal *temp, double xsize, double ysize,
   double zsize, const GSERIALIZED *sorigin, bool bitmatrix, bool border_inc,
   int *count)
@@ -1458,7 +1458,7 @@ tgeo_space_time_split(const Temporal *temp, double xsize, double ysize,
  * @param[out] space_bins Array of space bins
  * @param[out] count Number of elements in the output arrays
  */
-inline Temporal **
+Temporal **
 tgeo_space_split(const Temporal *temp, double xsize, double ysize,
   double zsize, const GSERIALIZED *sorigin, bool bitmatrix, bool border_inc,
   GSERIALIZED ***space_bins, int *count)

--- a/meos/src/geo/tpoint_spatialfuncs.c
+++ b/meos/src/geo/tpoint_spatialfuncs.c
@@ -3220,12 +3220,13 @@ bearing_tpoint_tpoint(const Temporal *temp1, const Temporal *temp2)
 static double
 geog_distance_geos(const GEOSGeometry *pt1, const GEOSGeometry *pt2)
 {
+  GEOSContextHandle_t ctx = geos_get_context();
   /* Skip PostGIS function calls */
   double x1, y1, x2, y2;
-  GEOSGeomGetX(pt1, &x1);
-  GEOSGeomGetY(pt1, &y1);
-  GEOSGeomGetX(pt2, &x2);
-  GEOSGeomGetY(pt2, &y2);
+  GEOSGeomGetX_r(ctx, pt1, &x1);
+  GEOSGeomGetY_r(ctx, pt1, &y1);
+  GEOSGeomGetX_r(ctx, pt2, &x2);
+  GEOSGeomGetY_r(ctx, pt2, &y2);
 
   /* Code taken from ptarray_distance_spheroid function in lwgeodetic.c */
 
@@ -3257,22 +3258,23 @@ geog_distance_geos(const GEOSGeometry *pt1, const GEOSGeometry *pt2)
 static double
 mrr_distance_geos(GEOSGeometry *geom, bool geodetic)
 {
+  GEOSContextHandle_t ctx = geos_get_context();
   double result = 0.0;
-  int numGeoms = GEOSGetNumGeometries(geom);
+  int numGeoms = GEOSGetNumGeometries_r(ctx, geom);
   if (numGeoms == 2)
   {
-    const GEOSGeometry *pt1 = GEOSGetGeometryN(geom, 0);
-    const GEOSGeometry *pt2 = GEOSGetGeometryN(geom, 1);
+    const GEOSGeometry *pt1 = GEOSGetGeometryN_r(ctx, geom, 0);
+    const GEOSGeometry *pt2 = GEOSGetGeometryN_r(ctx, geom, 1);
     if (geodetic)
       result = geog_distance_geos(pt1, pt2);
     else
-      GEOSDistance(pt1, pt2, &result);
+      GEOSDistance_r(ctx, pt1, pt2, &result);
   }
   else if (numGeoms > 2)
   {
-    GEOSGeometry *mrr_geom = GEOSMinimumRotatedRectangle(geom);
+    GEOSGeometry *mrr_geom = GEOSMinimumRotatedRectangle_r(ctx, geom);
     GEOSGeometry *pt1, *pt2;
-    switch (GEOSGeomTypeId(mrr_geom))
+    switch (GEOSGeomTypeId_r(ctx, mrr_geom))
     {
       case GEOS_POINT:
         result = 0;
@@ -3280,24 +3282,24 @@ mrr_distance_geos(GEOSGeometry *geom, bool geodetic)
       case GEOS_LINESTRING: /* compute length of linestring */
         if (geodetic)
         {
-          pt1 = GEOSGeomGetStartPoint(mrr_geom);
-          pt2 = GEOSGeomGetEndPoint(mrr_geom);
+          pt1 = GEOSGeomGetStartPoint_r(ctx, mrr_geom);
+          pt2 = GEOSGeomGetEndPoint_r(ctx, mrr_geom);
           result = geog_distance_geos(pt1, pt2);
-          GEOSGeom_destroy(pt1);
-          GEOSGeom_destroy(pt2);
+          GEOSGeom_destroy_r(ctx, pt1);
+          GEOSGeom_destroy_r(ctx, pt2);
         }
         else
-          GEOSGeomGetLength(mrr_geom, &result);
+          GEOSGeomGetLength_r(ctx, mrr_geom, &result);
         break;
       case GEOS_POLYGON: /* compute length of diagonal */
-        pt1 = GEOSGeomGetPointN(GEOSGetExteriorRing(mrr_geom), 0);
-        pt2 = GEOSGeomGetPointN(GEOSGetExteriorRing(mrr_geom), 2);
+        pt1 = GEOSGeomGetPointN_r(ctx, GEOSGetExteriorRing_r(ctx, mrr_geom), 0);
+        pt2 = GEOSGeomGetPointN_r(ctx, GEOSGetExteriorRing_r(ctx, mrr_geom), 2);
         if (geodetic)
           result = geog_distance_geos(pt1, pt2);
         else
-          GEOSDistance(pt1, pt2, &result);
-        GEOSGeom_destroy(pt1);
-        GEOSGeom_destroy(pt2);
+          GEOSDistance_r(ctx, pt1, pt2, &result);
+        GEOSGeom_destroy_r(ctx, pt1);
+        GEOSGeom_destroy_r(ctx, pt2);
         break;
       default:
         meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
@@ -3315,6 +3317,7 @@ mrr_distance_geos(GEOSGeometry *geom, bool geodetic)
 static GEOSGeometry *
 multipoint_make(const TSequence *seq, int start, int end)
 {
+  GEOSContextHandle_t ctx = geos_get_context();
   GSERIALIZED *gs = NULL; /* make compiler quiet */
   GEOSGeometry **geoms = palloc(sizeof(GEOSGeometry *) * (end - start + 1));
   for (int i = 0; i < end - start + 1; ++i)
@@ -3339,9 +3342,9 @@ multipoint_make(const TSequence *seq, int start, int end)
       return NULL;
     }
     const POINT2D *pt = GSERIALIZED_POINT2D_P(gs);
-    geoms[i] = GEOSGeom_createPointFromXY(pt->x, pt->y);
+    geoms[i] = GEOSGeom_createPointFromXY_r(ctx, pt->x, pt->y);
   }
-  GEOSGeometry *result = GEOSGeom_createCollection(GEOS_MULTIPOINT, geoms, end - start + 1);
+  GEOSGeometry *result = GEOSGeom_createCollection_r(ctx, GEOS_MULTIPOINT, geoms, end - start + 1);
   pfree(geoms);
   return result;
 }
@@ -3353,6 +3356,7 @@ multipoint_make(const TSequence *seq, int start, int end)
 static GEOSGeometry *
 multipoint_add_inst_free(GEOSGeometry *geom, const TInstant *inst)
 {
+  GEOSContextHandle_t ctx = geos_get_context();
   GSERIALIZED *gs = NULL; /* make compiler quiet */
   if (tpoint_type(inst->temptype))
     gs = DatumGetGserializedP(tinstant_value_p(inst));
@@ -3372,9 +3376,9 @@ multipoint_add_inst_free(GEOSGeometry *geom, const TInstant *inst)
     return NULL;
   }
   const POINT2D *pt = GSERIALIZED_POINT2D_P(gs);
-  GEOSGeometry *geom1 = GEOSGeom_createPointFromXY(pt->x, pt->y);
-  GEOSGeometry *result = GEOSUnion(geom, geom1);
-  GEOSGeom_destroy(geom1); GEOSGeom_destroy(geom);
+  GEOSGeometry *geom1 = GEOSGeom_createPointFromXY_r(ctx, pt->x, pt->y);
+  GEOSGeometry *result = GEOSUnion_r(ctx, geom, geom1);
+  GEOSGeom_destroy_r(ctx, geom1); GEOSGeom_destroy_r(ctx, geom);
   if (inst->temptype == T_TNPOINT)
     pfree(gs);
   return result;
@@ -3405,8 +3409,8 @@ tpointseq_stops_iter(const TSequence *seq, double maxdist, int64 mintunits,
   /* Use GEOS only for non-scalar input */
   bool geodetic = MEOS_FLAGS_GET_GEODETIC(seq->flags);
   GEOSGeometry *geom = NULL;
-  initGEOS(lwnotice, lwgeom_geos_error);
-  geom = GEOSGeom_createEmptyCollection(GEOS_MULTIPOINT);
+  GEOSContextHandle_t ctx = geos_get_context();
+  geom = GEOSGeom_createEmptyCollection_r(ctx, GEOS_MULTIPOINT);
 
   const TInstant *inst1 = NULL, *inst2 = NULL; /* make compiler quiet */
   int end, start = 0, nseqs = 0;
@@ -3426,7 +3430,7 @@ tpointseq_stops_iter(const TSequence *seq, double maxdist, int64 mintunits,
 
     if (rebuild_geom)
     {
-      GEOSGeom_destroy(geom);
+      GEOSGeom_destroy_r(ctx, geom);
       geom = multipoint_make(seq, start, end);
       rebuild_geom = false;
     }
@@ -3451,7 +3455,7 @@ tpointseq_stops_iter(const TSequence *seq, double maxdist, int64 mintunits,
     }
     previously_stopped = is_stopped;
   }
-  GEOSGeom_destroy(geom);
+  GEOSGeom_destroy_r(ctx, geom);
 
   inst2 = TSEQUENCE_INST_N(seq, end - 1);
   if (is_stopped && (int64)(inst2->t - inst1->t) >= mintunits)
@@ -3462,7 +3466,6 @@ tpointseq_stops_iter(const TSequence *seq, double maxdist, int64 mintunits,
     result[nseqs++] = tsequence_make(instants, end - start, true, true, LINEAR,
       NORMALIZE_NO);
   }
-  finishGEOS();
   return nseqs;
 }
 

--- a/meos/src/geo/tspatial.c
+++ b/meos/src/geo/tspatial.c
@@ -180,7 +180,7 @@ spatialset_out_fn(const Set *s, int maxdd, outfunc wkt_out, bool extended)
  * @brief Return the Well-Known Text (WKT) representation of a spatial set
  * @csqlfn #Spatialset_as_text()
  */
-inline char *
+char *
 spatialset_as_text(const Set *s, int maxdd)
 {
   return spatialset_out_fn(s, maxdd, &spatialbase_as_text, false);
@@ -193,7 +193,7 @@ spatialset_as_text(const Set *s, int maxdd)
  * @param[in] maxdd Maximum number of decimal digits
  * @csqlfn #Spatialset_as_ewkt()
  */
-inline char *
+char *
 spatialset_as_ewkt(const Set *s, int maxdd)
 {
   /* The SRID will be output as prefix, the elements will output the SRID*/
@@ -353,7 +353,7 @@ spatialarr_wkt_out(const Datum *spatialarr, MeosType elemtype, int count,
  * @param[in] count Number of elements in the input array
  * @param[in] maxdd Maximum number of decimal digits to output
  */
-inline char **
+char **
 spatialarr_as_text(const Datum *spatialarr, MeosType elemtype, int count, 
   int maxdd)
 {
@@ -369,7 +369,7 @@ spatialarr_as_text(const Datum *spatialarr, MeosType elemtype, int count,
  * @param[in] count Number of elements in the input array
  * @param[in] maxdd Maximum number of decimal digits to output
  */
-inline char **
+char **
 spatialarr_as_ewkt(const Datum *spatialarr, MeosType elemtype, int count, 
   int maxdd)
 {

--- a/meos/src/geo/tspatial_posops_meos.c
+++ b/meos/src/geo/tspatial_posops_meos.c
@@ -60,7 +60,7 @@
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Left_stbox_tspatial()
  */
-inline bool
+bool
 left_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &left_stbox_stbox, INVERT);
@@ -74,7 +74,7 @@ left_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Overleft_stbox_tspatial()
  */
-inline bool
+bool
 overleft_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &overleft_stbox_stbox, INVERT);
@@ -88,7 +88,7 @@ overleft_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Right_stbox_tspatial()
  */
-inline bool
+bool
 right_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &right_stbox_stbox, INVERT);
@@ -102,7 +102,7 @@ right_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Overright_stbox_tspatial()
  */
-inline bool
+bool
 overright_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &overright_stbox_stbox, INVERT);
@@ -115,7 +115,7 @@ overright_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Below_stbox_tspatial()
  */
-inline bool
+bool
 below_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &below_stbox_stbox, INVERT);
@@ -129,7 +129,7 @@ below_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Overbelow_stbox_tspatial()
  */
-inline bool
+bool
 overbelow_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &overbelow_stbox_stbox, INVERT);
@@ -142,7 +142,7 @@ overbelow_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Above_stbox_tspatial()
  */
-inline bool
+bool
 above_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &above_stbox_stbox, INVERT);
@@ -156,7 +156,7 @@ above_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Overabove_stbox_tspatial()
  */
-inline bool
+bool
 overabove_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &overabove_stbox_stbox, INVERT);
@@ -170,7 +170,7 @@ overabove_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Front_stbox_tspatial()
  */
-inline bool
+bool
 front_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &front_stbox_stbox, INVERT);
@@ -184,7 +184,7 @@ front_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Overfront_stbox_tspatial()
  */
-inline bool
+bool
 overfront_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &overfront_stbox_stbox, INVERT);
@@ -198,7 +198,7 @@ overfront_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Back_stbox_tspatial()
  */
-inline bool
+bool
 back_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &back_stbox_stbox, INVERT);
@@ -212,7 +212,7 @@ back_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Overback_stbox_tspatial()
  */
-inline bool
+bool
 overback_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &overback_stbox_stbox, INVERT);
@@ -226,7 +226,7 @@ overback_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Before_stbox_tspatial()
  */
-inline bool
+bool
 before_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &before_stbox_stbox, INVERT);
@@ -240,7 +240,7 @@ before_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Overbefore_stbox_tspatial()
  */
-inline bool
+bool
 overbefore_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &overbefore_stbox_stbox, INVERT);
@@ -253,7 +253,7 @@ overbefore_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #After_stbox_tspatial()
  */
-inline bool
+bool
 after_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &after_stbox_stbox, INVERT);
@@ -267,7 +267,7 @@ after_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Overafter_stbox_tspatial()
  */
-inline bool
+bool
 overafter_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &overafter_stbox_stbox, INVERT);
@@ -285,7 +285,7 @@ overafter_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] box Spatiotemporal box
 box * @csqlfn #Left_tspatial_stbox()
  */
-inline bool
+bool
 left_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &left_stbox_stbox, INVERT_NO);
@@ -299,7 +299,7 @@ left_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Overleft_tspatial_stbox()
  */
-inline bool
+bool
 overleft_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &overleft_stbox_stbox, INVERT_NO);
@@ -313,7 +313,7 @@ overleft_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Right_tspatial_stbox()
  */
-inline bool
+bool
 right_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &right_stbox_stbox, INVERT_NO);
@@ -327,7 +327,7 @@ right_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Overright_tspatial_stbox()
  */
-inline bool
+bool
 overright_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &overright_stbox_stbox, INVERT_NO);
@@ -340,7 +340,7 @@ overright_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Below_tspatial_stbox()
  */
-inline bool
+bool
 below_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &below_stbox_stbox, INVERT_NO);
@@ -354,7 +354,7 @@ below_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Overbelow_tspatial_stbox()
  */
-inline bool
+bool
 overbelow_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &overbelow_stbox_stbox, INVERT_NO);
@@ -367,7 +367,7 @@ overbelow_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Above_tspatial_stbox()
  */
-inline bool
+bool
 above_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &above_stbox_stbox, INVERT_NO);
@@ -381,7 +381,7 @@ above_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Overabove_tspatial_stbox()
  */
-inline bool
+bool
 overabove_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &overabove_stbox_stbox, INVERT_NO);
@@ -395,7 +395,7 @@ overabove_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Front_tspatial_stbox()
  */
-inline bool
+bool
 front_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &front_stbox_stbox, INVERT_NO);
@@ -409,7 +409,7 @@ front_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Overfront_tspatial_stbox()
  */
-inline bool
+bool
 overfront_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &overfront_stbox_stbox, INVERT_NO);
@@ -423,7 +423,7 @@ overfront_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Back_tspatial_stbox()
  */
-inline bool
+bool
 back_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &back_stbox_stbox, INVERT_NO);
@@ -437,7 +437,7 @@ back_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Overback_tspatial_stbox()
  */
-inline bool
+bool
 overback_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &overback_stbox_stbox, INVERT_NO);
@@ -451,7 +451,7 @@ overback_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Before_tspatial_stbox()
  */
-inline bool
+bool
 before_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &before_stbox_stbox, INVERT_NO);
@@ -465,7 +465,7 @@ before_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Overbefore_tspatial_stbox()
  */
-inline bool
+bool
 overbefore_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &overbefore_stbox_stbox, INVERT_NO);
@@ -478,7 +478,7 @@ overbefore_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #After_tspatial_stbox()
  */
-inline bool
+bool
 after_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &after_stbox_stbox, INVERT_NO);
@@ -492,7 +492,7 @@ after_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Overafter_tspatial_stbox()
  */
-inline bool
+bool
 overafter_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &overafter_stbox_stbox, INVERT_NO);
@@ -508,7 +508,7 @@ overafter_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Left_tspatial_tspatial()
  */
-inline bool
+bool
 left_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &left_stbox_stbox);
@@ -521,7 +521,7 @@ left_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Overleft_tspatial_tspatial()
  */
-inline bool
+bool
 overleft_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &overleft_stbox_stbox);
@@ -534,7 +534,7 @@ overleft_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Right_tspatial_tspatial()
  */
-inline bool
+bool
 right_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &right_stbox_stbox);
@@ -547,7 +547,7 @@ right_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Overright_tspatial_tspatial()
  */
-inline bool
+bool
 overright_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &overright_stbox_stbox);
@@ -560,7 +560,7 @@ overright_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Below_tspatial_tspatial()
  */
-inline bool
+bool
 below_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &below_stbox_stbox);
@@ -573,7 +573,7 @@ below_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Overbelow_tspatial_tspatial()
  */
-inline bool
+bool
 overbelow_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &overbelow_stbox_stbox);
@@ -586,7 +586,7 @@ overbelow_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Above_tspatial_tspatial()
  */
-inline bool
+bool
 above_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &above_stbox_stbox);
@@ -600,7 +600,7 @@ above_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Overabove_tspatial_tspatial()
  */
-inline bool
+bool
 overabove_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &overabove_stbox_stbox);
@@ -613,7 +613,7 @@ overabove_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Front_tspatial_tspatial()
  */
-inline bool
+bool
 front_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &front_stbox_stbox);
@@ -626,7 +626,7 @@ front_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Overfront_tspatial_tspatial()
  */
-inline bool
+bool
 overfront_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &overfront_stbox_stbox);
@@ -639,7 +639,7 @@ overfront_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Back_tspatial_tspatial()
  */
-inline bool
+bool
 back_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &back_stbox_stbox);
@@ -652,7 +652,7 @@ back_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Overback_tspatial_tspatial()
  */
-inline bool
+bool
 overback_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &overback_stbox_stbox);
@@ -665,7 +665,7 @@ overback_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Before_tspatial_tspatial()
  */
-inline bool
+bool
 before_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &before_stbox_stbox);
@@ -678,7 +678,7 @@ before_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Overbefore_tspatial_tspatial()
  */
-inline bool
+bool
 overbefore_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &overbefore_stbox_stbox);
@@ -691,7 +691,7 @@ overbefore_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #After_tspatial_tspatial()
  */
-inline bool
+bool
 after_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &after_stbox_stbox);
@@ -704,7 +704,7 @@ after_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Overafter_tspatial_tspatial()
  */
-inline bool
+bool
 overafter_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &overafter_stbox_stbox);

--- a/meos/src/geo/tspatial_tempspatialrels.c
+++ b/meos/src/geo/tspatial_tempspatialrels.c
@@ -811,7 +811,7 @@ tdisjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Tdisjoint_tgeo_tgeo()
  */
-inline Temporal *
+Temporal *
 tdisjoint_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return tinterrel_tspatial_tspatial(temp1, temp2, TDISJOINT);
@@ -856,7 +856,7 @@ tintersects_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Tintersects_tgeo_tgeo()
  */
-inline Temporal *
+Temporal *
 tintersects_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return tinterrel_tspatial_tspatial(temp1, temp2, TINTERSECTS);

--- a/meos/src/geo/tspatial_topops_meos.c
+++ b/meos/src/geo/tspatial_topops_meos.c
@@ -61,7 +61,7 @@
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Overlaps_stbox_tspatial()
  */
-inline bool
+bool
 overlaps_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &overlaps_stbox_stbox, INVERT);
@@ -75,7 +75,7 @@ overlaps_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Overlaps_tspatial_stbox()
  */
-inline bool
+bool
 overlaps_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &overlaps_stbox_stbox, INVERT_NO);
@@ -88,7 +88,7 @@ overlaps_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Overlaps_tspatial_tspatial()
  */
-inline bool
+bool
 overlaps_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &overlaps_stbox_stbox);
@@ -106,7 +106,7 @@ overlaps_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Contains_stbox_tspatial()
  */
-inline bool
+bool
 contains_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &contains_stbox_stbox, INVERT);
@@ -120,7 +120,7 @@ contains_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Contains_tspatial_stbox()
  */
-inline bool
+bool
 contains_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &contains_stbox_stbox, INVERT_NO);
@@ -133,7 +133,7 @@ contains_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Contains_tspatial_tspatial()
  */
-inline bool
+bool
 contains_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &contains_stbox_stbox);
@@ -151,7 +151,7 @@ contains_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Contained_stbox_tspatial()
  */
-inline bool
+bool
 contained_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &contained_stbox_stbox, INVERT);
@@ -165,7 +165,7 @@ contained_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Contained_tspatial_stbox()
  */
-inline bool
+bool
 contained_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &contained_stbox_stbox, INVERT_NO);
@@ -178,7 +178,7 @@ contained_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Contained_tspatial_tspatial()
  */
-inline bool
+bool
 contained_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &contained_stbox_stbox);
@@ -196,7 +196,7 @@ contained_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Same_stbox_tspatial()
  */
-inline bool
+bool
 same_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &same_stbox_stbox, INVERT);
@@ -210,7 +210,7 @@ same_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Same_tspatial_stbox()
  */
-inline bool
+bool
 same_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &same_stbox_stbox, INVERT_NO);
@@ -223,7 +223,7 @@ same_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Same_tspatial_tspatial()
  */
-inline bool
+bool
 same_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &same_stbox_stbox);
@@ -241,7 +241,7 @@ same_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Adjacent_stbox_tspatial()
  */
-inline bool
+bool
 adjacent_stbox_tspatial(const STBox *box, const Temporal *temp)
 {
   return boxop_tspatial_stbox(temp, box, &adjacent_stbox_stbox, INVERT);
@@ -255,7 +255,7 @@ adjacent_stbox_tspatial(const STBox *box, const Temporal *temp)
  * @param[in] box Spatiotemporal box
  * @csqlfn #Adjacent_tspatial_stbox()
  */
-inline bool
+bool
 adjacent_tspatial_stbox(const Temporal *temp, const STBox *box)
 {
   return boxop_tspatial_stbox(temp, box, &adjacent_stbox_stbox, INVERT_NO);
@@ -268,7 +268,7 @@ adjacent_tspatial_stbox(const Temporal *temp, const STBox *box)
  * @param[in] temp1,temp2 Spatiotemporal values
  * @csqlfn #Adjacent_tspatial_tspatial()
  */
-inline bool
+bool
 adjacent_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 {
   return boxop_tspatial_tspatial(temp1, temp2, &adjacent_stbox_stbox);

--- a/meos/src/npoint/npoint.c
+++ b/meos/src/npoint/npoint.c
@@ -1143,7 +1143,7 @@ nsegment_end_position(const Nsegment *ns)
  * is the one from the @p ways table, for performance reasons we simply get
  * the SRID of the table
  */
-inline int32_t
+int32_t
 npoint_srid(const Npoint *np UNUSED)
 {
   return get_srid_ways();
@@ -1158,7 +1158,7 @@ npoint_srid(const Npoint *np UNUSED)
  * is the one from the @p ways table, for performance reasons we simply get
  * the SRID of the table
  */
-inline int32_t
+int32_t
 nsegment_srid(const Nsegment *ns UNUSED)
 {
   return get_srid_ways();
@@ -1188,7 +1188,7 @@ npoint_eq(const Npoint *np1, const Npoint *np2)
  * @param[in] np1,np2 Network points
  * @csqlfn #Npoint_ne()
  */
-inline bool
+bool
 npoint_ne(const Npoint *np1, const Npoint *np2)
 {
   return ! npoint_eq(np1, np2);
@@ -1225,7 +1225,7 @@ npoint_cmp(const Npoint *np1, const Npoint *np2)
  * @param[in] np1,np2 Network points
  * @csqlfn #Npoint_lt()
  */
-inline bool
+bool
 npoint_lt(const Npoint *np1, const Npoint *np2)
 {
   return npoint_cmp(np1, np2) < 0;
@@ -1238,7 +1238,7 @@ npoint_lt(const Npoint *np1, const Npoint *np2)
  * @param[in] np1,np2 Network points
  * @csqlfn #Npoint_le()
  */
-inline bool
+bool
 npoint_le(const Npoint *np1, const Npoint *np2)
 {
   return npoint_cmp(np1, np2) <= 0;
@@ -1250,7 +1250,7 @@ npoint_le(const Npoint *np1, const Npoint *np2)
  * @param[in] np1,np2 Network points
  * @csqlfn #Npoint_gt()
  */
-inline bool
+bool
 npoint_gt(const Npoint *np1, const Npoint *np2)
 {
   return npoint_cmp(np1, np2) > 0;
@@ -1263,7 +1263,7 @@ npoint_gt(const Npoint *np1, const Npoint *np2)
  * @param[in] np1,np2 Network points
  * @csqlfn #Npoint_ge()
  */
-inline bool
+bool
 npoint_ge(const Npoint *np1, const Npoint *np2)
 {
   return npoint_cmp(np1, np2) >= 0;
@@ -1293,7 +1293,7 @@ nsegment_eq(const Nsegment *ns1, const Nsegment *ns2)
  * @param[in] ns1,ns2 Network segments
  * @csqlfn #Nsegment_ne()
  */
-inline bool
+bool
 nsegment_ne(const Nsegment *ns1, const Nsegment *ns2)
 {
   return ! nsegment_eq(ns1, ns2);
@@ -1335,7 +1335,7 @@ nsegment_cmp(const Nsegment *ns1, const Nsegment *ns2)
  * @param[in] ns1,ns2 Network segments
  * @csqlfn #Nsegment_lt()
  */
-inline bool
+bool
 nsegment_lt(const Nsegment *ns1, const Nsegment *ns2)
 {
   return nsegment_cmp(ns1, ns2) < 0;
@@ -1348,7 +1348,7 @@ nsegment_lt(const Nsegment *ns1, const Nsegment *ns2)
  * @param[in] ns1,ns2 Network segments
  * @csqlfn #Nsegment_le()
  */
-inline bool
+bool
 nsegment_le(const Nsegment *ns1, const Nsegment *ns2)
 {
   return nsegment_cmp(ns1, ns2) <= 0;
@@ -1361,7 +1361,7 @@ nsegment_le(const Nsegment *ns1, const Nsegment *ns2)
  * @param[in] ns1,ns2 Network segments
  * @csqlfn #Nsegment_gt()
  */
-inline bool
+bool
 nsegment_gt(const Nsegment *ns1, const Nsegment *ns2)
 {
   return nsegment_cmp(ns1, ns2) > 0;
@@ -1374,7 +1374,7 @@ nsegment_gt(const Nsegment *ns1, const Nsegment *ns2)
  * @param[in] ns1,ns2 Network segments
  * @csqlfn #Nsegment_ge()
  */
-inline bool
+bool
 nsegment_ge(const Nsegment *ns1, const Nsegment *ns2)
 {
   return nsegment_cmp(ns1, ns2) >= 0;

--- a/meos/src/npoint/tnpoint.c
+++ b/meos/src/npoint/tnpoint.c
@@ -810,7 +810,7 @@ tnpoint_restrict_npoint(const Temporal *temp, const Npoint *np, bool atfunc)
  * @param[in] np Network point
  * @csqlfn #Tnpoint_at_npoint()
  */
-inline Temporal *
+Temporal *
 tnpoint_at_npoint(const Temporal *temp, const Npoint *np)
 {
   return tnpoint_restrict_npoint(temp, np, REST_AT);
@@ -823,7 +823,7 @@ tnpoint_at_npoint(const Temporal *temp, const Npoint *np)
  * @param[in] np Network point
  * @csqlfn #Tnpoint_minus_npoint()
  */
-inline Temporal *
+Temporal *
 tnpoint_minus_npoint(const Temporal *temp, const Npoint *np)
 {
   return tnpoint_restrict_npoint(temp, np, REST_MINUS);
@@ -860,7 +860,7 @@ tnpoint_restrict_npointset(const Temporal *temp, const Set *s, bool atfunc)
  * @param[in] s Set of network points
  * @csqlfn #Tnpoint_at_npointset()
  */
-inline Temporal *
+Temporal *
 tnpoint_at_npointset(const Temporal *temp, const Set *s)
 {
   return tnpoint_restrict_npointset(temp, s, REST_AT);
@@ -874,7 +874,7 @@ tnpoint_at_npointset(const Temporal *temp, const Set *s)
  * @param[in] s Set of network points
  * @csqlfn #Tnpoint_minus_npointset()
  */
-inline Temporal *
+Temporal *
 tnpoint_minus_npointset(const Temporal *temp, const Set *s)
 {
   return tnpoint_restrict_npointset(temp, s, REST_MINUS);

--- a/meos/src/npoint/tnpoint_compops.c
+++ b/meos/src/npoint/tnpoint_compops.c
@@ -92,7 +92,7 @@ eacomp_tnpoint_tnpoint(const Temporal *temp1, const Temporal *temp2,
  * @param[in] temp Temporal network point
  * @csqlfn #Ever_eq_npoint_tnpoint()
  */
-inline int
+int
 ever_eq_npoint_tnpoint(const Npoint *np, const Temporal *temp)
 {
   return eacomp_tnpoint_npoint(temp, np, &datum2_eq, EVER);
@@ -107,7 +107,7 @@ ever_eq_npoint_tnpoint(const Npoint *np, const Temporal *temp)
  * @param[in] np Network point
  * @csqlfn #Ever_eq_tnpoint_npoint()
  */
-inline int
+int
 ever_eq_tnpoint_npoint(const Temporal *temp, const Npoint *np)
 {
   return eacomp_tnpoint_npoint(temp, np, &datum2_eq, EVER);
@@ -122,7 +122,7 @@ ever_eq_tnpoint_npoint(const Temporal *temp, const Npoint *np)
  * @param[in] temp Temporal network point
  * @csqlfn #Ever_ne_npoint_tnpoint()
  */
-inline int
+int
 ever_ne_npoint_tnpoint(const Npoint *np, const Temporal *temp)
 {
   return eacomp_tnpoint_npoint(temp, np, &datum2_ne, EVER);
@@ -137,7 +137,7 @@ ever_ne_npoint_tnpoint(const Npoint *np, const Temporal *temp)
  * @param[in] np Network point
  * @csqlfn #Ever_ne_tnpoint_npoint()
  */
-inline int
+int
 ever_ne_tnpoint_npoint(const Temporal *temp, const Npoint *np)
 {
   return eacomp_tnpoint_npoint(temp, np, &datum2_ne, EVER);
@@ -152,7 +152,7 @@ ever_ne_tnpoint_npoint(const Temporal *temp, const Npoint *np)
  * @param[in] temp Temporal network point
  * @csqlfn #Always_eq_npoint_tnpoint()
  */
-inline int
+int
 always_eq_npoint_tnpoint(const Npoint *np, const Temporal *temp)
 {
   return eacomp_tnpoint_npoint(temp, np, &datum2_eq, ALWAYS);
@@ -167,7 +167,7 @@ always_eq_npoint_tnpoint(const Npoint *np, const Temporal *temp)
  * @param[in] np Network point
  * @csqlfn #Always_eq_tnpoint_npoint()
  */
-inline int
+int
 always_eq_tnpoint_npoint(const Temporal *temp, const Npoint *np)
 {
   return eacomp_tnpoint_npoint(temp, np, &datum2_eq, ALWAYS);
@@ -182,7 +182,7 @@ always_eq_tnpoint_npoint(const Temporal *temp, const Npoint *np)
  * @param[in] temp Temporal network point
  * @csqlfn #Always_ne_npoint_tnpoint()
  */
-inline int
+int
 always_ne_npoint_tnpoint(const Npoint *np, const Temporal *temp)
 {
   return eacomp_tnpoint_npoint(temp, np, &datum2_ne, ALWAYS);
@@ -197,7 +197,7 @@ always_ne_npoint_tnpoint(const Npoint *np, const Temporal *temp)
  * @param[in] np Network point
  * @csqlfn #Always_ne_tnpoint_npoint()
  */
-inline int
+int
 always_ne_tnpoint_npoint(const Temporal *temp, const Npoint *np)
 {
   return eacomp_tnpoint_npoint(temp, np, &datum2_ne, ALWAYS);
@@ -211,7 +211,7 @@ always_ne_tnpoint_npoint(const Temporal *temp, const Npoint *np)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Ever_eq_tnpoint_tnpoint()
  */
-inline int
+int
 ever_eq_tnpoint_tnpoint(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tnpoint_tnpoint(temp1, temp2, &datum2_eq, EVER);
@@ -223,7 +223,7 @@ ever_eq_tnpoint_tnpoint(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Ever_ne_tnpoint_tnpoint()
  */
-inline int
+int
 ever_ne_tnpoint_tnpoint(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tnpoint_tnpoint(temp1, temp2, &datum2_ne, EVER);
@@ -235,7 +235,7 @@ ever_ne_tnpoint_tnpoint(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Always_eq_tnpoint_tnpoint()
  */
-inline int
+int
 always_eq_tnpoint_tnpoint(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tnpoint_tnpoint(temp1, temp2, &datum2_eq, ALWAYS);
@@ -247,7 +247,7 @@ always_eq_tnpoint_tnpoint(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #Always_ne_tnpoint_tnpoint()
  */
-inline int
+int
 always_ne_tnpoint_tnpoint(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tnpoint_tnpoint(temp1, temp2, &datum2_ne, ALWAYS);
@@ -285,7 +285,7 @@ tcomp_tnpoint_npoint(const Temporal *temp, const Npoint *np,
  * @param[in] np Network point
  * @csqlfn #Teq_tnpoint_npoint()
  */
-inline Temporal *
+Temporal *
 teq_tnpoint_npoint(const Temporal *temp, const Npoint *np)
 {
   return tcomp_tnpoint_npoint(temp, np, &datum2_eq);
@@ -299,7 +299,7 @@ teq_tnpoint_npoint(const Temporal *temp, const Npoint *np)
  * @param[in] np Network point
  * @csqlfn #Tne_tnpoint_npoint()
  */
-inline Temporal *
+Temporal *
 tne_tnpoint_npoint(const Temporal *temp, const Npoint *np)
 {
   return tcomp_tnpoint_npoint(temp, np, &datum2_ne);

--- a/meos/src/npoint/tnpoint_routeops.c
+++ b/meos/src/npoint/tnpoint_routeops.c
@@ -73,7 +73,7 @@ contains_rid_tnpoint_bigint(const Temporal *temp, int64 rid,
  * @brief Return true if a temporal network point and a route satisfy the
  * function
  */
-inline bool
+bool
 contained_rid_tnpoint_bigint(const Temporal *temp, int64 rid,
   bool invert)
 {
@@ -136,7 +136,7 @@ contains_rid_tnpoint_bigintset(const Temporal *temp, const Set *s,
  * @brief Return true if a temporal network point and a big integer set
  * satisfy the function
  */
-inline bool
+bool
 contained_rid_tnpoint_bigintset(const Temporal *temp, const Set *s,
   bool invert)
 {
@@ -181,7 +181,7 @@ contains_rid_tnpoint_npoint(const Temporal *temp, const Npoint *np,
  * @brief Return true if a temporal network point and a network point
  * satisfy the function
  */
-inline bool
+bool
 contained_rid_npoint_tnpoint(const Temporal *temp, const Npoint *np,
   bool invert)
 {

--- a/meos/src/npoint/tnpoint_spatialfuncs.c
+++ b/meos/src/npoint/tnpoint_spatialfuncs.c
@@ -511,7 +511,7 @@ tnpoint_restrict_geom(const Temporal *temp, const GSERIALIZED *gs, bool atfunc)
  * @param[in] gs Geometry
  * @csqlfn #Tnpoint_at_geom()
  */
-inline Temporal *
+Temporal *
 tnpoint_at_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tnpoint_restrict_geom(temp, gs, REST_AT);
@@ -524,7 +524,7 @@ tnpoint_at_geom(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] gs Geometry
  * @csqlfn #Tnpoint_minus_geom()
  */
-inline Temporal *
+Temporal *
 tnpoint_minus_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tnpoint_restrict_geom(temp, gs, REST_MINUS);
@@ -569,7 +569,7 @@ tnpoint_restrict_stbox(const Temporal *temp, const STBox *box, bool border_inc,
  * @param[in] border_inc True when the box contains the upper border
  * @sqlfn #Tnpoint_at_stbox()
  */
-inline Temporal *
+Temporal *
 tnpoint_at_stbox(const Temporal *temp, const STBox *box, bool border_inc)
 {
   return tnpoint_restrict_stbox(temp, box, border_inc, REST_AT);
@@ -583,7 +583,7 @@ tnpoint_at_stbox(const Temporal *temp, const STBox *box, bool border_inc)
  * @param[in] border_inc True when the box contains the upper border
  * @sqlfn #Tnpoint_minus_stbox()
  */
-inline Temporal *
+Temporal *
 tnpoint_minus_stbox(const Temporal *temp, const STBox *box, bool border_inc)
 {
   return tnpoint_restrict_stbox(temp, box, border_inc, REST_MINUS);

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -590,7 +590,7 @@ pose_wkt_out(const Pose *pose, bool extended, int maxdd)
  * @param[in] maxdd Maximum number of decimal digits
  * @csqlfn #Pose_as_text()
  */
-inline char *
+char *
 pose_as_text(const Pose *pose, int maxdd)
 {
   return pose_wkt_out(pose, false, maxdd);
@@ -1317,7 +1317,7 @@ pose_eq(const Pose *pose1, const Pose *pose2)
  * @brief Return true if the first pose is not equal to the second one
  * @param[in] pose1,pose2 Poses
  */
-inline bool
+bool
 pose_ne(const Pose *pose1, const Pose *pose2)
 {
   return ! pose_eq(pose1, pose2);
@@ -1357,7 +1357,7 @@ pose_same(const Pose *pose1, const Pose *pose2)
  * @brief Return true if the first pose is not equal to the second one
  * @param[in] pose1,pose2 Poses
  */
-inline bool
+bool
 pose_nsame(const Pose *pose1, const Pose *pose2)
 {
   return ! pose_same(pose1, pose2);
@@ -1400,7 +1400,7 @@ pose_cmp(const Pose *pose1, const Pose *pose2)
  * @brief Return true if the first pose is less than the second one
  * @param[in] pose1,pose2 Poses
  */
-inline bool
+bool
 pose_lt(const Pose *pose1, const Pose *pose2)
 {
   return pose_cmp(pose1, pose2) < 0;
@@ -1411,7 +1411,7 @@ pose_lt(const Pose *pose1, const Pose *pose2)
  * @brief Return true if the first pose is less than or equal to the second one
  * @param[in] pose1,pose2 Poses
  */
-inline bool
+bool
 pose_le(const Pose *pose1, const Pose *pose2)
 {
   return pose_cmp(pose1, pose2) <= 0;
@@ -1422,7 +1422,7 @@ pose_le(const Pose *pose1, const Pose *pose2)
  * @brief Return true if the first pose is greater than the second one
  * @param[in] pose1,pose2 Poses
  */
-inline bool
+bool
 pose_gt(const Pose *pose1, const Pose *pose2)
 {
   return pose_cmp(pose1, pose2) > 0;
@@ -1434,7 +1434,7 @@ pose_gt(const Pose *pose1, const Pose *pose2)
  * one
  * @param[in] pose1,pose2 Poses
  */
-inline bool
+bool
 pose_ge(const Pose *pose1, const Pose *pose2)
 {
   return pose_cmp(pose1, pose2) >= 0;

--- a/meos/src/pose/tpose_compops.c
+++ b/meos/src/pose/tpose_compops.c
@@ -97,7 +97,7 @@ eacomp_tpose_tpose(const Temporal *temp1, const Temporal *temp2,
  * @param[in] temp Temporal value
  * @csqlfn #Ever_eq_pose_tpose()
  */
-inline int
+int
 ever_eq_pose_tpose(const Pose *pose, const Temporal *temp)
 {
   return eacomp_tpose_pose(temp, pose, &datum2_eq, EVER);
@@ -111,7 +111,7 @@ ever_eq_pose_tpose(const Pose *pose, const Temporal *temp)
  * @param[in] pose Pose
  * @csqlfn #Ever_eq_tpose_pose()
  */
-inline int
+int
 ever_eq_tpose_pose(const Temporal *temp, const Pose *pose)
 {
   return eacomp_tpose_pose(temp, pose, &datum2_eq, EVER);
@@ -124,7 +124,7 @@ ever_eq_tpose_pose(const Temporal *temp, const Pose *pose)
  * @param[in] temp Temporal value
  * @csqlfn #Ever_ne_pose_tpose()
  */
-inline int
+int
 ever_ne_pose_tpose(const Pose *pose, const Temporal *temp)
 {
   return eacomp_tpose_pose(temp, pose, &datum2_ne, EVER);
@@ -138,7 +138,7 @@ ever_ne_pose_tpose(const Pose *pose, const Temporal *temp)
  * @param[in] pose Pose
  * @csqlfn #Ever_ne_tpose_pose()
  */
-inline int
+int
 ever_ne_tpose_pose(const Temporal *temp, const Pose *pose)
 {
   return eacomp_tpose_pose(temp, pose, &datum2_ne, EVER);
@@ -151,7 +151,7 @@ ever_ne_tpose_pose(const Temporal *temp, const Pose *pose)
  * @param[in] temp Temporal value
  * @csqlfn #Always_eq_pose_tpose()
  */
-inline int
+int
 always_eq_pose_tpose(const Pose *pose, const Temporal *temp)
 {
   return eacomp_tpose_pose(temp, pose, &datum2_eq, ALWAYS);
@@ -165,7 +165,7 @@ always_eq_pose_tpose(const Pose *pose, const Temporal *temp)
  * @param[in] pose Pose
  * @csqlfn #Always_eq_tpose_pose()
  */
-inline int
+int
 always_eq_tpose_pose(const Temporal *temp, const Pose *pose)
 {
   return eacomp_tpose_pose(temp, pose, &datum2_eq, ALWAYS);
@@ -178,7 +178,7 @@ always_eq_tpose_pose(const Temporal *temp, const Pose *pose)
  * @param[in] temp Temporal value
  * @csqlfn #Always_ne_pose_tpose()
  */
-inline int
+int
 always_ne_pose_tpose(const Pose *pose, const Temporal *temp)
 {
   return eacomp_tpose_pose(temp, pose, &datum2_ne, ALWAYS);
@@ -192,7 +192,7 @@ always_ne_pose_tpose(const Pose *pose, const Temporal *temp)
  * @param[in] pose Pose
  * @csqlfn #Always_ne_tpose_pose()
  */
-inline int
+int
 always_ne_tpose_pose(const Temporal *temp, const Pose *pose)
 {
   return eacomp_tpose_pose(temp, pose, &datum2_ne, ALWAYS);
@@ -206,7 +206,7 @@ always_ne_tpose_pose(const Temporal *temp, const Pose *pose)
  * @param[in] temp1,temp2 Temporal poses
  * @csqlfn #Ever_eq_tpose_tpose()
  */
-inline int
+int
 ever_eq_tpose_tpose(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tpose_tpose(temp1, temp2, &datum2_eq, EVER);
@@ -218,7 +218,7 @@ ever_eq_tpose_tpose(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal poses
  * @csqlfn #Ever_ne_tpose_tpose()
  */
-inline int
+int
 ever_ne_tpose_tpose(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tpose_tpose(temp1, temp2, &datum2_ne, EVER);
@@ -230,7 +230,7 @@ ever_ne_tpose_tpose(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal poses
  * @csqlfn #Always_eq_tpose_tpose()
  */
-inline int
+int
 always_eq_tpose_tpose(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tpose_tpose(temp1, temp2, &datum2_eq, ALWAYS);
@@ -242,7 +242,7 @@ always_eq_tpose_tpose(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal poses
  * @csqlfn #Always_ne_tpose_tpose()
  */
-inline int
+int
 always_ne_tpose_tpose(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_tpose_tpose(temp1, temp2, &datum2_ne, ALWAYS);
@@ -298,7 +298,7 @@ tcomp_tpose_pose(const Temporal *temp, const Pose *pose,
  * @param[in] temp Temporal value
  * @csqlfn #Teq_pose_tpose()
  */
-inline Temporal *
+Temporal *
 teq_pose_tpose(const Pose *pose, const Temporal *temp)
 {
   return tcomp_pose_tpose(pose, temp, &datum2_eq);
@@ -311,7 +311,7 @@ teq_pose_tpose(const Pose *pose, const Temporal *temp)
  * @param[in] temp Temporal value
  * @csqlfn #Tne_pose_tpose()
  */
-inline Temporal *
+Temporal *
 tne_pose_tpose(const Pose *pose, const Temporal *temp)
 {
   return tcomp_pose_tpose(pose, temp, &datum2_ne);
@@ -327,7 +327,7 @@ tne_pose_tpose(const Pose *pose, const Temporal *temp)
  * @param[in] pose Pose
  * @csqlfn #Teq_tpose_pose()
  */
-inline Temporal *
+Temporal *
 teq_tpose_pose(const Temporal *temp, const Pose *pose)
 {
   return tcomp_tpose_pose(temp, pose, &datum2_eq);
@@ -341,7 +341,7 @@ teq_tpose_pose(const Temporal *temp, const Pose *pose)
  * @param[in] pose Pose
  * @csqlfn #Tne_tpose_pose()
  */
-inline Temporal *
+Temporal *
 tne_tpose_pose(const Temporal *temp, const Pose *pose)
 {
   return tcomp_tpose_pose(temp, pose, &datum2_ne);

--- a/meos/src/pose/tpose_spatialfuncs.c
+++ b/meos/src/pose/tpose_spatialfuncs.c
@@ -109,7 +109,7 @@ tpose_restrict_geom(const Temporal *temp, const GSERIALIZED *gs, bool atfunc)
  * @param[in] gs Geometry
  * @csqlfn #Tpose_at_geom()
  */
-inline Temporal *
+Temporal *
 tpose_at_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tpose_restrict_geom(temp, gs, REST_AT);
@@ -122,7 +122,7 @@ tpose_at_geom(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] gs Geometry
  * @csqlfn #Tpose_minus_geom()
  */
-inline Temporal *
+Temporal *
 tpose_minus_geom(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tpose_restrict_geom(temp, gs, REST_MINUS);
@@ -173,7 +173,7 @@ tpose_restrict_stbox(const Temporal *temp, const STBox *box, bool border_inc,
  * @param[in] border_inc True when the box contains the upper border
  * @sqlfn #Tpose_at_stbox()
  */
-inline Temporal *
+Temporal *
 tpose_at_stbox(const Temporal *temp, const STBox *box, bool border_inc)
 {
   return tpose_restrict_stbox(temp, box, border_inc, REST_AT);
@@ -187,7 +187,7 @@ tpose_at_stbox(const Temporal *temp, const STBox *box, bool border_inc)
  * @param[in] border_inc True when the box contains the upper border
  * @sqlfn #Tpose_minus_stbox()
  */
-inline Temporal *
+Temporal *
 tpose_minus_stbox(const Temporal *temp, const STBox *box, bool border_inc)
 {
   return tpose_restrict_stbox(temp, box, border_inc, REST_MINUS);

--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -137,7 +137,7 @@ ensure_valid_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
  * representation
  * @param[in] str String
  */
-inline Temporal *
+Temporal *
 trgeo_in(const char *str)
 {
   /* Ensure the validity of the arguments */
@@ -152,7 +152,7 @@ trgeo_in(const char *str)
  * @return On error return @p NULL
  * @see #temporal_from_mfjson()
  */
-inline Temporal *
+Temporal *
 trgeo_from_mfjson(const char *mfjson)
 {
   /* Ensure the validity of the arguments */
@@ -219,7 +219,7 @@ trgeo_wkt_out(const Temporal *temp, int maxdd, bool extended)
  * @param[in] temp Temporal rigid geometry
  * @param[in] maxdd Maximum number of decimal digits
  */
-inline char *
+char *
 trgeo_as_text(const Temporal *temp, int maxdd)
 {
   return trgeo_wkt_out(temp, maxdd, false);
@@ -232,7 +232,7 @@ trgeo_as_text(const Temporal *temp, int maxdd)
  * @param[in] temp Temporal rigid geometry
  * @param[in] maxdd Maximum number of decimal digits
  */
-inline char *
+char *
 trgeo_as_ewkt(const Temporal *temp, int maxdd)
 {
   return trgeo_wkt_out(temp, maxdd, true);
@@ -1000,7 +1000,7 @@ trgeometry_restrict_values(const Temporal *temp, const Set *s, bool atfunc)
  * @param[in] s Set of values
  * @csqlfn #Temporal_at_values()
  */
-inline Temporal *
+Temporal *
 trgeo_at_values(const Temporal *temp, const Set *s)
 {
   return trgeometry_restrict_values(temp, s, REST_AT);
@@ -1014,7 +1014,7 @@ trgeo_at_values(const Temporal *temp, const Set *s)
  * @csqlfn #Temporal_minus_values()
  * @param[in] s Set of values
  */
-inline Temporal *
+Temporal *
 trgeo_minus_values(const Temporal *temp, const Set *s)
 {
   return trgeometry_restrict_values(temp, s, REST_MINUS);
@@ -1054,7 +1054,7 @@ trgeometry_restrict_timestamptz(const Temporal *temp, TimestampTz t, bool atfunc
  * @param[in] t Timestamptz
  * @csqlfn #Temporal_at_timestamptz()
  */
-inline Temporal *
+Temporal *
 trgeo_at_timestamptz(const Temporal *temp, TimestampTz t)
 {
   return trgeometry_restrict_timestamptz(temp, t, REST_AT);
@@ -1068,7 +1068,7 @@ trgeo_at_timestamptz(const Temporal *temp, TimestampTz t)
  * @param[in] t Timestamptz
  * @csqlfn #Temporal_minus_timestamptz()
  */
-inline Temporal *
+Temporal *
 trgeo_minus_timestamptz(const Temporal *temp, TimestampTz t)
 {
   return trgeometry_restrict_timestamptz(temp, t, REST_MINUS);
@@ -1107,7 +1107,7 @@ trgeometry_restrict_tstzset(const Temporal *temp, const Set *s, bool atfunc)
  * @param[in] s Set
  * @csqlfn #Temporal_at_tstzspanset()
  */
-inline Temporal *
+Temporal *
 trgeo_at_tstzset(const Temporal *temp, const Set *s)
 {
   return trgeometry_restrict_tstzset(temp, s, REST_AT);
@@ -1121,7 +1121,7 @@ trgeo_at_tstzset(const Temporal *temp, const Set *s)
  * @param[in] s Set
  * @csqlfn #Temporal_minus_tstzspanset()
  */
-inline Temporal *
+Temporal *
 trgeo_minus_tstzset(const Temporal *temp, const Set *s)
 {
   return trgeometry_restrict_tstzset(temp, s, REST_MINUS);
@@ -1160,7 +1160,7 @@ trgeometry_restrict_tstzspan(const Temporal *temp, const Span *s, bool atfunc)
  * @param[in] s Span
  * @csqlfn #Temporal_at_tstzspan()
  */
-inline Temporal *
+Temporal *
 trgeo_at_tstzspan(const Temporal *temp, const Span *s)
 {
   return trgeometry_restrict_tstzspan(temp, s, REST_AT);
@@ -1174,7 +1174,7 @@ trgeo_at_tstzspan(const Temporal *temp, const Span *s)
  * @param[in] s Span
  * @csqlfn #Temporal_minus_tstzspan()
  */
-inline Temporal *
+Temporal *
 trgeo_minus_tstzspan(const Temporal *temp, const Span *s)
 {
   return trgeometry_restrict_tstzspan(temp, s, REST_MINUS);
@@ -1214,7 +1214,7 @@ trgeometry_restrict_tstzspanset(const Temporal *temp, const SpanSet *ss,
  * @param[in] ss Span set
  * @csqlfn #Temporal_at_tstzspanset()
  */
-inline Temporal *
+Temporal *
 trgeo_at_tstzspanset(const Temporal *temp, const SpanSet *ss)
 {
   return trgeometry_restrict_tstzspanset(temp, ss, REST_AT);
@@ -1228,7 +1228,7 @@ trgeo_at_tstzspanset(const Temporal *temp, const SpanSet *ss)
  * @param[in] ss Span set
  * @csqlfn #Temporal_minus_tstzspanset()
  */
-inline Temporal *
+Temporal *
 trgeo_minus_tstzspanset(const Temporal *temp, const SpanSet *ss)
 {
   return trgeometry_restrict_tstzspanset(temp, ss, REST_MINUS);

--- a/meos/src/rgeo/trgeo_seq.c
+++ b/meos/src/rgeo/trgeo_seq.c
@@ -235,7 +235,7 @@ trgeoseq_make1_exp(const GSERIALIZED *geom, TInstant **instants,
  * @brief Construct a temporal sequence from an array of temporal instants
  * @pre The validity of the arguments has been tested before
  */
-inline TSequence *
+TSequence *
 trgeoseq_make1(const GSERIALIZED *geom, TInstant **instants, int count,
   bool lower_inc, bool upper_inc, interpType interp, bool normalize)
 {
@@ -278,7 +278,7 @@ trgeoseq_make_exp(const GSERIALIZED *geom, TInstant **instants,
  * @param[in] interp Interpolation
  * @param[in] normalize True if the resulting value should be normalized
  */
-inline TSequence *
+TSequence *
 trgeoseq_make(const GSERIALIZED *geom, TInstant **instants, int count,
   bool lower_inc, bool upper_inc, interpType interp, bool normalize)
 {
@@ -333,7 +333,7 @@ trgeoseq_make_free_exp(const GSERIALIZED *geom, TInstant **instants, int count,
  * @note Does not free the reference geometry
  * @see tsequence_make
  */
-inline TSequence *
+TSequence *
 trgeoseq_make_free(const GSERIALIZED *geom, TInstant **instants, int count,
   bool lower_inc, bool upper_inc, interpType interp, bool normalize)
 {

--- a/meos/src/rgeo/trgeo_seqset.c
+++ b/meos/src/rgeo/trgeo_seqset.c
@@ -241,7 +241,7 @@ trgeoseqset_make_exp(const GSERIALIZED *geom, TSequence **sequences,
  * temporal sequence sets before applying an operation to them.
  * @sqlfn tbool_seqset(), tint_seqset(), tfloat_seqset(), ttext_seqset(), etc.
  */
-inline TSequenceSet *
+TSequenceSet *
 trgeoseqset_make(const GSERIALIZED *geom, TSequence **sequences, int count,
   bool normalize)
 {

--- a/meos/src/rgeo/trgeo_spatialrels.c
+++ b/meos/src/rgeo/trgeo_spatialrels.c
@@ -173,7 +173,7 @@ ea_contains_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
  * https://postgis.net/docs/ST_Contains.html
  * @csqlfn #Acontains_geo_trgeometry()
  */
-inline int
+int
 econtains_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   return ea_contains_geo_trgeo(gs, temp, EVER);
@@ -191,7 +191,7 @@ econtains_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
  * https://postgis.net/docs/ST_Contains.html
  * @csqlfn #Acontains_geo_trgeometry()
  */
-inline int
+int
 acontains_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   return ea_contains_geo_trgeo(gs, temp, ALWAYS);
@@ -239,7 +239,7 @@ ea_covers_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
  * https://postgis.net/docs/ST_Contains.html
  * @csqlfn #Ecovers_geo_trgeometry()
  */
-inline int
+int
 ecovers_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   return ea_covers_geo_trgeo(gs, temp, EVER);
@@ -257,7 +257,7 @@ ecovers_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
  * https://postgis.net/docs/ST_Contains.html
  * @csqlfn #Acovers_geo_trgeometry()
  */
-inline int
+int
 acovers_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   return ea_covers_geo_trgeo(gs, temp, ALWAYS);
@@ -303,7 +303,7 @@ ea_covers_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
  * https://postgis.net/docs/ST_Contains.html
  * @csqlfn #Ecovers_trgeometry_geo()
  */
-inline int
+int
 ecovers_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_covers_trgeo_geo(temp, gs, EVER);
@@ -321,7 +321,7 @@ ecovers_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * https://postgis.net/docs/ST_Contains.html
  * @csqlfn #Acovers_trgeometry_geo()
  */
-inline int
+int
 acovers_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_covers_trgeo_geo(temp, gs, ALWAYS);
@@ -358,7 +358,7 @@ ea_disjoint_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
  * @param[in] gs Geometry
  * @csqlfn #Edisjoint_trgeometry_geo()
  */
-inline int
+int
 edisjoint_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_disjoint_trgeo_geo(temp, gs, EVER);
@@ -373,7 +373,7 @@ edisjoint_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @note aDisjoint(a, b) is equivalent to NOT eIntersects(a, b)
  * @csqlfn #Adisjoint_trgeometry_geo()
  */
-inline int
+int
 adisjoint_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_disjoint_trgeo_geo(temp, gs, ALWAYS);
@@ -387,7 +387,7 @@ adisjoint_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] temp1,temp2 Temporal rigid geometries
  * @csqlfn #Edisjoint_trgeometry_trgeometry()
  */
-inline int
+int
 edisjoint_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_spatialrel_tspatial_tspatial(temp1, temp2, &datum2_point_ne, EVER);
@@ -401,7 +401,7 @@ edisjoint_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal rigid geometries
  * @csqlfn #Adisjoint_trgeometry_trgeometry()
  */
-inline int
+int
 adisjoint_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_spatialrel_tspatial_tspatial(temp1, temp2, &datum2_point_ne,
@@ -421,7 +421,7 @@ adisjoint_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
  * @param[in] gs Geometry
  * @csqlfn #Eintersects_trgeometry_geo()
  */
-inline int
+int
 eintersects_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return spatialrel_trgeo_trav_geo(temp, gs, (Datum) NULL, 
@@ -437,7 +437,7 @@ eintersects_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @note aIntersects(trgeo, gs) is equivalent to NOT eDisjoint(trgeo, gs)
  * @csqlfn #Aintersects_trgeometry_geo()
  */
-inline int
+int
 aintersects_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return INVERT_RESULT(edisjoint_trgeo_geo(temp, gs));
@@ -451,7 +451,7 @@ aintersects_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] temp1,temp2 Temporal rigid geometries
  * @csqlfn #Eintersects_trgeometry_trgeometry()
  */
-inline int
+int
 eintersects_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_spatialrel_tspatial_tspatial(temp1, temp2, &datum2_point_eq, EVER);
@@ -464,7 +464,7 @@ eintersects_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal rigid geometries
  * @csqlfn #Aintersects_trgeometry_trgeometry()
  */
-inline int
+int
 aintersects_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_spatialrel_tspatial_tspatial(temp1, temp2, &datum2_point_eq,
@@ -842,7 +842,7 @@ ea_dwithin_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2,
  * @param[in] dist Distance
  * @csqlfn #EA_dwithin_trgeometry_trgeometry()
  */
-inline int
+int
 edwithin_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2, double dist)
 {
   return ea_dwithin_trgeo_trgeo(temp1, temp2, dist, EVER);
@@ -857,7 +857,7 @@ edwithin_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2, double dist)
  * @param[in] dist Distance
  * @csqlfn #Adwithin_trgeometry_trgeometry()
  */
-inline int
+int
 adwithin_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2, double dist)
 {
   return ea_dwithin_trgeo_trgeo(temp1, temp2, dist, ALWAYS);

--- a/meos/src/temporal/error.c
+++ b/meos/src/temporal/error.c
@@ -190,6 +190,45 @@ meos_initialize_error_handler(error_handler_fn err_handler)
   __atomic_store_n(&MEOS_ERROR_HANDLER, h, __ATOMIC_RELEASE);
   return;
 }
+
+/**
+ * @brief Error handler that records the errno without writing to stderr
+ * and without calling exit()
+ * @details The default error handler writes every error message to stderr
+ * and calls exit() at the ERROR level.  Both side effects are harmful in
+ * embedded contexts:
+ *
+ *   - exit() from a foreign thread in a JVM (JNR-FFI on Spark / JMEOS)
+ *     tears the host process down with SIGSEGV in libc.
+ *   - Unconditional stderr writes serialise per-row errors inside
+ *     cross-join queries (BerlinMOD Q10 / Q11 on mixed-SRID input emit
+ *     one stderr line per pair, dominating wall-clock at scale).
+ *
+ * This handler reports errors via meos_errno() only — the canonical
+ * library-style mechanism.  Callers that want a per-error log line should
+ * read meos_errno() after each MEOS call and route the message to the
+ * host's logging framework.
+ */
+static void
+noexit_error_handler(int errlevel __attribute__((__unused__)), int errcode,
+  const char *errmsg __attribute__((__unused__)))
+{
+  meos_errno_set(errcode);
+  return;
+}
+
+/**
+ * @brief Install the no-exit error handler
+ * @details Safe to call from multiple threads — the underlying atomic
+ * store is idempotent and always sets the same function pointer.
+ */
+void
+meos_initialize_noexit_error_handler(void)
+{
+  __atomic_store_n(&MEOS_ERROR_HANDLER,
+    (meos_error_handler_t) noexit_error_handler, __ATOMIC_RELEASE);
+  return;
+}
 #endif /* MEOS */
 
 /*****************************************************************************/

--- a/meos/src/temporal/meos.c
+++ b/meos/src/temporal/meos.c
@@ -42,6 +42,11 @@
 #include <gsl/gsl_randist.h>
 /* Proj */
 #include <proj.h>
+/* GEOS */
+#include <geos_c.h>
+/* PostGIS */
+#include <lwgeom_log.h>
+#include <lwgeom_geos.h>
 /* MEOS */
 #include <meos.h>
 
@@ -153,6 +158,59 @@ proj_get_context(void)
   if (! MEOS_PJ_CONTEXT)
     proj_initialize();
   return MEOS_PJ_CONTEXT;
+}
+
+/***************************************************************************
+ * Functions for the GEOS library
+ ***************************************************************************/
+
+/* Per-thread GEOS context.  Each thread owns its own handle so concurrent
+ * callers do not share GEOS state.  MEOS spatial helpers retrieve the
+ * handle via geos_get_context() and use the reentrant GEOSXxx_r API. */
+
+static MEOS_TLS GEOSContextHandle_t MEOS_GEOS_CONTEXT = NULL;
+
+/**
+ * @brief Initialize the GEOS library
+ */
+static void
+geos_initialize(void)
+{
+  if (! MEOS_GEOS_CONTEXT)
+  {
+    MEOS_GEOS_CONTEXT = GEOS_init_r();
+    GEOSContext_setNoticeHandler_r(MEOS_GEOS_CONTEXT, lwnotice);
+    GEOSContext_setErrorHandler_r(MEOS_GEOS_CONTEXT, lwgeom_geos_error);
+  }
+  return;
+}
+
+#if MEOS
+/**
+ * @brief Finalize the GEOS library
+ */
+static void
+geos_finalize(void)
+{
+  if (MEOS_GEOS_CONTEXT)
+  {
+    GEOS_finish_r(MEOS_GEOS_CONTEXT);
+    MEOS_GEOS_CONTEXT = NULL;
+  }
+  lwgeom_geos_finalize();
+  return;
+}
+#endif /* MEOS */
+
+/**
+ * @brief Return the per-thread GEOS context handle
+ */
+GEOSContextHandle_t
+geos_get_context(void)
+{
+  if (! MEOS_GEOS_CONTEXT)
+    geos_initialize();
+  return MEOS_GEOS_CONTEXT;
 }
 
 /*****************************************************************************/
@@ -570,6 +628,8 @@ meos_initialize(void)
   meos_initialize_timezone(NULL);
   /* Initialize PROJ */
   proj_initialize();
+  /* Initialize GEOS */
+  geos_initialize();
   /* Initialize GSL */
   gsl_initialize();
   return;
@@ -590,6 +650,8 @@ meos_finalize(void)
 #endif
   /* Finalize PROJ */
   proj_finalize();
+  /* Finalize GEOS */
+  geos_finalize();
   /* Finalize GSL */
   gsl_finalize();
   return;

--- a/meos/src/temporal/meos_catalog.c
+++ b/meos/src/temporal/meos_catalog.c
@@ -285,7 +285,7 @@ static const temptype_catalog_struct MEOS_TEMPTYPE_CATALOG[] =
 /**
  * @brief Return the string representation of the MEOS type
  */
-inline const char *
+const char *
 meostype_name(MeosType type)
 {
   return MEOS_TYPE_NAMES[type];
@@ -297,7 +297,7 @@ meostype_name(MeosType type)
  * @brief Return the string representation of the subtype of the temporal type
  * corresponding to the enum value
  */
-inline const char *
+const char *
 tempsubtype_name(tempSubtype subtype)
 {
   return MEOS_TEMPSUBTYPE_NAMES[subtype];
@@ -362,7 +362,7 @@ tempsubtype_from_string(const char *str, int16 *subtype)
  * @brief Ensure that the subtype of a temporal value is valid
  * @note The function is used for the dispatch functions for temporal types
  */
-inline bool
+bool
 temptype_subtype(tempSubtype subtype)
 {
   return (subtype == TINSTANT || subtype == TSEQUENCE ||
@@ -373,7 +373,7 @@ temptype_subtype(tempSubtype subtype)
  * @brief Ensure that the subtype of a temporal value is valid
  * @note The function is used for the the analyze and selectivity functions
  */
-inline bool
+bool
 temptype_subtype_all(tempSubtype subtype)
 {
   return (subtype == ANYTEMPSUBTYPE ||
@@ -386,7 +386,7 @@ temptype_subtype_all(tempSubtype subtype)
 /**
  * @brief Return the string name from a MEOS operator number
  */
-inline const char *
+const char *
 meosoper_name(meosOper oper)
 {
   return MEOS_OPER_NAMES[oper];
@@ -414,7 +414,7 @@ meosoper_from_string(const char *str)
  * @brief Return the string representation of the subtype of the temporal type
  * corresponding to the enum value
  */
-inline const char *
+const char *
 interptype_name(interpType interp)
 {
   return MEOS_INTERPTYPE_NAMES[interp];
@@ -581,7 +581,7 @@ spantype_spansettype(MeosType type)
  * that is, @p Set, @p Span, @p SpanSet, and @p Temporal
  * @note This function is only used in the asserts
  */
-inline bool
+bool
 meos_basetype(MeosType type)
 {
   return (type == T_BOOL || type == T_INT4 || type == T_INT8 || type == T_FLOAT8 ||
@@ -605,7 +605,7 @@ meos_basetype(MeosType type)
 /**
  * @brief Return true if the values of the base type are passed by value
  */
-inline bool
+bool
 basetype_byvalue(MeosType type)
 {
   return (type == T_BOOL || type == T_INT4 || type == T_INT8 || type == T_FLOAT8 ||
@@ -615,7 +615,7 @@ basetype_byvalue(MeosType type)
 /**
  * @brief Return true if the values of the base type are of variable length
  */
-inline bool
+bool
 basetype_varlength(MeosType type)
 {
   return (type == T_TEXT || type == T_GEOMETRY || type == T_GEOGRAPHY
@@ -670,7 +670,7 @@ meostype_length(MeosType type)
  * @brief Return true if the type is an alphanumeric base type
  * @note This function is only used in the asserts
  */
-inline bool
+bool
 alphanum_basetype(MeosType type)
 {
   return (type == T_BOOL || type == T_INT4 || type == T_INT8 ||
@@ -682,7 +682,7 @@ alphanum_basetype(MeosType type)
  * @brief Return true if the type is an alphanumeric base type
  * @note This function is only used in the asserts
  */
-inline bool
+bool
 alphanum_temptype(MeosType type)
 {
   return (type == T_TBOOL || type == T_TINT || type == T_TFLOAT ||
@@ -693,7 +693,7 @@ alphanum_temptype(MeosType type)
 /**
  * @brief Return true if the type is a geo base type
  */
-inline bool
+bool
 geo_basetype(MeosType type)
 {
   return (type == T_GEOMETRY || type == T_GEOGRAPHY);
@@ -702,7 +702,7 @@ geo_basetype(MeosType type)
 /**
  * @brief Return true if the type is a spatial base type
  */
-inline bool
+bool
 spatial_basetype(MeosType type)
 {
   return (type == T_GEOMETRY || type == T_GEOGRAPHY 
@@ -723,7 +723,7 @@ spatial_basetype(MeosType type)
 /**
  * @brief Return true if the type is a time type
  */
-inline bool
+bool
 time_type(MeosType type)
 {
   return (type == T_DATE || type == T_DATESET || type == T_DATESPAN ||
@@ -738,7 +738,7 @@ time_type(MeosType type)
  * @brief Return true if the type is a base type of a set type
  * @note This function is only used in the asserts
  */
-inline bool
+bool
 set_basetype(MeosType type)
 {
   return (type == T_TIMESTAMPTZ || type == T_DATE || type == T_INT4 ||
@@ -760,7 +760,7 @@ set_basetype(MeosType type)
 /**
  * @brief Return true if the type is a set type
  */
-inline bool
+bool
 set_type(MeosType type)
 {
   return (type == T_TSTZSET || type == T_DATESET || type == T_INTSET ||
@@ -781,7 +781,7 @@ set_type(MeosType type)
 /**
  * @brief Return true if the type is a number set type
  */
-inline bool
+bool
 numset_type(MeosType type)
 {
   return (type == T_INTSET || type == T_BIGINTSET || type == T_FLOATSET ||
@@ -807,7 +807,7 @@ ensure_numset_type(MeosType type)
 /**
  * @brief Return true if the type is a time set type
  */
-inline bool
+bool
 timeset_type(MeosType type)
 {
   return (type == T_DATESET || type == T_TSTZSET);
@@ -816,7 +816,7 @@ timeset_type(MeosType type)
 /**
  * @brief Return true if the type is a set type with a span as a bounding box
  */
-inline bool
+bool
 set_spantype(MeosType type)
 {
   return (type == T_INTSET || type == T_BIGINTSET || type == T_FLOATSET ||
@@ -839,7 +839,7 @@ ensure_set_spantype(MeosType type)
 /**
  * @brief Return true if the type is a set type
  */
-inline bool
+bool
 alphanumset_type(MeosType type)
 {
   return (type == T_TSTZSET || type == T_DATESET || type == T_INTSET ||
@@ -850,7 +850,7 @@ alphanumset_type(MeosType type)
 /**
  * @brief Return true if the type is a geo set type
  */
-inline bool
+bool
 geoset_type(MeosType type)
 {
   return (type == T_GEOMSET || type == T_GEOGSET);
@@ -873,7 +873,7 @@ ensure_geoset_type(MeosType type)
 /**
  * @brief Return true if the type is a geo set type
  */
-inline bool
+bool
 spatialset_type(MeosType type)
 {
   return (type == T_GEOMSET || type == T_GEOGSET
@@ -909,7 +909,7 @@ ensure_spatialset_type(MeosType type)
 /**
  * @brief Return true if the type is a span base type
  */
-inline bool
+bool
 span_basetype(MeosType type)
 {
   return (type == T_TIMESTAMPTZ || type == T_DATE || type == T_INT4 ||
@@ -919,7 +919,7 @@ span_basetype(MeosType type)
 /**
  * @brief Return true if the type is a canonical base type of a span type
  */
-inline bool
+bool
 span_canon_basetype(MeosType type)
 {
   return (type == T_DATE || type == T_INT4 || type == T_INT8);
@@ -939,7 +939,7 @@ span_type(MeosType type)
  * @brief Return true if the type has a span type as bounding box
  * @note This function is only used in the asserts
  */
-inline bool
+bool
 type_span_bbox(MeosType type)
 {
   return (set_spantype(type) || span_type(type) || spanset_type(type) ||
@@ -950,7 +950,7 @@ type_span_bbox(MeosType type)
  * @brief Return true if the type can be converted to a temporal box
  * @note This function is only used in the asserts
  */
-inline bool
+bool
 span_tbox_type(MeosType type)
 {
   return (type == T_INTSPAN || type == T_FLOATSPAN || type == T_TSTZSPAN);
@@ -973,7 +973,7 @@ ensure_span_tbox_type(MeosType type)
 /**
  * @brief Return true if the type is a number span type
  */
-inline bool
+bool
 numspan_basetype(MeosType type)
 {
   return (type == T_INT4 || type == T_INT8 || type == T_FLOAT8 ||
@@ -984,7 +984,7 @@ numspan_basetype(MeosType type)
 /**
  * @brief Return true if the type is a number span type
  */
-inline bool
+bool
 numspan_type(MeosType type)
 {
   return (type == T_INTSPAN || type == T_BIGINTSPAN || type == T_FLOATSPAN ||
@@ -1007,7 +1007,7 @@ ensure_numspan_type(MeosType type)
 /**
  * @brief Return true if the type is a time span type
  */
-inline bool
+bool
 timespan_basetype(MeosType type)
 {
   return (type == T_TIMESTAMPTZ || type == T_DATE);
@@ -1016,7 +1016,7 @@ timespan_basetype(MeosType type)
 /**
  * @brief Return true if the type is a time span type
  */
-inline bool
+bool
 timespan_type(MeosType type)
 {
   return (type == T_TSTZSPAN || type == T_DATESPAN);
@@ -1027,7 +1027,7 @@ timespan_type(MeosType type)
 /**
  * @brief Return true if the type is a span set type
  */
-inline bool
+bool
 spanset_type(MeosType type)
 {
   return (type == T_TSTZSPANSET || type == T_DATESPANSET ||
@@ -1037,7 +1037,7 @@ spanset_type(MeosType type)
 /**
  * @brief Return true if the type is a time span type
  */
-inline bool
+bool
 timespanset_type(MeosType type)
 {
   return (type == T_TSTZSPANSET || type == T_DATESPANSET);
@@ -1064,7 +1064,7 @@ ensure_timespanset_type(MeosType type)
  * @brief Return true if the type is an @b external temporal type
  * @note Function used in particular in the indexes
  */
-inline bool
+bool
 temporal_type(MeosType type)
 {
   return (type == T_TBOOL || type == T_TINT || type == T_TFLOAT ||
@@ -1092,7 +1092,7 @@ temporal_type(MeosType type)
  * @brief Return true if the type is a temporal base type
  * @note This function is only used in the asserts
  */
-inline bool
+bool
 temporal_basetype(MeosType type)
 {
   return (type == T_BOOL || type == T_INT4 || type == T_FLOAT8 ||
@@ -1121,7 +1121,7 @@ temporal_basetype(MeosType type)
  * subset whose values can vary linearly between samples (as opposed to
  * STEP-only types like tbool, tint, ttext, tgeometry, tgeography, th3index).
  */
-inline bool
+bool
 temptype_supports_linear(MeosType type)
 {
   return (type == T_TFLOAT || type == T_TDOUBLE2 || type == T_TDOUBLE3 ||
@@ -1146,7 +1146,7 @@ temptype_supports_linear(MeosType type)
  * @brief Return true if the type is a temporal alphanumeric type
  * @note This function is only used in the asserts
  */
-inline bool
+bool
 talphanum_type(MeosType type)
 {
   return (type == T_TBOOL || type == T_TINT || type == T_TFLOAT ||
@@ -1158,7 +1158,7 @@ talphanum_type(MeosType type)
  * @brief Return true if the type is a temporal alpha type (i.e., those whose
  * bounding box is a timestamptz span)
  */
-inline bool
+bool
 talpha_type(MeosType type)
 {
   return (type == T_TBOOL || type == T_TTEXT || type == T_TDOUBLE2 ||
@@ -1168,7 +1168,7 @@ talpha_type(MeosType type)
 /**
  * @brief Return true if the type is a temporal number type
  */
-inline bool
+bool
 tnumber_type(MeosType type)
 {
   return (type == T_TINT || type == T_TFLOAT);
@@ -1230,7 +1230,7 @@ tnumber_spantype(MeosType type)
  * types, in particular, all of them use the same bounding box @ STBox.
  * Therefore, it is used for the indexes and selectivity functions.
  */
-inline bool
+bool
 tspatial_type(MeosType type)
 {
   return (type == T_TGEOMPOINT || type == T_TGEOGPOINT || 
@@ -1268,7 +1268,7 @@ ensure_tspatial_type(MeosType type)
 /**
  * @brief Return true if a type is a temporal point type
  */
-inline bool
+bool
 tpoint_type(MeosType type)
 {
   return (type == T_TGEOMPOINT || type == T_TGEOGPOINT);
@@ -1290,7 +1290,7 @@ ensure_tpoint_type(MeosType type)
 /**
  * @brief Return true if a type is a temporal geo type
  */
-inline bool
+bool
 tgeo_type(MeosType type)
 {
   return (type == T_TGEOMETRY || type == T_TGEOGRAPHY);
@@ -1315,7 +1315,7 @@ ensure_tgeo_type(MeosType type)
  * @brief Return true if a type is a temporal type with geometry/geography as
  * base type
  */
-inline bool
+bool
 tgeo_type_all(MeosType type)
 {
   return (type == T_TGEOMETRY || type == T_TGEOGRAPHY ||
@@ -1340,7 +1340,7 @@ ensure_tgeo_type_all(MeosType type)
 /**
  * @brief Return true if a type is a temporal geometry type
  */
-inline bool
+bool
 tgeometry_type(MeosType type)
 {
   return (type == T_TGEOMPOINT || type == T_TGEOMETRY);
@@ -1363,7 +1363,7 @@ ensure_tgeometry_type(MeosType type)
 /**
  * @brief Return true if a type is a temporal geodetic type
  */
-inline bool
+bool
 tgeodetic_type(MeosType type)
 {
   return (type == T_TGEOGPOINT || type == T_TGEOGRAPHY);

--- a/meos/src/temporal/postgres_types.c
+++ b/meos/src/temporal/postgres_types.c
@@ -825,7 +825,7 @@ date2timestamptz_opt_overflow(DateADT dateVal, int *overflow)
  * @param[in] d Date
  * @note PostgreSQL function: @p date_timestamptz(PG_FUNCTION_ARGS)
  */
-inline TimestampTz
+TimestampTz
 date_to_timestamptz(DateADT d)
 {
   return date2timestamptz_opt_overflow(d, NULL);
@@ -1426,7 +1426,7 @@ timestamptz_out(TimestampTz t)
 {
   return timestamp_out_common(t, true);
 }
-inline char *
+char *
 pg_timestamptz_out(TimestampTz t)
 {
   return timestamp_out_common(t, true);

--- a/meos/src/temporal/set.c
+++ b/meos/src/temporal/set.c
@@ -1083,7 +1083,7 @@ set_eq(const Set *s1, const Set *s2)
  * @param[in] s1,s2 Sets
  * @csqlfn #Set_ne()
  */
-inline bool
+bool
 set_ne(const Set *s1, const Set *s2)
 {
   return ! set_eq(s1, s2);
@@ -1131,7 +1131,7 @@ set_cmp(const Set *s1, const Set *s2)
  * @param[in] s1,s2 Sets
  * @csqlfn #Set_lt()
  */
-inline bool
+bool
 set_lt(const Set *s1, const Set *s2)
 {
   return set_cmp(s1, s2) < 0;
@@ -1143,7 +1143,7 @@ set_lt(const Set *s1, const Set *s2)
  * @param[in] s1,s2 Sets
  * @csqlfn #Set_le()
  */
-inline bool
+bool
 set_le(const Set *s1, const Set *s2)
 {
   return set_cmp(s1, s2) <= 0;
@@ -1155,7 +1155,7 @@ set_le(const Set *s1, const Set *s2)
  * @param[in] s1,s2 Sets
  * @csqlfn #Set_gt()
  */
-inline bool
+bool
 set_gt(const Set *s1, const Set *s2)
 {
   return set_cmp(s1, s2) > 0;
@@ -1167,7 +1167,7 @@ set_gt(const Set *s1, const Set *s2)
  * @param[in] s1,s2 Sets
  * @csqlfn #Set_ge()
  */
-inline bool
+bool
 set_ge(const Set *s1, const Set *s2)
 {
   return set_cmp(s1, s2) >= 0;

--- a/meos/src/temporal/set_ops.c
+++ b/meos/src/temporal/set_ops.c
@@ -237,7 +237,7 @@ contains_set_set(const Set *s1, const Set *s2)
  * @param[in] value Value
  * @param[in] s Set
  */
-inline bool
+bool
 contained_value_set(Datum value, const Set *s)
 {
   return contains_set_value(s, value);
@@ -249,7 +249,7 @@ contained_value_set(Datum value, const Set *s)
  * @param[in] s1,s2 Sets
  * @csqlfn #Contained_set_set()
  */
-inline bool
+bool
 contained_set_set(const Set *s1, const Set *s2)
 {
   return contains_set_set(s2, s1);
@@ -346,7 +346,7 @@ left_set_set(const Set *s1, const Set *s2)
  * @param[in] value Value
  * @param[in] s Set
  */
-inline bool
+bool
 right_value_set(Datum value, const Set *s)
 {
   return left_set_value(s, value);
@@ -358,7 +358,7 @@ right_value_set(Datum value, const Set *s)
  * @param[in] s Set
  * @param[in] value Value
  */
-inline bool
+bool
 right_set_value(const Set *s, Datum value)
 {
   return left_value_set(value, s);
@@ -370,7 +370,7 @@ right_set_value(const Set *s, Datum value)
  * @param[in] s1,s2 Sets
  * @csqlfn #Right_set_set()
  */
-inline bool
+bool
 right_set_set(const Set *s1, const Set *s2)
 {
   return left_set_set(s2, s1);
@@ -513,7 +513,7 @@ union_set_value(const Set *s, Datum value)
  * @param[in] value Value
  * @param[in] s Set
  */
-inline Set *
+Set *
 union_value_set(Datum value, const Set *s)
 {
   return union_set_value(s, value);
@@ -559,7 +559,7 @@ intersection_set_value(const Set *s, Datum value)
  * @param[in] value Value
  * @param[in] s Set
  */
-inline Set *
+Set *
 intersection_value_set(Datum value, const Set *s)
 {
   return intersection_set_value(s, value);

--- a/meos/src/temporal/set_ops_meos.c
+++ b/meos/src/temporal/set_ops_meos.c
@@ -1087,7 +1087,7 @@ union_set_timestamptz(const Set *s, const TimestampTz t)
  * @param[in] i Value
  * @csqlfn #Union_set_value()
  */
-inline Set *
+Set *
 union_int_set(int i, const Set *s)
 {
   return union_set_int(s, i);
@@ -1100,7 +1100,7 @@ union_int_set(int i, const Set *s)
  * @param[in] i Value
  * @csqlfn #Union_set_value()
  */
-inline Set *
+Set *
 union_bigint_set(int64 i, const Set *s)
 {
   return union_set_bigint(s, i);
@@ -1113,7 +1113,7 @@ union_bigint_set(int64 i, const Set *s)
  * @param[in] d Value
  * @csqlfn #Union_set_value()
  */
-inline Set *
+Set *
 union_float_set(double d, const Set *s)
 {
   return union_set_float(s, d);
@@ -1126,7 +1126,7 @@ union_float_set(double d, const Set *s)
  * @param[in] txt Value
  * @csqlfn #Union_set_value()
  */
-inline Set *
+Set *
 union_text_set(const text *txt, const Set *s)
 {
   return union_set_text(s, txt);
@@ -1139,7 +1139,7 @@ union_text_set(const text *txt, const Set *s)
  * @param[in] d Value
  * @csqlfn #Union_set_value()
  */
-inline Set *
+Set *
 union_date_set(const DateADT d, const Set *s)
 {
   return union_set_date(s, d);
@@ -1152,7 +1152,7 @@ union_date_set(const DateADT d, const Set *s)
  * @param[in] t Value
  * @csqlfn #Union_set_value()
  */
-inline Set *
+Set *
 union_timestamptz_set(const TimestampTz t, const Set *s)
 {
   return union_set_timestamptz(s, t);
@@ -1261,7 +1261,7 @@ intersection_set_timestamptz(const Set *s, TimestampTz t)
  * @param[in] i Value
  * @csqlfn #Union_set_value()
  */
-inline Set *
+Set *
 intersection_int_set(int i, const Set *s)
 {
   return intersection_set_int(s, i);
@@ -1274,7 +1274,7 @@ intersection_int_set(int i, const Set *s)
  * @param[in] i Value
  * @csqlfn #Union_set_value()
  */
-inline Set *
+Set *
 intersection_bigint_set(int64 i, const Set *s)
 {
   return intersection_set_bigint(s, i);
@@ -1287,7 +1287,7 @@ intersection_bigint_set(int64 i, const Set *s)
  * @param[in] d Value
  * @csqlfn #Union_set_value()
  */
-inline Set *
+Set *
 intersection_float_set(double d, const Set *s)
 {
   return intersection_set_float(s, d);
@@ -1300,7 +1300,7 @@ intersection_float_set(double d, const Set *s)
  * @param[in] txt Value
  * @csqlfn #Union_set_value()
  */
-inline Set *
+Set *
 intersection_text_set(const text *txt, const Set *s)
 {
   return intersection_set_text(s, txt);
@@ -1313,7 +1313,7 @@ intersection_text_set(const text *txt, const Set *s)
  * @param[in] d Value
  * @csqlfn #Union_set_value()
  */
-inline Set *
+Set *
 intersection_date_set(const DateADT d, const Set *s)
 {
   return intersection_set_date(s, d);
@@ -1326,7 +1326,7 @@ intersection_date_set(const DateADT d, const Set *s)
  * @param[in] t Value
  * @csqlfn #Union_set_value()
  */
-inline Set *
+Set *
 intersection_timestamptz_set(const TimestampTz t, const Set *s)
 {
   return intersection_set_timestamptz(s, t);

--- a/meos/src/temporal/span.c
+++ b/meos/src/temporal/span.c
@@ -1503,7 +1503,7 @@ span_eq(const Span *s1, const Span *s2)
  * @param[in] s1,s2 Sets
  * @csqlfn #Span_ne()
  */
-inline bool
+bool
 span_ne(const Span *s1, const Span *s2)
 {
   return (! span_eq(s1, s2));
@@ -1546,7 +1546,7 @@ span_cmp(const Span *s1, const Span *s2)
  * @param[in] s1,s2 Sets
  * @csqlfn #Span_lt()
  */
-inline bool
+bool
 span_lt(const Span *s1, const Span *s2)
 {
   return span_cmp(s1, s2) < 0;
@@ -1558,7 +1558,7 @@ span_lt(const Span *s1, const Span *s2)
  * @param[in] s1,s2 Sets
  * @csqlfn #Span_le()
  */
-inline bool
+bool
 span_le(const Span *s1, const Span *s2)
 {
   return span_cmp(s1, s2) <= 0;
@@ -1571,7 +1571,7 @@ span_le(const Span *s1, const Span *s2)
  * @param[in] s1,s2 Sets
  * @csqlfn #Span_gt()
  */
-inline bool
+bool
 span_ge(const Span *s1, const Span *s2)
 {
   return span_cmp(s1, s2) >= 0;
@@ -1583,7 +1583,7 @@ span_ge(const Span *s1, const Span *s2)
  * @param[in] s1,s2 Sets
  * @csqlfn #Span_ge()
  */
-inline bool
+bool
 span_gt(const Span *s1, const Span *s2)
 {
   return span_cmp(s1, s2) > 0;

--- a/meos/src/temporal/span_ops.c
+++ b/meos/src/temporal/span_ops.c
@@ -177,7 +177,7 @@ contains_span_span(const Span *s1, const Span *s2)
  * @param[in] value Value
  * @param[in] s Span
  */
-inline bool
+bool
 contained_value_span(Datum value, const Span *s)
 {
   return contains_span_value(s, value);
@@ -189,7 +189,7 @@ contained_value_span(Datum value, const Span *s)
  * @param[in] s1,s2 Spans
  * @csqlfn #Contained_value_span()
  */
-inline bool
+bool
 contained_span_span(const Span *s1, const Span *s2)
 {
   return contains_span_span(s2, s1);
@@ -376,7 +376,7 @@ lfnadj_span_span(const Span *s1, const Span *s2)
  * @param[in] value Value
  * @param[in] s Span
  */
-inline bool
+bool
 right_value_span(Datum value, const Span *s)
 {
   return left_span_value(s, value);
@@ -388,7 +388,7 @@ right_value_span(Datum value, const Span *s)
  * @param[in] s Span
  * @param[in] value Value
  */
-inline bool
+bool
 right_span_value(const Span *s, Datum value)
 {
   return left_value_span(value, s);
@@ -400,7 +400,7 @@ right_span_value(const Span *s, Datum value)
  * @param[in] s1,s2 Spans
  * @csqlfn #Right_span_span()
  */
-inline bool
+bool
 right_span_span(const Span *s1, const Span *s2)
 {
   return left_span_span(s2, s1);

--- a/meos/src/temporal/spanset.c
+++ b/meos/src/temporal/spanset.c
@@ -178,7 +178,7 @@ spanset_find_value(const SpanSet *ss, Datum v, int *loc)
 }
 
 #if MEOS
-inline bool
+bool
 tstzspanset_find_timestamptz(const SpanSet *ss, TimestampTz t, int *loc)
 {
   return spanset_find_value(ss, TimestampTzGetDatum(t), loc);
@@ -1445,7 +1445,7 @@ spanset_eq(const SpanSet *ss1, const SpanSet *ss2)
  * @param[in] ss1,ss2 Span sets
  * @csqlfn #Spanset_ne()
  */
-inline bool
+bool
 spanset_ne(const SpanSet *ss1, const SpanSet *ss2)
 {
   return ! spanset_eq(ss1, ss2);
@@ -1496,7 +1496,7 @@ spanset_cmp(const SpanSet *ss1, const SpanSet *ss2)
  * @param[in] ss1,ss2 Span sets
  * @csqlfn #Spanset_lt()
  */
-inline bool
+bool
 spanset_lt(const SpanSet *ss1, const SpanSet *ss2)
 {
   return spanset_cmp(ss1, ss2) < 0;
@@ -1509,7 +1509,7 @@ spanset_lt(const SpanSet *ss1, const SpanSet *ss2)
  * @param[in] ss1,ss2 Span sets
  * @csqlfn #Spanset_le()
  */
-inline bool
+bool
 spanset_le(const SpanSet *ss1, const SpanSet *ss2)
 {
   return spanset_cmp(ss1, ss2) <= 0;
@@ -1522,7 +1522,7 @@ spanset_le(const SpanSet *ss1, const SpanSet *ss2)
  * @param[in] ss1,ss2 Span sets
  * @csqlfn #Spanset_ge()
  */
-inline bool
+bool
 spanset_ge(const SpanSet *ss1, const SpanSet *ss2)
 {
   return spanset_cmp(ss1, ss2) >= 0;
@@ -1534,7 +1534,7 @@ spanset_ge(const SpanSet *ss1, const SpanSet *ss2)
  * @param[in] ss1,ss2 Span sets
  * @csqlfn #Spanset_gt()
  */
-inline bool
+bool
 spanset_gt(const SpanSet *ss1, const SpanSet *ss2)
 {
   return spanset_cmp(ss1, ss2) > 0;

--- a/meos/src/temporal/spanset_ops.c
+++ b/meos/src/temporal/spanset_ops.c
@@ -190,7 +190,7 @@ contains_spanset_spanset(const SpanSet *ss1, const SpanSet *ss2)
  * @param[in] value Value
  * @param[in] ss Span set
  */
-inline bool
+bool
 contained_value_spanset(Datum value, const SpanSet *ss)
 {
   return contains_spanset_value(ss, value);
@@ -203,7 +203,7 @@ contained_value_spanset(Datum value, const SpanSet *ss)
  * @param[in] ss Span set
  * @csqlfn #Contained_span_spanset()
  */
-inline bool
+bool
 contained_span_spanset(const Span *s, const SpanSet *ss)
 {
   return contains_spanset_span(ss, s);
@@ -216,7 +216,7 @@ contained_span_spanset(const Span *s, const SpanSet *ss)
  * @param[in] s Span
  * @csqlfn #Contained_spanset_span()
  */
-inline bool
+bool
 contained_spanset_span(const SpanSet *ss, const Span *s)
 {
   return contains_span_spanset(s, ss);
@@ -228,7 +228,7 @@ contained_spanset_span(const SpanSet *ss, const Span *s)
  * @param[in] ss1,ss2 Span sets
  * @csqlfn #Contained_spanset_spanset()
  */
-inline bool
+bool
 contained_spanset_spanset(const SpanSet *ss1, const SpanSet *ss2)
 {
   return contains_spanset_spanset(ss2, ss1);
@@ -281,7 +281,7 @@ overlaps_spanset_span(const SpanSet *ss, const Span *s)
  * @param[in] ss Span set
  * @csqlfn #Overlaps_span_spanset()
  */
-inline bool
+bool
 overlaps_span_spanset(const Span *s, const SpanSet *ss)
 {
   return overlaps_spanset_span(ss, s);
@@ -340,7 +340,7 @@ overlaps_spanset_spanset(const SpanSet *ss1, const SpanSet *ss2)
  * @param[in] ss Span set
  * @param[in] value Value
  */
-inline bool
+bool
 adjacent_spanset_value(const SpanSet *ss, Datum value)
 {
   /* A span set and a value are adjacent if and only if the first or the last
@@ -355,7 +355,7 @@ adjacent_spanset_value(const SpanSet *ss, Datum value)
  * @param[in] ss Span set
  * @param[in] value Value
  */
-inline bool
+bool
 adjacent_value_spanset(Datum value, const SpanSet *ss)
 {
   return adjacent_spanset_value(ss, value);
@@ -396,7 +396,7 @@ adjacent_spanset_span(const SpanSet *ss, const Span *s)
  * @param[in] ss Span set
  * @csqlfn #Adjacent_span_spanset()
  */
-inline bool
+bool
 adjacent_span_spanset(const Span *s, const SpanSet *ss)
 {
   return adjacent_spanset_span(ss, s);
@@ -443,7 +443,7 @@ adjacent_spanset_spanset(const SpanSet *ss1, const SpanSet *ss2)
  * @param[in] value Value
  * @param[in] ss Span set
  */
-inline bool
+bool
 left_value_spanset(Datum value, const SpanSet *ss)
 {
   return left_value_span(value, SPANSET_SP_N(ss, 0));
@@ -471,7 +471,7 @@ left_span_spanset(const Span *s, const SpanSet *ss)
  * @param[in] ss Span set
  * @param[in] value Value
  */
-inline bool
+bool
 left_spanset_value(const SpanSet *ss, Datum value)
 {
   return left_span_value(SPANSET_SP_N(ss, ss->count - 1), value);
@@ -519,7 +519,7 @@ left_spanset_spanset(const SpanSet *ss1, const SpanSet *ss2)
  * @param[in] value Value
  * @param[in] ss Span set
  */
-inline bool
+bool
 right_value_spanset(Datum value, const SpanSet *ss)
 {
   return left_spanset_value(ss, value);
@@ -532,7 +532,7 @@ right_value_spanset(Datum value, const SpanSet *ss)
  * @param[in] ss Span set
  * @csqlfn #Right_span_spanset()
  */
-inline bool
+bool
 right_span_spanset(const Span *s, const SpanSet *ss)
 {
   return left_spanset_span(ss, s);
@@ -544,7 +544,7 @@ right_span_spanset(const Span *s, const SpanSet *ss)
  * @param[in] ss Span set
  * @param[in] value Value
  */
-inline bool
+bool
 right_spanset_value(const SpanSet *ss, Datum value)
 {
   return left_value_spanset(value, ss);
@@ -557,7 +557,7 @@ right_spanset_value(const SpanSet *ss, Datum value)
  * @param[in] s Span
  * @csqlfn #Right_spanset_span()
  */
-inline bool
+bool
 right_spanset_span(const SpanSet *ss, const Span *s)
 {
   return left_span_spanset(s, ss);
@@ -569,7 +569,7 @@ right_spanset_span(const SpanSet *ss, const Span *s)
  * @param[in] ss1,ss2 Span sets
  * @csqlfn #Right_spanset_spanset()
  */
-inline bool
+bool
 right_spanset_spanset(const SpanSet *ss1, const SpanSet *ss2)
 {
   return left_spanset_spanset(ss2, ss1);
@@ -585,7 +585,7 @@ right_spanset_spanset(const SpanSet *ss1, const SpanSet *ss2)
  * @param[in] ss Span set
  * @param[in] value Value
  */
-inline bool
+bool
 overleft_spanset_value(const SpanSet *ss, Datum value)
 {
   assert(ss);
@@ -1024,7 +1024,7 @@ intersection_spanset_span(const SpanSet *ss, const Span *s)
  * @param[in] ss Span set
  * @csqlfn #Intersection_span_spanset()
  */
-inline SpanSet *
+SpanSet *
 intersection_span_spanset(const Span *s, const SpanSet *ss)
 {
   return intersection_spanset_span(ss, s);

--- a/meos/src/temporal/tbox.c
+++ b/meos/src/temporal/tbox.c
@@ -249,7 +249,7 @@ number_timestamptz_to_tbox(Datum value, MeosType basetype, TimestampTz t)
  * @param[in] t Timestamp
  * @csqlfn #Number_timestamptz_to_tbox()
  */
-inline TBox *
+TBox *
 int_timestamptz_to_tbox(int i, TimestampTz t)
 {
   return number_timestamptz_to_tbox(Int32GetDatum(i), T_INT4, t);
@@ -262,7 +262,7 @@ int_timestamptz_to_tbox(int i, TimestampTz t)
  * @param[in] t Timestamp
  * @csqlfn #Number_timestamptz_to_tbox()
  */
-inline TBox *
+TBox *
 float_timestamptz_to_tbox(double d, TimestampTz t)
 {
   return number_timestamptz_to_tbox(Float8GetDatum(d), T_FLOAT8, t);
@@ -1368,7 +1368,7 @@ contains_tbox_tbox(const TBox *box1, const TBox *box2)
  * @param[in] box1,box2 Temporal boxes
  * @csqlfn #Contained_tbox_tbox()
  */
-inline bool
+bool
 contained_tbox_tbox(const TBox *box1, const TBox *box2)
 {
   return contains_tbox_tbox(box2, box1);
@@ -1714,7 +1714,7 @@ tbox_eq(const TBox *box1, const TBox *box2)
  * @param[in] box1,box2 Temporal boxes
  * @csqlfn #Tbox_ne()
  */
-inline bool
+bool
 tbox_ne(const TBox *box1, const TBox *box2)
 {
   return ! tbox_eq(box1, box2);
@@ -1766,7 +1766,7 @@ tbox_cmp(const TBox *box1, const TBox *box2)
  * @param[in] box1,box2 Temporal boxes
  * @csqlfn #Tbox_lt()
  */
-inline bool
+bool
 tbox_lt(const TBox *box1, const TBox *box2)
 {
   return tbox_cmp(box1, box2) < 0;
@@ -1779,7 +1779,7 @@ tbox_lt(const TBox *box1, const TBox *box2)
  * @param[in] box1,box2 Temporal boxes
  * @csqlfn #Tbox_le()
  */
-inline bool
+bool
 tbox_le(const TBox *box1, const TBox *box2)
 {
   return tbox_cmp(box1, box2) <= 0;
@@ -1792,7 +1792,7 @@ tbox_le(const TBox *box1, const TBox *box2)
  * @param[in] box1,box2 Temporal boxes
  * @csqlfn #Tbox_ge()
  */
-inline bool
+bool
 tbox_ge(const TBox *box1, const TBox *box2)
 {
   int cmp = tbox_cmp(box1, box2);
@@ -1805,7 +1805,7 @@ tbox_ge(const TBox *box1, const TBox *box2)
  * @param[in] box1,box2 Temporal boxes
  * @csqlfn #Tbox_gt()
  */
-inline bool
+bool
 tbox_gt(const TBox *box1, const TBox *box2)
 {
   return tbox_cmp(box1, box2) > 0;

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -3379,7 +3379,7 @@ temporal_eq(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal values
  * @csqlfn #Temporal_ne()
  */
-inline bool
+bool
 temporal_ne(const Temporal *temp1, const Temporal *temp2)
 {
   return ! temporal_eq(temp1, temp2);
@@ -3469,7 +3469,7 @@ temporal_cmp(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal values
  * @csqlfn #Temporal_lt()
  */
-inline bool
+bool
 temporal_lt(const Temporal *temp1, const Temporal *temp2)
 {
   return temporal_cmp(temp1, temp2) < 0;
@@ -3482,7 +3482,7 @@ temporal_lt(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal values
  * @csqlfn #Temporal_le()
  */
-inline bool
+bool
 temporal_le(const Temporal *temp1, const Temporal *temp2)
 {
   return temporal_cmp(temp1, temp2) <= 0;
@@ -3495,7 +3495,7 @@ temporal_le(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal values
  * @csqlfn #Temporal_gt()
  */
-inline bool
+bool
 temporal_ge(const Temporal *temp1, const Temporal *temp2)
 {
   return temporal_cmp(temp1, temp2) >= 0;
@@ -3507,7 +3507,7 @@ temporal_ge(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp1,temp2 Temporal values
  * @csqlfn #Temporal_ge()
  */
-inline bool
+bool
 temporal_gt(const Temporal *temp1, const Temporal *temp2)
 {
   return temporal_cmp(temp1, temp2) > 0;

--- a/meos/src/temporal/temporal_tile.c
+++ b/meos/src/temporal/temporal_tile.c
@@ -206,7 +206,7 @@ float_get_bin(double value, double size, double origin)
 /**
  * @brief Return the interval in the same representation as Postgres timestamps
  */
-inline int64
+int64
 interval_units(const Interval *interval)
 {
   return interval->time + (interval->day * USECS_PER_DAY);

--- a/meos/src/temporal/tinstant.c
+++ b/meos/src/temporal/tinstant.c
@@ -170,7 +170,7 @@ tinstant_to_string(const TInstant *inst, int maxdd, outfunc value_out)
  * @param[in] inst Temporal instant
  * @param[in] maxdd Maximum number of decimal digits
  */
-inline char *
+char *
 tinstant_out(const TInstant *inst, int maxdd)
 {
   return tinstant_to_string(inst, maxdd, &basetype_out);

--- a/meos/src/temporal/tsequence.c
+++ b/meos/src/temporal/tsequence.c
@@ -1075,7 +1075,7 @@ tsequence_make(TInstant **instants, int count, bool lower_inc, bool upper_inc,
  * @param[in] normalize True if the resulting value should be normalized
  * @see #tsequence_make
  */
-inline TSequence *
+TSequence *
 tsequence_make_free(TInstant **instants, int count, bool lower_inc,
   bool upper_inc, interpType interp, bool normalize)
 {
@@ -2472,7 +2472,7 @@ intersection_tcontseq_tdiscseq(const TSequence *seq1, const TSequence *seq2,
  * @param[out] inter1,inter2 Output values
  * @return Return false if the input values do not overlap on time.
  */
-inline bool
+bool
 intersection_tdiscseq_tcontseq(const TSequence *seq1, const TSequence *seq2,
   TSequence **inter1, TSequence **inter2)
 {
@@ -2734,7 +2734,7 @@ intersection_tsequence_tinstant(const TSequence *seq, const TInstant *inst,
  * @param[out] inter1, inter2 Output values
  * @return Return false if the input values do not overlap on time.
  */
-inline bool
+bool
 intersection_tinstant_tsequence(const TInstant *inst, const TSequence *seq,
   TInstant **inter1, TInstant **inter2)
 {

--- a/meos/src/temporal/tsequence_meos.c
+++ b/meos/src/temporal/tsequence_meos.c
@@ -69,7 +69,7 @@
  * @param[in] str String
  * @param[in] interp Interpolation
  */
-inline TSequence *
+TSequence *
 tboolseq_in(const char *str, interpType interp)
 {
   return tsequence_in(str, T_TBOOL, interp);
@@ -82,7 +82,7 @@ tboolseq_in(const char *str, interpType interp)
  * @param[in] str String
  * @param[in] interp Interpolation
  */
-inline TSequence *
+TSequence *
 tintseq_in(const char *str, interpType interp)
 {
   return tsequence_in(str, T_TINT, interp);
@@ -95,7 +95,7 @@ tintseq_in(const char *str, interpType interp)
  * @param[in] str String
  * @param[in] interp Interpolation
  */
-inline TSequence *
+TSequence *
 tfloatseq_in(const char *str, interpType interp)
 {
   return tsequence_in(str, T_TFLOAT, interp);
@@ -108,7 +108,7 @@ tfloatseq_in(const char *str, interpType interp)
  * @param[in] str String
  * @param[in] interp Interpolation
  */
-inline TSequence *
+TSequence *
 ttextseq_in(const char *str, interpType interp)
 {
   return tsequence_in(str, T_TTEXT, interp);

--- a/meos/src/temporal/type_in_meos.c
+++ b/meos/src/temporal/type_in_meos.c
@@ -57,7 +57,7 @@
  * @param[in] mfjson MFJSON object
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TInstant *
+TInstant *
 tboolinst_from_mfjson(json_object *mfjson)
 {
   return tinstant_from_mfjson(mfjson, false, 0, T_TBOOL);
@@ -69,7 +69,7 @@ tboolinst_from_mfjson(json_object *mfjson)
  * @param[in] mfjson MFJSON object
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TInstant *
+TInstant *
 tintinst_from_mfjson(json_object *mfjson)
 {
   return tinstant_from_mfjson(mfjson, false, 0, T_TINT);
@@ -81,7 +81,7 @@ tintinst_from_mfjson(json_object *mfjson)
  * @param[in] mfjson MFJSON object
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TInstant *
+TInstant *
 tfloatinst_from_mfjson(json_object *mfjson)
 {
   return tinstant_from_mfjson(mfjson, false, 0, T_TFLOAT);
@@ -93,7 +93,7 @@ tfloatinst_from_mfjson(json_object *mfjson)
  * @param[in] mfjson MFJSON object
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TInstant *
+TInstant *
 ttextinst_from_mfjson(json_object *mfjson)
 {
   return tinstant_from_mfjson(mfjson, false, 0, T_TTEXT);
@@ -107,7 +107,7 @@ ttextinst_from_mfjson(json_object *mfjson)
  * @param[in] mfjson MFJSON object
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequence *
+TSequence *
 tboolseq_from_mfjson(json_object *mfjson)
 {
   return tsequence_from_mfjson(mfjson, false, 0, T_TBOOL, STEP);
@@ -119,7 +119,7 @@ tboolseq_from_mfjson(json_object *mfjson)
  * @param[in] mfjson MFJSON object
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequence *
+TSequence *
 tintseq_from_mfjson(json_object *mfjson)
 {
   return tsequence_from_mfjson(mfjson, false, 0, T_TINT, STEP);
@@ -132,7 +132,7 @@ tintseq_from_mfjson(json_object *mfjson)
  * @param[in] interp Interpolation
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequence *
+TSequence *
 tfloatseq_from_mfjson(json_object *mfjson, interpType interp)
 {
   return tsequence_from_mfjson(mfjson, false, 0, T_TFLOAT, interp);
@@ -144,7 +144,7 @@ tfloatseq_from_mfjson(json_object *mfjson, interpType interp)
  * @param[in] mfjson MFJSON object
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequence *
+TSequence *
 ttextseq_from_mfjson(json_object *mfjson)
 {
   return tsequence_from_mfjson(mfjson, false, 0, T_TTEXT, STEP);
@@ -159,7 +159,7 @@ ttextseq_from_mfjson(json_object *mfjson)
  * @param[in] mfjson MFJSON object
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequenceSet *
+TSequenceSet *
 tboolseqset_from_mfjson(json_object *mfjson)
 {
   return tsequenceset_from_mfjson(mfjson, false, 0, T_TBOOL, STEP);
@@ -172,7 +172,7 @@ tboolseqset_from_mfjson(json_object *mfjson)
  * @param[in] mfjson MFJSON object
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequenceSet *
+TSequenceSet *
 tintseqset_from_mfjson(json_object *mfjson)
 {
   return tsequenceset_from_mfjson(mfjson, false, 0, T_TINT, STEP);
@@ -185,7 +185,7 @@ tintseqset_from_mfjson(json_object *mfjson)
  * @param[in] interp Interpolation
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequenceSet *
+TSequenceSet *
 tfloatseqset_from_mfjson(json_object *mfjson, interpType interp)
 {
   return tsequenceset_from_mfjson(mfjson, false, 0, T_TFLOAT, interp);
@@ -197,7 +197,7 @@ tfloatseqset_from_mfjson(json_object *mfjson, interpType interp)
  * @param[in] mfjson MFJSON object
  * @csqlfn #Temporal_from_mfjson()
  */
-inline TSequenceSet *
+TSequenceSet *
 ttextseqset_from_mfjson(json_object *mfjson)
 {
   return tsequenceset_from_mfjson(mfjson, false, 0, T_TTEXT, STEP);
@@ -212,7 +212,7 @@ ttextseqset_from_mfjson(json_object *mfjson)
  * @return On error return @p NULL
  * @see #temporal_from_mfjson()
  */
-inline Temporal *
+Temporal *
 tbool_from_mfjson(const char *mfjson)
 {
   return temporal_from_mfjson(mfjson, T_TBOOL);
@@ -225,7 +225,7 @@ tbool_from_mfjson(const char *mfjson)
  * @return On error return @p NULL
  * @see #temporal_from_mfjson()
  */
-inline Temporal *
+Temporal *
 tint_from_mfjson(const char *mfjson)
 {
   return temporal_from_mfjson(mfjson, T_TINT);

--- a/meos/test/threaded_geos_test.c
+++ b/meos/test/threaded_geos_test.c
@@ -1,0 +1,229 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2026, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Concurrent stress test combining the GEOS spatial-relationship
+ * surface, WKT parsing of temporal points, WKB roundtrip, temporal
+ * accessors, and per-thread geometry distance calls.
+ *
+ * Each worker thread independently runs the full lifecycle:
+ *   meos_initialize() →
+ *   parse a unique polygon + point pair and a unique tgeompoint trajectory →
+ *   hot loop:
+ *     geom_intersects2d / geom_contains / geom_covers / geom_distance2d
+ *       on the polygon/point pair (per-thread GEOS context handle),
+ *     tgeompoint_in WKT parse (lwgeom flex/bison TLS state),
+ *     temporal_as_wkb + temporal_from_wkb roundtrip (binary IO path),
+ *     temporal_num_instants / temporal_start_instant accessors,
+ *     tpoint_trajectory extracts the polyline (exercises the temporal →
+ *       GEOS conversion path),
+ *     meos_errno round-trip (thread-local errno) →
+ *   meos_finalize()
+ *
+ * Verifies that the per-thread GEOS context handle, lwgeom WKT/parser
+ * state, GMT bootstrap, GSL state, and meos_errno are all isolated:
+ * any sharing between worker threads would produce inconsistent results
+ * or a SIGSEGV.
+ *
+ * Build (Linux, after `cmake --install` to a prefix):
+ * @code
+ * gcc -Wall -g -O2 -I<prefix>/include -pthread \
+ *     -o threaded_geos_test threaded_geos_test.c -L<prefix>/lib -lmeos
+ * ./threaded_geos_test 16 20000   # 16 threads, 20000 iterations each
+ * @endcode
+ */
+
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <meos.h>
+#include <meos_geo.h>
+
+typedef struct
+{
+  int id;
+  int iters;
+  atomic_int errors;
+} worker_arg;
+
+static void *
+worker(void *arg)
+{
+  worker_arg *w = (worker_arg *) arg;
+
+  meos_initialize();
+  meos_initialize_timezone("UTC");
+
+  /* A unique polygon per thread; a point that is always inside it. */
+  char poly_wkt[256];
+  char point_wkt[256];
+  double base = (double) w->id;
+  snprintf(poly_wkt, sizeof(poly_wkt),
+    "POLYGON((%.1f %.1f,%.1f %.1f,%.1f %.1f,%.1f %.1f,%.1f %.1f))",
+    base, base, base + 10.0, base, base + 10.0, base + 10.0,
+    base, base + 10.0, base, base);
+  snprintf(point_wkt, sizeof(point_wkt),
+    "POINT(%.1f %.1f)", base + 5.0, base + 5.0);
+
+  GSERIALIZED *poly = geom_in(poly_wkt, -1);
+  GSERIALIZED *pt = geom_in(point_wkt, -1);
+  if (! poly || ! pt)
+  {
+    atomic_fetch_add(&w->errors, 1);
+    meos_finalize();
+    return NULL;
+  }
+
+  /* Per-thread tgeompoint WKT (unique coordinates by thread id). */
+  char tgeo_wkt[256];
+
+  for (int i = 0; i < w->iters; i++)
+  {
+    /* GEOS spatial-rel surface: every call dispatches through the
+     * per-thread GEOSContextHandle_t. */
+    if (! geom_intersects2d(poly, pt))
+      atomic_fetch_add(&w->errors, 1);
+    if (! geom_intersects2d(pt, poly))
+      atomic_fetch_add(&w->errors, 1);
+    if (! geom_contains(poly, pt))
+      atomic_fetch_add(&w->errors, 1);
+    if (! geom_covers(poly, pt))
+      atomic_fetch_add(&w->errors, 1);
+    if (geom_distance2d(poly, pt) != 0.0)
+      atomic_fetch_add(&w->errors, 1);
+
+    /* WKT parse + WKB roundtrip on a unique tgeompoint trajectory.
+     * The coordinates depend on i so each iteration parses a distinct
+     * string — the lwgeom flex/bison parser state must be per-thread for
+     * this to work concurrently. */
+    snprintf(tgeo_wkt, sizeof(tgeo_wkt),
+      "[POINT(%.3f %.3f)@2024-01-01, POINT(%.3f %.3f)@2024-01-02]",
+      base + 0.001 * i, base + 0.001 * i,
+      base + 0.001 * i + 1.0, base + 0.001 * i + 1.0);
+    Temporal *t = tgeompoint_in(tgeo_wkt);
+    if (! t)
+    {
+      atomic_fetch_add(&w->errors, 1);
+      continue;
+    }
+
+    /* Binary IO roundtrip exercises the WKB encoder/decoder paths and
+     * the GMT timezone bootstrap on first call per thread. */
+    size_t wkb_size = 0;
+    uint8_t *wkb = temporal_as_wkb(t, 0, &wkb_size);
+    if (! wkb || wkb_size == 0)
+      atomic_fetch_add(&w->errors, 1);
+    else
+    {
+      Temporal *t2 = temporal_from_wkb(wkb, wkb_size);
+      if (! t2 || temporal_num_instants(t2) != 2)
+        atomic_fetch_add(&w->errors, 1);
+      free(t2);
+      free(wkb);
+    }
+
+    /* Temporal → GEOS conversion path: tpoint_trajectory builds a
+     * GEOSGeometry from the temporal value, then converts back to
+     * GSERIALIZED. */
+    GSERIALIZED *traj = tpoint_trajectory(t, false);
+    if (! traj)
+      atomic_fetch_add(&w->errors, 1);
+    else
+    {
+      /* The trajectory must intersect itself. */
+      if (! geom_intersects2d(traj, traj))
+        atomic_fetch_add(&w->errors, 1);
+      free(traj);
+    }
+
+    free(t);
+
+    /* Per-thread errno marker. */
+    int marker = w->id * 1000003 + i;
+    meos_errno_set(marker);
+    if (meos_errno() != marker)
+      atomic_fetch_add(&w->errors, 1);
+    meos_errno_reset();
+  }
+
+  free(poly);
+  free(pt);
+  meos_finalize();
+  return NULL;
+}
+
+int
+main(int argc, char **argv)
+{
+  int nthreads = (argc > 1) ? atoi(argv[1]) : 4;
+  int iters = (argc > 2) ? atoi(argv[2]) : 1000;
+
+  if (nthreads <= 0 || iters <= 0)
+  {
+    fprintf(stderr, "Usage: %s <nthreads> <iters>\n", argv[0]);
+    return 2;
+  }
+
+  pthread_t *tids = calloc((size_t) nthreads, sizeof(pthread_t));
+  worker_arg *args = calloc((size_t) nthreads, sizeof(worker_arg));
+  if (! tids || ! args)
+  {
+    fprintf(stderr, "alloc failed\n");
+    return 2;
+  }
+
+  for (int i = 0; i < nthreads; i++)
+  {
+    args[i].id = i;
+    args[i].iters = iters;
+    atomic_init(&args[i].errors, 0);
+    if (pthread_create(&tids[i], NULL, worker, &args[i]) != 0)
+    {
+      fprintf(stderr, "pthread_create failed for thread %d\n", i);
+      return 2;
+    }
+  }
+
+  int total_errors = 0;
+  for (int i = 0; i < nthreads; i++)
+  {
+    pthread_join(tids[i], NULL);
+    total_errors += atomic_load(&args[i].errors);
+  }
+
+  free(tids);
+  free(args);
+
+  printf("threaded_geos_test: %d threads x %d iters, %d errors\n",
+    nthreads, iters, total_errors);
+  return total_errors == 0 ? 0 : 1;
+}

--- a/postgis/liblwgeom/lwgeom_geos.c
+++ b/postgis/liblwgeom/lwgeom_geos.c
@@ -76,6 +76,38 @@ lwgeom_geos_error_minversion(const char *functionality, const char *minver)
 	);
 }
 
+/* MEOS: per-thread GEOS context.
+ *
+ * liblwgeom calls GEOS through a thread-local context handle obtained
+ * from lwgeom_geos_context() and uses the reentrant GEOSXxx_r API.
+ * Each thread owns its handle, so concurrent callers do not share GEOS
+ * state.  Handlers are wired to lwnotice / lwgeom_geos_error on first
+ * acquisition; lwgeom_geos_finalize() releases the handle.
+ */
+/* MEOS */ static __thread GEOSContextHandle_t LWGEOM_GEOS_CTX = NULL;
+
+/* MEOS */ GEOSContextHandle_t
+/* MEOS */ lwgeom_geos_context(void)
+/* MEOS */ {
+/* MEOS */ 	if (! LWGEOM_GEOS_CTX)
+/* MEOS */ 	{
+/* MEOS */ 		LWGEOM_GEOS_CTX = GEOS_init_r();
+/* MEOS */ 		GEOSContext_setNoticeHandler_r(LWGEOM_GEOS_CTX, lwnotice);
+/* MEOS */ 		GEOSContext_setErrorHandler_r(LWGEOM_GEOS_CTX, lwgeom_geos_error);
+/* MEOS */ 	}
+/* MEOS */ 	return LWGEOM_GEOS_CTX;
+/* MEOS */ }
+
+/* MEOS */ void
+/* MEOS */ lwgeom_geos_finalize(void)
+/* MEOS */ {
+/* MEOS */ 	if (LWGEOM_GEOS_CTX)
+/* MEOS */ 	{
+/* MEOS */ 		GEOS_finish_r(LWGEOM_GEOS_CTX);
+/* MEOS */ 		LWGEOM_GEOS_CTX = NULL;
+/* MEOS */ 	}
+/* MEOS */ }
+
 /* Destroy any non-null GEOSGeometry* pointers passed as arguments */
 #define GEOS_FREE(...) \
 do { \
@@ -118,6 +150,7 @@ do { \
 /* Free any non-null GEOSGeometry* pointers passed as arguments *
  * Called by GEOS_FREE, which populates 'count' */
 static void geos_destroy(size_t count, ...) {
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 	va_list ap;
 	va_start(ap, count);
 	while (count--)
@@ -125,7 +158,7 @@ static void geos_destroy(size_t count, ...) {
 		GEOSGeometry* g = va_arg(ap, GEOSGeometry*);
 		if (g)
 		{
-			GEOSGeom_destroy(g);
+			GEOSGeom_destroy_r(ctx, g);
 		}
 	}
 	va_end(ap);
@@ -143,6 +176,7 @@ static void geos_destroy(size_t count, ...) {
 POINTARRAY*
 ptarray_from_GEOSCoordSeq(const GEOSCoordSequence* cs, uint8_t want3d)
 {
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 	uint32_t dims = 2;
 	POINTARRAY* pa;
 	uint32_t size = 0;
@@ -153,13 +187,13 @@ ptarray_from_GEOSCoordSeq(const GEOSCoordSequence* cs, uint8_t want3d)
 
 	LWDEBUG(2, "ptarray_fromGEOSCoordSeq called");
 
-	if (!GEOSCoordSeq_getSize(cs, &size)) lwerror("Exception thrown");
+	if (!GEOSCoordSeq_getSize_r(ctx, cs, &size)) lwerror("Exception thrown");
 
 	LWDEBUGF(4, " GEOSCoordSeq size: %d", size);
 
 	if (want3d)
 	{
-		if (!GEOSCoordSeq_getDimensions(cs, &dims)) lwerror("Exception thrown");
+		if (!GEOSCoordSeq_getDimensions_r(ctx, cs, &dims)) lwerror("Exception thrown");
 
 		LWDEBUGF(4, " GEOSCoordSeq dimensions: %d", dims);
 
@@ -171,15 +205,15 @@ ptarray_from_GEOSCoordSeq(const GEOSCoordSequence* cs, uint8_t want3d)
 
 	pa = ptarray_construct((dims == 3), 0, size);
 #if POSTGIS_GEOS_VERSION >= 31000
-	GEOSCoordSeq_copyToBuffer(cs, (double*) pa->serialized_pointlist, (dims == 3), 0);
+	GEOSCoordSeq_copyToBuffer_r(ctx, cs, (double*) pa->serialized_pointlist, (dims == 3), 0);
 	return pa;
 #else
 	for (i = 0; i < size; i++)
 	{
 		if (dims >= 3)
-			GEOSCoordSeq_getXYZ(cs, i, &(point.x), &(point.y), &(point.z));
+			GEOSCoordSeq_getXYZ_r(ctx, cs, i, &(point.x), &(point.y), &(point.z));
 		else
-			GEOSCoordSeq_getXY(cs, i, &(point.x), &(point.y));
+			GEOSCoordSeq_getXY_r(ctx, cs, i, &(point.x), &(point.y));
 
 		ptarray_set_point4d(pa, i, &point);
 	}
@@ -192,13 +226,14 @@ ptarray_from_GEOSCoordSeq(const GEOSCoordSequence* cs, uint8_t want3d)
 LWGEOM*
 GEOS2LWGEOM(const GEOSGeometry* geom, uint8_t want3d)
 {
-	int type = GEOSGeomTypeId(geom);
-	int SRID = GEOSGetSRID(geom);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
+	int type = GEOSGeomTypeId_r(ctx, geom);
+	int SRID = GEOSGetSRID_r(ctx, geom);
 
 	/* GEOS's 0 is equivalent to our unknown as for SRID values */
 	if (SRID == 0) SRID = SRID_UNKNOWN;
 
-	if (want3d && !GEOSHasZ(geom))
+	if (want3d && !GEOSHasZ_r(ctx, geom))
 	{
 		LWDEBUG(3, "Geometry has no Z, won't provide one");
 		want3d = 0;
@@ -214,32 +249,32 @@ GEOS2LWGEOM(const GEOSGeometry* geom, uint8_t want3d)
 
 	case GEOS_POINT:
 		LWDEBUG(4, "lwgeom_from_geometry: it's a Point");
-		cs = GEOSGeom_getCoordSeq(geom);
-		if (GEOSisEmpty(geom)) return (LWGEOM*)lwpoint_construct_empty(SRID, want3d, 0);
+		cs = GEOSGeom_getCoordSeq_r(ctx, geom);
+		if (GEOSisEmpty_r(ctx, geom)) return (LWGEOM*)lwpoint_construct_empty(SRID, want3d, 0);
 		pa = ptarray_from_GEOSCoordSeq(cs, want3d);
 		return (LWGEOM*)lwpoint_construct(SRID, NULL, pa);
 
 	case GEOS_LINESTRING:
 	case GEOS_LINEARRING:
 		LWDEBUG(4, "lwgeom_from_geometry: it's a LineString or LinearRing");
-		if (GEOSisEmpty(geom)) return (LWGEOM*)lwline_construct_empty(SRID, want3d, 0);
+		if (GEOSisEmpty_r(ctx, geom)) return (LWGEOM*)lwline_construct_empty(SRID, want3d, 0);
 
-		cs = GEOSGeom_getCoordSeq(geom);
+		cs = GEOSGeom_getCoordSeq_r(ctx, geom);
 		pa = ptarray_from_GEOSCoordSeq(cs, want3d);
 		return (LWGEOM*)lwline_construct(SRID, NULL, pa);
 
 	case GEOS_POLYGON:
 		LWDEBUG(4, "lwgeom_from_geometry: it's a Polygon");
-		if (GEOSisEmpty(geom)) return (LWGEOM*)lwpoly_construct_empty(SRID, want3d, 0);
-		ngeoms = GEOSGetNumInteriorRings(geom);
+		if (GEOSisEmpty_r(ctx, geom)) return (LWGEOM*)lwpoly_construct_empty(SRID, want3d, 0);
+		ngeoms = GEOSGetNumInteriorRings_r(ctx, geom);
 		ppaa = lwalloc(sizeof(POINTARRAY*) * (ngeoms + 1));
-		g = GEOSGetExteriorRing(geom);
-		cs = GEOSGeom_getCoordSeq(g);
+		g = GEOSGetExteriorRing_r(ctx, geom);
+		cs = GEOSGeom_getCoordSeq_r(ctx, g);
 		ppaa[0] = ptarray_from_GEOSCoordSeq(cs, want3d);
 		for (i = 0; i < ngeoms; i++)
 		{
-			g = GEOSGetInteriorRingN(geom, i);
-			cs = GEOSGeom_getCoordSeq(g);
+			g = GEOSGetInteriorRingN_r(ctx, geom, i);
+			cs = GEOSGeom_getCoordSeq_r(ctx, g);
 			ppaa[i + 1] = ptarray_from_GEOSCoordSeq(cs, want3d);
 		}
 		return (LWGEOM*)lwpoly_construct(SRID, NULL, ngeoms + 1, ppaa);
@@ -250,14 +285,14 @@ GEOS2LWGEOM(const GEOSGeometry* geom, uint8_t want3d)
 	case GEOS_GEOMETRYCOLLECTION:
 		LWDEBUG(4, "lwgeom_from_geometry: it's a Collection or Multi");
 
-		ngeoms = GEOSGetNumGeometries(geom);
+		ngeoms = GEOSGetNumGeometries_r(ctx, geom);
 		geoms = NULL;
 		if (ngeoms)
 		{
 			geoms = lwalloc(sizeof(LWGEOM*) * ngeoms);
 			for (i = 0; i < ngeoms; i++)
 			{
-				g = GEOSGetGeometryN(geom, i);
+				g = GEOSGetGeometryN_r(ctx, geom, i);
 				geoms[i] = GEOS2LWGEOM(g, want3d);
 			}
 		}
@@ -274,6 +309,7 @@ GEOSCoordSeq ptarray_to_GEOSCoordSeq(const POINTARRAY*, uint8_t fix_ring);
 GEOSCoordSeq
 ptarray_to_GEOSCoordSeq(const POINTARRAY* pa, uint8_t fix_ring)
 {
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 	uint32_t dims = 2;
 	uint32_t i;
 	int append_points = 0;
@@ -299,7 +335,7 @@ ptarray_to_GEOSCoordSeq(const POINTARRAY* pa, uint8_t fix_ring)
 
 #if POSTGIS_GEOS_VERSION >= 31000
 	if (append_points == 0) {
-		sq = GEOSCoordSeq_copyFromBuffer((const double*) pa->serialized_pointlist, pa->npoints, FLAGS_GET_Z(pa->flags), FLAGS_GET_M(pa->flags));
+		sq = GEOSCoordSeq_copyFromBuffer_r(ctx, (const double*) pa->serialized_pointlist, pa->npoints, FLAGS_GET_Z(pa->flags), FLAGS_GET_M(pa->flags));
 		if (!sq)
 		{
 			GEOS_FAIL();
@@ -307,7 +343,7 @@ ptarray_to_GEOSCoordSeq(const POINTARRAY* pa, uint8_t fix_ring)
 		return sq;
 	}
 #endif
-	if (!(sq = GEOSCoordSeq_create(pa->npoints + append_points, dims)))
+	if (!(sq = GEOSCoordSeq_create_r(ctx, pa->npoints + append_points, dims)))
 	{
 		GEOS_FAIL();
 	}
@@ -327,9 +363,9 @@ ptarray_to_GEOSCoordSeq(const POINTARRAY* pa, uint8_t fix_ring)
 		}
 
 		if (dims == 3)
-			GEOSCoordSeq_setXYZ(sq, i, p2d->x, p2d->y, p3d->z);
+			GEOSCoordSeq_setXYZ_r(ctx, sq, i, p2d->x, p2d->y, p3d->z);
 		else
-			GEOSCoordSeq_setXY(sq, i, p2d->x, p2d->y);
+			GEOSCoordSeq_setXY_r(ctx, sq, i, p2d->x, p2d->y);
 
 	}
 
@@ -345,9 +381,9 @@ ptarray_to_GEOSCoordSeq(const POINTARRAY* pa, uint8_t fix_ring)
 		for (i = pa->npoints; i < pa->npoints + append_points; i++)
 		{
 
-			GEOSCoordSeq_setXY(sq, i, p2d->x, p2d->y);
+			GEOSCoordSeq_setXY_r(ctx, sq, i, p2d->x, p2d->y);
 
-			if (dims == 3) GEOSCoordSeq_setZ(sq, i, p3d->z);
+			if (dims == 3) GEOSCoordSeq_setZ_r(ctx, sq, i, p3d->z);
 		}
 	}
 
@@ -358,38 +394,40 @@ ptarray_to_GEOSCoordSeq(const POINTARRAY* pa, uint8_t fix_ring)
 static inline GEOSGeometry*
 ptarray_to_GEOSLinearRing(const POINTARRAY* pa, uint8_t autofix)
 {
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 	GEOSCoordSeq sq;
 	GEOSGeom g;
 	sq = ptarray_to_GEOSCoordSeq(pa, autofix);
-	g = GEOSGeom_createLinearRing(sq);
+	g = GEOSGeom_createLinearRing_r(ctx, sq);
 	return g;
 }
 
 GEOSGeometry*
 GBOX2GEOS(const GBOX* box)
 {
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 	GEOSGeometry* envelope;
 	GEOSGeometry* ring;
-	GEOSCoordSequence* seq = GEOSCoordSeq_create(5, 2);
+	GEOSCoordSequence* seq = GEOSCoordSeq_create_r(ctx, 5, 2);
 	if (!seq) return NULL;
 
-	GEOSCoordSeq_setXY(seq, 0, box->xmin, box->ymin);
-	GEOSCoordSeq_setXY(seq, 1, box->xmax, box->ymin);
-	GEOSCoordSeq_setXY(seq, 2, box->xmax, box->ymax);
-	GEOSCoordSeq_setXY(seq, 3, box->xmin, box->ymax);
-	GEOSCoordSeq_setXY(seq, 4, box->xmin, box->ymin);
+	GEOSCoordSeq_setXY_r(ctx, seq, 0, box->xmin, box->ymin);
+	GEOSCoordSeq_setXY_r(ctx, seq, 1, box->xmax, box->ymin);
+	GEOSCoordSeq_setXY_r(ctx, seq, 2, box->xmax, box->ymax);
+	GEOSCoordSeq_setXY_r(ctx, seq, 3, box->xmin, box->ymax);
+	GEOSCoordSeq_setXY_r(ctx, seq, 4, box->xmin, box->ymin);
 
-	ring = GEOSGeom_createLinearRing(seq);
+	ring = GEOSGeom_createLinearRing_r(ctx, seq);
 	if (!ring)
 	{
-		GEOSCoordSeq_destroy(seq);
+		GEOSCoordSeq_destroy_r(ctx, seq);
 		return NULL;
 	}
 
-	envelope = GEOSGeom_createPolygon(ring, NULL, 0);
+	envelope = GEOSGeom_createPolygon_r(ctx, ring, NULL, 0);
 	if (!envelope)
 	{
-		GEOSGeom_destroy(ring);
+		GEOSGeom_destroy_r(ctx, ring);
 		return NULL;
 	}
 
@@ -399,6 +437,7 @@ GBOX2GEOS(const GBOX* box)
 GEOSGeometry*
 LWGEOM2GEOS(const LWGEOM* lwgeom, uint8_t autofix)
 {
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 	GEOSCoordSeq sq;
 	GEOSGeom g, shell;
 	GEOSGeom* geoms = NULL;
@@ -432,19 +471,19 @@ LWGEOM2GEOS(const LWGEOM* lwgeom, uint8_t autofix)
 		case POINTTYPE:
 		{
 			if (is_empty)
-				g = GEOSGeom_createEmptyPoint();
+				g = GEOSGeom_createEmptyPoint_r(ctx);
 			else
 			{
 				LWPOINT* lwp = (LWPOINT*)lwgeom;
 				if (lwgeom_has_z(lwgeom))
 				{
 					sq = ptarray_to_GEOSCoordSeq(lwp->point, 0);
-					g = GEOSGeom_createPoint(sq);
+					g = GEOSGeom_createPoint_r(ctx, sq);
 				}
 				else
 				{
 					const POINT2D* p = getPoint2d_cp(lwp->point, 0);
-					g = GEOSGeom_createPointFromXY(p->x, p->y);
+					g = GEOSGeom_createPointFromXY_r(ctx, p->x, p->y);
 				}
 			}
 			if (!g) return NULL;
@@ -454,7 +493,7 @@ LWGEOM2GEOS(const LWGEOM* lwgeom, uint8_t autofix)
 		case LINETYPE:
 		{
 			if (is_empty)
-				g = GEOSGeom_createEmptyLineString();
+				g = GEOSGeom_createEmptyLineString_r(ctx);
 			else
 			{
 				LWLINE* lwl = (LWLINE*)lwgeom;
@@ -468,7 +507,7 @@ LWGEOM2GEOS(const LWGEOM* lwgeom, uint8_t autofix)
 								       lwl->points->npoints);
 				}
 				sq = ptarray_to_GEOSCoordSeq(lwl->points, 0);
-				g = GEOSGeom_createLineString(sq);
+				g = GEOSGeom_createLineString_r(ctx, sq);
 			}
 			if (!g) return NULL;
 			break;
@@ -478,7 +517,7 @@ LWGEOM2GEOS(const LWGEOM* lwgeom, uint8_t autofix)
 		{
 			LWPOLY* lwpoly = (LWPOLY*)lwgeom;
 			if (is_empty)
-				g = GEOSGeom_createEmptyPolygon();
+				g = GEOSGeom_createEmptyPolygon_r(ctx);
 			else
 			{
 				shell = ptarray_to_GEOSLinearRing(lwpoly->rings[0], autofix);
@@ -493,13 +532,13 @@ LWGEOM2GEOS(const LWGEOM* lwgeom, uint8_t autofix)
 					{
 						uint32_t k;
 						for (k = 0; k < i - 1; k++)
-							GEOSGeom_destroy(geoms[k]);
+							GEOSGeom_destroy_r(ctx, geoms[k]);
 						lwfree(geoms);
-						GEOSGeom_destroy(shell);
+						GEOSGeom_destroy_r(ctx, shell);
 						return NULL;
 					}
 				}
-				g = GEOSGeom_createPolygon(shell, geoms, ngeoms);
+				g = GEOSGeom_createPolygon_r(ctx, shell, geoms, ngeoms);
 				if (geoms) lwfree(geoms);
 			}
 			if (!g) return NULL;
@@ -509,13 +548,13 @@ LWGEOM2GEOS(const LWGEOM* lwgeom, uint8_t autofix)
 		case TRIANGLETYPE:
 		{
 			if (is_empty)
-				g = GEOSGeom_createEmptyPolygon();
+				g = GEOSGeom_createEmptyPolygon_r(ctx);
 			else
 			{
 				LWTRIANGLE *lwt = (LWTRIANGLE *)lwgeom;
 				shell = ptarray_to_GEOSLinearRing(lwt->points, autofix);
 				if (!shell) return NULL;
-				g = GEOSGeom_createPolygon(shell, NULL, 0);
+				g = GEOSGeom_createPolygon_r(ctx, shell, NULL, 0);
 			}
 			if (!g) return NULL;
 			break;
@@ -553,13 +592,13 @@ LWGEOM2GEOS(const LWGEOM* lwgeom, uint8_t autofix)
 				{
 					uint32_t k;
 					for (k = 0; k < j; k++)
-						GEOSGeom_destroy(geoms[k]);
+						GEOSGeom_destroy_r(ctx, geoms[k]);
 					lwfree(geoms);
 					return NULL;
 				}
 				geoms[j++] = g;
 			}
-			g = GEOSGeom_createCollection(geostype, geoms, j);
+			g = GEOSGeom_createCollection_r(ctx, geostype, geoms, j);
 			if (ngeoms > 0) lwfree(geoms);
 			if (!g) return NULL;
 			break;
@@ -572,12 +611,12 @@ LWGEOM2GEOS(const LWGEOM* lwgeom, uint8_t autofix)
 		}
 	}
 
-	GEOSSetSRID(g, lwgeom->srid);
+	GEOSSetSRID_r(ctx, g, lwgeom->srid);
 
 #if LWDEBUG_LEVEL >= 4
-	wkt = GEOSGeomToWKT(g);
+	wkt = GEOSGeomToWKT_r(ctx, g);
 	LWDEBUGF(4, "LWGEOM2GEOS: GEOSGeom: %s", wkt);
-	GEOSFree(wkt);
+	GEOSFree_r(ctx, wkt);
 #endif
 
 	return g;
@@ -586,31 +625,33 @@ LWGEOM2GEOS(const LWGEOM* lwgeom, uint8_t autofix)
 GEOSGeometry*
 make_geos_point(double x, double y)
 {
-	GEOSCoordSequence* seq = GEOSCoordSeq_create(1, 2);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
+	GEOSCoordSequence* seq = GEOSCoordSeq_create_r(ctx, 1, 2);
 	GEOSGeometry* geom = NULL;
 
 	if (!seq) return NULL;
 
-	GEOSCoordSeq_setXY(seq, 0, x, y);
+	GEOSCoordSeq_setXY_r(ctx, seq, 0, x, y);
 
-	geom = GEOSGeom_createPoint(seq);
-	if (!geom) GEOSCoordSeq_destroy(seq);
+	geom = GEOSGeom_createPoint_r(ctx, seq);
+	if (!geom) GEOSCoordSeq_destroy_r(ctx, seq);
 	return geom;
 }
 
 GEOSGeometry*
 make_geos_segment(double x1, double y1, double x2, double y2)
 {
-	GEOSCoordSequence* seq = GEOSCoordSeq_create(2, 2);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
+	GEOSCoordSequence* seq = GEOSCoordSeq_create_r(ctx, 2, 2);
 	GEOSGeometry* geom = NULL;
 
 	if (!seq) return NULL;
 
-	GEOSCoordSeq_setXY(seq, 0, x1, y1);
-	GEOSCoordSeq_setXY(seq, 1, x2, y2);
+	GEOSCoordSeq_setXY_r(ctx, seq, 0, x1, y1);
+	GEOSCoordSeq_setXY_r(ctx, seq, 1, x2, y2);
 
-	geom = GEOSGeom_createLineString(seq);
-	if (!geom) GEOSCoordSeq_destroy(seq);
+	geom = GEOSGeom_createLineString_r(ctx, seq);
+	if (!geom) GEOSCoordSeq_destroy_r(ctx, seq);
 	return geom;
 }
 
@@ -667,17 +708,16 @@ lwgeom_normalize(const LWGEOM* geom)
 
 	if (srid == SRID_INVALID) return NULL;
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 
 	if (!(g = LWGEOM2GEOS(geom, AUTOFIX))) GEOS_FAIL();
 
-	if (GEOSNormalize(g) == -1) GEOS_FREE_AND_FAIL(g);
-	GEOSSetSRID(g, srid);
+	if (GEOSNormalize_r(ctx, g) == -1) GEOS_FREE_AND_FAIL(g);
+	GEOSSetSRID_r(ctx, g, srid);
 
 	if (!(result = GEOS2LWGEOM(g, is3d))) GEOS_FREE_AND_FAIL(g);
 
-	GEOSGeom_destroy(g);
-  finishGEOS(); // MEOS remove memory leak
+	GEOSGeom_destroy_r(ctx, g);
 	return result;
 }
 
@@ -705,7 +745,7 @@ lwgeom_intersection_prec(const LWGEOM* geom1, const LWGEOM* geom2, double prec)
 	/* Empty.Intersection(A) == Empty */
 	if (lwgeom_is_empty(geom1)) return lwgeom_clone_deep(geom1); /* match empty type? */
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 
 	if (!(g1 = LWGEOM2GEOS(geom1, AUTOFIX))) GEOS_FAIL();
 	if (!(g2 = LWGEOM2GEOS(geom2, AUTOFIX))) GEOS_FREE_AND_FAIL(g1);
@@ -714,24 +754,22 @@ lwgeom_intersection_prec(const LWGEOM* geom1, const LWGEOM* geom2, double prec)
 #if POSTGIS_GEOS_VERSION < 30900
 		lwgeom_geos_error_minversion("Fixed-precision intersection", "3.9");
 		GEOS_FREE_AND_FAIL(g1, g2);
-		finishGEOS(); // MEOS remove memory leak
 		return NULL;
 #else
-		g3 = GEOSIntersectionPrec(g1, g2, prec);
+		g3 = GEOSIntersectionPrec_r(ctx, g1, g2, prec);
 #endif
 	}
 	else
 	{
-		g3 = GEOSIntersection(g1, g2);
+		g3 = GEOSIntersection_r(ctx, g1, g2);
 	}
 
 	if (!g3) GEOS_FREE_AND_FAIL(g1, g2);
-	GEOSSetSRID(g3, srid);
+	GEOSSetSRID_r(ctx, g3, srid);
 
 	if (!(result = GEOS2LWGEOM(g3, is3d))) GEOS_FREE_AND_FAIL(g1, g2, g3);
 
 	GEOS_FREE(g1, g2, g3);
-	finishGEOS(); // MEOS remove memory leak
 	return result;
 }
 
@@ -755,7 +793,7 @@ lwgeom_linemerge_directed(const LWGEOM* geom, int directed)
 	/* Empty.Linemerge() == Empty */
 	if (lwgeom_is_empty(geom)) return lwgeom_clone_deep(geom); /* match empty type to linestring? */
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 
 	if (!(g1 = LWGEOM2GEOS(geom, AUTOFIX))) GEOS_FAIL();
 
@@ -766,16 +804,16 @@ lwgeom_linemerge_directed(const LWGEOM* geom, int directed)
 		GEOS_FREE_AND_FAIL(g1);
 		return NULL;
 #else
-		g3 = GEOSLineMergeDirected(g1);
+		g3 = GEOSLineMergeDirected_r(ctx, g1);
 #endif
 	}
 	else
 	{
-		g3 = GEOSLineMerge(g1);
+		g3 = GEOSLineMerge_r(ctx, g1);
 	}
 
 	if (!g3) GEOS_FREE_AND_FAIL(g1);
-	GEOSSetSRID(g3, srid);
+	GEOSSetSRID_r(ctx, g3, srid);
 
 	if (!(result = GEOS2LWGEOM(g3, is3d)))
 		GEOS_FREE_AND_FAIL(g1, g3);
@@ -805,7 +843,7 @@ lwgeom_unaryunion_prec(const LWGEOM* geom, double prec)
 	/* Empty.UnaryUnion() == Empty */
 	if (lwgeom_is_empty(geom)) return lwgeom_clone_deep(geom);
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 
 	if (!(g1 = LWGEOM2GEOS(geom, AUTOFIX))) GEOS_FAIL();
 
@@ -813,25 +851,23 @@ lwgeom_unaryunion_prec(const LWGEOM* geom, double prec)
 #if POSTGIS_GEOS_VERSION < 30900
 		lwgeom_geos_error_minversion("Fixed-precision unary union", "3.9");
 		GEOS_FREE_AND_FAIL(g1);
-		finishGEOS(); // MEOS to remove memory leak
 		return NULL;
 #else
-		g3 = GEOSUnaryUnionPrec(g1, prec);
+		g3 = GEOSUnaryUnionPrec_r(ctx, g1, prec);
 #endif
 	}
 	else
 	{
-		g3 = GEOSUnaryUnion(g1);
+		g3 = GEOSUnaryUnion_r(ctx, g1);
 	}
 
 	if (!g3) GEOS_FREE_AND_FAIL(g1);
-	GEOSSetSRID(g3, srid);
+	GEOSSetSRID_r(ctx, g3, srid);
 
 	if (!(result = GEOS2LWGEOM(g3, is3d)))
 		GEOS_FREE_AND_FAIL(g1, g3);
 
 	GEOS_FREE(g1, g3);
-	finishGEOS(); // MEOS to remove memory leak
 
 	return result;
 }
@@ -858,7 +894,7 @@ lwgeom_difference_prec(const LWGEOM* geom1, const LWGEOM* geom2, double prec)
 	/* Empty.Intersection(A) == Empty */
 	if (lwgeom_is_empty(geom1)) return lwgeom_clone_deep(geom1); /* match empty type? */
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 
 	if (!(g1 = LWGEOM2GEOS(geom1, AUTOFIX))) GEOS_FAIL();
 	if (!(g2 = LWGEOM2GEOS(geom2, AUTOFIX))) GEOS_FREE_AND_FAIL(g1);
@@ -867,25 +903,23 @@ lwgeom_difference_prec(const LWGEOM* geom1, const LWGEOM* geom2, double prec)
 #if POSTGIS_GEOS_VERSION < 30900
 		lwgeom_geos_error_minversion("Fixed-precision difference", "3.9");
 		GEOS_FREE_AND_FAIL(g1, g2);
-		finishGEOS(); // MEOS remove memory leak
 		return NULL;
 #else
-		g3 = GEOSDifferencePrec(g1, g2, prec);
+		g3 = GEOSDifferencePrec_r(ctx, g1, g2, prec);
 #endif
 	}
 	else
 	{
-		g3 = GEOSDifference(g1, g2);
+		g3 = GEOSDifference_r(ctx, g1, g2);
 	}
 
 	if (!g3) GEOS_FREE_AND_FAIL(g1, g2);
-	GEOSSetSRID(g3, srid);
+	GEOSSetSRID_r(ctx, g3, srid);
 
 	if (!(result = GEOS2LWGEOM(g3, is3d)))
 		GEOS_FREE_AND_FAIL(g1, g2, g3);
 
 	GEOS_FREE(g1, g2, g3);
-	finishGEOS(); // MEOS remove memory leak
 	return result;
 }
 
@@ -911,7 +945,7 @@ lwgeom_symdifference_prec(const LWGEOM* geom1, const LWGEOM* geom2, double prec)
 	/* Empty.DymDifference(B) == B */
 	if (lwgeom_is_empty(geom1)) return lwgeom_clone_deep(geom2);
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 
 	if (!(g1 = LWGEOM2GEOS(geom1, AUTOFIX))) GEOS_FAIL();
 	if (!(g2 = LWGEOM2GEOS(geom2, AUTOFIX))) GEOS_FREE_AND_FAIL(g1);
@@ -920,25 +954,23 @@ lwgeom_symdifference_prec(const LWGEOM* geom1, const LWGEOM* geom2, double prec)
 #if POSTGIS_GEOS_VERSION < 30900
 		lwgeom_geos_error_minversion("Fixed-precision symdifference", "3.9");
 		GEOS_FREE_AND_FAIL(g1, g2);
-		finishGEOS(); // MEOS remove memory leak
 		return NULL;
 #else
-		g3 = GEOSSymDifferencePrec(g1, g2, prec);
+		g3 = GEOSSymDifferencePrec_r(ctx, g1, g2, prec);
 #endif
 	}
 	else
 	{
-		g3 = GEOSSymDifference(g1, g2);
+		g3 = GEOSSymDifference_r(ctx, g1, g2);
 	}
 
 	if (!g3) GEOS_FREE_AND_FAIL(g1, g2);
-	GEOSSetSRID(g3, srid);
+	GEOSSetSRID_r(ctx, g3, srid);
 
 	if (!(result = GEOS2LWGEOM(g3, is3d)))
 		GEOS_FREE_AND_FAIL(g1, g2, g3);
 
 	GEOS_FREE(g1, g2, g3);
-	finishGEOS(); // MEOS remove memory leak
 	return result;
 }
 
@@ -958,20 +990,19 @@ lwgeom_centroid(const LWGEOM* geom)
 		return lwpoint_as_lwgeom(lwp);
 	}
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 
 	if (!(g1 = LWGEOM2GEOS(geom, AUTOFIX))) GEOS_FAIL();
 
-	g3 = GEOSGetCentroid(g1);
+	g3 = GEOSGetCentroid_r(ctx, g1);
 
 	if (!g3) GEOS_FREE_AND_FAIL(g1);
-	GEOSSetSRID(g3, srid);
+	GEOSSetSRID_r(ctx, g3, srid);
 
 	if (!(result = GEOS2LWGEOM(g3, is3d)))
 		GEOS_FREE_AND_FAIL(g1);
 
 	GEOS_FREE(g1, g3);
-	finishGEOS(); // MEOS remove memory leak
 
 	return result;
 }
@@ -994,20 +1025,19 @@ lwgeom_reduceprecision(const LWGEOM* geom, double gridSize)
 	if (lwgeom_is_empty(geom))
 		return lwgeom_clone_deep(geom);
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 
 	if (!(g1 = LWGEOM2GEOS(geom, AUTOFIX))) GEOS_FAIL();
 
-	g3 = GEOSGeom_setPrecision(g1, gridSize, 0);
+	g3 = GEOSGeom_setPrecision_r(ctx, g1, gridSize, 0);
 
 	if (!g3) GEOS_FREE_AND_FAIL(g1);
-	GEOSSetSRID(g3, srid);
+	GEOSSetSRID_r(ctx, g3, srid);
 
 	if (!(result = GEOS2LWGEOM(g3, is3d)))
 		GEOS_FREE_AND_FAIL(g1);
 
 	GEOS_FREE(g1, g3);
-	finishGEOS(); // MEOS remove memory leak
 	return result;
 #endif
 }
@@ -1028,20 +1058,19 @@ lwgeom_pointonsurface(const LWGEOM *geom)
 		return lwpoint_as_lwgeom(lwp);
 	}
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 
 	if (!(g1 = LWGEOM2GEOS(geom, AUTOFIX))) GEOS_FAIL();
 
-	g3 = GEOSPointOnSurface(g1);
+	g3 = GEOSPointOnSurface_r(ctx, g1);
 
 	if (!g3) GEOS_FREE_AND_FAIL(g1);
-	GEOSSetSRID(g3, srid);
+	GEOSSetSRID_r(ctx, g3, srid);
 
 	if (!(result = GEOS2LWGEOM(g3, is3d)))
 		GEOS_FREE_AND_FAIL(g1, g3);
 
 	GEOS_FREE(g1, g3);
-	finishGEOS(); // MEOS remove memory leak
 	return result;
 }
 
@@ -1067,7 +1096,7 @@ lwgeom_union_prec(const LWGEOM* geom1, const LWGEOM* geom2, double gridSize)
 	/* B.Union(empty) == B */
 	if (lwgeom_is_empty(geom2)) return lwgeom_clone_deep(geom1);
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 
 	if (!(g1 = LWGEOM2GEOS(geom1, AUTOFIX))) GEOS_FAIL();
 	if (!(g2 = LWGEOM2GEOS(geom2, AUTOFIX))) GEOS_FREE_AND_FAIL(g1);
@@ -1076,25 +1105,23 @@ lwgeom_union_prec(const LWGEOM* geom1, const LWGEOM* geom2, double gridSize)
 #if POSTGIS_GEOS_VERSION < 30900
 		lwgeom_geos_error_minversion("Fixed-precision union", "3.9");
 		GEOS_FREE_AND_FAIL(g1, g2);
-		finishGEOS(); // MEOS remove memory leak
 		return NULL;
 #else
-		g3 = GEOSUnionPrec(g1, g2, gridSize);
+		g3 = GEOSUnionPrec_r(ctx, g1, g2, gridSize);
 #endif
 	}
 	else
 	{
-		g3 = GEOSUnion(g1, g2);
+		g3 = GEOSUnion_r(ctx, g1, g2);
 	}
 
 	if (!g3) GEOS_FREE_AND_FAIL(g1, g2);
-	GEOSSetSRID(g3, srid);
+	GEOSSetSRID_r(ctx, g3, srid);
 
 	if (!(result = GEOS2LWGEOM(g3, is3d)))
 		GEOS_FREE_AND_FAIL(g1, g2, g3);
 
 	GEOS_FREE(g1, g2, g3);
-	finishGEOS(); // MEOS remove memory leak
 	return result;
 }
 
@@ -1111,12 +1138,12 @@ lwgeom_clip_by_rect(const LWGEOM *geom1, double x1, double y1, double x2, double
 
 	is3d = FLAGS_GET_Z(geom1->flags);
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 
 	if (!(g1 = LWGEOM2GEOS(geom1, AUTOFIX)))
 		GEOS_FAIL_DEBUG();
 
-	if (!(g3 = GEOSClipByRect(g1, x1, y1, x2, y2)))
+	if (!(g3 = GEOSClipByRect_r(ctx, g1, x1, y1, x2, y2)))
 		GEOS_FREE_AND_FAIL_DEBUG(g1);
 
 	GEOS_FREE(g1);
@@ -1128,7 +1155,6 @@ lwgeom_clip_by_rect(const LWGEOM *geom1, double x1, double y1, double x2, double
 
 	result->srid = geom1->srid;
 
-	finishGEOS(); // MEOS remove memory leak
 	return result;
 }
 
@@ -1146,20 +1172,19 @@ lwgeom_buildarea(const LWGEOM* geom)
 	/* Can't build an area from an empty! */
 	if (lwgeom_is_empty(geom)) return (LWGEOM*)lwpoly_construct_empty(srid, is3d, 0);
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 
 	if (!(g1 = LWGEOM2GEOS(geom, AUTOFIX))) GEOS_FAIL();
 
-	g3 = GEOSBuildArea(g1);
+	g3 = GEOSBuildArea_r(ctx, g1);
 
 	if (!g3) GEOS_FREE_AND_FAIL(g1);
-	GEOSSetSRID(g3, srid);
+	GEOSSetSRID_r(ctx, g3, srid);
 
 	/* If no geometries are in result collection, return NULL */
-	if (GEOSGetNumGeometries(g3) == 0)
+	if (GEOSGetNumGeometries_r(ctx, g3) == 0)
 	{
 		GEOS_FREE(g1, g3);
-		finishGEOS(); // MEOS remove memory leak
 		return NULL;
 	}
 
@@ -1167,7 +1192,6 @@ lwgeom_buildarea(const LWGEOM* geom)
 		GEOS_FREE_AND_FAIL(g1, g3);
 
 	GEOS_FREE(g1, g3);
-	finishGEOS(); // MEOS remove memory leak
 
 	return result;
 }
@@ -1183,12 +1207,12 @@ lwgeom_is_simple(const LWGEOM* geom)
 	/* Empty is always simple */
 	if (lwgeom_is_empty(geom)) return LW_TRUE;
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 
 	if (!(g = LWGEOM2GEOS(geom, AUTOFIX))) return -1;
 
-	simple = GEOSisSimple(g);
-	GEOSGeom_destroy(g);
+	simple = GEOSisSimple_r(ctx, g);
+	GEOSGeom_destroy_r(ctx, g);
 
 	if (simple == 2) /* exception thrown */
 	{
@@ -1209,12 +1233,12 @@ lwgeom_geos_noop(const LWGEOM* geom)
 
 	if (srid == SRID_INVALID) return NULL;
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 
 	if (!(g = LWGEOM2GEOS(geom, AUTOFIX))) GEOS_FAIL();
 
 	if (!g) GEOS_FREE_AND_FAIL(g);
-	GEOSSetSRID(g, srid);
+	GEOSSetSRID_r(ctx, g, srid);
 
 	if (!(result = GEOS2LWGEOM(g, is3d)))
 		GEOS_FREE_AND_FAIL(g);
@@ -1234,15 +1258,15 @@ lwgeom_snap(const LWGEOM* geom1, const LWGEOM* geom2, double tolerance)
 
 	if (srid == SRID_INVALID) return NULL;
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 
 	if (!(g1 = LWGEOM2GEOS(geom1, AUTOFIX))) GEOS_FAIL();
 	if (!(g2 = LWGEOM2GEOS(geom2, AUTOFIX))) GEOS_FREE_AND_FAIL(g1);
 
-	g3 = GEOSSnap(g1, g2, tolerance);
+	g3 = GEOSSnap_r(ctx, g1, g2, tolerance);
 
 	if (!g3) GEOS_FREE_AND_FAIL(g1, g2);
-	GEOSSetSRID(g3, srid);
+	GEOSSetSRID_r(ctx, g3, srid);
 
 	if (!(result = GEOS2LWGEOM(g3, is3d)))
 		GEOS_FREE_AND_FAIL(g1, g2, g3);
@@ -1261,15 +1285,15 @@ lwgeom_sharedpaths(const LWGEOM* geom1, const LWGEOM* geom2)
 
 	if (srid == SRID_INVALID) return NULL;
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 
 	if (!(g1 = LWGEOM2GEOS(geom1, AUTOFIX))) GEOS_FAIL();
 	if (!(g2 = LWGEOM2GEOS(geom2, AUTOFIX))) GEOS_FREE_AND_FAIL(g1);
 
-	g3 = GEOSSharedPaths(g1, g2);
+	g3 = GEOSSharedPaths_r(ctx, g1, g2);
 
 	if (!g3) GEOS_FREE_AND_FAIL(g1, g2);
-	GEOSSetSRID(g3, srid);
+	GEOSSetSRID_r(ctx, g3, srid);
 
 	if (!(result = GEOS2LWGEOM(g3, is3d)))
 		GEOS_FREE_AND_FAIL(g1, g2, g3);
@@ -1289,11 +1313,11 @@ lwline_offsetcurve(const LWLINE *lwline, double size, int quadsegs, int joinStyl
 
 	if (srid == SRID_INVALID) return NULL;
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 
 	if (!(g1 = LWGEOM2GEOS(geom, AUTOFIX))) GEOS_FAIL();
 
-	g3 = GEOSOffsetCurve(g1, size, quadsegs, joinStyle, mitreLimit);
+	g3 = GEOSOffsetCurve_r(ctx, g1, size, quadsegs, joinStyle, mitreLimit);
 
 	if (!g3)
 	{
@@ -1301,7 +1325,7 @@ lwline_offsetcurve(const LWLINE *lwline, double size, int quadsegs, int joinStyl
 		return NULL;
 	}
 
-	GEOSSetSRID(g3, srid);
+	GEOSSetSRID_r(ctx, g3, srid);
 
 	if (!(result = GEOS2LWGEOM(g3, is3d)))
 		GEOS_FREE_AND_FAIL(g1, g3);
@@ -1417,13 +1441,14 @@ lwgeom_offsetcurve(const LWGEOM* geom, double size, int quadsegs, int joinStyle,
 static GEOSGeometry*
 lwpoly_to_points_make_cell(double xmin, double ymin, double cell_size)
 {
-	GEOSCoordSequence *cs = GEOSCoordSeq_create(5, 2);
-	GEOSCoordSeq_setXY(cs, 0, xmin, ymin);
-	GEOSCoordSeq_setXY(cs, 1, xmin + cell_size, ymin);
-	GEOSCoordSeq_setXY(cs, 2, xmin + cell_size, ymin + cell_size);
-	GEOSCoordSeq_setXY(cs, 3, xmin, ymin + cell_size);
-	GEOSCoordSeq_setXY(cs, 4, xmin, ymin);
-	return GEOSGeom_createPolygon(GEOSGeom_createLinearRing(cs), NULL, 0);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
+	GEOSCoordSequence *cs = GEOSCoordSeq_create_r(ctx, 5, 2);
+	GEOSCoordSeq_setXY_r(ctx, cs, 0, xmin, ymin);
+	GEOSCoordSeq_setXY_r(ctx, cs, 1, xmin + cell_size, ymin);
+	GEOSCoordSeq_setXY_r(ctx, cs, 2, xmin + cell_size, ymin + cell_size);
+	GEOSCoordSeq_setXY_r(ctx, cs, 3, xmin, ymin + cell_size);
+	GEOSCoordSeq_setXY_r(ctx, cs, 4, xmin, ymin);
+	return GEOSGeom_createPolygon_r(ctx, GEOSGeom_createLinearRing_r(ctx, cs), NULL, 0);
 }
 
 LWMPOINT*
@@ -1507,14 +1532,14 @@ lwpoly_to_points(const LWPOLY* lwpoly, uint32_t npoints, int32_t seed)
 	}
 
 	/* Prepare the polygon for fast true/false testing */
-	initGEOS(lwnotice, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 	g = (GEOSGeometry*)LWGEOM2GEOS(lwgeom, 0);
 	if (!g)
 	{
 		lwerror("%s: Geometry could not be converted to GEOS: %s", __func__, lwgeom_geos_errmsg);
 		return NULL;
 	}
-	gprep = GEOSPrepare(g);
+	gprep = GEOSPrepare_r(ctx, g);
 
 	/* START_PROFILING(); */
 
@@ -1532,12 +1557,12 @@ lwpoly_to_points(const LWPOLY* lwpoly, uint32_t npoints, int32_t seed)
 			double xmin = bbox.xmin + i * sample_cell_size;
 			double ymin = bbox.ymin + j * sample_cell_size;
 			GEOSGeometry *gcell = lwpoly_to_points_make_cell(xmin, ymin, sample_cell_size);
-			intersects = GEOSPreparedIntersects(gprep, gcell);
-			GEOSGeom_destroy(gcell);
+			intersects = GEOSPreparedIntersects_r(ctx, gprep, gcell);
+			GEOSGeom_destroy_r(ctx, gcell);
 			if (intersects == 2)
 			{
-				GEOSPreparedGeom_destroy(gprep);
-				GEOSGeom_destroy(g);
+				GEOSPreparedGeom_destroy_r(ctx, gprep);
+				GEOSGeom_destroy_r(ctx, g);
 				lwerror("%s: GEOS exception on GEOSPreparedIntersects: %s", __func__, lwgeom_geos_errmsg);
 				return NULL;
 			}
@@ -1589,21 +1614,21 @@ lwpoly_to_points(const LWPOLY* lwpoly, uint32_t npoints, int32_t seed)
 			if (x >= bbox.xmax || y >= bbox.ymax) continue;
 
 #if POSTGIS_GEOS_VERSION >= 31200
-			contains = GEOSPreparedIntersectsXY(gprep, x, y);
+			contains = GEOSPreparedIntersectsXY_r(ctx, gprep, x, y);
 #else
 			{
 				GEOSGeometry *gpt;
-				GEOSCoordSequence *gseq = GEOSCoordSeq_create(1, 2);;
-				GEOSCoordSeq_setXY(gseq, 0, x, y);
-				gpt = GEOSGeom_createPoint(gseq);
-				contains = GEOSPreparedIntersects(gprep, gpt);
-				GEOSGeom_destroy(gpt);
+				GEOSCoordSequence *gseq = GEOSCoordSeq_create_r(ctx, 1, 2);;
+				GEOSCoordSeq_setXY_r(ctx, gseq, 0, x, y);
+				gpt = GEOSGeom_createPoint_r(ctx, gseq);
+				contains = GEOSPreparedIntersects_r(ctx, gprep, gpt);
+				GEOSGeom_destroy_r(ctx, gpt);
 			}
 #endif
 			if (contains == 2)
 			{
-				GEOSPreparedGeom_destroy(gprep);
-				GEOSGeom_destroy(g);
+				GEOSPreparedGeom_destroy_r(ctx, gprep);
+				GEOSGeom_destroy_r(ctx, g);
 				lwerror("%s: GEOS exception on GEOSPreparedIntersects: %s", __func__, lwgeom_geos_errmsg);
 				return NULL;
 			}
@@ -1621,15 +1646,15 @@ lwpoly_to_points(const LWPOLY* lwpoly, uint32_t npoints, int32_t seed)
 			/* Short-circuit check for ctrl-c occasionally */
 			npoints_tested++;
 			if (npoints_tested % 10000 == 0)
-				LW_ON_INTERRUPT(GEOSPreparedGeom_destroy(gprep); GEOSGeom_destroy(g); return NULL);
+				LW_ON_INTERRUPT(GEOSPreparedGeom_destroy_r(ctx, gprep); GEOSGeom_destroy_r(ctx, g); return NULL);
 
 			if (done) break;
 		}
 		if (done || iterations > 100) break;
 	}
 
-	GEOSPreparedGeom_destroy(gprep);
-	GEOSGeom_destroy(g);
+	GEOSPreparedGeom_destroy_r(ctx, gprep);
+	GEOSGeom_destroy_r(ctx, g);
 	lwfree(cells);
 
 	return mpt;
@@ -1696,13 +1721,14 @@ lwgeom_to_points(const LWGEOM* lwgeom, uint32_t npoints, int32_t seed)
 LWTIN*
 lwtin_from_geos(const GEOSGeometry* geom, uint8_t want3d)
 {
-	int type = GEOSGeomTypeId(geom);
-	int SRID = GEOSGetSRID(geom);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
+	int type = GEOSGeomTypeId_r(ctx, geom);
+	int SRID = GEOSGetSRID_r(ctx, geom);
 
 	/* GEOS's 0 is equivalent to our unknown as for SRID values */
 	if (SRID == 0) SRID = SRID_UNKNOWN;
 
-	if (want3d && !GEOSHasZ(geom))
+	if (want3d && !GEOSHasZ_r(ctx, geom))
 	{
 		LWDEBUG(3, "Geometry has no Z, won't provide one");
 		want3d = 0;
@@ -1715,7 +1741,7 @@ lwtin_from_geos(const GEOSGeometry* geom, uint8_t want3d)
 	case GEOS_GEOMETRYCOLLECTION:
 		LWDEBUG(4, "lwgeom_from_geometry: it's a Collection or Multi");
 
-		ngeoms = GEOSGetNumGeometries(geom);
+		ngeoms = GEOSGetNumGeometries_r(ctx, geom);
 		geoms = NULL;
 		if (ngeoms)
 		{
@@ -1731,9 +1757,9 @@ lwtin_from_geos(const GEOSGeometry* geom, uint8_t want3d)
 				const GEOSCoordSequence* cs;
 				POINTARRAY* pa;
 
-				poly = GEOSGetGeometryN(geom, i);
-				ring = GEOSGetExteriorRing(poly);
-				cs = GEOSGeom_getCoordSeq(ring);
+				poly = GEOSGetGeometryN_r(ctx, geom, i);
+				ring = GEOSGetExteriorRing_r(ctx, poly);
+				cs = GEOSGeom_getCoordSeq_r(ctx, ring);
 				pa = ptarray_from_GEOSCoordSeq(cs, want3d);
 
 				geoms[i] = lwtriangle_construct(SRID, NULL, pa);
@@ -1777,15 +1803,15 @@ lwgeom_delaunay_triangulation(const LWGEOM* geom, double tolerance, int32_t outp
 
 	if (srid == SRID_INVALID) return NULL;
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 
 	if (!(g1 = LWGEOM2GEOS(geom, AUTOFIX))) GEOS_FAIL();
 
 	/* if output != 1 we want polys */
-	g3 = GEOSDelaunayTriangulation(g1, tolerance, output == 1);
+	g3 = GEOSDelaunayTriangulation_r(ctx, g1, tolerance, output == 1);
 
 	if (!g3) GEOS_FREE_AND_FAIL(g1);
-	GEOSSetSRID(g3, srid);
+	GEOSSetSRID_r(ctx, g3, srid);
 
 	if (output == 2)
 	{
@@ -1809,13 +1835,14 @@ lwgeom_delaunay_triangulation(const LWGEOM* geom, double tolerance, int32_t outp
 static GEOSCoordSequence*
 lwgeom_get_geos_coordseq_2d(const LWGEOM* g, uint32_t num_points)
 {
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 	uint32_t i = 0;
 	uint8_t num_dims = 2;
 	LWPOINTITERATOR* it;
 	GEOSCoordSequence* coords;
 	POINT4D tmp;
 
-	coords = GEOSCoordSeq_create(num_points, num_dims);
+	coords = GEOSCoordSeq_create_r(ctx, num_points, num_dims);
 	if (!coords) return NULL;
 
 	it = lwpointiterator_create(g);
@@ -1824,18 +1851,18 @@ lwgeom_get_geos_coordseq_2d(const LWGEOM* g, uint32_t num_points)
 		if (i >= num_points)
 		{
 			lwerror("Incorrect num_points provided to lwgeom_get_geos_coordseq_2d");
-			GEOSCoordSeq_destroy(coords);
+			GEOSCoordSeq_destroy_r(ctx, coords);
 			lwpointiterator_destroy(it);
 			return NULL;
 		}
 
 #if POSTGIS_GEOS_VERSION < 30800
-		if (!GEOSCoordSeq_setX(coords, i, tmp.x) || !GEOSCoordSeq_setY(coords, i, tmp.y))
+		if (!GEOSCoordSeq_setX_r(ctx, coords, i, tmp.x) || !GEOSCoordSeq_setY_r(ctx, coords, i, tmp.y))
 #else
-		if (!GEOSCoordSeq_setXY(coords, i, tmp.x, tmp.y))
+		if (!GEOSCoordSeq_setXY_r(ctx, coords, i, tmp.x, tmp.y))
 #endif
 		{
-			GEOSCoordSeq_destroy(coords);
+			GEOSCoordSeq_destroy_r(ctx, coords);
 			lwpointiterator_destroy(it);
 			return NULL;
 		}
@@ -1864,7 +1891,7 @@ lwgeom_voronoi_diagram(const LWGEOM* g, const GBOX* env, double tolerance, int o
 		return lwcollection_as_lwgeom(empty);
 	}
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 
 	/* Instead of using the standard LWGEOM2GEOS transformer, we read the vertices of the LWGEOM directly and put
 	 * them into a single GEOS CoordinateSeq that can be used to define a LineString.  This allows us to process
@@ -1873,19 +1900,19 @@ lwgeom_voronoi_diagram(const LWGEOM* g, const GBOX* env, double tolerance, int o
 	coords = lwgeom_get_geos_coordseq_2d(g, num_points);
 	if (!coords) return NULL;
 
-	geos_geom = GEOSGeom_createLineString(coords);
+	geos_geom = GEOSGeom_createLineString_r(ctx, coords);
 	if (!geos_geom)
 	{
-		GEOSCoordSeq_destroy(coords);
+		GEOSCoordSeq_destroy_r(ctx, coords);
 		return NULL;
 	}
 
 	if (env) geos_env = GBOX2GEOS(env);
 
-	geos_result = GEOSVoronoiDiagram(geos_geom, geos_env, tolerance, output_edges);
+	geos_result = GEOSVoronoiDiagram_r(ctx, geos_geom, geos_env, tolerance, output_edges);
 
-	GEOSGeom_destroy(geos_geom);
-	if (env) GEOSGeom_destroy(geos_env);
+	GEOSGeom_destroy_r(ctx, geos_geom);
+	if (env) GEOSGeom_destroy_r(ctx, geos_env);
 
 	if (!geos_result)
 	{
@@ -1894,7 +1921,7 @@ lwgeom_voronoi_diagram(const LWGEOM* g, const GBOX* env, double tolerance, int o
 	}
 
 	lwgeom_result = GEOS2LWGEOM(geos_result, is_3d);
-	GEOSGeom_destroy(geos_result);
+	GEOSGeom_destroy_r(ctx, geos_result);
 
 	lwgeom_set_srid(lwgeom_result, srid);
 
@@ -1912,23 +1939,23 @@ lwgeom_concavehull(const LWGEOM* geom, double ratio, uint32_t allow_holes)
 	GEOSGeometry *g1, *g3;
 	int geosGeomType;
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 
 	if (!(g1 = LWGEOM2GEOS(geom, AUTOFIX))) GEOS_FAIL();
 
-	geosGeomType = GEOSGeomTypeId(g1);
+	geosGeomType = GEOSGeomTypeId_r(ctx, g1);
 	if (geosGeomType == GEOS_POLYGON || geosGeomType == GEOS_MULTIPOLYGON) {
 		int is_tight = LW_FALSE;
-		g3 = GEOSConcaveHullOfPolygons(g1, ratio, is_tight, allow_holes);
+		g3 = GEOSConcaveHullOfPolygons_r(ctx, g1, ratio, is_tight, allow_holes);
 	}
 	else {
-		g3 = GEOSConcaveHull(g1, ratio, allow_holes);
+		g3 = GEOSConcaveHull_r(ctx, g1, ratio, allow_holes);
 	}
 
 	if (!g3)
 		GEOS_FREE_AND_FAIL(g1);
 
-	GEOSSetSRID(g3, srid);
+	GEOSSetSRID_r(ctx, g3, srid);
 
 	if (!(result = GEOS2LWGEOM(g3, is3d)))
 		GEOS_FREE_AND_FAIL(g1, g3);
@@ -1945,16 +1972,16 @@ lwgeom_simplify_polygonal(const LWGEOM* geom, double vertex_fraction, uint32_t i
 	uint8_t is3d = FLAGS_GET_Z(geom->flags);
 	GEOSGeometry *g1, *g3;
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 
 	if (!(g1 = LWGEOM2GEOS(geom, AUTOFIX))) GEOS_FAIL();
 
-	g3 = GEOSPolygonHullSimplify(g1, is_outer, vertex_fraction);
+	g3 = GEOSPolygonHullSimplify_r(ctx, g1, is_outer, vertex_fraction);
 
 	if (!g3)
 		GEOS_FREE_AND_FAIL(g1);
 
-	GEOSSetSRID(g3, srid);
+	GEOSSetSRID_r(ctx, g3, srid);
 
 	if (!(result = GEOS2LWGEOM(g3, is3d)))
 		GEOS_FREE_AND_FAIL(g1, g3);
@@ -1973,15 +2000,15 @@ lwgeom_triangulate_polygon(const LWGEOM* geom)
 
 	if (srid == SRID_INVALID) return NULL;
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 
 	if (!(g1 = LWGEOM2GEOS(geom, AUTOFIX))) GEOS_FAIL();
 
 	/* if output != 1 we want polys */
-	g3 = GEOSConstrainedDelaunayTriangulation(g1);
+	g3 = GEOSConstrainedDelaunayTriangulation_r(ctx, g1);
 
 	if (!g3) GEOS_FREE_AND_FAIL(g1);
-	GEOSSetSRID(g3, srid);
+	GEOSSetSRID_r(ctx, g3, srid);
 
 	if (!(result = GEOS2LWGEOM(g3, is3d)))
 		GEOS_FREE_AND_FAIL(g1, g3);

--- a/postgis/liblwgeom/lwgeom_geos.h
+++ b/postgis/liblwgeom/lwgeom_geos.h
@@ -52,6 +52,12 @@ POINTARRAY* ptarray_from_GEOSCoordSeq(const GEOSCoordSequence* cs, uint8_t want3
 extern char lwgeom_geos_errmsg[];
 extern void lwgeom_geos_error(const char* fmt, ...) __attribute__ ((format (printf, 1, 2)));
 
+/* MEOS: per-thread GEOS context.  Every liblwgeom GEOS helper retrieves the
+ * thread-local handle via lwgeom_geos_context() and uses the reentrant
+ * GEOSXxx_r API. */
+/* MEOS */ extern GEOSContextHandle_t lwgeom_geos_context(void);
+/* MEOS */ extern void lwgeom_geos_finalize(void);
+
 
 /*
  * Debug macros
@@ -60,15 +66,16 @@ extern void lwgeom_geos_error(const char* fmt, ...) __attribute__ ((format (prin
 
 /* Display a notice and a WKT representation of a geometry
  * at the given debug level */
-#define LWDEBUGGEOS(level, geom, msg) \
-  if (POSTGIS_DEBUG_LEVEL >= level) \
-  do { \
-		GEOSWKTWriter *wktwriter = GEOSWKTWriter_create(); \
-		char *wkt = GEOSWKTWriter_write(wktwriter, (geom)); \
-		LWDEBUGF(1, msg " (GEOS): %s", wkt); \
-		GEOSFree(wkt); \
-		GEOSWKTWriter_destroy(wktwriter); \
-  } while (0);
+/* MEOS */ #define LWDEBUGGEOS(level, geom, msg) \
+/* MEOS */   if (POSTGIS_DEBUG_LEVEL >= level) \
+/* MEOS */   do { \
+/* MEOS */ 		GEOSContextHandle_t _ctx = lwgeom_geos_context(); \
+/* MEOS */ 		GEOSWKTWriter *wktwriter = GEOSWKTWriter_create_r(_ctx); \
+/* MEOS */ 		char *wkt = GEOSWKTWriter_write_r(_ctx, wktwriter, (geom)); \
+/* MEOS */ 		LWDEBUGF(1, msg " (GEOS): %s", wkt); \
+/* MEOS */ 		GEOSFree_r(_ctx, wkt); \
+/* MEOS */ 		GEOSWKTWriter_destroy_r(_ctx, wktwriter); \
+/* MEOS */   } while (0);
 
 #else /* POSTGIS_DEBUG_LEVEL <= 0 */
 

--- a/postgis/liblwgeom/lwgeom_geos_clean.c
+++ b/postgis/liblwgeom/lwgeom_geos_clean.c
@@ -306,7 +306,7 @@ lwgeom_make_valid_params(LWGEOM* lwgeom_in, char* make_valid_params)
 	 *          otherwise (adding only duplicates of existing points)
 	 */
 
-	initGEOS(lwgeom_geos_error, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 
 	lwgeom_out = lwgeom_make_geos_friendly(lwgeom_in);
 	if (!lwgeom_out) lwerror("Could not make a geos friendly geometry out of input");
@@ -328,10 +328,10 @@ lwgeom_make_valid_params(LWGEOM* lwgeom_in, char* make_valid_params)
 	}
 
 #if POSTGIS_GEOS_VERSION < 31000
-	geosout = GEOSMakeValid(geosgeom);
+	geosout = GEOSMakeValid_r(ctx, geosgeom);
 #else
 	if (!make_valid_params) {
-		geosout = GEOSMakeValid(geosgeom);
+		geosout = GEOSMakeValid_r(ctx, geosgeom);
 	}
 	else {
 		/*
@@ -346,44 +346,44 @@ lwgeom_make_valid_params(LWGEOM* lwgeom_in, char* make_valid_params)
 		param_list_text[OPTION_LIST_SIZE-1] = '\0'; /* ensure null-termination */
 		memset(param_list, 0, sizeof(param_list));
 		option_list_parse(param_list_text, param_list);
-		GEOSMakeValidParams *params = GEOSMakeValidParams_create();
+		GEOSMakeValidParams *params = GEOSMakeValidParams_create_r(ctx);
 		value = option_list_search(param_list, "method");
 		if (value) {
 			if (strcasecmp(value, "linework") == 0) {
-				GEOSMakeValidParams_setMethod(params, GEOS_MAKE_VALID_LINEWORK);
+				GEOSMakeValidParams_setMethod_r(ctx, params, GEOS_MAKE_VALID_LINEWORK);
 			}
 			else if (strcasecmp(value, "structure") == 0) {
-				GEOSMakeValidParams_setMethod(params, GEOS_MAKE_VALID_STRUCTURE);
+				GEOSMakeValidParams_setMethod_r(ctx, params, GEOS_MAKE_VALID_STRUCTURE);
 			}
 			else
 			{
-				GEOSMakeValidParams_destroy(params);
+				GEOSMakeValidParams_destroy_r(ctx, params);
 				lwerror("Unsupported value for 'method', '%s'. Use 'linework' or 'structure'.", value);
 			}
 		}
 		value = option_list_search(param_list, "keepcollapsed");
 		if (value) {
 			if (strcasecmp(value, "true") == 0) {
-				GEOSMakeValidParams_setKeepCollapsed(params, 1);
+				GEOSMakeValidParams_setKeepCollapsed_r(ctx, params, 1);
 			}
 			else if (strcasecmp(value, "false") == 0) {
-				GEOSMakeValidParams_setKeepCollapsed(params, 0);
+				GEOSMakeValidParams_setKeepCollapsed_r(ctx, params, 0);
 			}
 			else
 			{
-				GEOSMakeValidParams_destroy(params);
+				GEOSMakeValidParams_destroy_r(ctx, params);
 				lwerror("Unsupported value for 'keepcollapsed', '%s'. Use 'true' or 'false'", value);
 			}
 		}
-		geosout = GEOSMakeValidWithParams(geosgeom, params);
-		GEOSMakeValidParams_destroy(params);
+		geosout = GEOSMakeValidWithParams_r(ctx, geosgeom, params);
+		GEOSMakeValidParams_destroy_r(ctx, params);
 	}
 #endif
-	GEOSGeom_destroy(geosgeom);
+	GEOSGeom_destroy_r(ctx, geosgeom);
 	if (!geosout) return NULL;
 
 	lwgeom_out = GEOS2LWGEOM(geosout, is3d);
-	GEOSGeom_destroy(geosout);
+	GEOSGeom_destroy_r(ctx, geosout);
 
 	if (lwgeom_is_collection(lwgeom_in) && !lwgeom_is_collection(lwgeom_out))
 	{

--- a/postgis/liblwgeom/lwgeom_geos_cluster.c
+++ b/postgis/liblwgeom/lwgeom_geos_cluster.c
@@ -59,8 +59,9 @@ static int combine_geometries(UNIONFIND* uf, void** geoms, uint32_t num_geoms, v
 static GEOSGeometry*
 geos_envelope_surrogate(const LWGEOM* g)
 {
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 	if (lwgeom_is_empty(g))
-		return GEOSGeom_createEmptyPolygon();
+		return GEOSGeom_createEmptyPolygon_r(ctx);
 
 	if (lwgeom_get_type(g) == POINTTYPE) {
 		const POINT2D* pt = getPoint2d_cp(lwgeom_as_lwpoint(g)->point, 0);
@@ -79,12 +80,13 @@ geos_envelope_surrogate(const LWGEOM* g)
 static struct STRTree
 make_strtree(void** geoms, uint32_t num_geoms, char is_lwgeom)
 {
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 	struct STRTree tree;
 	tree.envelopes = 0;
 	tree.num_geoms = 0;
 	tree.geom_ids = 0;
 
-	tree.tree = GEOSSTRtree_create(STRTREE_NODE_CAPACITY);
+	tree.tree = GEOSSTRtree_create_r(ctx, STRTREE_NODE_CAPACITY);
 	if (tree.tree == NULL)
 	{
 		return tree;
@@ -100,7 +102,7 @@ make_strtree(void** geoms, uint32_t num_geoms, char is_lwgeom)
 		{
 			tree.geom_ids[i] = i;
 			tree.envelopes[i] = geos_envelope_surrogate(geoms[i]);
-			GEOSSTRtree_insert(tree.tree, tree.envelopes[i], &(tree.geom_ids[i]));
+			GEOSSTRtree_insert_r(ctx, tree.tree, tree.envelopes[i], &(tree.geom_ids[i]));
 		}
 	}
 	else
@@ -110,7 +112,7 @@ make_strtree(void** geoms, uint32_t num_geoms, char is_lwgeom)
 		for (i = 0; i < num_geoms; i++)
 		{
 			tree.geom_ids[i] = i;
-			GEOSSTRtree_insert(tree.tree, geoms[i], &(tree.geom_ids[i]));
+			GEOSSTRtree_insert_r(ctx, tree.tree, geoms[i], &(tree.geom_ids[i]));
 		}
 	}
 
@@ -121,14 +123,15 @@ make_strtree(void** geoms, uint32_t num_geoms, char is_lwgeom)
 static void
 destroy_strtree(struct STRTree * tree)
 {
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 	size_t i;
-	GEOSSTRtree_destroy(tree->tree);
+	GEOSSTRtree_destroy_r(ctx, tree->tree);
 
 	if (tree->envelopes)
 	{
 		for (i = 0; i < tree->num_geoms; i++)
 		{
-			GEOSGeom_destroy(tree->envelopes[i]);
+			GEOSGeom_destroy_r(ctx, tree->envelopes[i]);
 		}
 		lwfree(tree->envelopes);
 	}
@@ -157,6 +160,7 @@ query_accumulate(void* item, void* userdata)
 int
 union_intersecting_pairs(GEOSGeometry** geoms, uint32_t num_geoms, UNIONFIND* uf)
 {
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 	uint32_t p, i;
 	struct STRTree tree;
 	struct QueryContext cxt =
@@ -181,11 +185,11 @@ union_intersecting_pairs(GEOSGeometry** geoms, uint32_t num_geoms, UNIONFIND* uf
 	{
 		const GEOSPreparedGeometry* prep = NULL;
 
-		if (!geoms[p] || GEOSisEmpty(geoms[p]))
+		if (!geoms[p] || GEOSisEmpty_r(ctx, geoms[p]))
 			continue;
 
 		cxt.num_items_found = 0;
-		GEOSSTRtree_query(tree.tree, geoms[p], &query_accumulate, &cxt);
+		GEOSSTRtree_query_r(ctx, tree.tree, geoms[p], &query_accumulate, &cxt);
 
 		for (i = 0; i < cxt.num_items_found; i++)
 		{
@@ -193,7 +197,7 @@ union_intersecting_pairs(GEOSGeometry** geoms, uint32_t num_geoms, UNIONFIND* uf
 
 			if (p != q && UF_find(uf, p) != UF_find(uf, q))
 			{
-				int geos_type = GEOSGeomTypeId(geoms[p]);
+				int geos_type = GEOSGeomTypeId_r(ctx, geoms[p]);
 				int geos_result;
 
 				/* Don't build prepared a geometry around a Point or MultiPoint -
@@ -205,13 +209,13 @@ union_intersecting_pairs(GEOSGeometry** geoms, uint32_t num_geoms, UNIONFIND* uf
 					/* Lazy initialize prepared geometry */
 					if (prep == NULL)
 					{
-						prep = GEOSPrepare(geoms[p]);
+						prep = GEOSPrepare_r(ctx, geoms[p]);
 					}
-					geos_result = GEOSPreparedIntersects(prep, geoms[q]);
+					geos_result = GEOSPreparedIntersects_r(ctx, prep, geoms[q]);
 				}
 				else
 				{
-					geos_result = GEOSIntersects(geoms[p], geoms[q]);
+					geos_result = GEOSIntersects_r(ctx, geoms[p], geoms[q]);
 				}
 				if (geos_result > 1)
 				{
@@ -226,7 +230,7 @@ union_intersecting_pairs(GEOSGeometry** geoms, uint32_t num_geoms, UNIONFIND* uf
 		}
 
 		if (prep)
-			GEOSPreparedGeom_destroy(prep);
+			GEOSPreparedGeom_destroy_r(ctx, prep);
 
 		if (!success)
 			break;
@@ -262,6 +266,7 @@ cluster_intersecting(GEOSGeometry** geoms, uint32_t num_geoms, GEOSGeometry*** c
 static int
 dbscan_update_context(GEOSSTRtree* tree, struct QueryContext* cxt, LWGEOM** geoms, uint32_t p, double eps)
 {
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 	cxt->num_items_found = 0;
 
 	GEOSGeometry* query_envelope;
@@ -280,9 +285,9 @@ dbscan_update_context(GEOSSTRtree* tree, struct QueryContext* cxt, LWGEOM** geom
 	if (!query_envelope)
 		return LW_FAILURE;
 
-	GEOSSTRtree_query(tree, query_envelope, &query_accumulate, cxt);
+	GEOSSTRtree_query_r(ctx, tree, query_envelope, &query_accumulate, cxt);
 
-	GEOSGeom_destroy(query_envelope);
+	GEOSGeom_destroy_r(ctx, query_envelope);
 
 	return LW_SUCCESS;
 }
@@ -559,6 +564,7 @@ cluster_within_distance(LWGEOM** geoms, uint32_t num_geoms, double tolerance, LW
 static int
 combine_geometries(UNIONFIND* uf, void** geoms, uint32_t num_geoms, void*** clusterGeoms, uint32_t* num_clusters, char is_lwgeom)
 {
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 	size_t i, j, k;
 
 	/* Combine components of each cluster into their own GeometryCollection */
@@ -588,9 +594,9 @@ combine_geometries(UNIONFIND* uf, void** geoms, uint32_t num_geoms, void*** clus
 			}
 			else
 			{
-				int srid = GEOSGetSRID(((GEOSGeometry**) geoms_in_cluster)[0]);
-				GEOSGeometry* combined = GEOSGeom_createCollection(GEOS_GEOMETRYCOLLECTION, (GEOSGeometry**) geoms_in_cluster, j);
-				GEOSSetSRID(combined, srid);
+				int srid = GEOSGetSRID_r(ctx, ((GEOSGeometry**) geoms_in_cluster)[0]);
+				GEOSGeometry* combined = GEOSGeom_createCollection_r(ctx, GEOS_GEOMETRYCOLLECTION, (GEOSGeometry**) geoms_in_cluster, j);
+				GEOSSetSRID_r(ctx, combined, srid);
 				(*clusterGeoms)[k++] = combined;
 			}
 			j = 0;

--- a/postgis/liblwgeom/lwgeom_geos_node.c
+++ b/postgis/liblwgeom/lwgeom_geos_node.c
@@ -93,11 +93,11 @@ lwgeom_extract_endpoints(const LWGEOM* lwg)
 	return col;
 }
 
-/* Assumes initGEOS was called already */
 /* May return LWPOINT or LWMPOINT */
 static LWGEOM*
 lwgeom_extract_unique_endpoints(const LWGEOM* lwg)
 {
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 	LWGEOM* ret;
 	GEOSGeometry *gepu;
 	LWMPOINT *epall = lwgeom_extract_endpoints(lwg);
@@ -110,16 +110,16 @@ lwgeom_extract_unique_endpoints(const LWGEOM* lwg)
 
 	/* UnaryUnion to remove duplicates */
 	/* TODO: do it all within pgis using indices */
-	gepu = GEOSUnaryUnion(gepall);
+	gepu = GEOSUnaryUnion_r(ctx, gepall);
 	if ( ! gepu ) {
-		GEOSGeom_destroy(gepall);
+		GEOSGeom_destroy_r(ctx, gepall);
 		lwerror("GEOSUnaryUnion: %s", lwgeom_geos_errmsg);
 		return NULL;
 	}
-	GEOSGeom_destroy(gepall);
+	GEOSGeom_destroy_r(ctx, gepall);
 
 	ret = GEOS2LWGEOM(gepu, FLAGS_GET_Z(lwg->flags));
-	GEOSGeom_destroy(gepu);
+	GEOSGeom_destroy_r(ctx, gepu);
 	if ( ! ret ) {
 		lwerror("Error during GEOS2LWGEOM");
 		return NULL;
@@ -143,7 +143,7 @@ lwgeom_node(const LWGEOM* lwgeom_in)
 		return NULL;
 	}
 
-	initGEOS(lwgeom_geos_error, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 	g1 = LWGEOM2GEOS(lwgeom_in, 1);
 	if ( ! g1 ) {
 		lwerror("LWGEOM2GEOS: %s", lwgeom_geos_errmsg);
@@ -152,13 +152,13 @@ lwgeom_node(const LWGEOM* lwgeom_in)
 
 	ep = lwgeom_extract_unique_endpoints(lwgeom_in);
 	if ( ! ep ) {
-		GEOSGeom_destroy(g1);
+		GEOSGeom_destroy_r(ctx, g1);
 		lwerror("Error extracting unique endpoints from input");
 		return NULL;
 	}
 
-	gn = GEOSNode(g1);
-	GEOSGeom_destroy(g1);
+	gn = GEOSNode_r(ctx, g1);
+	GEOSGeom_destroy_r(ctx, g1);
 	if ( ! gn ) {
 		lwgeom_free(ep);
 		lwerror("GEOSNode: %s", lwgeom_geos_errmsg);
@@ -166,11 +166,11 @@ lwgeom_node(const LWGEOM* lwgeom_in)
 	}
 	LWDEBUGGEOS(1, gn, "Noded");
 
-	nl = GEOSGetNumGeometries(gn);
+	nl = GEOSGetNumGeometries_r(ctx, gn);
 	if ( nl > 1 )
 	{
-		gm = GEOSLineMerge(gn);
-		GEOSGeom_destroy(gn);
+		gm = GEOSLineMerge_r(ctx, gn);
+		GEOSGeom_destroy_r(ctx, gn);
 		if ( ! gm ) {
 			lwgeom_free(ep);
 			lwerror("GEOSLineMerge: %s", lwgeom_geos_errmsg);
@@ -180,7 +180,7 @@ lwgeom_node(const LWGEOM* lwgeom_in)
 		gn = gm;
 
 		lines = GEOS2LWGEOM(gn, FLAGS_GET_Z(lwgeom_in->flags));
-		GEOSGeom_destroy(gn);
+		GEOSGeom_destroy_r(ctx, gn);
 		if ( ! lines ) {
 			lwgeom_free(ep);
 			lwerror("Error during GEOS2LWGEOM");
@@ -189,9 +189,9 @@ lwgeom_node(const LWGEOM* lwgeom_in)
 	}
 	else if ( nl == 1 )
 	{
-		const GEOSGeometry *gc = GEOSGetGeometryN(gn, 0);
+		const GEOSGeometry *gc = GEOSGetGeometryN_r(ctx, gn, 0);
 		lines = GEOS2LWGEOM(gc, FLAGS_GET_Z(lwgeom_in->flags));
-		GEOSGeom_destroy(gn);
+		GEOSGeom_destroy_r(ctx, gn);
 		if ( ! lines ) {
 			lwgeom_free(ep);
 			lwerror("Error during GEOS2LWGEOM");
@@ -202,7 +202,7 @@ lwgeom_node(const LWGEOM* lwgeom_in)
 	{
 		/* No geometries, don't bother with re-adding endpoints */
 		lines = GEOS2LWGEOM(gn, FLAGS_GET_Z(lwgeom_in->flags));
-		GEOSGeom_destroy(gn);
+		GEOSGeom_destroy_r(ctx, gn);
 		if ( ! lines ) {
 			lwgeom_free(ep);
 			lwerror("Error during GEOS2LWGEOM");

--- a/postgis/liblwgeom/lwgeom_geos_split.c
+++ b/postgis/liblwgeom/lwgeom_geos_split.c
@@ -64,7 +64,7 @@ lwline_split_by_line(const LWLINE* lwline_in, const LWGEOM* blade_in)
 	 *      -> Return a collection of all elements resulting from the split
 	 */
 
-	initGEOS(lwgeom_geos_error, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 
 	g1 = LWGEOM2GEOS((LWGEOM*)lwline_in, 0);
 	if ( ! g1 )
@@ -75,7 +75,7 @@ lwline_split_by_line(const LWLINE* lwline_in, const LWGEOM* blade_in)
 	g2 = LWGEOM2GEOS(blade_in, 0);
 	if ( ! g2 )
 	{
-		GEOSGeom_destroy(g1);
+		GEOSGeom_destroy_r(ctx, g1);
 		lwerror("LWGEOM2GEOS: %s", lwgeom_geos_errmsg);
 		return NULL;
 	}
@@ -83,11 +83,11 @@ lwline_split_by_line(const LWLINE* lwline_in, const LWGEOM* blade_in)
 	/* If blade is a polygon, pick its boundary */
 	if ( blade_in->type == POLYGONTYPE || blade_in->type == MULTIPOLYGONTYPE )
 	{
-		gdiff = GEOSBoundary(g2);
-		GEOSGeom_destroy(g2);
+		gdiff = GEOSBoundary_r(ctx, g2);
+		GEOSGeom_destroy_r(ctx, g2);
 		if ( ! gdiff )
 		{
-			GEOSGeom_destroy(g1);
+			GEOSGeom_destroy_r(ctx, g1);
 			lwerror("GEOSBoundary: %s", lwgeom_geos_errmsg);
 			return NULL;
 		}
@@ -95,26 +95,26 @@ lwline_split_by_line(const LWLINE* lwline_in, const LWGEOM* blade_in)
 	}
 
 	/* If interior intersection is linear we can't split */
-	ret = GEOSRelatePattern(g1, g2, "1********");
+	ret = GEOSRelatePattern_r(ctx, g1, g2, "1********");
 	if ( 2 == ret )
 	{
 		lwerror("GEOSRelatePattern: %s", lwgeom_geos_errmsg);
-		GEOSGeom_destroy(g1);
-		GEOSGeom_destroy(g2);
+		GEOSGeom_destroy_r(ctx, g1);
+		GEOSGeom_destroy_r(ctx, g2);
 		return NULL;
 	}
 	if ( ret )
 	{
-		GEOSGeom_destroy(g1);
-		GEOSGeom_destroy(g2);
+		GEOSGeom_destroy_r(ctx, g1);
+		GEOSGeom_destroy_r(ctx, g2);
 		lwerror("Splitter line has linear intersection with input");
 		return NULL;
 	}
 
 
-	gdiff = GEOSDifference(g1,g2);
-	GEOSGeom_destroy(g1);
-	GEOSGeom_destroy(g2);
+	gdiff = GEOSDifference_r(ctx, g1,g2);
+	GEOSGeom_destroy_r(ctx, g1);
+	GEOSGeom_destroy_r(ctx, g2);
 	if (gdiff == NULL)
 	{
 		lwerror("GEOSDifference: %s", lwgeom_geos_errmsg);
@@ -122,7 +122,7 @@ lwline_split_by_line(const LWLINE* lwline_in, const LWGEOM* blade_in)
 	}
 
 	diff = GEOS2LWGEOM(gdiff, FLAGS_GET_Z(lwline_in->flags));
-	GEOSGeom_destroy(gdiff);
+	GEOSGeom_destroy_r(ctx, gdiff);
 	if (NULL == diff)
 	{
 		lwerror("GEOS2LWGEOM: %s", lwgeom_geos_errmsg);
@@ -368,7 +368,7 @@ lwpoly_split_by_line(const LWPOLY* lwpoly_in, const LWGEOM* blade_in)
 	 *      -> Return a collection of all elements resulting from the split
 	 */
 
-	initGEOS(lwgeom_geos_error, lwgeom_geos_error);
+	GEOSContextHandle_t ctx = lwgeom_geos_context(); /* MEOS */
 
 	g1 = LWGEOM2GEOS((LWGEOM*)lwpoly_in, 0);
 	if ( NULL == g1 )
@@ -376,10 +376,10 @@ lwpoly_split_by_line(const LWPOLY* lwpoly_in, const LWGEOM* blade_in)
 		lwerror("LWGEOM2GEOS: %s", lwgeom_geos_errmsg);
 		return NULL;
 	}
-	g1_bounds = GEOSBoundary(g1);
+	g1_bounds = GEOSBoundary_r(ctx, g1);
 	if ( NULL == g1_bounds )
 	{
-		GEOSGeom_destroy(g1);
+		GEOSGeom_destroy_r(ctx, g1);
 		lwerror("GEOSBoundary: %s", lwgeom_geos_errmsg);
 		return NULL;
 	}
@@ -387,41 +387,41 @@ lwpoly_split_by_line(const LWPOLY* lwpoly_in, const LWGEOM* blade_in)
 	g2 = LWGEOM2GEOS(blade_in, 0);
 	if ( NULL == g2 )
 	{
-		GEOSGeom_destroy(g1);
-		GEOSGeom_destroy(g1_bounds);
+		GEOSGeom_destroy_r(ctx, g1);
+		GEOSGeom_destroy_r(ctx, g1_bounds);
 		lwerror("LWGEOM2GEOS: %s", lwgeom_geos_errmsg);
 		return NULL;
 	}
 
-	vgeoms[0] = GEOSUnion(g1_bounds, g2);
+	vgeoms[0] = GEOSUnion_r(ctx, g1_bounds, g2);
 	if ( NULL == vgeoms[0] )
 	{
-		GEOSGeom_destroy(g1);
-		GEOSGeom_destroy(g2);
-		GEOSGeom_destroy(g1_bounds);
+		GEOSGeom_destroy_r(ctx, g1);
+		GEOSGeom_destroy_r(ctx, g2);
+		GEOSGeom_destroy_r(ctx, g1_bounds);
 		lwerror("GEOSUnion: %s", lwgeom_geos_errmsg);
 		return NULL;
 	}
 
-	polygons = GEOSPolygonize(vgeoms, 1);
+	polygons = GEOSPolygonize_r(ctx, vgeoms, 1);
 	if ( NULL == polygons )
 	{
-		GEOSGeom_destroy(g1);
-		GEOSGeom_destroy(g2);
-		GEOSGeom_destroy(g1_bounds);
-		GEOSGeom_destroy((GEOSGeometry*)vgeoms[0]);
+		GEOSGeom_destroy_r(ctx, g1);
+		GEOSGeom_destroy_r(ctx, g2);
+		GEOSGeom_destroy_r(ctx, g1_bounds);
+		GEOSGeom_destroy_r(ctx, (GEOSGeometry*)vgeoms[0]);
 		lwerror("GEOSPolygonize: %s", lwgeom_geos_errmsg);
 		return NULL;
 	}
 
 #ifndef NDEBUG
-	if ( GEOSGeomTypeId(polygons) != COLLECTIONTYPE )
+	if ( GEOSGeomTypeId_r(ctx, polygons) != COLLECTIONTYPE )
 	{
-		GEOSGeom_destroy(g1);
-		GEOSGeom_destroy(g2);
-		GEOSGeom_destroy(g1_bounds);
-		GEOSGeom_destroy((GEOSGeometry*)vgeoms[0]);
-		GEOSGeom_destroy(polygons);
+		GEOSGeom_destroy_r(ctx, g1);
+		GEOSGeom_destroy_r(ctx, g2);
+		GEOSGeom_destroy_r(ctx, g1_bounds);
+		GEOSGeom_destroy_r(ctx, (GEOSGeometry*)vgeoms[0]);
+		GEOSGeom_destroy_r(ctx, polygons);
 		lwerror("%s [%d] Unexpected return from GEOSpolygonize", __FILE__, __LINE__);
 		return 0;
 	}
@@ -431,7 +431,7 @@ lwpoly_split_by_line(const LWPOLY* lwpoly_in, const LWGEOM* blade_in)
 	 * the ones which are in holes of the original
 	 * geometries and return the rest in a collection
 	 */
-	n = GEOSGetNumGeometries(polygons);
+	n = GEOSGetNumGeometries_r(ctx, polygons);
 	out = lwcollection_construct_empty(COLLECTIONTYPE, lwpoly_in->srid,
 				     hasZ, 0);
 	/* Allocate space for all polys */
@@ -440,35 +440,35 @@ lwpoly_split_by_line(const LWPOLY* lwpoly_in, const LWGEOM* blade_in)
 	for (i=0; i<n; ++i)
 	{
 		GEOSGeometry* pos; /* point on surface */
-		const GEOSGeometry* p = GEOSGetGeometryN(polygons, i);
+		const GEOSGeometry* p = GEOSGetGeometryN_r(ctx, polygons, i);
 		int contains;
 
-		pos = GEOSPointOnSurface(p);
+		pos = GEOSPointOnSurface_r(ctx, p);
 		if ( ! pos )
 		{
-			GEOSGeom_destroy(g1);
-			GEOSGeom_destroy(g2);
-			GEOSGeom_destroy(g1_bounds);
-			GEOSGeom_destroy((GEOSGeometry*)vgeoms[0]);
-			GEOSGeom_destroy(polygons);
+			GEOSGeom_destroy_r(ctx, g1);
+			GEOSGeom_destroy_r(ctx, g2);
+			GEOSGeom_destroy_r(ctx, g1_bounds);
+			GEOSGeom_destroy_r(ctx, (GEOSGeometry*)vgeoms[0]);
+			GEOSGeom_destroy_r(ctx, polygons);
 			lwerror("GEOSPointOnSurface: %s", lwgeom_geos_errmsg);
 			return NULL;
 		}
 
-		contains = GEOSContains(g1, pos);
+		contains = GEOSContains_r(ctx, g1, pos);
 		if ( 2 == contains )
 		{
-			GEOSGeom_destroy(g1);
-			GEOSGeom_destroy(g2);
-			GEOSGeom_destroy(g1_bounds);
-			GEOSGeom_destroy((GEOSGeometry*)vgeoms[0]);
-			GEOSGeom_destroy(polygons);
-			GEOSGeom_destroy(pos);
+			GEOSGeom_destroy_r(ctx, g1);
+			GEOSGeom_destroy_r(ctx, g2);
+			GEOSGeom_destroy_r(ctx, g1_bounds);
+			GEOSGeom_destroy_r(ctx, (GEOSGeometry*)vgeoms[0]);
+			GEOSGeom_destroy_r(ctx, polygons);
+			GEOSGeom_destroy_r(ctx, pos);
 			lwerror("GEOSContains: %s", lwgeom_geos_errmsg);
 			return NULL;
 		}
 
-		GEOSGeom_destroy(pos);
+		GEOSGeom_destroy_r(ctx, pos);
 
 		if ( 0 == contains )
 		{
@@ -481,11 +481,11 @@ lwpoly_split_by_line(const LWPOLY* lwpoly_in, const LWGEOM* blade_in)
 		out->geoms[out->ngeoms++] = GEOS2LWGEOM(p, hasZ);
 	}
 
-	GEOSGeom_destroy(g1);
-	GEOSGeom_destroy(g2);
-	GEOSGeom_destroy(g1_bounds);
-	GEOSGeom_destroy((GEOSGeometry*)vgeoms[0]);
-	GEOSGeom_destroy(polygons);
+	GEOSGeom_destroy_r(ctx, g1);
+	GEOSGeom_destroy_r(ctx, g2);
+	GEOSGeom_destroy_r(ctx, g1_bounds);
+	GEOSGeom_destroy_r(ctx, (GEOSGeometry*)vgeoms[0]);
+	GEOSGeom_destroy_r(ctx, polygons);
 
 	return (LWGEOM*)out;
 }


### PR DESCRIPTION
Routes every GEOS call through a thread-local GEOSContextHandle_t and uses the reentrant GEOSXxx_r API throughout. MEOS owns its handle in meos/src/temporal/meos.c (MEOS_GEOS_CONTEXT plus geos_initialize/geos_finalize/geos_get_context, wired into meos_initialize/meos_finalize alongside GSL and PROJ); vendored liblwgeom owns its handle in postgis/liblwgeom/lwgeom_geos.c (LWGEOM_GEOS_CTX plus lwgeom_geos_context/lwgeom_geos_finalize). MEOS spatial helpers in postgis_funcs.c, tgeo_spatialfuncs.c, and tpoint_spatialfuncs.c retrieve the context per thread; the meos_call_geos2 callback signature takes GEOSContextHandle_t as its first parameter. Adds meos_initialize_noexit_error_handler(), which installs an error path that logs to stderr and sets meos_errno without calling exit(), so a MEOS error inside a JVM does not tear down the host process. Validation: the new meos/test/threaded_geos_test runs 16 threads x 20000 iterations x 5 repeats (~19M GEOS calls) with zero errors and stable RSS; pg_regress full suite 136/136 pass; MobilitySpark BerlinMOD local[2] clean across Q1 to Q11, and local[4] Q2 measured at 44s (2.05x speedup vs local[2]). Supersedes #939.