### PR TITLE
MEOS correctness batch: tnumber_trend step sequences, SRID bbox refresh, and MFJSON validation

### DIFF
--- a/meos/src/temporal/tnumber_mathfuncs.c
+++ b/meos/src/temporal/tnumber_mathfuncs.c
@@ -647,7 +647,7 @@ tnumberseq_trend(const TSequence *seq)
 TSequenceSet *
 tnumberseqset_trend(const TSequenceSet *ss)
 {
-  assert(ss); assert(MEOS_FLAGS_LINEAR_INTERP(ss->flags));
+  assert(ss);
   TSequence **sequences = palloc(sizeof(TSequence *) * ss->count);
   int nseqs = 0;
   for (int i = 0; i < ss->count; i++)
@@ -673,8 +673,8 @@ tnumber_trend(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(temp, NULL);
-  if (! ensure_linear_interp(temp->flags))
-    return NULL;
+  /* trend is defined for both step and linear interpolation */
+  VALIDATE_TNUMBER(temp, NULL);
 
   assert(temptype_subtype(temp->subtype));
   switch (temp->subtype)

--- a/mobilitydb/test/temporal/expected/026_tnumber_mathfuncs.test.out
+++ b/mobilitydb/test/temporal/expected/026_tnumber_mathfuncs.test.out
@@ -1461,13 +1461,29 @@ SELECT trend(tfloat '{[1@2000-01-01],[2@2000-01-02]}');
 
 /* Errors */
 SELECT trend(tfloat '1@2000-01-01');
-ERROR:  The temporal value must have linear interpolation
+ trend 
+-------
+ 
+(1 row)
+
 SELECT trend(tfloat '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03}');
-ERROR:  The temporal value must have linear interpolation
+                                               trend                                                
+----------------------------------------------------------------------------------------------------
+ [1@Sat Jan 01 00:00:00 2000 PST, -1@Sun Jan 02 00:00:00 2000 PST, -1@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
 SELECT trend(tfloat 'Interp=Step;[1@2000-01-01, 2@2000-01-02, 1@2000-01-03]');
-ERROR:  The temporal value must have linear interpolation
+                                               trend                                                
+----------------------------------------------------------------------------------------------------
+ [1@Sat Jan 01 00:00:00 2000 PST, -1@Sun Jan 02 00:00:00 2000 PST, -1@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
 SELECT trend(tfloat 'Interp=Step;{[1@2000-01-01, 2@2000-01-02, 1@2000-01-03],[3@2000-01-04, 3@2000-01-05]}');
-ERROR:  The temporal value must have linear interpolation
+                                                                                 trend                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[1@Sat Jan 01 00:00:00 2000 PST, -1@Sun Jan 02 00:00:00 2000 PST, -1@Mon Jan 03 00:00:00 2000 PST], [0@Tue Jan 04 00:00:00 2000 PST, 0@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
 SELECT round(derivative(tfloat '1@2000-01-01'), 6);
 ERROR:  The temporal value must have linear interpolation
 SELECT round(derivative(tfloat '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03}'), 6);


### PR DESCRIPTION
## tnumber_trend for step and discrete interpolation

`tnumber_trend` gated its input to linear interpolation, so `trend` on a step or
discrete temporal number errored with *"must have linear interpolation"*. But
`trend` is a **per-segment** quantity: for each pair of consecutive instants it is
the direction of the value change (**-1, 0 or +1**), and the result is always a
**step** temporal integer. That computation depends only on the instant values,
not on the input interpolation, so it is well defined for step and discrete
inputs too.

This replaces the `ensure_linear_interp` gate with `VALIDATE_TNUMBER` and drops
the linear-interpolation assertion in `tnumberseqset_trend`. The `026` regression
test is updated so the step and discrete `trend` cases return the per-segment
direction sequence instead of erroring.

Verified: `trend(step)` and `trend(linear)` over the same values produce the
identical per-segment `{-1,0,1}` step result, and the `026` / `026_tbl`
pg_regress tests pass.