### PR TITLE
Treat implicit function declarations as build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,6 +205,10 @@ add_compile_definitions(_USE_MATH_DEFINES)
 if(CMAKE_COMPILER_IS_GNUCC)
   # MobilityDB compiler flags
   add_definitions(-Wall -Wextra -std=gnu1x -Wunused-parameter -Wno-strict-aliasing)
+  # Treat an implicit function declaration as an error: it silently assumes an
+  # int return, truncating any 64-bit pointer the callee actually returns and
+  # producing a hard-to-trace crash at runtime rather than at build time.
+  add_definitions(-Werror=implicit-function-declaration -Werror=implicit-int)
   # -Wno-strict-aliasing was removed to access directly PostGIS points
   # See file tpoint_spatialfuncs.h
   # add_definitions(-Wall -Wextra -std=gnu1x -Wno-unused-parameter)


### PR DESCRIPTION
Add -Werror=implicit-function-declaration and -Werror=implicit-int to the GCC flags. An implicit declaration silently assumes an int return, truncating any 64-bit pointer the callee returns and turning a missing header into a runtime crash instead of a compile-time failure; promoting it to an error catches that class of bug at build time across the MEOS kernel and all extension targets. The full tree, including the vendored liblwgeom, h3-pg and pgcommon sources, builds clean under the stricter flag.