### PR TITLE
Bootstrap MEOS UTF-8 contract with portable lower-case smoke assertion

### DIFF
--- a/.github/workflows/meos_utf8_smoke.yml
+++ b/.github/workflows/meos_utf8_smoke.yml
@@ -1,0 +1,185 @@
+name: MEOS UTF-8 smoke
+
+# Guards the MEOS UTF-8 encoding contract for the standalone library.
+#
+# What this job pins:
+#   1. UTF-8 byte sequences round-trip through `text_in`/`text_out`,
+#      `ttext_in`/`ttext_out`, and `textset_in`/`textset_out` unchanged.
+#      The ttext / textset parsers only match ASCII delimiters
+#      (`"`, `,`, `}`, `]`, ...) and UTF-8 continuation bytes (>= 0x80)
+#      can never collide with them, so this is just byte-preservation.
+#
+#   2. The known limitation: `text_upper` / `text_lower` are an ASCII-only
+#      fold (PG's `asc_toupper` / `asc_tolower`). Non-ASCII bytes pass
+#      through unchanged. This is documented behaviour per the UTF-8
+#      contract in meos.h; the test asserts the documented behaviour so
+#      we don't accidentally regress in either direction (silent
+#      corruption *or* surprise Unicode-awareness).
+#
+# Together (1) + (2) form the encoding contract that downstream bindings
+# (PyMEOS, JMEOS, MEOS.NET, MEOS.js, RustMEOS, GoMEOS) can rely on.
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/meos_utf8_smoke.yml'
+      - 'cmake/**'
+      - 'meos/**'
+      - 'pgtypes/**'
+      - 'postgis/**'
+      - 'CMakeLists.txt'
+    branches-ignore:
+      - gh-pages
+  pull_request:
+    paths:
+      - '.github/workflows/meos_utf8_smoke.yml'
+      - 'cmake/**'
+      - 'meos/**'
+      - 'pgtypes/**'
+      - 'postgis/**'
+      - 'CMakeLists.txt'
+    branches-ignore:
+      - gh-pages
+
+jobs:
+  utf8-smoke:
+    name: utf8-smoke
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake ninja-build \
+            libgeos++-dev libproj-dev libjson-c-dev libgsl-dev
+
+      - name: Configure standalone MEOS
+        run: |
+          cmake -S . -B build-meos \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$PWD/meos-install" \
+            -DMEOS=ON \
+            -DCBUFFER=ON -DNPOINT=ON
+
+      - name: Build libmeos
+        run: cmake --build build-meos -j
+
+      - name: Install libmeos
+        run: cmake --install build-meos
+
+      - name: Compile UTF-8 smoke test
+        run: |
+          cat > /tmp/utf8_smoke.c <<'EOF'
+          /*
+           * UTF-8 contract smoke test for the MEOS library.
+           *
+           * Verifies: (1) UTF-8 bytes round-trip through text/ttext/textset
+           * I/O unchanged, and (2) ASCII-only case folding is the documented
+           * behaviour for text_upper/text_lower (non-ASCII bytes preserved).
+           */
+          #include <stdio.h>
+          #include <stdlib.h>
+          #include <string.h>
+          #include <meos.h>
+
+          static int fail = 0;
+
+          static void expect_contains(const char *what, const char *haystack,
+                                      const char *needle)
+          {
+            if (strstr(haystack, needle) == NULL) {
+              fprintf(stderr, "FAIL %s: expected %s in %s\n",
+                      what, needle, haystack);
+              fail = 1;
+            } else {
+              printf("ok   %s: contains %s\n", what, needle);
+            }
+          }
+
+          int main(void)
+          {
+            meos_initialize();
+            meos_initialize_timezone("UTC");
+
+            /* (1a) ttext round-trip preserves a German umlaut. */
+            {
+              Temporal *t = ttext_in("[\"Zürich\" @ 2001-01-01]");
+              if (!t) { fprintf(stderr, "FAIL ttext_in NULL\n"); return 1; }
+              char *out = ttext_out(t);
+              expect_contains("ttext de", out, "Zürich");
+              free(out); free(t);
+            }
+
+            /* (1b) ttext round-trip preserves CJK and Arabic. */
+            {
+              Temporal *t = ttext_in("[\"日本\" @ 2001-01-01]");
+              if (!t) { fprintf(stderr, "FAIL ttext_in cjk NULL\n"); return 1; }
+              char *out = ttext_out(t);
+              expect_contains("ttext cjk", out, "日本");
+              free(out); free(t);
+            }
+            {
+              Temporal *t = ttext_in("[\"العربية\" @ 2001-01-01]");
+              if (!t) { fprintf(stderr, "FAIL ttext_in ar NULL\n"); return 1; }
+              char *out = ttext_out(t);
+              expect_contains("ttext ar", out, "العربية");
+              free(out); free(t);
+            }
+
+            /* (1c) textset with mixed-script strings round-trips. */
+            {
+              Set *s = textset_in("{\"Zürich\", \"日本\", \"العربية\", \"한국\"}");
+              if (!s) { fprintf(stderr, "FAIL textset_in NULL\n"); return 1; }
+              char *out = textset_out(s);
+              expect_contains("textset de", out, "Zürich");
+              expect_contains("textset cjk", out, "日本");
+              expect_contains("textset ar", out, "العربية");
+              expect_contains("textset ko", out, "한국");
+              free(out); free(s);
+            }
+
+            /* (2) ASCII-only case folding is the documented contract:
+             * EVERY ASCII letter is folded; bytes >= 0x80 (the body of
+             * any UTF-8 multi-byte sequence) pass through unchanged.
+             *
+             * "Zürich" -> upper: Z stays, ü preserved, r/i/c/h fold to
+             *   R/I/C/H. Result: "ZüRICH".
+             * "ZÜRICH" -> lower: Z->z, Ü preserved, R/I/C/H fold to
+             *   r/i/c/h. Result: "zÜrich".
+             *
+             * These pins will need updating when (and only when) a
+             * Unicode-aware fold lands. */
+            {
+              text *t = text_in("Zürich");
+              text *u = text_upper(t);
+              char *out = text_out(u);
+              expect_contains("upper ascii-only", out, "ZüRICH");
+              free(out); free(t); free(u);
+            }
+            {
+              text *t = text_in("ZÜRICH");
+              text *u = text_lower(t);
+              char *out = text_out(u);
+              expect_contains("lower ascii-only", out, "zÜrich");
+              free(out); free(t); free(u);
+            }
+
+            meos_finalize();
+            if (fail) { fprintf(stderr, "UTF-8 smoke FAILED\n"); return 1; }
+            printf("UTF-8 smoke OK\n");
+            return 0;
+          }
+          EOF
+          gcc -I meos-install/include -L meos-install/lib \
+            -o /tmp/utf8_smoke /tmp/utf8_smoke.c -lmeos
+
+      - name: Run UTF-8 smoke test
+        env:
+          LD_LIBRARY_PATH: meos-install/lib
+          LANG: C.UTF-8
+        run: /tmp/utf8_smoke

--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -64,6 +64,36 @@
  *****************************************************************************/
 
 /*****************************************************************************
+ * UTF-8 / character encoding contract
+ *
+ * MEOS treats `text` values and the textual representations parsed by
+ * `*_in()` / `*_out()` as opaque byte sequences. The library is encoding-
+ * agnostic at I/O: any encoding with the property that ASCII characters
+ * (`,`, `}`, `]`, `"`, `\\`, whitespace, etc.) round-trip as their
+ * single-byte form is preserved verbatim. UTF-8 satisfies this property,
+ * so callers can pass UTF-8 text through `text_in`/`text_out`, set/array
+ * constructors, and `ttext`/`textset` parsers and get the same bytes
+ * back. Multi-byte UTF-8 continuation bytes (>= 0x80) never collide with
+ * ASCII delimiters, so the parsers are correct on UTF-8 input.
+ *
+ * What MEOS does NOT do today:
+ *   - Locale-aware text collation (`text_cmp` is byte-wise `memcmp`,
+ *     intentionally — see the locale contract above).
+ *   - Unicode-aware case folding. `text_upper`, `text_lower`, and
+ *     `text_initcap` (and the temporal variants `ttext_upper`, ...)
+ *     fold ASCII letters only; bytes >= 0x80 (the body of any
+ *     multi-byte UTF-8 sequence) are passed through unchanged. So
+ *     `text_upper("Zürich")` returns `"Zürich"`, not `"ZÜRICH"`. This
+ *     is documented behaviour pending the full Unicode-aware fold.
+ *   - Character-count APIs (`text_length`, `text_substring`, ...).
+ *     None are exposed; if added, byte-vs-codepoint semantics will
+ *     have to be specified explicitly.
+ *
+ * Round-tripping UTF-8 through MEOS is exercised by the
+ * `meos_utf8_smoke` CI workflow.
+ *****************************************************************************/
+
+/*****************************************************************************
  * Toolchain dependent definitions
  *****************************************************************************/
 

--- a/meos/src/temporal/postgres_types.c
+++ b/meos/src/temporal/postgres_types.c
@@ -140,7 +140,13 @@ datum_textcat(Datum l, Datum r)
  * @param[in] txt Text value
  * @note PostgreSQL function: @p lower() in file @p varlena.c.
  * Notice that @p DEFAULT_COLLATION_OID is used instead of
- * @p PG_GET_COLLATION()
+ * @p PG_GET_COLLATION().
+ *
+ * In standalone MEOS this is an ASCII-only fold: bytes 0x41..0x5A
+ * become 0x61..0x7A; bytes >= 0x80 (UTF-8 continuation/lead bytes)
+ * are left unchanged. So `text_lower("ZÜRICH")` returns `"zÜRICH"`
+ * (the ASCII letters are folded but `Ü` is preserved verbatim). This
+ * is the documented UTF-8 contract — see meos.h.
  */
 text *
 text_lower(const text *txt)
@@ -172,7 +178,12 @@ datum_lower(Datum value)
  * @param[in] txt Text value
  * @note PostgreSQL function: @p upper() in file @p varlena.c.
  * Notice that @p DEFAULT_COLLATION_OID is used instead of
- * @p PG_GET_COLLATION()
+ * @p PG_GET_COLLATION().
+ *
+ * In standalone MEOS this is an ASCII-only fold: bytes 0x61..0x7A
+ * become 0x41..0x5A; bytes >= 0x80 (UTF-8 continuation/lead bytes)
+ * are left unchanged. So `text_upper("Zürich")` returns `"ZüRICH"`,
+ * not `"ZÜRICH"`. This is the documented UTF-8 contract — see meos.h.
  */
 text *
 text_upper(const text *txt)
@@ -204,7 +215,10 @@ datum_upper(Datum value)
  * @param[in] txt Text value
  * @note PostgreSQL function: @p initcap() in file @p varlena.c.
  * Notice that @p DEFAULT_COLLATION_OID is used instead of
- * @p PG_GET_COLLATION()
+ * @p PG_GET_COLLATION().
+ *
+ * In standalone MEOS this is an ASCII-only fold; bytes >= 0x80 are
+ * passed through unchanged. See meos.h for the UTF-8 contract.
  */
 text *
 text_initcap(const text *txt)


### PR DESCRIPTION
Documents and enforces MEOS' UTF-8 contract with a portable lower-case smoke assertion that runs against the standalone library. Closes #403. Stacked on #957 (Draft until that merges). Split out of #934 per the one-change-per-PR policy.