### PR TITLE
Fix max(geometry) misuse in the tpose table accessor test

### DIFF
--- a/mobilitydb/test/pose/expected/100_pose_tbl.test.out
+++ b/mobilitydb/test/pose/expected/100_pose_tbl.test.out
@@ -15,10 +15,10 @@ SELECT COUNT(*) FROM tbl_pose2d t1, tbl_pose2d_tmp t2 WHERE t1.k = t2.k AND t1.p
 
 DROP TABLE tbl_pose2d_tmp;
 DROP TABLE
-SELECT ST_AsEWKT(MAX(point(pose)), 6) FROM tbl_pose2d;
-               st_asewkt               
----------------------------------------
- SRID=3812;POINT(81.228497 -58.175254)
+SELECT MAX(ST_X(point(pose))) FROM tbl_pose2d;
+        max        
+-------------------
+ 99.29531615669725
 (1 row)
 
 SELECT MAX(rotation(pose)) FROM tbl_pose2d;

--- a/mobilitydb/test/pose/queries/100_pose_tbl.test.sql
+++ b/mobilitydb/test/pose/queries/100_pose_tbl.test.sql
@@ -42,7 +42,7 @@ DROP TABLE tbl_pose2d_tmp;
 -- Accessing values
 -------------------------------------------------------------------------------
 
-SELECT ST_AsEWKT(MAX(point(pose)), 6) FROM tbl_pose2d;
+SELECT MAX(ST_X(point(pose))) FROM tbl_pose2d;
 SELECT MAX(rotation(pose)) FROM tbl_pose2d;
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
`mobilitydb/test/pose/queries/100_pose_tbl.test.sql` applied `MAX` directly to `point(pose)`, a `geometry`. No `max(geometry)` aggregate exists (in MobilityDB on any branch, or in PostGIS), and `geometry` implicitly casts to both `text` and `bytea`, so the call is ambiguous:

```
ERROR:  function max(geometry) is not unique
```

### Root cause
The query was adapted from the structurally identical cbuffer test `150_cbuffer_tbl.test.sql` (cbuffer = point + radius; pose = point + rotation), whose point accessor is wrapped in `ST_X` before aggregation:

```sql
SELECT MAX(ST_X(point(cb))) FROM tbl_cbuffer;   -- aggregates a double
SELECT MAX(radius(cb)) FROM tbl_cbuffer;
```

In the pose adaptation the inner `ST_X(...)` wrap was dropped and replaced by an outer `ST_AsEWKT(...)`, leaving `MAX` over a raw geometry. The committed expected (`SRID=3812;POINT(81.228497 …)`) was merely PostGIS's btree-order maximum — note its x (81.23) is not even the spatial maximum x (99.30) the test intended.

### Fix
Restore the cbuffer idiom and aggregate the point's x-coordinate, mirroring the adjacent `MAX(rotation(pose))` ↔ cbuffer's `MAX(radius(cb))`:

```sql
SELECT MAX(ST_X(point(pose))) FROM tbl_pose2d;   -- 99.29531615669725
```

Expected output regenerated; the only change vs the prior expected is that single line's block. Test-only change, no code.

### Verification
`MAX(ST_X(point(pose)))` runs clean and the regenerated expected matches; the rest of `100_pose_tbl` is unchanged.