### PR TITLE
Initialize upper_inc in the tgeo at-stbox restrict kernel

### DIFF
--- a/meos/src/geo/tgeo_restrict.c
+++ b/meos/src/geo/tgeo_restrict.c
@@ -755,7 +755,7 @@ tpointseq_linear_at_stbox_xyz(const TSequence *seq, const STBox *box,
   const TInstant *inst1 = TSEQUENCE_INST_N(seq, 0);
   const GSERIALIZED *p1 = DatumGetGserializedP(tinstant_value_p(inst1));
   bool lower_inc = seq->period.lower_inc;
-  bool upper_inc;
+  bool upper_inc = false;
   int ninsts = 0, nseqs = 0, nfree = 0;
   for (int i = 1; i < seq->count; i++)
   {


### PR DESCRIPTION
`tpointseq_linear_at_stbox_xyz` (meos/src/geo/tgeo_restrict.c) declares `bool upper_inc;` and assigns it on the first statement of its `for (i = 1; i < seq->count; i++)` loop. When `seq->count <= 1` the loop body never runs, so `upper_inc` is read **uninitialised** further down — undefined behaviour.

Initialize it to `false` at the declaration (matching the adjacent `lower_inc`). One-line, behaviour-preserving for the common path (the loop overwrites it before use); only removes the UB on the empty-loop edge.

Surfaced by an integration-coverage audit (`tools/integration_audit/audit.py`) as a fix that existed only on a local integration branch and in no PR — i.e. a crash-orphan that would be lost on accumulate regeneration. This un-strands it.