### PR TITLE
Pin the canonical span adjacency edge cases (tests)

### DIFF
--- a/mobilitydb/test/temporal/expected/005_span_ops.test.out
+++ b/mobilitydb/test/temporal/expected/005_span_ops.test.out
@@ -52,6 +52,42 @@ SELECT floatspan '[1, 3]' -|- floatspan '[1, 3]';
  f
 (1 row)
 
+SELECT floatspan '[1, 5]' -|- floatspan '[5, 9]';
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT floatspan '[1, 5)' -|- floatspan '[5, 9]';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT floatspan '[1, 5]' -|- floatspan '(5, 9]';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT floatspan '[1, 5)' -|- floatspan '(5, 9]';
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT intspan '[1, 5]' -|- intspan '[6, 10]';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT intspan '[1, 5]' -|- intspan '[5, 10]';
+ ?column? 
+----------
+ f
+(1 row)
+
 SELECT floatspan '[1, 2]' = floatspan '[1, 2]';
  ?column? 
 ----------

--- a/mobilitydb/test/temporal/queries/005_span_ops.test.sql
+++ b/mobilitydb/test/temporal/queries/005_span_ops.test.sql
@@ -51,6 +51,16 @@ SELECT 1.0 -|- floatspan '(1, 3]';
 SELECT floatspan '[1, 3]' -|- 1.0;
 SELECT floatspan '[1, 3]' -|- floatspan '[1, 3]';
 
+-- Canonical adjacency edge cases (issue #821): the inc/exc bits are decisive.
+-- Continuous (float): a shared INCLUSIVE bound is an overlap, NOT adjacency.
+SELECT floatspan '[1, 5]' -|- floatspan '[5, 9]';
+SELECT floatspan '[1, 5)' -|- floatspan '[5, 9]';
+SELECT floatspan '[1, 5]' -|- floatspan '(5, 9]';
+SELECT floatspan '[1, 5)' -|- floatspan '(5, 9]';
+-- Discrete (int): canonicalized half-open, so consecutive values are adjacent.
+SELECT intspan '[1, 5]' -|- intspan '[6, 10]';
+SELECT intspan '[1, 5]' -|- intspan '[5, 10]';
+
 -------------------------------------------------------------------------------
 
 SELECT floatspan '[1, 2]' = floatspan '[1, 2]';


### PR DESCRIPTION
Adds discriminating regression tests for span adjacency (`-|-`) in `005_span_ops` so any change back to a drop-the-bits predicate fails loudly: the four float inc/exc combinations at a shared boundary and the discrete consecutive/overlap cases. The canonical rule itself is documented on `adjacent_span_span` in the comment-only #1121; this PR is the automated guard. Note: the regression is already caught by the existing suite (`003_span`'s `floatspan '[3.5,5.5]' -|- 5.5` flips under drop-the-bits) — these cases make the four-way matrix explicit. Refs #821.