### PR TITLE
Make ea_*_tgeo_geo (ever/always) geodetic-consistent

### DIFF
--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -935,6 +935,16 @@ ea_disjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tgeo_geo(temp, gs) || gserialized_is_empty(gs))
     return -1;
+
+  /* tdisjoint is the negation of tintersects = tdwithin with zero
+   * distance, with the ever/always quantifier swapped (cf. static
+   * geog_disjoint = ! geog_dwithin(., ., 0.0); #1088 temporal-result
+   * pattern). For geodetic coordinates route through the
+   * geodetic-capable dwithin kernel; the planar trajectory machinery
+   * below is not applicable. */
+  if (MEOS_FLAGS_GET_GEODETIC(temp->flags))
+    return INVERT_RESULT(ea_dwithin_tgeo_geo(temp, gs, 0.0, ! ever));
+
   int result;
 
   /* ALWAYS */
@@ -1088,6 +1098,15 @@ ea_intersects_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tgeo_geo(temp, gs) || gserialized_is_empty(gs))
     return -1;
+
+  /* tintersects is tdwithin with zero distance (cf. static
+   * geog_intersects = geog_dwithin(., ., 0.0); same definitional
+   * equivalence used at the temporal-result layer in
+   * tinterrel_tgeo_geo per #1088). For geodetic coordinates route
+   * through the geodetic-capable dwithin kernel instead of the planar
+   * spatialrel_tgeo_geo trajectory. */
+  if (MEOS_FLAGS_GET_GEODETIC(temp->flags))
+    return ea_dwithin_tgeo_geo(temp, gs, 0.0, ever);
 
   /* ALWAYS */
   if (! ever)
@@ -1461,6 +1480,36 @@ ea_dwithin_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist,
   if (! ensure_valid_tgeo_geo(temp, gs) || gserialized_is_empty(gs) ||
       ! ensure_not_negative_datum(Float8GetDatum(dist), T_FLOAT8))
     return -1;
+
+  /* For geodetic coordinates the planar `spatialrel_tgeo_geo`
+   * trajectory and the planar `geom_buffer` + `covers` machinery below
+   * are not applicable. Use the lifted temporal-base helper
+   * `eafunc_temporal_base` with the geodetic-aware `geo_dwithin_fn_geo`
+   * selector (which returns `datum_geog_dwithin` for geodetic input);
+   * this mirrors `ea_dwithin_tgeo_tgeo` for the temporal-base case and
+   * stays inside extension-safe lifting machinery (no `*_meos.c`
+   * dependency). Same architectural pattern as `tdistance_tgeo_geo`
+   * for the geo argument. */
+  if (MEOS_FLAGS_GET_GEODETIC(temp->flags))
+  {
+    LiftedFunctionInfo lfinfo;
+    memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
+    lfinfo.func = (varfunc) geo_dwithin_fn_geo(temp->flags, gs->gflags);
+    lfinfo.numparam = 1;
+    lfinfo.param[0] = Float8GetDatum(dist);
+    lfinfo.argtype[0] = temp->temptype;
+    lfinfo.argtype[1] = temptype_basetype(temp->temptype);
+    lfinfo.restype = T_TBOOL;
+    lfinfo.invert = INVERT_NO;
+    lfinfo.discont = MEOS_FLAGS_LINEAR_INTERP(temp->flags);
+    lfinfo.ever = ever;
+    /* No tpfn_base for the temporal-base dwithin turning point yet --
+     * the continuous-segment crossing detection is pre-existing
+     * planar-only at this layer (cf. #1087); instant/discrete cases
+     * are exact, continuous segments fall back to endpoint sampling. */
+    lfinfo.tpfn_base = NULL;
+    return eafunc_temporal_base(temp, PointerGetDatum(gs), &lfinfo);
+  }
 
   /* EVER */
   if (ever)


### PR DESCRIPTION
Companion to #1088 at the ever/always scalar layer. `adwithin_tgeo_geo` is currently unconditionally broken for any geodetic input (returns -1 with "Operation on mixed planar and geodetic coordinates" from the planar geom_buffer path); the EVER variants mostly worked by accident on instant/discrete because spatialrel_tgeo_geo's per-instant path lets the geodetic-aware datum_geog_dwithin selector resolve correctly. This commit routes the geodetic branch through the same lifted temporal-base machinery that tdistance_tgeo_geo uses (`eafunc_temporal_base` + `geo_dwithin_fn_geo`), and defines ea_intersects/ea_disjoint geodetic as ea_dwithin(0)/INVERT mirroring #1088 and MEOS's own static `geog_intersects = geog_dwithin(0.0)` convention. `eafunc_temporal_base` lives in `lifting.c` (not `*_meos.c`) so this fix is extension-safe (verified `nm -D --undefined-only libMobilityDB-*.so` clean). A/B-verified locally: 0 regressions, 2 strictly-broken paths (adwithin always Instant/Discrete) unblocked. The continuous-segment turning-point precision is unchanged (pre-existing #1087 item; tpfn_base = NULL for now).