### PR TITLE
Rename temptype_continuous to temptype_supports_linear

### DIFF
--- a/meos/include/temporal/meos_catalog.h
+++ b/meos/include/temporal/meos_catalog.h
@@ -278,7 +278,7 @@ extern bool temporal_type(MeosType type);
 #ifndef NDEBUG
 extern bool temporal_basetype(MeosType type);
 #endif
-extern bool temptype_continuous(MeosType type);
+extern bool temptype_supports_linear(MeosType type);
 extern bool basetype_byvalue(MeosType type);
 extern bool basetype_varlength(MeosType type);
 extern int16 meostype_length(MeosType type);

--- a/meos/src/geo/tspatial.c
+++ b/meos/src/geo/tspatial.c
@@ -293,7 +293,7 @@ tspatial_as_ewkt(const Temporal *temp, int maxdd)
   char str1[18];
   /* Determine whether an interpolation prefix must follow the SRID prefix */
   interpType interp = MEOS_FLAGS_GET_INTERP(temp->flags);
-  bool interp_prefix = temptype_continuous(temp->temptype) && interp == STEP;
+  bool interp_prefix = temptype_supports_linear(temp->temptype) && interp == STEP;
   if (srid > 0)
     /* SRID_MAXIMUM is defined by PostGIS as 999999 */
     snprintf(str1, sizeof(str1), "SRID=%d%c", srid, interp_prefix ? ',' : ';');

--- a/meos/src/geo/tspatial_parser.c
+++ b/meos/src/geo/tspatial_parser.c
@@ -577,7 +577,7 @@ tspatial_parse(const char **str, MeosType temptype)
   int temp_srid = SRID_UNKNOWN;
   srid_parse(str, &temp_srid);
 
-  interpType interp = temptype_continuous(temptype) ? LINEAR : STEP;
+  interpType interp = temptype_supports_linear(temptype) ? LINEAR : STEP;
   /* Starts with "Interp=Step" */
   if (pg_strncasecmp(*str, "Interp=Step;", 12) == 0)
   {

--- a/meos/src/rgeo/trgeo_parser.c
+++ b/meos/src/rgeo/trgeo_parser.c
@@ -316,7 +316,7 @@ trgeo_parse(const char **str, MeosType temptype)
   int temp_srid = SRID_UNKNOWN;
   srid_parse(str, &temp_srid);
 
-  interpType interp = temptype_continuous(temptype) ? LINEAR : STEP;
+  interpType interp = temptype_supports_linear(temptype) ? LINEAR : STEP;
   /* Starts with "Interp=Step" */
   if (strncasecmp(*str, "Interp=Step;", 12) == 0)
   {

--- a/meos/src/temporal/meos_catalog.c
+++ b/meos/src/temporal/meos_catalog.c
@@ -1114,10 +1114,15 @@ temporal_basetype(MeosType type)
 #endif
 
 /**
- * @brief Return true if the type is a temporal continuous type
+ * @brief Return true if the temporal type supports LINEAR interpolation
+ * between samples
+ * @note Every MEOS temporal type is continuous in the sense that it has a
+ * value at every instant in its domain; this predicate identifies the
+ * subset whose values can vary linearly between samples (as opposed to
+ * STEP-only types like tbool, tint, ttext, tgeometry, tgeography, th3index).
  */
 inline bool
-temptype_continuous(MeosType type)
+temptype_supports_linear(MeosType type)
 {
   return (type == T_TFLOAT || type == T_TDOUBLE2 || type == T_TDOUBLE3 ||
       type == T_TDOUBLE4 || type == T_TGEOMPOINT || type == T_TGEOGPOINT

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -174,7 +174,7 @@ ensure_one_true(bool hasshift, bool haswidth)
 bool
 ensure_valid_interp(MeosType temptype, interpType interp)
 {
-  if (interp == LINEAR && ! temptype_continuous(temptype))
+  if (interp == LINEAR && ! temptype_supports_linear(temptype))
   {
     meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
       "The temporal type cannot have linear interpolation");
@@ -900,7 +900,7 @@ tsequence_from_base_temp(Datum value, MeosType temptype, const TSequence *seq)
   return MEOS_FLAGS_DISCRETE_INTERP(seq->flags) ? 
     tdiscseq_from_base_temp(value, temptype, seq) :
     tsequence_from_base_tstzspan(value, temptype, &seq->period,
-      temptype_continuous(temptype) ? LINEAR : STEP);
+      temptype_supports_linear(temptype) ? LINEAR : STEP);
 }
 
 /**
@@ -917,7 +917,7 @@ tsequenceset_from_base_temp(Datum value, MeosType temptype,
   const TSequenceSet *ss)
 {
   assert(ss);
-  interpType interp = temptype_continuous(temptype) ? LINEAR : STEP;
+  interpType interp = temptype_supports_linear(temptype) ? LINEAR : STEP;
   TSequence **sequences = palloc(sizeof(TSequence *) * ss->count);
   for (int i = 0; i < ss->count; i++)
   {

--- a/meos/src/temporal/tinstant.c
+++ b/meos/src/temporal/tinstant.c
@@ -248,7 +248,7 @@ tinstant_make(Datum value, MeosType temptype, TimestampTz t)
   result->t = t;
   SET_VARSIZE(result, size);
   MEOS_FLAGS_SET_BYVAL(result->flags, typbyval);
-  MEOS_FLAGS_SET_CONTINUOUS(result->flags, temptype_continuous(temptype));
+  MEOS_FLAGS_SET_CONTINUOUS(result->flags, temptype_supports_linear(temptype));
   MEOS_FLAGS_SET_X(result->flags, true);
   MEOS_FLAGS_SET_T(result->flags, true);
   // TODO Should we bypass the tests on tnpoint ?

--- a/meos/src/temporal/tsequence.c
+++ b/meos/src/temporal/tsequence.c
@@ -438,7 +438,7 @@ tsequence_join_test(const TSequence *seq1, const TSequence *seq2,
     /* If float/point sequences and collinear last/first segments having the same duration
        ..., 1@t1, 2@t2) [2@t2, 3@t3, ... -> ..., 1@t1, 3@t3, ...
     */
-    (temptype_continuous(seq1->temptype) && eq_last1_first1 &&
+    (temptype_supports_linear(seq1->temptype) && eq_last1_first1 &&
       datum_collinear(last2value, first1value, first2value, basetype,
         last2->t, first1->t, first2->t))
     ))

--- a/meos/src/temporal/type_parser.c
+++ b/meos/src/temporal/type_parser.c
@@ -857,7 +857,7 @@ temporal_parse(const char **str, MeosType temptype)
 {
   p_whitespace(str);
   Temporal *result = NULL;  /* keep compiler quiet */
-  interpType interp = temptype_continuous(temptype) ? LINEAR : STEP;
+  interpType interp = temptype_supports_linear(temptype) ? LINEAR : STEP;
   /* Starts with "Interp=Step;" */
   if (pg_strncasecmp(*str, "Interp=Step;", 12) == 0)
   {

--- a/mobilitydb/src/rgeo/trgeo.c
+++ b/mobilitydb/src/rgeo/trgeo.c
@@ -283,7 +283,7 @@ Trgeometry_seq_constructor(PG_FUNCTION_ARGS)
 {
   ArrayType *array = PG_GETARG_ARRAYTYPE_P(0);
   MeosType temptype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
-  interpType interp = temptype_continuous(temptype) ? LINEAR : STEP;
+  interpType interp = temptype_supports_linear(temptype) ? LINEAR : STEP;
   if (PG_NARGS() > 1 && ! PG_ARGISNULL(1))
   {
     text *interp_txt = PG_GETARG_TEXT_P(1);
@@ -349,7 +349,7 @@ Trgeometry_seqset_constructor_gaps(PG_FUNCTION_ARGS)
   double maxdist = -1.0;
   Interval *maxt = NULL;
   MeosType temptype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
-  interpType interp = temptype_continuous(temptype) ? LINEAR : STEP;
+  interpType interp = temptype_supports_linear(temptype) ? LINEAR : STEP;
   if (PG_NARGS() > 1 && ! PG_ARGISNULL(1))
     maxt = PG_GETARG_INTERVAL_P(1);
   if (PG_NARGS() > 2 && ! PG_ARGISNULL(2))

--- a/mobilitydb/src/temporal/temporal.c
+++ b/mobilitydb/src/temporal/temporal.c
@@ -557,7 +557,7 @@ Tsequence_constructor(PG_FUNCTION_ARGS)
   ArrayType *array = PG_GETARG_ARRAYTYPE_P(0);
   ensure_not_empty_array(array);
   MeosType temptype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
-  interpType interp = temptype_continuous(temptype) ? LINEAR : STEP;
+  interpType interp = temptype_supports_linear(temptype) ? LINEAR : STEP;
   if (PG_NARGS() > 1 && ! PG_ARGISNULL(1))
     interp = input_interp_string(fcinfo, 1);
   bool lower_inc = true, upper_inc = true;
@@ -614,7 +614,7 @@ Tsequenceset_constructor_gaps(PG_FUNCTION_ARGS)
   double maxdist = -1.0;
   Interval *maxt = NULL;
   MeosType temptype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
-  interpType interp = temptype_continuous(temptype) ? LINEAR : STEP;
+  interpType interp = temptype_supports_linear(temptype) ? LINEAR : STEP;
   if (PG_NARGS() > 1 && ! PG_ARGISNULL(1))
     maxt = PG_GETARG_INTERVAL_P(1);
   if (PG_NARGS() > 2 && ! PG_ARGISNULL(2))
@@ -669,7 +669,7 @@ Tsequence_from_base_tstzspan(PG_FUNCTION_ARGS)
   Datum value = PG_GETARG_ANYDATUM(0);
   Span *s = PG_GETARG_SPAN_P(1);
   MeosType temptype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
-  interpType interp = temptype_continuous(temptype) ? LINEAR : STEP;
+  interpType interp = temptype_supports_linear(temptype) ? LINEAR : STEP;
   if (PG_NARGS() > 2 && !PG_ARGISNULL(2))
     interp = input_interp_string(fcinfo, 2);
   PG_RETURN_TSEQUENCE_P(tsequence_from_base_tstzspan(value, temptype, s,
@@ -690,7 +690,7 @@ Tsequenceset_from_base_tstzspanset(PG_FUNCTION_ARGS)
   Datum value = PG_GETARG_ANYDATUM(0);
   SpanSet *ss = PG_GETARG_SPANSET_P(1);
   MeosType temptype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
-  interpType interp = temptype_continuous(temptype) ? LINEAR : STEP;
+  interpType interp = temptype_supports_linear(temptype) ? LINEAR : STEP;
   if (PG_NARGS() > 2 && !PG_ARGISNULL(2))
     interp = input_interp_string(fcinfo, 2);
 
@@ -1877,7 +1877,7 @@ Temporal_append_tinstant(PG_FUNCTION_ARGS)
   {
     /* Set default interpolation according to the base type */
     MeosType temptype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 1));
-    interp = temptype_continuous(temptype) ? LINEAR : STEP;
+    interp = temptype_supports_linear(temptype) ? LINEAR : STEP;
   }
   else
     interp = input_interp_string(fcinfo, 2);

--- a/mobilitydb/src/temporal/temporal_aggfuncs.c
+++ b/mobilitydb/src/temporal/temporal_aggfuncs.c
@@ -678,7 +678,7 @@ Temporal_app_tinst_transfn(PG_FUNCTION_ARGS)
   {
     /* Set default interpolation according to the base type */
     MeosType temptype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 1));
-    interp = temptype_continuous(temptype) ? LINEAR : STEP;
+    interp = temptype_supports_linear(temptype) ? LINEAR : STEP;
   }
   else
   {


### PR DESCRIPTION
Every MEOS temporal type is continuous in the topological sense — a tbool, ttext, or th3index has a value at every instant in its domain, it simply steps between values rather than interpolating linearly. The predicate that was named temptype_continuous actually tests whether the temporal type supports LINEAR interpolation between samples, which is a different and narrower property. The name is corrected and the doc comment is expanded to make the distinction explicit. All callers updated.