### PR TITLE
Vendor Apache Arrow C Data Interface

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -19,12 +19,18 @@ engines:
       - "postgis/**"
       - "postgres/**"
       - "pgtypes/**"
+      - "arrow/**"
     config:
       languages:
         - "c"
+# Vendored third-party trees are provenance-reviewed, not style-reviewed:
+# postgis/postgres/pgtypes are verbatim upstream source; arrow/ is the
+# vendored Apache-2.0 Arrow C Data Interface ABI header. We do not own
+# their style guidelines.
 exclude_paths:
   - "postgis/**"
   - "postgres/**"
   - "pgtypes/**"
+  - "arrow/**"
   - "meos/test/**"
   - "meos/examples/**"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,6 +276,10 @@ include_directories(SYSTEM ${GSL_INCLUDE_DIRS})
 message(STATUS "GSL_VERSION: ${GSL_VERSION}")
 add_definitions(-DGSL_VERSION_STRING="${GSL_VERSION}")
 
+# Apache Arrow C Data Interface (vendored, header-only; no libarrow link).
+# Set at the top level so both the MEOS and the MobilityDB builds find it.
+include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/arrow")
+
 #----------------------------------------------
 # Configure PostGIS with optional dependencies
 #----------------------------------------------

--- a/arrow/arrow_c_data_interface.h
+++ b/arrow/arrow_c_data_interface.h
@@ -1,0 +1,70 @@
+/*****************************************************************************
+ *
+ * Vendored verbatim from the Apache Arrow project: the Arrow C Data
+ * Interface ABI specification.
+ *
+ * Source: https://github.com/apache/arrow  (format/abi.h)
+ * Licensed to the Apache Software Foundation (ASF) under the
+ * Apache License, Version 2.0.
+ *
+ * This is a stable two-struct ABI (ArrowSchema / ArrowArray plus release
+ * callbacks). It is reproduced here so that MEOS can produce and consume
+ * Arrow columnar data without linking the Apache Arrow C++ library. No
+ * first-party MEOS code belongs in this file; it is third-party and is
+ * reviewed by provenance against the upstream specification.
+ *
+ *****************************************************************************/
+
+#ifndef MEOS_ARROW_C_DATA_INTERFACE_H
+#define MEOS_ARROW_C_DATA_INTERFACE_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ARROW_FLAG_DICTIONARY_ORDERED 1
+#define ARROW_FLAG_NULLABLE           2
+#define ARROW_FLAG_MAP_KEYS_SORTED    4
+
+struct ArrowSchema
+{
+  /* Array type description */
+  const char *format;
+  const char *name;
+  const char *metadata;
+  int64_t flags;
+  int64_t n_children;
+  struct ArrowSchema **children;
+  struct ArrowSchema *dictionary;
+
+  /* Release callback */
+  void (*release)(struct ArrowSchema *);
+  /* Opaque producer-specific data */
+  void *private_data;
+};
+
+struct ArrowArray
+{
+  /* Array data description */
+  int64_t length;
+  int64_t null_count;
+  int64_t offset;
+  int64_t n_buffers;
+  int64_t n_children;
+  const void **buffers;
+  struct ArrowArray **children;
+  struct ArrowArray *dictionary;
+
+  /* Release callback */
+  void (*release)(struct ArrowArray *);
+  /* Opaque producer-specific data */
+  void *private_data;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MEOS_ARROW_C_DATA_INTERFACE_H */

--- a/meos/CMakeLists.txt
+++ b/meos/CMakeLists.txt
@@ -237,6 +237,9 @@ install(
   FILES "${CMAKE_SOURCE_DIR}/meos/include/meos_tls.h"
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 install(
+  FILES "${CMAKE_SOURCE_DIR}/arrow/arrow_c_data_interface.h"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(
   FILES "${CMAKE_SOURCE_DIR}/meos/src/geo/spatial_ref_sys.csv"
   DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}")
 


### PR DESCRIPTION
Add the Apache Arrow C Data Interface ABI header (ArrowSchema and ArrowArray plus their release callbacks) verbatim from the Apache Arrow project under a dedicated top-level arrow/ directory, mirroring the existing vendored trees. The header is the stable cross-language ABI specification, reproduced so MEOS can produce and consume Arrow columnar data without linking the Apache Arrow C++ library; it contains no first-party code and is reviewed by provenance against upstream. It is exposed to the build as a SYSTEM include directory and installed alongside the MEOS public headers, and arrow/ is excluded from Codacy like the other vendored sources since we do not own its style guidelines.