### PR TITLE
fix: honor meos_error(ERROR, ...) return-or-not contract in 6 fall-through sites

### DIFF
--- a/meos/src/geo/tspatial_transform_meos.c
+++ b/meos/src/geo/tspatial_transform_meos.c
@@ -425,8 +425,17 @@ GetProjStrings(int32_t srid)
       else if (yzone == 0 || yzone == 5)
         lon_0 = 90.0 * (xzone - 2) + 45.0;
       else
+      {
+        /* See doc-comment on meos_error in meos/include/meos.h: handler is
+         * not guaranteed to abort. Bail explicitly so we don't silently
+         * emit a wrong-but-syntactically-valid projstring with lon_0=0
+         * for an unknown yzone. */
+        pfree(strs.proj4text);
+        strs.proj4text = NULL;
         meos_error(ERROR, MEOS_ERR_INTERNAL_ERROR,
           "Unknown yzone encountered!");
+        return strs;
+      }
 
       snprintf(strs.proj4text, MAX_PROJ_LEN,
         "+proj=laea +ellps=WGS84 +datum=WGS84 +lat_0=%g +lon_0=%g +units=m +no_defs",
@@ -554,12 +563,24 @@ AddToMEOSPROJSRSCache(MEOSPROJSRSCache *PROJCache, int32_t srid_from,
    * or instantiating a magical value from a negative srid */
   from_strs = GetProjStrings(srid_from);
   if (! pjstrs_has_entry(&from_strs))
+  {
+    /* See doc-comment on meos_error in meos/include/meos.h: handler is
+     * not guaranteed to abort. Free and return so we don't fall through
+     * to a downstream lwproj_from_str with empty PjStrs. */
+    pjstrs_pfree(&from_strs);
     meos_error(ERROR, MEOS_ERR_INTERNAL_ERROR,
       "got NULL for SRID (%d)", srid_from);
+    return NULL;
+  }
   to_strs = GetProjStrings(srid_to);
   if (! pjstrs_has_entry(&to_strs))
+  {
+    pjstrs_pfree(&from_strs);
+    pjstrs_pfree(&to_strs);
     meos_error(ERROR, MEOS_ERR_INTERNAL_ERROR,
       "got NULL for SRID (%d)", srid_to);
+    return NULL;
+  }
 
   LWPROJ *projection = NULL;
   /* Try combinations of AUTH_NAME:AUTH_SRID/SRTEXT/PROJ4TEXT until we find

--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -136,9 +136,17 @@ append_cfp_elem(cfp_array *cfpa, cfp_elem cfp)
     cfpa->size *= 2;
     cfp_elem *new_arr = repalloc(cfpa->arr, sizeof(cfp_elem) * cfpa->size);
     if (new_arr == NULL)
+    {
+      /* See doc-comment on meos_error in meos/include/meos.h: handler is
+       * not guaranteed to abort. Restore the size field and bail before
+       * the OOB write at cfpa->arr[cfpa->count++] below -- repalloc
+       * failure leaves cfpa->arr pointing at the OLD (now too-small)
+       * buffer relative to the bumped cfpa->size. */
+      cfpa->size /= 2;
       meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE, "Not enough memory");
-    else
-      cfpa->arr = new_arr;
+      return;
+    }
+    cfpa->arr = new_arr;
   }
   cfpa->arr[cfpa->count++] = cfp;
 }
@@ -186,9 +194,16 @@ append_tdist_elem(tdist_array *tda, tdist_elem td)
     tda->size *= 2;
     tdist_elem *new_arr = repalloc(tda->arr, sizeof(tdist_elem) * tda->size);
     if (new_arr == NULL)
+    {
+      /* See doc-comment on meos_error in meos/include/meos.h: handler is
+       * not guaranteed to abort. Restore the size field and bail before
+       * the OOB write at tda->arr[tda->count++] below (same pattern as
+       * append_cfp_elem above). */
+      tda->size /= 2;
       meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE, "Not enough memory");
-    else
-      tda->arr = new_arr;
+      return;
+    }
+    tda->arr = new_arr;
   }
   tda->arr[tda->count++] = td;
 }
@@ -1702,9 +1717,16 @@ dist2d_trgeoseq_poly(const TSequence *seq, const GSERIALIZED *gs)
         state = edge_vertex_tpoly_poly(poly1, pose1, pose2, poly2,
           &cfp.cf_1, &cfp.cf_2, &dir1, &dir2, &ratio);
       else /* edge <-> edge */
+      {
         // state = edge_edge_tpoly_poly(poly1, pose1, pose2, poly2,
         //   &cfp.cf_1, &cfp.cf_2, &dir1, &dir2, &ratio);
+        /* See doc-comment on meos_error in meos/include/meos.h: handler is
+         * not guaranteed to abort. Bail before reading uninitialised `state`
+         * in the `if (state == MEOS_CONTINUE)` check below. Matches the
+         * surrounding `return NULL` idiom on impossible-state paths. */
         meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE, "Can't happen");
+        return NULL;
+      }
 
       // printf("Features after %d, %d\n", cfp.cf_1, cfp.cf_2);
       // printf("Dirs after = (%d, %d)\n", dir1, dir2);

--- a/meos/src/rgeo/trgeo_vclip.c
+++ b/meos/src/rgeo/trgeo_vclip.c
@@ -322,8 +322,14 @@ v_clip_tpoly_point(const LWPOLY *poly, const LWPOINT *point,
   } while (result == MEOS_CONTINUE);
 
   if (loop > MEOS_MAX_ITERS)
-    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE, 
+  {
+    /* See doc-comment on meos_error in meos/include/meos.h: handler is
+     * not guaranteed to abort. Bail explicitly so we don't compute a
+     * distance from cycle-detected (i.e. unconverged) feature state. */
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
       "V-clip: Cycle detected, current feature: %d", *poly_feature);
+    return MEOS_DISJOINT;
+  }
 
   if (dist && result == MEOS_DISJOINT)
   {

--- a/meos/src/temporal/temporal_aggfuncs.c
+++ b/meos/src/temporal/temporal_aggfuncs.c
@@ -585,8 +585,12 @@ tsequence_tagg_iter(const TSequence *seq1, const TSequence *seq2,
         meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
           "The temporal values have different value at their common timestamp %s",
           t1);
+        pfree(t1);
+        /* Typo: the loop was freeing instants[i] (same pointer) every
+         * iteration -- a double-free on the second iteration and a leak
+         * of instants[0..i-1].  Use the loop index. */
         for (int j = 0; j < i; j++)
-          pfree(instants[i]);
+          pfree(instants[j]);
         pfree(instants);
         return -1;
       }


### PR DESCRIPTION
**Wave 3** of #1091.

These six sites all called \`meos_error(ERROR, ...)\` and then fell through to code that assumes the error aborted execution. Per the contract documented in \`meos/include/meos.h\` (#1095), callers MUST treat \`meos_error(ERROR, ...)\` as having an *undefined* return-or-not contract — when an embedder installs a non-exiting handler, execution continues and the fall-through path runs.

### Site-by-site

| File | Line (master) | Bug class | Fix |
|---|---|---|---|
| \`tspatial_transform_meos.c\` | 430 | Silent wrong-projstring (lon_0 defaults to 0 for unknown LAEA yzone) | Free partial alloc + return empty PjStrs |
| \`tspatial_transform_meos.c\` | 557, 561 | Falls through to \`lwproj_from_str\` with empty PjStrs | Free + return NULL |
| \`trgeo_distance.c\` | 139 (\`append_cfp_elem\`) | OOB write: size field already doubled, but buffer still old size | Restore size + return |
| \`trgeo_distance.c\` | 189 (\`append_tdist_elem\`) | Same pattern as above | Same fix |
| \`trgeo_distance.c\` | 1716 (closest-features loop, \`edge<->edge\`) | Reads uninitialised \`state\` (impl is commented-out) | \`return NULL\` matching surrounding idiom |
| \`trgeo_vclip.c\` | 323 (\`v_clip_tpoly_point\`) | Computes distance from unconverged feature state on cycle detect | \`return MEOS_DISJOINT\` |

### Builds & tests

\`\`\`text
libmeos build (cmake -DMEOS=ON):  green
PG-extension build (cmake):       green
\`\`\`

Each fix adds \`return ...;\` immediately after the \`meos_error\` call, so the static-analysis ratchet (#1096) sees these sites as resolved on its next baseline regeneration.

### Position in the #1091 plan

- ✅ **Wave 1** — Documentation (#1095)
- ✅ **Wave 2** — Static-analysis CI gate (#1096)
- ✅ **Wave 3** — Per-site fixes (**this PR**)
- ⬜ **Wave 4** — Close-read of remaining unexamined audit sites
- ⬜ **Wave 5** *(gated on Wave 4)* — Optional default-handler change

### Refs

\`Refs: #1089, #1090, #1091, #1093, #1095, #1096\`