### PR TITLE
Drop redundant memset-default field stores in LiftedFunctionInfo callsites

### DIFF
--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -357,7 +357,6 @@ tdistance_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) datum_cbuffer_distance;
-  lfinfo.numparam = 0;
   lfinfo.argtype[0] = temp->temptype;
   lfinfo.argtype[1] = temptype_basetype(temp->temptype);
   lfinfo.restype = T_TFLOAT;
@@ -406,7 +405,6 @@ tdistance_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) datum_cbuffer_distance;
-  lfinfo.numparam = 0;
   lfinfo.argtype[0] = temp1->temptype;
   lfinfo.argtype[1] = temp2->temptype;
   lfinfo.restype = T_TFLOAT;

--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -1502,7 +1502,6 @@ ea_dwithin_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
   lfinfo.param[0] = Float8GetDatum(dist);
   lfinfo.argtype[0] = lfinfo.argtype[1] = temp1->temptype;
   lfinfo.restype = T_TFLOAT;
-  lfinfo.reslinear = false;
   lfinfo.invert = INVERT_NO;
   lfinfo.discont = MEOS_FLAGS_LINEAR_INTERP(temp1->flags) ||
     MEOS_FLAGS_LINEAR_INTERP(temp2->flags);

--- a/meos/src/cbuffer/tcbuffer_tempspatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_tempspatialrels.c
@@ -616,7 +616,6 @@ tspatialrel_tcbuffer_cbuffer_int(const Temporal *temp, const Cbuffer *cb,
   lfinfo.argtype[0] = temp->temptype;
   lfinfo.argtype[1] = temptype_basetype(temp->temptype);
   lfinfo.restype = T_TBOOL;
-  lfinfo.reslinear = false;
   lfinfo.invert = invert;
   lfinfo.discont = false;
   return tfunc_temporal_base(temp, PointerGetDatum(cb), &lfinfo);

--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -392,7 +392,6 @@ tdistance_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) geo_distance_fn(temp->flags);
-  lfinfo.numparam = 0;
   lfinfo.argtype[0] = temp->temptype;
   lfinfo.argtype[1] = temptype_basetype(temp->temptype);
   lfinfo.restype = T_TFLOAT;
@@ -422,7 +421,6 @@ tdistance_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) geo_distance_fn(temp1->flags);
-  lfinfo.numparam = 0;
   lfinfo.argtype[0] = lfinfo.argtype[1] = temp1->temptype;
   lfinfo.restype = T_TFLOAT;
   lfinfo.reslinear = MEOS_FLAGS_LINEAR_INTERP(temp1->flags) ||

--- a/meos/src/geo/tgeo_spatialfuncs.c
+++ b/meos/src/geo/tgeo_spatialfuncs.c
@@ -1648,7 +1648,6 @@ tgeo_centroid(const Temporal *temp)
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) 
     (geodetic ? &datum2_geog_centroid : &datum2_geom_centroid);
-  lfinfo.numparam = 0;
   lfinfo.argtype[0] = temp->temptype;
   lfinfo.restype = geodetic ? T_TGEOGPOINT : T_TGEOMPOINT;
   return tfunc_temporal(temp, &lfinfo);

--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -513,7 +513,6 @@ ea_spatialrel_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2,
   lfinfo.numparam = 0;
   lfinfo.argtype[0] = lfinfo.argtype[1] = temp1->temptype;
   lfinfo.restype = T_TBOOL;
-  lfinfo.reslinear = false;
   lfinfo.invert = INVERT_NO;
   lfinfo.discont = MEOS_FLAGS_LINEAR_INTERP(temp1->flags) ||
     MEOS_FLAGS_LINEAR_INTERP(temp2->flags);
@@ -1702,7 +1701,6 @@ ea_dwithin_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2, double dist,
   lfinfo.param[0] = Float8GetDatum(dist);
   lfinfo.argtype[0] = lfinfo.argtype[1] = temp1->temptype;
   lfinfo.restype = T_TFLOAT;
-  lfinfo.reslinear = false;
   lfinfo.invert = INVERT_NO;
   lfinfo.discont = MEOS_FLAGS_LINEAR_INTERP(temp1->flags) ||
     MEOS_FLAGS_LINEAR_INTERP(temp2->flags);

--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -510,7 +510,6 @@ ea_spatialrel_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2,
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) func;
-  lfinfo.numparam = 0;
   lfinfo.argtype[0] = lfinfo.argtype[1] = temp1->temptype;
   lfinfo.restype = T_TBOOL;
   lfinfo.invert = INVERT_NO;

--- a/meos/src/geo/tpoint_spatialfuncs.c
+++ b/meos/src/geo/tpoint_spatialfuncs.c
@@ -179,7 +179,6 @@ tpoint_get_coord(const Temporal *temp, int coord)
     lfinfo.func = (varfunc) &point_get_y;
   else /* coord == 2 */
     lfinfo.func = (varfunc) &point_get_z;
-  lfinfo.numparam = 0;
   lfinfo.argtype[0] = temp->temptype;
   lfinfo.restype = T_TFLOAT;
   return tfunc_temporal(temp, &lfinfo);
@@ -3169,7 +3168,6 @@ bearing_tpoint_point(const Temporal *temp, const GSERIALIZED *gs, bool invert)
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) geo_bearing_fn(temp->flags);
-  lfinfo.numparam = 0;
   lfinfo.argtype[0] = temp->temptype;
   lfinfo.argtype[1] = temptype_basetype(temp->temptype);
   lfinfo.restype = T_TFLOAT;
@@ -3198,7 +3196,6 @@ bearing_tpoint_tpoint(const Temporal *temp1, const Temporal *temp2)
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) geo_bearing_fn(temp1->flags);
-  lfinfo.numparam = 0;
   lfinfo.argtype[0] = lfinfo.argtype[1] = temp1->temptype;
   lfinfo.restype = T_TFLOAT;
   lfinfo.reslinear = MEOS_FLAGS_LINEAR_INTERP(temp1->flags) ||

--- a/meos/src/geo/tspatial_tempspatialrels.c
+++ b/meos/src/geo/tspatial_tempspatialrels.c
@@ -579,7 +579,6 @@ tspatialrel_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2,
   lfinfo.param[0] = param;
   lfinfo.argtype[0] = lfinfo.argtype[1] = temp1->temptype;
   lfinfo.restype = T_TBOOL;
-  lfinfo.reslinear = false;
   lfinfo.invert = invert;
   lfinfo.discont = MEOS_FLAGS_LINEAR_INTERP(temp1->flags) ||
     MEOS_FLAGS_LINEAR_INTERP(temp2->flags);

--- a/meos/src/pose/tpose.c
+++ b/meos/src/pose/tpose.c
@@ -407,7 +407,6 @@ tpose_to_tpoint(const Temporal *temp)
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) &datum_pose_point;
-  lfinfo.numparam = 0;
   lfinfo.argtype[0] = temptype_basetype(temp->temptype);
   lfinfo.restype = T_TGEOMPOINT;
   Temporal *result = tfunc_temporal(temp, &lfinfo);
@@ -434,7 +433,6 @@ tpose_rotation(const Temporal *temp)
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) &datum_pose_rotation;
-  lfinfo.numparam = 0;
   lfinfo.argtype[0] = T_TPOSE;
   lfinfo.restype = T_TFLOAT;
   Temporal *result = tfunc_temporal(temp, &lfinfo);

--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -280,7 +280,6 @@ trgeo_to_tpoint(const Temporal *temp)
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) &datum_pose_point;
-  lfinfo.numparam = 0;
   lfinfo.argtype[0] = temptype_basetype(temp->temptype);
   lfinfo.restype = T_TGEOMPOINT;
   Temporal *result = tfunc_temporal(temp, &lfinfo);

--- a/meos/src/temporal/tbool_ops.c
+++ b/meos/src/temporal/tbool_ops.c
@@ -94,7 +94,6 @@ tnot_tbool(const Temporal *temp)
   lfinfo.numparam = 0;
   lfinfo.argtype[0] = T_TBOOL;
   lfinfo.restype = T_TBOOL;
-  lfinfo.reslinear = false;
   lfinfo.invert = INVERT_NO;
   lfinfo.discont = CONTINUOUS;
   return tfunc_temporal(temp, &lfinfo);
@@ -114,7 +113,6 @@ boolop_tbool_bool(const Temporal *temp, Datum b, datum_func2 func, bool invert)
   lfinfo.argtype[0] = T_TBOOL;
   lfinfo.argtype[1] = T_BOOL;
   lfinfo.restype = T_TBOOL;
-  lfinfo.reslinear = false;
   lfinfo.invert = invert;
   lfinfo.discont = CONTINUOUS;
   return tfunc_temporal_base(temp, b, &lfinfo);
@@ -135,7 +133,6 @@ boolop_tbool_tbool(const Temporal *temp1, const Temporal *temp2,
   lfinfo.func = (varfunc) func;
   lfinfo.argtype[0] = lfinfo.argtype[1] = T_TBOOL;
   lfinfo.restype = T_TBOOL;
-  lfinfo.reslinear = false;
   lfinfo.invert = INVERT_NO;
   lfinfo.discont = CONTINUOUS;
   return tfunc_temporal_temporal(temp1, temp2, &lfinfo);

--- a/meos/src/temporal/tbool_ops.c
+++ b/meos/src/temporal/tbool_ops.c
@@ -91,7 +91,6 @@ tnot_tbool(const Temporal *temp)
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) &datum_not;
-  lfinfo.numparam = 0;
   lfinfo.argtype[0] = T_TBOOL;
   lfinfo.restype = T_TBOOL;
   lfinfo.invert = INVERT_NO;

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -1010,7 +1010,6 @@ tbool_to_tint(const Temporal *temp)
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) datum_bool_to_int;
-  lfinfo.numparam = 0;
   lfinfo.argtype[0] = T_TBOOL;
   lfinfo.restype = T_TINT;
   return tfunc_temporal(temp, &lfinfo);
@@ -1031,7 +1030,6 @@ tint_to_tfloat(const Temporal *temp)
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) datum_int_to_float;
-  lfinfo.numparam = 0;
   lfinfo.argtype[0] = T_TINT;
   lfinfo.restype = T_TFLOAT;
   return tfunc_temporal(temp, &lfinfo);
@@ -1058,7 +1056,6 @@ tfloat_to_tint(const Temporal *temp)
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) datum_float_to_int;
-  lfinfo.numparam = 0;
   lfinfo.argtype[0] = T_TFLOAT;
   lfinfo.restype = T_TINT;
   return tfunc_temporal(temp, &lfinfo);
@@ -1318,7 +1315,6 @@ tfloat_floor(const Temporal *temp)
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) &datum_floor;
-  lfinfo.numparam = 0;
   lfinfo.argtype[0] = T_TFLOAT;
   lfinfo.restype = T_TFLOAT;
   return tfunc_temporal(temp, &lfinfo);
@@ -1339,7 +1335,6 @@ tfloat_ceil(const Temporal *temp)
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) &datum_ceil;
-  lfinfo.numparam = 0;
   lfinfo.argtype[0] = T_TFLOAT;
   lfinfo.restype = T_TFLOAT;
   return tfunc_temporal(temp, &lfinfo);
@@ -1425,7 +1420,6 @@ tfloat_radians(const Temporal *temp)
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) &datum_radians;
-  lfinfo.numparam = 0;
   lfinfo.argtype[0] = T_TFLOAT;
   lfinfo.restype = T_TFLOAT;
   return tfunc_temporal(temp, &lfinfo);

--- a/meos/src/temporal/temporal_compops.c
+++ b/meos/src/temporal/temporal_compops.c
@@ -77,7 +77,6 @@ eacomp_base_temporal(Datum value, const Temporal *temp,
   lfinfo.argtype[0] = temp->temptype;
   lfinfo.argtype[1] = basetype;
   lfinfo.restype = T_BOOL;
-  lfinfo.reslinear = false;
   lfinfo.invert = INVERT;
   lfinfo.discont = MEOS_FLAGS_LINEAR_INTERP(temp->flags);
   lfinfo.ever = ever;
@@ -107,7 +106,6 @@ eacomp_temporal_base(const Temporal *temp, Datum value,
   lfinfo.argtype[0] = temp->temptype;
   lfinfo.argtype[1] = basetype;
   lfinfo.restype = T_BOOL;
-  lfinfo.reslinear = false;
   lfinfo.invert = INVERT_NO;
   lfinfo.discont = MEOS_FLAGS_LINEAR_INTERP(temp->flags);
   lfinfo.ever = ever;
@@ -135,7 +133,6 @@ eacomp_temporal_temporal(const Temporal *temp1, const Temporal *temp2,
   lfinfo.param[0] = basetype;
   lfinfo.argtype[0] = lfinfo.argtype[1] = temp1->temptype;
   lfinfo.restype = T_BOOL;
-  lfinfo.reslinear = false;
   lfinfo.invert = INVERT_NO;
   lfinfo.discont = MEOS_FLAGS_LINEAR_INTERP(temp1->flags) ||
     MEOS_FLAGS_LINEAR_INTERP(temp2->flags);
@@ -689,7 +686,6 @@ tcomp_base_temporal(Datum value, const Temporal *temp,
   lfinfo.argtype[0] = temp->temptype;
   lfinfo.argtype[1] = basetype;
   lfinfo.restype = T_TBOOL;
-  lfinfo.reslinear = false;
   lfinfo.invert = INVERT;
   lfinfo.discont = MEOS_FLAGS_LINEAR_INTERP(temp->flags);
   return tfunc_temporal_base(temp, value, &lfinfo);
@@ -717,7 +713,6 @@ tcomp_temporal_base(const Temporal *temp, Datum value,
   lfinfo.argtype[0] = temp->temptype;
   lfinfo.argtype[1] = basetype;
   lfinfo.restype = T_TBOOL;
-  lfinfo.reslinear = false;
   lfinfo.invert = INVERT_NO;
   lfinfo.discont = MEOS_FLAGS_LINEAR_INTERP(temp->flags);
   return tfunc_temporal_base(temp, value, &lfinfo);
@@ -744,7 +739,6 @@ tcomp_temporal_temporal(const Temporal *temp1, const Temporal *temp2,
   lfinfo.param[0] = basetype;
   lfinfo.argtype[0] = lfinfo.argtype[1] = temp1->temptype;
   lfinfo.restype = T_TBOOL;
-  lfinfo.reslinear = false;
   lfinfo.invert = INVERT_NO;
   lfinfo.discont = MEOS_FLAGS_LINEAR_INTERP(temp1->flags) ||
     MEOS_FLAGS_LINEAR_INTERP(temp2->flags);

--- a/meos/src/temporal/tnumber_mathfuncs.c
+++ b/meos/src/temporal/tnumber_mathfuncs.c
@@ -757,7 +757,6 @@ tfloat_exp(const Temporal *temp)
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) datum_exp;
-  lfinfo.numparam = 0;
   lfinfo.argtype[0] = T_TFLOAT;
   lfinfo.restype = T_TFLOAT;
   return tfunc_temporal(temp, &lfinfo);
@@ -831,7 +830,6 @@ tfloat_ln(const Temporal *temp)
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) datum_ln;
-  lfinfo.numparam = 0;
   lfinfo.argtype[0] = T_TFLOAT;
   lfinfo.restype = T_TFLOAT;
   return tfunc_temporal(temp, &lfinfo);
@@ -904,7 +902,6 @@ tfloat_log10(const Temporal *temp)
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) datum_log10;
-  lfinfo.numparam = 0;
   lfinfo.argtype[0] = T_TFLOAT;
   lfinfo.restype = T_TFLOAT;
   return tfunc_temporal(temp, &lfinfo);

--- a/meos/src/temporal/ttext_funcs.c
+++ b/meos/src/temporal/ttext_funcs.c
@@ -86,7 +86,6 @@ textfunc_ttext_text(const Temporal *temp, Datum value, datum_func2 func,
   lfinfo.argtype[0] = T_TTEXT;
   lfinfo.argtype[1] = T_TEXT;
   lfinfo.restype = T_TTEXT;
-  lfinfo.reslinear = false;
   lfinfo.invert = invert;
   lfinfo.discont = CONTINUOUS;
   return tfunc_temporal_base(temp, value, &lfinfo);
@@ -110,7 +109,6 @@ textfunc_ttext_ttext(const Temporal *temp1, const Temporal *temp2,
   lfinfo.numparam = 0;
   lfinfo.argtype[0] = lfinfo.argtype[1] = T_TTEXT;
   lfinfo.restype = T_TTEXT;
-  lfinfo.reslinear = false;
   lfinfo.invert = INVERT_NO;
   lfinfo.discont = CONTINUOUS;
   return tfunc_temporal_temporal(temp1, temp2, &lfinfo);

--- a/meos/src/temporal/ttext_funcs.c
+++ b/meos/src/temporal/ttext_funcs.c
@@ -62,7 +62,6 @@ textfunc_ttext(const Temporal *temp, datum_func1 func)
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) func;
-  lfinfo.numparam = 0;
   lfinfo.argtype[0] = T_TTEXT;
   lfinfo.restype = T_TTEXT;
   return tfunc_temporal(temp, &lfinfo);
@@ -82,7 +81,6 @@ textfunc_ttext_text(const Temporal *temp, Datum value, datum_func2 func,
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) func;
-  lfinfo.numparam = 0;
   lfinfo.argtype[0] = T_TTEXT;
   lfinfo.argtype[1] = T_TEXT;
   lfinfo.restype = T_TTEXT;
@@ -106,7 +104,6 @@ textfunc_ttext_ttext(const Temporal *temp1, const Temporal *temp2,
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) func;
-  lfinfo.numparam = 0;
   lfinfo.argtype[0] = lfinfo.argtype[1] = T_TTEXT;
   lfinfo.restype = T_TTEXT;
   lfinfo.invert = INVERT_NO;

--- a/mobilitydb/src/geo/projection_gk.c
+++ b/mobilitydb/src/geo/projection_gk.c
@@ -272,7 +272,6 @@ tgeompoint_transform_gk(const Temporal *temp)
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) &gk;
-  lfinfo.numparam = 0;
   lfinfo.argtype[0] = temp->temptype;
   lfinfo.restype = temp->temptype;
   Temporal *result = tfunc_temporal(temp, &lfinfo);


### PR DESCRIPTION
memset(&lfinfo, 0, sizeof(LiftedFunctionInfo)) already zeroes every field, so any subsequent lfinfo.<field> = <memset-default> store is redundant. The two most common offenders were lfinfo.reslinear = false (19 sites across 7 files) and lfinfo.numparam = 0 (26 sites across 12 files). The two commits remove them. Pure cosmetic plus a small cycle saving on every lift; no semantic change.