### PR TITLE
Expose super_union_span_span in the public MEOS API

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -1030,6 +1030,7 @@ extern SpanSet *union_span_date(const Span *s, DateADT d);
 extern SpanSet *union_span_float(const Span *s, double d);
 extern SpanSet *union_span_int(const Span *s, int i);
 extern SpanSet *union_span_span(const Span *s1, const Span *s2);
+extern Span *super_union_span_span(const Span *s1, const Span *s2);
 extern SpanSet *union_span_spanset(const Span *s, const SpanSet *ss);
 extern SpanSet *union_span_timestamptz(const Span *s, TimestampTz t);
 extern SpanSet *union_spanset_bigint(const SpanSet *ss, int64 i);

--- a/meos/include/meos_internal.h
+++ b/meos/include/meos_internal.h
@@ -930,7 +930,6 @@ extern SpanSet *minus_spanset_value(const SpanSet *ss, Datum value);
 extern Set *minus_value_set(Datum value, const Set *s);
 extern SpanSet *minus_value_span(Datum value, const Span *s);
 extern SpanSet *minus_value_spanset(Datum value, const SpanSet *ss);
-extern Span *super_union_span_span(const Span *s1, const Span *s2);
 extern Set *union_set_value(const Set *s, Datum value);
 extern SpanSet *union_span_value(const Span *s, Datum value);
 extern SpanSet *union_spanset_value(const SpanSet *ss, Datum value);


### PR DESCRIPTION
Exposes `super_union_span_span` in the public `meos.h` (typed `Span` arguments, no `Datum`), the span analog of `union_tbox_tbox` and `union_stbox_stbox`. It returns the bounding span of two spans, so bindings call it directly instead of re-composing `spanset_span(union_span_span(...))`.

It takes a `strict` argument uniform with the box unions: `strict=true` raises an error when the spans are not contiguous; `strict=false` returns the bounding span spanning any gap. Internal callers (GiST split, span extent aggregate combine) pass `strict=false`. The `super_` prefix distinguishes this bounding union (-> `Span`) from the set union `union_span_span`, which returns a `SpanSet`.

Part of the cross-type parity completion; integrated build+test evidence = accumulate (fork PR #22).