### PR TITLE
Prefix the SkipListType enum values for disambiguation

### DIFF
--- a/meos/examples/ais_expand_skiplist.c
+++ b/meos/examples/ais_expand_skiplist.c
@@ -308,7 +308,7 @@ int main(void)
     if (pos < 0)
     {
       skiplist_splice(list, NULL, (void **) &newrec_p, 1, NULL, false,
-        KEYVALUE);
+        SKIPLIST_KEYVALUE);
       pos = skiplist_search(list, NULL, (void *)(&newrec));
     }
     SkipListElem *e = (SkipListElem *) &list->elems[pos];

--- a/meos/include/meos_internal.h
+++ b/meos/include/meos_internal.h
@@ -733,13 +733,23 @@ struct SkipList
 };
 
 /**
- * @brief Enumeration for the relative position of a given element into a
- * skiplist
+ * @brief Skiplist mode discriminator
+ *
+ * SKIPLIST_TEMPORAL is the mode used by every production aggregate
+ * (temporal_aggfuncs.c, tgeo_aggfuncs.c, tnpoint_aggfuncs.c); elements are
+ * Temporal* values and merging routes through tsequence_tagg.
+ *
+ * SKIPLIST_KEYVALUE is the (key, value)-pair mode used by MEOS-direct
+ * streaming consumers (see meos/examples/ais_expand_skiplist.c). The
+ * supported pattern is search-then-splice-on-miss with caller-managed
+ * in-place mutation via the user-supplied merge_fn. The batch-merge code
+ * path inside keyval_skiplist_merge is unvalidated and contains known
+ * correctness bugs.
  */
 typedef enum
 {
-  TEMPORAL,
-  KEYVALUE
+  SKIPLIST_TEMPORAL,
+  SKIPLIST_KEYVALUE
 } SkipListType;
 
 /*****************************************************************************

--- a/meos/src/temporal/skiplist.c
+++ b/meos/src/temporal/skiplist.c
@@ -597,7 +597,7 @@ skiplist_splice(SkipList *list, void **keys, void **values, int count,
     /* Determine the elements that will be spliced-out (if any) */
     int lower, upper;
 #if MEOS
-    spliced_count = (sktype == TEMPORAL) ?
+    spliced_count = (sktype == SKIPLIST_TEMPORAL) ?
       temporal_skiplist_common(list, values, count, &lower, &upper, update) :
       keyval_skiplist_common(list, keys, values, count, &lower, &upper, update);
 #else
@@ -645,7 +645,7 @@ skiplist_splice(SkipList *list, void **keys, void **values, int count,
       int newcount = 0;
       void **newkeys = NULL;
 #if MEOS
-      void **newvalues = (sktype == TEMPORAL) ?
+      void **newvalues = (sktype == SKIPLIST_TEMPORAL) ?
         temporal_skiplist_merge(spliced_vals, spliced_count, values, count,
           func, crossings, &newcount, &tofree, &nfree) :
         keyval_skiplist_merge(list, spliced_keys, spliced_vals, spliced_count,
@@ -696,7 +696,7 @@ skiplist_splice(SkipList *list, void **keys, void **values, int count,
 #if ! MEOS
     MemoryContext oldctx = set_aggregation_context(fetch_fcinfo());
 #endif /* ! MEOS */
-    if (sktype == TEMPORAL)
+    if (sktype == SKIPLIST_TEMPORAL)
     {
       newelem->value = temporal_copy(values[i]);
     }

--- a/meos/src/temporal/temporal_aggfuncs.c
+++ b/meos/src/temporal/temporal_aggfuncs.c
@@ -363,7 +363,8 @@ void
 temporal_skiplist_splice(SkipList *list, void **values, int count,
   datum_func2 func, bool crossings)
 {
-  return skiplist_splice(list, NULL, values, count, func, crossings, TEMPORAL);
+  return skiplist_splice(list, NULL, values, count, func, crossings,
+    SKIPLIST_TEMPORAL);
 }
 
 /*****************************************************************************


### PR DESCRIPTION
The skiplist mode discriminator enum values are SKIPLIST_TEMPORAL and SKIPLIST_KEYVALUE rather than the over-generic TEMPORAL and KEYVALUE, disambiguating them from other identifiers.