### PR TITLE
Make GEOS initialization thread-safe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,11 @@ int main() {
 # Other dependencies
 #--------------------------------
 
+# POSIX threads — needed for pthread_once in meos_initialize_geos()
+# On Linux ≥ glibc 2.34 pthreads are in libc; on older systems and MinGW
+# CMake's Threads::Threads target adds the correct -lpthread / -lwinpthread.
+find_package(Threads REQUIRED)
+
 # GEOS geometry library
 find_package(GEOS REQUIRED)
 include_directories(SYSTEM ${GEOS_INCLUDE_DIR})

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -1440,14 +1440,13 @@ static char
 meos_call_geos2(const GSERIALIZED *gs1, const GSERIALIZED *gs2,
   char (*func)(const GEOSGeometry *geos1, const GEOSGeometry *geos2))
 {
-  initGEOS(lwnotice, lwgeom_geos_error);
+  meos_initialize_geos();
 
   GEOSGeometry *geos1 = POSTGIS2GEOS(gs1);
   if (! geos1)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "First argument geometry could not be converted to GEOS");
-    finishGEOS();
     return 2;
   }
   GEOSGeometry *geos2 = POSTGIS2GEOS(gs2);
@@ -1456,7 +1455,6 @@ meos_call_geos2(const GSERIALIZED *gs1, const GSERIALIZED *gs2,
     GEOSGeom_destroy(geos1);
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "Second argument geometry could not be converted to GEOS");
-    finishGEOS();
     return 2;
   }
 
@@ -1466,7 +1464,6 @@ meos_call_geos2(const GSERIALIZED *gs1, const GSERIALIZED *gs2,
   if (result == 2)
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "GEOS returned error");
-  finishGEOS();
   return result;
 }
 
@@ -1609,14 +1606,13 @@ geom_relate_pattern(const GSERIALIZED *gs1, const GSERIALIZED *gs2, char *p)
 
   /* TODO handle empty */
 
-  initGEOS(lwnotice, lwgeom_geos_error);
+  meos_initialize_geos();
 
   GEOSGeometry *geos1 = POSTGIS2GEOS(gs1);
   if (!geos1)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "First argument geometry could not be converted to GEOS");
-    finishGEOS();
     return false;
   }
   GEOSGeometry *geos2 = POSTGIS2GEOS(gs2);
@@ -1625,7 +1621,6 @@ geom_relate_pattern(const GSERIALIZED *gs1, const GSERIALIZED *gs2, char *p)
     GEOSGeom_destroy(geos1);
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "Second argument geometry could not be converted to GEOS");
-    finishGEOS();
     return false;
   }
 
@@ -1645,7 +1640,6 @@ geom_relate_pattern(const GSERIALIZED *gs1, const GSERIALIZED *gs2, char *p)
   if (result == 2)
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "GEOSRelatePattern returned error");
-  finishGEOS();
   return (bool) result;
 }
 
@@ -1716,7 +1710,7 @@ geom_array_union(GSERIALIZED **gsarr, int count)
   GEOSGeometry *g = NULL;
   GEOSGeometry *g_union = NULL;
 
-  initGEOS(lwnotice, lwgeom_geos_error);
+  meos_initialize_geos();
 
   /* Collect the non-empty inputs and stuff them into a GEOS collection */
   GEOSGeometry **geoms = palloc(sizeof(GEOSGeometry *) * count);
@@ -1754,7 +1748,6 @@ geom_array_union(GSERIALIZED **gsarr, int count)
       {
         meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
           "One of the geometries in the set could not be converted to GEOS");
-        finishGEOS();
         return NULL;
       }
 
@@ -1773,7 +1766,6 @@ geom_array_union(GSERIALIZED **gsarr, int count)
     {
       meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
         "Could not create GEOS COLLECTION from geometry array");
-      finishGEOS();
       return NULL;
     }
 
@@ -1782,7 +1774,6 @@ geom_array_union(GSERIALIZED **gsarr, int count)
     if (! g_union)
     {
       meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR, "GEOSUnaryUnion");
-      finishGEOS();
       return NULL;
     }
 
@@ -1795,7 +1786,6 @@ geom_array_union(GSERIALIZED **gsarr, int count)
   /* No real geometries in our array, any empties? */
   else
   {
-    finishGEOS();
     /* If it was only empties, we'll return the largest type number */
     if (empty_type > 0)
     {
@@ -1810,7 +1800,6 @@ geom_array_union(GSERIALIZED **gsarr, int count)
   }
 
   pfree(geoms);
-  finishGEOS();
   if (! result)
     /* Union returned a NULL geometry */
     return NULL;
@@ -1852,14 +1841,13 @@ geom_convex_hull(const GSERIALIZED *gs)
 
   int32_t srid = gserialized_get_srid(gs);
 
-  initGEOS(lwnotice, lwgeom_geos_error);
+  meos_initialize_geos();
 
   GEOSGeometry *geos1 = POSTGIS2GEOS(gs);
   if (!geos1)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "First argument geometry could not be converted to GEOS");
-    finishGEOS();
     return NULL;
   }
 
@@ -1870,7 +1858,6 @@ geom_convex_hull(const GSERIALIZED *gs)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "GEOS convexhull() threw an error !");
-    finishGEOS();
     return NULL;
   }
 
@@ -1883,7 +1870,6 @@ geom_convex_hull(const GSERIALIZED *gs)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "convexhull() failed to convert GEOS geometry to LWGEOM");
-    finishGEOS();
     return NULL;
   }
 
@@ -1898,7 +1884,6 @@ geom_convex_hull(const GSERIALIZED *gs)
 
   GSERIALIZED *result = geo_serialize(lwout);
   lwgeom_free(lwout);
-  finishGEOS();
   if (! result)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
@@ -2060,14 +2045,13 @@ geom_buffer(const GSERIALIZED *gs, double size, const char *params)
 
   lwgeom_free(lwg);
 
-  initGEOS(lwnotice, lwgeom_geos_error);
+  meos_initialize_geos();
 
   g1 = POSTGIS2GEOS(gs);
   if (! g1)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "First argument geometry could not be converted to GEOS");
-    finishGEOS();
     return NULL;
   }
 
@@ -2101,7 +2085,6 @@ geom_buffer(const GSERIALIZED *gs, double size, const char *params)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "GEOSBuffer returned error");
-    finishGEOS();
     return NULL;
   }
 
@@ -2109,7 +2092,6 @@ geom_buffer(const GSERIALIZED *gs, double size, const char *params)
 
   GSERIALIZED *result = GEOS2POSTGIS(g3, gserialized_has_z(gs));
   GEOSGeom_destroy(g3);
-  finishGEOS();
   if (! result)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
@@ -2240,7 +2222,7 @@ geo_equals(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   if (VARSIZE(gs1) == VARSIZE(gs2) && ! memcmp(gs1, gs2, VARSIZE(gs1)))
       return 1;
 
-  initGEOS(lwnotice, lwgeom_geos_error);
+  meos_initialize_geos();
 
   GEOSGeometry *geos1 = POSTGIS2GEOS(gs1);
   if (! geos1)
@@ -2248,7 +2230,6 @@ geo_equals(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "First argument geometry could not be converted to GEOS");
     /* Clean up the global context */
-    finishGEOS();
     return -1;
   }
 
@@ -2258,7 +2239,6 @@ geo_equals(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "First argument geometry could not be converted to GEOS");
     GEOSGeom_destroy(geos1);
-    finishGEOS();
     return -1;
   }
 
@@ -2270,11 +2250,9 @@ geo_equals(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "GEOS equals() threw an error !");
-    finishGEOS();
     return -1;
   }
 
-  finishGEOS();
   return result;
 }
 

--- a/meos/src/geo/tgeo_spatialfuncs.c
+++ b/meos/src/geo/tgeo_spatialfuncs.c
@@ -1733,7 +1733,7 @@ geo_cluster_dbscan(const GSERIALIZED **geoms, uint32_t ngeoms,
 
   uint32_t i;
   char *is_in_cluster = NULL;
-  initGEOS(lwnotice, lwgeom_geos_error);
+  meos_initialize_geos();
   LWGEOM **lwgeoms = lwalloc(ngeoms * sizeof(LWGEOM *));
   UNIONFIND *uf = UF_create(ngeoms);
   for (i = 0; i < ngeoms; i++)
@@ -1757,7 +1757,6 @@ geo_cluster_dbscan(const GSERIALIZED **geoms, uint32_t ngeoms,
 
   uint32_t *result_ids = UF_get_collapsed_cluster_ids(uf, is_in_cluster);
   *count = uf->N;
-  finishGEOS();
   UF_destroy(uf);
   if (is_in_cluster)
     lwfree(is_in_cluster);
@@ -1791,7 +1790,7 @@ geo_cluster_intersecting(const GSERIALIZED **geoms, uint32_t ngeoms,
   /* TODO short-circuit for one element? */
 
   /* Ok, we really need geos now ;) */
-  initGEOS(lwnotice, lwgeom_geos_error);
+  meos_initialize_geos();
   GEOSGeometry **geos_inputs = palloc(ngeoms * sizeof(GEOSGeometry *));
   for (i = 0; i < ngeoms; i++)
   {
@@ -1841,7 +1840,6 @@ geo_cluster_intersecting(const GSERIALIZED **geoms, uint32_t ngeoms,
   }
   lwfree(geos_results);
   *count = nclusters;
-  finishGEOS();
   return result;
 }
 
@@ -1872,7 +1870,7 @@ geo_cluster_within(const GSERIALIZED **geoms, uint32_t ngeoms,
   }
 
   uint32_t i;
-  initGEOS(lwnotice, lwgeom_geos_error);
+  meos_initialize_geos();
   LWGEOM **lwgeoms = lwalloc(ngeoms * sizeof(LWGEOM *));
   for (i = 0; i < ngeoms; i++)
     lwgeoms[i] = lwgeom_from_gserialized(geoms[i]);
@@ -1899,7 +1897,6 @@ geo_cluster_within(const GSERIALIZED **geoms, uint32_t ngeoms,
     lwgeom_free(lw_results[i]);
   }
   lwfree(lw_results);
-  finishGEOS();
   *count = nclusters;
   return result;
 }

--- a/meos/src/geo/tpoint_spatialfuncs.c
+++ b/meos/src/geo/tpoint_spatialfuncs.c
@@ -3405,7 +3405,7 @@ tpointseq_stops_iter(const TSequence *seq, double maxdist, int64 mintunits,
   /* Use GEOS only for non-scalar input */
   bool geodetic = MEOS_FLAGS_GET_GEODETIC(seq->flags);
   GEOSGeometry *geom = NULL;
-  initGEOS(lwnotice, lwgeom_geos_error);
+  meos_initialize_geos();
   geom = GEOSGeom_createEmptyCollection(GEOS_MULTIPOINT);
 
   const TInstant *inst1 = NULL, *inst2 = NULL; /* make compiler quiet */
@@ -3462,7 +3462,6 @@ tpointseq_stops_iter(const TSequence *seq, double maxdist, int64 mintunits,
     result[nseqs++] = tsequence_make(instants, end - start, true, true, LINEAR,
       NORMALIZE_NO);
   }
-  finishGEOS();
   return nseqs;
 }
 

--- a/meos/src/temporal/meos.c
+++ b/meos/src/temporal/meos.c
@@ -42,6 +42,8 @@
 #include <gsl/gsl_randist.h>
 /* Proj */
 #include <proj.h>
+/* PostGIS */
+#include <lwgeom_geos.h>
 /* MEOS */
 #include <meos.h>
 
@@ -572,6 +574,8 @@ meos_initialize(void)
   proj_initialize();
   /* Initialize GSL */
   gsl_initialize();
+  /* Initialize GEOS — exactly once per process via pthread_once */
+  meos_initialize_geos();
   return;
 }
 

--- a/postgis/liblwgeom/lwgeom_geos.c
+++ b/postgis/liblwgeom/lwgeom_geos.c
@@ -32,6 +32,7 @@
 
 #include <stdarg.h>
 #include <stdlib.h>
+#include <pthread.h>
 
 LWTIN* lwtin_from_geos(const GEOSGeometry* geom, uint8_t want3d);
 
@@ -74,6 +75,34 @@ lwgeom_geos_error_minversion(const char *functionality, const char *minver)
 		" this version of PostGIS was built against version %s",
 		functionality, minver, lwgeom_geos_compiled_version()
 	);
+}
+
+/*
+ * Thread-safe once-per-process GEOS initialisation.
+ *
+ * The non-reentrant GEOS API (initGEOS / GEOSIntersects / ...) uses a single
+ * global GEOSContextHandle_t.  Calling initGEOS concurrently from multiple
+ * threads corrupts that handle.  We therefore call it exactly once, protected
+ * by pthread_once, and never call finishGEOS from individual operations
+ * (those calls used to clean up "per-call" state that was never truly
+ * per-call — the handle is process-global).
+ *
+ * GEOSGeometry objects created and destroyed within each function call are
+ * independent allocations and are safe to use concurrently once GEOS is
+ * initialised.
+ */
+static pthread_once_t meos_geos_once_ctrl = PTHREAD_ONCE_INIT;
+
+static void
+meos_geos_init_fn(void)
+{
+	initGEOS(lwnotice, lwgeom_geos_error);
+}
+
+void
+meos_initialize_geos(void)
+{
+	pthread_once(&meos_geos_once_ctrl, meos_geos_init_fn);
 }
 
 /* Destroy any non-null GEOSGeometry* pointers passed as arguments */
@@ -667,7 +696,7 @@ lwgeom_normalize(const LWGEOM* geom)
 
 	if (srid == SRID_INVALID) return NULL;
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	meos_initialize_geos();
 
 	if (!(g = LWGEOM2GEOS(geom, AUTOFIX))) GEOS_FAIL();
 
@@ -677,7 +706,6 @@ lwgeom_normalize(const LWGEOM* geom)
 	if (!(result = GEOS2LWGEOM(g, is3d))) GEOS_FREE_AND_FAIL(g);
 
 	GEOSGeom_destroy(g);
-  finishGEOS(); // MEOS remove memory leak
 	return result;
 }
 
@@ -705,7 +733,7 @@ lwgeom_intersection_prec(const LWGEOM* geom1, const LWGEOM* geom2, double prec)
 	/* Empty.Intersection(A) == Empty */
 	if (lwgeom_is_empty(geom1)) return lwgeom_clone_deep(geom1); /* match empty type? */
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	meos_initialize_geos();
 
 	if (!(g1 = LWGEOM2GEOS(geom1, AUTOFIX))) GEOS_FAIL();
 	if (!(g2 = LWGEOM2GEOS(geom2, AUTOFIX))) GEOS_FREE_AND_FAIL(g1);
@@ -714,7 +742,6 @@ lwgeom_intersection_prec(const LWGEOM* geom1, const LWGEOM* geom2, double prec)
 #if POSTGIS_GEOS_VERSION < 30900
 		lwgeom_geos_error_minversion("Fixed-precision intersection", "3.9");
 		GEOS_FREE_AND_FAIL(g1, g2);
-		finishGEOS(); // MEOS remove memory leak
 		return NULL;
 #else
 		g3 = GEOSIntersectionPrec(g1, g2, prec);
@@ -731,7 +758,6 @@ lwgeom_intersection_prec(const LWGEOM* geom1, const LWGEOM* geom2, double prec)
 	if (!(result = GEOS2LWGEOM(g3, is3d))) GEOS_FREE_AND_FAIL(g1, g2, g3);
 
 	GEOS_FREE(g1, g2, g3);
-	finishGEOS(); // MEOS remove memory leak
 	return result;
 }
 
@@ -755,7 +781,7 @@ lwgeom_linemerge_directed(const LWGEOM* geom, int directed)
 	/* Empty.Linemerge() == Empty */
 	if (lwgeom_is_empty(geom)) return lwgeom_clone_deep(geom); /* match empty type to linestring? */
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	meos_initialize_geos();
 
 	if (!(g1 = LWGEOM2GEOS(geom, AUTOFIX))) GEOS_FAIL();
 
@@ -805,7 +831,7 @@ lwgeom_unaryunion_prec(const LWGEOM* geom, double prec)
 	/* Empty.UnaryUnion() == Empty */
 	if (lwgeom_is_empty(geom)) return lwgeom_clone_deep(geom);
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	meos_initialize_geos();
 
 	if (!(g1 = LWGEOM2GEOS(geom, AUTOFIX))) GEOS_FAIL();
 
@@ -813,7 +839,6 @@ lwgeom_unaryunion_prec(const LWGEOM* geom, double prec)
 #if POSTGIS_GEOS_VERSION < 30900
 		lwgeom_geos_error_minversion("Fixed-precision unary union", "3.9");
 		GEOS_FREE_AND_FAIL(g1);
-		finishGEOS(); // MEOS to remove memory leak
 		return NULL;
 #else
 		g3 = GEOSUnaryUnionPrec(g1, prec);
@@ -831,7 +856,6 @@ lwgeom_unaryunion_prec(const LWGEOM* geom, double prec)
 		GEOS_FREE_AND_FAIL(g1, g3);
 
 	GEOS_FREE(g1, g3);
-	finishGEOS(); // MEOS to remove memory leak
 
 	return result;
 }
@@ -858,7 +882,7 @@ lwgeom_difference_prec(const LWGEOM* geom1, const LWGEOM* geom2, double prec)
 	/* Empty.Intersection(A) == Empty */
 	if (lwgeom_is_empty(geom1)) return lwgeom_clone_deep(geom1); /* match empty type? */
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	meos_initialize_geos();
 
 	if (!(g1 = LWGEOM2GEOS(geom1, AUTOFIX))) GEOS_FAIL();
 	if (!(g2 = LWGEOM2GEOS(geom2, AUTOFIX))) GEOS_FREE_AND_FAIL(g1);
@@ -867,7 +891,6 @@ lwgeom_difference_prec(const LWGEOM* geom1, const LWGEOM* geom2, double prec)
 #if POSTGIS_GEOS_VERSION < 30900
 		lwgeom_geos_error_minversion("Fixed-precision difference", "3.9");
 		GEOS_FREE_AND_FAIL(g1, g2);
-		finishGEOS(); // MEOS remove memory leak
 		return NULL;
 #else
 		g3 = GEOSDifferencePrec(g1, g2, prec);
@@ -885,7 +908,6 @@ lwgeom_difference_prec(const LWGEOM* geom1, const LWGEOM* geom2, double prec)
 		GEOS_FREE_AND_FAIL(g1, g2, g3);
 
 	GEOS_FREE(g1, g2, g3);
-	finishGEOS(); // MEOS remove memory leak
 	return result;
 }
 
@@ -911,7 +933,7 @@ lwgeom_symdifference_prec(const LWGEOM* geom1, const LWGEOM* geom2, double prec)
 	/* Empty.DymDifference(B) == B */
 	if (lwgeom_is_empty(geom1)) return lwgeom_clone_deep(geom2);
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	meos_initialize_geos();
 
 	if (!(g1 = LWGEOM2GEOS(geom1, AUTOFIX))) GEOS_FAIL();
 	if (!(g2 = LWGEOM2GEOS(geom2, AUTOFIX))) GEOS_FREE_AND_FAIL(g1);
@@ -920,7 +942,6 @@ lwgeom_symdifference_prec(const LWGEOM* geom1, const LWGEOM* geom2, double prec)
 #if POSTGIS_GEOS_VERSION < 30900
 		lwgeom_geos_error_minversion("Fixed-precision symdifference", "3.9");
 		GEOS_FREE_AND_FAIL(g1, g2);
-		finishGEOS(); // MEOS remove memory leak
 		return NULL;
 #else
 		g3 = GEOSSymDifferencePrec(g1, g2, prec);
@@ -938,7 +959,6 @@ lwgeom_symdifference_prec(const LWGEOM* geom1, const LWGEOM* geom2, double prec)
 		GEOS_FREE_AND_FAIL(g1, g2, g3);
 
 	GEOS_FREE(g1, g2, g3);
-	finishGEOS(); // MEOS remove memory leak
 	return result;
 }
 
@@ -958,7 +978,7 @@ lwgeom_centroid(const LWGEOM* geom)
 		return lwpoint_as_lwgeom(lwp);
 	}
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	meos_initialize_geos();
 
 	if (!(g1 = LWGEOM2GEOS(geom, AUTOFIX))) GEOS_FAIL();
 
@@ -971,7 +991,6 @@ lwgeom_centroid(const LWGEOM* geom)
 		GEOS_FREE_AND_FAIL(g1);
 
 	GEOS_FREE(g1, g3);
-	finishGEOS(); // MEOS remove memory leak
 
 	return result;
 }
@@ -994,7 +1013,7 @@ lwgeom_reduceprecision(const LWGEOM* geom, double gridSize)
 	if (lwgeom_is_empty(geom))
 		return lwgeom_clone_deep(geom);
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	meos_initialize_geos();
 
 	if (!(g1 = LWGEOM2GEOS(geom, AUTOFIX))) GEOS_FAIL();
 
@@ -1007,7 +1026,6 @@ lwgeom_reduceprecision(const LWGEOM* geom, double gridSize)
 		GEOS_FREE_AND_FAIL(g1);
 
 	GEOS_FREE(g1, g3);
-	finishGEOS(); // MEOS remove memory leak
 	return result;
 #endif
 }
@@ -1028,7 +1046,7 @@ lwgeom_pointonsurface(const LWGEOM *geom)
 		return lwpoint_as_lwgeom(lwp);
 	}
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	meos_initialize_geos();
 
 	if (!(g1 = LWGEOM2GEOS(geom, AUTOFIX))) GEOS_FAIL();
 
@@ -1041,7 +1059,6 @@ lwgeom_pointonsurface(const LWGEOM *geom)
 		GEOS_FREE_AND_FAIL(g1, g3);
 
 	GEOS_FREE(g1, g3);
-	finishGEOS(); // MEOS remove memory leak
 	return result;
 }
 
@@ -1067,7 +1084,7 @@ lwgeom_union_prec(const LWGEOM* geom1, const LWGEOM* geom2, double gridSize)
 	/* B.Union(empty) == B */
 	if (lwgeom_is_empty(geom2)) return lwgeom_clone_deep(geom1);
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	meos_initialize_geos();
 
 	if (!(g1 = LWGEOM2GEOS(geom1, AUTOFIX))) GEOS_FAIL();
 	if (!(g2 = LWGEOM2GEOS(geom2, AUTOFIX))) GEOS_FREE_AND_FAIL(g1);
@@ -1076,7 +1093,6 @@ lwgeom_union_prec(const LWGEOM* geom1, const LWGEOM* geom2, double gridSize)
 #if POSTGIS_GEOS_VERSION < 30900
 		lwgeom_geos_error_minversion("Fixed-precision union", "3.9");
 		GEOS_FREE_AND_FAIL(g1, g2);
-		finishGEOS(); // MEOS remove memory leak
 		return NULL;
 #else
 		g3 = GEOSUnionPrec(g1, g2, gridSize);
@@ -1094,7 +1110,6 @@ lwgeom_union_prec(const LWGEOM* geom1, const LWGEOM* geom2, double gridSize)
 		GEOS_FREE_AND_FAIL(g1, g2, g3);
 
 	GEOS_FREE(g1, g2, g3);
-	finishGEOS(); // MEOS remove memory leak
 	return result;
 }
 
@@ -1111,7 +1126,7 @@ lwgeom_clip_by_rect(const LWGEOM *geom1, double x1, double y1, double x2, double
 
 	is3d = FLAGS_GET_Z(geom1->flags);
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	meos_initialize_geos();
 
 	if (!(g1 = LWGEOM2GEOS(geom1, AUTOFIX)))
 		GEOS_FAIL_DEBUG();
@@ -1128,7 +1143,6 @@ lwgeom_clip_by_rect(const LWGEOM *geom1, double x1, double y1, double x2, double
 
 	result->srid = geom1->srid;
 
-	finishGEOS(); // MEOS remove memory leak
 	return result;
 }
 
@@ -1146,7 +1160,7 @@ lwgeom_buildarea(const LWGEOM* geom)
 	/* Can't build an area from an empty! */
 	if (lwgeom_is_empty(geom)) return (LWGEOM*)lwpoly_construct_empty(srid, is3d, 0);
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	meos_initialize_geos();
 
 	if (!(g1 = LWGEOM2GEOS(geom, AUTOFIX))) GEOS_FAIL();
 
@@ -1159,7 +1173,6 @@ lwgeom_buildarea(const LWGEOM* geom)
 	if (GEOSGetNumGeometries(g3) == 0)
 	{
 		GEOS_FREE(g1, g3);
-		finishGEOS(); // MEOS remove memory leak
 		return NULL;
 	}
 
@@ -1167,7 +1180,6 @@ lwgeom_buildarea(const LWGEOM* geom)
 		GEOS_FREE_AND_FAIL(g1, g3);
 
 	GEOS_FREE(g1, g3);
-	finishGEOS(); // MEOS remove memory leak
 
 	return result;
 }
@@ -1183,7 +1195,7 @@ lwgeom_is_simple(const LWGEOM* geom)
 	/* Empty is always simple */
 	if (lwgeom_is_empty(geom)) return LW_TRUE;
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	meos_initialize_geos();
 
 	if (!(g = LWGEOM2GEOS(geom, AUTOFIX))) return -1;
 
@@ -1209,7 +1221,7 @@ lwgeom_geos_noop(const LWGEOM* geom)
 
 	if (srid == SRID_INVALID) return NULL;
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	meos_initialize_geos();
 
 	if (!(g = LWGEOM2GEOS(geom, AUTOFIX))) GEOS_FAIL();
 
@@ -1234,7 +1246,7 @@ lwgeom_snap(const LWGEOM* geom1, const LWGEOM* geom2, double tolerance)
 
 	if (srid == SRID_INVALID) return NULL;
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	meos_initialize_geos();
 
 	if (!(g1 = LWGEOM2GEOS(geom1, AUTOFIX))) GEOS_FAIL();
 	if (!(g2 = LWGEOM2GEOS(geom2, AUTOFIX))) GEOS_FREE_AND_FAIL(g1);
@@ -1261,7 +1273,7 @@ lwgeom_sharedpaths(const LWGEOM* geom1, const LWGEOM* geom2)
 
 	if (srid == SRID_INVALID) return NULL;
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	meos_initialize_geos();
 
 	if (!(g1 = LWGEOM2GEOS(geom1, AUTOFIX))) GEOS_FAIL();
 	if (!(g2 = LWGEOM2GEOS(geom2, AUTOFIX))) GEOS_FREE_AND_FAIL(g1);
@@ -1289,7 +1301,7 @@ lwline_offsetcurve(const LWLINE *lwline, double size, int quadsegs, int joinStyl
 
 	if (srid == SRID_INVALID) return NULL;
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	meos_initialize_geos();
 
 	if (!(g1 = LWGEOM2GEOS(geom, AUTOFIX))) GEOS_FAIL();
 
@@ -1507,7 +1519,7 @@ lwpoly_to_points(const LWPOLY* lwpoly, uint32_t npoints, int32_t seed)
 	}
 
 	/* Prepare the polygon for fast true/false testing */
-	initGEOS(lwnotice, lwgeom_geos_error);
+	meos_initialize_geos();
 	g = (GEOSGeometry*)LWGEOM2GEOS(lwgeom, 0);
 	if (!g)
 	{
@@ -1777,7 +1789,7 @@ lwgeom_delaunay_triangulation(const LWGEOM* geom, double tolerance, int32_t outp
 
 	if (srid == SRID_INVALID) return NULL;
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	meos_initialize_geos();
 
 	if (!(g1 = LWGEOM2GEOS(geom, AUTOFIX))) GEOS_FAIL();
 
@@ -1864,7 +1876,7 @@ lwgeom_voronoi_diagram(const LWGEOM* g, const GBOX* env, double tolerance, int o
 		return lwcollection_as_lwgeom(empty);
 	}
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	meos_initialize_geos();
 
 	/* Instead of using the standard LWGEOM2GEOS transformer, we read the vertices of the LWGEOM directly and put
 	 * them into a single GEOS CoordinateSeq that can be used to define a LineString.  This allows us to process
@@ -1912,7 +1924,7 @@ lwgeom_concavehull(const LWGEOM* geom, double ratio, uint32_t allow_holes)
 	GEOSGeometry *g1, *g3;
 	int geosGeomType;
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	meos_initialize_geos();
 
 	if (!(g1 = LWGEOM2GEOS(geom, AUTOFIX))) GEOS_FAIL();
 
@@ -1945,7 +1957,7 @@ lwgeom_simplify_polygonal(const LWGEOM* geom, double vertex_fraction, uint32_t i
 	uint8_t is3d = FLAGS_GET_Z(geom->flags);
 	GEOSGeometry *g1, *g3;
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	meos_initialize_geos();
 
 	if (!(g1 = LWGEOM2GEOS(geom, AUTOFIX))) GEOS_FAIL();
 
@@ -1973,7 +1985,7 @@ lwgeom_triangulate_polygon(const LWGEOM* geom)
 
 	if (srid == SRID_INVALID) return NULL;
 
-	initGEOS(lwnotice, lwgeom_geos_error);
+	meos_initialize_geos();
 
 	if (!(g1 = LWGEOM2GEOS(geom, AUTOFIX))) GEOS_FAIL();
 

--- a/postgis/liblwgeom/lwgeom_geos.h
+++ b/postgis/liblwgeom/lwgeom_geos.h
@@ -52,6 +52,17 @@ POINTARRAY* ptarray_from_GEOSCoordSeq(const GEOSCoordSequence* cs, uint8_t want3
 extern char lwgeom_geos_errmsg[];
 extern void lwgeom_geos_error(const char* fmt, ...) __attribute__ ((format (printf, 1, 2)));
 
+/*
+ * Thread-safe GEOS initialisation.
+ *
+ * Call initGEOS exactly once per process (guarded by pthread_once) so that
+ * multiple MEOS threads do not concurrently modify the single global
+ * GEOSContextHandle used by the non-reentrant GEOS API.  Individual
+ * operations must never call finishGEOS() — the context lives for the
+ * lifetime of the process.
+ */
+extern void meos_initialize_geos(void);
+
 
 /*
  * Debug macros


### PR DESCRIPTION
Guard the single global GEOS context with a pthread_once initializer (meos_initialize_geos) and call it at the MEOS init path and before each GEOS-using geo entry point, replacing the per-operation initGEOS/finishGEOS pairs that tore the context down after every call. Concurrent MEOS worker threads no longer race on initGEOS, and repeated GEOS operations within a process reuse the live context. The vendored liblwgeom change is isolated in its own commit from the first-party MEOS wiring, and POSIX threads are linked via find_package(Threads) for the pthread_once guard.