### PR TITLE
Add extent(tpose) and timeTiles(tgeogpoint)

### DIFF
--- a/mobilitydb/sql/geo/058_tpoint_tile.in.sql
+++ b/mobilitydb/sql/geo/058_tpoint_tile.in.sql
@@ -109,6 +109,11 @@ CREATE FUNCTION timeTiles(tgeompoint, duration interval,
   RETURNS SETOF index_stbox
   AS 'SELECT @extschema@.timeTiles(@extschema@.stbox($1), $2, $3, $4)'
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION timeTiles(tgeogpoint, duration interval,
+  torigin timestamptz DEFAULT '2000-01-03', borderInc boolean DEFAULT TRUE)
+  RETURNS SETOF index_stbox
+  AS 'SELECT @extschema@.timeTiles(@extschema@.stbox($1), $2, $3, $4)'
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION spaceTimeTiles(tgeompoint, xsize float, ysize float,
   zsize float, duration interval, sorigin geometry DEFAULT 'Point(0 0 0)',

--- a/mobilitydb/sql/pose/111_tpose_aggfuncs.in.sql
+++ b/mobilitydb/sql/pose/111_tpose_aggfuncs.in.sql
@@ -48,6 +48,17 @@ CREATE AGGREGATE tcount(tpose) (
   PARALLEL = SAFE
 );
 
+CREATE FUNCTION tspatial_extent_transfn(stbox, tpose)
+  RETURNS stbox
+  AS 'MODULE_PATHNAME', 'Tspatial_extent_transfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+CREATE AGGREGATE extent(tpose) (
+  SFUNC = tspatial_extent_transfn,
+  STYPE = stbox,
+  COMBINEFUNC = stbox_extent_combinefn,
+  PARALLEL = safe
+);
+
 -- The function is not strict
 CREATE FUNCTION wcount_transfn(internal, tpose, interval)
   RETURNS internal


### PR DESCRIPTION
Closes two cross-type gaps:

- `extent(tpose)`: the spatial bounding-box aggregate, via the generic `tspatial_extent_transfn` used by every other spatial temporal type.
- `timeTiles(tgeogpoint)`: pure-time tiling through the stbox, mirroring the existing `timeTiles(tgeompoint)` definition. Only the time tiling applies to geodetic points; the planar space tiling stays a reason-marked exclusion.

This brings tgeogpoint to 100% on the cross-type surface and closes the tpose extent gap.

Part of the cross-type parity completion; integrated build+test evidence = accumulate (fork PR #22).