### PR TITLE
Add SeqSetGaps coverage in 152_tcbuffer

### DIFF
--- a/mobilitydb/test/cbuffer/expected/152_tcbuffer.test.out
+++ b/mobilitydb/test/cbuffer/expected/152_tcbuffer.test.out
@@ -2374,3 +2374,13 @@ SELECT tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)
  t
 (1 row)
 
+SELECT numSequences(tcbufferSeqSetGaps(ARRAY[
+  tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01',
+  tcbuffer 'Cbuffer(Point(2 2), 0.5)@2000-01-02',
+  tcbuffer 'Cbuffer(Point(3 3), 0.5)@2000-01-03'
+]::tcbuffer[], '5 minutes'::interval));
+ numsequences 
+--------------
+            3
+(1 row)
+

--- a/mobilitydb/test/cbuffer/queries/152_tcbuffer.test.sql
+++ b/mobilitydb/test/cbuffer/queries/152_tcbuffer.test.sql
@@ -596,3 +596,13 @@ SELECT tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)
 SELECT tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03], [Cbuffer(Point(2 2), 0.6)@2000-01-04, Cbuffer(Point(2 2), 0.6)@2000-01-05]}' >= tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03], [Cbuffer(Point(2 2), 0.6)@2000-01-04, Cbuffer(Point(2 2), 0.6)@2000-01-05]}';
 
 -------------------------------------------------------------------------------/
+
+-- Coverage for tcbufferSeqSetGaps (constructor with gap detection) — declared
+-- in mobilitydb/sql/cbuffer/152_tcbuffer.in.sql:186 but previously untested.
+SELECT numSequences(tcbufferSeqSetGaps(ARRAY[
+  tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01',
+  tcbuffer 'Cbuffer(Point(2 2), 0.5)@2000-01-02',
+  tcbuffer 'Cbuffer(Point(3 3), 0.5)@2000-01-03'
+]::tcbuffer[], '5 minutes'::interval));
+
+-------------------------------------------------------------------------------/


### PR DESCRIPTION
Adds SeqSetGaps coverage to the 152_tcbuffer regression test. Split out of #947.