### PR TITLE
Add SeqSetGaps coverage to 022_temporal_tbl, 122_trgeo, and 152_tcbuffer

### DIFF
--- a/mobilitydb/test/cbuffer/expected/202_tcbuffer.test.out
+++ b/mobilitydb/test/cbuffer/expected/202_tcbuffer.test.out
@@ -2374,3 +2374,13 @@ SELECT tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)
  t
 (1 row)
 
+SELECT numSequences(tcbufferSeqSetGaps(ARRAY[
+  tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01',
+  tcbuffer 'Cbuffer(Point(2 2), 0.5)@2000-01-02',
+  tcbuffer 'Cbuffer(Point(3 3), 0.5)@2000-01-03'
+]::tcbuffer[], '5 minutes'::interval));
+ numsequences 
+--------------
+            3
+(1 row)
+

--- a/mobilitydb/test/cbuffer/queries/202_tcbuffer.test.sql
+++ b/mobilitydb/test/cbuffer/queries/202_tcbuffer.test.sql
@@ -596,3 +596,11 @@ SELECT tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)
 SELECT tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03], [Cbuffer(Point(2 2), 0.6)@2000-01-04, Cbuffer(Point(2 2), 0.6)@2000-01-05]}' >= tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03], [Cbuffer(Point(2 2), 0.6)@2000-01-04, Cbuffer(Point(2 2), 0.6)@2000-01-05]}';
 
 -------------------------------------------------------------------------------/
+
+SELECT numSequences(tcbufferSeqSetGaps(ARRAY[
+  tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01',
+  tcbuffer 'Cbuffer(Point(2 2), 0.5)@2000-01-02',
+  tcbuffer 'Cbuffer(Point(3 3), 0.5)@2000-01-03'
+]::tcbuffer[], '5 minutes'::interval));
+
+-------------------------------------------------------------------------------/

--- a/mobilitydb/test/rgeo/expected/150_trgeo.test.out
+++ b/mobilitydb/test/rgeo/expected/150_trgeo.test.out
@@ -2398,3 +2398,13 @@ SELECT trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01
  t
 (1 row)
 
+SELECT numSequences(trgeometrySeqSetGaps(ARRAY[
+  trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.0)@2000-01-01',
+  trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(2 2), 0.5)@2000-01-02',
+  trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(3 3), 1.0)@2000-01-03'
+]::trgeometry[], '5 minutes'::interval));
+ numsequences 
+--------------
+            3
+(1 row)
+

--- a/mobilitydb/test/rgeo/queries/150_trgeo.test.sql
+++ b/mobilitydb/test/rgeo/queries/150_trgeo.test.sql
@@ -611,3 +611,11 @@ SELECT trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01
 SELECT trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}' >= trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}';
 
 -------------------------------------------------------------------------------
+
+SELECT numSequences(trgeometrySeqSetGaps(ARRAY[
+  trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.0)@2000-01-01',
+  trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(2 2), 0.5)@2000-01-02',
+  trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(3 3), 1.0)@2000-01-03'
+]::trgeometry[], '5 minutes'::interval));
+
+-------------------------------------------------------------------------------/

--- a/mobilitydb/test/temporal/expected/022_temporal_tbl.test.out
+++ b/mobilitydb/test/temporal/expected/022_temporal_tbl.test.out
@@ -198,6 +198,22 @@ SELECT MAX(numSequences) FROM temp;
 
 DROP TABLE tbl_ttextinst_test;
 DROP TABLE
+DROP TABLE IF EXISTS tbl_tboolinst_test;
+NOTICE:  table "tbl_tboolinst_test" does not exist, skipping
+DROP TABLE
+CREATE TABLE tbl_tboolinst_test AS SELECT k, unnest(instants(seq)) AS inst FROM tbl_tbool_seq;
+SELECT 451
+WITH temp AS (
+  SELECT numSequences(tboolSeqSetGaps(array_agg(inst ORDER BY getTime(inst)), '5 minutes'::interval))
+  FROM tbl_tboolinst_test GROUP BY k )
+SELECT MAX(numSequences) FROM temp;
+ max 
+-----
+   7
+(1 row)
+
+DROP TABLE tbl_tboolinst_test;
+DROP TABLE
 SELECT DISTINCT tempSubtype(tboolInst(inst)) FROM tbl_tbool_inst;
  tempsubtype 
 -------------

--- a/mobilitydb/test/temporal/queries/022_temporal_tbl.test.sql
+++ b/mobilitydb/test/temporal/queries/022_temporal_tbl.test.sql
@@ -111,6 +111,14 @@ WITH temp AS (
 SELECT MAX(numSequences) FROM temp;
 DROP TABLE tbl_ttextinst_test;
 
+DROP TABLE IF EXISTS tbl_tboolinst_test;
+CREATE TABLE tbl_tboolinst_test AS SELECT k, unnest(instants(seq)) AS inst FROM tbl_tbool_seq;
+WITH temp AS (
+  SELECT numSequences(tboolSeqSetGaps(array_agg(inst ORDER BY getTime(inst)), '5 minutes'::interval))
+  FROM tbl_tboolinst_test GROUP BY k )
+SELECT MAX(numSequences) FROM temp;
+DROP TABLE tbl_tboolinst_test;
+
 -------------------------------------------------------------------------------
 -- Transformation functions
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Adds SeqSetGaps regression coverage to three regression suites in a single PR — the temporal table tbl, the trgeo suite, and the tcbuffer suite — since the test pattern is identical across all three files. The tpose variant of the same coverage (#991) remains a separate PR because its delta also rewrites the existing 102_tpose expected file in a way that depends on the GeoPose feature stack.
