### PR TITLE
Fix branch_ignore typo in remaining workflow triggers

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -11,7 +11,8 @@ on:
       - 'mobilitydb/**'
       - 'postgis/**'
       - 'LICENSE.txt'
-    branch_ignore: gh-pages
+    branches-ignore:
+      - gh-pages
 
 jobs:
   license_check:

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -10,7 +10,8 @@ on:
       - 'mobilitydb/**'
       - 'postgis/**'
       - 'CMakeLists.txt'
-    branch_ignore: gh-pages
+    branches-ignore:
+      - gh-pages
   pull_request:
     paths:
       - '.github/workflows/clang.yml'
@@ -19,7 +20,8 @@ on:
       - 'mobilitydb/**'
       - 'postgis/**'
       - 'CMakeLists.txt'
-    branch_ignore: gh-pages
+    branches-ignore:
+      - gh-pages
 
 jobs:
   Test_clang:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,11 @@ name: "CodeQL"
 
 on:
   push:
-    branch_ignore: gh-pages
+    branches-ignore:
+      - gh-pages
   pull_request:
-    branch_ignore: gh-pages
+    branches-ignore:
+      - gh-pages
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,7 +10,8 @@ on:
       - 'mobilitydb/**'
       - 'postgis/**'
       - 'CMakeLists.txt'
-    branch_ignore: gh-pages
+    branches-ignore:
+      - gh-pages
   pull_request:
     paths:
       - '.github/workflows/macos.yml'
@@ -19,7 +20,8 @@ on:
       - 'mobilitydb/**'
       - 'postgis/**'
       - 'CMakeLists.txt'
-    branch_ignore: gh-pages
+    branches-ignore:
+      - gh-pages
 
 jobs:
   build:

--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -10,7 +10,8 @@ on:
       - 'mobilitydb/**'
       - 'postgis/**'
       - 'CMakeLists.txt'
-    branch_ignore: gh-pages
+    branches-ignore:
+      - gh-pages
   pull_request:
     paths:
       - '.github/workflows/meos.yml'
@@ -19,7 +20,8 @@ on:
       - 'mobilitydb/**'
       - 'postgis/**'
       - 'CMakeLists.txt'
-    branch_ignore: gh-pages
+    branches-ignore:
+      - gh-pages
 
 jobs:
   build:

--- a/.github/workflows/pgversion.yml
+++ b/.github/workflows/pgversion.yml
@@ -15,7 +15,8 @@ on:
       - 'mobilitydb/**'
       - 'postgis/**'
       - 'CMakeLists.txt'
-    branch_ignore: gh-pages
+    branches-ignore:
+      - gh-pages
   pull_request:
     paths:
       - '.github/workflows/pgversion.yml'
@@ -24,7 +25,8 @@ on:
       - 'mobilitydb/**'
       - 'postgis/**'
       - 'CMakeLists.txt'
-    branch_ignore: gh-pages
+    branches-ignore:
+      - gh-pages
 
 jobs:
   build:

--- a/.github/workflows/windows_msys2.yml
+++ b/.github/workflows/windows_msys2.yml
@@ -10,7 +10,8 @@ on:
       - 'mobilitydb/**'
       - 'postgis/**'
       - 'CMakeLists.txt'
-    branch_ignore: gh-pages
+    branches-ignore:
+      - gh-pages
   pull_request:
     paths:
       - '.github/workflows/windows_msys2.yml'
@@ -19,7 +20,8 @@ on:
       - 'mobilitydb/**'
       - 'postgis/**'
       - 'CMakeLists.txt'
-    branch_ignore: gh-pages
+    branches-ignore:
+      - gh-pages
 
 jobs:
   build:


### PR DESCRIPTION
The supported GitHub Actions key is branches-ignore (under push or pull_request) with a list of glob patterns, not the silently-ignored branch_ignore. The typo dates back to the original workflows; only #955 fixes it in the new macOS workflow. This sweeps the remaining seven workflows: macos.yml, pgversion.yml, codeql.yml, check-code.yml, meos.yml, windows_msys2.yml, and clang.yml.