### PR TITLE
Make the ways CSV path runtime-configurable (meos_set_ways_csv)

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -390,6 +390,7 @@ extern char *meos_get_datestyle(void);
 extern char *meos_get_intervalstyle(void);
 
 extern void meos_set_spatial_ref_sys_csv(const char* path);
+extern void meos_set_ways_csv(const char* path);
 
 extern void meos_initialize(void);
 extern void meos_finalize(void);

--- a/meos/src/npoint/ways_meos.c
+++ b/meos/src/npoint/ways_meos.c
@@ -36,6 +36,7 @@
 /* C */
 #include <assert.h>
 #include <float.h>
+#include <string.h>
 /* PostgreSQL */
 #include <postgres.h>
 /* PostGIS */
@@ -53,9 +54,24 @@
 /* Maximum length in characters of a geometry string in the input data */
 #define MAX_LEN_GEOM 100001
 
-/* Location of the ways CSV file */
-// #define WAYS_CSV "/usr/local/share/ways.csv"
-#define WAYS_CSV "/usr/local/share/ways1000.csv"
+/* Default location of the ways CSV file. Overridable at run time with
+ * `meos_set_ways_csv()`, mirroring `meos_set_spatial_ref_sys_csv()`. This
+ * lets MEOS embedders (which cannot rely on a fixed install prefix) point
+ * at a deployment-specific network file. */
+char *WAYS_CSV = "/usr/local/share/ways1000.csv";
+
+/**
+ * @ingroup meos_setup
+ * @brief Set the location of the ways CSV file used to resolve npoint route
+ * geometries
+ * @param[in] path Full path to the ways CSV file
+ */
+void
+meos_set_ways_csv(const char *path)
+{
+  WAYS_CSV = malloc(strlen(path) + 1);
+  strcpy(WAYS_CSV, path);
+}
 
 /**
  * @brief Structure to represent a record in the ways CSV file
@@ -240,7 +256,8 @@ get_ways_record(int64 rid, ways_record *rec)
   if (! file)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
-      "Cannot open the ways CSV file");
+      "Cannot open the ways CSV file (reading from %s); set its location with "
+      "meos_set_ways_csv()", WAYS_CSV);
     return false;
   }
 
@@ -394,7 +411,8 @@ geompoint_to_npoint(const GSERIALIZED *gs)
   if (! file)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
-      "Cannot open the ways CSV file");
+      "Cannot open the ways CSV file (reading from %s); set its location with "
+      "meos_set_ways_csv()", WAYS_CSV);
     return NULL;
   }
 


### PR DESCRIPTION
## Summary

Makes the MEOS ways-network CSV location runtime-configurable, mirroring
the existing `meos_set_spatial_ref_sys_csv()`. The path was a hardcoded
compile-time `#define WAYS_CSV "/usr/local/share/ways1000.csv"`, which is
a foot-gun for any MEOS *embedder* that cannot rely on a fixed install
prefix — e.g. a stream engine that statically links libmeos and resolves
`tnpoint` route geometries at run time.

## Change

- `meos/src/npoint/ways_meos.c`: `#define WAYS_CSV …` → a mutable global
  `char *WAYS_CSV = "/usr/local/share/ways1000.csv"` plus a setter
  `meos_set_ways_csv(const char *path)`. Identical shape to
  `SPATIAL_REF_SYS_CSV` / `meos_set_spatial_ref_sys_csv()` in
  `tspatial_transform_meos.c`.
- `meos/include/meos.h`: declare `meos_set_ways_csv()` next to its sibling.
- The "Cannot open the ways CSV file" error now reports the path it tried
  and names the setter — previously the failure gave no hint where it was
  looking, which made it hard to diagnose in embedded use.

Default behaviour is unchanged (same default path); existing callers and
the PostgreSQL extension (which uses `ways.c`, not `ways_meos.c`) are
unaffected.

## Motivation

Encountered while bringing `tnpoint` spatial relationships to a streaming
engine that embeds libmeos: `tnpoint_to_tgeompoint()` aborted with
`Cannot open the ways CSV file` because the engine's image has no
`/usr/local/share/ways1000.csv` and no way to point MEOS elsewhere. With
this setter the embedder calls `meos_set_ways_csv("/path/to/network.csv")`
once at init. Complements the data-portability direction in the
[npoint-portability RFC (#863)](https://github.com/MobilityDB/MobilityDB/discussions/863).

## Verification

- libmeos (`-DMEOS=ON`) builds and links clean.
- PostgreSQL extension (`-DMEOS=OFF`) builds clean (declaration only;
  no behavioural change to the extension).
