### PR TITLE
fix: honor meos_error(ERROR, ...) contract in math/aggfuncs/datagen fall-throughs

### DIFF
--- a/meos/src/geo/tpoint_datagen.c
+++ b/meos/src/geo/tpoint_datagen.c
@@ -54,8 +54,14 @@ pt_angle(POINT2D p1, POINT2D p2, POINT2D p3)
 {
   double result, az1 = 0, az2 = 0; /* make compilier quiet */
   if (! azimuth_pt_pt(&p1, &p2, &az1) ||  ! azimuth_pt_pt(&p3, &p2, &az2))
+  {
+    /* See doc-comment on meos_error in meos/include/meos.h: handler is
+     * not guaranteed to abort. Return 0 explicitly rather than fall
+     * through with stale az1=az2=0 producing a silently-zero angle. */
     meos_error(ERROR, MEOS_ERR_INTERNAL_ERROR,
       "Cannot compute angle betwen equal points");
+    return 0.0;
+  }
   result = az2 - az1;
   result += (result < 0) * 2 * M_PI; /* we dont want negative angle */
   return result / RADIANS_PER_DEGREE;

--- a/meos/src/temporal/temporal_aggfuncs.c
+++ b/meos/src/temporal/temporal_aggfuncs.c
@@ -564,8 +564,12 @@ tsequence_tagg_iter(const TSequence *seq1, const TSequence *seq2,
         meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
           "The temporal values have different value at their common timestamp %s",
           t1);
+        pfree(t1);
+        /* Typo: the loop was freeing instants[i] (same pointer) every
+         * iteration -- a double-free on the second iteration and a leak
+         * of instants[0..i-1].  Use the loop index. */
         for (int j = 0; j < i; j++)
-          pfree(instants[i]);
+          pfree(instants[j]);
         pfree(instants);
         return -1;
       }

--- a/meos/src/temporal/tnumber_mathfuncs.c
+++ b/meos/src/temporal/tnumber_mathfuncs.c
@@ -815,11 +815,20 @@ float_ln(double d)
    * SQL standard.
    */
   if (d == 0.0)
+  {
+    /* See doc-comment on meos_error in meos/include/meos.h: handler is
+     * not guaranteed to abort. Return NaN explicitly so log(0) does not
+     * fall through and end up returning -inf as a "valid" result. */
     meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
       "cannot take logarithm of zero");
+    return get_float8_nan();
+  }
   if (d < 0)
+  {
     meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
       "cannot take logarithm of a negative number");
+    return get_float8_nan();
+  }
 
   result = log(d);
   if (unlikely(isinf(result)) && !isinf(d))
@@ -919,11 +928,20 @@ float_log10(double d)
    * same error code for an analogous error condition.
    */
   if (d == 0.0)
+  {
+    /* See doc-comment on meos_error in meos/include/meos.h: handler is
+     * not guaranteed to abort. Return NaN explicitly so log10(0) does
+     * not fall through and end up returning -inf as a "valid" result. */
     meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
       "Cannot take logarithm of zero");
+    return get_float8_nan();
+  }
   if (d < 0)
+  {
     meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
       "Cannot take logarithm of a negative number");
+    return get_float8_nan();
+  }
 
   result = log10(d);
   if (unlikely(isinf(result)) && !isinf(d))


### PR DESCRIPTION
**Wave 4** of #1091.

Five more \`meos_error(ERROR, ...)\` callsites discovered during the close-read of the static-analysis baseline (#1096). All fell through to silently-wrong arithmetic when an embedder installs a non-exiting error handler.

### Site-by-site

| File | Line | Bug class | Fix |
|---|---|---|---|
| \`tnumber_mathfuncs.c\` | 818 (\`float_ln\`, d==0) | Returns -inf silently | \`return get_float8_nan()\` |
| \`tnumber_mathfuncs.c\` | 821 (\`float_ln\`, d<0) | Returns NaN silently | \`return get_float8_nan()\` |
| \`tnumber_mathfuncs.c\` | 922, 925 (\`float_log10\`) | Same as above | Same fix |
| \`tpoint_datagen.c\` | 57 (\`pt_angle\`, equal points) | Returns 0° silently (zero-init makes az1=az2=0) | \`return 0.0\` |
| \`temporal_aggfuncs.c\` | 564 (synchronisation mismatch) | Two pre-existing bugs in same block (typo'd cleanup index + leaked \`pg_timestamptz_out\` string) | Index-fix + \`pfree(t1)\` |

The \`temporal_aggfuncs.c:564\` block had two pre-existing bugs beyond the contract violation:

\`\`\`c
for (int j = 0; j < i; j++)
  pfree(instants[i]);    // should be instants[j] -- double-free
\`\`\`

…freed \`instants[i]\` on every iteration (double-free on iter 2, leaking \`instants[0..i-1]\`). And the surrounding code never \`pfree\`'d the \`pg_timestamptz_out(...)\` result. Both fixed in the same patch.

### Builds & tests

\`\`\`text
libmeos build (cmake -DMEOS=ON):  green
PG-extension build (cmake):       green
\`\`\`

### Position in the #1091 plan

- ✅ **Wave 1** — Documentation (#1095)
- ✅ **Wave 2** — Static-analysis CI gate (#1096)
- ✅ **Wave 3** — Per-site fixes for the 4 originally-flagged audit suspects (#1097, 6 sites)
- ✅ **Wave 4** — Close-read of remaining baselined sites (**this PR**, 5 sites + 2 piggyback bugs)
- ⬜ **Wave 5** *(gated on Wave 4)* — Optional default-handler change

### Refs

\`Refs: #1089, #1090, #1091, #1093, #1095, #1096, #1097\`