### PR TITLE
Add SeqSetGaps coverage in 122_trgeo

### DIFF
--- a/mobilitydb/test/rgeo/expected/122_trgeo.test.out
+++ b/mobilitydb/test/rgeo/expected/122_trgeo.test.out
@@ -2398,3 +2398,13 @@ SELECT trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01
  t
 (1 row)
 
+SELECT numSequences(trgeometrySeqSetGaps(ARRAY[
+  trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.0)@2000-01-01',
+  trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(2 2), 0.5)@2000-01-02',
+  trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(3 3), 1.0)@2000-01-03'
+]::trgeometry[], '5 minutes'::interval));
+ numsequences 
+--------------
+            3
+(1 row)
+

--- a/mobilitydb/test/rgeo/queries/122_trgeo.test.sql
+++ b/mobilitydb/test/rgeo/queries/122_trgeo.test.sql
@@ -611,3 +611,13 @@ SELECT trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01
 SELECT trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}' >= trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}';
 
 -------------------------------------------------------------------------------
+
+-- Coverage for trgeometrySeqSetGaps (constructor with gap detection) —
+-- declared in mobilitydb/sql/rgeo/122_trgeo.in.sql:180 but previously untested.
+SELECT numSequences(trgeometrySeqSetGaps(ARRAY[
+  trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.0)@2000-01-01',
+  trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(2 2), 0.5)@2000-01-02',
+  trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(3 3), 1.0)@2000-01-03'
+]::trgeometry[], '5 minutes'::interval));
+
+-------------------------------------------------------------------------------/


### PR DESCRIPTION
Adds SeqSetGaps coverage to the 122_trgeo regression test. Split out of #946.