### PR TITLE
Add MF-JSON input and output for the temporal network point type

### DIFF
--- a/doc/es/temporal_spatial_p1.xml
+++ b/doc/es/temporal_spatial_p1.xml
@@ -131,7 +131,7 @@ SELECT asEWKT(ARRAY[geometry 'SRID=5676;Point(0 0)', 'SRID=5676;Point(1 1)']);
 					<listitem><para>1: JSON_C_TO_STRING_SPACED</para></listitem>
 					<listitem><para>2: JSON_C_TO_STRING_PRETTY</para></listitem>
 				</itemizedlist>
-				<para>El argumento <varname>maxdecdigits</varname> puede usarse para establecer el número máximo de decimales en la salida de los valores en punto flotante (por defecto 15).</para>
+				<para>El argumento <varname>maxdecdigits</varname> puede usarse para establecer el número máximo de decimales en la salida de los valores en punto flotante (por defecto 15). Un punto de red temporal se codifica con el nombre de tipo <varname>MovingNetworkPoint</varname>; dado que un punto de red hace referencia a una ubicación en una ruta y no a una coordenada, cada valor es un objeto con un miembro entero <varname>route</varname> y un miembro numérico <varname>position</varname>, que reflejan los accesores <varname>route</varname> y <varname>getPosition</varname>.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT asMFJSON(tgeompoint 'Point(1 2)@2019-01-01 18:00:00.15+02');
 /* {"type":"MovingPoint","coordinates":[[1,2]],"datetimes":["2019-01-01T17:00:00.15+01"],
@@ -148,6 +148,11 @@ SELECT asMFJSON(tgeompoint 'SRID=4326;
     "period":{"begin":"2019-01-01 17:00:00.15+01","end":"2019-01-01 17:00:00.15+01"}},
     "coordinates":[[50.81,4.38]],"datetimes":["2019-01-01T17:00:00.15+01"],
     "interpolations":"None"} */
+SELECT asMFJSON(tnpoint 'Npoint(1, 0.5)@2019-01-01 18:00:00.15+02');
+/* {"type":"MovingNetworkPoint",
+    "crs":{"type":"Name","properties":{"name":"EPSG:5676"}},
+    "values":[{"route":1,"position":0.5}],
+    "datetimes":["2019-01-01T17:00:00.15+01"],"interpolation":"None"} */
 </programlisting>
 			</listitem>
 

--- a/doc/temporal_spatial_p1.xml
+++ b/doc/temporal_spatial_p1.xml
@@ -131,7 +131,7 @@ SELECT asEWKT(ARRAY[geometry 'SRID=5676;Point(0 0)', 'SRID=5676;Point(1 1)']);
 					<listitem><para>1: JSON_C_TO_STRING_SPACED</para></listitem>
 					<listitem><para>2: JSON_C_TO_STRING_PRETTY</para></listitem>
 				</itemizedlist>
-				<para>The <varname>maxdecdigits</varname> argument can be used to set the maximum number of decimal places in the output of floating point values (default 15).</para>
+				<para>The <varname>maxdecdigits</varname> argument can be used to set the maximum number of decimal places in the output of floating point values (default 15). A temporal network point is encoded with the type name <varname>MovingNetworkPoint</varname>; since a network point references a location on a route rather than a coordinate, each value is an object with an integer <varname>route</varname> member and a numeric <varname>position</varname> member, mirroring the <varname>route</varname> and <varname>getPosition</varname> accessors.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asMFJSON(tgeompoint 'Point(1 2)@2019-01-01 18:00:00.15+02');
 /* {"type":"MovingPoint","coordinates":[[1,2]],"datetimes":["2019-01-01T17:00:00.15+01"],
@@ -148,6 +148,11 @@ SELECT asMFJSON(tgeompoint 'SRID=4326;
     "period":{"begin":"2019-01-01 17:00:00.15+01","end":"2019-01-01 17:00:00.15+01"}},
     "coordinates":[[50.81,4.38]],"datetimes":["2019-01-01T17:00:00.15+01"],
     "interpolations":"None"} */
+SELECT asMFJSON(tnpoint 'Npoint(1, 0.5)@2019-01-01 18:00:00.15+02');
+/* {"type":"MovingNetworkPoint",
+    "crs":{"type":"Name","properties":{"name":"EPSG:5676"}},
+    "values":[{"route":1,"position":0.5}],
+    "datetimes":["2019-01-01T17:00:00.15+01"],"interpolation":"None"} */
 </programlisting>
 			</listitem>
 

--- a/meos/include/meos_npoint.h
+++ b/meos/include/meos_npoint.h
@@ -235,6 +235,7 @@ extern Set *union_set_npoint(const Set *s, const Npoint *np);
  *****************************************************************************/
 
 extern Temporal *tnpoint_in(const char *str);
+extern Temporal *tnpoint_from_mfjson(const char *mfjson);
 extern char *tnpoint_out(const Temporal *temp, int maxdd);
 
 /*****************************************************************************

--- a/meos/src/npoint/tnpoint.c
+++ b/meos/src/npoint/tnpoint.c
@@ -224,6 +224,20 @@ tnpoint_in(const char *str)
 
 /**
  * @ingroup meos_npoint_inout
+ * @brief Return a temporal network point from its MF-JSON representation
+ * @param[in] mfjson MFJSON string
+ * @return On error return @p NULL
+ * @see #temporal_from_mfjson()
+ */
+Temporal *
+tnpoint_from_mfjson(const char *mfjson)
+{
+  VALIDATE_NOT_NULL(mfjson, NULL);
+  return temporal_from_mfjson(mfjson, T_TNPOINT);
+}
+
+/**
+ * @ingroup meos_npoint_inout
  * @brief Return the Well-Known Text (WKT) representation of a temporal
  * network point
  * @param[in] temp Temporal network point

--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -688,6 +688,78 @@ parse_mfjson_poses(json_object *mfjson, int32_t srid, int *count)
 
 /*****************************************************************************/
 
+#if NPOINT
+/**
+ * @brief Return a network point from its MF-JSON representation
+ * @details A network point value is a JSON object with an integer `route`
+ * member (the route identifier) and a numeric `position` member (the
+ * relative position along the route), e.g. `{"route":1,"position":0.5}`.
+ * The member names mirror the @p route and @p getPosition accessors. A
+ * network point is a network-relative reference, so there is no coordinate
+ * or Z/geodetic handling as for points or poses.
+ */
+static Npoint *
+parse_mfjson_npoint(json_object *mfjson, int32_t srid UNUSED)
+{
+  assert(mfjson);
+  json_object *route = findMemberByName(mfjson, "route");
+  if (route == NULL)
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "Unable to find 'route' in MFJSON string");
+    return NULL;
+  }
+  json_object *position = findMemberByName(mfjson, "position");
+  if (position == NULL)
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "Unable to find 'position' in MFJSON string");
+    return NULL;
+  }
+  return npoint_make((int64) json_object_get_int64(route),
+    json_object_get_double(position));
+}
+
+/**
+ * @brief Return an array of network points from its MF-JSON values
+ */
+static Datum *
+parse_mfjson_npoints(json_object *mfjson, int32_t srid, int *count)
+{
+  json_object *mfjsonTmp = mfjson;
+  json_object *values_json = findMemberByName(mfjsonTmp, "values");
+  if (values_json == NULL)
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "Unable to find 'values' in MFJSON string");
+    return NULL;
+  }
+  if (json_object_get_type(values_json) != json_type_array)
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "Invalid 'values' array in MFJSON string");
+    return NULL;
+  }
+  int nvalues = (int) json_object_array_length(values_json);
+  if (nvalues < 1)
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "Invalid value of 'values' array in MFJSON string");
+    return NULL;
+  }
+  Datum *values = palloc(sizeof(Datum) * nvalues);
+  for (int i = 0; i < nvalues; ++i)
+  {
+    json_object *np = json_object_array_get_idx(values_json, i);
+    values[i] = PointerGetDatum(parse_mfjson_npoint(np, srid));
+  }
+  *count = nvalues;
+  return values;
+}
+#endif /* NPOINT */
+
+/*****************************************************************************/
+
 /**
  * @brief Return an array of timestamps from their MF-JSON datetimes values
  */
@@ -768,6 +840,10 @@ tinstant_from_mfjson(json_object *mfjson, bool spatial, int32_t srid,
     else if (temptype == T_TPOSE || temptype == T_TRGEOMETRY)
       values = parse_mfjson_poses(mfjson, srid, &nvalues);
 #endif /* POSE */
+#if NPOINT
+    else if (temptype == T_TNPOINT)
+      values = parse_mfjson_npoints(mfjson, srid, &nvalues);
+#endif /* NPOINT */
     else
     {
       meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
@@ -815,6 +891,10 @@ tinstarr_from_mfjson(json_object *mfjson, bool isgeo, int32_t srid,
     else if (temptype == T_TPOSE || temptype == T_TRGEOMETRY)
       values = parse_mfjson_poses(mfjson, srid, &nvalues);
 #endif /* RGEO */
+#if NPOINT
+    else if (temptype == T_TNPOINT)
+      values = parse_mfjson_npoints(mfjson, srid, &nvalues);
+#endif /* NPOINT */
    else
     {
       meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
@@ -952,7 +1032,8 @@ ensure_temptype_mfjson(const char *typestr)
       strcmp(typestr, "MovingPoint") != 0 &&
       strcmp(typestr, "MovingGeometry") != 0  &&
       strcmp(typestr, "MovingPose") != 0 &&
-      strcmp(typestr, "MovingRigidGeometry") != 0 )
+      strcmp(typestr, "MovingRigidGeometry") != 0 &&
+      strcmp(typestr, "MovingNetworkPoint") != 0 )
   {
     meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
       "Invalid 'type' value in MFJSON string: %s", typestr);
@@ -1036,6 +1117,10 @@ temporal_from_mfjson(const char *mfjson, MeosType temptype)
     jtemptype = T_TPOSE;
   else if (strcmp(typestr, "MovingRigidGeometry") == 0)
     jtemptype = T_TRGEOMETRY;
+#if NPOINT
+  else if (strcmp(typestr, "MovingNetworkPoint") == 0)
+    jtemptype = T_TNPOINT;
+#endif /* NPOINT */
 
   if (temptype != T_UNKNOWN && jtemptype != temptype)
   {

--- a/meos/src/temporal/type_out.c
+++ b/meos/src/temporal/type_out.c
@@ -287,6 +287,31 @@ stringbuffer_append_char(sb, '}');
 }
 #endif /* POSE */
 
+#if NPOINT
+/**
+ * @brief Write into the buffer a network point in the MF-JSON representation
+ * @details A network point is a network-relative reference: an integer
+ * `route` member (the route identifier) and a numeric `position` member
+ * (the relative position along the route), e.g.
+ * `{"route":1,"position":0.5}`. The member names mirror the @p route and
+ * @p getPosition accessors. There is no coordinate or Z/geodetic handling
+ * as for points or poses.
+ */
+static void
+npoint_as_json_sb(stringbuffer_t *sb, const Npoint *np, int precision)
+{
+  assert(precision <= OUT_MAX_DOUBLE_PRECISION);
+  char *rid = int8_out(npoint_route(np));
+  stringbuffer_append_len(sb, "{\"route\":", 9);
+  stringbuffer_aprintf(sb, "%s", rid);
+  stringbuffer_append_len(sb, ",\"position\":", 12);
+  stringbuffer_append_double(sb, npoint_position(np), precision);
+  stringbuffer_append_char(sb, '}');
+  pfree(rid);
+  return;
+}
+#endif /* NPOINT */
+
 /**
  * @brief Write into the buffer a base value in the MF-JSON representation
  */
@@ -448,6 +473,7 @@ bbox_as_mfjson_sb(stringbuffer_t *sb, MeosType temptype, const bboxunion *box,
     case T_TGEOGRAPHY:
     case T_TPOSE:
     case T_TRGEOMETRY:
+    case T_TNPOINT:
       stbox_as_mfjson_sb(sb, (STBox *) box, precision);
       break;
     default: /* Error! */
@@ -496,6 +522,11 @@ temptype_as_mfjson_sb(stringbuffer_t *sb, MeosType temptype)
 #if RGEO
     case T_TRGEOMETRY:
       stringbuffer_append_len(sb, "{\"type\":\"MovingRigidGeometry\",", 30);
+      break;
+#endif
+#if NPOINT
+    case T_TNPOINT:
+      stringbuffer_append_len(sb, "{\"type\":\"MovingNetworkPoint\",", 29);
       break;
 #endif
     default: /* Error! */
@@ -563,6 +594,13 @@ tinstant_as_mfjson_sb(stringbuffer_t *sb, const TInstant *inst,
     pose_as_json_sb(sb, DatumGetPoseP(tinstant_value_p(inst)), precision);
   }
 #endif /* RGEO */
+#if NPOINT
+  else if (inst->temptype == T_TNPOINT)
+  {
+    stringbuffer_append_len(sb, "\"values\":[", 10);
+    npoint_as_json_sb(sb, DatumGetNpointP(tinstant_value_p(inst)), precision);
+  }
+#endif /* NPOINT */
   else
   {
     stringbuffer_append_len(sb, "\"values\":[", 10);
@@ -642,9 +680,15 @@ tsequence_as_mfjson_sb(stringbuffer_t *sb, const TSequence *seq,
       pose_as_json_sb(sb, DatumGetPoseP(tinstant_value_p(inst)), precision);
     }
 #endif /* RGEO */
+#if NPOINT
+    else if (inst->temptype == T_TNPOINT)
+    {
+      npoint_as_json_sb(sb, DatumGetNpointP(tinstant_value_p(inst)), precision);
+    }
+#endif /* NPOINT */
     else
     {
-      success = temporal_base_as_mfjson_sb(sb, tinstant_value_p(inst), 
+      success = temporal_base_as_mfjson_sb(sb, tinstant_value_p(inst),
         inst->temptype, precision);
       /* Propagate errors up */
       if (! success)
@@ -738,6 +782,12 @@ tsequenceset_as_mfjson_sb(stringbuffer_t *sb, const TSequenceSet *ss,
         pose_as_json_sb(sb, DatumGetPoseP(tinstant_value_p(inst)), precision);
       }
 #endif /* RGEO */
+#if NPOINT
+      else if (inst->temptype == T_TNPOINT)
+      {
+        npoint_as_json_sb(sb, DatumGetNpointP(tinstant_value_p(inst)), precision);
+      }
+#endif /* NPOINT */
       else
       {
         success = temporal_base_as_mfjson_sb(sb, tinstant_value_p(inst),

--- a/mobilitydb/sql/npoint/083_tnpoint.in.sql
+++ b/mobilitydb/sql/npoint/083_tnpoint.in.sql
@@ -88,6 +88,10 @@ CREATE FUNCTION tnpointFromHexWKB(text)
   RETURNS tnpoint
   AS 'MODULE_PATHNAME', 'Temporal_from_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION tnpointFromMFJSON(text)
+  RETURNS tnpoint
+  AS 'MODULE_PATHNAME', 'Temporal_from_mfjson'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************/
 
@@ -98,6 +102,12 @@ CREATE FUNCTION asText(tnpoint, maxdecimaldigits int4 DEFAULT 15)
 CREATE FUNCTION asText(tnpoint[], maxdecimaldigits int4 DEFAULT 15)
   RETURNS text[]
   AS 'MODULE_PATHNAME', 'Spatialarr_as_text'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION asMFJSON(tnpoint, options int4 DEFAULT 0,
+    flags int4 DEFAULT 0, maxdecimaldigits int4 DEFAULT 15)
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Temporal_as_mfjson'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION asBinary(tnpoint, endianenconding text DEFAULT '')

--- a/mobilitydb/test/npoint/expected/083_tnpoint.test.out
+++ b/mobilitydb/test/npoint/expected/083_tnpoint.test.out
@@ -322,6 +322,142 @@ SELECT tnpointFromHexWKB(asHexWKB(tnpoint 'Interp=Step;{[Npoint(1, 0.2)@2000-01-
  Interp=Step;{[NPoint(1,0.2)@Sat Jan 01 00:00:00 2000 PST, NPoint(1,0.4)@Sun Jan 02 00:00:00 2000 PST, NPoint(1,0.5)@Mon Jan 03 00:00:00 2000 PST], [NPoint(2,0.6)@Tue Jan 04 00:00:00 2000 PST, NPoint(2,0.6)@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
+SELECT asMFJSON(tnpoint 'Npoint(1, 0.5)@2000-01-01');
+                                                                                            asmfjson                                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"type":"MovingNetworkPoint","crs":{"type":"Name","properties":{"name":"EPSG:5676"}},"values":[{"route":1,"position":0.5}],"datetimes":["Sat Jan 01T00:00:00 2000 PST"],"interpolation":"None"}
+(1 row)
+
+SELECT asMFJSON(tnpoint '{Npoint(1, 0.3)@2000-01-01, Npoint(2, 0.5)@2000-01-02, Npoint(1, 0.3)@2000-01-03}');
+                                                                                                                                                                         asmfjson                                                                                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"type":"MovingNetworkPoint","crs":{"type":"Name","properties":{"name":"EPSG:5676"}},"values":[{"route":1,"position":0.3},{"route":2,"position":0.5},{"route":1,"position":0.3}],"datetimes":["Sat Jan 01T00:00:00 2000 PST","Sun Jan 02T00:00:00 2000 PST","Mon Jan 03T00:00:00 2000 PST"],"lower_inc":true,"upper_inc":true,"interpolation":"Discrete"}
+(1 row)
+
+SELECT asMFJSON(tnpoint '[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02, Npoint(1, 0.5)@2000-01-03]');
+                                                                                                                                                                        asmfjson                                                                                                                                                                         
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"type":"MovingNetworkPoint","crs":{"type":"Name","properties":{"name":"EPSG:5676"}},"values":[{"route":1,"position":0.2},{"route":1,"position":0.4},{"route":1,"position":0.5}],"datetimes":["Sat Jan 01T00:00:00 2000 PST","Sun Jan 02T00:00:00 2000 PST","Mon Jan 03T00:00:00 2000 PST"],"lower_inc":true,"upper_inc":true,"interpolation":"Linear"}
+(1 row)
+
+SELECT asMFJSON(tnpoint 'Interp=Step;[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02, Npoint(1, 0.5)@2000-01-03]');
+                                                                                                                                                                       asmfjson                                                                                                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"type":"MovingNetworkPoint","crs":{"type":"Name","properties":{"name":"EPSG:5676"}},"values":[{"route":1,"position":0.2},{"route":1,"position":0.4},{"route":1,"position":0.5}],"datetimes":["Sat Jan 01T00:00:00 2000 PST","Sun Jan 02T00:00:00 2000 PST","Mon Jan 03T00:00:00 2000 PST"],"lower_inc":true,"upper_inc":true,"interpolation":"Step"}
+(1 row)
+
+SELECT asMFJSON(tnpoint '{[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02, Npoint(1, 0.2)@2000-01-03],[Npoint(2, 0.6)@2000-01-04, Npoint(2, 0.6)@2000-01-05]}');
+                                                                                                                                                                                                                                                                         asmfjson                                                                                                                                                                                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"type":"MovingNetworkPoint","crs":{"type":"Name","properties":{"name":"EPSG:5676"}},"sequences":[{"values":[{"route":1,"position":0.2},{"route":1,"position":0.4},{"route":1,"position":0.2}],"datetimes":["Sat Jan 01T00:00:00 2000 PST","Sun Jan 02T00:00:00 2000 PST","Mon Jan 03T00:00:00 2000 PST"],"lower_inc":true,"upper_inc":true},{"values":[{"route":2,"position":0.6},{"route":2,"position":0.6}],"datetimes":["Tue Jan 04T00:00:00 2000 PST","Wed Jan 05T00:00:00 2000 PST"],"lower_inc":true,"upper_inc":true}],"interpolation":"Linear"}
+(1 row)
+
+SELECT asMFJSON(tnpoint 'Npoint(1, 0.123456789)@2000-01-01', 0, 0, 6);
+                                                                                               asmfjson                                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"type":"MovingNetworkPoint","crs":{"type":"Name","properties":{"name":"EPSG:5676"}},"values":[{"route":1,"position":0.123457}],"datetimes":["Sat Jan 01T00:00:00 2000 PST"],"interpolation":"None"}
+(1 row)
+
+SELECT asMFJSON(tnpoint 'Npoint(1, 0.5)@2000-01-01', 0, 0, 20);
+                                                                                            asmfjson                                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"type":"MovingNetworkPoint","crs":{"type":"Name","properties":{"name":"EPSG:5676"}},"values":[{"route":1,"position":0.5}],"datetimes":["Sat Jan 01T00:00:00 2000 PST"],"interpolation":"None"}
+(1 row)
+
+SELECT asMFJSON(tnpoint 'Npoint(1, 0.5)@2000-01-01', 0, 0, -1);
+                                                                                           asmfjson                                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"type":"MovingNetworkPoint","crs":{"type":"Name","properties":{"name":"EPSG:5676"}},"values":[{"route":1,"position":0}],"datetimes":["Sat Jan 01T00:00:00 2000 PST"],"interpolation":"None"}
+(1 row)
+
+SELECT asMFJSON(tnpoint 'SRID=4326;Npoint(1, 0.5)@2019-01-01 18:00:00.15+02', 1, 0, 2);
+                                                                                                                                                                                asmfjson                                                                                                                                                                                
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"type":"MovingNetworkPoint","crs":{"type":"Name","properties":{"name":"EPSG:5676"}},"bbox":[[48.72,77.76],[48.72,77.76]],"period":{"begin":"Tue Jan 01T08:00:00.15 2019 PST","end":"Tue Jan 01T08:00:00.15 2019 PST","lower_inc":true,"upper_inc":true},"values":[{"route":1,"position":0.5}],"datetimes":["Tue Jan 01T08:00:00.15 2019 PST"],"interpolation":"None"}
+(1 row)
+
+SELECT asMFJSON(tnpoint 'SRID=4326;Npoint(1, 0.5)@2019-01-01 18:00:00.15+02', 2, 0, 2);
+                                                                                              asmfjson                                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"type":"MovingNetworkPoint","crs":{"type":"Name","properties":{"name":"EPSG:5676"}},"values":[{"route":1,"position":0.5}],"datetimes":["Tue Jan 01T08:00:00.15 2019 PST"],"interpolation":"None"}
+(1 row)
+
+SELECT asMFJSON(tnpoint 'SRID=4326;Npoint(1, 0.5)@2019-01-01 18:00:00.15+02', 3, 0, 2);
+                                                                                                                                                                                asmfjson                                                                                                                                                                                
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"type":"MovingNetworkPoint","crs":{"type":"Name","properties":{"name":"EPSG:5676"}},"bbox":[[48.72,77.76],[48.72,77.76]],"period":{"begin":"Tue Jan 01T08:00:00.15 2019 PST","end":"Tue Jan 01T08:00:00.15 2019 PST","lower_inc":true,"upper_inc":true},"values":[{"route":1,"position":0.5}],"datetimes":["Tue Jan 01T08:00:00.15 2019 PST"],"interpolation":"None"}
+(1 row)
+
+SELECT asMFJSON(tnpoint 'SRID=4326;Npoint(1, 0.5)@2019-01-01 18:00:00.15+02', 4, 0, 2);
+                                                                                                      asmfjson                                                                                                       
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"type":"MovingNetworkPoint","crs":{"type":"Name","properties":{"name":"urn:ogc:def:crs:EPSG::5676"}},"values":[{"route":1,"position":0.5}],"datetimes":["Tue Jan 01T08:00:00.15 2019 PST"],"interpolation":"None"}
+(1 row)
+
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint 'Npoint(1, 0.5)@2000-01-01')));
+                   astext                   
+--------------------------------------------
+ NPoint(1,0.5)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint '{Npoint(1, 0.3)@2000-01-01, Npoint(2, 0.5)@2000-01-02}')));
+                                          astext                                          
+------------------------------------------------------------------------------------------
+ {NPoint(1,0.3)@Sat Jan 01 00:00:00 2000 PST, NPoint(2,0.5)@Sun Jan 02 00:00:00 2000 PST}
+(1 row)
+
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint '[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02]')));
+                                          astext                                          
+------------------------------------------------------------------------------------------
+ [NPoint(1,0.2)@Sat Jan 01 00:00:00 2000 PST, NPoint(1,0.4)@Sun Jan 02 00:00:00 2000 PST]
+(1 row)
+
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint '[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.2)@2000-01-02)')));
+                                          astext                                          
+------------------------------------------------------------------------------------------
+ [NPoint(1,0.2)@Sat Jan 01 00:00:00 2000 PST, NPoint(1,0.2)@Sun Jan 02 00:00:00 2000 PST)
+(1 row)
+
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint 'Interp=Step;[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02]')));
+                                                astext                                                
+------------------------------------------------------------------------------------------------------
+ Interp=Step;[NPoint(1,0.2)@Sat Jan 01 00:00:00 2000 PST, NPoint(1,0.4)@Sun Jan 02 00:00:00 2000 PST]
+(1 row)
+
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint '{[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02],[Npoint(2, 0.6)@2000-01-03, Npoint(2, 0.6)@2000-01-04]}')));
+                                                                                        astext                                                                                        
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[NPoint(1,0.2)@Sat Jan 01 00:00:00 2000 PST, NPoint(1,0.4)@Sun Jan 02 00:00:00 2000 PST], [NPoint(2,0.6)@Mon Jan 03 00:00:00 2000 PST, NPoint(2,0.6)@Tue Jan 04 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint 'Npoint(1, 0.5)@2000-01-01', 3)));
+                   astext                   
+--------------------------------------------
+ NPoint(1,0.5)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint '[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02]', 3)));
+                                          astext                                          
+------------------------------------------------------------------------------------------
+ [NPoint(1,0.2)@Sat Jan 01 00:00:00 2000 PST, NPoint(1,0.4)@Sun Jan 02 00:00:00 2000 PST]
+(1 row)
+
+SELECT tnpointFromMFJSON('ABC');
+ERROR:  Error while processing MFJSON string unexpected character (at offset 0)
+SELECT tnpointFromMFJSON('{"type":"XXX","values":[{"route":1,"position":0.5}],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"None"}');
+ERROR:  Invalid 'type' value in MFJSON string: XXX
+SELECT tnpointFromMFJSON('{"type":"MovingNetworkPoint","valuesxxx":[{"route":1,"position":0.5}],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"None"}');
+ERROR:  Unable to find 'values' in MFJSON string
+SELECT tnpointFromMFJSON('{"type":"MovingNetworkPoint","values":[{"routexxx":1,"position":0.5}],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"None"}');
+ERROR:  Unable to find 'route' in MFJSON string
+SELECT tnpointFromMFJSON('{"type":"MovingNetworkPoint","values":[{"route":1,"positionxxx":0.5}],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"None"}');
+ERROR:  Unable to find 'position' in MFJSON string
+SELECT tnpointFromMFJSON('{"type":"MovingNetworkPoint","values":[{"route":1,"position":0.5}],"datetimess":["2000-01-01T00:00:00+01"],"interpolation":"None"}');
+ERROR:  Unable to find 'datetimes' in MFJSON string
+SELECT tnpointFromMFJSON('{"type":"MovingNetworkPoint","values":[{"route":1,"position":0.5}],"datetimes":["XXXX"],"interpolation":"None"}');
+ERROR:  invalid input syntax for type timestamp with time zone: "XXXX"
+SELECT tnpointFromMFJSON('{"type":"MovingNetworkPoint","values":[{"route":1,"position":0.5}],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"XXX"}');
+ERROR:  Invalid 'interpolation' value in MFJSON string
 SELECT tnpoint('npoint(1,0)'::npoint, '2012-01-01'::timestamp);
                  tnpoint                  
 ------------------------------------------

--- a/mobilitydb/test/npoint/queries/083_tnpoint.test.sql
+++ b/mobilitydb/test/npoint/queries/083_tnpoint.test.sql
@@ -106,6 +106,44 @@ SELECT tnpointFromHexWKB(asHexWKB(tnpoint 'Interp=Step;[Npoint(1, 0.2)@2000-01-0
 SELECT tnpointFromHexWKB(asHexWKB(tnpoint 'Interp=Step;{[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02, Npoint(1, 0.5)@2000-01-03], [Npoint(2, 0.6)@2000-01-04, Npoint(2, 0.6)@2000-01-05] }', 'XDR'));
 
 -------------------------------------------------------------------------------
+-- Input/output in MF-JSON format
+-------------------------------------------------------------------------------
+
+SELECT asMFJSON(tnpoint 'Npoint(1, 0.5)@2000-01-01');
+SELECT asMFJSON(tnpoint '{Npoint(1, 0.3)@2000-01-01, Npoint(2, 0.5)@2000-01-02, Npoint(1, 0.3)@2000-01-03}');
+SELECT asMFJSON(tnpoint '[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02, Npoint(1, 0.5)@2000-01-03]');
+SELECT asMFJSON(tnpoint 'Interp=Step;[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02, Npoint(1, 0.5)@2000-01-03]');
+SELECT asMFJSON(tnpoint '{[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02, Npoint(1, 0.2)@2000-01-03],[Npoint(2, 0.6)@2000-01-04, Npoint(2, 0.6)@2000-01-05]}');
+
+SELECT asMFJSON(tnpoint 'Npoint(1, 0.123456789)@2000-01-01', 0, 0, 6);
+SELECT asMFJSON(tnpoint 'Npoint(1, 0.5)@2000-01-01', 0, 0, 20);
+SELECT asMFJSON(tnpoint 'Npoint(1, 0.5)@2000-01-01', 0, 0, -1);
+SELECT asMFJSON(tnpoint 'SRID=4326;Npoint(1, 0.5)@2019-01-01 18:00:00.15+02', 1, 0, 2);
+SELECT asMFJSON(tnpoint 'SRID=4326;Npoint(1, 0.5)@2019-01-01 18:00:00.15+02', 2, 0, 2);
+SELECT asMFJSON(tnpoint 'SRID=4326;Npoint(1, 0.5)@2019-01-01 18:00:00.15+02', 3, 0, 2);
+SELECT asMFJSON(tnpoint 'SRID=4326;Npoint(1, 0.5)@2019-01-01 18:00:00.15+02', 4, 0, 2);
+
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint 'Npoint(1, 0.5)@2000-01-01')));
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint '{Npoint(1, 0.3)@2000-01-01, Npoint(2, 0.5)@2000-01-02}')));
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint '[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02]')));
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint '[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.2)@2000-01-02)')));
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint 'Interp=Step;[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02]')));
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint '{[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02],[Npoint(2, 0.6)@2000-01-03, Npoint(2, 0.6)@2000-01-04]}')));
+
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint 'Npoint(1, 0.5)@2000-01-01', 3)));
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint '[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02]', 3)));
+
+-- Errors
+SELECT tnpointFromMFJSON('ABC');
+SELECT tnpointFromMFJSON('{"type":"XXX","values":[{"route":1,"position":0.5}],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"None"}');
+SELECT tnpointFromMFJSON('{"type":"MovingNetworkPoint","valuesxxx":[{"route":1,"position":0.5}],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"None"}');
+SELECT tnpointFromMFJSON('{"type":"MovingNetworkPoint","values":[{"routexxx":1,"position":0.5}],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"None"}');
+SELECT tnpointFromMFJSON('{"type":"MovingNetworkPoint","values":[{"route":1,"positionxxx":0.5}],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"None"}');
+SELECT tnpointFromMFJSON('{"type":"MovingNetworkPoint","values":[{"route":1,"position":0.5}],"datetimess":["2000-01-01T00:00:00+01"],"interpolation":"None"}');
+SELECT tnpointFromMFJSON('{"type":"MovingNetworkPoint","values":[{"route":1,"position":0.5}],"datetimes":["XXXX"],"interpolation":"None"}');
+SELECT tnpointFromMFJSON('{"type":"MovingNetworkPoint","values":[{"route":1,"position":0.5}],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"XXX"}');
+
+-------------------------------------------------------------------------------
 -- Constructors
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
Temporal network points previously had no MF-JSON serialization, so they could not round-trip through the Moving Features JSON representation that the other spatiotemporal types support. This adds a parser and emitter for the temporal network point type guarded by NPOINT, using the typestring MovingNetworkPoint and encoding each value as an object with an integer route member and a numeric position member, mirroring the route and getPosition accessors. A network point is a network-relative reference rather than a coordinate, so there is no coordinate or Z/geodetic handling. The type is wired through the input value dispatch, typestring validation and mapping, the output emitter and the three value-emit sites, and the bounding-box emission for the BBOX and CRS options. It adds the tnpoint_from_mfjson MEOS wrapper, the tnpointFromMFJSON and asMFJSON(tnpoint) SQL functions, the English and Spanish documentation in the shared spatial chapter, and pg_regress coverage with golden output captured from a local NPOINT build.