### PR TITLE
Propagate tsample to tnpoint, tpose, and tcbuffer

### DIFF
--- a/mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
+++ b/mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
@@ -441,6 +441,12 @@ CREATE FUNCTION round(tcbuffer[], integer DEFAULT 0)
   AS 'MODULE_PATHNAME', 'Temporalarr_round'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION tsample(tcbuffer, duration interval,
+  origin timestamptz DEFAULT '2000-01-03', interp text DEFAULT 'discrete')
+  RETURNS tcbuffer
+  AS 'MODULE_PATHNAME', 'Temporal_tsample'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE FUNCTION shiftTime(tcbuffer, interval)
   RETURNS tcbuffer
   AS 'MODULE_PATHNAME', 'Temporal_shift_time'

--- a/mobilitydb/sql/npoint/302_tnpoint.in.sql
+++ b/mobilitydb/sql/npoint/302_tnpoint.in.sql
@@ -213,6 +213,12 @@ CREATE FUNCTION round(tnpoint[], integer DEFAULT 0)
   AS 'MODULE_PATHNAME', 'Temporalarr_round'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION tsample(tnpoint, duration interval,
+  origin timestamptz DEFAULT '2000-01-03', interp text DEFAULT 'discrete')
+  RETURNS tnpoint
+  AS 'MODULE_PATHNAME', 'Temporal_tsample'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 /******************************************************************************
  * Append functions
  ******************************************************************************/

--- a/mobilitydb/sql/pose/102_tpose.in.sql
+++ b/mobilitydb/sql/pose/102_tpose.in.sql
@@ -426,6 +426,12 @@ CREATE FUNCTION round(tpose[], integer DEFAULT 0)
   AS 'MODULE_PATHNAME', 'Temporalarr_round'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION tsample(tpose, duration interval,
+  origin timestamptz DEFAULT '2000-01-03', interp text DEFAULT 'discrete')
+  RETURNS tpose
+  AS 'MODULE_PATHNAME', 'Temporal_tsample'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE FUNCTION shiftTime(tpose, interval)
   RETURNS tpose
   AS 'MODULE_PATHNAME', 'Temporal_shift_time'


### PR DESCRIPTION
`tsample` (temporal resampling at regular bins) is backed by the type-generic `Temporal_tsample`, which resamples via value-at-timestamp with no per-type averaging, so it applies unchanged to every temporal type.

Binds it for tnpoint, tpose, and tcbuffer (it was already defined for tgeompoint/tgeogpoint/tgeometry/trgeometry), closing that cross-type gap. `tsample(tpose)`/`tsample(tcbuffer)` return correctly interpolated samples; `tsample(tnpoint)` resamples the network position.

Coordinate merge order with the open trgeo PR #820.

Part of the cross-type parity completion; integrated build+test evidence = accumulate (fork PR #22).