### PR TITLE
Bootstrap MEOS locale safety with portable strtod_l

### DIFF
--- a/.github/workflows/meos_locale.yml
+++ b/.github/workflows/meos_locale.yml
@@ -1,0 +1,111 @@
+name: MEOS locale safety
+
+# Guards the MEOS locale contract (numeric I/O is always C-locale).
+#
+# This job:
+#   1. Builds the standalone MEOS C library on Linux.
+#   2. Installs a locale that uses ',' as the decimal separator
+#      (de_DE.UTF-8 — same shape as fr_FR, it_IT, es_ES, etc.).
+#   3. Sets LC_NUMERIC to that locale and runs a tiny C test that calls
+#      meos_initialize() and parses '[1.5@2001-01-01]' as a tfloat.
+#
+# The meos_strtod() wrapper pins numeric input to the C locale, so the
+# parse succeeds and the round-tripped value contains "1.5". A bare libc
+# strtod() would respect LC_NUMERIC and parse '.' as a thousands
+# separator, producing 15 and failing the test.
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/meos_locale.yml'
+      - 'cmake/**'
+      - 'meos/**'
+      - 'pgtypes/**'
+      - 'postgis/**'
+      - 'CMakeLists.txt'
+    branches-ignore:
+      - gh-pages
+  pull_request:
+    paths:
+      - '.github/workflows/meos_locale.yml'
+      - 'cmake/**'
+      - 'meos/**'
+      - 'pgtypes/**'
+      - 'postgis/**'
+      - 'CMakeLists.txt'
+    branches-ignore:
+      - gh-pages
+
+jobs:
+  meos-locale-smoke:
+    name: locale-smoke
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build deps and de_DE.UTF-8 locale
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake ninja-build \
+            libgeos++-dev libproj-dev libjson-c-dev libgsl-dev \
+            locales
+          sudo locale-gen de_DE.UTF-8
+          sudo update-locale
+          locale -a | grep -i de_DE
+
+      - name: Configure standalone MEOS
+        run: |
+          cmake -S . -B build-meos \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$PWD/meos-install" \
+            -DMEOS=ON \
+            -DCBUFFER=ON -DNPOINT=ON
+
+      - name: Build libmeos
+        run: cmake --build build-meos -j
+
+      - name: Install libmeos
+        run: cmake --install build-meos
+
+      - name: Compile locale smoke test
+        run: |
+          cat > /tmp/locale_smoke.c <<'EOF'
+          #include <stdio.h>
+          #include <stdlib.h>
+          #include <string.h>
+          #include <locale.h>
+          #include <meos.h>
+          int main(void) {
+            if (!setlocale(LC_NUMERIC, "de_DE.UTF-8")) {
+              fprintf(stderr, "FAIL: de_DE.UTF-8 not installed\n"); return 2;
+            }
+            meos_initialize();
+            meos_initialize_timezone("UTC");
+            Temporal *t = tfloat_in("[1.5@2001-01-01]");
+            if (!t) { fprintf(stderr, "FAIL: tfloat_in NULL\n"); return 1; }
+            char *out = tfloat_out(t, 6);
+            printf("parsed: %s\n", out);
+            int ok = strstr(out, "1.5") != NULL;
+            free(out); free(t); meos_finalize();
+            if (!ok) { fprintf(stderr, "FAIL: 1.5 mis-parsed under de_DE\n"); return 1; }
+            printf("OK\n"); return 0;
+          }
+          EOF
+          gcc -I meos-install/include -L meos-install/lib \
+            -o /tmp/locale_smoke /tmp/locale_smoke.c -lmeos
+
+      - name: Run locale smoke test under LC_NUMERIC=de_DE.UTF-8
+        env:
+          LD_LIBRARY_PATH: meos-install/lib
+          LC_NUMERIC: de_DE.UTF-8
+        run: /tmp/locale_smoke
+
+      - name: Run locale smoke test under LC_ALL=de_DE.UTF-8
+        env:
+          LD_LIBRARY_PATH: meos-install/lib
+          LC_ALL: de_DE.UTF-8
+        run: /tmp/locale_smoke

--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -48,6 +48,22 @@
 #endif
 
 /*****************************************************************************
+ * Locale contract
+ *
+ * MEOS pins all numeric I/O to the C locale: textual representations of
+ * doubles always use '.' as the decimal separator, regardless of the
+ * calling process's LC_NUMERIC setting. This guarantees that WKT, set,
+ * span, and temporal-constant parsing produces stable results across
+ * environments (CI, downstream bindings such as PyMEOS / JMEOS, ...).
+ *
+ * MEOS does NOT call setlocale() at initialization; downstream consumers
+ * remain free to set whatever process locale they need for *their own*
+ * code (display, message catalogs, ...). Locale-aware text collation is
+ * not yet wired up; varstr_cmp() falls back to byte-wise memcmp pending
+ * the full collation work.
+ *****************************************************************************/
+
+/*****************************************************************************
  * Toolchain dependent definitions
  *****************************************************************************/
 

--- a/meos/src/temporal/type_parser.c
+++ b/meos/src/temporal/type_parser.c
@@ -273,7 +273,8 @@ bool
 double_parse(const char **str, double *result)
 {
   char *nextstr = (char *) *str;
-  *result = strtod(*str, &nextstr);
+  /* Locale-safe: pins the decimal separator to '.' (see meos_strtod). */
+  *result = meos_strtod(*str, &nextstr);
   if (*str == nextstr)
   {
     meos_error(ERROR, MEOS_ERR_TEXT_INPUT,

--- a/pgtypes/pgtypes.h
+++ b/pgtypes/pgtypes.h
@@ -374,6 +374,9 @@ extern uint32 float8_hash(float8 key);
 extern uint64 float8_hash_extended(float8 key, uint64 seed);
 extern float8 float8_in(const char *str);
 extern float8 float8_larger(float8 num1, float8 num2);
+/* Locale-safe strtod(): pins numeric input to the C locale (the decimal
+ * separator is always '.') regardless of the process's LC_NUMERIC. */
+extern double meos_strtod(const char *str, char **endptr);
 extern float8 float8_lgamma(float8 num);
 extern float8 float8_ln(float8 num);
 extern float8 float8_log10(float8 num);

--- a/pgtypes/utils/datetime.c
+++ b/pgtypes/utils/datetime.c
@@ -27,6 +27,7 @@
 #include "meos.h"
 #include "utils/datetime.h"
 #include "utils/tzparser.h"
+#include "pgtypes.h"  /* meos_strtod */
 
 #include "../../meos/include/meos_error.h"
 
@@ -703,7 +704,7 @@ ParseFraction(char *cp, double *frac)
       return DTERR_BAD_FORMAT;
 
     errno = 0;
-    *frac = strtod(cp, &cp);
+    *frac = meos_strtod(cp, &cp);
     /* check for parse failure (probably redundant given prior check) */
     if (*cp != '\0' || errno != 0)
       return DTERR_BAD_FORMAT;
@@ -3778,7 +3779,7 @@ ParseISO8601Number(char *str, char **endptr, int64 *ipart, double *fpart)
   if (!(isdigit((unsigned char) *str) || *str == '-' || *str == '.'))
     return DTERR_BAD_FORMAT;
   errno = 0;
-  double val = strtod(str, endptr);
+  double val = meos_strtod(str, endptr);
   /* did we not see anything that looks like a double? */
   if (*endptr == str || errno != 0)
     return DTERR_BAD_FORMAT;

--- a/pgtypes/utils/float.c
+++ b/pgtypes/utils/float.c
@@ -329,6 +329,87 @@ float4_out(float4 num)
 }
 
 /*
+ * Locale-safe wrapper for strtod(). MEOS reads doubles back from text in
+ * many parsers (WKT, sets, spans, temporal constants, ...). The libc
+ * strtod() honors LC_NUMERIC, so under e.g. de_DE.UTF-8 it expects a
+ * comma decimal separator and would silently mis-parse "1.5" — breaking
+ * the entire WKT round-trip.
+ *
+ * MEOS pins numeric I/O to the C locale regardless of the process locale.
+ * Two implementation strategies are tried in order:
+ *
+ *   1. POSIX strtod_l() against a private, lazily-initialised locale_t.
+ *      This is thread-safe.
+ *   2. Save / setlocale(LC_NUMERIC,"C") / strtod / restore. Portable
+ *      everywhere strtod_l is unavailable, but not thread-safe (the
+ *      restore window is observable to other threads). MEOS is not
+ *      thread-safe overall, so this is acceptable as a fallback.
+ *
+ * MEOS does not call setlocale() at initialization because downstream
+ * consumers (PyMEOS, JMEOS, ...) can legitimately want a non-C locale
+ * for their own code (display, message catalogs, ...).
+ *
+ * See the locale contract documented in meos.h.
+ *
+ * <locale.h> (locale_t, setlocale, newlocale) and <string.h> (strcmp,
+ * strlen) are pulled in transitively via <postgres.h>; including them
+ * again here would be redundant and would trip Codacy's cppcheck wrapper
+ * with cppcheck_missingIncludeSystem on every PR (it doesn't see
+ * compile_commands.json).
+ */
+#if defined(LC_NUMERIC_MASK) && defined(__GLIBC__)
+  #define MEOS_HAVE_STRTOD_L 1
+#elif defined(LC_NUMERIC_MASK) && (defined(__APPLE__) || defined(__FreeBSD__))
+  #define MEOS_HAVE_STRTOD_L 1
+#endif
+
+#if MEOS_HAVE_STRTOD_L
+/* Explicit forward declarations: strtod_l/newlocale require POSIX 2008
+ * feature test macros to appear in <stdlib.h>/<locale.h>, and the MEOS
+ * build doesn't set those globally (the postgres headers manage their
+ * own feature macros). Without a visible prototype the compiler treats
+ * strtod_l as returning int, which silently truncates the returned
+ * double. */
+extern double strtod_l(const char *str, char **endptr, locale_t loc);
+extern locale_t newlocale(int category_mask, const char *locale,
+  locale_t base);
+/* Note: freelocale's return type differs across platforms (POSIX/macOS
+ * declare it as int, glibc < 2.32 as void), so we don't forward-declare
+ * it. We never call it anyway: the C-locale handle lives for the
+ * process lifetime. */
+static locale_t meos_c_locale = (locale_t) 0;
+#endif
+
+double
+meos_strtod(const char *str, char **endptr)
+{
+#if MEOS_HAVE_STRTOD_L
+  if (meos_c_locale == (locale_t) 0)
+    meos_c_locale = newlocale(LC_NUMERIC_MASK, "C", (locale_t) 0);
+  if (meos_c_locale != (locale_t) 0)
+    return strtod_l(str, endptr, meos_c_locale);
+#endif
+  /* Portable fallback: save the current LC_NUMERIC, switch to "C" for
+   * the parse, restore it. Not thread-safe (other threads could see the
+   * "C" value during the parse), but always correct.
+   *
+   * Skip the dance if we are already in a C-equivalent locale, which
+   * avoids two strdup/free pairs on the hot path. */
+  const char *cur = setlocale(LC_NUMERIC, NULL);
+  if (cur == NULL || strcmp(cur, "C") == 0 || strcmp(cur, "POSIX") == 0)
+    return strtod(str, endptr);
+  char *saved = strdup(cur);
+  setlocale(LC_NUMERIC, "C");
+  double val = strtod(str, endptr);
+  if (saved != NULL)
+  {
+    setlocale(LC_NUMERIC, saved);
+    free(saved);
+  }
+  return val;
+}
+
+/*
  * float8in_internal - guts of float8in()
  *
  * This is exposed for use by functions that want a reasonably
@@ -370,7 +451,7 @@ pg_float8in_internal(char *num, char **endptr_p, const char *type_name,
   }
 
   errno = 0;
-  val = strtod(num, &endptr);
+  val = meos_strtod(num, &endptr);
 
   /* did we not see anything that looks like a double? */
   if (endptr == num || errno != 0)


### PR DESCRIPTION
Replaces the PostgreSQL-internal strtod_l usage with a portable variant so MEOS can locale-safely parse numeric literals on macOS, BSD, and MSVC. Closes #425. Split out of #934 per the one-change-per-PR policy.