### PR TITLE
Prefix-rename pg-vendored symbols to meos_* (host symbol collision fix)

### DIFF
--- a/pgtypes/c.h
+++ b/pgtypes/c.h
@@ -1364,7 +1364,130 @@ typedef intptr_t sigjmp_buf[5];
 #endif							/* __MINGW64__ */
 #endif							/* WIN32 */
 
-/* /port compatibility functions */
+/* port.h is included after the symbol-collision shim below so that its pg_*
+ * prototypes expand to the same meos_pg_* names as the call sites and the
+ * definitions; included before the shim, the prototypes would stay pg_* while
+ * the calls expand to meos_pg_*, an implicit declaration. */
+
+/* === MEOS pg-vendored symbol-collision shim =============================
+ *
+ * Prefix-rename pg-vendored symbols to avoid collision with host code that
+ * statically links its own copy of PostgreSQL's timestamp / timezone /
+ * port helpers (DuckDB-as-MobilityDuck-host is the motivating case).
+ *
+ * Without these defines, MEOS-internal calls like
+ *     tspatialinst_parse() -> timestamp_parse() -> pg_next_dst_boundary()
+ * can resolve to the HOST process's copies of those functions at dynamic-
+ * link time, which use a separate IANATimeZoneCache that MEOS never
+ * initialized — producing NULL-deref SIGSEGVs on the first parse of any
+ * temporal-instance literal carrying a timestamp.
+ *
+ * Compile-time rename: every MEOS .c source includes postgres.h before
+ * any pg-vendored declaration, so the #defines below cover both the
+ * function DEFINITIONS in postgres-utils, postgres-timezone, postgres-port
+ * and every internal CALL site under meos-src.  Pure-MEOS API names (the
+ * meos_-prefixed family declared in meos.h) are NOT renamed.
+ */
+#define DateTimeParseError                       meos_DateTimeParseError
+#define DecodeDateTime                           meos_DecodeDateTime
+#define DecodeISO8601Interval                    meos_DecodeISO8601Interval
+#define DecodeInterval                           meos_DecodeInterval
+#define DecodeSpecial                            meos_DecodeSpecial
+#define DecodeTimeOnly                           meos_DecodeTimeOnly
+#define DecodeTimezone                           meos_DecodeTimezone
+#define DecodeTimezoneAbbrev                     meos_DecodeTimezoneAbbrev
+#define DecodeUnits                              meos_DecodeUnits
+#define DetermineTimeZoneAbbrevOffset            meos_DetermineTimeZoneAbbrevOffset
+#define DetermineTimeZoneOffset                  meos_DetermineTimeZoneOffset
+#define EncodeDateOnly                           meos_EncodeDateOnly
+#define EncodeDateTime                           meos_EncodeDateTime
+#define EncodeInterval                           meos_EncodeInterval
+#define EncodeSpecialDate                        meos_EncodeSpecialDate
+#define EncodeSpecialTimestamp                   meos_EncodeSpecialTimestamp
+#define EncodeTimeOnly                           meos_EncodeTimeOnly
+#define GetCurrentDateTime                       meos_GetCurrentDateTime
+#define GetCurrentTimeUsec                       meos_GetCurrentTimeUsec
+#define GetCurrentTimestamp                      meos_GetCurrentTimestamp
+#define GetEpochTime                             meos_GetEpochTime
+#define ParseDateTime                            meos_ParseDateTime
+#define ReadDir                                  meos_ReadDir
+#define SetEpochTimestamp                        meos_SetEpochTimestamp
+#define ValidateDate                             meos_ValidateDate
+#define asc_initcap                              meos_asc_initcap
+#define asc_tolower                              meos_asc_tolower
+#define asc_toupper                              meos_asc_toupper
+#define date2isoweek                             meos_date2isoweek
+#define date2isoyear                             meos_date2isoyear
+#define date2isoyearday                          meos_date2isoyearday
+#define date2j                                   meos_date2j
+#define dt2time                                  meos_dt2time
+#define elog                                     meos_elog
+#define float8_cmp_internal                      meos_float8_cmp_internal
+#define float_overflow_error                     meos_float_overflow_error
+#define float_underflow_error                    meos_float_underflow_error
+#define float_zero_divide_error                  meos_float_zero_divide_error
+#define hash_bytes                               meos_hash_bytes
+#define hash_bytes_extended                      meos_hash_bytes_extended
+#define hash_bytes_uint32                        meos_hash_bytes_uint32
+#define hash_bytes_uint32_extended               meos_hash_bytes_uint32_extended
+#define interval2tm                              meos_interval2tm
+#define isoweek2date                             meos_isoweek2date
+#define isoweek2j                                meos_isoweek2j
+#define isoweekdate2date                         meos_isoweekdate2date
+#define j2date                                   meos_j2date
+#define j2day                                    meos_j2day
+#define pg_ascii_tolower                         meos_pg_ascii_tolower
+#define pg_ascii_toupper                         meos_pg_ascii_toupper
+#define pg_get_timezone_name                     meos_pg_get_timezone_name
+#define pg_get_timezone_offset                   meos_pg_get_timezone_offset
+#define pg_gmtime                                meos_pg_gmtime
+#define pg_interpret_timezone_abbrev             meos_pg_interpret_timezone_abbrev
+#define pg_interval_to_char                      meos_pg_interval_to_char
+#define pg_lltoa                                 meos_pg_lltoa
+#define pg_localtime                             meos_pg_localtime
+#define pg_ltoa                                  meos_pg_ltoa
+#define pg_next_dst_boundary                     meos_pg_next_dst_boundary
+#define pg_open_tzfile                           meos_pg_open_tzfile
+#define pg_qsort                                 meos_pg_qsort
+#define pg_qsort_strcmp                          meos_pg_qsort_strcmp
+#define pg_strcasecmp                            meos_pg_strcasecmp
+#define pg_strncasecmp                           meos_pg_strncasecmp
+#define pg_strtoint32                            meos_pg_strtoint32
+#define pg_strtoint64                            meos_pg_strtoint64
+#define pg_timestamp_to_char                     meos_pg_timestamp_to_char
+#define pg_timestamptz_to_char                   meos_pg_timestamptz_to_char
+#define pg_to_date                               meos_pg_to_date
+#define pg_to_timestamp                          meos_pg_to_timestamp
+#define pg_tolower                               meos_pg_tolower
+#define pg_toupper                               meos_pg_toupper
+#define pg_tz_acceptable                         meos_pg_tz_acceptable
+#define pg_tzset                                 meos_pg_tzset
+#define pg_tzset_offset                          meos_pg_tzset_offset
+#define pg_ulltoa_n                              meos_pg_ulltoa_n
+#define pg_ultoa_n                               meos_pg_ultoa_n
+#define pg_ultostr                               meos_pg_ultostr
+#define pg_ultostr_zeropad                       meos_pg_ultostr_zeropad
+#define pgfnames                                 meos_pgfnames
+#define pgfnames_cleanup                         meos_pgfnames_cleanup
+#define qsort_arg                                meos_qsort_arg
+#define scanner_isspace                          meos_scanner_isspace
+#define select_default_timezone                  meos_select_default_timezone
+#define string_hash                              meos_string_hash
+#define strtoint                                 meos_strtoint
+#define tag_hash                                 meos_tag_hash
+#define time2tm                                  meos_time2tm
+#define time_overflows                           meos_time_overflows
+#define timestamp2tm                             meos_timestamp2tm
+#define timestamp_cmp_internal                   meos_timestamp_cmp_internal
+#define tm2interval                              meos_tm2interval
+#define tm2time                                  meos_tm2time
+#define tm2timestamp                             meos_tm2timestamp
+#define tzload                                   meos_tzload
+#define tzparse                                  meos_tzparse
+#define uint32_hash                              meos_uint32_hash
+
+/* /port compatibility functions, included with the shim active so the pg_*
+ * prototypes match the meos_pg_* call sites and definitions */
 #include "port.h"
 
 /* IWYU pragma: end_exports */


### PR DESCRIPTION
## Prefix-rename pg-vendored symbols to `meos_*` (host symbol-collision fix)

### Problem

When MEOS is linked into a host process that already ships its own copy of PostgreSQL's vendored timestamp/timezone/port helpers, the dynamic linker resolves MEOS-internal references to the **host's** copies. The host's copies use a separate timezone catalog (e.g. DuckDB's `IANATimeZoneCache`) that MEOS never initialized via `meos_initialize_timezone(...)`, so the very first parse of any temporal-instance literal carrying a timestamp NULL-derefs in `pg_next_dst_boundary` and SIGSEGVs.

DuckDB-as-host is the motivating case: it statically links its own PostgreSQL-vendored timestamp and timezone helpers into `libduckdb.so`, so parsing an instant literal crashes uniformly on Linux amd64:

```
Thread 7 "unittest" received signal SIGSEGV, Segmentation fault.
0x00007ffff4525a59 in pg_next_dst_boundary () from libduckdb.so

#0  pg_next_dst_boundary ()                  ← from libduckdb.so
#1  DetermineTimeZoneOffsetInternal ()
#2  DecodeDateTime ()
#3  timestamp_in_common.part ()
#4  timestamp_parse ()                       ← from libduckdb.so
#5  tspatialinst_parse ()                    ← MEOS, but resolved via libduckdb.so
#6  tspatial_parse ()
#7  tpoint_parse ()
#8  tgeogpoint_in ()
```

Triggered by parsing `'Point(0 0)@2000-01-01'::TGEOGPOINT` — the timestamp portion in `tspatialinst_parse` calls `timestamp_parse`, which the linker resolves to the host's exported `timestamp_parse` (rather than MEOS's local copy). The host's `timestamp_parse → DecodeDateTime → DetermineTimeZoneOffsetInternal → pg_next_dst_boundary` then walks the host's tz table, which is null in MEOS's runtime context.

### Fix

Single-file change: append a compile-time rename shim at the end of `pgtypes/c.h` (the lowest common include for every PostgreSQL-vendored .c in MEOS). The shim `#define`s **97 colliding pg-vendored names** (`pg_next_dst_boundary`, `DecodeDateTime`, `DetermineTimeZoneOffset`, `tzload`, `pg_localtime`, `pg_gmtime`, etc.) to `meos_`-prefixed counterparts.

```c
/* === MEOS pg-vendored symbol-collision shim ============================= */
#define DateTimeParseError                       meos_DateTimeParseError
#define DecodeDateTime                           meos_DecodeDateTime
#define DecodeISO8601Interval                    meos_DecodeISO8601Interval
…
#define tzload                                   meos_tzload
#define tzparse                                  meos_tzparse
#define uint32_hash                              meos_uint32_hash
```

Every MEOS .c source includes `c.h` (via `postgres.h`), so the `#define`s cover both the function **definitions** in `pgtypes/{utils,timezone,port}/*.c` and every internal **call site** under `meos/src/**/*.c`.

**Pure-MEOS API names (the `meos_*` family already declared in `meos.h`, plus the `*_in`/`*_out`/`*_hash` family and the rest of the public surface) are NOT renamed** — only the 97 names that overlap with a stock libpgsupport / libpgcommon build.

### Derivation of the rename set

```
nm $LIBMEOS_SO | awk '$2=="T"' | sort -u > meos_globals.txt
nm $HOST_SO    | awk '$2 ~ /^[Tt]$/' | sort -u > host_globals.txt
comm -12 meos_globals.txt host_globals.txt | grep -v '^meos_' > rename_list.txt   # 97 entries
```

### Verification

- Standalone MEOS build (`cmake -DMEOS=ON`) succeeds with the full feature set under `-Werror` (including `-Werror=implicit-function-declaration`, which would flag any call site whose prototype was missed by the rename).
- `nm libmeos.so | grep -xFf rename_list.txt | wc -l` → **0**: none of the 97 colliding names remain as a defined symbol in `libmeos.so`; they are present only as their `meos_`-prefixed counterparts.

### Why this is the standard MEOS approach

MEOS already prefixes its public API as `meos_*` (declared in `meos.h`). Extending the same prefix to the pg-vendored internal helpers private-namespaces the vendored symbols — the same pattern PostgreSQL's `libpgcommon` / `libpgport` use when bundled into an external project that has its own libc / libcommon.

### Files changed

- `pgtypes/c.h` (+124 lines)