### PR TITLE
Add eCovers, aCovers, and tCovers (geometry, tgeompoint) overloads

### DIFF
--- a/mobilitydb/sql/geo/070_tpoint_spatialrels.in.sql
+++ b/mobilitydb/sql/geo/070_tpoint_spatialrels.in.sql
@@ -178,6 +178,37 @@ CREATE FUNCTION aDisjoint(tgeogpoint, tgeogpoint)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************
+ * eCovers, aCovers
+ *
+ * For a temporal point the value at every instant is a point; ST_Covers and
+ * ST_Intersects are equivalent on a (polygon, point) pair, so the Covers
+ * overloads on tgeompoint / tgeogpoint dispatch to the same C kernels as the
+ * Intersects overloads.
+ *****************************************************************************/
+
+CREATE FUNCTION eCovers(geometry, tgeompoint)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Eintersects_geo_tgeo'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION eCovers(geography, tgeogpoint)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Eintersects_geo_tgeo'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION aCovers(geometry, tgeompoint)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Aintersects_geo_tgeo'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION aCovers(geography, tgeogpoint)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Aintersects_geo_tgeo'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/*****************************************************************************
  * eIntersects, aIntersects
  *****************************************************************************/
 

--- a/mobilitydb/sql/geo/072_tpoint_tempspatialrels.in.sql
+++ b/mobilitydb/sql/geo/072_tpoint_tempspatialrels.in.sql
@@ -64,6 +64,19 @@ CREATE FUNCTION tDisjoint(tgeogpoint, tgeogpoint)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************
+ * tCovers
+ *
+ * For a temporal point the value at every instant is a point; ST_Covers and
+ * ST_Intersects are equivalent on a (polygon, point) pair, so the tCovers
+ * overload on tgeompoint dispatches to the same C kernel as tIntersects.
+ *****************************************************************************/
+
+CREATE FUNCTION tCovers(geometry, tgeompoint)
+  RETURNS tbool
+  AS 'MODULE_PATHNAME', 'Tintersects_geo_tgeo'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/*****************************************************************************
  * tIntersects
  *****************************************************************************/
 

--- a/mobilitydb/test/geo/expected/070_tpoint_spatialrels.test.out
+++ b/mobilitydb/test/geo/expected/070_tpoint_spatialrels.test.out
@@ -342,6 +342,54 @@ CONTEXT:  SQL function "edisjoint" statement 1
 SELECT eDisjoint(tgeompoint 'Point(1 1)@2000-01-01', geometry 'SRID=5676;Point(1 1)');
 ERROR:  Operation on mixed SRID
 CONTEXT:  SQL function "edisjoint" statement 1
+SELECT eCovers(geometry 'Point(1 1)', tgeompoint 'Point(1 1)@2000-01-01');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT eCovers(geometry 'Polygon((0 0, 10 0, 10 10, 0 10, 0 0))', tgeompoint '[Point(1 1)@2000-01-01, Point(20 20)@2000-01-02]');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT aCovers(geometry 'Polygon((0 0, 10 0, 10 10, 0 10, 0 0))', tgeompoint '[Point(1 1)@2000-01-01, Point(5 5)@2000-01-02]');
+ acovers 
+---------
+ t
+(1 row)
+
+SELECT aCovers(geometry 'Polygon((0 0, 10 0, 10 10, 0 10, 0 0))', tgeompoint '[Point(1 1)@2000-01-01, Point(20 20)@2000-01-02]');
+ acovers 
+---------
+ f
+(1 row)
+
+SELECT eCovers(geometry 'Point empty', tgeompoint 'Point(1 1)@2000-01-01');
+ ecovers 
+---------
+ 
+(1 row)
+
+SELECT aCovers(geometry 'Point empty', tgeompoint 'Point(1 1)@2000-01-01');
+ acovers 
+---------
+ 
+(1 row)
+
+SELECT eCovers(geography 'Point(1.5 1.5)', tgeogpoint 'Point(1.5 1.5)@2000-01-01');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT aCovers(geography 'Point(1.5 1.5)', tgeogpoint 'Point(1.5 1.5)@2000-01-01');
+ acovers 
+---------
+ t
+(1 row)
+
 SELECT eIntersects(geometry 'Point(1 1)', tgeompoint 'Point(1 1)@2000-01-01');
  eintersects 
 -------------

--- a/mobilitydb/test/geo/expected/070_tpoint_spatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/070_tpoint_spatialrels_tbl.test.out
@@ -130,6 +130,18 @@ SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2 WHERE aDisjoint(t1
     14
 (1 row)
 
+SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE eCovers(g, temp);
+ count 
+-------
+  3280
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE aCovers(g, temp);
+ count 
+-------
+   173
+(1 row)
+
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE eIntersects(g, temp);
  count 
 -------

--- a/mobilitydb/test/geo/expected/072_tpoint_tempspatialrels.test.out
+++ b/mobilitydb/test/geo/expected/072_tpoint_tempspatialrels.test.out
@@ -252,6 +252,24 @@ SELECT tDisjoint(geometry 'SRID=5676;Point(1 1)', tgeompoint 'Point(1 1)@2000-01
 ERROR:  Operation on mixed SRID
 SELECT tDisjoint(tgeompoint 'Point(1 1)@2000-01-01', geometry 'SRID=5676;Point(1 1)');
 ERROR:  Operation on mixed SRID
+SELECT tCovers(geometry 'Polygon((0 0, 10 0, 10 10, 0 10, 0 0))', tgeompoint 'Point(1 1)@2000-01-01');
+            tcovers             
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tCovers(geometry 'Polygon((0 0, 10 0, 10 10, 0 10, 0 0))', tgeompoint '[Point(1 1)@2000-01-01, Point(20 20)@2000-01-02]');
+                                                                      tcovers                                                                       
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 11:22:06.315789 2000 PST], (f@Sat Jan 01 11:22:06.315789 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tCovers(geometry 'Polygon empty', tgeompoint 'Point(1 1)@2000-01-01');
+ tcovers 
+---------
+ 
+(1 row)
+
 SELECT tIntersects(NULL::geometry, tgeompoint 'Point(1 1)@2000-01-01');
  tintersects 
 -------------

--- a/mobilitydb/test/geo/expected/072_tpoint_tempspatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/072_tpoint_tempspatialrels_tbl.test.out
@@ -111,6 +111,13 @@ SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom_point, tbl_tgeompoint
+  WHERE tCovers(g, temp) IS NOT NULL;
+ count 
+-------
+  9900
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geom_point, tbl_tgeompoint
   WHERE tIntersects(g, temp) IS NOT NULL;
  count 
 -------

--- a/mobilitydb/test/geo/queries/070_tpoint_spatialrels.test.sql
+++ b/mobilitydb/test/geo/queries/070_tpoint_spatialrels.test.sql
@@ -116,6 +116,25 @@ SELECT eDisjoint(geometry 'SRID=5676;Point(1 1)', tgeompoint 'Point(1 1)@2000-01
 SELECT eDisjoint(tgeompoint 'Point(1 1)@2000-01-01', geometry 'SRID=5676;Point(1 1)');
 
 -------------------------------------------------------------------------------
+-- eCovers, aCovers
+-------------------------------------------------------------------------------
+
+------------------------
+-- Geo x Temporal
+------------------------
+-- 2D
+SELECT eCovers(geometry 'Point(1 1)', tgeompoint 'Point(1 1)@2000-01-01');
+SELECT eCovers(geometry 'Polygon((0 0, 10 0, 10 10, 0 10, 0 0))', tgeompoint '[Point(1 1)@2000-01-01, Point(20 20)@2000-01-02]');
+SELECT aCovers(geometry 'Polygon((0 0, 10 0, 10 10, 0 10, 0 0))', tgeompoint '[Point(1 1)@2000-01-01, Point(5 5)@2000-01-02]');
+SELECT aCovers(geometry 'Polygon((0 0, 10 0, 10 10, 0 10, 0 0))', tgeompoint '[Point(1 1)@2000-01-01, Point(20 20)@2000-01-02]');
+-- Empty
+SELECT eCovers(geometry 'Point empty', tgeompoint 'Point(1 1)@2000-01-01');
+SELECT aCovers(geometry 'Point empty', tgeompoint 'Point(1 1)@2000-01-01');
+-- Geography
+SELECT eCovers(geography 'Point(1.5 1.5)', tgeogpoint 'Point(1.5 1.5)@2000-01-01');
+SELECT aCovers(geography 'Point(1.5 1.5)', tgeogpoint 'Point(1.5 1.5)@2000-01-01');
+
+-------------------------------------------------------------------------------
 -- eIntersects
 -------------------------------------------------------------------------------
 

--- a/mobilitydb/test/geo/queries/070_tpoint_spatialrels_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/070_tpoint_spatialrels_tbl.test.sql
@@ -77,6 +77,13 @@ SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_geog3D t2 WHERE t1.k % 3 = 0 AND t
 SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2 WHERE aDisjoint(t1.temp, t2.temp);
 
 -------------------------------------------------------------------------------
+-- eCovers, aCovers
+-------------------------------------------------------------------------------
+
+SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE eCovers(g, temp);
+SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE aCovers(g, temp);
+
+-------------------------------------------------------------------------------
 -- eIntersects, aIntersects
 -- aIntersects is not provided for geography
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/geo/queries/072_tpoint_tempspatialrels.test.sql
+++ b/mobilitydb/test/geo/queries/072_tpoint_tempspatialrels.test.sql
@@ -100,6 +100,14 @@ SELECT tDisjoint(geometry 'SRID=5676;Point(1 1)', tgeompoint 'Point(1 1)@2000-01
 SELECT tDisjoint(tgeompoint 'Point(1 1)@2000-01-01', geometry 'SRID=5676;Point(1 1)');
 
 -------------------------------------------------------------------------------
+-- tCovers
+-------------------------------------------------------------------------------
+
+SELECT tCovers(geometry 'Polygon((0 0, 10 0, 10 10, 0 10, 0 0))', tgeompoint 'Point(1 1)@2000-01-01');
+SELECT tCovers(geometry 'Polygon((0 0, 10 0, 10 10, 0 10, 0 0))', tgeompoint '[Point(1 1)@2000-01-01, Point(20 20)@2000-01-02]');
+SELECT tCovers(geometry 'Polygon empty', tgeompoint 'Point(1 1)@2000-01-01');
+
+-------------------------------------------------------------------------------
 -- tIntersects
 -------------------------------------------------------------------------------
 

--- a/mobilitydb/test/geo/queries/072_tpoint_tempspatialrels_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/072_tpoint_tempspatialrels_tbl.test.sql
@@ -88,6 +88,13 @@ SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2
   WHERE tDisjoint(t1.temp, t2.temp) ?= true <> eDisjoint(t1.temp, t2.temp);
 
 -------------------------------------------------------------------------------
+-- tCovers
+-------------------------------------------------------------------------------
+
+SELECT COUNT(*) FROM tbl_geom_point, tbl_tgeompoint
+  WHERE tCovers(g, temp) IS NOT NULL;
+
+-------------------------------------------------------------------------------
 -- tIntersects
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
For a temporal point the value at every instant is a point, and ST_Covers and ST_Intersects are equivalent on a (polygon, point) pair, so the new Covers SQL overloads on tgeompoint and tgeogpoint dispatch to the same C kernels as the existing Intersects overloads. Closes the gap surfaced when calling eCovers, aCovers, or tCovers with a geometry and a tgeompoint at the SQL level; previously the call failed to resolve against the parent tgeometry overload because the tgeompoint to tgeometry cast rejects linear interpolation.