### PR TITLE
Make the temporal spatial relationships geodetic-consistent

### DIFF
--- a/meos/src/geo/tspatial_tempspatialrels.c
+++ b/meos/src/geo/tspatial_tempspatialrels.c
@@ -466,6 +466,21 @@ tinterrel_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool tinter)
   if (! ensure_valid_tgeo_geo(temp, gs) || gserialized_is_empty(gs))
     return NULL;
 
+  /* tintersects is tdwithin with a zero distance and tdisjoint is its
+   * negation (as in the static case, geog_intersects =
+   * geog_dwithin(., ., 0.0)). For geodetic coordinates the planar
+   * intersects below is not applicable; route through the
+   * geodetic-capable tdwithin kernel. */
+  if (MEOS_FLAGS_GET_GEODETIC(temp->flags))
+  {
+    Temporal *dw = tdwithin_tgeo_geo(temp, gs, 0.0);
+    if (! dw || tinter)
+      return dw;
+    Temporal *result = tnot_tbool(dw);
+    pfree(dw);
+    return result;
+  }
+
   /* 3D only if both arguments are 3D */
   datum_func2 func = MEOS_FLAGS_GET_Z(temp->flags) && FLAGS_GET_Z(gs->gflags) ?
       &datum_geom_intersects3d : &datum_geom_intersects2d;
@@ -1438,18 +1453,21 @@ Temporal *
 tdwithin_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist)
 {
   VALIDATE_TSPATIAL(temp, NULL); VALIDATE_NOT_NULL(gs, NULL);
-  /* Ensure the validity of the arguments */
+  /* Ensure the validity of the arguments. ensure_valid_tspatial_geo
+   * already enforces that the temporal geo and the geometry have the
+   * same geodetic flag, so geodetic coordinates are supported here the
+   * same way as in #Tdistance_tgeo_geo (no ensure_not_geodetic_geo). */
   if (! ensure_valid_tspatial_geo(temp, gs) || gserialized_is_empty(gs) ||
-      (tpoint_type(temp->temptype) &&
-        (! ensure_point_type(gs) || ! ensure_not_geodetic_geo(gs))) ||
+      (tpoint_type(temp->temptype) && ! ensure_point_type(gs)) ||
       ! ensure_not_negative_datum(Float8GetDatum(dist), T_FLOAT8))
     return NULL;
 
-  /* Determine the distance and the turning point functions to be applied */
-  datum_func3 func =
-    /* 3D only if both arguments are 3D */
-    MEOS_FLAGS_GET_Z(temp->flags) && FLAGS_GET_Z(gs->gflags) ?
-    &datum_geom_dwithin3d : &datum_geom_dwithin2d;
+  /* Determine the distance and the turning point functions to be applied.
+   * geo_dwithin_fn_geo selects the geodetic dwithin for geodetic
+   * coordinates and the 2D/3D planar dwithin otherwise (identical planar
+   * behaviour to before), mirroring how Tdistance_tgeo_geo selects its
+   * distance function. */
+  datum_func3 func = geo_dwithin_fn_geo(temp->flags, gs->gflags);
   tpfunc_temp tpfn = &tpointsegm_tdwithin_turnpt;
   /* Call the generic function passing the two functions as arguments */
   return tdwithin_tspatial_spatial(temp, PointerGetDatum(gs),


### PR DESCRIPTION
See commit message. Closes the geodetic-spatial-relationship irregularity (tintersects/tdisjoint are tdwithin(0); tdwithin mirrors tdistance). Planar behaviour unchanged; geodetic instant/discrete intersects/disjoint/dwithin now correct instead of erroring. Deeper pre-existing gaps (geodetic ttouches; continuous geodetic turning-point precision) tracked in #1087. Verified against the composed integration surface: full PyMEOS suite 4492 passed.