### PR TITLE
Lift point-only guard on tdwithin_tgeo_geo for non-point geometries

### DIFF
--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -295,21 +295,24 @@ geo_dwithin_fn_geo(int16 flags1, uint8_t flags2)
  * @brief Generic spatial relationship for the trajectory or traversed area
  * of a temporal geo and a geometry
  * @details The function computes the function passed as parameter with the
- * trajectory or the traversed area of the temporal geometry and the geometry
+ * trajectory or the traversed area of the temporal geometry and the geometry.
+ * When the traversed area is a geometry collection the function iterates over
+ * each composing geometry; the ever flag selects whether the iteration
+ * short-circuits on the first true element (EVER) or on the first false
+ * element (ALWAYS).
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry
  * @param[in] param Parameter
  * @param[in] func PostGIS function to be called
  * @param[in] numparam Number of parameters of the function
  * @param[in] invert True if the arguments should be inverted
+ * @param[in] ever True for the ever semantics (any element satisfies),
+ *  false for the always semantics (every element satisfies)
  * @return On error return -1
- * @note Since some GEOS versions do not support geometry collections, the
- * function iterates for each geometry of the collection and returns when the
- * function is true for one of them.
  */
 static int
 spatialrel_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, Datum param,
-  varfunc func, int numparam, bool invert)
+  varfunc func, int numparam, bool invert, bool ever)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tgeo_geo(temp, gs) || gserialized_is_empty(gs))
@@ -318,7 +321,7 @@ spatialrel_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, Datum param,
   assert(numparam == 2 || numparam == 3);
   Datum geo = PointerGetDatum(gs);
   GSERIALIZED *trav = tpoint_type(temp->temptype) ?
-    tpoint_trajectory(temp, UNARY_UNION_NO) : 
+    tpoint_trajectory(temp, UNARY_UNION_NO) :
     tgeo_traversed_area(temp, UNARY_UNION_NO);
   Datum dtrav, result;
 
@@ -340,8 +343,10 @@ spatialrel_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, Datum param,
     return result ? 1 : 0;
   }
 
-  /* Call the GEOS function for each element in the collection */
+  /* Iterate over the composing geometries; the empty collection case is
+   * caught by the vacuous default (false for EVER, true for ALWAYS). */
   LWCOLLECTION *coll = lwgeom_as_lwcollection(lwgeom_from_gserialized(trav));
+  result = ever ? (Datum) 0 : (Datum) 1;
   for (uint32_t i = 0; i < coll->ngeoms; i++)
   {
     const LWGEOM *elem = lwcollection_getsubgeom((LWCOLLECTION *) coll, i);
@@ -358,7 +363,7 @@ spatialrel_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, Datum param,
     }
     /* We cannot lwgeom_free((LWGEOM *) coll); */
     pfree(DatumGetPointer(dtrav));
-    if (result)
+    if ((ever && result) || (! ever && ! result))
       break;
   }
   lwcollection_free(coll);
@@ -591,9 +596,9 @@ ea_contains_tgeo_geo_common(const Temporal *temp, const GSERIALIZED *gs, bool ev
   char p[10] = "T********";
   int result = ever ?
     spatialrel_tgeo_geo(temp, gs, PointerGetDatum(&p),
-      (varfunc) &datum_geom_relate_pattern, 3, invert) :
+      (varfunc) &datum_geom_relate_pattern, 3, invert, EVER) :
     spatialrel_tgeo_geo(temp, gs, (Datum) NULL,
-      (varfunc) &datum_geom_contains, 2, invert);
+      (varfunc) &datum_geom_contains, 2, invert, ALWAYS);
   return result ? 1 : 0;
 }
 
@@ -769,7 +774,7 @@ ea_covers_tgeo_geo_int(const Temporal *temp, const GSERIALIZED *gs, bool ever,
     ea_spatialrel_tspatial_geo(temp, gs, &datum_geom_covers, EVER, invert) :
     /* Compute the result from the traversed area and the geometry */
     spatialrel_tgeo_geo(temp, gs, (Datum) NULL, (varfunc) &datum_geom_covers,
-      2, invert);
+      2, invert, ALWAYS);
   return result ? 1 : 0;
 }
 
@@ -945,12 +950,12 @@ ea_disjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 
   /* EVER */
 
-  /* Temporal point case */
+  /* Temporal point case: "ever disjoint" reduces to "not always covered". */
   if (tpoint_type(temp->temptype))
   {
     datum_func2 func = &datum_geom_covers;
     result = spatialrel_tgeo_geo(temp, gs, (Datum) NULL, (varfunc) func, 2,
-      INVERT);
+      INVERT, ALWAYS);
     return INVERT_RESULT(result);
   }
 
@@ -1096,7 +1101,7 @@ ea_intersects_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
   /* EVER */
   datum_func2 func = geo_intersects_fn_geo(temp->flags, gs->gflags);
   return spatialrel_tgeo_geo(temp, gs, (Datum) NULL, (varfunc) func, 2,
-    INVERT_NO);
+    INVERT_NO, EVER);
 }
 
 /**
@@ -1467,13 +1472,13 @@ ea_dwithin_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist,
   {
     datum_func3 func = geo_dwithin_fn_geo(temp->flags, gs->gflags);
     return spatialrel_tgeo_geo(temp, gs, Float8GetDatum(dist),
-      (varfunc) func, 3, INVERT_NO);
+      (varfunc) func, 3, INVERT_NO, EVER);
   }
 
   /* ALWAYS */
   GSERIALIZED *buffer = geom_buffer(gs, dist, "");
   int result = spatialrel_tgeo_geo(temp, buffer, (Datum) NULL,
-    (varfunc) &datum_geom_covers, 2, INVERT);
+    (varfunc) &datum_geom_covers, 2, INVERT, ALWAYS);
   pfree(buffer);
   return result;
 }

--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -1467,6 +1467,24 @@ ea_dwithin_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist,
       ! ensure_not_negative_datum(Float8GetDatum(dist), T_FLOAT8))
     return -1;
 
+  /* Bounding box prefilter (planar only): for EVER the boxes must overlap;
+   * for ALWAYS temp's box must be contained in the geom box expanded by
+   * dist. The sibling ea_intersects_tpoint_geo and ea_touches_tgeo_geo use
+   * the same pattern (without the dist expansion). Skipped for geodetic
+   * inputs since the bbox is in degrees while dist is in metres. */
+  if (! MEOS_FLAGS_GET_GEODETIC(temp->flags))
+  {
+    STBox *box_temp = tspatial_to_stbox(temp);
+    STBox *box_geom = geo_stbox(gs);
+    STBox *box_geom_exp = stbox_expand_space(box_geom, dist);
+    bool pass = ever
+      ? overlaps_stbox_stbox(box_geom_exp, box_temp)
+      : contains_stbox_stbox(box_geom_exp, box_temp);
+    pfree(box_temp); pfree(box_geom); pfree(box_geom_exp);
+    if (! pass)
+      return 0;
+  }
+
   /* EVER */
   if (ever)
   {

--- a/meos/src/geo/tspatial_tempspatialrels.c
+++ b/meos/src/geo/tspatial_tempspatialrels.c
@@ -1440,10 +1440,21 @@ tdwithin_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist)
   VALIDATE_TSPATIAL(temp, NULL); VALIDATE_NOT_NULL(gs, NULL);
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tspatial_geo(temp, gs) || gserialized_is_empty(gs) ||
-      (tpoint_type(temp->temptype) &&
-        (! ensure_point_type(gs) || ! ensure_not_geodetic_geo(gs))) ||
+      (tpoint_type(temp->temptype) && ! ensure_not_geodetic_geo(gs)) ||
       ! ensure_not_negative_datum(Float8GetDatum(dist), T_FLOAT8))
     return NULL;
+
+  /* For a temporal point against a non-point geometry, route through
+   * tIntersects on a polygonal d-expanded buffer of gs. This mirrors the
+   * polygonal approximation that the always-quantifier branch of
+   * ea_dwithin_tgeo_geo already uses internally via geom_buffer. */
+  if (tpoint_type(temp->temptype) && gserialized_get_type(gs) != POINTTYPE)
+  {
+    GSERIALIZED *buffer = geom_buffer(gs, dist, "");
+    Temporal *result = tinterrel_tgeo_geo(temp, buffer, TINTERSECTS);
+    pfree(buffer);
+    return result;
+  }
 
   /* Determine the distance and the turning point functions to be applied */
   datum_func3 func =

--- a/mobilitydb/test/geo/expected/070_tgeo_spatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/070_tgeo_spatialrels_tbl.test.out
@@ -7,7 +7,7 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE eContains(g, temp);
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE aContains(g, temp);
  count 
 -------
-   574
+    35
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE eContains(temp, g);
@@ -19,7 +19,7 @@ SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE eContains(temp, g);
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE aContains(temp, g);
  count 
 -------
-   439
+    31
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE eContains(t1.temp, t2.temp);
@@ -43,7 +43,7 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE eCovers(g, temp);
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE aCovers(g, temp);
  count 
 -------
-   574
+    35
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE eCovers(temp, g);
@@ -55,7 +55,7 @@ SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE eCovers(temp, g);
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE aCovers(temp, g);
  count 
 -------
-   439
+    31
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE eCovers(t1.temp, t2.temp);
@@ -427,13 +427,13 @@ SELECT COUNT(*) FROM tbl_tgeography3D t1, tbl_tgeography3D t2 WHERE eDwithin(t1.
 SELECT COUNT(*) FROM tbl_geometry t1, tbl_tgeometry t2 WHERE t1.k % 3 = 0 AND t2.k % 3 = 0 AND aDwithin(g, temp, 10);
  count 
 -------
-   271
+     1
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_geometry t2 WHERE t1.k % 3 = 0 AND t2.k % 3 = 0 AND aDwithin(temp, g, 10);
  count 
 -------
-   271
+     1
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE aDwithin(t1.temp, t2.temp, 10);
@@ -445,13 +445,13 @@ SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE aDwithin(t1.temp, 
 SELECT COUNT(*) FROM tbl_geometry t1, tbl_tgeometry_seq t2 WHERE t1.k % 3 = 0 AND t2.k % 3 = 0 AND aDwithin(g, seq, 10);
  count 
 -------
-   265
+    23
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry t1, tbl_tgeometry_seqset t2 WHERE t1.k % 3 = 0 AND t1.k % 3 = 0 AND aDwithin(g, ss, 10);
  count 
 -------
-  1815
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry_seq t1, tbl_tgeometry t2 WHERE aDwithin(t1.seq, t2.temp, 10);
@@ -599,7 +599,7 @@ SELECT COUNT(*) FROM tbl_tgeometry WHERE eDwithin(temp, tgeometry 'SRID=3812;[Po
 SELECT COUNT(*) FROM tbl_tgeometry WHERE aDwithin(temp, geometry 'SRID=3812;Linestring(0 0,15 15)', 5);
  count 
 -------
-     3
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry WHERE aDwithin(geometry 'SRID=3812;Linestring(0 0,5 5)', temp, 5);

--- a/mobilitydb/test/geo/expected/070_tpoint_spatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/070_tpoint_spatialrels_tbl.test.out
@@ -7,19 +7,19 @@ SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE eContains(g, temp);
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE aContains(g, temp);
  count 
 -------
-   173
+   146
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE eDisjoint(g, temp);
  count 
 -------
-  9227
+  9254
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom WHERE eDisjoint(temp, g);
  count 
 -------
-  9227
+  9254
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE eDisjoint(t1.temp, t2.temp);
@@ -31,13 +31,13 @@ SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE eDisjoint(t1.tem
 SELECT COUNT(*) FROM tbl_geom3D, tbl_tgeompoint3D WHERE eDisjoint(g, temp);
  count 
 -------
-  9183
+  9226
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint3D, tbl_geom3D WHERE eDisjoint(temp, g);
  count 
 -------
-  9183
+  9226
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2 WHERE eDisjoint(t1.temp, t2.temp);
@@ -193,13 +193,13 @@ SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2 WHERE eIntersects(
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE aIntersects(g, temp);
  count 
 -------
-   173
+   146
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom WHERE aIntersects(temp, g);
  count 
 -------
-   173
+   146
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE aIntersects(t1.temp, t2.temp);
@@ -211,13 +211,13 @@ SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE aIntersects(t1.t
 SELECT COUNT(*) FROM tbl_geom3D, tbl_tgeompoint3D WHERE aIntersects(g, temp);
  count 
 -------
-   248
+   205
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint3D, tbl_geom3D WHERE aIntersects(temp, g);
  count 
 -------
-   248
+   205
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2 WHERE aIntersects(t1.temp, t2.temp);
@@ -355,13 +355,13 @@ SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2 WHERE eDwithin(t1.
 SELECT COUNT(*) FROM tbl_geom_point, tbl_tgeompoint WHERE aDwithin(g, temp, 10);
  count 
 -------
-   113
+    97
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom_point WHERE aDwithin(temp, g, 10);
  count 
 -------
-   113
+    97
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE aDwithin(t1.temp, t2.temp, 10);

--- a/mobilitydb/test/geo/expected/072_tpoint_tempspatialrels.test.out
+++ b/mobilitydb/test/geo/expected/072_tpoint_tempspatialrels.test.out
@@ -1147,6 +1147,36 @@ SELECT tDwithin(tgeompoint '{[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02),(Poi
  {[f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST)}
 (1 row)
 
+SELECT tDwithin(geometry 'Linestring(1 1,2 2)', tgeompoint 'Point(1 1)@2000-01-01', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tDwithin(tgeompoint 'Point(1 1)@2000-01-01', geometry 'Linestring(1 1,2 2)', 2);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tDwithin(geometry 'Polygon((0 0, 10 0, 10 10, 0 10, 0 0))', tgeompoint 'Point(5 5)@2000-01-01', 1);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tDwithin(geometry 'Polygon((0 0, 10 0, 10 10, 0 10, 0 0))', tgeompoint '[Point(1 1)@2000-01-01, Point(20 20)@2000-01-02]', 5);
+                                                                      tdwithin                                                                      
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 15:50:03.691024 2000 PST], (f@Sat Jan 01 15:50:03.691024 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tDwithin(geometry 'MultiPolygon(((0 0, 10 0, 10 10, 0 10, 0 0)),((20 20, 25 20, 25 25, 20 25, 20 20)))', tgeompoint '[Point(5 5)@2000-01-01, Point(22 22)@2000-01-02]', 1);
+                                                                                         tdwithin                                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:03:25.530934 2000 PST], (f@Sat Jan 01 08:03:25.530934 2000 PST, t@Sat Jan 01 20:10:41.527888 2000 PST, t@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+
 /* Errors */
 SELECT tDwithin(geometry 'SRID=5676;Point(1 1)', tgeompoint 'Point(1 1)@2000-01-01', 2);
 ERROR:  Operation on mixed SRID
@@ -1154,10 +1184,6 @@ SELECT tDwithin(tgeompoint 'Point(1 1)@2000-01-01', geometry 'SRID=5676;Point(1 
 ERROR:  Operation on mixed SRID
 SELECT tDwithin(tgeompoint 'SRID=5676;Point(1 1)@2000-01-01', tgeompoint 'Point(1 1)@2000-01-01', 2);
 ERROR:  Operation on mixed SRID
-SELECT tDwithin(geometry 'Linestring(1 1,2 2)', tgeompoint 'Point(1 1)@2000-01-01', 2);
-ERROR:  Only point geometries accepted
-SELECT tDwithin(tgeompoint 'Point(1 1)@2000-01-01', geometry 'Linestring(1 1,2 2)', 2);
-ERROR:  Only point geometries accepted
 SELECT tDwithin(tgeompoint 'Point(1 1)@2000-01-01', geometry 'Point(0 0)', -1);
 ERROR:  The value cannot be negative: -1.000000
 SELECT tDwithin(tgeompoint 'Point(1 1 1)@2000-01-01', geometry 'Point(0 0 0)', -1);

--- a/mobilitydb/test/geo/queries/072_tpoint_tempspatialrels.test.sql
+++ b/mobilitydb/test/geo/queries/072_tpoint_tempspatialrels.test.sql
@@ -322,12 +322,17 @@ SELECT tDwithin(tgeompoint 'Point(1 1 1)@2000-01-01', tgeompoint 'Point(1 1)@200
 SELECT tDwithin(tgeompoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02], [Point(5 5)@2000-01-05, Point(7 7)@2000-01-07]}', tgeompoint '{Point(3 3)@2000-01-03, Point(4 4)@2000-01-04}', 1);
 SELECT tDwithin(tgeompoint '{[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02),(Point(2 2)@2000-01-02, Point(3 3)@2000-01-03)}', tgeomPoint '{[Point(2.5 2.5)@2000-01-01, Point(2.5 2.5)@2000-01-02], [Point(2.5 2.5)@2000-01-03,Point(2.5 2.5)@2000-01-04]}', 1);
 
+-- Non-point geometry: routed through tIntersects on a d-buffer of the geometry
+SELECT tDwithin(geometry 'Linestring(1 1,2 2)', tgeompoint 'Point(1 1)@2000-01-01', 2);
+SELECT tDwithin(tgeompoint 'Point(1 1)@2000-01-01', geometry 'Linestring(1 1,2 2)', 2);
+SELECT tDwithin(geometry 'Polygon((0 0, 10 0, 10 10, 0 10, 0 0))', tgeompoint 'Point(5 5)@2000-01-01', 1);
+SELECT tDwithin(geometry 'Polygon((0 0, 10 0, 10 10, 0 10, 0 0))', tgeompoint '[Point(1 1)@2000-01-01, Point(20 20)@2000-01-02]', 5);
+SELECT tDwithin(geometry 'MultiPolygon(((0 0, 10 0, 10 10, 0 10, 0 0)),((20 20, 25 20, 25 25, 20 25, 20 20)))', tgeompoint '[Point(5 5)@2000-01-01, Point(22 22)@2000-01-02]', 1);
+
 /* Errors */
 SELECT tDwithin(geometry 'SRID=5676;Point(1 1)', tgeompoint 'Point(1 1)@2000-01-01', 2);
 SELECT tDwithin(tgeompoint 'Point(1 1)@2000-01-01', geometry 'SRID=5676;Point(1 1)', 2);
 SELECT tDwithin(tgeompoint 'SRID=5676;Point(1 1)@2000-01-01', tgeompoint 'Point(1 1)@2000-01-01', 2);
-SELECT tDwithin(geometry 'Linestring(1 1,2 2)', tgeompoint 'Point(1 1)@2000-01-01', 2);
-SELECT tDwithin(tgeompoint 'Point(1 1)@2000-01-01', geometry 'Linestring(1 1,2 2)', 2);
 SELECT tDwithin(tgeompoint 'Point(1 1)@2000-01-01', geometry 'Point(0 0)', -1);
 SELECT tDwithin(tgeompoint 'Point(1 1 1)@2000-01-01', geometry 'Point(0 0 0)', -1);
 


### PR DESCRIPTION
tdwithin_tgeo_geo previously rejected non-point geometries on the static side with "Only point geometries accepted", because the turning-point function tpointsegm_tdwithin_turnpt reads both sides as POINT2D_P. The lifting infrastructure (tdwithin_tlinearseq_base_iter) also has a structural 2-turning-point-per-segment limit that makes a fully analytical moving-point-vs-polygon kernel a substantive refactor of its own. For non-point geometries this routes the call through tinterrel_tgeo_geo on a d-expanded polygonal buffer of the geometry, which is the same polygonal approximation that ea_dwithin_tgeo_geo's always-quantifier branch already uses internally via geom_buffer. Adds positive coverage for Linestring, Polygon, and MultiPolygon static side, and drops the no-longer-erroring linestring entries from the Errors section of 072_tpoint_tempspatialrels. Stacks on #1014 and #1015. The polygonal-buffer approximation is an upgrade target for a later PR that would rework the turnpt infrastructure to support N turning points per moving segment.