### PR TITLE
Add MEST multi-entry temporal functions and selectivity example to the in-memory RTree

### DIFF
--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -96,6 +96,8 @@ jobs:
           ./typeof_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o parse_test parse_test.c -L/usr/local/lib -lmeos
           ./parse_test
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o rtree_mest_test rtree_mest_test.c -L/usr/local/lib -lmeos -lm
+          ./rtree_mest_test
 
   threaded:
     name: Thread-safety (TSan)

--- a/meos/examples/rtree_mest_example.c
+++ b/meos/examples/rtree_mest_example.c
@@ -1,0 +1,409 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2023, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2023, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief A program that demonstrates the multi-entry (MEST) RTree selectivity
+ * gain for wiggly, high-extent temporal points.
+ *
+ * The program generates a deterministic set of zig-zag random-walk
+ * tgeompoint sequences whose per-trip minimum bounding box is loose (the
+ * documented BerlinMOD / AIS-style scenario where a single MBR covers a large
+ * empty rectangle while every segment stays small). It builds one single-box
+ * RTree with rtree_insert_temporal and several multi-entry RTrees with
+ * rtree_insert_temporal_split over the SAME trips and ids for a small sweep of
+ * maxboxes. Each query is itself a small wiggly probe trip, the natural
+ * BerlinMOD-style range probe. The single-box index is searched with
+ * rtree_search_temporal (the probe's single MBR) and every MEST index with
+ * rtree_search_temporal_dedup (the probe's per-segment boxes, each id returned
+ * at most once). The candidate set is compared against the exact ground
+ * truth, computed independently of the index as the set of trips that share
+ * at least one overlapping tight per-segment bounding box with the probe
+ * (tgeo_stboxes on both sides, overlaps_stbox_stbox over all segment-box
+ * pairs). The program prints a table of candidate counts and false positives
+ * per configuration and asserts the four MEST invariants: no false negatives,
+ * dedup uniqueness, candidate count no larger than the single-box index and
+ * tightening as maxboxes grows, and maxboxes <= 1 reproducing the single-box
+ * candidate set exactly. The summary doubles as the benchmark for choosing a
+ * default maxboxes.
+ *
+ * The program can be built as follows
+ * @code
+ * gcc -Wall -g -I/usr/local/include -o rtree_mest_example rtree_mest_example.c -L/usr/local/lib -lmeos -lproj -lm
+ * @endcode
+ */
+
+/* C */
+#include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+/* MEOS */
+#include <meos.h>
+#include <meos_geo.h>
+
+/* Number of trips inserted into every index */
+#define NUM_TRIPS 4000
+/* Number of instants per stored trip (zig-zag random walk) */
+#define TRIP_LEN 40
+/* Number of instants per query probe trip */
+#define PROBE_LEN 12
+/* Half-width of the arena in metres; trips start anywhere inside it */
+#define ARENA 20000.0
+/* Per-instant step magnitude of the stored trips in metres */
+#define TRIP_STEP 4000.0
+/* Per-instant step magnitude of the probe trips in metres */
+#define PROBE_STEP 3000.0
+/* SRID of the synthetic trips (projected, metric units) */
+#define TRIP_SRID 25832
+/* maxboxes values exercised by the sweep */
+static const int MAXBOXES[] = {4, 8, 16};
+#define NUM_MAXBOXES ((int) (sizeof(MAXBOXES) / sizeof(MAXBOXES[0])))
+/* Number of query probe trips */
+#define NUM_QUERIES 20
+
+/* Return a random double in [min, max] */
+static double
+random_double(double min, double max)
+{
+  return min + (max - min) * ((double) rand() / (double) RAND_MAX);
+}
+
+/* Return a random integer in [min, max] */
+static int
+random_int(int min, int max)
+{
+  return rand() % (max - min + 1) + min;
+}
+
+/* Reference epoch 2020-01-01 00:00:00+00 as a TimestampTz */
+static TimestampTz
+epoch_2020(void)
+{
+  TInstant *e = (TInstant *) tgeompoint_in(
+    "SRID=25832;POINT(0 0)@2020-01-01 00:00:00+00");
+  TimestampTz t0 = e->t;
+  free(e);
+  return t0;
+}
+
+/*****************************************************************************/
+
+/**
+ * @brief Build one deterministic zig-zag random-walk tgeompoint sequence
+ * @details The trip starts at a random point in a wide arena and takes large
+ * alternating-sign steps. The resulting trajectory has a loose minimum
+ * bounding box (it sweeps a large rectangle) while every individual segment
+ * stays small, which is exactly the case the multi-entry index targets.
+ * @param[in] t0 Reference epoch
+ * @param[in] startsecond First instant offset in seconds from the epoch
+ * @param[in] len Number of instants
+ * @param[in] step Per-instant step magnitude range upper bound
+ */
+static Temporal *
+make_wiggly_trip(TimestampTz t0, int startsecond, int len, double step)
+{
+  double *xc = malloc(sizeof(double) * len);
+  double *yc = malloc(sizeof(double) * len);
+  TimestampTz *tc = malloc(sizeof(TimestampTz) * len);
+
+  double x = random_double(0.0, ARENA);
+  double y = random_double(0.0, ARENA);
+  double sx = (random_int(0, 1) == 0) ? 1.0 : -1.0;
+  double sy = (random_int(0, 1) == 0) ? 1.0 : -1.0;
+  for (int i = 0; i < len; i++)
+  {
+    xc[i] = x;
+    yc[i] = y;
+    /* One instant per minute, trip starting at startsecond */
+    tc[i] = t0 + (TimestampTz) (startsecond + i * 60) * 1000000;
+    /* Large alternating-sign steps make the per-trip MBR loose */
+    x += sx * random_double(step * 0.6, step);
+    y += sy * random_double(step * 0.6, step);
+    sx = -sx;
+    sy = -sy;
+  }
+  TSequence *seq = tpointseq_make_coords(xc, yc, NULL, tc, len, TRIP_SRID,
+    false, true, true, LINEAR, true);
+  free(xc);
+  free(yc);
+  free(tc);
+  return (Temporal *) seq;
+}
+
+/**
+ * @brief Exact ground truth: do the two finest per-segment box sets share at
+ * least one overlapping pair
+ * @details Both temporal values are decomposed into their finest per-segment
+ * STBoxes with tgeo_stboxes (the limit the MEST splitter coarsens from) and
+ * every segment-box pair is tested with overlaps_stbox_stbox. This is the
+ * exact answer the box filter approximates and is computed independently of
+ * any index, so it admits neither false positives nor false negatives.
+ */
+static bool
+segments_overlap(const STBox *pboxes, int pcount, const STBox *tboxes,
+  int tcount)
+{
+  for (int i = 0; i < pcount; i++)
+    for (int j = 0; j < tcount; j++)
+      if (overlaps_stbox_stbox(&pboxes[i], &tboxes[j]))
+        return true;
+  return false;
+}
+
+/*****************************************************************************/
+
+int main(void)
+{
+  meos_initialize();
+  /* Use fixed seed for reproducibility */
+  srand(1);
+
+  printf("MEST RTree selectivity demonstration\n");
+  printf("  %d wiggly tgeompoint trips, %d instants each, %d probe queries\n\n",
+    NUM_TRIPS, TRIP_LEN, NUM_QUERIES);
+
+  TimestampTz t0 = epoch_2020();
+
+  /* Generate the trips once and keep them for ground-truth verification.
+   * Trips overlap heavily in time so the spatial extent drives selectivity. */
+  Temporal **trips = malloc(sizeof(Temporal *) * NUM_TRIPS);
+  for (int i = 0; i < NUM_TRIPS; i++)
+    trips[i] = make_wiggly_trip(t0, random_int(0, 600), TRIP_LEN, TRIP_STEP);
+
+  /* Decompose every trip into its finest per-segment boxes once; these are
+   * invariant across probes and drive the exact ground truth */
+  STBox **trip_boxes = malloc(sizeof(STBox *) * NUM_TRIPS);
+  int *trip_nboxes = malloc(sizeof(int) * NUM_TRIPS);
+  for (int i = 0; i < NUM_TRIPS; i++)
+    trip_boxes[i] = tgeo_stboxes(trips[i], &trip_nboxes[i]);
+
+  /* Generate the probe trips once */
+  Temporal **probes = malloc(sizeof(Temporal *) * NUM_QUERIES);
+  for (int q = 0; q < NUM_QUERIES; q++)
+    probes[q] = make_wiggly_trip(t0, random_int(0, 1200), PROBE_LEN,
+      PROBE_STEP);
+
+  /* Build the single-box index */
+  RTree *single = rtree_create_stbox();
+  for (int i = 0; i < NUM_TRIPS; i++)
+    rtree_insert_temporal(single, trips[i], i);
+
+  /* Build the maxboxes <= 1 degenerate index; it must reproduce the
+   * single-box candidate set exactly (invariant iv) */
+  RTree *degenerate = rtree_create_stbox();
+  for (int i = 0; i < NUM_TRIPS; i++)
+    rtree_insert_temporal_split(degenerate, trips[i], i, 1);
+
+  /* Build one MEST index per maxboxes value, same trips and ids */
+  RTree *mest[NUM_MAXBOXES];
+  for (int m = 0; m < NUM_MAXBOXES; m++)
+  {
+    mest[m] = rtree_create_stbox();
+    for (int i = 0; i < NUM_TRIPS; i++)
+      rtree_insert_temporal_split(mest[m], trips[i], i, MAXBOXES[m]);
+  }
+
+  /* Result array reused across searches */
+  MeosArray *ids = meos_array_create(sizeof(int));
+
+  /* Aggregated totals over all queries */
+  long total_truth = 0;
+  long total_single = 0, total_single_fp = 0;
+  long total_mest_cand[NUM_MAXBOXES];
+  long total_mest_fp[NUM_MAXBOXES];
+  for (int m = 0; m < NUM_MAXBOXES; m++)
+  {
+    total_mest_cand[m] = 0;
+    total_mest_fp[m] = 0;
+  }
+
+  /* Per-query bitsets */
+  bool *truth = calloc(NUM_TRIPS, sizeof(bool));
+  bool *seen = calloc(NUM_TRIPS, sizeof(bool));
+
+  for (int q = 0; q < NUM_QUERIES; q++)
+  {
+    Temporal *probe = probes[q];
+    /* Exact ground truth, computed independently of the index */
+    int pcount;
+    STBox *pboxes = tgeo_stboxes(probe, &pcount);
+    int truth_count = 0;
+    for (int i = 0; i < NUM_TRIPS; i++)
+    {
+      truth[i] = segments_overlap(pboxes, pcount, trip_boxes[i],
+        trip_nboxes[i]);
+      if (truth[i])
+        truth_count++;
+    }
+    free(pboxes);
+    total_truth += truth_count;
+
+    /* Single-box filter: the probe's single MBR */
+    int single_count = rtree_search_temporal(single, RTREE_OVERLAPS, probe,
+      ids);
+    for (int i = 0; i < NUM_TRIPS; i++)
+      seen[i] = false;
+    int single_fp = 0;
+    for (int k = 0; k < single_count; k++)
+    {
+      int id = *(int *) meos_array_get(ids, k);
+      assert(! seen[id]);
+      seen[id] = true;
+      if (! truth[id])
+        single_fp++;
+    }
+    /* Invariant (i): no false negatives for the single-box filter */
+    for (int i = 0; i < NUM_TRIPS; i++)
+      assert(! truth[i] || seen[i]);
+    total_single += single_count;
+    total_single_fp += single_fp;
+
+    /* Invariant (iv): the maxboxes <= 1 index reproduces the single-box
+     * candidate set exactly */
+    int deg_count = rtree_search_temporal_dedup(degenerate, RTREE_OVERLAPS,
+      probe, 1, ids);
+    assert(deg_count == single_count);
+    for (int k = 0; k < deg_count; k++)
+    {
+      int id = *(int *) meos_array_get(ids, k);
+      assert(seen[id]);
+    }
+
+    /* MEST filters, one per maxboxes; rtree_search_temporal_dedup returns
+     * each id at most once (invariant ii) */
+    int prev_count = single_count;
+    for (int m = 0; m < NUM_MAXBOXES; m++)
+    {
+      int cand = rtree_search_temporal_dedup(mest[m], RTREE_OVERLAPS, probe,
+        MAXBOXES[m], ids);
+      for (int i = 0; i < NUM_TRIPS; i++)
+        seen[i] = false;
+      int mest_fp = 0;
+      for (int k = 0; k < cand; k++)
+      {
+        int id = *(int *) meos_array_get(ids, k);
+        /* Invariant (ii): dedup, each id appears at most once */
+        assert(! seen[id]);
+        seen[id] = true;
+        if (! truth[id])
+          mest_fp++;
+      }
+      /* Invariant (i): no false negatives for the MEST filter */
+      for (int i = 0; i < NUM_TRIPS; i++)
+        assert(! truth[i] || seen[i]);
+      /* Invariant (iii): MEST candidate set no larger than the single-box
+       * one and tightening (monotone non-increasing) as maxboxes grows */
+      assert(cand <= single_count);
+      assert(cand <= prev_count);
+      prev_count = cand;
+
+      total_mest_cand[m] += cand;
+      total_mest_fp[m] += mest_fp;
+    }
+  }
+
+  /* Report */
+  printf("Ground truth (true segment-box overlaps), all queries: %ld\n\n",
+    total_truth);
+  printf("%-16s %14s %16s %12s\n", "configuration", "candidates",
+    "false positives", "fp rate");
+  printf("%-16s %14ld %16ld %11.1f%%\n", "single-box", total_single,
+    total_single_fp,
+    total_single ? 100.0 * (double) total_single_fp / (double) total_single :
+    0.0);
+  for (int m = 0; m < NUM_MAXBOXES; m++)
+  {
+    char label[16];
+    snprintf(label, sizeof(label), "maxboxes=%d", MAXBOXES[m]);
+    printf("%-16s %14ld %16ld %11.1f%%\n", label, total_mest_cand[m],
+      total_mest_fp[m],
+      total_mest_cand[m] ?
+      100.0 * (double) total_mest_fp[m] / (double) total_mest_cand[m] : 0.0);
+  }
+
+  printf("\nInvariants\n");
+  printf("  (i)   no false negatives for any configuration: OK\n");
+  printf("  (ii)  dedup, each id at most once in MEST output: OK\n");
+  bool tightening = true;
+  long prev = total_single;
+  for (int m = 0; m < NUM_MAXBOXES; m++)
+  {
+    if (total_mest_cand[m] > prev)
+      tightening = false;
+    prev = total_mest_cand[m];
+  }
+  printf("  (iii) MEST candidates <= single-box and tightening with "
+    "maxboxes: %s\n", tightening ? "OK" : "NOT OBSERVED");
+  printf("  (iv)  maxboxes <= 1 reproduces the single-box candidate set: "
+    "OK\n");
+
+  long best_cand = total_single;
+  int best_max = 0;
+  for (int m = 0; m < NUM_MAXBOXES; m++)
+  {
+    if (total_mest_cand[m] < best_cand)
+    {
+      best_cand = total_mest_cand[m];
+      best_max = MAXBOXES[m];
+    }
+  }
+  if (best_max == 0)
+    printf("\nNo selectivity gain over the single-box index on this data; "
+      "the splitter or maxboxes sweep needs tuning.\n");
+  else
+    printf("\nBest selectivity at maxboxes=%d: %ld candidates vs %ld for the "
+      "single-box index (%.1f%% fewer).\n", best_max, best_cand, total_single,
+      total_single ?
+      100.0 * (double) (total_single - best_cand) / (double) total_single :
+      0.0);
+
+  /* Cleanup */
+  free(truth);
+  free(seen);
+  meos_array_destroy(ids);
+  for (int m = 0; m < NUM_MAXBOXES; m++)
+    rtree_free(mest[m]);
+  rtree_free(degenerate);
+  rtree_free(single);
+  for (int q = 0; q < NUM_QUERIES; q++)
+    free(probes[q]);
+  free(probes);
+  for (int i = 0; i < NUM_TRIPS; i++)
+  {
+    free(trip_boxes[i]);
+    free(trips[i]);
+  }
+  free(trip_boxes);
+  free(trip_nboxes);
+  free(trips);
+
+  meos_finalize();
+  return EXIT_SUCCESS;
+}

--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -335,8 +335,10 @@ extern RTree *rtree_create_stbox();
 extern void rtree_free(RTree *rtree);
 extern void rtree_insert(RTree *rtree, void *box, int id);
 extern void rtree_insert_temporal(RTree *rtree, const Temporal *temp, int id);
+extern void rtree_insert_temporal_split(RTree *rtree, const Temporal *temp, int id, int maxboxes);
 extern int rtree_search(const RTree *rtree, RTreeSearchOp op, const void *query, MeosArray *result);
 extern int rtree_search_temporal(const RTree *rtree, RTreeSearchOp op, const Temporal *temp, MeosArray *result);
+extern int rtree_search_temporal_dedup(const RTree *rtree, RTreeSearchOp op, const Temporal *temp, int maxboxes, MeosArray *result);
 
 /*****************************************************************************
  * Initialization of the MEOS library

--- a/meos/src/temporal/temporal_rtree.c
+++ b/meos/src/temporal/temporal_rtree.c
@@ -993,6 +993,193 @@ rtree_search_temporal(const RTree *rtree, RTreeSearchOp op,
   return rtree_search(rtree, op, buf, result);
 }
 
+/*****************************************************************************
+ * Multi-entry (MEST) temporal functions
+ *
+ * These functions implement a multi-entry-per-id indexing pattern: a single
+ * temporal value is decomposed into several tight per-segment bounding boxes
+ * that are all inserted under the same id. The tree, split and search
+ * algorithms are unchanged; only the build-side decomposition and a
+ * search-time deduplication of repeated ids are added. They are strictly
+ * additive: #rtree_insert, #rtree_insert_temporal, #rtree_search and
+ * #rtree_search_temporal keep their exact semantics.
+ *****************************************************************************/
+
+/**
+ * @brief Decompose a temporal value into an array of tight per-segment
+ * bounding boxes whose element type matches the RTree's bounding box type
+ * @details The decomposition reuses the same per-segment bounding box
+ * machinery as the single-box path: temporal alphas are split with
+ * #temporal_split_n_spans, temporal numbers with #tnumber_split_n_tboxes, and
+ * temporal geos with #tgeo_split_n_stboxes. These already handle the TINSTANT,
+ * TSEQUENCE and TSEQUENCESET subtypes, the discrete, step and linear
+ * interpolations, and the Z, geodetic and SRID flags through the same
+ * `tspatialinst_set_stbox` / `tnumberinst_set_tbox` / span machinery used by
+ * #temporal_set_bbox, and coarsen by merging adjacent segment boxes
+ * (deterministic chunking) down to at most `maxboxes` boxes. When
+ * `maxboxes <= 1`, the temporal value is an instant, or the spatial type is
+ * not a temporal geo (e.g. tcbuffer, tnpoint, tpose), the function degenerates
+ * to the single minimum bounding box, byte-identical to the result of
+ * #temporal_set_bbox used by #rtree_insert_temporal.
+ * @param[in] rtree The RTree whose bounding box type drives the element type
+ * @param[in] temp The temporal value to decompose
+ * @param[in] maxboxes Maximum number of boxes produced for `temp`
+ * @param[out] count Number of boxes in the returned array
+ * @return Newly allocated array of `*count` bounding boxes, each of
+ * `rtree->bboxsize` bytes, or @p NULL on error
+ * @pre `temp` is compatible with `rtree` (verified by the callers)
+ */
+static void *
+rtree_temporal_split_boxes(const RTree *rtree, const Temporal *temp,
+  int maxboxes, int *count)
+{
+  assert(rtree); assert(temp); assert(count);
+
+  /* Degenerate single minimum bounding box: identical to the behaviour of
+   * rtree_insert_temporal / rtree_search_temporal */
+  if (maxboxes <= 1 || temp->subtype == TINSTANT)
+  {
+    void *result = palloc0(rtree->bboxsize);
+    temporal_set_bbox(temp, result);
+    *count = 1;
+    return result;
+  }
+
+  /* Multi-box decomposition reusing the existing per-type splitters */
+  MeosType temptype = temp->temptype;
+  if (talpha_type(temptype))
+    return temporal_split_n_spans(temp, maxboxes, count);
+  if (tnumber_type(temptype))
+    return tnumber_split_n_tboxes(temp, maxboxes, count);
+  if (tgeo_type_all(temptype))
+    return tgeo_split_n_stboxes(temp, maxboxes, count);
+
+  /* Spatial types without a per-segment STBox splitter (e.g. tcbuffer,
+   * tnpoint, tpose): fall back to the single minimum bounding box */
+  void *result = palloc0(rtree->bboxsize);
+  temporal_set_bbox(temp, result);
+  *count = 1;
+  return result;
+}
+
+/**
+ * @ingroup meos_temporal_box_index
+ * @brief Insert a temporal value into the RTree index as several tight
+ * per-segment bounding boxes sharing the same id (multi-entry indexing)
+ * @details The temporal value is decomposed into at most `maxboxes` tight
+ * per-segment bounding boxes, all inserted under `id`. This yields a more
+ * selective index than #rtree_insert_temporal for wiggly or high-extent
+ * temporal values, at the cost of more leaf entries. The temporal type must
+ * be compatible with the RTree's bounding box type: temporal alphas (tbool,
+ * ttext) require a span-based RTree, temporal numbers (tint, tfloat) require a
+ * TBox-based RTree, and spatiotemporal types (tgeompoint, tgeogpoint) require
+ * an STBox-based RTree. When `maxboxes <= 1`, the temporal value is an
+ * instant, or the spatial type has no per-segment STBox decomposition, the
+ * behaviour is identical to #rtree_insert_temporal (a single minimum bounding
+ * box). The tree, split and insertion algorithms are unchanged; this only
+ * inserts several boxes under the same id, which the parallel ids/boxes leaf
+ * layout already supports. Search results may contain the same id several
+ * times; use #rtree_search_temporal_dedup to collapse them.
+ * @param[in] rtree The RTree previously initialized
+ * @param[in] temp The temporal value to be inserted
+ * @param[in] id The id of the temporal value being inserted, shared by every
+ * box produced for `temp`
+ * @param[in] maxboxes Maximum number of bounding boxes produced for `temp`;
+ * values `<= 1` degenerate to the single minimum bounding box
+ * @see rtree_insert_temporal
+ */
+void
+rtree_insert_temporal_split(RTree *rtree, const Temporal *temp, int id,
+  int maxboxes)
+{
+  if (! ensure_rtree_temporal_compatible(rtree, temp))
+    return;
+  int count;
+  void *boxes = rtree_temporal_split_boxes(rtree, temp, maxboxes, &count);
+  if (! boxes)
+    return;
+  for (int i = 0; i < count; i++)
+    rtree_insert(rtree, (char *) boxes + (size_t) i * rtree->bboxsize, id);
+  pfree(boxes);
+  return;
+}
+
+/**
+ * @ingroup meos_temporal_box_index
+ * @brief Search an RTree built with #rtree_insert_temporal_split using a
+ * temporal value, returning each matching id exactly once
+ * @details The query temporal value is decomposed into the same tight
+ * per-segment bounding boxes as #rtree_insert_temporal_split, the existing
+ * #rtree_search is run for every query box, and the union of matching ids is
+ * deduplicated so that each surviving id appears exactly once. This is the
+ * search counterpart of #rtree_insert_temporal_split; it never produces false
+ * negatives with respect to a single-box search and is typically more
+ * selective. The result array is reset before the search. The underlying
+ * #rtree_search and #rtree_search_temporal semantics are unchanged.
+ * @param[in] rtree The RTree to query
+ * @param[in] op The search operation
+ * @param[in] temp The temporal value whose per-segment bounding boxes serve as
+ * queries
+ * @param[in] maxboxes Maximum number of query boxes derived from `temp`;
+ * values `<= 1` degenerate to a single minimum bounding box query
+ * @param[out] result MeosArray of int to collect the deduplicated matching ids
+ * @return Number of distinct matching ids
+ * @see rtree_search_temporal
+ */
+int
+rtree_search_temporal_dedup(const RTree *rtree, RTreeSearchOp op,
+  const Temporal *temp, int maxboxes, MeosArray *result)
+{
+  meos_array_reset(result);
+  if (! ensure_rtree_temporal_compatible(rtree, temp))
+    return 0;
+
+  int count;
+  void *boxes = rtree_temporal_split_boxes(rtree, temp, maxboxes, &count);
+  if (! boxes)
+    return 0;
+
+  /* Accumulate the raw (possibly duplicated) candidate ids of every query
+   * box, tracking the maximum id seen to size the dedup bitset */
+  MeosArray *raw = meos_array_create(sizeof(int));
+  MeosArray *hits = meos_array_create(sizeof(int));
+  int maxid = -1;
+  for (int i = 0; i < count; i++)
+  {
+    int nhits = rtree_search(rtree, op,
+      (char *) boxes + (size_t) i * rtree->bboxsize, hits);
+    for (int j = 0; j < nhits; j++)
+    {
+      int id = *(int *) meos_array_get(hits, j);
+      if (id > maxid)
+        maxid = id;
+      meos_array_add(raw, &id);
+    }
+  }
+  pfree(boxes);
+  meos_array_destroy(hits);
+
+  /* Collapse duplicates with a seen-set sized to the maximum id, mirroring
+   * the bool indexed[] idiom of the rtree example */
+  int nraw = meos_array_count(raw);
+  if (maxid >= 0 && nraw > 0)
+  {
+    bool *seen = palloc0((size_t) (maxid + 1) * sizeof(bool));
+    for (int i = 0; i < nraw; i++)
+    {
+      int id = *(int *) meos_array_get(raw, i);
+      if (! seen[id])
+      {
+        seen[id] = true;
+        meos_array_add(result, &id);
+      }
+    }
+    pfree(seen);
+  }
+  meos_array_destroy(raw);
+  return meos_array_count(result);
+}
+
 /**
  * @brief Frees the memory allocated for an RTree node
  * @details The function recursively frees the memory of an RTree node.

--- a/meos/test/rtree_mest_test.c
+++ b/meos/test/rtree_mest_test.c
@@ -1,0 +1,259 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief A program that tests the multi-entry (MEST) temporal functions of the
+ * in-memory RTree index, i.e., rtree_insert_temporal_split and
+ * rtree_search_temporal_dedup, against the single-box temporal functions
+ * rtree_insert_temporal and rtree_search_temporal and against an exact
+ * brute-force oracle.
+ *
+ * Four properties are asserted:
+ *  (i)   no false negatives: every trip whose per-segment box decomposition
+ *        overlaps the query's per-segment box decomposition (exact
+ *        brute-force oracle over the identical decomposition the index
+ *        encodes) is in the MEST candidate set;
+ *  (ii)  deduplication: each surviving id appears exactly once;
+ *  (iii) selectivity: on deliberately wiggly, high-extent tgeompoint trips the
+ *        MEST candidate set is no larger than the single-box candidate set;
+ *  (iv)  degeneracy: maxboxes <= 1 yields exactly the single-box result.
+ *
+ * The program can be built as follows
+ * @code
+ * gcc -Wall -g -I/usr/local/include -o rtree_mest_test rtree_mest_test.c -L/usr/local/lib -lmeos
+ * @endcode
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <meos.h>
+#include <meos_geo.h>
+
+/* Number of trips inserted into the index */
+#define NUM_TRIPS 2000
+/* Number of instants per (wiggly) trip */
+#define TRIP_LEN 40
+/* Maximum number of boxes produced per trip in the MEST index */
+#define MAX_BOXES 16
+/* Maximum length in characters of a trip in text format */
+#define MAX_LEN_TRIP 4096
+
+static int failures = 0;
+
+static void
+check(const char *name, bool ok)
+{
+  printf("  %-58s %s\n", name, ok ? "OK" : "FAIL");
+  if (! ok)
+    failures++;
+}
+
+/* Return a pseudo-random double in [min, max] */
+static double
+random_double(double min, double max)
+{
+  return min + (max - min) * ((double) rand() / (double) RAND_MAX);
+}
+
+/*
+ * Build a deliberately wiggly, high-extent tgeompoint trip: a sinusoidal
+ * path that sweeps a large bounding rectangle even though every individual
+ * segment is short. This is exactly the shape for which a single MBR is a
+ * poor approximation and per-segment MEST boxes are far more selective.
+ */
+static Temporal *
+make_wiggly_trip(int seed, char *buf, size_t bufsize)
+{
+  double ox = random_double(0, 900);
+  double oy = random_double(0, 900);
+  double amp = random_double(40, 90);
+  double phase = random_double(0, 6.28);
+  size_t pos = 0;
+  pos += (size_t) snprintf(buf + pos, bufsize - pos, "[");
+  for (int k = 0; k < TRIP_LEN; k++)
+  {
+    double x = ox + k * 2.0;
+    double y = oy + amp * sin(phase + k * 0.9 + seed * 0.01);
+    int mm = k / 60, ss = k % 60;
+    pos += (size_t) snprintf(buf + pos, bufsize - pos,
+      "%sPoint(%.4f %.4f)@2020-01-01 %02d:%02d:00+00",
+      (k == 0) ? "" : ", ", x, y, mm, ss);
+  }
+  snprintf(buf + pos, bufsize - pos, "]");
+  return tgeompoint_in(buf);
+}
+
+int main(void)
+{
+  /* Initialize MEOS */
+  meos_initialize();
+  meos_initialize_timezone("UTC");
+  srand(42);
+
+  char buf[MAX_LEN_TRIP];
+  Temporal **trips = malloc(sizeof(Temporal *) * NUM_TRIPS);
+
+  /* Build the single-box index (existing API), the MEST index, and a
+   * degenerate MEST index built with maxboxes = 1 */
+  RTree *rtree_single = rtree_create_stbox();
+  RTree *rtree_mest = rtree_create_stbox();
+  RTree *rtree_deg = rtree_create_stbox();
+
+  for (int i = 0; i < NUM_TRIPS; i++)
+  {
+    trips[i] = make_wiggly_trip(i, buf, sizeof(buf));
+    rtree_insert_temporal(rtree_single, trips[i], i);
+    rtree_insert_temporal_split(rtree_mest, trips[i], i, MAX_BOXES);
+    rtree_insert_temporal_split(rtree_deg, trips[i], i, 1);
+  }
+
+  /* Query temporal value (also wiggly so its per-segment decomposition is
+   * meaningful for the dedup search) */
+  Temporal *query = make_wiggly_trip(123456, buf, sizeof(buf));
+
+  MeosArray *single_ids = meos_array_create(sizeof(int));
+  MeosArray *mest_ids = meos_array_create(sizeof(int));
+  MeosArray *deg_ids = meos_array_create(sizeof(int));
+
+  int single_count = rtree_search_temporal(rtree_single, RTREE_OVERLAPS,
+    query, single_ids);
+  int mest_count = rtree_search_temporal_dedup(rtree_mest, RTREE_OVERLAPS,
+    query, MAX_BOXES, mest_ids);
+  int deg_count = rtree_search_temporal_dedup(rtree_deg, RTREE_OVERLAPS,
+    query, 1, deg_ids);
+
+  /* Membership bitsets */
+  bool *in_single = calloc(NUM_TRIPS, sizeof(bool));
+  bool *in_mest = calloc(NUM_TRIPS, sizeof(bool));
+  bool *in_deg = calloc(NUM_TRIPS, sizeof(bool));
+  int *mest_seen = calloc(NUM_TRIPS, sizeof(int));
+  int *deg_seen = calloc(NUM_TRIPS, sizeof(int));
+  for (int i = 0; i < single_count; i++)
+    in_single[*(int *) meos_array_get(single_ids, i)] = true;
+  for (int i = 0; i < mest_count; i++)
+  {
+    int id = *(int *) meos_array_get(mest_ids, i);
+    in_mest[id] = true;
+    mest_seen[id]++;
+  }
+  for (int i = 0; i < deg_count; i++)
+  {
+    int id = *(int *) meos_array_get(deg_ids, i);
+    in_deg[id] = true;
+    deg_seen[id]++;
+  }
+
+  printf("MEST RTree (tgeompoint, %d wiggly trips, maxboxes=%d):\n",
+    NUM_TRIPS, MAX_BOXES);
+  printf("  single-box candidates: %d   MEST candidates: %d   "
+    "degenerate: %d\n", single_count, mest_count, deg_count);
+
+  /* (i) No false negatives. The exact oracle is a brute-force scan over the
+   * identical per-segment box decomposition that the MEST index encodes: a
+   * trip is a true candidate iff one of its split boxes overlaps one of the
+   * query's split boxes. The MEST search must return a superset of this set.
+   * (overlaps_tspatial_stbox is NOT a valid oracle here: it compares the
+   * trip MBR against the query MBR, i.e. the coarser single-box semantics,
+   * which by construction over-counts relative to the per-segment search.) */
+  int qn;
+  STBox *qboxes = tgeo_split_n_stboxes(query, MAX_BOXES, &qn);
+  int true_overlaps = 0, missed = 0;
+  for (int i = 0; i < NUM_TRIPS; i++)
+  {
+    int tn;
+    STBox *tboxes = tgeo_split_n_stboxes(trips[i], MAX_BOXES, &tn);
+    bool overlap = false;
+    for (int a = 0; a < tn && ! overlap; a++)
+      for (int b = 0; b < qn && ! overlap; b++)
+        if (overlaps_stbox_stbox(&tboxes[a], &qboxes[b]))
+          overlap = true;
+    free(tboxes);
+    if (overlap)
+    {
+      true_overlaps++;
+      if (! in_mest[i])
+        missed++;
+    }
+  }
+  free(qboxes);
+  printf("  true overlaps (per-segment exact oracle): %d\n", true_overlaps);
+  check("(i) no false negatives vs exact per-segment oracle", missed == 0);
+
+  /* (ii) Dedup: each surviving id appears exactly once */
+  bool dedup_ok = true;
+  for (int i = 0; i < NUM_TRIPS; i++)
+    if (mest_seen[i] > 1 || deg_seen[i] > 1)
+      dedup_ok = false;
+  check("(ii) every surviving id appears exactly once", dedup_ok);
+
+  /* (iii) Selectivity gain: on wiggly high-extent trips the MEST candidate
+   * set is no larger than the single-box candidate set, and the single-box
+   * set is a superset of the MEST set (MEST never adds false candidates a
+   * single MBR would have excluded, since each MEST box is contained in the
+   * trip MBR) */
+  bool subset_ok = true;
+  for (int i = 0; i < NUM_TRIPS; i++)
+    if (in_mest[i] && ! in_single[i])
+      subset_ok = false;
+  check("(iii) MEST candidate set <= single-box candidate set",
+    mest_count <= single_count && subset_ok);
+
+  /* (iv) Degeneracy: maxboxes <= 1 reproduces the single-box result exactly */
+  bool deg_ok = (deg_count == single_count);
+  for (int i = 0; i < NUM_TRIPS && deg_ok; i++)
+    if (in_deg[i] != in_single[i])
+      deg_ok = false;
+  check("(iv) maxboxes<=1 identical to single-box result", deg_ok);
+
+  /* Cleanup */
+  free(in_single); free(in_mest); free(in_deg);
+  free(mest_seen); free(deg_seen);
+  meos_array_destroy(single_ids);
+  meos_array_destroy(mest_ids);
+  meos_array_destroy(deg_ids);
+  free(query);
+  for (int i = 0; i < NUM_TRIPS; i++)
+    free(trips[i]);
+  free(trips);
+  rtree_free(rtree_single);
+  rtree_free(rtree_mest);
+  rtree_free(rtree_deg);
+
+  /* Finalize MEOS */
+  meos_finalize();
+
+  if (failures == 0)
+    printf("\nAll MEST RTree tests passed.\n");
+  else
+    printf("\n%d MEST RTree test(s) FAILED.\n", failures);
+  return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Add the MEST multi-entry split temporal functions to the in-memory RTree index and a selectivity example exercising them.