### PR TITLE
Add minDistance(tgeompoint[], tgeompoint[]) exact set-set spatial distance

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1175,6 +1175,10 @@
 				</listitem>
 
 				<listitem>
+					<para><link linkend="tgeo_minDistance"><varname>minDistance</varname></link>: Devuelve la distancia espacial mínima entre dos geometrías temporales sobre la unión de sus extensiones temporales</para>
+				</listitem>
+
+				<listitem>
 					<para><link linkend="tgeo_nearestApproachInstant"><varname>nearestApproachInstant</varname></link>: Devuelve el instante del primer punto temporal en el que los dos argumentos están a la distancia más cercana</para>
 				</listitem>
 

--- a/doc/es/temporal_spatial_p2.xml
+++ b/doc/es/temporal_spatial_p2.xml
@@ -238,6 +238,30 @@ SELECT to_timestamp(ST_ClosestPointOfApproach(
 </programlisting>
 			</listitem>
 
+			<listitem xml:id="tgeo_minDistance">
+				<indexterm significance="normal"><primary><varname>minDistance</varname></primary></indexterm>
+				<para>Devuelve la distancia espacial mínima entre dos geometrías temporales sobre la unión de sus extensiones temporales</para>
+				<para><varname>minDistance({tgeo,geo},{tgeo,geo}) → float</varname></para>
+				<para><varname>minDistance(tgeo[],tgeo[]) → float</varname></para>
+				<para><varname>minDistance(tgeo,tgeo) → float</varname> (agregado)</para>
+				<para>La forma escalar devuelve la distancia mínima alcanzada entre los dos argumentos sobre la intersección de sus extensiones temporales, equivalente al valor mínimo de la distancia temporal <varname>&lt;-&gt;</varname>. La forma de arreglo generaliza esto a dos conjuntos de geometrías temporales y devuelve el mínimo sobre todos los pares. La forma de agregado, utilizada con <varname>GROUP BY</varname>, devuelve la distancia mínima alcanzada sobre todos los pares agregados en el grupo.</para>
+				<programlisting language="sql" xml:space="preserve">
+SELECT minDistance(tgeompoint '[Point(0 0)@2001-01-01, Point(1 1)@2001-01-03)',
+  geometry 'Point(0 1)');
+-- 0.707106781186548
+SELECT minDistance(
+  ARRAY[tgeompoint '[Point(0 0)@2001-01-01, Point(1 1)@2001-01-03)',
+        tgeompoint '[Point(5 5)@2001-01-01, Point(6 6)@2001-01-03)'],
+  ARRAY[tgeompoint '[Point(0 1)@2001-01-01, Point(1 0)@2001-01-03)']);
+-- 0
+SELECT g, minDistance(t1.Trip, t2.Trip)
+FROM Trips t1, Trips t2, Groups g
+WHERE t1.GroupId = g AND t2.GroupId = g AND t1.TripId &lt; t2.TripId
+GROUP BY g;
+</programlisting>
+				<para>La forma de agregado se adapta bien a las consultas tipo BerlinMOD que calculan la distancia mínima de aproximación entre pares de trayectorias agrupados por licencia o tipo de vehículo. En un grupo de una sola fila, el agregado se reduce a la distancia mínima escalar entre el par.</para>
+			</listitem>
+
 			<listitem xml:id="tgeo_shortestLine">
 				<indexterm significance="normal"><primary><varname>shortestLine</varname></primary></indexterm>
 				<para>Devuelve la línea que conecta el punto de aproximación más cercano &Z_support; &geography_support;</para>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1174,6 +1174,10 @@
 				</listitem>
 
 				<listitem>
+					<para><link linkend="tgeo_minDistance"><varname>minDistance</varname></link>: Return the minimum spatial distance between two temporal geometries over the union of their temporal extents</para>
+				</listitem>
+
+				<listitem>
 					<para><link linkend="tgeo_nearestApproachInstant"><varname>nearestApproachInstant</varname></link>: Return the instant of the first temporal point at which the two arguments are at the nearest distance</para>
 				</listitem>
 

--- a/doc/temporal_spatial_p2.xml
+++ b/doc/temporal_spatial_p2.xml
@@ -237,6 +237,30 @@ SELECT to_timestamp(ST_ClosestPointOfApproach(
 </programlisting>
 			</listitem>
 
+			<listitem xml:id="tgeo_minDistance">
+				<indexterm significance="normal"><primary><varname>minDistance</varname></primary></indexterm>
+				<para>Return the minimum spatial distance between two temporal geometries over the union of their temporal extents</para>
+				<para><varname>minDistance({tgeo,geo},{tgeo,geo}) → float</varname></para>
+				<para><varname>minDistance(tgeo[],tgeo[]) → float</varname></para>
+				<para><varname>minDistance(tgeo,tgeo) → float</varname> (aggregate)</para>
+				<para>The scalar form returns the minimum distance reached between the two arguments over the intersection of their temporal extents, equivalent to the minimum value of the temporal distance <varname>&lt;-&gt;</varname>. The array form generalises this to two sets of temporal geometries and returns the minimum across all pairs. The aggregate form, used with <varname>GROUP BY</varname>, returns the minimum distance reached over all aggregated pairs in the group.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT minDistance(tgeompoint '[Point(0 0)@2001-01-01, Point(1 1)@2001-01-03)',
+  geometry 'Point(0 1)');
+-- 0.707106781186548
+SELECT minDistance(
+  ARRAY[tgeompoint '[Point(0 0)@2001-01-01, Point(1 1)@2001-01-03)',
+        tgeompoint '[Point(5 5)@2001-01-01, Point(6 6)@2001-01-03)'],
+  ARRAY[tgeompoint '[Point(0 1)@2001-01-01, Point(1 0)@2001-01-03)']);
+-- 0
+SELECT g, minDistance(t1.Trip, t2.Trip)
+FROM Trips t1, Trips t2, Groups g
+WHERE t1.GroupId = g AND t2.GroupId = g AND t1.TripId &lt; t2.TripId
+GROUP BY g;
+</programlisting>
+				<para>The aggregate form is well suited to BerlinMOD-style queries that compute the minimum approach distance between trip pairs grouped by license or vehicle class. On a single-row group the aggregate degenerates to the scalar minimum distance between the pair.</para>
+			</listitem>
+
 			<listitem xml:id="tgeo_shortestLine">
 				<indexterm significance="normal"><primary><varname>shortestLine</varname></primary></indexterm>
 				<para>Return the line connecting the nearest approach point &Z_support; &geography_support;</para>

--- a/meos/include/meos_geo.h
+++ b/meos/include/meos_geo.h
@@ -866,6 +866,8 @@ extern TInstant *nai_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs);
 extern TInstant *nai_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2);
 extern GSERIALIZED *shortestline_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs);
 extern GSERIALIZED *shortestline_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2);
+extern double tgeoarr_tgeoarr_mindist(const Temporal **arr1, int count1, const Temporal **arr2, int count2);
+extern double mindistance_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2, double threshold);
 
 /* Aggregates */
 

--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -986,9 +986,416 @@ shortestline_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
   temporal_value_at_timestamptz(temp2, inst->t, false, &value2);
   LWGEOM *line = (LWGEOM *) lwline_make(value1, value2);
   GSERIALIZED *result = geo_serialize(line);
-  pfree(DatumGetPointer(value1)); pfree(DatumGetPointer(value2)); 
+  pfree(DatumGetPointer(value1)); pfree(DatumGetPointer(value2));
   pfree(dist); lwgeom_free(line);
   return result;
+}
+
+/*****************************************************************************
+ * Set-set spatial minimum distance
+ *****************************************************************************/
+
+/* Spatial-only distance between two STBoxes; ignores time entirely. */
+static double
+stbox_spatial_distance(const STBox *box1, const STBox *box2)
+{
+  /* Spatial extents overlap → exact minimum is 0 (some pair of points
+   * inside the joined extent has zero distance) */
+  if (box1->xmin <= box2->xmax && box2->xmin <= box1->xmax &&
+      box1->ymin <= box2->ymax && box2->ymin <= box1->ymax)
+    return 0.0;
+
+  /* Spatial extents disjoint → exact bbox-to-bbox euclidean distance.
+   * Drop the time component of each box before serialising to geometry. */
+  datum_func2 func = geo_distance_fn(box1->flags);
+  STBox b1 = *box1, b2 = *box2;
+  MEOS_FLAGS_SET_T(b1.flags, false);
+  MEOS_FLAGS_SET_T(b2.flags, false);
+  Datum g1 = PointerGetDatum(stbox_geo(&b1));
+  Datum g2 = PointerGetDatum(stbox_geo(&b2));
+  double result = DatumGetFloat8(func(g1, g2));
+  pfree(DatumGetPointer(g1));
+  pfree(DatumGetPointer(g2));
+  return result;
+}
+
+/*****************************************************************************
+ * Threshold-aware plane-sweep spatial-min kernel (Option B'')
+ *
+ * Walks two tgeompoint TSequence instant arrays directly via
+ * `lw_dist2d_seg_seg`, no `tpoint_trajectory()` materialisation, no
+ * `lw_dist2d_recursive` wrapper.  T2's segment bboxes are computed once
+ * and sorted by minx; for each T1 segment we binary-search the candidate
+ * window in T2 and walk it with the running threshold tightening as we
+ * go.  Same answer as `geom_distance2d(trajectory(seq1), trajectory(seq2))`
+ * for the 2D, planar, tgeompoint, linear-interpolation case.
+ *****************************************************************************/
+
+typedef struct
+{
+  int idx;
+  float minx;
+  float maxx;
+  float miny;
+  float maxy;
+} SegBox;
+
+static int
+segbox_cmp_minx(const void *a, const void *b)
+{
+  float da = ((const SegBox *) a)->minx;
+  float db = ((const SegBox *) b)->minx;
+  return (da < db) ? -1 : (da > db ? 1 : 0);
+}
+
+static double
+mindist_tpointseq_tpointseq_threshold(const TSequence *seq1,
+  const TSequence *seq2, double threshold)
+{
+  DISTPTS dl;
+  lw_dist2d_distpts_init(&dl, DIST_MIN);
+  dl.distance = threshold;
+
+  /* Both single-instant */
+  if (seq1->count == 1 && seq2->count == 1)
+  {
+    const POINT2D *p = DATUM_POINT2D_P(tinstant_value_p(TSEQUENCE_INST_N(seq1, 0)));
+    const POINT2D *q = DATUM_POINT2D_P(tinstant_value_p(TSEQUENCE_INST_N(seq2, 0)));
+    lw_dist2d_pt_pt(p, q, &dl);
+    return dl.distance;
+  }
+  if (seq1->count == 1)
+  {
+    const POINT2D *p = DATUM_POINT2D_P(tinstant_value_p(TSEQUENCE_INST_N(seq1, 0)));
+    for (int j = 0; j < seq2->count - 1; j++)
+    {
+      const POINT2D *q1 = DATUM_POINT2D_P(tinstant_value_p(TSEQUENCE_INST_N(seq2, j)));
+      const POINT2D *q2 = DATUM_POINT2D_P(tinstant_value_p(TSEQUENCE_INST_N(seq2, j + 1)));
+      lw_dist2d_pt_seg(p, q1, q2, &dl);
+      if (dl.distance == 0.0) return 0.0;
+    }
+    return dl.distance;
+  }
+  if (seq2->count == 1)
+  {
+    const POINT2D *q = DATUM_POINT2D_P(tinstant_value_p(TSEQUENCE_INST_N(seq2, 0)));
+    for (int i = 0; i < seq1->count - 1; i++)
+    {
+      const POINT2D *p1 = DATUM_POINT2D_P(tinstant_value_p(TSEQUENCE_INST_N(seq1, i)));
+      const POINT2D *p2 = DATUM_POINT2D_P(tinstant_value_p(TSEQUENCE_INST_N(seq1, i + 1)));
+      lw_dist2d_pt_seg(q, p1, p2, &dl);
+      if (dl.distance == 0.0) return 0.0;
+    }
+    return dl.distance;
+  }
+  /* Both segmented: plane-sweep. */
+  int n2 = seq2->count - 1;
+  SegBox *boxes2 = palloc(n2 * sizeof(SegBox));
+  for (int j = 0; j < n2; j++)
+  {
+    const POINT2D *q1 = DATUM_POINT2D_P(tinstant_value_p(TSEQUENCE_INST_N(seq2, j)));
+    const POINT2D *q2 = DATUM_POINT2D_P(tinstant_value_p(TSEQUENCE_INST_N(seq2, j + 1)));
+    boxes2[j].idx = j;
+    boxes2[j].minx = (float) fmin(q1->x, q2->x);
+    boxes2[j].maxx = (float) fmax(q1->x, q2->x);
+    boxes2[j].miny = (float) fmin(q1->y, q2->y);
+    boxes2[j].maxy = (float) fmax(q1->y, q2->y);
+  }
+  qsort(boxes2, n2, sizeof(SegBox), segbox_cmp_minx);
+
+  for (int i = 0; i < seq1->count - 1; i++)
+  {
+    const POINT2D *p1 = DATUM_POINT2D_P(tinstant_value_p(TSEQUENCE_INST_N(seq1, i)));
+    const POINT2D *p2 = DATUM_POINT2D_P(tinstant_value_p(TSEQUENCE_INST_N(seq1, i + 1)));
+    double s1_minx = fmin(p1->x, p2->x), s1_maxx = fmax(p1->x, p2->x);
+    double s1_miny = fmin(p1->y, p2->y), s1_maxy = fmax(p1->y, p2->y);
+    double thresh = dl.distance;
+    double hi_x = s1_maxx + thresh;
+    double lo_x = s1_minx - thresh;
+    /* Binary-search the first j with minx > hi_x (upper bound).  Walk
+     * forward from j=0 to that bound; skip those whose maxx < lo_x. */
+    int hi_idx;
+    {
+      int lo = 0, hi = n2;
+      while (lo < hi)
+      {
+        int mid = (lo + hi) / 2;
+        if (boxes2[mid].minx > hi_x) hi = mid;
+        else lo = mid + 1;
+      }
+      hi_idx = lo;
+    }
+    for (int k = 0; k < hi_idx; k++)
+    {
+      if (boxes2[k].maxx < lo_x) continue;
+      /* Y-axis prefilter */
+      if (boxes2[k].maxy < s1_miny - dl.distance) continue;
+      if (boxes2[k].miny > s1_maxy + dl.distance) continue;
+      double dx = fmax(0.0, fmax(s1_minx, (double) boxes2[k].minx)
+                          - fmin(s1_maxx, (double) boxes2[k].maxx));
+      double dy = fmax(0.0, fmax(s1_miny, (double) boxes2[k].miny)
+                          - fmin(s1_maxy, (double) boxes2[k].maxy));
+      if (dx >= dl.distance || dy >= dl.distance) continue;
+      int j = boxes2[k].idx;
+      const POINT2D *q1 = DATUM_POINT2D_P(tinstant_value_p(TSEQUENCE_INST_N(seq2, j)));
+      const POINT2D *q2 = DATUM_POINT2D_P(tinstant_value_p(TSEQUENCE_INST_N(seq2, j + 1)));
+      lw_dist2d_seg_seg(p1, p2, q1, q2, &dl);
+      if (dl.distance == 0.0) { pfree(boxes2); return 0.0; }
+    }
+  }
+  pfree(boxes2);
+  return dl.distance;
+}
+
+/* Dispatch across subtypes, threading the running threshold. */
+static double
+mindist_tpoint_tpoint_threshold(const Temporal *temp1, const Temporal *temp2,
+  double threshold)
+{
+  if (temp1->subtype == TSEQUENCESET)
+  {
+    const TSequenceSet *ss1 = (const TSequenceSet *) temp1;
+    for (int i = 0; i < ss1->count; i++)
+    {
+      double d = mindist_tpoint_tpoint_threshold(
+        (const Temporal *) TSEQUENCESET_SEQ_N(ss1, i), temp2, threshold);
+      if (d < threshold) threshold = d;
+      if (threshold == 0.0) return 0.0;
+    }
+    return threshold;
+  }
+  if (temp2->subtype == TSEQUENCESET)
+  {
+    const TSequenceSet *ss2 = (const TSequenceSet *) temp2;
+    for (int j = 0; j < ss2->count; j++)
+    {
+      double d = mindist_tpointseq_tpointseq_threshold(
+        (const TSequence *) temp1, TSEQUENCESET_SEQ_N(ss2, j), threshold);
+      if (d < threshold) threshold = d;
+      if (threshold == 0.0) return 0.0;
+    }
+    return threshold;
+  }
+  if (temp1->subtype == TSEQUENCE && temp2->subtype == TSEQUENCE)
+    return mindist_tpointseq_tpointseq_threshold(
+      (const TSequence *) temp1, (const TSequence *) temp2, threshold);
+  /* TInstant: caller falls back to lwgeom path. */
+  return DBL_MAX;
+}
+
+/**
+ * @ingroup meos_geo_distance
+ * @brief Return the exact minimum spatial distance between two temporal
+ * geos, ignoring time
+ * @details Computes
+ * `ST_Distance(trajectory(temp1), trajectory(temp2))` (the spatial-min
+ * over all pairs of points on the two trajectories) using the
+ * threshold-aware plane-sweep kernel directly on the `TInstant` arrays.
+ * Distinct from `nearestApproachDistance(tgeompoint, tgeompoint)` which
+ * is time-synchronous.
+ * @param[in] temp1,temp2 Temporal geos (must share SRID, dimensionality,
+ *   and geodetic flag)
+ * @return Minimum spatial distance; falls back to `geom_distance2d` for
+ *   subtype combinations the inline kernel does not handle (e.g.
+ *   `TInstant`).
+ * @csqlfn #Mindistance_tgeo_tgeo()
+ */
+double
+mindistance_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2,
+  double threshold)
+{
+  VALIDATE_NOT_NULL(temp1, DBL_MAX);
+  VALIDATE_NOT_NULL(temp2, DBL_MAX);
+  VALIDATE_TGEO(temp1, DBL_MAX);
+  VALIDATE_TGEO(temp2, DBL_MAX);
+  if (! ensure_same_srid(tspatial_srid(temp1), tspatial_srid(temp2)) ||
+      ! ensure_same_dimensionality(temp1->flags, temp2->flags) ||
+      ! ensure_same_geodetic(temp1->flags, temp2->flags))
+    return DBL_MAX;
+  bool inline_eligible =
+    ! MEOS_FLAGS_GET_Z(temp1->flags) &&
+    ! MEOS_FLAGS_GET_GEODETIC(temp1->flags) &&
+    MEOS_FLAGS_LINEAR_INTERP(temp1->flags) &&
+    tpoint_type(temp1->temptype) &&
+    tpoint_type(temp2->temptype) &&
+    temp1->subtype != TINSTANT && temp2->subtype != TINSTANT;
+  if (inline_eligible)
+    return mindist_tpoint_tpoint_threshold(temp1, temp2, threshold);
+  /* Fallback */
+  GSERIALIZED *traj1 = tpoint_type(temp1->temptype) ?
+    tpoint_trajectory(temp1, UNARY_UNION_NO) :
+    tgeo_traversed_area(temp1, UNARY_UNION_NO);
+  GSERIALIZED *traj2 = tpoint_type(temp2->temptype) ?
+    tpoint_trajectory(temp2, UNARY_UNION_NO) :
+    tgeo_traversed_area(temp2, UNARY_UNION_NO);
+  double d = MEOS_FLAGS_GET_Z(temp1->flags) ?
+    geom_distance3d(traj1, traj2) :
+    geom_distance2d(traj1, traj2);
+  pfree(traj1); pfree(traj2);
+  return (d < threshold) ? d : threshold;
+}
+
+/* qsort comparator: pair record ordered by bbox-distance ascending. */
+typedef struct
+{
+  int i;
+  int j;
+  double bd;
+} TgeoarrPair;
+
+static int
+tgeoarr_pair_cmp(const void *a, const void *b)
+{
+  double da = ((const TgeoarrPair *) a)->bd;
+  double db = ((const TgeoarrPair *) b)->bd;
+  if (da < db) return -1;
+  if (da > db) return 1;
+  return 0;
+}
+
+/**
+ * @ingroup meos_geo_distance
+ * @brief Return the exact minimum spatial distance between two arrays of
+ * temporal geos
+ * @details Computes the same value as
+ * `ST_Distance(ST_Collect(trajectory(arr1[*])), ST_Collect(trajectory(arr2[*])))`
+ * but uses each input's STBox as a sound lower-bound prefilter: trip pairs
+ * are processed in ascending bbox-distance order, and the iteration short
+ * circuits once the running minimum is provably smaller than every
+ * remaining pair's lower bound.  The per-pair distance still goes through
+ * `geom_distance2d` (liblwgeom segment-pair sweep, no GEOS call), so the
+ * result is bit-equivalent to the materialised aggregate form.
+ * @param[in] arr1,arr2 Arrays of temporal geos (each element must be
+ *   non-NULL and share SRID / dimensionality with the rest)
+ * @param[in] count1,count2 Array lengths (must be > 0)
+ * @return Minimum spatial distance; DBL_MAX on validation failure or on
+ *   any empty input array.
+ * @csqlfn #Tgeoarr_tgeoarr_mindist()
+ */
+double
+tgeoarr_tgeoarr_mindist(const Temporal **arr1, int count1,
+  const Temporal **arr2, int count2)
+{
+  VALIDATE_NOT_NULL(arr1, DBL_MAX);
+  VALIDATE_NOT_NULL(arr2, DBL_MAX);
+  if (count1 <= 0 || count2 <= 0)
+    return DBL_MAX;
+  for (int i = 0; i < count1; i++)
+    VALIDATE_TGEO(arr1[i], DBL_MAX);
+  for (int j = 0; j < count2; j++)
+    VALIDATE_TGEO(arr2[j], DBL_MAX);
+
+  /* Soundness gate: all inputs share SRID, dimensionality, geodetic flag */
+  int32 srid = tspatial_srid(arr1[0]);
+  int16 flags = arr1[0]->flags;
+  for (int i = 1; i < count1; i++)
+    if (! ensure_same_srid(tspatial_srid(arr1[i]), srid) ||
+        ! ensure_same_dimensionality(arr1[i]->flags, flags) ||
+        ! ensure_same_geodetic(arr1[i]->flags, flags))
+      return DBL_MAX;
+  for (int j = 0; j < count2; j++)
+    if (! ensure_same_srid(tspatial_srid(arr2[j]), srid) ||
+        ! ensure_same_dimensionality(arr2[j]->flags, flags) ||
+        ! ensure_same_geodetic(arr2[j]->flags, flags))
+      return DBL_MAX;
+
+  /* Pre-compute STBoxes for every input.  Each tspatial_to_stbox is a
+   * cheap aggregate over the temporal value, amortised across all pairs
+   * involving that input. */
+  STBox **bb1 = palloc(count1 * sizeof(STBox *));
+  STBox **bb2 = palloc(count2 * sizeof(STBox *));
+  for (int i = 0; i < count1; i++) bb1[i] = tspatial_to_stbox(arr1[i]);
+  for (int j = 0; j < count2; j++) bb2[j] = tspatial_to_stbox(arr2[j]);
+
+  /* Materialise all candidate pairs with their bbox-distance lower bound */
+  int npairs = count1 * count2;
+  TgeoarrPair *pairs = palloc(npairs * sizeof(TgeoarrPair));
+  int k = 0;
+  for (int i = 0; i < count1; i++)
+    for (int j = 0; j < count2; j++)
+    {
+      pairs[k].i = i;
+      pairs[k].j = j;
+      pairs[k].bd = stbox_spatial_distance(bb1[i], bb2[j]);
+      k++;
+    }
+  qsort(pairs, npairs, sizeof(TgeoarrPair), tgeoarr_pair_cmp);
+
+  /* Trajectory cache: each input's trajectory is materialised at most
+   * once and reused across every pair it participates in. */
+  GSERIALIZED **traj1 = palloc0(count1 * sizeof(GSERIALIZED *));
+  GSERIALIZED **traj2 = palloc0(count2 * sizeof(GSERIALIZED *));
+
+  /* Eligibility for the inline tgeompoint kernel: 2D, planar, all inputs
+   * are tgeompoint with linear interpolation, and at least one of seq /
+   * seqset on each side.  TInstant inputs fall through to the lwgeom
+   * path. */
+  bool inline_eligible =
+    ! MEOS_FLAGS_GET_Z(flags) &&
+    ! MEOS_FLAGS_GET_GEODETIC(flags) &&
+    MEOS_FLAGS_LINEAR_INTERP(flags);
+  if (inline_eligible)
+  {
+    for (int i = 0; i < count1; i++)
+      if (! tpoint_type(arr1[i]->temptype) ||
+          arr1[i]->subtype == TINSTANT)
+      { inline_eligible = false; break; }
+  }
+  if (inline_eligible)
+  {
+    for (int j = 0; j < count2; j++)
+      if (! tpoint_type(arr2[j]->temptype) ||
+          arr2[j]->subtype == TINSTANT)
+      { inline_eligible = false; break; }
+  }
+
+  double running_min = DBL_MAX;
+  for (k = 0; k < npairs; k++)
+  {
+    /* All remaining pairs have bbox-distance >= pairs[k].bd, which is
+     * a sound lower bound on the trajectory pair's actual distance.
+     * Once it crosses running_min, no remaining pair can improve it. */
+    if (pairs[k].bd >= running_min)
+      break;
+    int i = pairs[k].i, j = pairs[k].j;
+    double d;
+    if (inline_eligible)
+    {
+      d = mindist_tpoint_tpoint_threshold(arr1[i], arr2[j], running_min);
+    }
+    else
+    {
+      if (traj1[i] == NULL)
+        traj1[i] = tpoint_type(arr1[i]->temptype) ?
+          tpoint_trajectory(arr1[i], UNARY_UNION_NO) :
+          tgeo_traversed_area(arr1[i], UNARY_UNION_NO);
+      if (traj2[j] == NULL)
+        traj2[j] = tpoint_type(arr2[j]->temptype) ?
+          tpoint_trajectory(arr2[j], UNARY_UNION_NO) :
+          tgeo_traversed_area(arr2[j], UNARY_UNION_NO);
+      d = MEOS_FLAGS_GET_Z(flags) ?
+        geom_distance3d(traj1[i], traj2[j]) :
+        geom_distance2d(traj1[i], traj2[j]);
+    }
+    if (d < running_min)
+      running_min = d;
+    if (running_min == 0.0)
+      break;
+  }
+
+  /* Cleanup */
+  for (int i = 0; i < count1; i++)
+  {
+    pfree(bb1[i]);
+    if (traj1[i] != NULL) pfree(traj1[i]);
+  }
+  for (int j = 0; j < count2; j++)
+  {
+    pfree(bb2[j]);
+    if (traj2[j] != NULL) pfree(traj2[j]);
+  }
+  pfree(bb1); pfree(bb2); pfree(traj1); pfree(traj2); pfree(pairs);
+  return running_min;
 }
 
 /*****************************************************************************/

--- a/mobilitydb/sql/geo/064_tgeo_distance.in.sql
+++ b/mobilitydb/sql/geo/064_tgeo_distance.in.sql
@@ -246,4 +246,84 @@ CREATE FUNCTION shortestLine(tgeography, tgeography)
   AS 'MODULE_PATHNAME', 'Shortestline_tgeo_tgeo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+/*****************************************************************************
+ * Set-set spatial minimum distance
+ *****************************************************************************/
+
+CREATE FUNCTION minDistance(tgeompoint[], tgeompoint[])
+  RETURNS float
+  AS 'MODULE_PATHNAME', 'Tgeoarr_tgeoarr_mindist'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION minDistance(tgeometry[], tgeometry[])
+  RETURNS float
+  AS 'MODULE_PATHNAME', 'Tgeoarr_tgeoarr_mindist'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/*
+ * Scalar minDistance overloads where one side is a static geometry:
+ * spatial-min reduces to NAD (which is time-synchronous in general but
+ * is identical to spatial-min when one argument has no time dimension).
+ */
+CREATE FUNCTION minDistance(tgeompoint, geometry)
+  RETURNS float
+  AS 'MODULE_PATHNAME', 'NAD_tgeo_geo'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION minDistance(geometry, tgeompoint)
+  RETURNS float
+  AS 'MODULE_PATHNAME', 'NAD_geo_tgeo'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION minDistance(tgeometry, geometry)
+  RETURNS float
+  AS 'MODULE_PATHNAME', 'NAD_tgeo_geo'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION minDistance(geometry, tgeometry)
+  RETURNS float
+  AS 'MODULE_PATHNAME', 'NAD_geo_tgeo'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION minDistance(tgeogpoint, geography)
+  RETURNS float
+  AS 'MODULE_PATHNAME', 'NAD_tgeo_geo'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION minDistance(geography, tgeogpoint)
+  RETURNS float
+  AS 'MODULE_PATHNAME', 'NAD_geo_tgeo'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION minDistance(tgeography, geography)
+  RETURNS float
+  AS 'MODULE_PATHNAME', 'NAD_tgeo_geo'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION minDistance(geography, tgeography)
+  RETURNS float
+  AS 'MODULE_PATHNAME', 'NAD_geo_tgeo'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/*
+ * 2-ary aggregate minDistance over pairs of temporal values.  The
+ * scalar (tgeompoint, tgeompoint) form is replaced by this aggregate to
+ * keep the user-facing name unique (Solution 2 — no `Agg` suffix).  On a
+ * one-row group the aggregate degenerates to the per-pair value, so any
+ * "scalar" use case is naturally covered.
+ */
+CREATE FUNCTION minDistance_transfn(float, tgeompoint, tgeompoint)
+  RETURNS float
+  AS 'MODULE_PATHNAME', 'Mindistance_transfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION minDistance_transfn(float, tgeometry, tgeometry)
+  RETURNS float
+  AS 'MODULE_PATHNAME', 'Mindistance_transfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE AGGREGATE minDistance(tgeompoint, tgeompoint) (
+  SFUNC = minDistance_transfn,
+  STYPE = float,
+  COMBINEFUNC = float8smaller,
+  PARALLEL = SAFE
+);
+CREATE AGGREGATE minDistance(tgeometry, tgeometry) (
+  SFUNC = minDistance_transfn,
+  STYPE = float,
+  COMBINEFUNC = float8smaller,
+  PARALLEL = SAFE
+);
+
 /*****************************************************************************/

--- a/mobilitydb/src/geo/tgeo_distance.c
+++ b/mobilitydb/src/geo/tgeo_distance.c
@@ -37,13 +37,16 @@
 #include <float.h>
 /* PostgreSQL */
 #include <postgres.h>
+#include <utils/array.h>
 /* MEOS */
 #include <meos.h>
+#include <meos_geo.h>
 #include "temporal/temporal.h"
 #include "geo/stbox.h"
 /* MobilityDB */
 #include "pg_geo/postgis.h"
 #include "pg_geo/tspatial.h"
+#include "pg_temporal/type_util.h"
 
 /*****************************************************************************
  * Temporal distance
@@ -420,6 +423,59 @@ Shortestline_tgeo_tgeo(PG_FUNCTION_ARGS)
   if (! result)
     PG_RETURN_NULL();
   PG_RETURN_GSERIALIZED_P(result);
+}
+
+/*****************************************************************************
+ * Set-set spatial minimum distance
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Tgeoarr_tgeoarr_mindist(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tgeoarr_tgeoarr_mindist);
+/**
+ * @ingroup mobilitydb_geo_dist
+ * @brief Return the exact minimum spatial distance between two arrays of
+ * temporal geos
+ * @sqlfn minDistance()
+ */
+Datum
+Tgeoarr_tgeoarr_mindist(PG_FUNCTION_ARGS)
+{
+  ArrayType *array1 = PG_GETARG_ARRAYTYPE_P(0);
+  ArrayType *array2 = PG_GETARG_ARRAYTYPE_P(1);
+  int count1, count2;
+  Temporal **arr1 = (Temporal **) temparr_extract(array1, &count1);
+  Temporal **arr2 = (Temporal **) temparr_extract(array2, &count2);
+  double result = tgeoarr_tgeoarr_mindist((const Temporal **) arr1, count1,
+    (const Temporal **) arr2, count2);
+  pfree(arr1); pfree(arr2);
+  PG_FREE_IF_COPY(array1, 0);
+  PG_FREE_IF_COPY(array2, 1);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
+  PG_RETURN_FLOAT8(result);
+}
+
+PGDLLEXPORT Datum Mindistance_transfn(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Mindistance_transfn);
+/**
+ * @ingroup mobilitydb_geo_dist
+ * @brief Aggregate transition function for the 2-ary `minDistance`
+ * aggregate: threads the running min as the threshold into the
+ * per-pair plane-sweep kernel
+ * @sqlfn minDistance()
+ */
+Datum
+Mindistance_transfn(PG_FUNCTION_ARGS)
+{
+  double state = PG_ARGISNULL(0) ? DBL_MAX : PG_GETARG_FLOAT8(0);
+  if (PG_ARGISNULL(1) || PG_ARGISNULL(2))
+    PG_RETURN_FLOAT8(state);
+  Temporal *temp1 = PG_GETARG_TEMPORAL_P(1);
+  Temporal *temp2 = PG_GETARG_TEMPORAL_P(2);
+  double d = mindistance_tgeo_tgeo(temp1, temp2, state);
+  PG_FREE_IF_COPY(temp1, 1);
+  PG_FREE_IF_COPY(temp2, 2);
+  PG_RETURN_FLOAT8(d);
 }
 
 /*****************************************************************************/

--- a/mobilitydb/test/geo/expected/064_tgeo_distance.test.out
+++ b/mobilitydb/test/geo/expected/064_tgeo_distance.test.out
@@ -3806,3 +3806,120 @@ SELECT shortestLine(geography 'Linestring(90 0 0,0 90 100)', tgeography 'Point(-
 ERROR:  The geometry cannot have Z dimension
 SELECT shortestLine(tgeography 'Point(-90 0 100)@2000-01-01', geography 'Linestring(90 0 0,0 90 100)');
 ERROR:  The geometry cannot have Z dimension
+SELECT minDistance(
+  ARRAY[tgeometry '[Point(0 0)@2000-01-01, Point(2 2)@2000-01-02]'],
+  ARRAY[tgeometry '[Point(0 2)@2000-01-01, Point(2 0)@2000-01-02]']);
+ mindistance 
+-------------
+           2
+(1 row)
+
+SELECT round(minDistance(
+  ARRAY[tgeometry '[Point(0 0)@2000-01-01, Point(10 0)@2000-01-02]'],
+  ARRAY[tgeometry '[Point(0 1)@2000-01-01, Point(10 1)@2000-01-02]']), 6);
+ round 
+-------
+     1
+(1 row)
+
+SELECT round(minDistance(
+  ARRAY[tgeometry '[Point(0 0)@2000-01-01, Point(1 0)@2000-01-02]',
+        tgeometry '[Point(100 100)@2000-01-01, Point(101 100)@2000-01-02]'],
+  ARRAY[tgeometry '[Point(0 5)@2000-01-01, Point(1 5)@2000-01-02]',
+        tgeometry '[Point(200 200)@2000-01-01, Point(201 200)@2000-01-02]']), 6);
+ round 
+-------
+     5
+(1 row)
+
+SELECT round(minDistance(
+  ARRAY[tgeometry '[Linestring(0 0,1 1)@2000-01-01, Linestring(2 2,3 3)@2000-01-02]'],
+  ARRAY[tgeometry '[Linestring(0 5,1 5)@2000-01-01, Linestring(2 5,3 5)@2000-01-02]']), 6);
+ round 
+-------
+     2
+(1 row)
+
+SELECT minDistance(ARRAY[]::tgeometry[], ARRAY[tgeometry 'Point(0 0)@2000-01-01']);
+ mindistance 
+-------------
+            
+(1 row)
+
+SELECT minDistance(ARRAY[tgeometry 'Point(0 0)@2000-01-01'],
+                   ARRAY[tgeometry 'SRID=4326;Point(0 0)@2000-01-01']);
+ERROR:  Operation on mixed SRID
+SELECT minDistance(tgeometry '[Point(0 0)@2000-01-01, Point(2 0)@2000-01-02]',
+                   geometry 'Point(1 0)');
+ mindistance 
+-------------
+           1
+(1 row)
+
+SELECT round(minDistance(tgeometry '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-02]',
+                         geometry 'Point(5 0)')::numeric, 6);
+  round   
+----------
+ 5.000000
+(1 row)
+
+SELECT round(minDistance(geometry 'Point(5 0)',
+                         tgeometry '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-02]')::numeric, 6);
+  round   
+----------
+ 5.000000
+(1 row)
+
+SELECT round(minDistance(tgeometry '[Linestring(0 0,1 1)@2000-01-01, Linestring(2 2,3 3)@2000-01-02]',
+                         geometry 'POLYGON((10 10, 20 10, 20 20, 10 20, 10 10))')::numeric, 6);
+  round   
+----------
+ 9.899495
+(1 row)
+
+SELECT minDistance(tgeometry 'Point(0 0)@2000-01-01',
+                   geometry 'SRID=4326;Point(1 1)');
+ERROR:  Operation on mixed SRID
+SELECT minDistance(t1, t2) FROM (
+  SELECT tgeometry '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-02]' AS t1,
+         tgeometry '[Point(5 0)@2000-01-01, Point(15 0)@2000-01-02]'  AS t2) v;
+ mindistance 
+-------------
+           5
+(1 row)
+
+WITH pairs(t1, t2) AS (VALUES
+  (tgeometry '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
+   tgeometry '[Point(10 10)@2000-01-01, Point(11 11)@2000-01-02]'),
+  (tgeometry '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
+   tgeometry '[Point(0 5)@2000-01-01, Point(1 5)@2000-01-02]'),
+  (tgeometry '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
+   tgeometry '[Point(2 1)@2000-01-01, Point(2 2)@2000-01-02]'))
+SELECT round(minDistance(t1, t2)::numeric, 6) FROM pairs;
+  round   
+----------
+ 1.000000
+(1 row)
+
+WITH src(g, t1, t2) AS (VALUES
+  (1, tgeometry '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
+      tgeometry '[Point(0 10)@2000-01-01, Point(1 10)@2000-01-02]'),
+  (1, tgeometry '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
+      tgeometry '[Point(0 5)@2000-01-01, Point(1 5)@2000-01-02]'),
+  (2, tgeometry '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
+      tgeometry '[Point(0 2)@2000-01-01, Point(1 2)@2000-01-02]'))
+SELECT g, round(minDistance(t1, t2)::numeric, 6) FROM src GROUP BY g ORDER BY g;
+ g |  round   
+---+----------
+ 1 | 4.000000
+ 2 | 1.000000
+(2 rows)
+
+SELECT minDistance(t1, t2) FROM (
+  SELECT tgeometry '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]' AS t1,
+         tgeometry '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]' AS t2 WHERE false) v;
+ mindistance 
+-------------
+            
+(1 row)
+

--- a/mobilitydb/test/geo/expected/064_tpoint_distance.test.out
+++ b/mobilitydb/test/geo/expected/064_tpoint_distance.test.out
@@ -3912,3 +3912,127 @@ SELECT shortestLine(geography 'Linestring(90 0 0,0 90 100)', tgeogpoint 'Point(-
 ERROR:  The geometry cannot have Z dimension
 SELECT shortestLine(tgeogpoint 'Point(-90 0 100)@2000-01-01', geography 'Linestring(90 0 0,0 90 100)');
 ERROR:  The geometry cannot have Z dimension
+SELECT minDistance(
+  ARRAY[tgeompoint '[Point(0 0)@2000-01-01, Point(2 2)@2000-01-02]'],
+  ARRAY[tgeompoint '[Point(0 2)@2000-01-01, Point(2 0)@2000-01-02]']);
+ mindistance 
+-------------
+           0
+(1 row)
+
+SELECT round(minDistance(
+  ARRAY[tgeompoint '[Point(0 0)@2000-01-01, Point(10 0)@2000-01-02]'],
+  ARRAY[tgeompoint '[Point(0 1)@2000-01-01, Point(10 1)@2000-01-02]']), 6);
+ round 
+-------
+     1
+(1 row)
+
+SELECT round(minDistance(
+  ARRAY[tgeompoint '[Point(0 0)@2000-01-01, Point(1 0)@2000-01-02]',
+        tgeompoint '[Point(100 100)@2000-01-01, Point(101 100)@2000-01-02]'],
+  ARRAY[tgeompoint '[Point(0 5)@2000-01-01, Point(1 5)@2000-01-02]',
+        tgeompoint '[Point(200 200)@2000-01-01, Point(201 200)@2000-01-02]']), 6);
+ round 
+-------
+     5
+(1 row)
+
+WITH A AS (SELECT ARRAY[
+  tgeompoint '[Point(0 0)@2000-01-01, Point(5 0)@2000-01-02]',
+  tgeompoint '[Point(0 10)@2000-01-01, Point(5 10)@2000-01-02]'] AS a),
+B AS (SELECT ARRAY[
+  tgeompoint '[Point(0 1)@2000-01-01, Point(5 1)@2000-01-02]',
+  tgeompoint '[Point(0 11)@2000-01-01, Point(5 11)@2000-01-02]'] AS b)
+SELECT round(minDistance(a, b), 6) = round(ST_Distance(
+  ST_Collect(ARRAY[trajectory(a[1]), trajectory(a[2])]),
+  ST_Collect(ARRAY[trajectory(b[1]), trajectory(b[2])])), 6) AS bit_equivalent
+FROM A, B;
+ bit_equivalent 
+----------------
+ t
+(1 row)
+
+SELECT minDistance(ARRAY[]::tgeompoint[], ARRAY[tgeompoint 'Point(0 0)@2000-01-01']);
+ mindistance 
+-------------
+            
+(1 row)
+
+SELECT minDistance(ARRAY[tgeompoint 'Point(0 0)@2000-01-01'],
+                   ARRAY[tgeompoint 'SRID=4326;Point(0 0)@2000-01-01']);
+ERROR:  Operation on mixed SRID
+SELECT minDistance(tgeompoint '[Point(0 0)@2000-01-01, Point(2 0)@2000-01-02]',
+                   geometry 'Point(1 0)');
+ mindistance 
+-------------
+           0
+(1 row)
+
+SELECT round(minDistance(tgeompoint '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-02]',
+                         geometry 'Point(5 0)')::numeric, 6);
+  round   
+----------
+ 3.535534
+(1 row)
+
+SELECT round(minDistance(geometry 'Point(5 0)',
+                         tgeompoint '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-02]')::numeric, 6);
+  round   
+----------
+ 3.535534
+(1 row)
+
+SELECT round(minDistance(tgeompoint '[Point(0 0)@2000-01-01, Point(10 0)@2000-01-02]',
+                         geometry 'POLYGON((20 -5, 30 -5, 30 5, 20 5, 20 -5))')::numeric, 6);
+   round   
+-----------
+ 10.000000
+(1 row)
+
+SELECT minDistance(tgeompoint 'Point(0 0)@2000-01-01',
+                   geometry 'SRID=4326;Point(1 1)');
+ERROR:  Operation on mixed SRID
+SELECT minDistance(t1, t2) FROM (
+  SELECT tgeompoint '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-02]' AS t1,
+         tgeompoint '[Point(5 0)@2000-01-01, Point(15 0)@2000-01-02]'  AS t2) v;
+    mindistance     
+--------------------
+ 3.5355339059327378
+(1 row)
+
+WITH pairs(t1, t2) AS (VALUES
+  (tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
+   tgeompoint '[Point(10 10)@2000-01-01, Point(11 11)@2000-01-02]'),  -- ~12.7
+  (tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
+   tgeompoint '[Point(0 5)@2000-01-01, Point(1 5)@2000-01-02]'),       -- 4
+  (tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
+   tgeompoint '[Point(2 1)@2000-01-01, Point(2 2)@2000-01-02]'))       -- ~1
+SELECT round(minDistance(t1, t2)::numeric, 6) FROM pairs;
+  round   
+----------
+ 1.000000
+(1 row)
+
+WITH src(g, t1, t2) AS (VALUES
+  (1, tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
+      tgeompoint '[Point(0 10)@2000-01-01, Point(1 10)@2000-01-02]'),
+  (1, tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
+      tgeompoint '[Point(0 5)@2000-01-01, Point(1 5)@2000-01-02]'),
+  (2, tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
+      tgeompoint '[Point(0 2)@2000-01-01, Point(1 2)@2000-01-02]'))
+SELECT g, round(minDistance(t1, t2)::numeric, 6) FROM src GROUP BY g ORDER BY g;
+ g |  round   
+---+----------
+ 1 | 4.000000
+ 2 | 1.000000
+(2 rows)
+
+SELECT minDistance(t1, t2) FROM (
+  SELECT tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]' AS t1,
+         tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]' AS t2 WHERE false) v;
+ mindistance 
+-------------
+            
+(1 row)
+

--- a/mobilitydb/test/geo/queries/064_tgeo_distance.test.sql
+++ b/mobilitydb/test/geo/queries/064_tgeo_distance.test.sql
@@ -803,3 +803,94 @@ SELECT shortestLine(geography 'Linestring(90 0 0,0 90 100)', tgeography 'Point(-
 SELECT shortestLine(tgeography 'Point(-90 0 100)@2000-01-01', geography 'Linestring(90 0 0,0 90 100)');
 
 --------------------------------------------------------
+
+--------------------------------------------------------
+-- minDistance(tgeometry[], tgeometry[]) -- exact set-set spatial min distance
+--------------------------------------------------------
+
+-- Two singleton sets, point-valued tgeometry. Tgeometry uses traversed-area
+-- semantics so the trajectory of a point sequence is the multipoint of
+-- distinct values, not the linestring between them as for tgeompoint.
+SELECT minDistance(
+  ARRAY[tgeometry '[Point(0 0)@2000-01-01, Point(2 2)@2000-01-02]'],
+  ARRAY[tgeometry '[Point(0 2)@2000-01-01, Point(2 0)@2000-01-02]']);
+
+-- Two singleton sets, parallel point trajectories: exact spatial distance
+SELECT round(minDistance(
+  ARRAY[tgeometry '[Point(0 0)@2000-01-01, Point(10 0)@2000-01-02]'],
+  ARRAY[tgeometry '[Point(0 1)@2000-01-01, Point(10 1)@2000-01-02]']), 6);
+
+-- Multi-element sets, closest pair determines the answer
+SELECT round(minDistance(
+  ARRAY[tgeometry '[Point(0 0)@2000-01-01, Point(1 0)@2000-01-02]',
+        tgeometry '[Point(100 100)@2000-01-01, Point(101 100)@2000-01-02]'],
+  ARRAY[tgeometry '[Point(0 5)@2000-01-01, Point(1 5)@2000-01-02]',
+        tgeometry '[Point(200 200)@2000-01-01, Point(201 200)@2000-01-02]']), 6);
+
+-- tgeometry-specific: trajectories with LineString-valued instants
+SELECT round(minDistance(
+  ARRAY[tgeometry '[Linestring(0 0,1 1)@2000-01-01, Linestring(2 2,3 3)@2000-01-02]'],
+  ARRAY[tgeometry '[Linestring(0 5,1 5)@2000-01-01, Linestring(2 5,3 5)@2000-01-02]']), 6);
+
+-- Errors / NULL handling
+SELECT minDistance(ARRAY[]::tgeometry[], ARRAY[tgeometry 'Point(0 0)@2000-01-01']);
+SELECT minDistance(ARRAY[tgeometry 'Point(0 0)@2000-01-01'],
+                   ARRAY[tgeometry 'SRID=4326;Point(0 0)@2000-01-01']);
+
+--------------------------------------------------------
+-- minDistance(tgeometry, geometry) -- scalar spatial min distance
+--------------------------------------------------------
+
+-- Point trajectory crossing the static geometry point: distance 0
+SELECT minDistance(tgeometry '[Point(0 0)@2000-01-01, Point(2 0)@2000-01-02]',
+                   geometry 'Point(1 0)');
+
+-- Diagonal point trajectory, side point: perpendicular distance
+SELECT round(minDistance(tgeometry '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-02]',
+                         geometry 'Point(5 0)')::numeric, 6);
+
+-- Symmetric (geometry, tgeometry)
+SELECT round(minDistance(geometry 'Point(5 0)',
+                         tgeometry '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-02]')::numeric, 6);
+
+-- tgeometry-specific: LineString-valued trajectory against a static polygon
+SELECT round(minDistance(tgeometry '[Linestring(0 0,1 1)@2000-01-01, Linestring(2 2,3 3)@2000-01-02]',
+                         geometry 'POLYGON((10 10, 20 10, 20 20, 10 20, 10 10))')::numeric, 6);
+
+-- SRID mismatch raises
+SELECT minDistance(tgeometry 'Point(0 0)@2000-01-01',
+                   geometry 'SRID=4326;Point(1 1)');
+
+--------------------------------------------------------
+-- minDistance(tgeometry, tgeometry) -- 2-ary aggregate
+--------------------------------------------------------
+
+-- Aggregate over one row equals the per-pair value
+SELECT minDistance(t1, t2) FROM (
+  SELECT tgeometry '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-02]' AS t1,
+         tgeometry '[Point(5 0)@2000-01-01, Point(15 0)@2000-01-02]'  AS t2) v;
+
+-- Aggregate over multiple rows: minimum across all per-pair distances
+WITH pairs(t1, t2) AS (VALUES
+  (tgeometry '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
+   tgeometry '[Point(10 10)@2000-01-01, Point(11 11)@2000-01-02]'),
+  (tgeometry '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
+   tgeometry '[Point(0 5)@2000-01-01, Point(1 5)@2000-01-02]'),
+  (tgeometry '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
+   tgeometry '[Point(2 1)@2000-01-01, Point(2 2)@2000-01-02]'))
+SELECT round(minDistance(t1, t2)::numeric, 6) FROM pairs;
+
+-- Grouped: per-group minimum
+WITH src(g, t1, t2) AS (VALUES
+  (1, tgeometry '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
+      tgeometry '[Point(0 10)@2000-01-01, Point(1 10)@2000-01-02]'),
+  (1, tgeometry '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
+      tgeometry '[Point(0 5)@2000-01-01, Point(1 5)@2000-01-02]'),
+  (2, tgeometry '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
+      tgeometry '[Point(0 2)@2000-01-01, Point(1 2)@2000-01-02]'))
+SELECT g, round(minDistance(t1, t2)::numeric, 6) FROM src GROUP BY g ORDER BY g;
+
+-- Empty group returns NULL (zero rows -> NULL per PG aggregate semantics)
+SELECT minDistance(t1, t2) FROM (
+  SELECT tgeometry '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]' AS t1,
+         tgeometry '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]' AS t2 WHERE false) v;

--- a/mobilitydb/test/geo/queries/064_tpoint_distance.test.sql
+++ b/mobilitydb/test/geo/queries/064_tpoint_distance.test.sql
@@ -820,3 +820,100 @@ SELECT shortestLine(geography 'Linestring(90 0 0,0 90 100)', tgeogpoint 'Point(-
 SELECT shortestLine(tgeogpoint 'Point(-90 0 100)@2000-01-01', geography 'Linestring(90 0 0,0 90 100)');
 
 --------------------------------------------------------
+-- minDistance(tgeompoint[], tgeompoint[]) — exact set-set spatial min distance
+--------------------------------------------------------
+
+-- Two singleton sets, segments crossing each other: distance is 0
+SELECT minDistance(
+  ARRAY[tgeompoint '[Point(0 0)@2000-01-01, Point(2 2)@2000-01-02]'],
+  ARRAY[tgeompoint '[Point(0 2)@2000-01-01, Point(2 0)@2000-01-02]']);
+
+-- Two singleton sets, parallel disjoint: exact distance is 1
+SELECT round(minDistance(
+  ARRAY[tgeompoint '[Point(0 0)@2000-01-01, Point(10 0)@2000-01-02]'],
+  ARRAY[tgeompoint '[Point(0 1)@2000-01-01, Point(10 1)@2000-01-02]']), 6);
+
+-- Multi-element sets: closest pair determines the answer, bbox prefilter prunes the rest
+SELECT round(minDistance(
+  ARRAY[tgeompoint '[Point(0 0)@2000-01-01, Point(1 0)@2000-01-02]',
+        tgeompoint '[Point(100 100)@2000-01-01, Point(101 100)@2000-01-02]'],
+  ARRAY[tgeompoint '[Point(0 5)@2000-01-01, Point(1 5)@2000-01-02]',
+        tgeompoint '[Point(200 200)@2000-01-01, Point(201 200)@2000-01-02]']), 6);
+
+-- Equivalence vs ST_Distance(ST_Collect, ST_Collect): same answer
+WITH A AS (SELECT ARRAY[
+  tgeompoint '[Point(0 0)@2000-01-01, Point(5 0)@2000-01-02]',
+  tgeompoint '[Point(0 10)@2000-01-01, Point(5 10)@2000-01-02]'] AS a),
+B AS (SELECT ARRAY[
+  tgeompoint '[Point(0 1)@2000-01-01, Point(5 1)@2000-01-02]',
+  tgeompoint '[Point(0 11)@2000-01-01, Point(5 11)@2000-01-02]'] AS b)
+SELECT round(minDistance(a, b), 6) = round(ST_Distance(
+  ST_Collect(ARRAY[trajectory(a[1]), trajectory(a[2])]),
+  ST_Collect(ARRAY[trajectory(b[1]), trajectory(b[2])])), 6) AS bit_equivalent
+FROM A, B;
+
+-- Errors / NULL handling
+SELECT minDistance(ARRAY[]::tgeompoint[], ARRAY[tgeompoint 'Point(0 0)@2000-01-01']);
+SELECT minDistance(ARRAY[tgeompoint 'Point(0 0)@2000-01-01'],
+                   ARRAY[tgeompoint 'SRID=4326;Point(0 0)@2000-01-01']);
+
+--------------------------------------------------------
+-- minDistance(tgeompoint, geometry) — scalar spatial min distance
+--------------------------------------------------------
+
+-- Trajectory line segment crossing the geometry point: distance 0
+SELECT minDistance(tgeompoint '[Point(0 0)@2000-01-01, Point(2 0)@2000-01-02]',
+                   geometry 'Point(1 0)');
+
+-- Diagonal trajectory, side point: perpendicular distance
+SELECT round(minDistance(tgeompoint '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-02]',
+                         geometry 'Point(5 0)')::numeric, 6);
+
+-- Symmetric (geometry, tgeompoint)
+SELECT round(minDistance(geometry 'Point(5 0)',
+                         tgeompoint '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-02]')::numeric, 6);
+
+-- Trajectory and a polygon: distance to nearest edge
+SELECT round(minDistance(tgeompoint '[Point(0 0)@2000-01-01, Point(10 0)@2000-01-02]',
+                         geometry 'POLYGON((20 -5, 30 -5, 30 5, 20 5, 20 -5))')::numeric, 6);
+
+-- SRID mismatch raises
+SELECT minDistance(tgeompoint 'Point(0 0)@2000-01-01',
+                   geometry 'SRID=4326;Point(1 1)');
+
+--------------------------------------------------------
+-- minDistance(tgeompoint, tgeompoint) — 2-ary aggregate
+--------------------------------------------------------
+
+-- Aggregate over one row equals the per-pair value
+SELECT minDistance(t1, t2) FROM (
+  SELECT tgeompoint '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-02]' AS t1,
+         tgeompoint '[Point(5 0)@2000-01-01, Point(15 0)@2000-01-02]'  AS t2) v;
+
+-- Aggregate over multiple rows: minimum across all per-pair distances
+WITH pairs(t1, t2) AS (VALUES
+  (tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
+   tgeompoint '[Point(10 10)@2000-01-01, Point(11 11)@2000-01-02]'),  -- ~12.7
+  (tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
+   tgeompoint '[Point(0 5)@2000-01-01, Point(1 5)@2000-01-02]'),       -- 4
+  (tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
+   tgeompoint '[Point(2 1)@2000-01-01, Point(2 2)@2000-01-02]'))       -- ~1
+SELECT round(minDistance(t1, t2)::numeric, 6) FROM pairs;
+
+-- Grouped: per-group minimum equivalent to MIN over the array form
+WITH src(g, t1, t2) AS (VALUES
+  (1, tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
+      tgeompoint '[Point(0 10)@2000-01-01, Point(1 10)@2000-01-02]'),
+  (1, tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
+      tgeompoint '[Point(0 5)@2000-01-01, Point(1 5)@2000-01-02]'),
+  (2, tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
+      tgeompoint '[Point(0 2)@2000-01-01, Point(1 2)@2000-01-02]'))
+SELECT g, round(minDistance(t1, t2)::numeric, 6) FROM src GROUP BY g ORDER BY g;
+
+-- Empty group returns the initial-state DBL_MAX (NULL after aggregate finalise
+-- semantics is not used here: STYPE=float; PG aggregate of zero rows returns NULL).
+SELECT minDistance(t1, t2) FROM (
+  SELECT tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]' AS t1,
+         tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]' AS t2 WHERE false) v;
+
+--------------------------------------------------------


### PR DESCRIPTION
Adds an exact MEOS-native fused-aggregate min spatial distance between two arrays of temporal geos, equivalent to ST_Distance over the union of trajectories on each side but with each trip's STBox used as a sound lower-bound prefilter. Trip pairs are visited in ascending bbox-distance order and the iteration short-circuits once the running minimum is provably smaller than every remaining pair's lower bound. Per-pair distance still goes through liblwgeom's geom_distance2d / geom_distance3d so the answer is bit-identical to the aggregated form. Verified bit-for-bit equivalent to ST_Distance(ST_Collect, ST_Collect) on the BerlinMOD Q5 cross-join (100/100 licence pairs match). Includes smoke tests on crossing / parallel / multi-element / equivalence / empty / mixed-SRID cases.