### PR TITLE
MEOS bug audit: memory leaks, skiplist safety, and MFJSON parser fixes

### DIFF
--- a/meos/src/temporal/meos_catalog.c
+++ b/meos/src/temporal/meos_catalog.c
@@ -304,6 +304,13 @@ static const temptype_catalog_struct MEOS_TEMPTYPE_CATALOG[] =
 const char *
 meostype_name(MeosType type)
 {
+  /* Defensive: an out-of-range or unmapped MeosType returns NULL from
+   * the designated-initializer array, and propagating that through to
+   * meos_error's %s segfaults inside __strlen_avx2. Return a sentinel
+   * string instead so the caller's error message survives. */
+  const int n = (int) (sizeof(MEOS_TYPE_NAMES) / sizeof(MEOS_TYPE_NAMES[0]));
+  if ((int) type < 0 || (int) type >= n || MEOS_TYPE_NAMES[type] == NULL)
+    return "unknown";
   return MEOS_TYPE_NAMES[type];
 }
 


### PR DESCRIPTION
## Guard meostype_name against an out-of-range MeosType

`meostype_name` indexed `MEOS_TYPE_NAMES` with an unchecked `MeosType`. An
out-of-range or unmapped type yielded a NULL/garbage name that `meos_error`'s
`%s` then dereferenced, segfaulting inside `strlen`. It now returns the sentinel
`"unknown"` for any out-of-range type or NULL name entry. Purely additive (+7),
no behaviour change for valid types.