### PR TITLE
Normalize the set-set minDistance function name to mindistance_tgeoarr_tgeoarr

### DIFF
--- a/meos/include/meos_geo.h
+++ b/meos/include/meos_geo.h
@@ -866,7 +866,7 @@ extern TInstant *nai_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs);
 extern TInstant *nai_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2);
 extern GSERIALIZED *shortestline_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs);
 extern GSERIALIZED *shortestline_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2);
-extern double tgeoarr_tgeoarr_mindist(const Temporal **arr1, int count1, const Temporal **arr2, int count2);
+extern double mindistance_tgeoarr_tgeoarr(const Temporal **arr1, int count1, const Temporal **arr2, int count2);
 extern double mindistance_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2, double threshold);
 
 /* Aggregates */

--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -1268,10 +1268,10 @@ tgeoarr_pair_cmp(const void *a, const void *b)
  * @param[in] count1,count2 Array lengths (must be > 0)
  * @return Minimum spatial distance; DBL_MAX on validation failure or on
  *   any empty input array.
- * @csqlfn #Tgeoarr_tgeoarr_mindist()
+ * @csqlfn #Mindistance_tgeoarr_tgeoarr()
  */
 double
-tgeoarr_tgeoarr_mindist(const Temporal **arr1, int count1,
+mindistance_tgeoarr_tgeoarr(const Temporal **arr1, int count1,
   const Temporal **arr2, int count2)
 {
   VALIDATE_NOT_NULL(arr1, DBL_MAX);

--- a/mobilitydb/sql/geo/064_tgeo_distance.in.sql
+++ b/mobilitydb/sql/geo/064_tgeo_distance.in.sql
@@ -252,11 +252,11 @@ CREATE FUNCTION shortestLine(tgeography, tgeography)
 
 CREATE FUNCTION minDistance(tgeompoint[], tgeompoint[])
   RETURNS float
-  AS 'MODULE_PATHNAME', 'Tgeoarr_tgeoarr_mindist'
+  AS 'MODULE_PATHNAME', 'Mindistance_tgeoarr_tgeoarr'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION minDistance(tgeometry[], tgeometry[])
   RETURNS float
-  AS 'MODULE_PATHNAME', 'Tgeoarr_tgeoarr_mindist'
+  AS 'MODULE_PATHNAME', 'Mindistance_tgeoarr_tgeoarr'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*

--- a/mobilitydb/src/geo/tgeo_distance.c
+++ b/mobilitydb/src/geo/tgeo_distance.c
@@ -429,8 +429,8 @@ Shortestline_tgeo_tgeo(PG_FUNCTION_ARGS)
  * Set-set spatial minimum distance
  *****************************************************************************/
 
-PGDLLEXPORT Datum Tgeoarr_tgeoarr_mindist(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Tgeoarr_tgeoarr_mindist);
+PGDLLEXPORT Datum Mindistance_tgeoarr_tgeoarr(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Mindistance_tgeoarr_tgeoarr);
 /**
  * @ingroup mobilitydb_geo_dist
  * @brief Return the exact minimum spatial distance between two arrays of
@@ -438,14 +438,14 @@ PG_FUNCTION_INFO_V1(Tgeoarr_tgeoarr_mindist);
  * @sqlfn minDistance()
  */
 Datum
-Tgeoarr_tgeoarr_mindist(PG_FUNCTION_ARGS)
+Mindistance_tgeoarr_tgeoarr(PG_FUNCTION_ARGS)
 {
   ArrayType *array1 = PG_GETARG_ARRAYTYPE_P(0);
   ArrayType *array2 = PG_GETARG_ARRAYTYPE_P(1);
   int count1, count2;
   Temporal **arr1 = (Temporal **) temparr_extract(array1, &count1);
   Temporal **arr2 = (Temporal **) temparr_extract(array2, &count2);
-  double result = tgeoarr_tgeoarr_mindist((const Temporal **) arr1, count1,
+  double result = mindistance_tgeoarr_tgeoarr((const Temporal **) arr1, count1,
     (const Temporal **) arr2, count2);
   pfree(arr1); pfree(arr2);
   PG_FREE_IF_COPY(array1, 0);


### PR DESCRIPTION
Rename the set-set kernel and wrapper from tgeoarr_tgeoarr_mindist to mindistance_tgeoarr_tgeoarr, matching the operation-first full-word form of the scalar mindistance_tgeo_tgeo, and update the @csqlfn linkage tag accordingly. The minDistance SQL surface and its manual entry are unchanged.