### PR TITLE
meos(win32): vendor PostgreSQL dirent.{c,h} shim for native MSVC builds

### DIFF
--- a/pgtypes/CMakeLists.txt
+++ b/pgtypes/CMakeLists.txt
@@ -94,6 +94,13 @@ configure_file(pg_config.h.in pg_config.h @ONLY)
 include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/pgtypes")
 include_directories(SYSTEM "${CMAKE_BINARY_DIR}/pgtypes")
 
+# Native Windows MSVC has no <dirent.h>; put the vendored win32_msvc shim header
+# on the include path so the MEOS code that includes <dirent.h> (pgfnames.c,
+# pgtz.c, fd.c, ...) resolves it. MinGW ships its own, so this is MSVC-only.
+if(WIN32 AND MSVC)
+  include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/pgtypes/port/win32_msvc")
+endif()
+
 # When building the MobilityDB extension (MEOS=OFF) on Windows or macOS, the
 # pgtypes "frontend"-style files duplicate symbols that the postgres backend
 # already provides (palloc, pg_strncasecmp, pg_snprintf, enlargeStringInfo,

--- a/pgtypes/port/CMakeLists.txt
+++ b/pgtypes/port/CMakeLists.txt
@@ -22,6 +22,13 @@ if(NOT PGTYPES_EXT_WIN32)
   )
 endif()
 
+# Native Windows MSVC has no <dirent.h>; compile the vendored opendir/readdir/
+# closedir shim (the implementation paired with port/win32_msvc/dirent.h). The
+# .c body is itself guarded against MinGW, which ships its own <dirent.h>.
+if(WIN32)
+  list(APPEND PORT_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/dirent.c)
+endif()
+
 set(PGTYPES_SOURCES ${PGTYPES_SOURCES} ${PORT_SOURCES}
   # Mandatory so that the variable update is visible in the parent directory's scope
   PARENT_SCOPE

--- a/pgtypes/port/dirent.c
+++ b/pgtypes/port/dirent.c
@@ -1,0 +1,130 @@
+/*-------------------------------------------------------------------------
+ *
+ * dirent.c
+ *    Windows-only opendir/readdir/closedir implementation backed by
+ *    Win32 FindFirstFile/FindNextFile.  Vendored from PostgreSQL
+ *    upstream src/port/dirent.c (BSD-licensed); the same shim
+ *    PostgreSQL uses for its standalone Windows MSVC builds.
+ *
+ *    Compiled only on WIN32 + non-MinGW (MinGW provides its own
+ *    <dirent.h> implementation; this file is excluded there via the
+ *    CMakeLists.txt guard).
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#ifdef WIN32
+#ifndef __MINGW32__
+
+#include <windows.h>
+
+#include "dirent.h"
+
+struct DIR
+{
+	char	   *dirname;
+	struct dirent ret;			/* returned by readdir */
+	HANDLE		handle;
+};
+
+DIR *
+opendir(const char *dirname)
+{
+	DWORD		attr;
+	DIR		   *d;
+
+	/* Make sure it is a directory. */
+	attr = GetFileAttributes(dirname);
+	if (attr == INVALID_FILE_ATTRIBUTES)
+	{
+		errno = ENOENT;
+		return NULL;
+	}
+	if ((attr & FILE_ATTRIBUTE_DIRECTORY) == 0)
+	{
+		errno = ENOTDIR;
+		return NULL;
+	}
+
+	d = malloc(sizeof(DIR));
+	if (!d)
+	{
+		errno = ENOMEM;
+		return NULL;
+	}
+	d->dirname = malloc(strlen(dirname) + 4);	/* +3 for "\*?" + nul */
+	if (!d->dirname)
+	{
+		free(d);
+		errno = ENOMEM;
+		return NULL;
+	}
+	strcpy(d->dirname, dirname);
+	if (d->dirname[strlen(d->dirname) - 1] != '/' &&
+		d->dirname[strlen(d->dirname) - 1] != '\\')
+		strcat(d->dirname, "\\");		/* add a backslash */
+	strcat(d->dirname, "*");			/* match everything */
+
+	d->handle = INVALID_HANDLE_VALUE;
+	d->ret.d_ino = 0;					/* no inodes on Windows */
+	d->ret.d_reclen = 0;				/* not used in any current MEOS code */
+	d->ret.d_type = DT_UNKNOWN;
+
+	return d;
+}
+
+struct dirent *
+readdir(DIR *d)
+{
+	WIN32_FIND_DATA fd;
+
+	if (d->handle == INVALID_HANDLE_VALUE)
+	{
+		d->handle = FindFirstFile(d->dirname, &fd);
+		if (d->handle == INVALID_HANDLE_VALUE)
+		{
+			errno = ENOENT;
+			return NULL;
+		}
+	}
+	else
+	{
+		if (!FindNextFile(d->handle, &fd))
+		{
+			if (GetLastError() == ERROR_NO_MORE_FILES)
+			{
+				/* No error; we are simply done. */
+				errno = 0;
+				return NULL;
+			}
+
+			_dosmaperr(GetLastError());
+			return NULL;
+		}
+	}
+
+	strcpy(d->ret.d_name, fd.cFileName);	/* fd.cFileName is bounded by NAME_MAX+1 */
+	d->ret.d_namlen = (unsigned short) strlen(d->ret.d_name);
+	d->ret.d_type =
+		(fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) ? DT_DIR :
+		(fd.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) ? DT_LNK :
+		DT_REG;
+
+	return &d->ret;
+}
+
+int
+closedir(DIR *d)
+{
+	int			ret = 0;
+
+	if (d->handle != INVALID_HANDLE_VALUE)
+		ret = !FindClose(d->handle);
+	free(d->dirname);
+	free(d);
+	return ret;
+}
+
+#endif	/* !__MINGW32__ */
+#endif	/* WIN32 */


### PR DESCRIPTION
Native Windows MSVC has no `<dirent.h>`, which MEOS code such as `pgfnames.c`, `pgtz.c` and `fd.c` includes. The matching header `pgtypes/port/win32_msvc/dirent.h` is already vendored in the tree; this adds the `opendir`/`readdir`/`closedir` implementation that backs it (PostgreSQL upstream `src/port/dirent.c`, BSD-licensed) and wires it in.

- **`pgtypes/port/dirent.c`**: the vendored shim, guarded so MinGW (which ships its own `<dirent.h>`) compiles it as a no-op.
- **`pgtypes/port/CMakeLists.txt`**: compile `dirent.c` on Windows.
- **`pgtypes/CMakeLists.txt`**: put `port/win32_msvc` on the include path under MSVC so the standalone build resolves `<dirent.h>` to the vendored shim.

All Windows-gated, so non-Windows builds are unaffected (verified: the Linux MEOS + extension build is unchanged). Composes with the native-Windows bootstrap (#959).