### PR TITLE
Expose Edge struct and edge-rtree helpers via geo/tpoint_geom_clip.h

### DIFF
--- a/meos/include/geo/tpoint_geom_clip.h
+++ b/meos/include/geo/tpoint_geom_clip.h
@@ -1,0 +1,84 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @brief Edge extraction and R-tree indexing utilities for 2D geometries.
+ *
+ * Provides the geometry-edge enumeration and an R-tree of per-edge bounding
+ * boxes. Used by the temporal point clipping path and by other operators that
+ * need to query "which edges of a static geometry are near a moving object"
+ * without paying O(N_edges) per call.
+ */
+
+#ifndef __TPOINT_GEOM_CLIP_H__
+#define __TPOINT_GEOM_CLIP_H__
+
+/* PostgreSQL */
+#include <postgres.h>
+/* PostGIS */
+#include <liblwgeom.h>
+/* MEOS */
+#include <meos.h>
+#include "temporal/meos_catalog.h"
+#include "temporal/temporal_rtree.h"
+
+/*****************************************************************************/
+
+/**
+ * @brief Enumeration defining the edge types
+ */
+typedef enum
+{
+  EDGE_POINT = 0,
+  EDGE_LINE,
+  EDGE_POLY
+} EdgeType;
+
+/**
+ * @brief Structure keeping a geometry edge
+ */
+typedef struct
+{
+  double x1, y1, x2, y2;         /**< Coordinates of the start/end 2D points */
+  double xmin, ymin, xmax, ymax; /**< Precomputed bounding box of the edge */
+  double dx, dy, length;         /**< Precomputed dx, dy, and length */
+  EdgeType etype;                /**< Edge type */
+} Edge;
+
+/*****************************************************************************/
+
+extern MeosArray *geom_extract_edges(const LWGEOM *geom);
+
+extern RTree *build_edge_rtree(const Edge *edges, int nedges, int32_t srid);
+
+extern int point_in_polygon(double x, double y, Edge **edges, int nedges);
+
+/*****************************************************************************/
+
+#endif /* __TPOINT_GEOM_CLIP_H__ */

--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -51,6 +51,7 @@
 #include "temporal/temporal_restrict.h"
 #include "geo/tgeo.h"
 #include "geo/tgeo_spatialfuncs.h"
+#include "geo/tpoint_geom_clip.h"
 
 /* Minimum number of edges to use an R-tree index in order to compensate the
  * overhead of the tree construction and destruction */
@@ -66,29 +67,10 @@ static MeosArray *intervals = NULL;
 static MeosArray *periods = NULL;
 static int *rtree_results = NULL;
 
-/**
- * @brief Enumeration defining the edge types 
- */
-typedef enum
-{
-  EDGE_POINT = 0,
-  EDGE_LINE,
-  EDGE_POLY
-} EdgeType;
+/* The Edge struct and EdgeType enum are in geo/tpoint_geom_clip.h */
 
 /**
- * @brief Structure keeping a geometry edge
- */
-typedef struct
-{
-  double x1, y1, x2, y2;         /**< Coordinates of the start/end 2D points */
-  double xmin, ymin, xmax, ymax; /**< Precomputed bounding box of the edge */
-  double dx, dy, length;         /**< Precomputed dx, dy, and length */
-  EdgeType etype;                /**< Edge type */
-} Edge;
-
-/**
- * @brief Enumeration defining the intersection types 
+ * @brief Enumeration defining the intersection types
  */
 typedef enum
 {
@@ -245,9 +227,9 @@ point_on_segment(double px, double py, double x1, double y1, double x2,
 }
 
 /**
- * @brief Return true if a point is located in a polygon 
+ * @brief Return true if a point is located in a polygon
  */
-static inline int
+int
 point_in_polygon(double x, double y, Edge **edges, int nedges)
 {
   int inside = 0;
@@ -938,9 +920,9 @@ geom_extract_edges_iter(const LWGEOM *geom, MeosArray *edges)
 }
 
 /**
- * @brief Return the edges of a geometry in a dynamic array 
+ * @brief Return the edges of a geometry in a dynamic array
  */
-static MeosArray *
+MeosArray *
 geom_extract_edges(const LWGEOM *geom)
 {
   MeosArray *edges = meos_array_create(sizeof(Edge));
@@ -951,7 +933,7 @@ geom_extract_edges(const LWGEOM *geom)
 /**
  * @brief Build an R-tree from edges
  */
-static RTree *
+RTree *
 build_edge_rtree(const Edge *edges, int nedges, int32_t srid)
 {
   RTree *rtree = rtree_create_stbox();


### PR DESCRIPTION
The geometry-edge enumeration, the per-edge R-tree builder and the ray-casting point-in-polygon test in tpoint_geom_clip.c were file-local. This declares the Edge struct, EdgeType, geom_extract_edges, build_edge_rtree and point_in_polygon in a new geo/tpoint_geom_clip.h and removes the duplicate typedefs from the source; it is a visibility-only change. Note that tpoint_geom_clip.c is currently dormant (not listed in meos/src/geo/CMakeLists.txt and not API-current), so this header is preparatory: a separate change must port that file to the current MeosArray and R-tree APIs and add it to the build before the declared symbols are actually linkable. It is the first step toward the GEOS-free analytic capsule-vs-polygon distance path.