### PR TITLE
Exclude vendored paths from CodeQL analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,8 @@
+name: "MobilityDB CodeQL config"
+
+paths-ignore:
+  - postgres/**
+  - postgis/**
+  - pgtypes/**
+  - h3-pg/**
+  - meos/postgis/**

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,6 +45,7 @@ jobs:
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
+        config-file: ./.github/codeql/codeql-config.yml
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.


### PR DESCRIPTION
Adds a CodeQL config file under .github/codeql/codeql-config.yml that excludes postgres, postgis, pgtypes, h3-pg, and the vendored postgis subtree under meos/postgis from analysis, and wires it into the CodeQL workflow via config-file. This mirrors the cppcheck workflow's existing path filters so the same vendored-upstream blocks are out of scope for both analyzers. Without this, every PR that imports a new vendored block (such as the pgtypes regex library on the jsontypes PR) starts the CodeQL job in the red on upstream findings the project cannot patch.