### PR TITLE
Add the cross-type parity audit harness under tools/parity_audit/

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -28,3 +28,4 @@ exclude_paths:
   - "pgtypes/**"
   - "meos/test/**"
   - "meos/examples/**"
+  - "tools/parity_audit/**"

--- a/tools/parity_audit/README.md
+++ b/tools/parity_audit/README.md
@@ -1,0 +1,71 @@
+<!--
+Copyright(c) MobilityDB Contributors
+
+This documentation is licensed under a
+Creative Commons Attribution-Share Alike 3.0 License
+https://creativecommons.org/licenses/by-sa/3.0/
+-->
+
+# Cross-type parity audit harness
+
+Measures **cross-type parity** — whether a function defined for one temporal
+spatial type is also defined for the others wherever it makes sense — and
+reports the result as a coverage matrix plus a reason-marked exception/gap
+register. The model is defined in
+[`doc/methodology/cross_type_parity.md`](../../doc/methodology/cross_type_parity.md).
+
+The point is to **measure parity, not assert it**: a function counts as covered
+only when it is actually present, never because a wrapper or alias names it.
+
+## What it computes
+
+Each temporal spatial type is measured against its **family reference**
+(Point → `tgeompoint`; Extended-shape → `tgeometry`): a member is expected to
+cover the reference's operators **minus** that type's documented exceptions.
+Absences are split into three reason-marked buckets so none is ever
+"implemented" by mistake:
+
+1. **Semantic** — the operation is formally meaningless for the type.
+2. **Structural** — the operation cannot be supported due to a
+   representation / underlying-library limit (e.g. PostGIS circular segments
+   are planar-2D, so there is no geodetic `tcbuffer`).
+3. **Real gap** — methodology-expected, genuinely missing → fix it.
+
+The exception reasons are kept in step with the methodology doc's
+*Intentional Exclusions* section.
+
+## Usage
+
+The core (`parity_audit.py`) is platform-agnostic: it consumes a TSV of
+`(operator<TAB>first-arg-type[<TAB>…])` rows produced by a per-platform
+**adapter**, and prints the matrix + the three sections.
+
+```bash
+# MobilityDB (PostgreSQL): query the live catalog of the build under test
+psql -d <db> -At -F $'\t' -f tools/parity_audit/adapters/mobilitydb.sql \
+  > /tmp/funcs.tsv
+python3 tools/parity_audit/parity_audit.py /tmp/funcs.tsv
+
+# compare two builds (e.g. baseline vs accumulated) — prints a Δ column
+python3 tools/parity_audit/parity_audit.py accumulated.tsv baseline.tsv
+```
+
+## Adapters (one per platform — same core)
+
+Only the step that produces the `(operator, receiver-type)` pairs changes; the
+diff engine is shared, so every platform is measured the same way.
+
+| Platform | Adapter source of `(op, type)` pairs |
+|---|---|
+| MobilityDB | `pg_proc` over extension-owned functions (`adapters/mobilitydb.sql`) |
+| MobilityDuck | `duckdb_functions()` |
+| MobilitySpark | the registered-UDF catalog |
+| MEOS / FFI bindings | `nm -D` on the pinned library + signature parse |
+
+## The full backing gate (before claiming "covered")
+
+This harness measures the **registration/exposure** layer. A function is only
+truly *backed* when, in addition, its MEOS symbol is exported in the pinned
+library (`nm -D --defined-only <lib> | grep " T <fn>$"`) and a test exercises
+it. Registration ≠ backing; a symbol present but unregistered is still not
+callable. Measure both layers.

--- a/tools/parity_audit/adapters/mobilitydb.sql
+++ b/tools/parity_audit/adapters/mobilitydb.sql
@@ -1,0 +1,21 @@
+-- MobilityDB adapter for the cross-type parity harness.
+--
+-- Emits one TSV row per (operator, first-arg type) over the functions owned by
+-- the mobilitydb extension. First arg = the receiver, per the MEOS name-prefix
+-- object model. Pipe the output to parity_audit.py:
+--
+--   psql -d <db> -At -F $'\t' -f tools/parity_audit/adapters/mobilitydb.sql \
+--     > /tmp/mobilitydb_funcs.tsv
+--   python3 tools/parity_audit/parity_audit.py /tmp/mobilitydb_funcs.tsv
+--
+-- Run against a database with the build under test installed
+-- (CREATE EXTENSION mobilitydb CASCADE).
+
+SELECT p.proname,
+       COALESCE((p.proargtypes[0])::regtype::text, ''),
+       pg_get_function_arguments(p.oid),
+       pg_get_function_result(p.oid)
+FROM pg_proc p
+JOIN pg_depend d ON d.objid = p.oid AND d.deptype = 'e'
+JOIN pg_extension e ON e.oid = d.refobjid AND e.extname = 'mobilitydb'
+ORDER BY 1, 2;

--- a/tools/parity_audit/parity_audit.py
+++ b/tools/parity_audit/parity_audit.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Parity-audit harness — TRUE parity with REASON-MARKED exceptions (3 buckets).
+
+Per user directives (2026-05-22): cross-type absences are one of:
+  1. SEMANTIC exclusion  — op formally meaningless for the type
+  2. STRUCTURAL exclusion — op unsupported due to a library/representation limit
+  3. REAL gap            — methodology-expected, genuinely missing => implement
+Exceptions are reason-marked so no future session implements a non-gap. Reasons
+track doc/methodology/cross_type_parity.md §Intentional Exclusions (PR #1002).
+
+Platform-agnostic core: consumes (op, first-arg-type) pairs from any adapter.
+Usage: parity_audit.py <pairs.tsv> [baseline.tsv]
+"""
+from __future__ import annotations
+import re
+import sys
+from collections import defaultdict
+
+FAMILIES = {
+    "Point":          ("tgeompoint", ["tgeogpoint", "tnpoint"]),
+    "Extended-shape": ("tgeometry",  ["trgeometry", "tcbuffer", "tpose"]),
+}
+TEMPORAL_TYPES = {"tgeompoint", "tgeogpoint", "tnpoint", "tgeometry",
+                  "tgeography", "trgeometry", "tcbuffer", "tpose",
+                  "tint", "tfloat", "tbool", "ttext"}
+
+AFFINE = {"affine", "rotate", "rotatex", "rotatey", "rotatez",
+          "translate", "transscale", "scale"}
+SIMILARITY = {"frechetdistance", "dynamictimewarp", "dyntimewarpdistance",
+              "dyntimewarppath", "frechetdistancepath"}
+SWEPT = {"traversedarea", "convexhull", "centroid"}
+POSITION = {"temporal_left", "temporal_right", "temporal_above", "temporal_below",
+            "temporal_front", "temporal_back", "temporal_overleft",
+            "temporal_overright", "temporal_overabove", "temporal_overbelow",
+            "temporal_overfront", "temporal_overback"}
+# DE-9IM relate-based predicates: GEOS planar-only, PostGIS geography lacks
+# ST_Touches/ST_Contains/ST_Relate => undefined for geodetic types.
+RELATE = {"etouches", "atouches", "ttouches", "econtains", "acontains",
+          "tcontains", "ecovers", "acovers", "tcovers"}
+
+# Per-op exclusion rules: (types, ops, category, reason).
+RULES = [
+    (["trgeometry", "tcbuffer", "tnpoint", "tpose"], AFFINE, "semantic",
+     "affine transform bypasses the type invariant (rigid pose / center+radius / route+fraction)"),
+    (["trgeometry", "tcbuffer", "tpose"], SIMILARITY, "semantic",
+     "trajectory similarity (Frechet/DTW) is undefined outside the point family"),
+    (["tpose"], SWEPT, "semantic",
+     "tpose carries no shape, so there is nothing to sweep"),
+    (["tnpoint"], {"atgeometry", "minusgeometry"}, "semantic",
+     "a network point is constrained to a 1-D edge; use route filtering"),
+    (["tgeogpoint", "tnpoint"], SWEPT, "semantic",
+     "a point's continuous form collapses to trajectory()/stbox()"),
+    (["tgeogpoint"], AFFINE, "structural",
+     "affine transforms have no action on geodetic points"),
+    (["tgeogpoint"], POSITION, "structural",
+     "planar relative-position operators (<<,>>,&<) are undefined on the sphere"),
+    (["tgeogpoint"], {"atgeometry", "minusgeometry", "geometry"}, "structural",
+     "geodetic type uses the geography variants, not the planar geometry ones"),
+    (["tgeogpoint"], RELATE, "structural",
+     "touches/contains/covers use the GEOS DE-9IM relate matrix (planar-only); "
+     "PostGIS geography has no ST_Touches/ST_Contains/ST_Relate"),
+]
+
+# Type-level structural facts (documentation; not tied to one op name).
+TYPE_STRUCTURAL = {
+    "tcbuffer": "planar-2D only, NO geodetic/geography variant — all PostGIS "
+                "operations on circular segments are planar-2D",
+    "tgeometry": "linear interpolation unsupported (discrete/step only) — "
+                 "otherwise there would need to be a 'morphing' function that "
+                 "interpolates between two arbitrary geometries at two "
+                 "timestamps, which does not exist",
+    "tgeography": "linear interpolation unsupported (discrete/step only) — same "
+                  "no-morphing-function limitation as tgeometry, plus geodetic",
+}
+
+ALIASES = {"tgeo_teq": "temporal_teq", "tgeo_tne": "temporal_tne"}
+_CONSTRUCTOR = re.compile(r"^t\w+(inst|seq|seqset)$")
+
+
+def is_noise(op):
+    """True for internal helpers and cross-type casts/constructors (a different
+    facet that should not count as an operator in the parity matrix)."""
+    return op.startswith("_") or op in TEMPORAL_TYPES or bool(_CONSTRUCTOR.match(op))
+
+
+def excl_for(t):
+    """Return {op: (category, reason)} of all exclusions that apply to type ``t``."""
+    out = {}
+    for types, ops, cat, reason in RULES:
+        if t in types:
+            for op in ops:
+                out[op] = (cat, reason)
+    return out
+
+
+def load(path):
+    """Load (op, first-arg-type) pairs from an adapter TSV into {op: {types}}."""
+    op2types = defaultdict(set)
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            p = line.rstrip("\n").split("\t")
+            if len(p) >= 2 and p[1]:
+                op = ALIASES.get(p[0], p[0])
+                if not is_noise(op):
+                    op2types[op].add(p[1])
+    return op2types
+
+
+def report(path):
+    """Compute per-type coverage vs the family reference, with reason-marked
+    semantic/structural exclusions, from the adapter TSV at ``path``."""
+    op2types = load(path)
+    res = {}
+    for fam, (ref, members) in FAMILIES.items():
+        ref_ops = {op for op, ts in op2types.items() if ref in ts}
+        for m in members:
+            ex = excl_for(m)
+            expected = {op for op in ref_ops if op not in ex}
+            present = {op for op in expected if m in op2types[op]}
+            res[m] = {
+                "fam": fam, "present": len(present), "expected": len(expected),
+                "gaps": sorted(expected - present),
+                "sem": sorted((o, ex[o][1]) for o in ref_ops
+                              if ex.get(o, ("",))[0] == "semantic"),
+                "struct": sorted((o, ex[o][1]) for o in ref_ops
+                                 if ex.get(o, ("",))[0] == "structural")}
+    return res
+
+
+def main(path, baseline=None):
+    """Print the parity matrix and the three reason-marked exclusion sections."""
+    res = report(path)
+    base = report(baseline) if baseline else None
+    print("# TRUE cross-type parity (reason-marked exceptions)\n")
+    print("| family | type | present/expected | TRUE parity |" + (" Δ |" if base else ""))
+    print("|---|---|---|---|" + ("---|" if base else ""))
+
+    def pct_of(r):
+        return 100 * r["present"] / r["expected"] if r["expected"] else 0.0
+    for m, r in res.items():
+        pct = pct_of(r)
+        d = f" {pct - pct_of(base[m]):+.1f} |" if base else ""
+        print(f"| {r['fam']} | {m} | {r['present']}/{r['expected']} | {pct:.1f}% |{d}")
+
+    print("\n## Semantic exclusions — formally meaningless, do NOT implement\n")
+    for m, r in res.items():
+        for op, reason in r["sem"]:
+            print(f"- `{op}` on **{m}** — {reason}")
+    print("\n## Structural exclusions — library/representation-limited, do NOT implement\n")
+    for t, note in TYPE_STRUCTURAL.items():
+        print(f"- **{t}** (type-level) — {note}")
+    for m, r in res.items():
+        for op, reason in r["struct"]:
+            print(f"- `{op}` on **{m}** — {reason}")
+    print("\n## Real gaps — methodology-expected, genuinely missing (implement)\n")
+    for m, r in res.items():
+        if r["gaps"]:
+            print(f"- **{m}** ({len(r['gaps'])}): {', '.join(r['gaps'][:30])}"
+                  + (" …" if len(r["gaps"]) > 30 else ""))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1], sys.argv[2] if len(sys.argv) > 2 else None)


### PR DESCRIPTION
Adds `tools/parity_audit/`, a platform-agnostic harness that **measures** cross-type parity (per `doc/methodology/cross_type_parity.md`) instead of asserting it.

It consumes `(operator, receiver-type)` pairs from a per-platform adapter and reports the coverage matrix plus three reason-marked sections — **semantic** exclusions, **structural** exclusions, and **real gaps** — so a measured parity number is produced and no by-design exception (affine on structured types; no geodetic `tcbuffer`; no linear interpolation for `tgeometry`/`tgeography`; geodetic touches/contains/covers; …) is mistaken for a gap.

Contents:
- `parity_audit.py` — the platform-agnostic core (family-reference model: Point→`tgeompoint`, Extended-shape→`tgeometry`; reason-marked exception buckets). An optional second argument diffs two builds.
- `adapters/mobilitydb.sql` — the MobilityDB `pg_proc` adapter; the same core takes DuckDB / Spark / `nm -D` adapters.
- `README.md` — usage, the per-tool adapter pattern, and the full backing gate (symbol + registration + test).

Complements the cross-type parity methodology doc: the doc defines the model, this measures against it.