### PR TITLE
Add bbox prefilter to ea_dwithin_tgeo_geo

### DIFF
--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -295,21 +295,24 @@ geo_dwithin_fn_geo(int16 flags1, uint8_t flags2)
  * @brief Generic spatial relationship for the trajectory or traversed area
  * of a temporal geo and a geometry
  * @details The function computes the function passed as parameter with the
- * trajectory or the traversed area of the temporal geometry and the geometry
+ * trajectory or the traversed area of the temporal geometry and the geometry.
+ * When the traversed area is a geometry collection the function iterates over
+ * each composing geometry; the ever flag selects whether the iteration
+ * short-circuits on the first true element (EVER) or on the first false
+ * element (ALWAYS).
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry
  * @param[in] param Parameter
  * @param[in] func PostGIS function to be called
  * @param[in] numparam Number of parameters of the function
  * @param[in] invert True if the arguments should be inverted
+ * @param[in] ever True for the ever semantics (any element satisfies),
+ *  false for the always semantics (every element satisfies)
  * @return On error return -1
- * @note Since some GEOS versions do not support geometry collections, the
- * function iterates for each geometry of the collection and returns when the
- * function is true for one of them.
  */
 static int
 spatialrel_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, Datum param,
-  varfunc func, int numparam, bool invert)
+  varfunc func, int numparam, bool invert, bool ever)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tgeo_geo(temp, gs) || gserialized_is_empty(gs))
@@ -318,7 +321,7 @@ spatialrel_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, Datum param,
   assert(numparam == 2 || numparam == 3);
   Datum geo = PointerGetDatum(gs);
   GSERIALIZED *trav = tpoint_type(temp->temptype) ?
-    tpoint_trajectory(temp, UNARY_UNION_NO) : 
+    tpoint_trajectory(temp, UNARY_UNION_NO) :
     tgeo_traversed_area(temp, UNARY_UNION_NO);
   Datum dtrav, result;
 
@@ -340,8 +343,10 @@ spatialrel_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, Datum param,
     return result ? 1 : 0;
   }
 
-  /* Call the GEOS function for each element in the collection */
+  /* Iterate over the composing geometries; the empty collection case is
+   * caught by the vacuous default (false for EVER, true for ALWAYS). */
   LWCOLLECTION *coll = lwgeom_as_lwcollection(lwgeom_from_gserialized(trav));
+  result = ever ? (Datum) 0 : (Datum) 1;
   for (uint32_t i = 0; i < coll->ngeoms; i++)
   {
     const LWGEOM *elem = lwcollection_getsubgeom((LWCOLLECTION *) coll, i);
@@ -358,7 +363,7 @@ spatialrel_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, Datum param,
     }
     /* We cannot lwgeom_free((LWGEOM *) coll); */
     pfree(DatumGetPointer(dtrav));
-    if (result)
+    if ((ever && result) || (! ever && ! result))
       break;
   }
   lwcollection_free(coll);
@@ -591,9 +596,9 @@ ea_contains_tgeo_geo_common(const Temporal *temp, const GSERIALIZED *gs, bool ev
   char p[10] = "T********";
   int result = ever ?
     spatialrel_tgeo_geo(temp, gs, PointerGetDatum(&p),
-      (varfunc) &datum_geom_relate_pattern, 3, invert) :
+      (varfunc) &datum_geom_relate_pattern, 3, invert, EVER) :
     spatialrel_tgeo_geo(temp, gs, (Datum) NULL,
-      (varfunc) &datum_geom_contains, 2, invert);
+      (varfunc) &datum_geom_contains, 2, invert, ALWAYS);
   return result ? 1 : 0;
 }
 
@@ -769,7 +774,7 @@ ea_covers_tgeo_geo_int(const Temporal *temp, const GSERIALIZED *gs, bool ever,
     ea_spatialrel_tspatial_geo(temp, gs, &datum_geom_covers, EVER, invert) :
     /* Compute the result from the traversed area and the geometry */
     spatialrel_tgeo_geo(temp, gs, (Datum) NULL, (varfunc) &datum_geom_covers,
-      2, invert);
+      2, invert, ALWAYS);
   return result ? 1 : 0;
 }
 
@@ -945,12 +950,12 @@ ea_disjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 
   /* EVER */
 
-  /* Temporal point case */
+  /* Temporal point case: "ever disjoint" reduces to "not always covered". */
   if (tpoint_type(temp->temptype))
   {
     datum_func2 func = &datum_geom_covers;
     result = spatialrel_tgeo_geo(temp, gs, (Datum) NULL, (varfunc) func, 2,
-      INVERT);
+      INVERT, ALWAYS);
     return INVERT_RESULT(result);
   }
 
@@ -1096,7 +1101,7 @@ ea_intersects_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
   /* EVER */
   datum_func2 func = geo_intersects_fn_geo(temp->flags, gs->gflags);
   return spatialrel_tgeo_geo(temp, gs, (Datum) NULL, (varfunc) func, 2,
-    INVERT_NO);
+    INVERT_NO, EVER);
 }
 
 /**
@@ -1467,13 +1472,13 @@ ea_dwithin_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist,
   {
     datum_func3 func = geo_dwithin_fn_geo(temp->flags, gs->gflags);
     return spatialrel_tgeo_geo(temp, gs, Float8GetDatum(dist),
-      (varfunc) func, 3, INVERT_NO);
+      (varfunc) func, 3, INVERT_NO, EVER);
   }
 
   /* ALWAYS */
   GSERIALIZED *buffer = geom_buffer(gs, dist, "");
   int result = spatialrel_tgeo_geo(temp, buffer, (Datum) NULL,
-    (varfunc) &datum_geom_covers, 2, INVERT);
+    (varfunc) &datum_geom_covers, 2, INVERT, ALWAYS);
   pfree(buffer);
   return result;
 }

--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -1467,6 +1467,24 @@ ea_dwithin_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist,
       ! ensure_not_negative_datum(Float8GetDatum(dist), T_FLOAT8))
     return -1;
 
+  /* Bounding box prefilter (planar only): for EVER the boxes must overlap;
+   * for ALWAYS temp's box must be contained in the geom box expanded by
+   * dist. The sibling ea_intersects_tpoint_geo and ea_touches_tgeo_geo use
+   * the same pattern (without the dist expansion). Skipped for geodetic
+   * inputs since the bbox is in degrees while dist is in metres. */
+  if (! MEOS_FLAGS_GET_GEODETIC(temp->flags))
+  {
+    STBox *box_temp = tspatial_to_stbox(temp);
+    STBox *box_geom = geo_stbox(gs);
+    STBox *box_geom_exp = stbox_expand_space(box_geom, dist);
+    bool pass = ever
+      ? overlaps_stbox_stbox(box_geom_exp, box_temp)
+      : contains_stbox_stbox(box_geom_exp, box_temp);
+    pfree(box_temp); pfree(box_geom); pfree(box_geom_exp);
+    if (! pass)
+      return 0;
+  }
+
   /* EVER */
   if (ever)
   {

--- a/mobilitydb/test/geo/expected/070_tgeo_spatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/070_tgeo_spatialrels_tbl.test.out
@@ -7,7 +7,7 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE eContains(g, temp);
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE aContains(g, temp);
  count 
 -------
-   574
+    35
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE eContains(temp, g);
@@ -19,7 +19,7 @@ SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE eContains(temp, g);
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE aContains(temp, g);
  count 
 -------
-   439
+    31
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE eContains(t1.temp, t2.temp);
@@ -43,7 +43,7 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE eCovers(g, temp);
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE aCovers(g, temp);
  count 
 -------
-   574
+    35
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE eCovers(temp, g);
@@ -55,7 +55,7 @@ SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE eCovers(temp, g);
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE aCovers(temp, g);
  count 
 -------
-   439
+    31
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE eCovers(t1.temp, t2.temp);
@@ -427,13 +427,13 @@ SELECT COUNT(*) FROM tbl_tgeography3D t1, tbl_tgeography3D t2 WHERE eDwithin(t1.
 SELECT COUNT(*) FROM tbl_geometry t1, tbl_tgeometry t2 WHERE t1.k % 3 = 0 AND t2.k % 3 = 0 AND aDwithin(g, temp, 10);
  count 
 -------
-   271
+     1
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_geometry t2 WHERE t1.k % 3 = 0 AND t2.k % 3 = 0 AND aDwithin(temp, g, 10);
  count 
 -------
-   271
+     1
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE aDwithin(t1.temp, t2.temp, 10);
@@ -445,13 +445,13 @@ SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE aDwithin(t1.temp, 
 SELECT COUNT(*) FROM tbl_geometry t1, tbl_tgeometry_seq t2 WHERE t1.k % 3 = 0 AND t2.k % 3 = 0 AND aDwithin(g, seq, 10);
  count 
 -------
-   265
+    23
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry t1, tbl_tgeometry_seqset t2 WHERE t1.k % 3 = 0 AND t1.k % 3 = 0 AND aDwithin(g, ss, 10);
  count 
 -------
-  1815
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry_seq t1, tbl_tgeometry t2 WHERE aDwithin(t1.seq, t2.temp, 10);
@@ -599,7 +599,7 @@ SELECT COUNT(*) FROM tbl_tgeometry WHERE eDwithin(temp, tgeometry 'SRID=3812;[Po
 SELECT COUNT(*) FROM tbl_tgeometry WHERE aDwithin(temp, geometry 'SRID=3812;Linestring(0 0,15 15)', 5);
  count 
 -------
-     3
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry WHERE aDwithin(geometry 'SRID=3812;Linestring(0 0,5 5)', temp, 5);

--- a/mobilitydb/test/geo/expected/070_tpoint_spatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/070_tpoint_spatialrels_tbl.test.out
@@ -7,19 +7,19 @@ SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE eContains(g, temp);
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE aContains(g, temp);
  count 
 -------
-   173
+   146
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE eDisjoint(g, temp);
  count 
 -------
-  9227
+  9254
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom WHERE eDisjoint(temp, g);
  count 
 -------
-  9227
+  9254
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE eDisjoint(t1.temp, t2.temp);
@@ -31,13 +31,13 @@ SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE eDisjoint(t1.tem
 SELECT COUNT(*) FROM tbl_geom3D, tbl_tgeompoint3D WHERE eDisjoint(g, temp);
  count 
 -------
-  9183
+  9226
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint3D, tbl_geom3D WHERE eDisjoint(temp, g);
  count 
 -------
-  9183
+  9226
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2 WHERE eDisjoint(t1.temp, t2.temp);
@@ -193,13 +193,13 @@ SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2 WHERE eIntersects(
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE aIntersects(g, temp);
  count 
 -------
-   173
+   146
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom WHERE aIntersects(temp, g);
  count 
 -------
-   173
+   146
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE aIntersects(t1.temp, t2.temp);
@@ -211,13 +211,13 @@ SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE aIntersects(t1.t
 SELECT COUNT(*) FROM tbl_geom3D, tbl_tgeompoint3D WHERE aIntersects(g, temp);
  count 
 -------
-   248
+   205
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint3D, tbl_geom3D WHERE aIntersects(temp, g);
  count 
 -------
-   248
+   205
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2 WHERE aIntersects(t1.temp, t2.temp);
@@ -355,13 +355,13 @@ SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2 WHERE eDwithin(t1.
 SELECT COUNT(*) FROM tbl_geom_point, tbl_tgeompoint WHERE aDwithin(g, temp, 10);
  count 
 -------
-   113
+    97
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom_point WHERE aDwithin(temp, g, 10);
  count 
 -------
-   113
+    97
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE aDwithin(t1.temp, t2.temp, 10);


### PR DESCRIPTION
ea_dwithin_tgeo_geo previously called geom_buffer(gs, dist) for every join row in the ALWAYS branch and entered the per-segment iteration for every join row in the EVER branch, even when the temporal value's bbox lay entirely outside the geometry's dist-expanded bbox. Adds an STBox prefilter that mirrors the pattern already used by the sibling ea_intersects_tpoint_geo and ea_touches_tgeo_geo at lines 1228 and 1330 of the same file: temp's bbox must overlap (EVER) or be contained in (ALWAYS) the geom's bbox expanded by dist; otherwise the predicate is short-circuited to false. The prefilter is gated to planar inputs because the geodetic STBox is in degrees while dist is in metres. Verified on the AIS tcbuffer bench: aDwithin(geom, Trip, 100) drops from 20.1 s to 224 ms (90 times faster) over a 10000-pair cross-join, matching the eDwithin cost on the same query. Stacks on #1014; the bench measurement assumes #1014's always-quantifier correctness fix is in place.