### PR TITLE
[comment-only] MEOS Doxygen/SQL comment cleanup: parameter nullability + @csqlfn de-tagging

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -3556,7 +3556,7 @@ geo_from_geojson(const char *geojson)
  * @param[in] gs Geometry/geography
  * @param[in] option Option
  * @param[in] precision Maximum number of decimal digits
- * @param[in] srs Spatial reference system
+ * @param[in] srs Spatial reference system, may be `NULL`
  * @note PostGIS function: @p LWGEOM_asGeoJson(PG_FUNCTION_ARGS)
  */
 char *

--- a/meos/src/geo/tgeo_aggfuncs.c
+++ b/meos/src/geo/tgeo_aggfuncs.c
@@ -203,7 +203,7 @@ tpoint_transform_tcentroid(const Temporal *temp, int *count)
  * @ingroup meos_geo_agg
  * @brief Transition function for temporal centroid aggregation of temporal
  * points
- * @param[in] state Current aggregate value
+ * @param[in] state Current aggregate value, may be `NULL`
  * @param[in] temp Temporal point
  * @csqlfn #Tpoint_tcentroid_transfn()
  */
@@ -247,8 +247,8 @@ tpoint_tcentroid_transfn(SkipList *state, Temporal *temp)
  * @ingroup meos_geo_agg
  * @brief Transition function for temporal extent aggregation of spatiotemporal
  * values
- * @param[in] state Current aggregate value
- * @param[in] temp Spatiotemporal value
+ * @param[in] state Current aggregate value, may be `NULL`
+ * @param[in] temp Spatiotemporal value, may be `NULL`
  * @csqlfn #Tspatial_extent_transfn()
  */
 STBox *
@@ -366,7 +366,7 @@ tpointseq_tcentroid_finalfn(TSequence **sequences, int count, int32_t srid)
 /**
  * @ingroup meos_geo_agg
  * @brief Final function for temporal centroid aggregation of temporal points
- * @param[in] state Current aggregate value
+ * @param[in] state Current aggregate value, may be `NULL`
  * @csqlfn #Tpoint_tcentroid_finalfn()
  */
 Temporal *

--- a/meos/src/geo/tgeo_spatialfuncs.c
+++ b/meos/src/geo/tgeo_spatialfuncs.c
@@ -1482,7 +1482,7 @@ tgeoseqset_scale(const TSequenceSet *ss, const POINT4D *factors)
  * @brief Scale a temporal geo by given factors
  * @param[in] temp Temporal geo
  * @param[in] scale Geometry for the scale factors
- * @param[in] sorigin Point geometry for the origin
+ * @param[in] sorigin Point geometry for the origin, may be `NULL`
  * @csqlfn #Tgeo_scale()
  */
 Temporal *

--- a/meos/src/npoint/tnpoint_aggfuncs.c
+++ b/meos/src/npoint/tnpoint_aggfuncs.c
@@ -51,7 +51,7 @@
  * @ingroup meos_npoint_agg
  * @brief Transition function for temporal centroid aggregation of temporal
  * network points
- * @param[in] state Current aggregate value
+ * @param[in] state Current aggregate value, may be `NULL`
  * @param[in] temp Temporal network point
  * @csqlfn #Tnpoint_tcentroid_transfn()
  */

--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -1299,7 +1299,7 @@ trgeo_after_timestamptz(const Temporal *temp, TimestampTz t, bool atfunc)
  * @param[in] inst Temporal instant
  * @param[in] interp Interpolation
  * @param[in] maxdist Maximum distance for defining a gap
- * @param[in] maxt Maximum time interval for defining a gap
+ * @param[in] maxt Maximum time interval for defining a gap, may be `NULL`
  * @param[in] expand True when reserving space for additional instants
  * @csqlfn #Temporal_append_tinstant()
  * @return When the temporal value passed as first argument has space for 

--- a/meos/src/rgeo/trgeo_seqset.c
+++ b/meos/src/rgeo/trgeo_seqset.c
@@ -305,7 +305,7 @@ trgeoseqset_make_valid_gaps(const GSERIALIZED *geom, TInstant **instants,
  * @param[in] count Number of elements in the array
  * @param[in] interp Interpolation
  * @param[in] maxdist Maximum distance for defining a gap
- * @param[in] maxt Maximum time interval for defining a gap
+ * @param[in] maxt Maximum time interval for defining a gap, may be `NULL`
  * @sqlfn tint_seqset_gaps(), tfloat_seqset_gaps(),
  * tgeompoint_seqset_gaps(), tgeogpoint_seqset_gaps()
  */

--- a/meos/src/temporal/set.c
+++ b/meos/src/temporal/set.c
@@ -461,7 +461,6 @@ set_make_exp(const Datum *values, int count, int maxcount, MeosType basetype,
  * @param[in] basetype Type of the values
  * @param[in] order True when the values should be ordered and duplicates
  * should be removed
- * @csqlfn #Set_constructor()
  */
 Set *
 set_make(const Datum *values, int count, MeosType basetype, bool order)
@@ -518,7 +517,6 @@ set_copy(const Set *s)
  * @brief Convert a value into a set
  * @param[in] value Value
  * @param[in] basetype Type of the value
- * @csqlfn #Value_to_set()
  */
 Set *
 value_set(Datum value, MeosType basetype)
@@ -669,7 +667,6 @@ set_end_value(const Set *s)
  * @param[in] n Number (1-based)
  * @param[out] result Value
  * @return Return true if the value is found
- * @csqlfn #Set_value_n()
  */
 bool
 set_value_n(const Set *s, int n, Datum *result)

--- a/meos/src/temporal/span.c
+++ b/meos/src/temporal/span.c
@@ -1303,7 +1303,6 @@ tstzspan_shift_scale1(Span *s, const Interval *shift, const Interval *duration,
  * @param[in] width Width of the result
  * @param[in] hasshift True when the shift argument is given
  * @param[in] haswidth True when the width argument is given
- * @csqlfn #Numspan_shift(), #Numspan_scale(), #Numspan_shift_scale()
  */
 Span *
 numspan_shift_scale(const Span *s, Datum shift, Datum width, bool hasshift,

--- a/meos/src/temporal/span_aggfuncs.c
+++ b/meos/src/temporal/span_aggfuncs.c
@@ -50,7 +50,7 @@
 /**
  * @ingroup meos_internal_setspan_agg
  * @brief Transition function for span extent aggregate of values
- * @param[in,out] state Current aggregate state
+ * @param[in,out] state Current aggregate state, may be `NULL`
  * @param[in] value Value to aggregate
  * @param[in] basetype Type of the value
  */
@@ -70,8 +70,8 @@ spanbase_extent_transfn(Span *state, Datum value, MeosType basetype)
 /**
  * @ingroup meos_setspan_agg
  * @brief Transition function for span extent aggregate of sets
- * @param[in,out] state Current aggregate state
- * @param[in] s Set to aggregate
+ * @param[in,out] state Current aggregate state, may be `NULL`
+ * @param[in] s Set to aggregate, may be `NULL`
  */
 Span *
 set_extent_transfn(Span *state, const Set *s)
@@ -100,8 +100,8 @@ set_extent_transfn(Span *state, const Set *s)
 /**
  * @ingroup meos_setspan_agg
  * @brief Transition function for span extent aggregate of spans
- * @param[in,out] state Current aggregate state
- * @param[in] s Span to aggregate
+ * @param[in,out] state Current aggregate state, may be `NULL`
+ * @param[in] s Span to aggregate, may be `NULL`
  */
 Span *
 span_extent_transfn(Span *state, const Span *s)
@@ -127,8 +127,8 @@ span_extent_transfn(Span *state, const Span *s)
 /**
  * @ingroup meos_setspan_agg
  * @brief Transition function for span extent aggregate of span sets
- * @param[in,out] state Current aggregate state
- * @param[in] ss Span set to aggregate
+ * @param[in,out] state Current aggregate state, may be `NULL`
+ * @param[in] ss Span set to aggregate, may be `NULL`
  */
 Span *
 spanset_extent_transfn(Span *state, const SpanSet *ss)

--- a/meos/src/temporal/span_aggfuncs_meos.c
+++ b/meos/src/temporal/span_aggfuncs_meos.c
@@ -49,7 +49,7 @@
 /**
  * @ingroup meos_setspan_agg
  * @brief Transition function for span extent aggregate of integers
- * @param[in,out] state Current aggregate state
+ * @param[in,out] state Current aggregate state, may be `NULL`
  * @param[in] i Value to aggregate
  */
 Span *
@@ -64,7 +64,7 @@ int_extent_transfn(Span *state, int i)
 /**
  * @ingroup meos_setspan_agg
  * @brief Transition function for span extent aggregate of big integers
- * @param[in,out] state Current aggregate state
+ * @param[in,out] state Current aggregate state, may be `NULL`
  * @param[in] i Value to aggregate
  */
 Span *
@@ -79,7 +79,7 @@ bigint_extent_transfn(Span *state, int64 i)
 /**
  * @ingroup meos_setspan_agg
  * @brief Transition function for span extent aggregate of floats
- * @param[in,out] state Current aggregate state
+ * @param[in,out] state Current aggregate state, may be `NULL`
  * @param[in] d Value to aggregate
  */
 Span *
@@ -94,7 +94,7 @@ float_extent_transfn(Span *state, double d)
 /**
  * @ingroup meos_setspan_agg
  * @brief Transition function for span extent aggregate of dates
- * @param[in,out] state Current aggregate state
+ * @param[in,out] state Current aggregate state, may be `NULL`
  * @param[in] d Value to aggregate
  */
 Span *
@@ -109,7 +109,7 @@ date_extent_transfn(Span *state, DateADT d)
 /**
  * @ingroup meos_setspan_agg
  * @brief Transition function for span extent aggregate of timestamptz
- * @param[in,out] state Current aggregate state
+ * @param[in,out] state Current aggregate state, may be `NULL`
  * @param[in] t Value to aggregate
  */
 Span *
@@ -214,7 +214,7 @@ spanset_append_spanset(SpanSet *ss1, const SpanSet *ss2, bool expand)
 /**
  * @ingroup meos_setspan_agg
  * @brief Transition function for span set aggregate union
- * @param[in,out] state Current aggregate state
+ * @param[in,out] state Current aggregate state, may be `NULL`
  * @param[in] s Span to aggregate
  * @return When the state variable has space for adding the new span, the 
  * function returns the current state variable. Otherwise, a NEW state 
@@ -244,7 +244,7 @@ span_union_transfn(SpanSet *state, const Span *s)
 /**
  * @ingroup meos_setspan_agg
  * @brief Transition function for span set aggregate union
- * @param[in,out] state Current aggregate state
+ * @param[in,out] state Current aggregate state, may be `NULL`
  * @param[in] ss Span set to aggregate
  * @return When the state variable has space for adding the new span set, the 
  * function returns the current state variable. Otherwise, a NEW state 
@@ -278,7 +278,7 @@ spanset_union_transfn(SpanSet *state, const SpanSet *ss)
 /**
  * @ingroup meos_setspan_agg
  * @brief Transition function for set aggregate of values
- * @param[in] state Current aggregate state
+ * @param[in] state Current aggregate state, may be `NULL`
  */
 SpanSet *
 spanset_union_finalfn(SpanSet *state)

--- a/meos/src/temporal/span_ops.c
+++ b/meos/src/temporal/span_ops.c
@@ -273,8 +273,27 @@ adjacent_span_span(const Span *s1, const Span *s2)
     return false;
 
   /*
-   * Two spans A..B and C..D are adjacent if and only if
-   * B is adjacent to C, or D is adjacent to A.
+   * Canonical span-adjacency rule (issue #821). Two spans are adjacent iff
+   * they meet at a single boundary value that EXACTLY ONE of them contains;
+   * equal bounds that are both inclusive is an OVERLAP, not adjacency. The
+   * inclusive/exclusive bits are therefore decisive:
+   *
+   *   adjacent  <=>  (upper1 == lower2 && upper_inc1 != lower_inc2)
+   *              ||  (upper2 == lower1 && upper_inc2 != lower_inc1)
+   *
+   * This single predicate is correct for BOTH base-type families because the
+   * integer-vs-float difference lives in how the span is STORED, not here:
+   *   - Discrete (int, bigint, date): canonicalized at construction to
+   *     half-open [lower, upper+1) (see span_set), so consecutive values are
+   *     adjacent, e.g. intspan '[1,5]' -|- '[6,10]' = true.
+   *   - Continuous (float, timestamptz): bounds kept, so a shared inclusive
+   *     endpoint overlaps, e.g. floatspan '[1,5]' -|- '[5,9]' = false, while
+   *     '[1,5)' -|- '[5,9]' = true.
+   * Do NOT "simplify" this to a bare share-a-boundary test (upper == lower,
+   * ignoring the bits) to match the bounding-box dispatch: that regresses the
+   * continuous case (it makes floatspan '[1,5]' -|- '[5,9]' return true).
+   * Bounding-box adjacency is a conservative index pre-filter that THIS exact
+   * predicate re-checks, so the box side does not need this precision.
    */
   return (
     (datum_eq(s1->upper, s2->lower, s1->basetype) &&

--- a/meos/src/temporal/span_ops.c
+++ b/meos/src/temporal/span_ops.c
@@ -249,7 +249,6 @@ ovadj_span_span(const Span *s1, const Span *s2)
  * @brief Return true if a span and a value are adjacent
  * @param[in] s Span
  * @param[in] value Value
- * @csqlfn #Adjacent_span_value()
  */
 bool
 adjacent_span_value(const Span *s, Datum value)
@@ -534,7 +533,6 @@ super_union_span_span(const Span *s1, const Span *s2)
  * @brief Return the union of a span and a value
  * @param[in] s Span
  * @param[in] value Value
- * @csqlfn #Union_span_value()
  */
 SpanSet *
 union_span_value(const Span *s, Datum value)

--- a/meos/src/temporal/spanset_ops.c
+++ b/meos/src/temporal/spanset_ops.c
@@ -339,7 +339,6 @@ overlaps_spanset_spanset(const SpanSet *ss1, const SpanSet *ss2)
  * @brief Return true if a span set and a value are adjacent
  * @param[in] ss Span set
  * @param[in] value Value
- * @csqlfn #Adjacent_spanset_value()
  */
 inline bool
 adjacent_spanset_value(const SpanSet *ss, Datum value)
@@ -355,7 +354,6 @@ adjacent_spanset_value(const SpanSet *ss, Datum value)
  * @brief Return true if a span set and a value are adjacent
  * @param[in] ss Span set
  * @param[in] value Value
- * @csqlfn #Adjacent_spanset_value()
  */
 inline bool
 adjacent_value_spanset(Datum value, const SpanSet *ss)

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -2076,7 +2076,6 @@ tnumber_avg_value(const Temporal *temp)
  * @param[in] n Number (1-based)
  * @param[out] result Resulting timestamp
  * @return On error return false
- * @csqlfn #Temporal_value_n()
  */
 bool
 temporal_value_n(const Temporal *temp, int n, Datum *result)

--- a/meos/src/temporal/temporal_aggfuncs.c
+++ b/meos/src/temporal/temporal_aggfuncs.c
@@ -718,7 +718,7 @@ tsequence_tagg(TSequence **sequences1, int count1, TSequence **sequences2,
 /**
  * @brief Generic transition function for aggregating temporal values
  * of instant subtype
- * @param[in,out] state Current aggregate state
+ * @param[in,out] state Current aggregate state, may be `NULL`
  * @param[in] inst Temporal value to aggregate
  * @param[in] func Function, may be NULL for the merge aggregate function
  */
@@ -738,7 +738,7 @@ tinstant_tagg_transfn(SkipList *state, const TInstant *inst, datum_func2 func)
 /**
  * @brief Generic transition function for aggregating temporal discrete
  * sequence values
- * @param[in,out] state Skiplist containing the state
+ * @param[in,out] state Skiplist containing the state, may be `NULL`
  * @param[in] seq Temporal value
  * @param[in] func Function, may be NULL for the merge aggregate function
  */
@@ -758,7 +758,7 @@ tdiscseq_tagg_transfn(SkipList *state, const TSequence *seq, datum_func2 func)
 /**
  * @brief Generic transition function for aggregating temporal values
  * of sequence subtype
- * @param[in,out] state Skiplist containing the state
+ * @param[in,out] state Skiplist containing the state, may be `NULL`
  * @param[in] seq Temporal value
  * @param[in] func Function, may be NULL for the merge aggregate function
  * @param[in] crossings True if turning points are added in the segments
@@ -777,7 +777,7 @@ tcontseq_tagg_transfn(SkipList *state, const TSequence *seq,
 /**
  * @brief Generic transition function for aggregating temporal values
  * of sequence set subtype
- * @param[in,out] state Skiplist containing the state
+ * @param[in,out] state Skiplist containing the state, may be `NULL`
  * @param[in] ss Temporal value
  * @param[in] func Function, may be NULL for the merge aggregate function
  * @param[in] crossings True if turning points are added in the segments
@@ -799,7 +799,7 @@ tsequenceset_tagg_transfn(SkipList *state, const TSequenceSet *ss,
 /**
  * @brief Generic transition function for aggregating temporal values
  * of sequence set subtype
- * @param[in,out] state Skiplist containing the state
+ * @param[in,out] state Skiplist containing the state, may be `NULL`
  * @param[in] temp Temporal value
  * @param[in] func Function, may be NULL for the merge aggregate function
  * @param[in] crossings True if turning points are added in the segments
@@ -825,7 +825,7 @@ temporal_tagg_transfn(SkipList *state, const Temporal *temp, datum_func2 func,
 
 /**
  * @brief Generic combine function for aggregating temporal values
- * @param[in] state1, state2 State values
+ * @param[in] state1, state2 State values, may be `NULL`
  * @param[in] func Aggregate function
  * @param[in] crossings True if turning points are added in the segments
  * @note This function is called for aggregating temporal points and thus
@@ -872,7 +872,7 @@ skiplist_temporal_values(SkipList *list)
 /**
  * @ingroup meos_temporal_agg
  * @brief Generic final function for aggregating temporal values
- * @param[in] state Current aggregate state
+ * @param[in] state Current aggregate state, may be `NULL`
  * @csqlfn #Temporal_tagg_finalfn()
  */
 Temporal *
@@ -989,7 +989,7 @@ temporal_transform_tagg(const Temporal *temp, int *count,
 /**
  * @brief Transition function for aggregating temporal values that require a
  * transformation to each composing instant/sequence
- * @param[in] state Current state
+ * @param[in] state Current state, may be `NULL`
  * @param[in] temp New temporal value
  * @param[in] func Aggregate function
  * @param[in] crossings True if turning points are added in the segments
@@ -1198,7 +1198,7 @@ temporal_transform_tcount(const Temporal *temp, int *count)
 /**
  * @ingroup meos_temporal_agg
  * @brief Transition function for temporal count aggregate of timestamps
- * @param[in,out] state Current aggregate state
+ * @param[in,out] state Current aggregate state, may be `NULL`
  * @param[in] t Timestamp to aggregate
  * @csqlfn #Timestamptz_tcount_transfn()
  */
@@ -1222,7 +1222,7 @@ timestamptz_tcount_transfn(SkipList *state, TimestampTz t)
 /**
  * @ingroup meos_temporal_agg
  * @brief Transition function for temporal count aggregate of timestamp sets
- * @param[in,out] state Current aggregate state
+ * @param[in,out] state Current aggregate state, may be `NULL`
  * @param[in] s Timestamp set to aggregate
  * @csqlfn #Tstzset_tcount_transfn()
  */
@@ -1253,7 +1253,7 @@ tstzset_tcount_transfn(SkipList *state, const Set *s)
 /**
  * @ingroup meos_temporal_agg
  * @brief Transition function for temporal count aggregate of timestamptz spans
- * @param[in,out] state Current aggregate state
+ * @param[in,out] state Current aggregate state, may be `NULL`
  * @param[in] s Timestamp span to aggregate
  * @csqlfn #Tstzspan_tcount_transfn()
  */
@@ -1285,7 +1285,7 @@ tstzspan_tcount_transfn(SkipList *state, const Span *s)
  * @ingroup meos_temporal_agg
  * @brief Transition function for temporal count aggregate of timestamptz span
  * sets
- * @param[in,out] state Current aggregate state
+ * @param[in,out] state Current aggregate state, may be `NULL`
  * @param[in] ss Timestamp span set to aggregate
  * @csqlfn #Tstzspanset_tcount_transfn()
  */
@@ -1321,7 +1321,7 @@ tstzspanset_tcount_transfn(SkipList *state, const SpanSet *ss)
 /**
  * @ingroup meos_temporal_agg
  * @brief Transition function for temporal count aggregation
- * @param[in,out] state Current aggregate state
+ * @param[in,out] state Current aggregate state, may be `NULL`
  * @param[in] temp Temporal value to aggregate
  * @csqlfn #Temporal_tcount_transfn()
  */
@@ -1407,7 +1407,7 @@ tsequence_tavg_finalfn(TSequence **sequences, int count)
 /**
  * @ingroup meos_temporal_agg
  * @brief Final function for temporal average aggregation
- * @param[in] state Current aggregate state
+ * @param[in] state Current aggregate state, may be `NULL`
  * @csqlfn #Tnumber_tavg_finalfn()
  */
 Temporal *
@@ -1435,8 +1435,8 @@ tnumber_tavg_finalfn(SkipList *state)
 /**
  * @ingroup meos_temporal_agg
  * @brief Transition function for temporal extent aggregate of temporal values
- * @param[in,out] state Current aggregate state
- * @param[in] temp Temporal value to aggregate
+ * @param[in,out] state Current aggregate state, may be `NULL`
+ * @param[in] temp Temporal value to aggregate, may be `NULL`
  * @csqlfn #Temporal_extent_transfn()
  */
 Span *
@@ -1461,8 +1461,8 @@ temporal_extent_transfn(Span *state, const Temporal *temp)
 /**
  * @ingroup meos_temporal_agg
  * @brief Transition function for temporal extent aggregate of temporal numbers
- * @param[in,out] state Current aggregate state
- * @param[in] temp Temporal value to aggregate
+ * @param[in,out] state Current aggregate state, may be `NULL`
+ * @param[in] temp Temporal value to aggregate, may be `NULL`
  * @csqlfn #Tnumber_extent_transfn()
  */
 TBox *
@@ -1500,11 +1500,11 @@ tnumber_extent_transfn(TBox *state, const Temporal *temp)
 /**
  * @ingroup meos_internal_temporal_agg
  * @brief Transition function for append temporal instant aggregate
- * @param[in,out] state Current aggregate state
+ * @param[in,out] state Current aggregate state, may be `NULL`
  * @param[in] inst Temporal value to aggregate
  * @param[in] interp Interpolation
  * @param[in] maxdist Maximum distance
- * @param[in] maxt Maximum duration
+ * @param[in] maxt Maximum duration, may be `NULL`
  * @csqlfn #Temporal_app_tinst_transfn()
  */
 Temporal *
@@ -1534,7 +1534,7 @@ temporal_app_tinst_transfn(Temporal *state, const TInstant *inst,
 /**
  * @ingroup meos_internal_temporal_agg
  * @brief Transition function for append temporal sequence aggregate
- * @param[in,out] state Current aggregate state
+ * @param[in,out] state Current aggregate state, may be `NULL`
  * @param[in] seq Temporal value to aggregate
  * @csqlfn #Temporal_app_tseq_transfn()
  */

--- a/meos/src/temporal/temporal_compops.c
+++ b/meos/src/temporal/temporal_compops.c
@@ -147,7 +147,6 @@ eacomp_temporal_temporal(const Temporal *temp1, const Temporal *temp2,
  * @brief Return true if a temporal value is ever equal to a base value
  * @param[in] temp Temporal value
  * @param[in] value Value
- * @csqlfn #Ever_eq_temporal_base()
  */
 int
 ever_eq_temporal_base(const Temporal *temp, Datum value)
@@ -160,7 +159,6 @@ ever_eq_temporal_base(const Temporal *temp, Datum value)
  * @brief Return true if a temporal value is ever different from a base value
  * @param[in] temp Temporal value
  * @param[in] value Value
- * @csqlfn #Ever_ne_temporal_base()
  */
 int
 ever_ne_temporal_base(const Temporal *temp, Datum value)
@@ -173,7 +171,6 @@ ever_ne_temporal_base(const Temporal *temp, Datum value)
  * @brief Return true if a temporal value is ever less than a base value
  * @param[in] temp Temporal value
  * @param[in] value Value
- * @csqlfn #Ever_lt_temporal_base()
  */
 int
 ever_lt_temporal_base(const Temporal *temp, Datum value)
@@ -187,7 +184,6 @@ ever_lt_temporal_base(const Temporal *temp, Datum value)
  * value
  * @param[in] temp Temporal value
  * @param[in] value Value
- * @csqlfn #Ever_le_temporal_base()
  */
 int
 ever_le_temporal_base(const Temporal *temp, Datum value)
@@ -200,7 +196,6 @@ ever_le_temporal_base(const Temporal *temp, Datum value)
  * @brief Return true if a temporal value is ever greater than a base value
  * @param[in] temp Temporal value
  * @param[in] value Value
- * @csqlfn #Ever_gt_temporal_base()
  */
 int
 ever_gt_temporal_base(const Temporal *temp, Datum value)
@@ -214,7 +209,6 @@ ever_gt_temporal_base(const Temporal *temp, Datum value)
  * base value
  * @param[in] temp Temporal value
  * @param[in] value Value
- * @csqlfn #Ever_ge_temporal_base()
  */
 int
 ever_ge_temporal_base(const Temporal *temp, Datum value)
@@ -229,7 +223,6 @@ ever_ge_temporal_base(const Temporal *temp, Datum value)
  * @brief Return true if a temporal value is ever equal to a base value
  * @param[in] value Value
  * @param[in] temp Temporal value
- * @csqlfn #Ever_eq_base_temporal()
  */
 int
 ever_eq_base_temporal(Datum value, const Temporal *temp)
@@ -242,7 +235,6 @@ ever_eq_base_temporal(Datum value, const Temporal *temp)
  * @brief Return true if a temporal value is ever different from a base value
  * @param[in] value Value
  * @param[in] temp Temporal value
- * @csqlfn #Ever_ne_base_temporal()
  */
 int
 ever_ne_base_temporal(Datum value, const Temporal *temp)
@@ -255,7 +247,6 @@ ever_ne_base_temporal(Datum value, const Temporal *temp)
  * @brief Return true if a temporal value is ever less than a base value
  * @param[in] value Value
  * @param[in] temp Temporal value
- * @csqlfn #Ever_lt_base_temporal()
  */
 int
 ever_lt_base_temporal(Datum value, const Temporal *temp)
@@ -269,7 +260,6 @@ ever_lt_base_temporal(Datum value, const Temporal *temp)
  * value
  * @param[in] value Value
  * @param[in] temp Temporal value
- * @csqlfn #Ever_le_base_temporal()
  */
 int
 ever_le_base_temporal(Datum value, const Temporal *temp)
@@ -282,7 +272,6 @@ ever_le_base_temporal(Datum value, const Temporal *temp)
  * @brief Return true if a temporal value is ever greater than a base value
  * @param[in] value Value
  * @param[in] temp Temporal value
- * @csqlfn #Ever_gt_base_temporal()
  */
 int
 ever_gt_base_temporal(Datum value, const Temporal *temp)
@@ -296,7 +285,6 @@ ever_gt_base_temporal(Datum value, const Temporal *temp)
  * base value
  * @param[in] value Value
  * @param[in] temp Temporal value
- * @csqlfn #Ever_ge_base_temporal()
  */
 int
 ever_ge_base_temporal(Datum value, const Temporal *temp)
@@ -311,7 +299,6 @@ ever_ge_base_temporal(Datum value, const Temporal *temp)
  * @brief Return true if a temporal value is always equal to a base value
  * @param[in] temp Temporal value
  * @param[in] value Value
- * @csqlfn #Always_eq_temporal_base()
  */
 int
 always_eq_temporal_base(const Temporal *temp, Datum value)
@@ -324,7 +311,6 @@ always_eq_temporal_base(const Temporal *temp, Datum value)
  * @brief Return true if a temporal value is always different from a base value
  * @param[in] temp Temporal value
  * @param[in] value Value
- * @csqlfn #Always_ne_temporal_base()
  */
 int
 always_ne_temporal_base(const Temporal *temp, Datum value)
@@ -337,7 +323,6 @@ always_ne_temporal_base(const Temporal *temp, Datum value)
  * @brief Return true if a temporal value is always less than a base value
  * @param[in] temp Temporal value
  * @param[in] value Value
- * @csqlfn #Always_lt_temporal_base()
  */
 int
 always_lt_temporal_base(const Temporal *temp, Datum value)
@@ -351,7 +336,6 @@ always_lt_temporal_base(const Temporal *temp, Datum value)
  * base value
  * @param[in] temp Temporal value
  * @param[in] value Value
- * @csqlfn #Always_le_temporal_base()
  */
 int
 always_le_temporal_base(const Temporal *temp, Datum value)
@@ -364,7 +348,6 @@ always_le_temporal_base(const Temporal *temp, Datum value)
  * @brief Return true if a temporal value is always greater than a base value
  * @param[in] temp Temporal value
  * @param[in] value Value
- * @csqlfn #Always_gt_temporal_base()
  */
 int
 always_gt_temporal_base(const Temporal *temp, Datum value)
@@ -378,7 +361,6 @@ always_gt_temporal_base(const Temporal *temp, Datum value)
  * base value
  * @param[in] temp Temporal value
  * @param[in] value Value
- * @csqlfn #Always_ge_temporal_base()
  */
 int
 always_ge_temporal_base(const Temporal *temp, Datum value)
@@ -393,7 +375,6 @@ always_ge_temporal_base(const Temporal *temp, Datum value)
  * @brief Return true if a temporal value is always equal to a base value
  * @param[in] value Value
  * @param[in] temp Temporal value
- * @csqlfn #Always_eq_base_temporal()
  */
 int
 always_eq_base_temporal(Datum value, const Temporal *temp)
@@ -406,7 +387,6 @@ always_eq_base_temporal(Datum value, const Temporal *temp)
  * @brief Return true if a temporal value is always different from a base value
  * @param[in] value Value
  * @param[in] temp Temporal value
- * @csqlfn #Always_ne_base_temporal()
  */
 int
 always_ne_base_temporal(Datum value, const Temporal *temp)
@@ -419,7 +399,6 @@ always_ne_base_temporal(Datum value, const Temporal *temp)
  * @brief Return true if a temporal value is always less than a base value
  * @param[in] value Value
  * @param[in] temp Temporal value
- * @csqlfn #Always_lt_base_temporal()
  */
 int
 always_lt_base_temporal(Datum value, const Temporal *temp)
@@ -433,7 +412,6 @@ always_lt_base_temporal(Datum value, const Temporal *temp)
  * value
  * @param[in] value Value
  * @param[in] temp Temporal value
- * @csqlfn #Always_le_base_temporal()
  */
 int
 always_le_base_temporal(Datum value, const Temporal *temp)
@@ -446,7 +424,6 @@ always_le_base_temporal(Datum value, const Temporal *temp)
  * @brief Return true if a temporal value is always greater than a base value
  * @param[in] value Value
  * @param[in] temp Temporal value
- * @csqlfn #Always_gt_base_temporal()
  */
 int
 always_gt_base_temporal(Datum value, const Temporal *temp)
@@ -460,7 +437,6 @@ always_gt_base_temporal(Datum value, const Temporal *temp)
  * base value
  * @param[in] value Value
  * @param[in] temp Temporal value
- * @csqlfn #Always_ge_base_temporal()
  */
 int
 always_ge_base_temporal(Datum value, const Temporal *temp)

--- a/meos/src/temporal/temporal_modif.c
+++ b/meos/src/temporal/temporal_modif.c
@@ -517,7 +517,7 @@ temporal_convert_same_subtype(const Temporal *temp1, const Temporal *temp2,
 /**
  * @ingroup meos_temporal_modif
  * @brief Merge two temporal values
- * @param[in] temp1,temp2 Temporal values
+ * @param[in] temp1,temp2 Temporal values, may be `NULL`
  * @return Return @p NULL if both arguments are @p NULL.
  * If one argument is null, return the other argument.
  * @csqlfn #Temporal_merge()

--- a/meos/src/temporal/tinstant.c
+++ b/meos/src/temporal/tinstant.c
@@ -403,7 +403,6 @@ tinstant_insts(const TInstant *inst, int *count)
  * @param[out] result Result
  * @note Since the corresponding function for temporal sequences need to
  * interpolate the value, it is necessary to return a copy of the value
- * @csqlfn #Temporal_value_at_timestamptz()
  */
 bool
 tinstant_value_at_timestamptz(const TInstant *inst, TimestampTz t,
@@ -503,7 +502,6 @@ tsequenceset_to_tinstant(const TSequenceSet *ss)
  * @brief Return a temporal instant whose value is shifted by a value
  * @param[in] inst Temporal instant
  * @param[in] shift Value to shift the instant
- * @csqlfn #Tnumber_shift_value()
  */
 TInstant *
 tnumberinst_shift_value(const TInstant *inst, Datum shift)

--- a/meos/src/temporal/tsequence.c
+++ b/meos/src/temporal/tsequence.c
@@ -1597,8 +1597,6 @@ tsequence_shift_scale_time_iter(TSequence *seq, TimestampTz delta,
  * @param[in] hasshift True when the shift argument is given
  * @param[in] haswidth True when the width argument is given
  * @pre The width is greater than 0 if it is not NULL // TODO
- * @csqlfn #Tnumber_shift_value(), #Tnumber_scale_value(),
- * #Tnumber_shift_scale_value()
  */
 TSequence *
 tnumberseq_shift_scale_value(const TSequence *seq, Datum shift, Datum width,
@@ -2150,7 +2148,6 @@ tsegment_value_at_timestamptz(Datum start, Datum end, MeosType temptype,
  * @param[in] strict True if inclusive/exclusive bounds are taken into account
  * @param[out] result Result
  * @return Return true if the timestamp is contained in the temporal sequence
- * @csqlfn #Temporal_value_at_timestamptz()
  */
 bool
 tcontseq_value_at_timestamptz(const TSequence *seq, TimestampTz t, bool strict,
@@ -2215,7 +2212,6 @@ tcontseq_value_at_timestamptz(const TSequence *seq, TimestampTz t, bool strict,
  * @param[in] strict True if inclusive/exclusive bounds are taken into account
  * @param[out] result Result
  * @return Return true if the timestamp is contained in the temporal sequence
- * @csqlfn #Temporal_value_at_timestamptz()
  */
 bool
 tsequence_value_at_timestamptz(const TSequence *seq, TimestampTz t,

--- a/meos/src/temporal/tsequenceset.c
+++ b/meos/src/temporal/tsequenceset.c
@@ -884,7 +884,6 @@ tnumberseqset_avg_val(const TSequenceSet *ss)
  * @param[in] ss Temporal sequence set
  * @param[in] n Number
  * @param[out] result Value
- * @csqlfn #Temporal_value_n()
  */
 bool
 tsequenceset_value_n(const TSequenceSet *ss, int n, Datum *result)
@@ -1273,7 +1272,6 @@ tsequenceset_timestamps(const TSequenceSet *ss, int *count)
  * @param[out] result Base value
  * @return Return true if the timestamp is contained in the temporal sequence set
  * @pre A bounding box test has been done before by the calling function
- * @csqlfn #Temporal_value_at_timestamptz()
  */
 bool
 tsequenceset_value_at_timestamptz(const TSequenceSet *ss, TimestampTz t,

--- a/meos/src/temporal/tsequenceset.c
+++ b/meos/src/temporal/tsequenceset.c
@@ -446,7 +446,7 @@ tsequenceset_make_free(TSequence **sequences, int count, bool normalize)
  * @param[in] merge True if a merge operation, which implies that the two
  *   consecutive instants may be equal
  * @param[in] maxdist Maximum distance to split the temporal sequence
- * @param[in] maxt Maximum time interval to split the temporal sequence
+ * @param[in] maxt Maximum time interval to split the temporal sequence, may be `NULL`
  * @param[out] nsplits Number of splits
  * @return Array of indices at which the temporal sequence is split
  */
@@ -524,7 +524,7 @@ tsequenceset_make_gaps_valid(TInstant **instants, int count, bool lower_inc,
  * @param[in] count Number of elements in the array
  * @param[in] interp Interpolation
  * @param[in] maxdist Maximum distance for defining a gap
- * @param[in] maxt Maximum time interval for defining a gap
+ * @param[in] maxt Maximum time interval for defining a gap, may be `NULL`
  * @csqlfn #Tsequenceset_constructor_gaps()
  */
 TSequenceSet *

--- a/meos/src/temporal/type_out.c
+++ b/meos/src/temporal/type_out.c
@@ -773,7 +773,7 @@ tsequenceset_as_mfjson_sb(stringbuffer_t *sb, const TSequenceSet *ss,
  * @param[in] flags Flags
  * @param[in] precision Number of decimal digits. It is only used when the base
  * type has floating point components, such as tfloat or tgeometry
- * @param[in] srs Spatial reference system
+ * @param[in] srs Spatial reference system, may be `NULL`
  * @return On error return @p NULL
  * @csqlfn #Temporal_as_mfjson()
  */

--- a/mobilitydb/sql/cbuffer/160_tcbuffer_distance.in.sql
+++ b/mobilitydb/sql/cbuffer/160_tcbuffer_distance.in.sql
@@ -36,6 +36,7 @@
  * Distance functions
  *****************************************************************************/
 
+-- The function is not strict
 CREATE FUNCTION distance(geometry, cbuffer)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_geo_cbuffer'

--- a/mobilitydb/sql/cbuffer/161_tcbuffer_aggfuncs.in.sql
+++ b/mobilitydb/sql/cbuffer/161_tcbuffer_aggfuncs.in.sql
@@ -32,6 +32,7 @@
  * @brief Aggregate functions for temporal circular buffers
  */
 
+-- The function is not strict
 CREATE FUNCTION tcount_transfn(internal, tcbuffer)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Temporal_tcount_transfn'
@@ -47,6 +48,7 @@ CREATE AGGREGATE tcount(tcbuffer) (
   PARALLEL = SAFE
 );
 
+-- The function is not strict
 CREATE FUNCTION wcount_transfn(internal, tcbuffer, interval)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Temporal_wcount_transfn'
@@ -64,6 +66,7 @@ CREATE AGGREGATE wcount(tcbuffer, interval) (
 
 /*****************************************************************************/
 
+-- The function is not strict
 CREATE FUNCTION temporal_merge_transfn(internal, tcbuffer)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Temporal_merge_transfn'

--- a/mobilitydb/sql/cbuffer/164_tcbuffer_tempspatialrels.in.sql
+++ b/mobilitydb/sql/cbuffer/164_tcbuffer_tempspatialrels.in.sql
@@ -165,6 +165,7 @@ CREATE FUNCTION tDwithin(cbuffer, tcbuffer, dist float)
   RETURNS tbool
   AS 'MODULE_PATHNAME', 'Tdwithin_cbuffer_tcbuffer'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+-- The function is not strict
 CREATE FUNCTION tDwithin(tcbuffer, cbuffer, dist float)
   RETURNS tbool
   AS 'MODULE_PATHNAME', 'Tdwithin_tcbuffer_cbuffer'

--- a/mobilitydb/sql/geo/051_stbox.in.sql
+++ b/mobilitydb/sql/geo/051_stbox.in.sql
@@ -646,6 +646,7 @@ CREATE FUNCTION quadSplit(stbox)
  * Extent aggreation
  *****************************************************************************/
 
+-- The function is not strict
 CREATE FUNCTION stbox_extent_transfn(stbox, stbox)
   RETURNS stbox
   AS 'MODULE_PATHNAME', 'Stbox_extent_transfn'

--- a/mobilitydb/sql/geo/064_tgeo_distance.in.sql
+++ b/mobilitydb/sql/geo/064_tgeo_distance.in.sql
@@ -304,6 +304,7 @@ CREATE FUNCTION minDistance(geography, tgeography)
  * one-row group the aggregate degenerates to the per-pair value, so any
  * "scalar" use case is naturally covered.
  */
+-- The function is not strict
 CREATE FUNCTION minDistance_transfn(float, tgeompoint, tgeompoint)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Mindistance_transfn'

--- a/mobilitydb/sql/geo/068_tgeo_aggfuncs.in.sql
+++ b/mobilitydb/sql/geo/068_tgeo_aggfuncs.in.sql
@@ -32,6 +32,7 @@
  * @brief Aggregate functions for temporal geometries/geographies
  */
 
+-- The function is not strict
 CREATE FUNCTION tspatial_extent_transfn(stbox, tgeometry)
   RETURNS stbox
   AS 'MODULE_PATHNAME', 'Tspatial_extent_transfn'
@@ -56,6 +57,7 @@ CREATE AGGREGATE extent(tgeography) (
 
 /*****************************************************************************/
 
+-- The function is not strict
 CREATE FUNCTION tcount_transfn(internal, tgeometry)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Temporal_tcount_transfn'
@@ -86,6 +88,7 @@ CREATE AGGREGATE tcount(tgeography) (
   PARALLEL = SAFE
 );
 
+-- The function is not strict
 CREATE FUNCTION wcount_transfn(internal, tgeometry, interval)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Temporal_wcount_transfn'
@@ -116,6 +119,7 @@ CREATE AGGREGATE wcount(tgeography, interval) (
 
 /*****************************************************************************/
 
+-- The function is not strict
 CREATE FUNCTION temporal_merge_transfn(internal, tgeometry)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Temporal_merge_transfn'

--- a/mobilitydb/sql/geo/068_tpoint_aggfuncs.in.sql
+++ b/mobilitydb/sql/geo/068_tpoint_aggfuncs.in.sql
@@ -32,6 +32,7 @@
  * @brief Aggregate functions for temporal points
  */
 
+-- The function is not strict
 CREATE FUNCTION tspatial_extent_transfn(stbox, tgeompoint)
   RETURNS stbox
   AS 'MODULE_PATHNAME', 'Tspatial_extent_transfn'
@@ -56,6 +57,7 @@ CREATE AGGREGATE extent(tgeogpoint) (
 
 /*****************************************************************************/
 
+-- The function is not strict
 CREATE FUNCTION tcount_transfn(internal, tgeompoint)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Temporal_tcount_transfn'
@@ -86,6 +88,7 @@ CREATE AGGREGATE tcount(tgeogpoint) (
   PARALLEL = SAFE
 );
 
+-- The function is not strict
 CREATE FUNCTION wcount_transfn(internal, tgeompoint, interval)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Temporal_wcount_transfn'
@@ -114,6 +117,7 @@ CREATE AGGREGATE wcount(tgeogpoint, interval) (
   PARALLEL = SAFE
 );
 
+-- The function is not strict
 CREATE FUNCTION tcentroid_transfn(internal, tgeompoint)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Tpoint_tcentroid_transfn'
@@ -139,6 +143,7 @@ CREATE AGGREGATE tcentroid(tgeompoint) (
 
 /*****************************************************************************/
 
+-- The function is not strict
 CREATE FUNCTION temporal_merge_transfn(internal, tgeompoint)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Temporal_merge_transfn'

--- a/mobilitydb/sql/geo/072_tgeo_tempspatialrels.in.sql
+++ b/mobilitydb/sql/geo/072_tgeo_tempspatialrels.in.sql
@@ -135,6 +135,7 @@ CREATE FUNCTION tDwithin(geometry, tgeometry, dist float)
   RETURNS tbool
   AS 'MODULE_PATHNAME', 'Tdwithin_geo_tgeo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+-- The function is not strict
 CREATE FUNCTION tDwithin(tgeometry, geometry, dist float)
   RETURNS tbool
   AS 'MODULE_PATHNAME', 'Tdwithin_tgeo_geo'

--- a/mobilitydb/sql/npoint/095_tnpoint_aggfuncs.in.sql
+++ b/mobilitydb/sql/npoint/095_tnpoint_aggfuncs.in.sql
@@ -32,6 +32,7 @@
  * @brief Aggregate functions for temporal network points
  */
 
+-- The function is not strict
 CREATE FUNCTION tcount_transfn(internal, tnpoint)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Temporal_tcount_transfn'
@@ -47,6 +48,7 @@ CREATE AGGREGATE tcount(tnpoint) (
   PARALLEL = SAFE
 );
 
+-- The function is not strict
 CREATE FUNCTION wcount_transfn(internal, tnpoint, interval)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Temporal_wcount_transfn'
@@ -62,6 +64,7 @@ CREATE AGGREGATE wcount(tnpoint, interval) (
   PARALLEL = SAFE
 );
 
+-- The function is not strict
 CREATE FUNCTION tcentroid_transfn(internal, tnpoint)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Tnpoint_tcentroid_transfn'
@@ -79,6 +82,7 @@ CREATE AGGREGATE tcentroid(tnpoint) (
 
 /*****************************************************************************/
 
+-- The function is not strict
 CREATE FUNCTION temporal_merge_transfn(internal, tnpoint)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Temporal_merge_transfn'

--- a/mobilitydb/sql/pose/111_tpose_aggfuncs.in.sql
+++ b/mobilitydb/sql/pose/111_tpose_aggfuncs.in.sql
@@ -32,6 +32,7 @@
  * @brief Aggregate functions for temporal poses
  */
 
+-- The function is not strict
 CREATE FUNCTION tcount_transfn(internal, tpose)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Temporal_tcount_transfn'
@@ -47,6 +48,7 @@ CREATE AGGREGATE tcount(tpose) (
   PARALLEL = SAFE
 );
 
+-- The function is not strict
 CREATE FUNCTION wcount_transfn(internal, tpose, interval)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Temporal_wcount_transfn'
@@ -64,6 +66,7 @@ CREATE AGGREGATE wcount(tpose, interval) (
 
 /*****************************************************************************/
 
+-- The function is not strict
 CREATE FUNCTION temporal_merge_transfn(internal, tpose)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Temporal_merge_transfn'

--- a/mobilitydb/sql/rgeo/131_trgeo_aggfuncs.in.sql
+++ b/mobilitydb/sql/rgeo/131_trgeo_aggfuncs.in.sql
@@ -32,6 +32,7 @@
  * @brief Aggregate functions for temporal rigid geometries
  */
 
+-- The function is not strict
 CREATE FUNCTION tcount_transfn(internal, trgeometry)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Temporal_tcount_transfn'
@@ -47,6 +48,7 @@ CREATE AGGREGATE tcount(trgeometry) (
   PARALLEL = SAFE
 );
 
+-- The function is not strict
 CREATE FUNCTION wcount_transfn(internal, trgeometry, interval)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Temporal_wcount_transfn'
@@ -64,6 +66,7 @@ CREATE AGGREGATE wcount(trgeometry, interval) (
 
 /*****************************************************************************/
 
+-- The function is not strict
 CREATE FUNCTION temporal_merge_transfn(internal, trgeometry)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Temporal_merge_transfn'

--- a/mobilitydb/sql/temporal/015_span_aggfuncs.in.sql
+++ b/mobilitydb/sql/temporal/015_span_aggfuncs.in.sql
@@ -35,6 +35,7 @@
 /*****************************************************************************/
 -- span + span
 
+-- The function is not strict
 CREATE FUNCTION span_extent_transfn(intspan, intspan)
   RETURNS intspan
   AS 'MODULE_PATHNAME', 'Span_extent_transfn'
@@ -112,6 +113,7 @@ CREATE AGGREGATE extent(tstzspan) (
 /*****************************************************************************/
 -- span + base
 
+-- The function is not strict
 CREATE FUNCTION span_extent_transfn(intspan, integer)
   RETURNS intspan
   AS 'MODULE_PATHNAME', 'Spanbase_extent_transfn'
@@ -167,6 +169,7 @@ CREATE AGGREGATE extent(timestamptz) (
 /*****************************************************************************/
 -- span + <type>
 
+-- The function is not strict
 CREATE FUNCTION set_extent_transfn(intspan, intset)
   RETURNS intspan
   AS 'MODULE_PATHNAME', 'Set_extent_transfn'
@@ -219,6 +222,7 @@ CREATE AGGREGATE extent(tstzset) (
   PARALLEL = safe
 );
 
+-- The function is not strict
 CREATE FUNCTION spanset_extent_transfn(intspan, intspanset)
   RETURNS intspan
   AS 'MODULE_PATHNAME', 'Spanset_extent_transfn'
@@ -273,6 +277,7 @@ CREATE AGGREGATE extent(tstzspanset) (
 
 /*****************************************************************************/
 
+-- The function is not strict
 CREATE FUNCTION intspan_union_finalfn(internal)
   RETURNS intspanset
   AS 'MODULE_PATHNAME', 'Span_union_finalfn'
@@ -352,6 +357,7 @@ CREATE AGGREGATE spanUnion(tstzspan) (
 
 /*****************************************************************************/
 
+-- The function is not strict
 CREATE FUNCTION spanset_union_transfn(internal, intspanset)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Spanset_union_transfn'

--- a/mobilitydb/sql/temporal/021_tbox.in.sql
+++ b/mobilitydb/sql/temporal/021_tbox.in.sql
@@ -508,6 +508,7 @@ CREATE OPERATOR * (
  * Extent aggregation
  *****************************************************************************/
 
+-- The function is not strict
 CREATE FUNCTION tbox_extent_transfn(tbox, tbox)
   RETURNS tbox
   AS 'MODULE_PATHNAME', 'Tbox_extent_transfn'

--- a/mobilitydb/sql/temporal/022_temporal.in.sql
+++ b/mobilitydb/sql/temporal/022_temporal.in.sql
@@ -41,6 +41,7 @@ CREATE TYPE ttext;
  * Utility functions
  *****************************************************************************/
 
+-- The function is not strict
 CREATE FUNCTION mobilitydb_version()
   RETURNS text
   AS 'MODULE_PATHNAME', 'Mobilitydb_version'

--- a/mobilitydb/sql/temporal/040_temporal_aggfuncs.in.sql
+++ b/mobilitydb/sql/temporal/040_temporal_aggfuncs.in.sql
@@ -32,6 +32,7 @@
  * @brief Temporal aggregate functions
  */
 
+-- The function is not strict
 CREATE FUNCTION temporal_extent_transfn(tstzspan, tbool)
   RETURNS tstzspan
   AS 'MODULE_PATHNAME', 'Temporal_extent_transfn'
@@ -58,6 +59,7 @@ CREATE AGGREGATE extent(ttext) (
   PARALLEL = safe
 );
 
+-- The function is not strict
 CREATE FUNCTION tnumber_extent_transfn(tbox, tint)
   RETURNS tbox
   AS 'MODULE_PATHNAME', 'Tnumber_extent_transfn'
@@ -98,6 +100,7 @@ CREATE FUNCTION taggstate_deserialize(bytea, internal)
 
 /*****************************************************************************/
 
+-- The function is not strict
 CREATE FUNCTION tcount_transfn(internal, timestamptz)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Timestamptz_tcount_transfn'
@@ -166,6 +169,7 @@ CREATE AGGREGATE tcount(tstzspanset) (
 
 /*****************************************************************************/
 
+-- The function is not strict
 CREATE FUNCTION tcount_transfn(internal, tbool)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Temporal_tcount_transfn'
@@ -223,6 +227,7 @@ CREATE AGGREGATE tor(tbool) (
 
 /*****************************************************************************/
 
+-- The function is not strict
 CREATE FUNCTION tcount_transfn(internal, tint)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Temporal_tcount_transfn'
@@ -313,6 +318,7 @@ CREATE AGGREGATE tavg(tint) (
   PARALLEL = SAFE
 );
 
+-- The function is not strict
 CREATE FUNCTION tcount_transfn(internal, tfloat)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Temporal_tcount_transfn'
@@ -346,6 +352,7 @@ CREATE FUNCTION tfloat_tagg_finalfn(internal)
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Temporal_tagg_finalfn'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+-- The function is not strict
 CREATE FUNCTION tavg_transfn(internal, tfloat)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Tnumber_tavg_transfn'
@@ -400,6 +407,7 @@ CREATE AGGREGATE tavg(tfloat) (
 
 /*****************************************************************************/
 
+-- The function is not strict
 CREATE FUNCTION tcount_transfn(internal, ttext)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Temporal_tcount_transfn'
@@ -457,6 +465,7 @@ CREATE AGGREGATE tmax(ttext) (
 
 /*****************************************************************************/
 
+-- The function is not strict
 CREATE FUNCTION temporal_merge_transfn(internal, tbool)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Temporal_merge_transfn'

--- a/mobilitydb/sql/temporal/042_temporal_waggfuncs.in.sql
+++ b/mobilitydb/sql/temporal/042_temporal_waggfuncs.in.sql
@@ -32,6 +32,7 @@
  * @brief Moving window temporal aggregate functions
  */
 
+-- The function is not strict
 CREATE FUNCTION tint_wmin_transfn(internal, tint, interval)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Tint_wmin_transfn'
@@ -101,6 +102,7 @@ CREATE AGGREGATE wavg(tint, interval) (
 
 /*****************************************************************************/
 
+-- The function is not strict
 CREATE FUNCTION tfloat_wmin_transfn(internal, tfloat, interval)
   RETURNS internal
   AS 'MODULE_PATHNAME', 'Tfloat_wmin_transfn'


### PR DESCRIPTION
> **Comment-only PR** — Doxygen + SQL-comment changes only, no code or behavior change. Merged under the comment-only self-merge exception.

Two comment-only cleanups of the MEOS C sources, consolidated into one PR so they stay out of the code-review chain. Both feed the binding codegens that read the MEOS name/nullability metadata.

**Commit 1 — parameter nullability (codegen SoT).** Appends `, may be `NULL`` to the `@param` Doxygen of every parameter the C function accepts `NULL` for (`srs`, `maxt`, the aggregate `state` accumulators incl. the `*_extent_transfn` family, `temporal_merge`, `tgeo_scale`), and adds the `-- The function is not strict` SQL comment where missing. Grounded against the PG wrappers' `PG_ARGISNULL` handling, the non-`STRICT`/`DEFAULT NULL` SQL, and the C-body NULL guards.

**Commit 2 — @csqlfn de-tagging.** Removes the redundant `@csqlfn` from 40 core Datum-generic functions whose typed `*_meos.c` wrapper already carries the same tag. A Datum-generic is not binding-callable, so its `@csqlfn` wrongly attaches a SQL name to an uncallable function. The typed wrappers keep their tags; the few generics with no wrapper yet keep theirs pending one.

Verified comment-only: every changed line is a Doxygen `@param`/`@csqlfn` line or a `-- ` SQL comment.

Refs #821.
