### PR TITLE
Emit SIZEOF_LONG_LONG in the rendered pg_config.h

### DIFF
--- a/cmake/ConfigurePgConfig.cmake
+++ b/cmake/ConfigurePgConfig.cmake
@@ -25,6 +25,13 @@ check_type_size("long"            SIZEOF_LONG             BUILTIN_TYPES_ONLY)
 check_type_size("size_t"          SIZEOF_SIZE_T)
 check_type_size("long long int"   SIZEOF_LONG_LONG_INT    BUILTIN_TYPES_ONLY)
 
+# postgres/port/pg_bitutils.h selects __builtin_clzll/ctzll via
+# SIZEOF_LONG_LONG when SIZEOF_LONG != 8 (e.g. wasm32-emscripten and other
+# ILP32 targets). Mirror PG's own configure, which emits SIZEOF_LONG_LONG
+# from AC_CHECK_SIZEOF([long long]); on LP64 hosts the SIZEOF_LONG == 8
+# branch wins first, which is why this was never needed before.
+set(SIZEOF_LONG_LONG "${SIZEOF_LONG_LONG_INT}")
+
 #-----------------------------------------------------------------------
 # 2. Alignment (no native CMake check; use offsetof trick via CHECK_C_SOURCE_RUNS)
 #-----------------------------------------------------------------------

--- a/postgres/pg_config.h.in
+++ b/postgres/pg_config.h.in
@@ -20,6 +20,7 @@
  */
 #define SIZEOF_VOID_P         @SIZEOF_VOID_P@
 #define SIZEOF_LONG           @SIZEOF_LONG@
+#define SIZEOF_LONG_LONG      @SIZEOF_LONG_LONG@
 #define SIZEOF_SIZE_T         @SIZEOF_SIZE_T@
 
 /*


### PR DESCRIPTION
postgres/port/pg_bitutils.h selects __builtin_clzll/ctzll through SIZEOF_LONG_LONG when SIZEOF_LONG is not 8, but the narrowed pg_config.h.in template never emitted that macro, so on ILP32 targets such as wasm32-emscripten it expanded to 0 and the file hit its "cannot find integer type of the same size as uint64_t" #error, breaking the DuckDB-Wasm builds in the downstream MobilityDuck CI. On LP64 hosts the SIZEOF_LONG == 8 branch wins first, which is why this was never observed before. This renders SIZEOF_LONG_LONG from the value ConfigurePgConfig.cmake already computes, mirroring what PostgreSQL's own configure produces; verified that the configured pg_config.h gains the define on a native build with zero change to the LP64 path.