### PR TITLE
Bootstrap native Windows MEOS build

### DIFF
--- a/.github/workflows/windows_msys2_meos.yml
+++ b/.github/workflows/windows_msys2_meos.yml
@@ -1,0 +1,110 @@
+name: Build MEOS on Windows (MSYS2/UCRT64)
+
+# Builds the standalone MEOS C library natively on Windows under MSYS2's
+# UCRT64 runtime, providing native Windows MEOS build coverage.
+#
+# What this job verifies:
+#   * cmake -DMEOS=ON resolves all dependencies under MSYS2 mingw-w64
+#     (json-c, geos, proj, gsl, tzdata).
+#   * The standalone libmeos.dll links cleanly.
+#   * A minimal smoke test (meos/test/temporal_test) builds and runs.
+#
+# Note: full MSVC support requires sweeping PGDLLEXPORT onto every public
+# extern declaration in meos.h / meos_*.h.  That is intentionally left as
+# a follow-up; MinGW-GCC under MSYS2 exports symbols by default
+# (--export-all-symbols) so this CI runs without that sweep.
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/windows_msys2_meos.yml'
+      - 'cmake/**'
+      - 'meos/**'
+      - 'pgtypes/**'
+      - 'postgis/**'
+      - 'CMakeLists.txt'
+    branch_ignore: gh-pages
+  pull_request:
+    paths:
+      - '.github/workflows/windows_msys2_meos.yml'
+      - 'cmake/**'
+      - 'meos/**'
+      - 'pgtypes/**'
+      - 'postgis/**'
+      - 'CMakeLists.txt'
+    branch_ignore: gh-pages
+
+jobs:
+  build-meos:
+    name: meos-windows
+    runs-on: windows-latest
+    continue-on-error: true
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup MSYS2 (UCRT64)
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-ninja
+            mingw-w64-ucrt-x86_64-json-c
+            mingw-w64-ucrt-x86_64-geos
+            mingw-w64-ucrt-x86_64-proj
+            mingw-w64-ucrt-x86_64-gsl
+            mingw-w64-ucrt-x86_64-tzdata
+
+      - name: Resolve native timezone data path
+        run: |
+          # cygpath -m converts the MSYS2 POSIX path to a Windows-native path
+          # (forward slashes, e.g. C:/msys64/ucrt64/share/zoneinfo) that fopen()
+          # inside the compiled DLL can open at runtime.
+          TZDATA_WIN=$(cygpath -m "$MSYSTEM_PREFIX/share/zoneinfo")
+          echo "MEOS_TZDATA_WIN=$TZDATA_WIN" >> "$GITHUB_ENV"
+
+      - name: Configure (MEOS=ON, no PostgreSQL extension)
+        run: |
+          # POSE pulls in RGEO via CMAKE_DEPENDENT_OPTION; RGEO stays off
+          # because rgeo's compilation on Windows depends on PostGIS
+          # build-tree generated headers that are not available there.
+          cmake -S . -B build-meos \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$PWD/meos-install" \
+            -DMEOS=ON \
+            -DCBUFFER=ON -DNPOINT=ON -DPOSE=OFF -DRGEO=OFF \
+            -DMEOS_TZDATA_DIR="$MEOS_TZDATA_WIN"
+
+      - name: Build libmeos
+        run: cmake --build build-meos -j
+
+      - name: Install libmeos
+        run: cmake --install build-meos
+
+      - name: Show built artifacts
+        run: |
+          ls -la build-meos/
+          ls -la meos-install/bin meos-install/lib meos-install/include 2>/dev/null || true
+          # CMake on MSYS2/MinGW puts the .dll in the install bin/ dir and
+          # the .dll.a import lib in lib/. Confirm both exist.
+          test -f build-meos/meos/libmeos.dll || (echo "libmeos.dll not produced"; exit 1)
+
+      - name: Smoke test (build temporal_test against installed libmeos)
+        run: |
+          gcc -Werror=implicit-function-declaration -Werror=implicit-int \
+            -I meos-install/include \
+            -L meos-install/lib \
+            -o meos-install/temporal_test.exe \
+            meos/test/temporal_test.c \
+            -lmeos
+          PATH="$PWD/meos-install/bin:$PWD/meos-install/lib:$PWD/build-meos:$PATH" ./meos-install/temporal_test.exe \
+            || (echo "temporal_test.exe failed at runtime"; exit 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,15 @@ if(MEOS)
   # not used in the MobilityDB PostgreSQL extension.
   message(STATUS "MEOS=1: Including user-facing MEOS API functions")
   add_definitions(-DMEOS=1)
+  # On Windows the vendored PostgreSQL port headers select the win32 typedefs
+  # (uid_t/gid_t in port/win32_port.h, pulled in by port.h via "#if defined(WIN32)")
+  # from the bare WIN32 macro. The MEOS build omits pg_config_os.h (which would
+  # "#define WIN32"), and the C++ targets compile with strict -std=c++17, which
+  # (unlike -std=gnu++17 and the C targets' -std=gnu1x) does NOT predefine bare
+  # WIN32. Define it explicitly so the C and C++ MEOS translation units agree.
+  if(WIN32)
+    add_definitions(-DWIN32)
+  endif()
 else()
   message(STATUS "MEOS=0: Building MEOS core for MobilityDB (internal API only)")
   add_definitions(-DMEOS=0)

--- a/meos/CMakeLists.txt
+++ b/meos/CMakeLists.txt
@@ -272,6 +272,18 @@ if(POINTCLOUD)
   endif()
 endif()
 
+# postgis (libpostgis.a) references the GEOS C-API reentrant (GEOS*_r), PROJ
+# (proj_*) and GeographicLib geodesic (geod_*) symbols. With GNU ld these
+# dependency import/static libraries must appear AFTER their consumer on the
+# link line, otherwise their archive members are never pulled in and the link
+# fails with undefined references (seen on Windows/MSYS2 UCRT64, where
+# libgeos_c.dll.a / libproj.dll.a are import libraries treated like archives).
+# Re-list GEOS and PROJ after postgis so they resolve postgis's symbols. The
+# repetition is harmless on platforms where order does not matter (e.g. Linux
+# shared objects).
+target_link_libraries(${MEOS_LIB_NAME} ${GEOS_LIBRARY})
+target_link_libraries(${MEOS_LIB_NAME} ${PROJ_LIBRARIES})
+
 #--------------------------------
 # Belongs to MEOS
 #--------------------------------

--- a/meos/include/postgres_ext_defs.in.h
+++ b/meos/include/postgres_ext_defs.in.h
@@ -3,18 +3,20 @@
 
 #define DatumGetPointer(X) ((Pointer) (X))
 
+#include <stdint.h>
+
 typedef char *Pointer;
 typedef uintptr_t Datum;
 
 typedef signed char int8;
 typedef signed short int16;
 typedef signed int int32;
-typedef long int int64;
+typedef int64_t int64;
 
 typedef unsigned char uint8;
 typedef unsigned short uint16;
 typedef unsigned int uint32;
-typedef unsigned long int uint64;
+typedef uint64_t uint64;
 
 typedef int32 DateADT;
 typedef int64 TimeADT;

--- a/meos/src/rgeo/trgeo_parser.c
+++ b/meos/src/rgeo/trgeo_parser.c
@@ -313,7 +313,7 @@ trgeo_parse(const char **str, MeosType temptype)
 
   interpType interp = temptype_supports_linear(temptype) ? LINEAR : STEP;
   /* Starts with "Interp=Step" */
-  if (strncasecmp(*str, "Interp=Step;", 12) == 0)
+  if (pg_strncasecmp(*str, "Interp=Step;", 12) == 0)
   {
     /* Move str after the semicolon */
     *str += 12;

--- a/meos/src/temporal/temporal_restrict_meos.c
+++ b/meos/src/temporal/temporal_restrict_meos.c
@@ -224,7 +224,7 @@ tbool_value_at_timestamptz(const Temporal *temp, TimestampTz t, bool strict,
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TBOOL(temp, false); VALIDATE_NOT_NULL(value, false);
-  Datum res;
+  Datum res = (Datum) 0;
   bool result = temporal_value_at_timestamptz(temp, t, strict, &res);
   *value = DatumGetBool(res);
   return result;
@@ -246,7 +246,7 @@ tint_value_at_timestamptz(const Temporal *temp, TimestampTz t, bool strict,
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TINT(temp, false); VALIDATE_NOT_NULL(value, false);
-  Datum res;
+  Datum res = (Datum) 0;
   bool result = temporal_value_at_timestamptz(temp, t, strict, &res);
   *value = DatumGetInt32(res);
   return result;
@@ -290,7 +290,7 @@ tfloat_value_at_timestamptz(const Temporal *temp, TimestampTz t, bool strict,
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TFLOAT(temp, false); VALIDATE_NOT_NULL(value, false);
-  Datum res;
+  Datum res = (Datum) 0;
   bool result = temporal_value_at_timestamptz(temp, t, strict, &res);
   *value = DatumGetFloat8(res);
   return result;
@@ -312,7 +312,7 @@ ttext_value_at_timestamptz(const Temporal *temp, TimestampTz t, bool strict,
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TTEXT(temp, false); VALIDATE_NOT_NULL(value, false);
-  Datum res;
+  Datum res = (Datum) 0;
   bool result = temporal_value_at_timestamptz(temp, t, strict, &res);
   *value = DatumGetTextP(res);
   return result;

--- a/pgtypes/CMakeLists.txt
+++ b/pgtypes/CMakeLists.txt
@@ -131,10 +131,15 @@ endif()
 
 # Set the location of the directory of the time zone database. macOS may also
 # have /var/db/timezone/zoneinfo but /usr/share/zoneinfo is the standard
-# fallback; Windows has no such path so leave SYSTEMTZDIR undefined and let
-# pgtypes use its bundled lookup, or, in extension mode, defer to the
-# postgres backend's own timezone resolution.
-if(NOT WIN32)
+# fallback. An explicit -DMEOS_TZDATA_DIR overrides everything: this is how the
+# Windows (UCRT64) build points standalone MEOS at the native tzdata package
+# (e.g. cygpath -m "$MSYSTEM_PREFIX/share/zoneinfo"), since Windows has no
+# /usr/share/zoneinfo and pg_TZDIR()'s get_share_path() fallback would resolve
+# to a non-existent relative "share/timezone" and abort meos_initialize().
+if(MEOS_TZDATA_DIR)
+  add_definitions(-DSYSTEMTZDIR="${MEOS_TZDATA_DIR}")
+  message(STATUS "Directory of the time zone database: ${MEOS_TZDATA_DIR}")
+elseif(NOT WIN32)
   add_definitions(-DSYSTEMTZDIR="/usr/share/zoneinfo")
   message(STATUS "Directory of the time zone database: /usr/share/zoneinfo")
 endif()

--- a/pgtypes/port.h
+++ b/pgtypes/port.h
@@ -343,8 +343,10 @@ extern bool rmtree(const char *path, bool rmtopdir);
 extern HANDLE pgwin32_open_handle(const char *, int, bool);
 extern int	pgwin32_open(const char *, int,...);
 extern FILE *pgwin32_fopen(const char *, const char *);
+#if !(defined(MEOS) && MEOS)  /* MEOS: standalone uses the CRT; pgwin32_* impls are PG-backend-only */
 #define		open(a,b,c) pgwin32_open(a,b,c)
 #define		fopen(a,b) pgwin32_fopen(a,b)
+#endif
 
 /*
  * Mingw-w64 headers #define popen and pclose to _popen and _pclose.  We want
@@ -365,8 +367,10 @@ extern FILE *pgwin32_fopen(const char *, const char *);
 extern int	pgwin32_system(const char *command);
 extern FILE *pgwin32_popen(const char *command, const char *type);
 
+#if !(defined(MEOS) && MEOS)  /* MEOS: standalone uses the CRT; pgwin32_* impls are PG-backend-only */
 #define system(a) pgwin32_system(a)
 #define popen(a,b) pgwin32_popen(a,b)
+#endif
 #define pclose(a) _pclose(a)
 
 #else							/* !WIN32 */
@@ -429,7 +433,7 @@ extern int	getpeereid(int sock, uid_t *uid, gid_t *gid);
 extern void explicit_bzero(void *buf, size_t len);
 #endif
 
-#ifdef HAVE_BUGGY_STRTOF
+#if defined(HAVE_BUGGY_STRTOF) && !(defined(MEOS) && MEOS)  /* MEOS: pg_strtof is PG-backend-only; MEOS uses meos_strtof at the call sites */
 extern float pg_strtof(const char *nptr, char **endptr);
 #define strtof(a,b) (pg_strtof((a),(b)))
 #endif

--- a/pgtypes/port/CMakeLists.txt
+++ b/pgtypes/port/CMakeLists.txt
@@ -22,11 +22,17 @@ if(NOT PGTYPES_EXT_WIN32)
   )
 endif()
 
-# Native Windows MSVC has no <dirent.h>; compile the vendored opendir/readdir/
-# closedir shim (the implementation paired with port/win32_msvc/dirent.h). The
-# .c body is itself guarded against MinGW, which ships its own <dirent.h>.
+# Native Windows MSVC has no <dirent.h>; MEOS timezone code (pgtypes/timezone/
+# pgtz.c) includes it. Add the vendored shim (BSD-licensed from PostgreSQL
+# upstream). MinGW already provides its own <dirent.h>, so the .c body is
+# itself guarded against MinGW.
 if(WIN32)
   list(APPEND PORT_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/dirent.c)
+  # The mingw-w64 / UCRT runtime does not export _dosmaperr through its import
+  # libraries, and PostgreSQL's win32error.c is normally backend-only. Vendor
+  # it so pg_locale.c / dirent.c / fd.c (which call _dosmaperr after a failed
+  # Win32 call) link in both the standalone MEOS and the extension builds.
+  list(APPEND PORT_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/win32error.c)
 endif()
 
 set(PGTYPES_SOURCES ${PGTYPES_SOURCES} ${PORT_SOURCES}

--- a/pgtypes/port/win32_port.h
+++ b/pgtypes/port/win32_port.h
@@ -472,7 +472,9 @@ extern int	_pglstat64(const char *name, struct stat *buf);
  */
 extern char *pgwin32_setlocale(int category, const char *locale);
 
+#if !(defined(MEOS) && MEOS)  /* MEOS: standalone uses the CRT setlocale; pgwin32_* is PG-backend-only */
 #define setlocale(a,b) pgwin32_setlocale(a,b)
+#endif
 
 
 /* In backend/port/win32/signal.c */
@@ -541,9 +543,15 @@ extern int	pgwin32_putenv(const char *);
 extern int	pgwin32_setenv(const char *name, const char *value, int overwrite);
 extern int	pgwin32_unsetenv(const char *name);
 
+#if defined(MEOS) && MEOS  /* MEOS: use the UCRT env funcs; the pgwin32_* impls are PG-backend-only and not vendored */
+#define putenv(x) _putenv(x)
+#define setenv(x,y,z) _putenv_s((x),(y))
+#define unsetenv(x) _putenv_s((x),"")
+#else
 #define putenv(x) pgwin32_putenv(x)
 #define setenv(x,y,z) pgwin32_setenv(x,y,z)
 #define unsetenv(x) pgwin32_unsetenv(x)
+#endif
 
 /* in port/win32security.c */
 extern int	pgwin32_is_service(void);

--- a/pgtypes/port/win32error.c
+++ b/pgtypes/port/win32error.c
@@ -1,0 +1,199 @@
+/*-------------------------------------------------------------------------
+ *
+ * win32error.c
+ *    Map a Win32 error code (GetLastError()) onto a POSIX errno value and
+ *    store it in the C runtime errno.  Vendored from PostgreSQL upstream
+ *    src/port/win32error.c (PostgreSQL/BSD-licensed).
+ *
+ *    The mingw-w64 / UCRT C runtime keeps _dosmaperr as an internal symbol
+ *    that is not exported through the import libraries, and PostgreSQL's
+ *    src/port/win32error.c is normally compiled only into the backend (and
+ *    therefore is not part of the vendored pgtypes subset).  Standalone MEOS
+ *    (and the extension) pull pg_locale.c / dirent.c / fd.c which call
+ *    _dosmaperr() after a failed Win32 call, so provide our own copy here.
+ *
+ *    Compiled only on WIN32 (see pgtypes/port/CMakeLists.txt).
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#ifdef WIN32
+
+#include <windows.h>
+
+static const struct
+{
+	DWORD		winerr;
+	int			doserr;
+}			doserrors[] =
+
+{
+	{
+		ERROR_INVALID_FUNCTION, EINVAL
+	},
+	{
+		ERROR_FILE_NOT_FOUND, ENOENT
+	},
+	{
+		ERROR_PATH_NOT_FOUND, ENOENT
+	},
+	{
+		ERROR_TOO_MANY_OPEN_FILES, EMFILE
+	},
+	{
+		ERROR_ACCESS_DENIED, EACCES
+	},
+	{
+		ERROR_INVALID_HANDLE, EBADF
+	},
+	{
+		ERROR_ARENA_TRASHED, ENOMEM
+	},
+	{
+		ERROR_NOT_ENOUGH_MEMORY, ENOMEM
+	},
+	{
+		ERROR_INVALID_BLOCK, ENOMEM
+	},
+	{
+		ERROR_BAD_ENVIRONMENT, E2BIG
+	},
+	{
+		ERROR_BAD_FORMAT, ENOEXEC
+	},
+	{
+		ERROR_INVALID_ACCESS, EINVAL
+	},
+	{
+		ERROR_INVALID_DATA, EINVAL
+	},
+	{
+		ERROR_INVALID_DRIVE, ENOENT
+	},
+	{
+		ERROR_CURRENT_DIRECTORY, EACCES
+	},
+	{
+		ERROR_NOT_SAME_DEVICE, EXDEV
+	},
+	{
+		ERROR_NO_MORE_FILES, ENOENT
+	},
+	{
+		ERROR_LOCK_VIOLATION, EACCES
+	},
+	{
+		ERROR_SHARING_VIOLATION, EACCES
+	},
+	{
+		ERROR_BAD_NETPATH, ENOENT
+	},
+	{
+		ERROR_NETWORK_ACCESS_DENIED, EACCES
+	},
+	{
+		ERROR_BAD_NET_NAME, ENOENT
+	},
+	{
+		ERROR_FILE_EXISTS, EEXIST
+	},
+	{
+		ERROR_CANNOT_MAKE, EACCES
+	},
+	{
+		ERROR_FAIL_I24, EACCES
+	},
+	{
+		ERROR_INVALID_PARAMETER, EINVAL
+	},
+	{
+		ERROR_NO_PROC_SLOTS, EAGAIN
+	},
+	{
+		ERROR_DRIVE_LOCKED, EACCES
+	},
+	{
+		ERROR_BROKEN_PIPE, EPIPE
+	},
+	{
+		ERROR_DISK_FULL, ENOSPC
+	},
+	{
+		ERROR_INVALID_TARGET_HANDLE, EBADF
+	},
+	{
+		ERROR_INVALID_HANDLE, EINVAL
+	},
+	{
+		ERROR_WAIT_NO_CHILDREN, ECHILD
+	},
+	{
+		ERROR_CHILD_NOT_COMPLETE, ECHILD
+	},
+	{
+		ERROR_DIRECT_ACCESS_HANDLE, EBADF
+	},
+	{
+		ERROR_NEGATIVE_SEEK, EINVAL
+	},
+	{
+		ERROR_SEEK_ON_DEVICE, EACCES
+	},
+	{
+		ERROR_DIR_NOT_EMPTY, ENOTEMPTY
+	},
+	{
+		ERROR_NOT_LOCKED, EACCES
+	},
+	{
+		ERROR_BAD_PATHNAME, ENOENT
+	},
+	{
+		ERROR_MAX_THRDS_REACHED, EAGAIN
+	},
+	{
+		ERROR_LOCK_FAILED, EACCES
+	},
+	{
+		ERROR_ALREADY_EXISTS, EEXIST
+	},
+	{
+		ERROR_FILENAME_EXCED_RANGE, ENOENT
+	},
+	{
+		ERROR_NESTING_NOT_ALLOWED, EAGAIN
+	},
+	{
+		ERROR_NOT_ENOUGH_QUOTA, ENOMEM
+	}
+};
+
+void
+_dosmaperr(unsigned long e)
+{
+	size_t		i;
+
+	if (e == 0)
+	{
+		errno = 0;
+		return;
+	}
+
+	for (i = 0; i < lengthof(doserrors); i++)
+	{
+		if (doserrors[i].winerr == e)
+		{
+			int			doserr = doserrors[i].doserr;
+
+			errno = doserr;
+			return;
+		}
+	}
+
+	/* Could not find a known errno mapping; use EINVAL as a generic fallback. */
+	errno = EINVAL;
+}
+
+#endif							/* WIN32 */

--- a/pgtypes/timezone/pgtz.c
+++ b/pgtypes/timezone/pgtz.c
@@ -22,8 +22,8 @@
 #include "utils/datetime.h"
 #include "utils/date.h"
 #include "pgtz.h"
-#include "../../meos/include/meos_tls.h"  /* MEOS: MEOS_TLS */
 #include "../../meos/include/meos_error.h"
+#include "../../meos/include/meos_tls.h"  /* MEOS: MEOS_TLS */
 
 /**
  * Structure to represent the timezone cache hash table, which extends
@@ -139,9 +139,27 @@ pg_TZDIR(void)
   if (done_tzdir)
     return tzdir;
 
+#if defined(MEOS) && MEOS
+  /* MEOS
+   * Standalone MEOS library: there is no PostgreSQL backend, hence no
+   * `my_exec_path` global to derive a share directory from, and platforms
+   * that leave SYSTEMTZDIR undefined (notably the MSYS2/UCRT64 Windows
+   * build) provide no system zoneinfo path either.  Reading my_exec_path
+   * here would not even compile ('my_exec_path' undeclared).  Resolve the
+   * zoneinfo directory from the TZDIR environment variable (the standard
+   * tzcode convention); if it is unset, fall back to a "share/timezone"
+   * directory relative to the process so a consumer that ships a bundled
+   * zoneinfo can still load it. */
+  const char *tzdir_env = getenv("TZDIR");
+  if (tzdir_env && tzdir_env[0])
+    strlcpy(tzdir, tzdir_env, sizeof(tzdir));
+  else
+    strlcpy(tzdir, "share/timezone", sizeof(tzdir));
+#else
   get_share_path(my_exec_path, tzdir);
   // strlcpy(tzdir + strlen(tzdir), "/timezone", MAXPGPATH - strlen(tzdir));
   strncpy(tzdir + strlen(tzdir), "/timezone", MAXPGPATH - strlen(tzdir));
+#endif /* MEOS */
 
   done_tzdir = true;
   return tzdir;
@@ -529,10 +547,18 @@ meos_ensure_timezone(void)
 void
 meos_finalize_timezone(void)
 {
+  /* Idempotency: null each slot after destroying it so a second
+   * meos_finalize() call does not double-free. */
   if (session_timezone)
-    pfree(session_timezone); 
+  {
+    pfree(session_timezone);
+    session_timezone = NULL;
+  }
   if (timezone_cache)
+  {
     tzcache_my_destroy(timezone_cache);
+    timezone_cache = NULL;
+  }
   return;
 }
 

--- a/pgtypes/utils/float.c
+++ b/pgtypes/utils/float.c
@@ -380,6 +380,20 @@ extern locale_t newlocale(int category_mask, const char *locale,
 static locale_t meos_c_locale = (locale_t) 0;
 #endif
 
+/* On Windows, <postgres.h> transitively pulls in port/win32_port.h which
+ * redefines setlocale() to pgwin32_setlocale() -- a PostgreSQL-internal
+ * helper provided by libpgport. MEOS standalone builds do not link
+ * libpgport, so the macro causes an undefined-reference link error in the
+ * portable fallback path of meos_strtod() below. Undefine it so the libc
+ * setlocale prototype (pulled in transitively via <locale.h>) remains the
+ * call target. The non-MEOS in-extension build keeps the macro and its
+ * libpgport linkage (the server backend statically links libpgport). */
+#if defined(_WIN32) && defined(MEOS)
+  #ifdef setlocale
+    #undef setlocale
+  #endif
+#endif
+
 double
 meos_strtod(const char *str, char **endptr)
 {

--- a/tools/scripts/check_int64_in_headers.sh
+++ b/tools/scripts/check_int64_in_headers.sh
@@ -43,10 +43,19 @@
 
 set -euo pipefail
 
+# meos/include/postgres_ext_defs.in.h is the ONE base-type definition template that
+# must spell int64 as `typedef int64_t int64` — it DEFINES the PG alias from the C99
+# type, exactly as the vendored pgtypes/c.h (already excluded) does. int64_t is the
+# only spelling that resolves to the same 64-bit type as the installed pg_*.h on EVERY
+# platform (long int on Linux LP64, long long on Windows LLP64 and macOS); a hardcoded
+# `long int` is 32-bit on Windows and conflicts with pg_text.h's int64_t. Exclude the
+# template like the other vendored base-type headers; the ban still covers all API
+# signatures (which must use the int64 / uint64 aliases, never int64_t directly).
 violations=$(grep -rEn '\bu?int64_t\b' \
   meos/include \
   mobilitydb/pg_include \
-  2>/dev/null || true)
+  2>/dev/null \
+  | grep -vE 'meos/include/postgres_ext_defs[^:]*\.h:' || true)
 
 if [ -n "$violations" ]; then
   cat >&2 <<'EOF'


### PR DESCRIPTION
Adds a non-blocking Windows CI workflow (continue-on-error, informational until cross-platform parity catches up) that builds the standalone MEOS library on Windows via MSYS2 UCRT64 with CMake and Ninja, together with the Windows-specific build and source fixes it depends on:

- define `int64` as `int64_t` so it stays 64-bit under LLP64, avoiding the TimestampTz truncation and pointer corruption a 32-bit `long` causes on Windows;
- re-list GEOS and PROJ after postgis so single-pass GNU ld resolves the reentrant GEOS, PROJ and geodesic symbols that libpostgis references;
- supply the `WIN32` macro to the C++ translation units so the Clipper2 and C sources agree on the platform typedefs;
- resolve the native timezone data directory on Windows (`SYSTEMTZDIR` / `MEOS_TZDATA_DIR`) rather than the unavailable `my_exec_path` share path;
- restore the pgwin32 `win32error` / `_dosmaperr` helper and the MEOS libc guards in the pgtypes port layer;
- bypass the setlocale-to-`pgwin32_setlocale` macro in `meos_strtod`, use `pg_strncasecmp` in the rgeo parser, and initialize the value-at-timestamp result Datums.

Closes #513.