### PR TITLE
Add SQL coverage for tpose spatialfuncs and distance

### DIFF
--- a/mobilitydb/test/pose/expected/105_tpose_spatialfuncs.test.out
+++ b/mobilitydb/test/pose/expected/105_tpose_spatialfuncs.test.out
@@ -1,0 +1,182 @@
+SELECT SRID(tpose 'Pose(Point(1 2),0.5)@2000-01-01');
+ srid 
+------
+    0
+(1 row)
+
+SELECT SRID(tpose 'SRID=5676;Pose(Point(1 2),0.5)@2000-01-01');
+ srid 
+------
+ 5676
+(1 row)
+
+SELECT asEWKT(setSRID(tpose 'Pose(Point(1 2),0.5)@2000-01-01', 5676));
+                           asewkt                            
+-------------------------------------------------------------
+ SRID=5676;Pose(POINT(1 2),0.5)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(atGeometry(
+  tpose 'Pose(Point(0 0),0)@2000-01-01',
+  'Polygon((-1 -1,1 -1,1 1,-1 1,-1 -1))'::geometry));
+                     astext                      
+-------------------------------------------------
+ Pose(POINT(0 0),0)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(atGeometry(
+  tpose 'Pose(Point(10 10),0)@2000-01-01',
+  'Polygon((-1 -1,1 -1,1 1,-1 1,-1 -1))'::geometry));
+ astext 
+--------
+ 
+(1 row)
+
+SELECT asText(minusGeometry(
+  tpose 'Pose(Point(0 0),0)@2000-01-01',
+  'Polygon((-1 -1,1 -1,1 1,-1 1,-1 -1))'::geometry));
+ astext 
+--------
+ 
+(1 row)
+
+SELECT asText(minusGeometry(
+  tpose 'Pose(Point(10 10),0)@2000-01-01',
+  'Polygon((-1 -1,1 -1,1 1,-1 1,-1 -1))'::geometry));
+                      astext                       
+---------------------------------------------------
+ Pose(POINT(10 10),0)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(atGeometry(
+  tpose '{Pose(Point(0 0),0)@2000-01-01, Pose(Point(10 0),0)@2000-01-02}',
+  'Polygon((-1 -1,1 -1,1 1,-1 1,-1 -1))'::geometry));
+                      astext                       
+---------------------------------------------------
+ {Pose(POINT(0 0),0)@Sat Jan 01 00:00:00 2000 PST}
+(1 row)
+
+SELECT asText(minusGeometry(
+  tpose '{Pose(Point(0 0),0)@2000-01-01, Pose(Point(10 0),0)@2000-01-02}',
+  'Polygon((-1 -1,1 -1,1 1,-1 1,-1 -1))'::geometry));
+                       astext                       
+----------------------------------------------------
+ {Pose(POINT(10 0),0)@Sun Jan 02 00:00:00 2000 PST}
+(1 row)
+
+SELECT asText(atGeometry(
+  tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(5 0),0)@2000-01-06]',
+  'Polygon((1 -1,3 -1,3 1,1 1,1 -1))'::geometry));
+                                                astext                                                
+------------------------------------------------------------------------------------------------------
+ {[Pose(POINT(1 0),0)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(3 0),0)@Tue Jan 04 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(minusGeometry(
+  tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(5 0),0)@2000-01-06]',
+  'Polygon((1 -1,3 -1,3 1,1 1,1 -1))'::geometry));
+                                                                                                  astext                                                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[Pose(POINT(0 0),0)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 0),0)@Sun Jan 02 00:00:00 2000 PST), (Pose(POINT(3 0),0)@Tue Jan 04 00:00:00 2000 PST, Pose(POINT(5 0),0)@Thu Jan 06 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(atGeometry(
+  tpose '{[Pose(Point(0 0),0)@2000-01-01, Pose(Point(5 0),0)@2000-01-06]}',
+  'Polygon((1 -1,3 -1,3 1,1 1,1 -1))'::geometry));
+                                                astext                                                
+------------------------------------------------------------------------------------------------------
+ {[Pose(POINT(1 0),0)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(3 0),0)@Tue Jan 04 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(minusGeometry(
+  tpose '{[Pose(Point(0 0),0)@2000-01-01, Pose(Point(5 0),0)@2000-01-06]}',
+  'Polygon((1 -1,3 -1,3 1,1 1,1 -1))'::geometry));
+                                                                                                  astext                                                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[Pose(POINT(0 0),0)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 0),0)@Sun Jan 02 00:00:00 2000 PST), (Pose(POINT(3 0),0)@Tue Jan 04 00:00:00 2000 PST, Pose(POINT(5 0),0)@Thu Jan 06 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(atStbox(
+  tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(5 0),0)@2000-01-06]',
+  stbox 'STBOX X((1,-1),(3,1))'));
+                                                astext                                                
+------------------------------------------------------------------------------------------------------
+ {[Pose(POINT(1 0),0)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(3 0),0)@Tue Jan 04 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(minusStbox(
+  tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(5 0),0)@2000-01-06]',
+  stbox 'STBOX X((1,-1),(3,1))'));
+                                                                                                  astext                                                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[Pose(POINT(0 0),0)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 0),0)@Sun Jan 02 00:00:00 2000 PST), (Pose(POINT(3 0),0)@Tue Jan 04 00:00:00 2000 PST, Pose(POINT(5 0),0)@Thu Jan 06 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(atStbox(
+  tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(5 0),0)@2000-01-06]',
+  stbox 'STBOX T([2000-01-02, 2000-01-04])'));
+ERROR:  The stbox must have X dimension
+SELECT asText(minusStbox(
+  tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(5 0),0)@2000-01-06]',
+  stbox 'STBOX T([2000-01-02, 2000-01-04])'));
+ERROR:  The stbox must have X dimension
+SELECT asText(atStbox(
+  tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(5 0),0)@2000-01-06]',
+  stbox 'STBOX XT(((1,-1),(3,1)),[2000-01-02, 2000-01-04])'));
+                                                astext                                                
+------------------------------------------------------------------------------------------------------
+ {[Pose(POINT(1 0),0)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(3 0),0)@Tue Jan 04 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(minusStbox(
+  tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(5 0),0)@2000-01-06]',
+  stbox 'STBOX XT(((1,-1),(3,1)),[2000-01-02, 2000-01-04])'));
+                                                                                                  astext                                                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[Pose(POINT(0 0),0)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 0),0)@Sun Jan 02 00:00:00 2000 PST), (Pose(POINT(3 0),0)@Tue Jan 04 00:00:00 2000 PST, Pose(POINT(5 0),0)@Thu Jan 06 00:00:00 2000 PST]}
+(1 row)
+
+SELECT atGeometry(
+  tpose 'Pose(Point(10 10),0)@2000-01-01',
+  'Polygon((0 0,1 0,1 1,0 1,0 0))'::geometry);
+ atgeometry 
+------------
+ 
+(1 row)
+
+SELECT atStbox(
+  tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(1 0),0)@2000-01-02]',
+  stbox 'STBOX X((10,-1),(20,1))');
+ atstbox 
+---------
+ 
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE atGeometry(temp,
+  ST_SetSRID('Polygon((-200 -200,200 -200,200 200,-200 200,-200 -200))'::geometry, 3812)) IS NOT NULL;
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE minusGeometry(temp,
+  ST_SetSRID('Polygon((-200 -200,200 -200,200 200,-200 200,-200 -200))'::geometry, 3812)) IS NOT NULL;
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE atStbox(temp,
+  stbox 'SRID=3812;STBOX XT(((-200,-200),(200,200)),[2001-06-01, 2001-12-31])') IS NOT NULL;
+ count 
+-------
+    59
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE minusStbox(temp,
+  stbox 'SRID=3812;STBOX XT(((-200,-200),(200,200)),[2001-06-01, 2001-12-31])') IS NOT NULL;
+ count 
+-------
+    41
+(1 row)
+

--- a/mobilitydb/test/pose/expected/113_tpose_distance.test.out
+++ b/mobilitydb/test/pose/expected/113_tpose_distance.test.out
@@ -1,0 +1,192 @@
+SELECT round(tDistance(geometry 'Point(1 0)', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'), 6);
+                                              round                                               
+--------------------------------------------------------------------------------------------------
+ [1@Sat Jan 01 00:00:00 2000 PST, 0@Sun Jan 02 00:00:00 2000 PST, 3@Wed Jan 05 00:00:00 2000 PST]
+(1 row)
+
+SELECT round(tDistance(pose 'Pose(Point(1 0),0)', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'), 6);
+                                              round                                               
+--------------------------------------------------------------------------------------------------
+ [1@Sat Jan 01 00:00:00 2000 PST, 0@Sun Jan 02 00:00:00 2000 PST, 3@Wed Jan 05 00:00:00 2000 PST]
+(1 row)
+
+SELECT round(tDistance(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', geometry 'Point(1 0)'), 6);
+                                              round                                               
+--------------------------------------------------------------------------------------------------
+ [1@Sat Jan 01 00:00:00 2000 PST, 0@Sun Jan 02 00:00:00 2000 PST, 3@Wed Jan 05 00:00:00 2000 PST]
+(1 row)
+
+SELECT round(tDistance(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', pose 'Pose(Point(1 0),0)'), 6);
+                                              round                                               
+--------------------------------------------------------------------------------------------------
+ [1@Sat Jan 01 00:00:00 2000 PST, 0@Sun Jan 02 00:00:00 2000 PST, 3@Wed Jan 05 00:00:00 2000 PST]
+(1 row)
+
+SELECT round(tDistance(
+  tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]',
+  tpose '[Pose(Point(0 2),0)@2000-01-01, Pose(Point(4 2),0)@2000-01-05]'), 6);
+                              round                               
+------------------------------------------------------------------
+ [2@Sat Jan 01 00:00:00 2000 PST, 2@Wed Jan 05 00:00:00 2000 PST]
+(1 row)
+
+SELECT asText(nearestApproachInstant(geometry 'Point(2 0)', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'));
+                     astext                      
+-------------------------------------------------
+ Pose(POINT(2 0),0)@Mon Jan 03 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(nearestApproachInstant(stbox 'STBOX X((1,-1),(3,1))', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'));
+                     astext                      
+-------------------------------------------------
+ Pose(POINT(1 0),0)@Sun Jan 02 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(nearestApproachInstant(pose 'Pose(Point(2 0),0)', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'));
+                     astext                      
+-------------------------------------------------
+ Pose(POINT(2 0),0)@Mon Jan 03 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(nearestApproachInstant(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', geometry 'Point(2 0)'));
+                     astext                      
+-------------------------------------------------
+ Pose(POINT(2 0),0)@Mon Jan 03 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(nearestApproachInstant(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', stbox 'STBOX X((1,-1),(3,1))'));
+                     astext                      
+-------------------------------------------------
+ Pose(POINT(1 0),0)@Sun Jan 02 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(nearestApproachInstant(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', pose 'Pose(Point(2 0),0)'));
+                     astext                      
+-------------------------------------------------
+ Pose(POINT(2 0),0)@Mon Jan 03 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(nearestApproachInstant(
+  tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]',
+  tpose '[Pose(Point(0 2),0)@2000-01-01, Pose(Point(4 2),0)@2000-01-05]'));
+                     astext                      
+-------------------------------------------------
+ Pose(POINT(0 0),0)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT round(nearestApproachDistance(geometry 'Point(2 0)', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'), 6);
+ round 
+-------
+     0
+(1 row)
+
+SELECT round(nearestApproachDistance(stbox 'STBOX X((1,-1),(3,1))', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'), 6);
+ round 
+-------
+     0
+(1 row)
+
+SELECT round(nearestApproachDistance(pose 'Pose(Point(2 0),0)', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'), 6);
+ round 
+-------
+     0
+(1 row)
+
+SELECT round(nearestApproachDistance(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', geometry 'Point(2 0)'), 6);
+ round 
+-------
+     0
+(1 row)
+
+SELECT round(nearestApproachDistance(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', stbox 'STBOX X((1,-1),(3,1))'), 6);
+ round 
+-------
+     0
+(1 row)
+
+SELECT round(nearestApproachDistance(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', pose 'Pose(Point(2 0),0)'), 6);
+ round 
+-------
+     0
+(1 row)
+
+SELECT round(nearestApproachDistance(
+  tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]',
+  tpose '[Pose(Point(0 2),0)@2000-01-01, Pose(Point(4 2),0)@2000-01-05]'), 6);
+ round 
+-------
+     2
+(1 row)
+
+SELECT ST_AsText(shortestLine(geometry 'Point(2 0)', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'));
+      st_astext      
+---------------------
+ LINESTRING(2 0,2 0)
+(1 row)
+
+SELECT ST_AsText(shortestLine(stbox 'STBOX X((1,-1),(3,1))', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'));
+      st_astext      
+---------------------
+ LINESTRING(1 0,1 0)
+(1 row)
+
+SELECT ST_AsText(shortestLine(pose 'Pose(Point(2 0),0)', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'));
+      st_astext      
+---------------------
+ LINESTRING(2 0,2 0)
+(1 row)
+
+SELECT ST_AsText(shortestLine(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', geometry 'Point(2 0)'));
+      st_astext      
+---------------------
+ LINESTRING(2 0,2 0)
+(1 row)
+
+SELECT ST_AsText(shortestLine(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', stbox 'STBOX X((1,-1),(3,1))'));
+      st_astext      
+---------------------
+ LINESTRING(1 0,1 0)
+(1 row)
+
+SELECT ST_AsText(shortestLine(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', pose 'Pose(Point(2 0),0)'));
+      st_astext      
+---------------------
+ LINESTRING(2 0,2 0)
+(1 row)
+
+SELECT ST_AsText(shortestLine(
+  tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]',
+  tpose '[Pose(Point(0 2),0)@2000-01-01, Pose(Point(4 2),0)@2000-01-05]'));
+      st_astext      
+---------------------
+ LINESTRING(0 0,0 2)
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d t1, tbl_tpose2d t2
+WHERE tDistance(t1.temp, t2.temp) IS NOT NULL LIMIT 10;
+ count 
+-------
+   104
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d t1, tbl_tpose2d t2
+WHERE nearestApproachInstant(t1.temp, t2.temp) IS NOT NULL LIMIT 10;
+ count 
+-------
+   104
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d t1, tbl_tpose2d t2
+WHERE nearestApproachDistance(t1.temp, t2.temp) IS NOT NULL LIMIT 10;
+ count 
+-------
+ 10000
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d t1, tbl_tpose2d t2
+WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL LIMIT 10;
+ count 
+-------
+   104
+(1 row)
+

--- a/mobilitydb/test/pose/queries/105_tpose_spatialfuncs.test.sql
+++ b/mobilitydb/test/pose/queries/105_tpose_spatialfuncs.test.sql
@@ -1,0 +1,134 @@
+-------------------------------------------------------------------------------
+--
+-- This MobilityDB code is provided under The PostgreSQL License.
+-- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+-- contributors
+--
+-- MobilityDB includes portions of PostGIS version 3 source code released
+-- under the GNU General Public License (GPLv2 or later).
+-- Copyright (c) 2001-2025, PostGIS contributors
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice and
+-- this paragraph and the following two paragraphs appear in all copies.
+--
+-- IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+-- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+-- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+-- EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+-- OF SUCH DAMAGE.
+--
+-- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+-- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+-- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+--
+-------------------------------------------------------------------------------
+-- SRID functions
+
+SELECT SRID(tpose 'Pose(Point(1 2),0.5)@2000-01-01');
+SELECT SRID(tpose 'SRID=5676;Pose(Point(1 2),0.5)@2000-01-01');
+
+SELECT asEWKT(setSRID(tpose 'Pose(Point(1 2),0.5)@2000-01-01', 5676));
+
+-------------------------------------------------------------------------------
+-- atGeometry / minusGeometry — instant
+
+SELECT asText(atGeometry(
+  tpose 'Pose(Point(0 0),0)@2000-01-01',
+  'Polygon((-1 -1,1 -1,1 1,-1 1,-1 -1))'::geometry));
+SELECT asText(atGeometry(
+  tpose 'Pose(Point(10 10),0)@2000-01-01',
+  'Polygon((-1 -1,1 -1,1 1,-1 1,-1 -1))'::geometry));
+SELECT asText(minusGeometry(
+  tpose 'Pose(Point(0 0),0)@2000-01-01',
+  'Polygon((-1 -1,1 -1,1 1,-1 1,-1 -1))'::geometry));
+SELECT asText(minusGeometry(
+  tpose 'Pose(Point(10 10),0)@2000-01-01',
+  'Polygon((-1 -1,1 -1,1 1,-1 1,-1 -1))'::geometry));
+
+-------------------------------------------------------------------------------
+-- atGeometry / minusGeometry — discrete sequence
+
+SELECT asText(atGeometry(
+  tpose '{Pose(Point(0 0),0)@2000-01-01, Pose(Point(10 0),0)@2000-01-02}',
+  'Polygon((-1 -1,1 -1,1 1,-1 1,-1 -1))'::geometry));
+SELECT asText(minusGeometry(
+  tpose '{Pose(Point(0 0),0)@2000-01-01, Pose(Point(10 0),0)@2000-01-02}',
+  'Polygon((-1 -1,1 -1,1 1,-1 1,-1 -1))'::geometry));
+
+-------------------------------------------------------------------------------
+-- atGeometry / minusGeometry — continuous sequence
+
+SELECT asText(atGeometry(
+  tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(5 0),0)@2000-01-06]',
+  'Polygon((1 -1,3 -1,3 1,1 1,1 -1))'::geometry));
+SELECT asText(minusGeometry(
+  tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(5 0),0)@2000-01-06]',
+  'Polygon((1 -1,3 -1,3 1,1 1,1 -1))'::geometry));
+
+-------------------------------------------------------------------------------
+-- atGeometry / minusGeometry — sequence set
+
+SELECT asText(atGeometry(
+  tpose '{[Pose(Point(0 0),0)@2000-01-01, Pose(Point(5 0),0)@2000-01-06]}',
+  'Polygon((1 -1,3 -1,3 1,1 1,1 -1))'::geometry));
+SELECT asText(minusGeometry(
+  tpose '{[Pose(Point(0 0),0)@2000-01-01, Pose(Point(5 0),0)@2000-01-06]}',
+  'Polygon((1 -1,3 -1,3 1,1 1,1 -1))'::geometry));
+
+-------------------------------------------------------------------------------
+-- atStbox / minusStbox — spatial only
+
+SELECT asText(atStbox(
+  tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(5 0),0)@2000-01-06]',
+  stbox 'STBOX X((1,-1),(3,1))'));
+SELECT asText(minusStbox(
+  tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(5 0),0)@2000-01-06]',
+  stbox 'STBOX X((1,-1),(3,1))'));
+
+-------------------------------------------------------------------------------
+-- atStbox / minusStbox — temporal only
+
+SELECT asText(atStbox(
+  tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(5 0),0)@2000-01-06]',
+  stbox 'STBOX T([2000-01-02, 2000-01-04])'));
+SELECT asText(minusStbox(
+  tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(5 0),0)@2000-01-06]',
+  stbox 'STBOX T([2000-01-02, 2000-01-04])'));
+
+-------------------------------------------------------------------------------
+-- atStbox / minusStbox — spatiotemporal
+
+SELECT asText(atStbox(
+  tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(5 0),0)@2000-01-06]',
+  stbox 'STBOX XT(((1,-1),(3,1)),[2000-01-02, 2000-01-04])'));
+SELECT asText(minusStbox(
+  tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(5 0),0)@2000-01-06]',
+  stbox 'STBOX XT(((1,-1),(3,1)),[2000-01-02, 2000-01-04])'));
+
+-------------------------------------------------------------------------------
+-- NULL returns: no overlap
+
+SELECT atGeometry(
+  tpose 'Pose(Point(10 10),0)@2000-01-01',
+  'Polygon((0 0,1 0,1 1,0 1,0 0))'::geometry);
+SELECT atStbox(
+  tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(1 0),0)@2000-01-02]',
+  stbox 'STBOX X((10,-1),(20,1))');
+
+-------------------------------------------------------------------------------
+-- Table queries
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE atGeometry(temp,
+  ST_SetSRID('Polygon((-200 -200,200 -200,200 200,-200 200,-200 -200))'::geometry, 3812)) IS NOT NULL;
+SELECT COUNT(*) FROM tbl_tpose2d WHERE minusGeometry(temp,
+  ST_SetSRID('Polygon((-200 -200,200 -200,200 200,-200 200,-200 -200))'::geometry, 3812)) IS NOT NULL;
+SELECT COUNT(*) FROM tbl_tpose2d WHERE atStbox(temp,
+  stbox 'SRID=3812;STBOX XT(((-200,-200),(200,200)),[2001-06-01, 2001-12-31])') IS NOT NULL;
+SELECT COUNT(*) FROM tbl_tpose2d WHERE minusStbox(temp,
+  stbox 'SRID=3812;STBOX XT(((-200,-200),(200,200)),[2001-06-01, 2001-12-31])') IS NOT NULL;
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/pose/queries/113_tpose_distance.test.sql
+++ b/mobilitydb/test/pose/queries/113_tpose_distance.test.sql
@@ -1,0 +1,100 @@
+-------------------------------------------------------------------------------
+--
+-- This MobilityDB code is provided under The PostgreSQL License.
+-- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+-- contributors
+--
+-- MobilityDB includes portions of PostGIS version 3 source code released
+-- under the GNU General Public License (GPLv2 or later).
+-- Copyright (c) 2001-2025, PostGIS contributors
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice and
+-- this paragraph and the following two paragraphs appear in all copies.
+--
+-- IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+-- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+-- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+-- EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+-- OF SUCH DAMAGE.
+--
+-- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+-- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+-- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+--
+-------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- tDistance
+-------------------------------------------------------------------------------
+
+SELECT round(tDistance(geometry 'Point(1 0)', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'), 6);
+SELECT round(tDistance(pose 'Pose(Point(1 0),0)', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'), 6);
+SELECT round(tDistance(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', geometry 'Point(1 0)'), 6);
+SELECT round(tDistance(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', pose 'Pose(Point(1 0),0)'), 6);
+SELECT round(tDistance(
+  tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]',
+  tpose '[Pose(Point(0 2),0)@2000-01-01, Pose(Point(4 2),0)@2000-01-05]'), 6);
+
+-------------------------------------------------------------------------------
+-- nearestApproachInstant
+-------------------------------------------------------------------------------
+
+SELECT asText(nearestApproachInstant(geometry 'Point(2 0)', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'));
+SELECT asText(nearestApproachInstant(stbox 'STBOX X((1,-1),(3,1))', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'));
+SELECT asText(nearestApproachInstant(pose 'Pose(Point(2 0),0)', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'));
+SELECT asText(nearestApproachInstant(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', geometry 'Point(2 0)'));
+SELECT asText(nearestApproachInstant(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', stbox 'STBOX X((1,-1),(3,1))'));
+SELECT asText(nearestApproachInstant(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', pose 'Pose(Point(2 0),0)'));
+SELECT asText(nearestApproachInstant(
+  tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]',
+  tpose '[Pose(Point(0 2),0)@2000-01-01, Pose(Point(4 2),0)@2000-01-05]'));
+
+-------------------------------------------------------------------------------
+-- nearestApproachDistance
+-------------------------------------------------------------------------------
+
+SELECT round(nearestApproachDistance(geometry 'Point(2 0)', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'), 6);
+SELECT round(nearestApproachDistance(stbox 'STBOX X((1,-1),(3,1))', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'), 6);
+SELECT round(nearestApproachDistance(pose 'Pose(Point(2 0),0)', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'), 6);
+SELECT round(nearestApproachDistance(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', geometry 'Point(2 0)'), 6);
+SELECT round(nearestApproachDistance(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', stbox 'STBOX X((1,-1),(3,1))'), 6);
+SELECT round(nearestApproachDistance(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', pose 'Pose(Point(2 0),0)'), 6);
+SELECT round(nearestApproachDistance(
+  tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]',
+  tpose '[Pose(Point(0 2),0)@2000-01-01, Pose(Point(4 2),0)@2000-01-05]'), 6);
+
+-------------------------------------------------------------------------------
+-- shortestLine
+-------------------------------------------------------------------------------
+
+SELECT ST_AsText(shortestLine(geometry 'Point(2 0)', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'));
+SELECT ST_AsText(shortestLine(stbox 'STBOX X((1,-1),(3,1))', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'));
+SELECT ST_AsText(shortestLine(pose 'Pose(Point(2 0),0)', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'));
+SELECT ST_AsText(shortestLine(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', geometry 'Point(2 0)'));
+SELECT ST_AsText(shortestLine(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', stbox 'STBOX X((1,-1),(3,1))'));
+SELECT ST_AsText(shortestLine(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', pose 'Pose(Point(2 0),0)'));
+SELECT ST_AsText(shortestLine(
+  tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]',
+  tpose '[Pose(Point(0 2),0)@2000-01-01, Pose(Point(4 2),0)@2000-01-05]'));
+
+-------------------------------------------------------------------------------
+-- Table queries
+-------------------------------------------------------------------------------
+
+SELECT COUNT(*) FROM tbl_tpose2d t1, tbl_tpose2d t2
+WHERE tDistance(t1.temp, t2.temp) IS NOT NULL LIMIT 10;
+
+SELECT COUNT(*) FROM tbl_tpose2d t1, tbl_tpose2d t2
+WHERE nearestApproachInstant(t1.temp, t2.temp) IS NOT NULL LIMIT 10;
+
+SELECT COUNT(*) FROM tbl_tpose2d t1, tbl_tpose2d t2
+WHERE nearestApproachDistance(t1.temp, t2.temp) IS NOT NULL LIMIT 10;
+
+SELECT COUNT(*) FROM tbl_tpose2d t1, tbl_tpose2d t2
+WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL LIMIT 10;
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
Adds the missing SQL regression coverage for tpose spatial functions and distance. Split out of #945.