### PR TITLE
Document the meos_error return-or-not contract

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -350,6 +350,25 @@ typedef enum
 
 } errorCode;
 
+/**
+ * Report an error at the given level/code with a printf-style message.
+ *
+ * @note Return-or-not contract is **undefined**: this function MAY
+ * return control to the caller, depending on the installed error
+ * handler. The default handler `exit(EXIT_FAILURE)`s on `ERROR` (safe
+ * for one-shot CLI use), but any custom handler an embedder installs
+ * via `meos_initialize_error_handler` may return -- and code that
+ * assumed `meos_error(ERROR, ...)` would never return has historically
+ * SIGSEGV'd on the next dereference (MobilityDB#1089, #1093).
+ *
+ * **Convention** (enforced by a static-analysis CI check): every
+ * `meos_error(ERROR, ...)` callsite MUST be immediately followed by a
+ * `return` (with a sentinel value if the function has a non-void
+ * return type), `goto cleanup_label`, `break`, or equivalent
+ * control-transfer. NEVER let execution fall through and assume the
+ * call did not return. This makes every callsite safe regardless of
+ * which handler an embedder installs.
+ */
 extern void meos_error(int errlevel, int errcode, const char *format, ...);
 
 /* Set or read error level */

--- a/meos/src/temporal/error.c
+++ b/meos/src/temporal/error.c
@@ -196,6 +196,18 @@ meos_initialize_error_handler(error_handler_fn err_handler)
 
 /**
  * @brief Function handling error messages
+ *
+ * @note Return-or-not contract is *undefined*: depending on the
+ * installed handler this function MAY return to the caller. The
+ * default handler `exit(EXIT_FAILURE)`s on `ERROR` (safe for one-shot
+ * CLI use); any custom handler installed via
+ * `meos_initialize_error_handler` may return. Code in MEOS that calls
+ * `meos_error(ERROR, ...)` MUST be immediately followed by a `return`,
+ * `goto`, `break`, or sentinel assignment -- NEVER let execution fall
+ * through. Historic fall-through bugs caused by relying on the
+ * exit-on-ERROR path: MobilityDB#1089 (closed by PR #1090), #1093
+ * (wider audit). See the corresponding doc comment on the public
+ * declaration of `meos_error` in `meos/include/meos.h`.
  */
 void
 meos_error(int errlevel, int errcode, const char *format, ...)


### PR DESCRIPTION
Document on `meos.h` and `error.c` that `meos_error(int errlevel, ...)` has an undefined return-or-not contract: depending on the installed error handler it may return control to the caller, so a caller must follow the call with an immediate control transfer (return with a sentinel, goto, break, exit, or continue) and never fall through. Documentation only; no behavioural change.