### PR TITLE
Rename the public trgeometry C API from trgeo to trgeometry

### DIFF
--- a/meos/include/meos_rgeo.h
+++ b/meos/include/meos_rgeo.h
@@ -74,99 +74,97 @@
  * Input/output functions
  *****************************************************************************/
 
-extern char *trgeo_out(const Temporal *temp);
+extern char *trgeometry_out(const Temporal *temp);
 
 /*****************************************************************************
  * Constructor functions
  *****************************************************************************/
 
 extern TInstant *trgeoinst_make(const GSERIALIZED *geom, const Pose *pose, TimestampTz t);
-extern Temporal *geo_tpose_to_trgeo(const GSERIALIZED *gs, const Temporal *temp);
+extern Temporal *geo_tpose_to_trgeometry(const GSERIALIZED *gs, const Temporal *temp);
 
 /*****************************************************************************
  * Conversion functions
  *****************************************************************************/
 
-extern Temporal *trgeo_to_tpose(const Temporal *temp);
-extern Temporal *trgeo_to_tpoint(const Temporal *temp);
+extern Temporal *trgeometry_to_tpose(const Temporal *temp);
+extern Temporal *trgeometry_to_tpoint(const Temporal *temp);
 
 /*****************************************************************************
  * Accessor functions
  *****************************************************************************/
 
-extern TInstant *trgeo_end_instant(const Temporal *temp);
-extern TSequence *trgeo_end_sequence(const Temporal *temp);
-extern GSERIALIZED *trgeo_end_value(const Temporal *temp);
-extern GSERIALIZED *trgeo_geom(const Temporal *temp);
-extern TInstant *trgeo_instant_n(const Temporal *temp, int n);
-extern TInstant **trgeo_instants(const Temporal *temp, int *count);
-extern Set *trgeo_points(const Temporal *temp);
-extern Temporal *trgeo_rotation(const Temporal *temp);
-extern TSequence **trgeo_segments(const Temporal *temp, int *count);
-extern TSequence *trgeo_sequence_n(const Temporal *temp, int i);
-extern TSequence **trgeo_sequences(const Temporal *temp, int *count);
-extern TInstant *trgeo_start_instant(const Temporal *temp);
-extern TSequence *trgeo_start_sequence(const Temporal *temp);
-extern GSERIALIZED *trgeo_start_value(const Temporal *temp);
-extern bool trgeo_value_n(const Temporal *temp, int n, GSERIALIZED **result);
-extern GSERIALIZED *trgeo_traversed_area(const Temporal *temp, bool unary_union);
+extern TInstant *trgeometry_end_instant(const Temporal *temp);
+extern TSequence *trgeometry_end_sequence(const Temporal *temp);
+extern GSERIALIZED *trgeometry_end_value(const Temporal *temp);
+extern GSERIALIZED *trgeometry_geom(const Temporal *temp);
+extern TInstant *trgeometry_instant_n(const Temporal *temp, int n);
+extern TInstant **trgeometry_instants(const Temporal *temp, int *count);
+extern Set *trgeometry_points(const Temporal *temp);
+extern Temporal *trgeometry_rotation(const Temporal *temp);
+extern TSequence **trgeometry_segments(const Temporal *temp, int *count);
+extern TSequence *trgeometry_sequence_n(const Temporal *temp, int i);
+extern TSequence **trgeometry_sequences(const Temporal *temp, int *count);
+extern TInstant *trgeometry_start_instant(const Temporal *temp);
+extern TSequence *trgeometry_start_sequence(const Temporal *temp);
+extern GSERIALIZED *trgeometry_start_value(const Temporal *temp);
+extern bool trgeometry_value_n(const Temporal *temp, int n, GSERIALIZED **result);
+extern GSERIALIZED *trgeometry_traversed_area(const Temporal *temp, bool unary_union);
 
 /*****************************************************************************
  * Transformation functions
  *****************************************************************************/
 
-extern Temporal *trgeo_append_tinstant(Temporal *temp, const TInstant *inst, interpType interp, double maxdist, const Interval *maxt, bool expand);
-extern Temporal *trgeo_append_tsequence(Temporal *temp, const TSequence *seq, bool expand);
-extern Temporal *trgeo_delete_timestamptz(const Temporal *temp, TimestampTz t, bool connect);
-extern Temporal *trgeo_delete_tstzset(const Temporal *temp, const Set *s, bool connect);
-extern Temporal *trgeo_delete_tstzspan(const Temporal *temp, const Span *s, bool connect);
-extern Temporal *trgeo_delete_tstzspanset(const Temporal *temp, const SpanSet *ss, bool connect);
-extern Temporal *trgeo_round(const Temporal *temp, int maxdd);
-extern Temporal *trgeo_set_interp(const Temporal *temp, interpType interp);
-extern TInstant *trgeo_to_tinstant(const Temporal *temp);
+extern Temporal *trgeometry_append_tinstant(Temporal *temp, const TInstant *inst, interpType interp, double maxdist, const Interval *maxt, bool expand);
+extern Temporal *trgeometry_append_tsequence(Temporal *temp, const TSequence *seq, bool expand);
+extern Temporal *trgeometry_delete_timestamptz(const Temporal *temp, TimestampTz t, bool connect);
+extern Temporal *trgeometry_delete_tstzset(const Temporal *temp, const Set *s, bool connect);
+extern Temporal *trgeometry_delete_tstzspan(const Temporal *temp, const Span *s, bool connect);
+extern Temporal *trgeometry_delete_tstzspanset(const Temporal *temp, const SpanSet *ss, bool connect);
+extern Temporal *trgeometry_round(const Temporal *temp, int maxdd);
+extern Temporal *trgeometry_set_interp(const Temporal *temp, interpType interp);
+extern TInstant *trgeometry_to_tinstant(const Temporal *temp);
 
 /*****************************************************************************
  * Restriction functions
  *****************************************************************************/
 
-extern Temporal *trgeo_after_timestamptz(const Temporal *temp, TimestampTz t, bool strict);
-extern Temporal *trgeo_before_timestamptz(const Temporal *temp, TimestampTz t, bool strict);
+extern Temporal *trgeometry_after_timestamptz(const Temporal *temp, TimestampTz t, bool strict);
+extern Temporal *trgeometry_before_timestamptz(const Temporal *temp, TimestampTz t, bool strict);
 
-extern Temporal *trgeo_restrict_value(const Temporal *temp, Datum value, bool atfunc);
-extern Temporal *trgeo_restrict_values(const Temporal *temp, const Set *s, bool atfunc);
+extern Temporal *trgeometry_restrict_value(const Temporal *temp, Datum value, bool atfunc);
+extern Temporal *trgeometry_restrict_values(const Temporal *temp, const Set *s, bool atfunc);
 
-extern Temporal *trgeo_restrict_timestamptz(const Temporal *temp, TimestampTz t, bool atfunc);
-extern Temporal *trgeo_restrict_tstzset(const Temporal *temp, const Set *s, bool atfunc);
-extern Temporal *trgeo_restrict_tstzspan(const Temporal *temp, const Span *s, bool atfunc);
-extern Temporal *trgeo_restrict_tstzspanset(const Temporal *temp, const SpanSet *ss, bool atfunc);
+extern Temporal *trgeometry_restrict_timestamptz(const Temporal *temp, TimestampTz t, bool atfunc);
+extern Temporal *trgeometry_restrict_tstzset(const Temporal *temp, const Set *s, bool atfunc);
+extern Temporal *trgeometry_restrict_tstzspan(const Temporal *temp, const Span *s, bool atfunc);
+extern Temporal *trgeometry_restrict_tstzspanset(const Temporal *temp, const SpanSet *ss, bool atfunc);
 
-// extern Temporal *trgeo_at_geom(const Temporal *temp, const GSERIALIZED *gs);
-// extern Temporal *trgeo_at_geo(const Temporal *temp, const GSERIALIZED *gs);
-// extern Temporal *trgeo_at_stbox(const Temporal *temp, const STBox *box, bool border_inc);
-// extern Temporal *trgeo_at_elevation(const Temporal *temp, const Span *s);
-// extern Temporal *trgeo_minus_geom(const Temporal *temp, const GSERIALIZED *gs);
-// extern Temporal *trgeo_minus_geo(const Temporal *temp, const GSERIALIZED *gs);
-// extern Temporal *trgeo_minus_stbox(const Temporal *temp, const STBox *box, bool border_inc);
-// extern Temporal *trgeo_minus_elevation(const Temporal *temp, const Span *s);
+// extern Temporal *trgeometry_at_geom(const Temporal *temp, const GSERIALIZED *gs);
+// extern Temporal *trgeometry_at_stbox(const Temporal *temp, const STBox *box, bool border_inc);
+// extern Temporal *trgeometry_at_elevation(const Temporal *temp, const Span *s);
+// extern Temporal *trgeometry_minus_geom(const Temporal *temp, const GSERIALIZED *gs);
+// extern Temporal *trgeometry_minus_stbox(const Temporal *temp, const STBox *box, bool border_inc);
+// extern Temporal *trgeometry_minus_elevation(const Temporal *temp, const Span *s);
 
 /*****************************************************************************
  * Distance functions
  *****************************************************************************/
 
-extern Temporal *tdistance_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs);
-extern Temporal *tdistance_trgeo_tpoint(const Temporal *temp1, const Temporal *temp2);
-extern Temporal *tdistance_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2);
-extern double nad_stbox_trgeo(const STBox *box, const Temporal *temp);
-extern double nad_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs);
-extern double nad_trgeo_stbox(const Temporal *temp, const STBox *box);
-extern double nad_trgeo_tpoint(const Temporal *temp1, const Temporal *temp2);
-extern double nad_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2);
-extern TInstant *nai_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs);
-extern TInstant *nai_trgeo_tpoint(const Temporal *temp1, const Temporal *temp2);
-extern TInstant *nai_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2);
-extern GSERIALIZED *shortestline_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs);
-extern GSERIALIZED *shortestline_trgeo_tpoint(const Temporal *temp1, const Temporal *temp2);
-extern GSERIALIZED *shortestline_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2);
+extern Temporal *tdistance_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs);
+extern Temporal *tdistance_trgeometry_tpoint(const Temporal *temp1, const Temporal *temp2);
+extern Temporal *tdistance_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2);
+extern double nad_stbox_trgeometry(const STBox *box, const Temporal *temp);
+extern double nad_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs);
+extern double nad_trgeometry_stbox(const Temporal *temp, const STBox *box);
+extern double nad_trgeometry_tpoint(const Temporal *temp1, const Temporal *temp2);
+extern double nad_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2);
+extern TInstant *nai_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs);
+extern TInstant *nai_trgeometry_tpoint(const Temporal *temp1, const Temporal *temp2);
+extern TInstant *nai_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2);
+extern GSERIALIZED *shortestline_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs);
+extern GSERIALIZED *shortestline_trgeometry_tpoint(const Temporal *temp1, const Temporal *temp2);
+extern GSERIALIZED *shortestline_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2);
 
 /*****************************************************************************
  * Comparison functions
@@ -174,22 +172,22 @@ extern GSERIALIZED *shortestline_trgeo_trgeo(const Temporal *temp1, const Tempor
 
 /* Ever/always and temporal comparison functions */
 
-extern int always_eq_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp);
-extern int always_eq_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs);
-extern int always_eq_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2);
-extern int always_ne_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp);
-extern int always_ne_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs);
-extern int always_ne_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2);
-extern int ever_eq_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp);
-extern int ever_eq_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs);
-extern int ever_eq_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2);
-extern int ever_ne_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp);
-extern int ever_ne_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs);
-extern int ever_ne_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2);
-extern Temporal *teq_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp);
-extern Temporal *teq_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs);
-extern Temporal *tne_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp);
-extern Temporal *tne_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs);
+extern int always_eq_geo_trgeometry(const GSERIALIZED *gs, const Temporal *temp);
+extern int always_eq_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs);
+extern int always_eq_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2);
+extern int always_ne_geo_trgeometry(const GSERIALIZED *gs, const Temporal *temp);
+extern int always_ne_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs);
+extern int always_ne_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2);
+extern int ever_eq_geo_trgeometry(const GSERIALIZED *gs, const Temporal *temp);
+extern int ever_eq_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs);
+extern int ever_eq_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2);
+extern int ever_ne_geo_trgeometry(const GSERIALIZED *gs, const Temporal *temp);
+extern int ever_ne_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs);
+extern int ever_ne_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2);
+extern Temporal *teq_geo_trgeometry(const GSERIALIZED *gs, const Temporal *temp);
+extern Temporal *teq_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs);
+extern Temporal *tne_geo_trgeometry(const GSERIALIZED *gs, const Temporal *temp);
+extern Temporal *tne_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs);
 
 /*****************************************************************************/
 

--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -168,7 +168,7 @@ trgeo_from_mfjson(const char *mfjson)
  * @param[in] temp Temporal rigid geometry
  */
 char *
-trgeo_out(const Temporal *temp)
+trgeometry_out(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
@@ -249,7 +249,7 @@ trgeo_as_ewkt(const Temporal *temp, int maxdd)
  * @param[in] temp Temporal rigid geometry
  */
 Temporal *
-trgeo_to_tpose(const Temporal *temp)
+trgeometry_to_tpose(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
@@ -272,7 +272,7 @@ trgeo_to_tpose(const Temporal *temp)
  * @param[in] temp Temporal rigid geometry
  */
 Temporal *
-trgeo_to_tpoint(const Temporal *temp)
+trgeometry_to_tpoint(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
@@ -314,7 +314,7 @@ trgeo_geom_p(const Temporal *temp)
  * @param[in] temp Temporal rigid geometry
  */
 GSERIALIZED *
-trgeo_geom(const Temporal *temp)
+trgeometry_geom(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
@@ -397,7 +397,7 @@ geo_tposeseqset_to_trgeo(const GSERIALIZED *gs, const TSequenceSet *ss)
  * @param[in] temp Temporal pose
  */
 Temporal *
-geo_tpose_to_trgeo(const GSERIALIZED *gs, const Temporal *temp)
+geo_tpose_to_trgeometry(const GSERIALIZED *gs, const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TPOSE(temp, NULL); VALIDATE_NOT_NULL(gs, NULL);
@@ -444,7 +444,7 @@ geom_apply_pose(const GSERIALIZED *gs, const Pose *pose)
  * @csqlfn #Trgeometry_start_value()
  */
 GSERIALIZED *
-trgeo_start_value(const Temporal *temp)
+trgeometry_start_value(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
@@ -472,7 +472,7 @@ trgeo_start_value(const Temporal *temp)
  * @param[in] temp Temporal rigid geometry
  */
 GSERIALIZED *
-trgeo_end_value(const Temporal *temp)
+trgeometry_end_value(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
@@ -509,7 +509,7 @@ trgeo_end_value(const Temporal *temp)
  * @csqlfn #Trgeometry_value_n()
  */
 bool
-trgeo_value_n(const Temporal *temp, int n, GSERIALIZED **result)
+trgeometry_value_n(const Temporal *temp, int n, GSERIALIZED **result)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, false); VALIDATE_NOT_NULL(result, false);
@@ -572,7 +572,7 @@ trgeo_value_at_timestamptz(const Temporal *temp, TimestampTz t, bool strict,
  * @csqlfn #Temporal_start_instant()
  */
 TInstant *
-trgeo_start_instant(const Temporal *temp)
+trgeometry_start_instant(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
@@ -592,7 +592,7 @@ trgeo_start_instant(const Temporal *temp)
  * @csqlfn #Temporal_end_instant()
  */
 TInstant *
-trgeo_end_instant(const Temporal *temp)
+trgeometry_end_instant(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
@@ -613,7 +613,7 @@ trgeo_end_instant(const Temporal *temp)
  * @csqlfn #Temporal_instant_n()
  */
 TInstant *
-trgeo_instant_n(const Temporal *temp, int n)
+trgeometry_instant_n(const Temporal *temp, int n)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
@@ -638,7 +638,7 @@ trgeo_instant_n(const Temporal *temp, int n)
  * @csqlfn #Temporal_instants()
  */
 TInstant **
-trgeo_instants(const Temporal *temp, int *count)
+trgeometry_instants(const Temporal *temp, int *count)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL); VALIDATE_NOT_NULL(count, NULL);
@@ -665,7 +665,7 @@ trgeo_instants(const Temporal *temp, int *count)
  * @csqlfn #Temporal_start_sequence()
  */
 TSequence *
-trgeo_start_sequence(const Temporal *temp)
+trgeometry_start_sequence(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
@@ -689,7 +689,7 @@ trgeo_start_sequence(const Temporal *temp)
  * @csqlfn #Temporal_end_sequence()
  */
 TSequence *
-trgeo_end_sequence(const Temporal *temp)
+trgeometry_end_sequence(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
 
@@ -715,7 +715,7 @@ trgeo_end_sequence(const Temporal *temp)
  * @csqlfn #Temporal_sequence_n()
  */
 TSequence *
-trgeo_sequence_n(const Temporal *temp, int n)
+trgeometry_sequence_n(const Temporal *temp, int n)
 {
   /* Ensure the validity of the arguments */
 
@@ -750,7 +750,7 @@ trgeo_sequence_n(const Temporal *temp, int n)
  * @csqlfn #Temporal_sequences()
  */
 TSequence **
-trgeo_sequences(const Temporal *temp, int *count)
+trgeometry_sequences(const Temporal *temp, int *count)
 {
   /* Ensure the validity of the arguments */
 
@@ -783,7 +783,7 @@ trgeo_sequences(const Temporal *temp, int *count)
  * @csqlfn #Temporal_round()
  */
 Temporal *
-trgeo_round(const Temporal *temp, int maxdd)
+trgeometry_round(const Temporal *temp, int maxdd)
 {
   /* Ensure the validity of the arguments */
 
@@ -791,10 +791,10 @@ trgeo_round(const Temporal *temp, int maxdd)
   if (! ensure_not_negative(maxdd))
     return NULL;
 
-  Temporal *tpose = trgeo_to_tpose(temp);
+  Temporal *tpose = trgeometry_to_tpose(temp);
   GSERIALIZED *res_geo = geo_round(trgeo_geom_p(temp), maxdd);
   Temporal *res_tpose = temporal_round(tpose, maxdd);
-  Temporal *result = geo_tpose_to_trgeo(res_geo, res_tpose);
+  Temporal *result = geo_tpose_to_trgeometry(res_geo, res_tpose);
   pfree(tpose); pfree(res_geo); pfree(res_tpose);
   return result;
 }
@@ -808,7 +808,7 @@ trgeo_round(const Temporal *temp, int maxdd)
  * @csqlfn #Trgeometry_to_tinstant()
  */
 TInstant *
-trgeo_to_tinstant(const Temporal *temp)
+trgeometry_to_tinstant(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
 
@@ -851,7 +851,7 @@ trgeo_to_tsequence(const Temporal *temp, const char *interp_str)
     else
       interp = MEOS_FLAGS_GET_CONTINUOUS(temp->flags) ? LINEAR : STEP;
   }
-  Temporal *tpose = trgeo_to_tpose(temp);
+  Temporal *tpose = trgeometry_to_tpose(temp);
   TSequence *res = temporal_tsequence(tpose, interp);
   TSequence *result = geo_tposeseq_to_trgeo(trgeo_geom_p(temp), res);
   pfree(res); pfree(tpose);
@@ -882,7 +882,7 @@ trgeo_to_tsequenceset(const Temporal *temp, const char *interp_str)
     if (interp == INTERP_NONE || interp == DISCRETE)
       interp = MEOS_FLAGS_GET_CONTINUOUS(temp->flags) ? LINEAR : STEP;
   }
-  Temporal *tpose = trgeo_to_tpose(temp);
+  Temporal *tpose = trgeometry_to_tpose(temp);
   TSequenceSet *res = temporal_tsequenceset(tpose, interp);
   TSequenceSet *result = geo_tposeseqset_to_trgeo(trgeo_geom_p(temp), res);
   pfree(res); pfree(tpose);
@@ -899,17 +899,17 @@ trgeo_to_tsequenceset(const Temporal *temp, const char *interp_str)
  * @csqlfn #Temporal_set_interp()
  */
 Temporal *
-trgeo_set_interp(const Temporal *temp, interpType interp)
+trgeometry_set_interp(const Temporal *temp, interpType interp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
-  Temporal *tpose = trgeo_to_tpose(temp);
+  Temporal *tpose = trgeometry_to_tpose(temp);
   Temporal *res = temporal_set_interp(tpose, interp);
   if (! res)
     return NULL;
   /* We need to explicitly set the temporal type to T_TPOSE */
   res->temptype = T_TPOSE;
-  Temporal *result = geo_tpose_to_trgeo(trgeo_geom_p(temp), res);
+  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res); pfree(tpose);
   return result;
 }
@@ -930,7 +930,7 @@ trgeo_set_interp(const Temporal *temp, interpType interp)
  * @csqlfn #Temporal_restrict_value()
  */
 Temporal *
-trgeo_restrict_value(const Temporal *temp, Datum value, bool atfunc)
+trgeometry_restrict_value(const Temporal *temp, Datum value, bool atfunc)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
@@ -938,7 +938,7 @@ trgeo_restrict_value(const Temporal *temp, Datum value, bool atfunc)
   Temporal *res = temporal_restrict_value(temp, value, atfunc);
   if (! res)
     return NULL;
-  Temporal *result = geo_tpose_to_trgeo(trgeo_geom_p(temp), res);
+  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res);
   return result;
 }
@@ -953,7 +953,7 @@ trgeo_restrict_value(const Temporal *temp, Datum value, bool atfunc)
 Temporal *
 trgeo_at_value(const Temporal *temp, const GSERIALIZED *gs)
 {
-  return trgeo_restrict_value(temp, PointerGetDatum(gs), REST_AT);
+  return trgeometry_restrict_value(temp, PointerGetDatum(gs), REST_AT);
 }
 
 /**
@@ -966,7 +966,7 @@ trgeo_at_value(const Temporal *temp, const GSERIALIZED *gs)
 Temporal *
 trgeo_minus_value(const Temporal *temp, const GSERIALIZED *gs)
 {
-  return trgeo_restrict_value(temp, PointerGetDatum(gs), REST_MINUS);
+  return trgeometry_restrict_value(temp, PointerGetDatum(gs), REST_MINUS);
 }
 
 /*****************************************************************************/
@@ -981,14 +981,14 @@ trgeo_minus_value(const Temporal *temp, const GSERIALIZED *gs)
  * @csqlfn #Temporal_restrict_values()
  */
 Temporal *
-trgeo_restrict_values(const Temporal *temp, const Set *s, bool atfunc)
+trgeometry_restrict_values(const Temporal *temp, const Set *s, bool atfunc)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL); VALIDATE_GEOMSET(s, NULL); 
   Temporal *res = temporal_restrict_values(temp, s, atfunc);
   if (! res)
     return NULL;
-  Temporal *result = geo_tpose_to_trgeo(trgeo_geom_p(temp), res);
+  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res);
   return result;
 }
@@ -1003,7 +1003,7 @@ trgeo_restrict_values(const Temporal *temp, const Set *s, bool atfunc)
 inline Temporal *
 trgeo_at_values(const Temporal *temp, const Set *s)
 {
-  return trgeo_restrict_values(temp, s, REST_AT);
+  return trgeometry_restrict_values(temp, s, REST_AT);
 }
 
 /**
@@ -1017,7 +1017,7 @@ trgeo_at_values(const Temporal *temp, const Set *s)
 inline Temporal *
 trgeo_minus_values(const Temporal *temp, const Set *s)
 {
-  return trgeo_restrict_values(temp, s, REST_MINUS);
+  return trgeometry_restrict_values(temp, s, REST_MINUS);
 }
 
 /*****************************************************************************/
@@ -1032,17 +1032,17 @@ trgeo_minus_values(const Temporal *temp, const Set *s)
  * @csqlfn #Temporal_restrict_timestamptz()
  */
 Temporal *
-trgeo_restrict_timestamptz(const Temporal *temp, TimestampTz t, bool atfunc)
+trgeometry_restrict_timestamptz(const Temporal *temp, TimestampTz t, bool atfunc)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
 
-  Temporal *tpose = trgeo_to_tpose(temp);
+  Temporal *tpose = trgeometry_to_tpose(temp);
   Temporal *res = temporal_restrict_timestamptz(tpose, t, atfunc);
   pfree(tpose); 
   if (! res)
     return NULL;
-  Temporal *result = geo_tpose_to_trgeo(trgeo_geom_p(temp), res);
+  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res);
   return result;
 }
@@ -1057,7 +1057,7 @@ trgeo_restrict_timestamptz(const Temporal *temp, TimestampTz t, bool atfunc)
 inline Temporal *
 trgeo_at_timestamptz(const Temporal *temp, TimestampTz t)
 {
-  return trgeo_restrict_timestamptz(temp, t, REST_AT);
+  return trgeometry_restrict_timestamptz(temp, t, REST_AT);
 }
 
 /**
@@ -1071,7 +1071,7 @@ trgeo_at_timestamptz(const Temporal *temp, TimestampTz t)
 inline Temporal *
 trgeo_minus_timestamptz(const Temporal *temp, TimestampTz t)
 {
-  return trgeo_restrict_timestamptz(temp, t, REST_MINUS);
+  return trgeometry_restrict_timestamptz(temp, t, REST_MINUS);
 }
 
 /*****************************************************************************/
@@ -1086,16 +1086,16 @@ trgeo_minus_timestamptz(const Temporal *temp, TimestampTz t)
  * @csqlfn #Temporal_restrict_tstzset()
  */
 Temporal *
-trgeo_restrict_tstzset(const Temporal *temp, const Set *s, bool atfunc)
+trgeometry_restrict_tstzset(const Temporal *temp, const Set *s, bool atfunc)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL); VALIDATE_TSTZSET(s, NULL);
-  Temporal *tpose = trgeo_to_tpose(temp);
+  Temporal *tpose = trgeometry_to_tpose(temp);
   Temporal *res = temporal_restrict_tstzset(tpose, s, atfunc);
   pfree(tpose);
   if (! res)
     return NULL;
-  Temporal *result = geo_tpose_to_trgeo(trgeo_geom_p(temp), res);
+  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res);
   return result;
 }
@@ -1110,7 +1110,7 @@ trgeo_restrict_tstzset(const Temporal *temp, const Set *s, bool atfunc)
 inline Temporal *
 trgeo_at_tstzset(const Temporal *temp, const Set *s)
 {
-  return trgeo_restrict_tstzset(temp, s, REST_AT);
+  return trgeometry_restrict_tstzset(temp, s, REST_AT);
 }
 
 /**
@@ -1124,7 +1124,7 @@ trgeo_at_tstzset(const Temporal *temp, const Set *s)
 inline Temporal *
 trgeo_minus_tstzset(const Temporal *temp, const Set *s)
 {
-  return trgeo_restrict_tstzset(temp, s, REST_MINUS);
+  return trgeometry_restrict_tstzset(temp, s, REST_MINUS);
 }
 
 /*****************************************************************************/
@@ -1139,16 +1139,16 @@ trgeo_minus_tstzset(const Temporal *temp, const Set *s)
  * @csqlfn #Temporal_restrict_tstzspan()
  */
 Temporal *
-trgeo_restrict_tstzspan(const Temporal *temp, const Span *s, bool atfunc)
+trgeometry_restrict_tstzspan(const Temporal *temp, const Span *s, bool atfunc)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL); VALIDATE_TSTZSPAN(s, NULL);
-  Temporal *tpose = trgeo_to_tpose(temp);
+  Temporal *tpose = trgeometry_to_tpose(temp);
   Temporal *res = temporal_restrict_tstzspan(tpose, s, atfunc);
   pfree(tpose);
   if (! res)
     return NULL;
-  Temporal *result = geo_tpose_to_trgeo(trgeo_geom_p(temp), res);
+  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res);
   return result;
 }
@@ -1163,7 +1163,7 @@ trgeo_restrict_tstzspan(const Temporal *temp, const Span *s, bool atfunc)
 inline Temporal *
 trgeo_at_tstzspan(const Temporal *temp, const Span *s)
 {
-  return trgeo_restrict_tstzspan(temp, s, REST_AT);
+  return trgeometry_restrict_tstzspan(temp, s, REST_AT);
 }
 
 /**
@@ -1177,7 +1177,7 @@ trgeo_at_tstzspan(const Temporal *temp, const Span *s)
 inline Temporal *
 trgeo_minus_tstzspan(const Temporal *temp, const Span *s)
 {
-  return trgeo_restrict_tstzspan(temp, s, REST_MINUS);
+  return trgeometry_restrict_tstzspan(temp, s, REST_MINUS);
 }
 
 /*****************************************************************************/
@@ -1192,17 +1192,17 @@ trgeo_minus_tstzspan(const Temporal *temp, const Span *s)
  * @csqlfn #Temporal_restrict_tstzspanset()
  */
 Temporal *
-trgeo_restrict_tstzspanset(const Temporal *temp, const SpanSet *ss,
+trgeometry_restrict_tstzspanset(const Temporal *temp, const SpanSet *ss,
   bool atfunc)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL); VALIDATE_TSTZSPANSET(ss, NULL);
-  Temporal *tpose = trgeo_to_tpose(temp);
+  Temporal *tpose = trgeometry_to_tpose(temp);
   Temporal *res = temporal_restrict_tstzspanset(tpose, ss, atfunc);
   pfree(tpose);
   if (! res)
     return NULL;
-  Temporal *result = geo_tpose_to_trgeo(trgeo_geom_p(temp), res);
+  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res);
   return result;
 }
@@ -1217,7 +1217,7 @@ trgeo_restrict_tstzspanset(const Temporal *temp, const SpanSet *ss,
 inline Temporal *
 trgeo_at_tstzspanset(const Temporal *temp, const SpanSet *ss)
 {
-  return trgeo_restrict_tstzspanset(temp, ss, REST_AT);
+  return trgeometry_restrict_tstzspanset(temp, ss, REST_AT);
 }
 
 /**
@@ -1231,7 +1231,7 @@ trgeo_at_tstzspanset(const Temporal *temp, const SpanSet *ss)
 inline Temporal *
 trgeo_minus_tstzspanset(const Temporal *temp, const SpanSet *ss)
 {
-  return trgeo_restrict_tstzspanset(temp, ss, REST_MINUS);
+  return trgeometry_restrict_tstzspanset(temp, ss, REST_MINUS);
 }
 
 /*****************************************************************************/
@@ -1247,17 +1247,17 @@ trgeo_minus_tstzspanset(const Temporal *temp, const SpanSet *ss)
  * @csqlfn #Temporal_before_timestamptz()
  */
 Temporal *
-trgeo_before_timestamptz(const Temporal *temp, TimestampTz t, bool atfunc)
+trgeometry_before_timestamptz(const Temporal *temp, TimestampTz t, bool atfunc)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
 
-  Temporal *tpose = trgeo_to_tpose(temp);
+  Temporal *tpose = trgeometry_to_tpose(temp);
   Temporal *res = temporal_before_timestamptz(tpose, t, atfunc);
   pfree(tpose); 
   if (! res)
     return NULL;
-  Temporal *result = geo_tpose_to_trgeo(trgeo_geom_p(temp), res);
+  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res);
   return result;
 }
@@ -1273,17 +1273,17 @@ trgeo_before_timestamptz(const Temporal *temp, TimestampTz t, bool atfunc)
  * @csqlfn #Temporal_after_timestamptz()
  */
 Temporal *
-trgeo_after_timestamptz(const Temporal *temp, TimestampTz t, bool atfunc)
+trgeometry_after_timestamptz(const Temporal *temp, TimestampTz t, bool atfunc)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
 
-  Temporal *tpose = trgeo_to_tpose(temp);
+  Temporal *tpose = trgeometry_to_tpose(temp);
   Temporal *res = temporal_after_timestamptz(tpose, t, atfunc);
   pfree(tpose); 
   if (! res)
     return NULL;
-  Temporal *result = geo_tpose_to_trgeo(trgeo_geom_p(temp), res);
+  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res);
   return result;
 }
@@ -1311,7 +1311,7 @@ trgeo_after_timestamptz(const Temporal *temp, TimestampTz t, bool atfunc)
  * @endcode
  */
 Temporal *
-trgeo_append_tinstant(Temporal *temp, const TInstant *inst, 
+trgeometry_append_tinstant(Temporal *temp, const TInstant *inst, 
   interpType interp, double maxdist, const Interval *maxt, bool expand)
 {
   /* Ensure the validity of the arguments */
@@ -1320,14 +1320,14 @@ trgeo_append_tinstant(Temporal *temp, const TInstant *inst,
       ! ensure_temporal_isof_subtype((Temporal *) inst, TINSTANT))
     return NULL;
 
-  Temporal *tpose = trgeo_to_tpose(temp);
+  Temporal *tpose = trgeometry_to_tpose(temp);
   TInstant *tpose_inst = trgeoinst_tposeinst(inst);
   Temporal *res = temporal_append_tinstant(tpose, tpose_inst, interp, maxdist,
     maxt, expand);
   if (! res)
     return NULL;
   
-  Temporal *result = geo_tpose_to_trgeo(trgeo_geom_p(temp), res);
+  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res); pfree(tpose); pfree(tpose_inst);
   return result;
 }
@@ -1341,7 +1341,7 @@ trgeo_append_tinstant(Temporal *temp, const TInstant *inst,
  * @csqlfn #Temporal_append_tsequence()
  */
 Temporal *
-trgeo_append_tsequence(Temporal *temp, const TSequence *seq, bool expand)
+trgeometry_append_tsequence(Temporal *temp, const TSequence *seq, bool expand)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL); VALIDATE_TRGEOMETRY(seq, NULL);
@@ -1351,12 +1351,12 @@ trgeo_append_tsequence(Temporal *temp, const TSequence *seq, bool expand)
       ! ensure_temporal_isof_subtype((Temporal *) seq, TSEQUENCE))
     return NULL;
 
-  Temporal *tpose = trgeo_to_tpose(temp);
+  Temporal *tpose = trgeometry_to_tpose(temp);
   TSequence *tpose_seq = trgeoseq_tposeseq(seq);
   Temporal *res = temporal_append_tsequence(tpose, tpose_seq, expand);
   if (! res)
     return NULL;
-  Temporal *result = geo_tpose_to_trgeo(trgeo_geom_p(temp), res);
+  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res); pfree(tpose); pfree(tpose_seq);
   return result;
 }
@@ -1369,16 +1369,16 @@ trgeo_append_tsequence(Temporal *temp, const TSequence *seq, bool expand)
  * @csqlfn #Temporal_delete_timestamptz
  */
 Temporal *
-trgeo_delete_timestamptz(const Temporal *temp, TimestampTz t, bool connect)
+trgeometry_delete_timestamptz(const Temporal *temp, TimestampTz t, bool connect)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
-  Temporal *tpose = trgeo_to_tpose(temp);
+  Temporal *tpose = trgeometry_to_tpose(temp);
   Temporal *res = temporal_delete_timestamptz(tpose, t, connect);
   pfree(tpose);
   if (! res)
     return NULL;
-  Temporal *result = geo_tpose_to_trgeo(trgeo_geom_p(temp), res);
+  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res);
   return result;
 }
@@ -1394,16 +1394,16 @@ trgeo_delete_timestamptz(const Temporal *temp, TimestampTz t, bool connect)
  * @csqlfn #Temporal_delete_tstzset()
  */
 Temporal *
-trgeo_delete_tstzset(const Temporal *temp, const Set *s, bool connect)
+trgeometry_delete_tstzset(const Temporal *temp, const Set *s, bool connect)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL); VALIDATE_TSTZSET(s, NULL);
-  Temporal *tpose = trgeo_to_tpose(temp);
+  Temporal *tpose = trgeometry_to_tpose(temp);
   Temporal *res = temporal_delete_tstzset(tpose, s, connect);
   pfree(tpose);
   if (! res)
     return NULL;
-  Temporal *result = geo_tpose_to_trgeo(trgeo_geom_p(temp), res);
+  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res);
   return result;
 }
@@ -1418,16 +1418,16 @@ trgeo_delete_tstzset(const Temporal *temp, const Set *s, bool connect)
  * @csqlfn #Temporal_delete_tstzspan()
  */
 Temporal *
-trgeo_delete_tstzspan(const Temporal *temp, const Span *s, bool connect)
+trgeometry_delete_tstzspan(const Temporal *temp, const Span *s, bool connect)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL); VALIDATE_TSTZSPAN(s, NULL);
-  Temporal *tpose = trgeo_to_tpose(temp);
+  Temporal *tpose = trgeometry_to_tpose(temp);
   Temporal *res = temporal_delete_tstzspan(tpose, s, connect);
   pfree(tpose);
   if (! res)
     return NULL;
-  Temporal *result = geo_tpose_to_trgeo(trgeo_geom_p(temp), res);
+  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res);
   return result;
 }
@@ -1442,17 +1442,17 @@ trgeo_delete_tstzspan(const Temporal *temp, const Span *s, bool connect)
  * @csqlfn #Temporal_delete_tstzspanset()
  */
 Temporal *
-trgeo_delete_tstzspanset(const Temporal *temp, const SpanSet *ss,
+trgeometry_delete_tstzspanset(const Temporal *temp, const SpanSet *ss,
   bool connect)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL); VALIDATE_TSTZSPANSET(ss, NULL);
-  Temporal *tpose = trgeo_to_tpose(temp);
+  Temporal *tpose = trgeometry_to_tpose(temp);
   Temporal *res = temporal_delete_tstzspanset(tpose, ss, connect);
   pfree(tpose);
   if (! res)
     return NULL;
-  Temporal *result = geo_tpose_to_trgeo(trgeo_geom_p(temp), res);
+  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res);
   return result;
 }

--- a/meos/src/rgeo/trgeo_compops.c
+++ b/meos/src/rgeo/trgeo_compops.c
@@ -93,10 +93,10 @@ eacomp_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2,
  * @brief Return true if a geometry is ever equal to a temporal rigid geometry
  * @param[in] gs Geometry
  * @param[in] temp Temporal value
- * @csqlfn #Ever_eq_geo_trgeo()
+ * @csqlfn #Ever_eq_geo_trgeometry()
  */
 inline int
-ever_eq_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
+ever_eq_geo_trgeometry(const GSERIALIZED *gs, const Temporal *temp)
 {
   return eacomp_trgeo_geo(temp, gs, &datum2_eq, EVER);
 }
@@ -107,10 +107,10 @@ ever_eq_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
  * geometry
  * @param[in] temp Temporal value
  * @param[in] gs Geometry
- * @csqlfn #Ever_eq_trgeo_geo()
+ * @csqlfn #Ever_eq_trgeometry_geo()
  */
 inline int
-ever_eq_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
+ever_eq_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return eacomp_trgeo_geo(temp, gs, &datum2_eq, EVER);
 }
@@ -121,10 +121,10 @@ ever_eq_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * geometry
  * @param[in] gs Geometry
  * @param[in] temp Temporal value
- * @csqlfn #Ever_ne_geo_trgeo()
+ * @csqlfn #Ever_ne_geo_trgeometry()
  */
 inline int
-ever_ne_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
+ever_ne_geo_trgeometry(const GSERIALIZED *gs, const Temporal *temp)
 {
   return eacomp_trgeo_geo(temp, gs, &datum2_ne, EVER);
 }
@@ -135,10 +135,10 @@ ever_ne_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
  * geometry
  * @param[in] temp Temporal value
  * @param[in] gs Geometry
- * @csqlfn #Ever_ne_trgeo_geo()
+ * @csqlfn #Ever_ne_trgeometry_geo()
  */
 inline int
-ever_ne_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
+ever_ne_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return eacomp_trgeo_geo(temp, gs, &datum2_ne, EVER);
 }
@@ -149,10 +149,10 @@ ever_ne_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * geometry
  * @param[in] gs Geometry
  * @param[in] temp Temporal value
- * @csqlfn #Always_eq_geo_trgeo()
+ * @csqlfn #Always_eq_geo_trgeometry()
  */
 inline int
-always_eq_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
+always_eq_geo_trgeometry(const GSERIALIZED *gs, const Temporal *temp)
 {
   return eacomp_trgeo_geo(temp, gs, &datum2_eq, ALWAYS);
 }
@@ -163,10 +163,10 @@ always_eq_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
  * geometry
  * @param[in] temp Temporal value
  * @param[in] gs Geometry
- * @csqlfn #Always_eq_trgeo_geo()
+ * @csqlfn #Always_eq_trgeometry_geo()
  */
 inline int
-always_eq_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
+always_eq_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return eacomp_trgeo_geo(temp, gs, &datum2_eq, ALWAYS);
 }
@@ -177,10 +177,10 @@ always_eq_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * geometry
  * @param[in] gs Geometry
  * @param[in] temp Temporal value
- * @csqlfn #Always_ne_geo_trgeo()
+ * @csqlfn #Always_ne_geo_trgeometry()
  */
 inline int
-always_ne_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
+always_ne_geo_trgeometry(const GSERIALIZED *gs, const Temporal *temp)
 {
   return eacomp_trgeo_geo(temp, gs, &datum2_ne, ALWAYS);
 }
@@ -191,10 +191,10 @@ always_ne_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
  * geometry
  * @param[in] temp Temporal value
  * @param[in] gs Geometry
- * @csqlfn #Always_ne_trgeo_geo()
+ * @csqlfn #Always_ne_trgeometry_geo()
  */
 inline int
-always_ne_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
+always_ne_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return eacomp_trgeo_geo(temp, gs, &datum2_ne, ALWAYS);
 }
@@ -205,10 +205,10 @@ always_ne_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @ingroup meos_rgeo_comp_ever
  * @brief Return true if two temporal rigid geometries are ever equal
  * @param[in] temp1,temp2 Temporal rigid geometries
- * @csqlfn #Ever_eq_trgeo_trgeo()
+ * @csqlfn #Ever_eq_trgeometry_trgeometry()
  */
 inline int
-ever_eq_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
+ever_eq_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_trgeo_trgeo(temp1, temp2, &datum2_eq, EVER);
 }
@@ -217,10 +217,10 @@ ever_eq_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
  * @ingroup meos_rgeo_comp_ever
  * @brief Return true if two temporal rigid geometries are ever different
  * @param[in] temp1,temp2 Temporal rigid geometries
- * @csqlfn #Ever_ne_trgeo_trgeo()
+ * @csqlfn #Ever_ne_trgeometry_trgeometry()
  */
 inline int
-ever_ne_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
+ever_ne_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_trgeo_trgeo(temp1, temp2, &datum2_ne, EVER);
 }
@@ -229,10 +229,10 @@ ever_ne_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
  * @ingroup meos_rgeo_comp_ever
  * @brief Return true if two temporal rigid geometries are always equal
  * @param[in] temp1,temp2 Temporal rigid geometries
- * @csqlfn #Always_eq_trgeo_trgeo()
+ * @csqlfn #Always_eq_trgeometry_trgeometry()
  */
 inline int
-always_eq_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
+always_eq_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_trgeo_trgeo(temp1, temp2, &datum2_eq, ALWAYS);
 }
@@ -241,10 +241,10 @@ always_eq_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
  * @ingroup meos_rgeo_comp_ever
  * @brief Return true if two temporal rigid geometries are always different
  * @param[in] temp1,temp2 Temporal rigid geometries
- * @csqlfn #Always_ne_trgeo_trgeo()
+ * @csqlfn #Always_ne_trgeometry_trgeometry()
  */
 inline int
-always_ne_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
+always_ne_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2)
 {
   return eacomp_trgeo_trgeo(temp1, temp2, &datum2_ne, ALWAYS);
 }
@@ -297,10 +297,10 @@ tcomp_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
  * geometry
  * @param[in] gs Geometry
  * @param[in] temp Temporal value
- * @csqlfn #Teq_geo_trgeo()
+ * @csqlfn #Teq_geo_trgeometry()
  */
 inline Temporal *
-teq_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
+teq_geo_trgeometry(const GSERIALIZED *gs, const Temporal *temp)
 {
   return tcomp_geo_trgeo(gs, temp, &datum2_eq);
 }
@@ -311,10 +311,10 @@ teq_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
  * geometry
  * @param[in] gs Geometry
  * @param[in] temp Temporal value
- * @csqlfn #Tne_geo_trgeo()
+ * @csqlfn #Tne_geo_trgeometry()
  */
 inline Temporal *
-tne_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
+tne_geo_trgeometry(const GSERIALIZED *gs, const Temporal *temp)
 {
   return tcomp_geo_trgeo(gs, temp, &datum2_ne);
 }
@@ -327,10 +327,10 @@ tne_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
  * geometry
  * @param[in] temp Temporal value
  * @param[in] gs Geometry
- * @csqlfn #Teq_trgeo_geo()
+ * @csqlfn #Teq_trgeometry_geo()
  */
 inline Temporal *
-teq_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
+teq_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tcomp_trgeo_geo(temp, gs, &datum2_eq);
 }
@@ -341,10 +341,10 @@ teq_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * geometry
  * @param[in] temp Temporal value
  * @param[in] gs Geometry
- * @csqlfn #Tne_trgeo_geo()
+ * @csqlfn #Tne_trgeometry_geo()
  */
 inline Temporal *
-tne_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
+tne_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return tcomp_trgeo_geo(temp, gs, &datum2_ne);
 }

--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -1829,7 +1829,7 @@ dist2d_trgeoseqset_geo(const TSequenceSet *ss, const GSERIALIZED *gs)
  * @sqlop @p <->
  */
 Temporal *
-tdistance_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
+tdistance_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
@@ -1861,7 +1861,7 @@ tdistance_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @sqlop @p <->
  */
 Temporal *
-tdistance_trgeo_tpoint(const Temporal *temp1 UNUSED,
+tdistance_trgeometry_tpoint(const Temporal *temp1 UNUSED,
   const Temporal *temp2 UNUSED)
 {
   /* Ensure the validity of the arguments */
@@ -1880,7 +1880,7 @@ tdistance_trgeo_tpoint(const Temporal *temp1 UNUSED,
  * @sqlop @p <->
  */
 Temporal *
-tdistance_trgeo_trgeo(const Temporal *temp1 UNUSED,
+tdistance_trgeometry_trgeometry(const Temporal *temp1 UNUSED,
   const Temporal *temp2 UNUSED)
 {
   /* Ensure the validity of the arguments */
@@ -1904,7 +1904,7 @@ tdistance_trgeo_trgeo(const Temporal *temp1 UNUSED,
  * @sqlfn nearestApproachInstant()
  */
 TInstant *
-nai_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
+nai_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
@@ -1916,7 +1916,7 @@ nai_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
     result = tinstant_copy((TInstant *) temp);
   else
   {
-    Temporal *dist = tdistance_trgeo_geo(temp, gs);
+    Temporal *dist = tdistance_trgeometry_geo(temp, gs);
     if (dist != NULL)
     {
       const TInstant *min = temporal_min_instant(dist);
@@ -1938,14 +1938,14 @@ nai_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @sqlfn nearestApproachInstant()
  */
 TInstant *
-nai_trgeo_tpoint(const Temporal *temp1, const Temporal *temp2)
+nai_trgeometry_tpoint(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_tpoint(temp1, temp2))
     return NULL;
 
   TInstant *result = NULL;
-  Temporal *dist = tdistance_trgeo_tpoint(temp1, temp2);
+  Temporal *dist = tdistance_trgeometry_tpoint(temp1, temp2);
   if (dist != NULL)
   {
     const TInstant *min = temporal_min_instant(dist);
@@ -1966,14 +1966,14 @@ nai_trgeo_tpoint(const Temporal *temp1, const Temporal *temp2)
  * @sqlfn nearestApproachInstant()
  */
 TInstant *
-nai_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
+nai_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_trgeo(temp1, temp2))
     return NULL;
 
   TInstant *result = NULL;
-  Temporal *dist = tdistance_trgeo_trgeo(temp1, temp2);
+  Temporal *dist = tdistance_trgeometry_trgeometry(temp1, temp2);
   if (dist != NULL)
   {
     const TInstant *min = temporal_min_instant(dist);
@@ -1998,13 +1998,13 @@ nai_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
  * @sqlop @p |=|
  */
 double
-nad_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
+nad_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
     return DBL_MAX;
 
-  Temporal *dist = tdistance_trgeo_geo(temp, gs);
+  Temporal *dist = tdistance_trgeometry_geo(temp, gs);
   double result = DatumGetFloat8(temporal_min_value(dist));
   pfree(dist);
   return result;
@@ -2017,7 +2017,7 @@ nad_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @sqlop @p |=|
  */
 double
-nad_trgeo_stbox(const Temporal *temp, const STBox *box)
+nad_trgeometry_stbox(const Temporal *temp, const STBox *box)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_stbox(temp, box))
@@ -2038,7 +2038,7 @@ nad_trgeo_stbox(const Temporal *temp, const STBox *box)
     temporal_restrict_tstzspan(temp, &inter, REST_AT) :
     (Temporal *) temp;
   /* Compute the result */
-  Temporal *dist = tdistance_trgeo_geo(temp, geo);
+  Temporal *dist = tdistance_trgeometry_geo(temp, geo);
   double result = DatumGetFloat8(temporal_min_value(dist));
   pfree(geo);
   if (hast)
@@ -2053,13 +2053,13 @@ nad_trgeo_stbox(const Temporal *temp, const STBox *box)
  * @sqlop @p |=|
  */
 double
-nad_trgeo_tpoint(const Temporal *temp1, const Temporal *temp2)
+nad_trgeometry_tpoint(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_tpoint(temp2, temp2))
     return DBL_MAX;
 
-  Temporal *dist = tdistance_trgeo_tpoint(temp1, temp2);
+  Temporal *dist = tdistance_trgeometry_tpoint(temp1, temp2);
   if (dist == NULL)
     return DBL_MAX;
 
@@ -2075,13 +2075,13 @@ nad_trgeo_tpoint(const Temporal *temp1, const Temporal *temp2)
  * @sqlop @p |=|
  */
 double
-nad_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
+nad_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_trgeo(temp2, temp2))
     return DBL_MAX;
 
-  Temporal *dist = tdistance_trgeo_trgeo(temp1, temp2);
+  Temporal *dist = tdistance_trgeometry_trgeometry(temp1, temp2);
   if (dist == NULL)
     return DBL_MAX;
 
@@ -2101,13 +2101,13 @@ nad_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
  * @sqlfn shortestLine()
  */
 GSERIALIZED *
-shortestline_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
+shortestline_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
     return NULL;
   
-  Temporal *dist = tdistance_trgeo_geo(temp, gs);
+  Temporal *dist = tdistance_trgeometry_geo(temp, gs);
   const TInstant *inst = temporal_min_instant(dist);
   /* Timestamp t may be at an exclusive bound */
   Datum value;
@@ -2125,13 +2125,13 @@ shortestline_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @sqlfn shortestLine()
  */
 GSERIALIZED *
-shortestline_trgeo_tpoint(const Temporal *temp1, const Temporal *temp2)
+shortestline_trgeometry_tpoint(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_tpoint(temp1, temp2))
     return NULL;
 
-  Temporal *dist = tdistance_trgeo_tpoint(temp1, temp2);
+  Temporal *dist = tdistance_trgeometry_tpoint(temp1, temp2);
   if (dist == NULL)
     return NULL;
   const TInstant *inst = temporal_min_instant(dist);
@@ -2152,13 +2152,13 @@ shortestline_trgeo_tpoint(const Temporal *temp1, const Temporal *temp2)
  * @sqlfn shortestLine()
  */
 GSERIALIZED *
-shortestline_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
+shortestline_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_trgeo(temp1, temp2))
     return NULL;
 
-  Temporal *dist = tdistance_trgeo_trgeo(temp1, temp2);
+  Temporal *dist = tdistance_trgeometry_trgeometry(temp1, temp2);
   if (dist == NULL)
     return NULL;
   const TInstant *inst = temporal_min_instant(dist);

--- a/meos/src/rgeo/trgeo_spatialrels.c
+++ b/meos/src/rgeo/trgeo_spatialrels.c
@@ -77,7 +77,7 @@ spatialrel_trgeo_trav_geo(const Temporal *temp, const GSERIALIZED *gs,
 
   assert(numparam == 2 || numparam == 3);
   Datum geo = PointerGetDatum(gs);
-  Datum trav = PointerGetDatum(trgeo_traversed_area(temp, UNARY_UNION_NO));
+  Datum trav = PointerGetDatum(trgeometry_traversed_area(temp, UNARY_UNION_NO));
   Datum result;
   if (numparam == 2)
   {
@@ -116,7 +116,7 @@ spatialrel_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
 
   assert(numparam == 2 || numparam == 3);
   Datum dgeo = PointerGetDatum(gs);
-  Datum dtrav = PointerGetDatum(trgeo_traversed_area(temp, UNARY_UNION_NO));
+  Datum dtrav = PointerGetDatum(trgeometry_traversed_area(temp, UNARY_UNION_NO));
   Datum result;
   if (numparam == 2)
   {
@@ -154,7 +154,7 @@ ea_contains_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
     return -1;
-  GSERIALIZED *trav = trgeo_traversed_area(temp, UNARY_UNION_NO);
+  GSERIALIZED *trav = trgeometry_traversed_area(temp, UNARY_UNION_NO);
   bool result = ever ? geom_relate_pattern(gs, trav, "T********") :
     geom_contains(gs, trav);
   pfree(trav);
@@ -171,7 +171,7 @@ ea_contains_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
  * geometry
  * https://postgis.net/docs/ST_Relate.html
  * https://postgis.net/docs/ST_Contains.html
- * @csqlfn #Acontains_geo_trgeo()
+ * @csqlfn #Acontains_geo_trgeometry()
  */
 inline int
 econtains_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
@@ -189,7 +189,7 @@ econtains_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
  * geometry
  * https://postgis.net/docs/ST_Relate.html
  * https://postgis.net/docs/ST_Contains.html
- * @csqlfn #Acontains_geo_trgeo()
+ * @csqlfn #Acontains_geo_trgeometry()
  */
 inline int
 acontains_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
@@ -237,7 +237,7 @@ ea_covers_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
  * geometry
  * https://postgis.net/docs/ST_Relate.html
  * https://postgis.net/docs/ST_Contains.html
- * @csqlfn #Ecovers_geo_trgeo()
+ * @csqlfn #Ecovers_geo_trgeometry()
  */
 inline int
 ecovers_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
@@ -255,7 +255,7 @@ ecovers_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
  * geometry
  * https://postgis.net/docs/ST_Relate.html
  * https://postgis.net/docs/ST_Contains.html
- * @csqlfn #Acovers_geo_trgeo()
+ * @csqlfn #Acovers_geo_trgeometry()
  */
 inline int
 acovers_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp)
@@ -301,7 +301,7 @@ ea_covers_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
  * geometry
  * https://postgis.net/docs/ST_Relate.html
  * https://postgis.net/docs/ST_Contains.html
- * @csqlfn #Ecovers_trgeo_geo()
+ * @csqlfn #Ecovers_trgeometry_geo()
  */
 inline int
 ecovers_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
@@ -319,7 +319,7 @@ ecovers_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * geometry
  * https://postgis.net/docs/ST_Relate.html
  * https://postgis.net/docs/ST_Contains.html
- * @csqlfn #Acovers_trgeo_geo()
+ * @csqlfn #Acovers_trgeometry_geo()
  */
 inline int
 acovers_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
@@ -356,7 +356,7 @@ ea_disjoint_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
  * disjoint, 0 if not, and -1 on error or if the geometry is empty
  * @param[in] temp Temporal rigid geometry
  * @param[in] gs Geometry
- * @csqlfn #Edisjoint_trgeo_geo()
+ * @csqlfn #Edisjoint_trgeometry_geo()
  */
 inline int
 edisjoint_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
@@ -371,7 +371,7 @@ edisjoint_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] temp Temporal rigid geometry
  * @param[in] gs Geometry
  * @note aDisjoint(a, b) is equivalent to NOT eIntersects(a, b)
- * @csqlfn #Adisjoint_trgeo_geo()
+ * @csqlfn #Adisjoint_trgeometry_geo()
  */
 inline int
 adisjoint_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
@@ -385,7 +385,7 @@ adisjoint_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @brief Return 1 if the temporal rigid geometries are ever disjoint, 0 if not,
  * and -1 on error or if the temporal rigid geometries do not intersect in time
  * @param[in] temp1,temp2 Temporal rigid geometries
- * @csqlfn #Edisjoint_trgeo_trgeo()
+ * @csqlfn #Edisjoint_trgeometry_trgeometry()
  */
 inline int
 edisjoint_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
@@ -399,7 +399,7 @@ edisjoint_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
  * not, and -1 on error or if the temporal rigid geometries do not intersect
  * in time
  * @param[in] temp1,temp2 Temporal rigid geometries
- * @csqlfn #Adisjoint_trgeo_trgeo()
+ * @csqlfn #Adisjoint_trgeometry_trgeometry()
  */
 inline int
 adisjoint_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
@@ -419,7 +419,7 @@ adisjoint_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
  * 0 if not, and -1 on error or if the geometry is empty
  * @param[in] temp Temporal rigid geometry
  * @param[in] gs Geometry
- * @csqlfn #Eintersects_trgeo_geo()
+ * @csqlfn #Eintersects_trgeometry_geo()
  */
 inline int
 eintersects_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
@@ -435,7 +435,7 @@ eintersects_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] temp Temporal rigid geometry
  * @param[in] gs Geometry
  * @note aIntersects(trgeo, gs) is equivalent to NOT eDisjoint(trgeo, gs)
- * @csqlfn #Aintersects_trgeo_geo()
+ * @csqlfn #Aintersects_trgeometry_geo()
  */
 inline int
 aintersects_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
@@ -449,7 +449,7 @@ aintersects_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @brief Return 1 if the temporal rigid geometries ever intersect, 0 if not,
  * and -1 on error or if the temporal rigid geometries do not intersect in time
  * @param[in] temp1,temp2 Temporal rigid geometries
- * @csqlfn #Eintersects_trgeo_trgeo()
+ * @csqlfn #Eintersects_trgeometry_trgeometry()
  */
 inline int
 eintersects_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
@@ -462,7 +462,7 @@ eintersects_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
  * @brief Return 1 if the temporal rigid geometries always intersect, 0 if not,
  * and -1 on error or if the temporal rigid geometries do not intersect in time
  * @param[in] temp1,temp2 Temporal rigid geometries
- * @csqlfn #Aintersects_trgeo_trgeo()
+ * @csqlfn #Aintersects_trgeometry_trgeometry()
  */
 inline int
 aintersects_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
@@ -482,7 +482,7 @@ aintersects_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
  * if not, and -1 on error or if the geometry is empty
  * @param[in] temp Temporal rigid geometry
  * @param[in] gs Geometry
- * @csqlfn #Etouches_trgeo_geo()
+ * @csqlfn #Etouches_trgeometry_geo()
  */
 int
 etouches_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
@@ -500,7 +500,7 @@ etouches_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
     return 0;
 
   datum_func2 func = geo_intersects_fn_geo(temp->flags, gs->gflags);
-  GSERIALIZED *trav = trgeo_traversed_area(temp, UNARY_UNION_NO);
+  GSERIALIZED *trav = trgeometry_traversed_area(temp, UNARY_UNION_NO);
   GSERIALIZED *geobound = geom_boundary(gs);
   bool result = false;
   if (geobound && ! gserialized_is_empty(geobound))
@@ -526,7 +526,7 @@ etouches_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * 0 if not, and -1 on error or if the geometry is empty
  * @param[in] temp Temporal rigid geometry
  * @param[in] gs Geometry
- * @csqlfn #Atouches_trgeo_geo()
+ * @csqlfn #Atouches_trgeometry_geo()
  */
 int
 atouches_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
@@ -547,7 +547,7 @@ atouches_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
   bool result = false;
   if (geobound && ! gserialized_is_empty(geobound))
   {
-    // TODO trgeo_minus_geom(temp, geobound, NULL);
+    // TODO trgeometry_minus_geom(temp, geobound, NULL);
     Temporal *temp1 = (Temporal *) temp;
     result = (temp1 == NULL);
     if (temp1)
@@ -588,7 +588,7 @@ edwithin_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist)
  * @param[in] temp Temporal rigid geometry
  * @param[in] gs Geometry
  * @param[in] dist Distance
- * @csqlfn #Adwithin_trgeo_geo()
+ * @csqlfn #Adwithin_trgeometry_geo()
  */
 int
 adwithin_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist)
@@ -810,7 +810,7 @@ ea_dwithin_trgeo_trgeo_sync(const Temporal *sync1, const Temporal *sync2,
  * @param[in] temp1,temp2 Temporal rigid geometries
  * @param[in] dist Distance
  * @param[in] ever True for the ever semantics, false for the always semantics
- * @csqlfn #EA_dwithin_trgeo_trgeo()
+ * @csqlfn #EA_dwithin_trgeometry_trgeometry()
  */
 int
 ea_dwithin_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2,
@@ -840,7 +840,7 @@ ea_dwithin_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2,
  * on time
  * @param[in] temp1,temp2 Temporal rigid geometries
  * @param[in] dist Distance
- * @csqlfn #EA_dwithin_trgeo_trgeo()
+ * @csqlfn #EA_dwithin_trgeometry_trgeometry()
  */
 inline int
 edwithin_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2, double dist)
@@ -855,7 +855,7 @@ edwithin_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2, double dist)
  * intersect on time
  * @param[in] temp1,temp2 Temporal rigid geometries
  * @param[in] dist Distance
- * @csqlfn #Adwithin_trgeo_trgeo()
+ * @csqlfn #Adwithin_trgeometry_trgeometry()
  */
 inline int
 adwithin_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2, double dist)

--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -1147,7 +1147,7 @@ temporal_from_mfjson(const char *mfjson, MeosType temptype)
   json_object_put(poObj);
 #if RGEO
   if (temptype_orig == T_TRGEOMETRY && temptype == T_TPOSE)
-    return geo_tpose_to_trgeo(gs, result);
+    return geo_tpose_to_trgeometry(gs, result);
 #endif /* RGEO */
   return result;
 }
@@ -2002,7 +2002,7 @@ temporal_from_wkb_state(meos_wkb_parse_state *s)
 #if RGEO
   if (s->temptype == T_TPOSE && temptype_orig == T_TRGEOMETRY)
   {
-    Temporal *result = geo_tpose_to_trgeo(gs, res);
+    Temporal *result = geo_tpose_to_trgeometry(gs, res);
     pfree(gs); pfree(res);
     return result;
   }

--- a/mobilitydb/sql/rgeo/124_trgeo_compops.in.sql
+++ b/mobilitydb/sql/rgeo/124_trgeo_compops.in.sql
@@ -38,12 +38,12 @@
 
 CREATE FUNCTION ever_eq(geometry, trgeometry)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Ever_eq_geo_trgeo'
+  AS 'MODULE_PATHNAME', 'Ever_eq_geo_trgeometry'
   SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION always_eq(geometry, trgeometry)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Always_eq_geo_trgeo'
+  AS 'MODULE_PATHNAME', 'Always_eq_geo_trgeometry'
   SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
@@ -62,11 +62,11 @@ CREATE OPERATOR %= (
 
 CREATE FUNCTION ever_ne(geometry, trgeometry)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Ever_ne_geo_trgeo'
+  AS 'MODULE_PATHNAME', 'Ever_ne_geo_trgeometry'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION always_ne(geometry, trgeometry)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Always_ne_geo_trgeo'
+  AS 'MODULE_PATHNAME', 'Always_ne_geo_trgeometry'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR ?<> (
@@ -86,12 +86,12 @@ CREATE OPERATOR %<> (
 
 CREATE FUNCTION ever_eq(trgeometry, geometry)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Ever_eq_trgeo_geo'
+  AS 'MODULE_PATHNAME', 'Ever_eq_trgeometry_geo'
   SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION always_eq(trgeometry, geometry)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Always_eq_trgeo_geo'
+  AS 'MODULE_PATHNAME', 'Always_eq_trgeometry_geo'
   SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
@@ -110,11 +110,11 @@ CREATE OPERATOR %= (
 
 CREATE FUNCTION ever_ne(trgeometry, geometry)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Ever_ne_trgeo_geo'
+  AS 'MODULE_PATHNAME', 'Ever_ne_trgeometry_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION always_ne(trgeometry, geometry)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Always_ne_trgeo_geo'
+  AS 'MODULE_PATHNAME', 'Always_ne_trgeometry_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR ?<> (
@@ -134,12 +134,12 @@ CREATE OPERATOR %<> (
 
 CREATE FUNCTION ever_eq(trgeometry, trgeometry)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Ever_eq_trgeo_trgeo'
+  AS 'MODULE_PATHNAME', 'Ever_eq_trgeometry_trgeometry'
   SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION always_eq(trgeometry, trgeometry)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Always_eq_trgeo_trgeo'
+  AS 'MODULE_PATHNAME', 'Always_eq_trgeometry_trgeometry'
   SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
@@ -158,11 +158,11 @@ CREATE OPERATOR %= (
 
 CREATE FUNCTION ever_ne(trgeometry, trgeometry)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Ever_ne_trgeo_trgeo'
+  AS 'MODULE_PATHNAME', 'Ever_ne_trgeometry_trgeometry'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION always_ne(trgeometry, trgeometry)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Always_ne_trgeo_trgeo'
+  AS 'MODULE_PATHNAME', 'Always_ne_trgeometry_trgeometry'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR ?<> (
@@ -184,11 +184,11 @@ CREATE OPERATOR %<> (
 
 CREATE FUNCTION temporal_teq(geometry, trgeometry)
   RETURNS tbool
-  AS 'MODULE_PATHNAME', 'Teq_geo_trgeo'
+  AS 'MODULE_PATHNAME', 'Teq_geo_trgeometry'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION temporal_teq(trgeometry, geometry)
   RETURNS tbool
-  AS 'MODULE_PATHNAME', 'Teq_trgeo_geo'
+  AS 'MODULE_PATHNAME', 'Teq_trgeometry_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION temporal_teq(trgeometry, trgeometry)
   RETURNS tbool
@@ -217,11 +217,11 @@ CREATE OPERATOR #= (
 
 CREATE FUNCTION temporal_tne(geometry, trgeometry)
   RETURNS tbool
-  AS 'MODULE_PATHNAME', 'Tne_geo_trgeo'
+  AS 'MODULE_PATHNAME', 'Tne_geo_trgeometry'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION temporal_tne(trgeometry, geometry)
   RETURNS tbool
-  AS 'MODULE_PATHNAME', 'Tne_trgeo_geo'
+  AS 'MODULE_PATHNAME', 'Tne_trgeometry_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION temporal_tne(trgeometry, trgeometry)
   RETURNS tbool

--- a/mobilitydb/sql/rgeo/133_trgeo_distance.in.sql
+++ b/mobilitydb/sql/rgeo/133_trgeo_distance.in.sql
@@ -38,23 +38,23 @@
 
 CREATE FUNCTION tdistance(trgeometry, geometry)
   RETURNS tfloat
-  AS 'MODULE_PATHNAME', 'Tdistance_trgeo_geo'
+  AS 'MODULE_PATHNAME', 'Tdistance_trgeometry_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION tdistance(geometry, trgeometry)
   RETURNS tfloat
-  AS 'MODULE_PATHNAME', 'Tdistance_geo_trgeo'
+  AS 'MODULE_PATHNAME', 'Tdistance_geo_trgeometry'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION tdistance(trgeometry, tgeompoint)
   RETURNS tfloat
-  AS 'MODULE_PATHNAME', 'Tdistance_trgeo_tpoint'
+  AS 'MODULE_PATHNAME', 'Tdistance_trgeometry_tpoint'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION tdistance(tgeompoint, trgeometry)
   RETURNS tfloat
-  AS 'MODULE_PATHNAME', 'Tdistance_tpoint_trgeo'
+  AS 'MODULE_PATHNAME', 'Tdistance_tpoint_trgeometry'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION tdistance(trgeometry, trgeometry)
   RETURNS tfloat
-  AS 'MODULE_PATHNAME', 'Tdistance_trgeo_trgeo'
+  AS 'MODULE_PATHNAME', 'Tdistance_trgeometry_trgeometry'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <-> (
@@ -89,55 +89,55 @@ CREATE OPERATOR <-> (
 
 CREATE FUNCTION nearestApproachInstant(trgeometry, geometry)
   RETURNS trgeometry
-  AS 'MODULE_PATHNAME', 'NAI_trgeo_geo'
+  AS 'MODULE_PATHNAME', 'NAI_trgeometry_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION nearestApproachInstant(geometry, trgeometry)
   RETURNS trgeometry
-  AS 'MODULE_PATHNAME', 'NAI_geo_trgeo'
+  AS 'MODULE_PATHNAME', 'NAI_geo_trgeometry'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION nearestApproachInstant(trgeometry, tgeompoint)
   RETURNS trgeometry
-  AS 'MODULE_PATHNAME', 'NAI_trgeo_tpoint'
+  AS 'MODULE_PATHNAME', 'NAI_trgeometry_tpoint'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 /* TODO: Maybe change output type here.
  * Currently we return a trgeometry instant
  * even if the left argument is a tgeompoint */
 CREATE FUNCTION nearestApproachInstant(tgeompoint, trgeometry)
   RETURNS trgeometry
-  AS 'MODULE_PATHNAME', 'NAI_tpoint_trgeo'
+  AS 'MODULE_PATHNAME', 'NAI_tpoint_trgeometry'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION nearestApproachInstant(trgeometry, trgeometry)
   RETURNS trgeometry
-  AS 'MODULE_PATHNAME', 'NAI_trgeo_trgeo'
+  AS 'MODULE_PATHNAME', 'NAI_trgeometry_trgeometry'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION nearestApproachDistance(trgeometry, geometry)
   RETURNS float
-  AS 'MODULE_PATHNAME', 'NAD_trgeo_geo'
+  AS 'MODULE_PATHNAME', 'NAD_trgeometry_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION nearestApproachDistance(geometry, trgeometry)
   RETURNS float
-  AS 'MODULE_PATHNAME', 'NAD_geo_trgeo'
+  AS 'MODULE_PATHNAME', 'NAD_geo_trgeometry'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION nearestApproachDistance(trgeometry, stbox)
   RETURNS float
-  AS 'MODULE_PATHNAME', 'NAD_trgeo_stbox'
+  AS 'MODULE_PATHNAME', 'NAD_trgeometry_stbox'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION nearestApproachDistance(stbox, trgeometry)
   RETURNS float
-  AS 'MODULE_PATHNAME', 'NAD_stbox_trgeo'
+  AS 'MODULE_PATHNAME', 'NAD_stbox_trgeometry'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION nearestApproachDistance(trgeometry, tgeompoint)
   RETURNS float
-  AS 'MODULE_PATHNAME', 'NAD_trgeo_tpoint'
+  AS 'MODULE_PATHNAME', 'NAD_trgeometry_tpoint'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION nearestApproachDistance(tgeompoint, trgeometry)
   RETURNS float
-  AS 'MODULE_PATHNAME', 'NAD_tpoint_trgeo'
+  AS 'MODULE_PATHNAME', 'NAD_tpoint_trgeometry'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION nearestApproachDistance(trgeometry, trgeometry)
   RETURNS float
-  AS 'MODULE_PATHNAME', 'NAD_trgeo_trgeo'
+  AS 'MODULE_PATHNAME', 'NAD_trgeometry_trgeometry'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR |=| (
@@ -178,23 +178,23 @@ CREATE OPERATOR |=| (
 
 CREATE FUNCTION shortestLine(trgeometry, geometry)
   RETURNS geometry
-  AS 'MODULE_PATHNAME', 'Shortestline_trgeo_geo'
+  AS 'MODULE_PATHNAME', 'Shortestline_trgeometry_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION shortestLine(geometry, trgeometry)
   RETURNS geometry
-  AS 'MODULE_PATHNAME', 'Shortestline_geo_trgeo'
+  AS 'MODULE_PATHNAME', 'Shortestline_geo_trgeometry'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION shortestLine(trgeometry, tgeompoint)
   RETURNS geometry
-  AS 'MODULE_PATHNAME', 'Shortestline_trgeo_tpoint'
+  AS 'MODULE_PATHNAME', 'Shortestline_trgeometry_tpoint'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION shortestLine(tgeompoint, trgeometry)
   RETURNS geometry
-  AS 'MODULE_PATHNAME', 'Shortestline_tpoint_trgeo'
+  AS 'MODULE_PATHNAME', 'Shortestline_tpoint_trgeometry'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION shortestLine(trgeometry, trgeometry)
   RETURNS geometry
-  AS 'MODULE_PATHNAME', 'Shortestline_trgeo_trgeo'
+  AS 'MODULE_PATHNAME', 'Shortestline_trgeometry_trgeometry'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************/

--- a/mobilitydb/src/rgeo/trgeo.c
+++ b/mobilitydb/src/rgeo/trgeo.c
@@ -111,7 +111,7 @@ Datum
 Trgeometry_out(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
-  char *result = trgeo_out(temp);
+  char *result = trgeometry_out(temp);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_CSTRING(result);
 }
@@ -389,7 +389,7 @@ Trgeometry_constructor(PG_FUNCTION_ARGS)
 {
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(0);
   Temporal *tpose = PG_GETARG_TEMPORAL_P(1);
-  Temporal *result = geo_tpose_to_trgeo(gs, tpose);
+  Temporal *result = geo_tpose_to_trgeometry(gs, tpose);
   PG_FREE_IF_COPY(gs, 0);
   if (! result)
     PG_RETURN_NULL();
@@ -411,7 +411,7 @@ Datum
 Trgeometry_to_tpose(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
-  Temporal *result = trgeo_to_tpose(temp);
+  Temporal *result = trgeometry_to_tpose(temp);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_POINTER(result);
 }
@@ -427,7 +427,7 @@ Datum
 Trgeometry_to_tpoint(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
-  Temporal *result = trgeo_to_tpoint(temp);
+  Temporal *result = trgeometry_to_tpoint(temp);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_POINTER(result);
 }
@@ -443,7 +443,7 @@ Datum
 Trgeometry_to_geom(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
-  GSERIALIZED *result = trgeo_geom(temp);
+  GSERIALIZED *result = trgeometry_geom(temp);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_POINTER(result);
 }
@@ -463,7 +463,7 @@ Datum
 Trgeometry_start_value(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
-  GSERIALIZED *result = trgeo_start_value(temp);
+  GSERIALIZED *result = trgeometry_start_value(temp);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_POINTER(result);
 }
@@ -479,7 +479,7 @@ Datum
 Trgeometry_end_value(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
-  GSERIALIZED *result = trgeo_end_value(temp);
+  GSERIALIZED *result = trgeometry_end_value(temp);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_POINTER(result);
 }
@@ -497,7 +497,7 @@ Trgeometry_value_n(PG_FUNCTION_ARGS)
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   int n = PG_GETARG_INT32(1); /* Assume 1-based */
   GSERIALIZED *result;
-  bool found = trgeo_value_n(temp, n, &result);
+  bool found = trgeometry_value_n(temp, n, &result);
   PG_FREE_IF_COPY(temp, 0);
   if (! found)
     PG_RETURN_NULL();
@@ -541,7 +541,7 @@ Datum
 Trgeometry_to_tinstant(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
-  TInstant *result = trgeo_to_tinstant(temp);
+  TInstant *result = trgeometry_to_tinstant(temp);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_TINSTANT_P(result);
 }

--- a/mobilitydb/src/rgeo/trgeo_compops.c
+++ b/mobilitydb/src/rgeo/trgeo_compops.c
@@ -53,8 +53,8 @@
  * Ever/always comparison functions
  *****************************************************************************/
 
-PGDLLEXPORT Datum Ever_eq_geo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Ever_eq_geo_trgeo);
+PGDLLEXPORT Datum Ever_eq_geo_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Ever_eq_geo_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_comp_ever
  * @brief Return true if a temporal rigid geometry is ever equal to a geometry
@@ -62,13 +62,13 @@ PG_FUNCTION_INFO_V1(Ever_eq_geo_trgeo);
  * @sqlop @p ?=
  */
 inline Datum
-Ever_eq_geo_trgeo(PG_FUNCTION_ARGS)
+Ever_eq_geo_trgeometry(PG_FUNCTION_ARGS)
 {
-  return EAcomp_geo_tspatial(fcinfo, &ever_eq_geo_trgeo);
+  return EAcomp_geo_tspatial(fcinfo, &ever_eq_geo_trgeometry);
 }
 
-PGDLLEXPORT Datum Always_eq_geo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Always_eq_geo_trgeo);
+PGDLLEXPORT Datum Always_eq_geo_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Always_eq_geo_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_comp_ever
  * @brief Return true if a temporal rigid geometry is always equal to a
@@ -77,13 +77,13 @@ PG_FUNCTION_INFO_V1(Always_eq_geo_trgeo);
  * @sqlop @p %=
  */
 inline Datum
-Always_eq_geo_trgeo(PG_FUNCTION_ARGS)
+Always_eq_geo_trgeometry(PG_FUNCTION_ARGS)
 {
-  return EAcomp_geo_tspatial(fcinfo, &always_eq_geo_trgeo);
+  return EAcomp_geo_tspatial(fcinfo, &always_eq_geo_trgeometry);
 }
 
-PGDLLEXPORT Datum Ever_ne_geo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Ever_ne_geo_trgeo);
+PGDLLEXPORT Datum Ever_ne_geo_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Ever_ne_geo_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_comp_ever
  * @brief Return true if a temporal rigid geometry is ever different from a
@@ -92,13 +92,13 @@ PG_FUNCTION_INFO_V1(Ever_ne_geo_trgeo);
  * @sqlop @p ?<>
  */
 inline Datum
-Ever_ne_geo_trgeo(PG_FUNCTION_ARGS)
+Ever_ne_geo_trgeometry(PG_FUNCTION_ARGS)
 {
-  return EAcomp_geo_tspatial(fcinfo, &ever_ne_geo_trgeo);
+  return EAcomp_geo_tspatial(fcinfo, &ever_ne_geo_trgeometry);
 }
 
-PGDLLEXPORT Datum Always_ne_geo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Always_ne_geo_trgeo);
+PGDLLEXPORT Datum Always_ne_geo_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Always_ne_geo_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_comp_ever
  * @brief Return true if a temporal rigid geometry is always different from a
@@ -107,15 +107,15 @@ PG_FUNCTION_INFO_V1(Always_ne_geo_trgeo);
  * @sqlop @p %<>
  */
 inline Datum
-Always_ne_geo_trgeo(PG_FUNCTION_ARGS)
+Always_ne_geo_trgeometry(PG_FUNCTION_ARGS)
 {
-  return EAcomp_geo_tspatial(fcinfo, &always_ne_geo_trgeo);
+  return EAcomp_geo_tspatial(fcinfo, &always_ne_geo_trgeometry);
 }
 
 /*****************************************************************************/
 
-PGDLLEXPORT Datum Ever_eq_trgeo_geo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Ever_eq_trgeo_geo);
+PGDLLEXPORT Datum Ever_eq_trgeometry_geo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Ever_eq_trgeometry_geo);
 /**
  * @ingroup mobilitydb_rgeo_comp_ever
  * @brief Return true if a temporal rigid geometry is ever equal to a geometry
@@ -123,13 +123,13 @@ PG_FUNCTION_INFO_V1(Ever_eq_trgeo_geo);
  * @sqlop @p ?=
  */
 inline Datum
-Ever_eq_trgeo_geo(PG_FUNCTION_ARGS)
+Ever_eq_trgeometry_geo(PG_FUNCTION_ARGS)
 {
-  return EAcomp_tspatial_geo(fcinfo, &ever_eq_trgeo_geo);
+  return EAcomp_tspatial_geo(fcinfo, &ever_eq_trgeometry_geo);
 }
 
-PGDLLEXPORT Datum Always_eq_trgeo_geo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Always_eq_trgeo_geo);
+PGDLLEXPORT Datum Always_eq_trgeometry_geo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Always_eq_trgeometry_geo);
 /**
  * @ingroup mobilitydb_rgeo_comp_ever
  * @brief Return true if a temporal rigid geometry is always equal to a
@@ -138,13 +138,13 @@ PG_FUNCTION_INFO_V1(Always_eq_trgeo_geo);
  * @sqlop @p %=
  */
 inline Datum
-Always_eq_trgeo_geo(PG_FUNCTION_ARGS)
+Always_eq_trgeometry_geo(PG_FUNCTION_ARGS)
 {
-  return EAcomp_tspatial_geo(fcinfo, &always_eq_trgeo_geo);
+  return EAcomp_tspatial_geo(fcinfo, &always_eq_trgeometry_geo);
 }
 
-PGDLLEXPORT Datum Ever_ne_trgeo_geo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Ever_ne_trgeo_geo);
+PGDLLEXPORT Datum Ever_ne_trgeometry_geo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Ever_ne_trgeometry_geo);
 /**
  * @ingroup mobilitydb_rgeo_comp_ever
  * @brief Return true if a temporal rigid geometry is ever different from a
@@ -153,13 +153,13 @@ PG_FUNCTION_INFO_V1(Ever_ne_trgeo_geo);
  * @sqlop @p ?<>
  */
 inline Datum
-Ever_ne_trgeo_geo(PG_FUNCTION_ARGS)
+Ever_ne_trgeometry_geo(PG_FUNCTION_ARGS)
 {
-  return EAcomp_tspatial_geo(fcinfo, &ever_ne_trgeo_geo);
+  return EAcomp_tspatial_geo(fcinfo, &ever_ne_trgeometry_geo);
 }
 
-PGDLLEXPORT Datum Always_ne_trgeo_geo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Always_ne_trgeo_geo);
+PGDLLEXPORT Datum Always_ne_trgeometry_geo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Always_ne_trgeometry_geo);
 /**
  * @ingroup mobilitydb_rgeo_comp_ever
  * @brief Return true if a temporal rigid geometry is always different from a
@@ -168,15 +168,15 @@ PG_FUNCTION_INFO_V1(Always_ne_trgeo_geo);
  * @sqlop @p %<>
  */
 inline Datum
-Always_ne_trgeo_geo(PG_FUNCTION_ARGS)
+Always_ne_trgeometry_geo(PG_FUNCTION_ARGS)
 {
-  return EAcomp_tspatial_geo(fcinfo, &always_ne_trgeo_geo);
+  return EAcomp_tspatial_geo(fcinfo, &always_ne_trgeometry_geo);
 }
 
 /*****************************************************************************/
 
-PGDLLEXPORT Datum Ever_eq_trgeo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Ever_eq_trgeo_trgeo);
+PGDLLEXPORT Datum Ever_eq_trgeometry_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Ever_eq_trgeometry_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_comp_ever
  * @brief Return true if two temporal poses are ever equal
@@ -184,13 +184,13 @@ PG_FUNCTION_INFO_V1(Ever_eq_trgeo_trgeo);
  * @sqlop @p ?=
  */
 inline Datum
-Ever_eq_trgeo_trgeo(PG_FUNCTION_ARGS)
+Ever_eq_trgeometry_trgeometry(PG_FUNCTION_ARGS)
 {
-  return EAcomp_temporal_temporal(fcinfo, &ever_eq_trgeo_trgeo);
+  return EAcomp_temporal_temporal(fcinfo, &ever_eq_trgeometry_trgeometry);
 }
 
-PGDLLEXPORT Datum Always_eq_trgeo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Always_eq_trgeo_trgeo);
+PGDLLEXPORT Datum Always_eq_trgeometry_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Always_eq_trgeometry_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_comp_ever
  * @brief Return true if two temporal poses are always equal
@@ -198,13 +198,13 @@ PG_FUNCTION_INFO_V1(Always_eq_trgeo_trgeo);
  * @sqlop @p %=
  */
 inline Datum
-Always_eq_trgeo_trgeo(PG_FUNCTION_ARGS)
+Always_eq_trgeometry_trgeometry(PG_FUNCTION_ARGS)
 {
-  return EAcomp_temporal_temporal(fcinfo, &always_eq_trgeo_trgeo);
+  return EAcomp_temporal_temporal(fcinfo, &always_eq_trgeometry_trgeometry);
 }
 
-PGDLLEXPORT Datum Ever_ne_trgeo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Ever_ne_trgeo_trgeo);
+PGDLLEXPORT Datum Ever_ne_trgeometry_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Ever_ne_trgeometry_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_comp_ever
  * @brief Return true if two temporal poses are ever different
@@ -212,13 +212,13 @@ PG_FUNCTION_INFO_V1(Ever_ne_trgeo_trgeo);
  * @sqlop @p ?<>
  */
 inline Datum
-Ever_ne_trgeo_trgeo(PG_FUNCTION_ARGS)
+Ever_ne_trgeometry_trgeometry(PG_FUNCTION_ARGS)
 {
-  return EAcomp_temporal_temporal(fcinfo, &ever_ne_trgeo_trgeo);
+  return EAcomp_temporal_temporal(fcinfo, &ever_ne_trgeometry_trgeometry);
 }
 
-PGDLLEXPORT Datum Always_ne_trgeo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Always_ne_trgeo_trgeo);
+PGDLLEXPORT Datum Always_ne_trgeometry_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Always_ne_trgeometry_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_comp_ever
  * @brief Return true if two temporal poses are always different
@@ -226,17 +226,17 @@ PG_FUNCTION_INFO_V1(Always_ne_trgeo_trgeo);
  * @sqlop @p %<>
  */
 inline Datum
-Always_ne_trgeo_trgeo(PG_FUNCTION_ARGS)
+Always_ne_trgeometry_trgeometry(PG_FUNCTION_ARGS)
 {
-  return EAcomp_temporal_temporal(fcinfo, &always_ne_trgeo_trgeo);
+  return EAcomp_temporal_temporal(fcinfo, &always_ne_trgeometry_trgeometry);
 }
 
 /*****************************************************************************
  * Temporal comparison functions
  *****************************************************************************/
 
-PGDLLEXPORT Datum Teq_geo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Teq_geo_trgeo);
+PGDLLEXPORT Datum Teq_geo_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Teq_geo_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_comp_temp
  * @brief Return true if a temporal rigid geometry is ever equal to a gs
@@ -244,13 +244,13 @@ PG_FUNCTION_INFO_V1(Teq_geo_trgeo);
  * @sqlop @p #=
  */
 inline Datum
-Teq_geo_trgeo(PG_FUNCTION_ARGS)
+Teq_geo_trgeometry(PG_FUNCTION_ARGS)
 {
-  return Tcomp_geo_tspatial(fcinfo, &teq_geo_trgeo);
+  return Tcomp_geo_tspatial(fcinfo, &teq_geo_trgeometry);
 }
 
-PGDLLEXPORT Datum Tne_geo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Tne_geo_trgeo);
+PGDLLEXPORT Datum Tne_geo_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tne_geo_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_comp_temp
  * @brief Return true if a temporal rigid geometry is ever different from a
@@ -259,15 +259,15 @@ PG_FUNCTION_INFO_V1(Tne_geo_trgeo);
  * @sqlop @p #<>
  */
 inline Datum
-Tne_geo_trgeo(PG_FUNCTION_ARGS)
+Tne_geo_trgeometry(PG_FUNCTION_ARGS)
 {
-  return Tcomp_geo_tspatial(fcinfo, &tne_geo_trgeo);
+  return Tcomp_geo_tspatial(fcinfo, &tne_geo_trgeometry);
 }
 
 /*****************************************************************************/
 
-PGDLLEXPORT Datum Teq_trgeo_geo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Teq_trgeo_geo);
+PGDLLEXPORT Datum Teq_trgeometry_geo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Teq_trgeometry_geo);
 /**
  * @ingroup mobilitydb_rgeo_comp_temp
  * @brief Return true if a temporal rigid geometry is ever equal to a gs
@@ -275,13 +275,13 @@ PG_FUNCTION_INFO_V1(Teq_trgeo_geo);
  * @sqlop @p #=
  */
 inline Datum
-Teq_trgeo_geo(PG_FUNCTION_ARGS)
+Teq_trgeometry_geo(PG_FUNCTION_ARGS)
 {
-  return Tcomp_tspatial_geo(fcinfo, &teq_trgeo_geo);
+  return Tcomp_tspatial_geo(fcinfo, &teq_trgeometry_geo);
 }
 
-PGDLLEXPORT Datum Tne_trgeo_geo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Tne_trgeo_geo);
+PGDLLEXPORT Datum Tne_trgeometry_geo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tne_trgeometry_geo);
 /**
  * @ingroup mobilitydb_rgeo_comp_temp
  * @brief Return true if a temporal rigid geometry is ever different from a
@@ -290,15 +290,15 @@ PG_FUNCTION_INFO_V1(Tne_trgeo_geo);
  * @sqlop @p #<>
  */
 inline Datum
-Tne_trgeo_geo(PG_FUNCTION_ARGS)
+Tne_trgeometry_geo(PG_FUNCTION_ARGS)
 {
-  return Tcomp_tspatial_geo(fcinfo, &tne_trgeo_geo);
+  return Tcomp_tspatial_geo(fcinfo, &tne_trgeometry_geo);
 }
 
 /*****************************************************************************/
 
-PGDLLEXPORT Datum Teq_trgeo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Teq_trgeo_trgeo);
+PGDLLEXPORT Datum Teq_trgeometry_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Teq_trgeometry_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_comp_temp
  * @brief Return true if two temporal poses are ever equal
@@ -306,13 +306,13 @@ PG_FUNCTION_INFO_V1(Teq_trgeo_trgeo);
  * @sqlop @p #=
  */
 inline Datum
-Teq_trgeo_trgeo(PG_FUNCTION_ARGS)
+Teq_trgeometry_trgeometry(PG_FUNCTION_ARGS)
 {
   return Tcomp_temporal_temporal(fcinfo, &datum2_eq);
 }
 
-PGDLLEXPORT Datum Tne_trgeo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Tne_trgeo_trgeo);
+PGDLLEXPORT Datum Tne_trgeometry_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tne_trgeometry_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_comp_temp
  * @brief Return true if two temporal poses are ever different
@@ -320,7 +320,7 @@ PG_FUNCTION_INFO_V1(Tne_trgeo_trgeo);
  * @sqlop @p #<>
  */
 inline Datum
-Tne_trgeo_trgeo(PG_FUNCTION_ARGS)
+Tne_trgeometry_trgeometry(PG_FUNCTION_ARGS)
 {
   return Tcomp_temporal_temporal(fcinfo, &datum2_ne);
 }

--- a/mobilitydb/src/rgeo/trgeo_distance.c
+++ b/mobilitydb/src/rgeo/trgeo_distance.c
@@ -65,7 +65,7 @@
  * Temporal distance
  *****************************************************************************/
 
-PG_FUNCTION_INFO_V1(Tdistance_trgeo_geo);
+PG_FUNCTION_INFO_V1(Tdistance_trgeometry_geo);
 /**
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the temporal distance between a temporal rigid geometry and a
@@ -74,13 +74,13 @@ PG_FUNCTION_INFO_V1(Tdistance_trgeo_geo);
  * @sqlop @p <->
  */
 PGDLLEXPORT Datum
-Tdistance_trgeo_geo(PG_FUNCTION_ARGS)
+Tdistance_trgeometry_geo(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(1);
   /* Store fcinfo into a global variable */
   store_fcinfo(fcinfo);
-  Temporal *result = tdistance_trgeo_geo(temp, gs);
+  Temporal *result = tdistance_trgeometry_geo(temp, gs);
   PG_FREE_IF_COPY(temp, 0);
   PG_FREE_IF_COPY(gs, 1);
   if (! result)
@@ -88,7 +88,7 @@ Tdistance_trgeo_geo(PG_FUNCTION_ARGS)
   PG_RETURN_POINTER(result);
 }
 
-PG_FUNCTION_INFO_V1(Tdistance_geo_trgeo);
+PG_FUNCTION_INFO_V1(Tdistance_geo_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the temporal distance between a geometry and a temporal rigid
@@ -97,13 +97,13 @@ PG_FUNCTION_INFO_V1(Tdistance_geo_trgeo);
  * @sqlop @p <->
  */
 PGDLLEXPORT Datum
-Tdistance_geo_trgeo(PG_FUNCTION_ARGS)
+Tdistance_geo_trgeometry(PG_FUNCTION_ARGS)
 {
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(0);
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
   /* Store fcinfo into a global variable */
   store_fcinfo(fcinfo);
-  Temporal *result = tdistance_trgeo_geo(temp, gs);
+  Temporal *result = tdistance_trgeometry_geo(temp, gs);
   PG_FREE_IF_COPY(gs, 0);
   PG_FREE_IF_COPY(temp, 1);
   if (! result)
@@ -111,7 +111,7 @@ Tdistance_geo_trgeo(PG_FUNCTION_ARGS)
   PG_RETURN_POINTER(result);
 }
 
-PG_FUNCTION_INFO_V1(Tdistance_trgeo_tpoint);
+PG_FUNCTION_INFO_V1(Tdistance_trgeometry_tpoint);
 /**
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the temporal distance between two temporal rigid geometries
@@ -119,13 +119,13 @@ PG_FUNCTION_INFO_V1(Tdistance_trgeo_tpoint);
  * @sqlop @p <->
  */
 PGDLLEXPORT Datum
-Tdistance_trgeo_tpoint(PG_FUNCTION_ARGS)
+Tdistance_trgeometry_tpoint(PG_FUNCTION_ARGS)
 {
   Temporal *temp1 = PG_GETARG_TEMPORAL_P(0);
   Temporal *temp2 = PG_GETARG_TEMPORAL_P(1);
   /* Store fcinfo into a global variable */
   store_fcinfo(fcinfo);
-  Temporal *result = tdistance_trgeo_tpoint(temp1, temp2);
+  Temporal *result = tdistance_trgeometry_tpoint(temp1, temp2);
   PG_FREE_IF_COPY(temp1, 0);
   PG_FREE_IF_COPY(temp2, 1);
   if (! result)
@@ -133,7 +133,7 @@ Tdistance_trgeo_tpoint(PG_FUNCTION_ARGS)
   PG_RETURN_POINTER(result);
 }
 
-PG_FUNCTION_INFO_V1(Tdistance_tpoint_trgeo);
+PG_FUNCTION_INFO_V1(Tdistance_tpoint_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the temporal distance between two temporal rigid geometries
@@ -141,13 +141,13 @@ PG_FUNCTION_INFO_V1(Tdistance_tpoint_trgeo);
  * @sqlop @p <->
  */
 PGDLLEXPORT Datum
-Tdistance_tpoint_trgeo(PG_FUNCTION_ARGS)
+Tdistance_tpoint_trgeometry(PG_FUNCTION_ARGS)
 {
   Temporal *temp1 = PG_GETARG_TEMPORAL_P(0);
   Temporal *temp2 = PG_GETARG_TEMPORAL_P(1);
   /* Store fcinfo into a global variable */
   store_fcinfo(fcinfo);
-  Temporal *result = tdistance_trgeo_tpoint(temp2, temp1);
+  Temporal *result = tdistance_trgeometry_tpoint(temp2, temp1);
   PG_FREE_IF_COPY(temp1, 0);
   PG_FREE_IF_COPY(temp2, 1);
   if (! result)
@@ -155,7 +155,7 @@ Tdistance_tpoint_trgeo(PG_FUNCTION_ARGS)
   PG_RETURN_POINTER(result);
 }
 
-PG_FUNCTION_INFO_V1(Tdistance_trgeo_trgeo);
+PG_FUNCTION_INFO_V1(Tdistance_trgeometry_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the temporal distance between two temporal rigid geometries
@@ -163,13 +163,13 @@ PG_FUNCTION_INFO_V1(Tdistance_trgeo_trgeo);
  * @sqlop @p <->
  */
 PGDLLEXPORT Datum
-Tdistance_trgeo_trgeo(PG_FUNCTION_ARGS)
+Tdistance_trgeometry_trgeometry(PG_FUNCTION_ARGS)
 {
   Temporal *temp1 = PG_GETARG_TEMPORAL_P(0);
   Temporal *temp2 = PG_GETARG_TEMPORAL_P(1);
   /* Store fcinfo into a global variable */
   store_fcinfo(fcinfo);
-  Temporal *result = tdistance_trgeo_trgeo(temp1, temp2);
+  Temporal *result = tdistance_trgeometry_trgeometry(temp1, temp2);
   PG_FREE_IF_COPY(temp1, 0);
   PG_FREE_IF_COPY(temp2, 1);
   if (! result)
@@ -181,7 +181,7 @@ Tdistance_trgeo_trgeo(PG_FUNCTION_ARGS)
  * Nearest approach instant (NAI)
  *****************************************************************************/
 
-PG_FUNCTION_INFO_V1(NAI_trgeo_geo);
+PG_FUNCTION_INFO_V1(NAI_trgeometry_geo);
 /**
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the nearest approach instant between a temporal rigid geometry
@@ -189,13 +189,13 @@ PG_FUNCTION_INFO_V1(NAI_trgeo_geo);
  * @sqlfn nearestApproachInstant()
  */
 PGDLLEXPORT Datum
-NAI_trgeo_geo(PG_FUNCTION_ARGS)
+NAI_trgeometry_geo(PG_FUNCTION_ARGS)
 {
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(1);
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   /* Store fcinfo into a global variable */
   store_fcinfo(fcinfo);
-  TInstant *result = nai_trgeo_geo(temp, gs);
+  TInstant *result = nai_trgeometry_geo(temp, gs);
   PG_FREE_IF_COPY(temp, 0);
   PG_FREE_IF_COPY(gs, 1);
   if (! result)
@@ -203,7 +203,7 @@ NAI_trgeo_geo(PG_FUNCTION_ARGS)
   PG_RETURN_POINTER(result);
 }
 
-PG_FUNCTION_INFO_V1(NAI_geo_trgeo);
+PG_FUNCTION_INFO_V1(NAI_geo_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the nearest approach instant between a geometry and a temporal
@@ -211,13 +211,13 @@ PG_FUNCTION_INFO_V1(NAI_geo_trgeo);
  * @sqlfn nearestApproachInstant()
  */
 PGDLLEXPORT Datum
-NAI_geo_trgeo(PG_FUNCTION_ARGS)
+NAI_geo_trgeometry(PG_FUNCTION_ARGS)
 {
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(0);
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
   /* Store fcinfo into a global variable */
   store_fcinfo(fcinfo);
-  TInstant *result = nai_trgeo_geo(temp, gs);
+  TInstant *result = nai_trgeometry_geo(temp, gs);
   PG_FREE_IF_COPY(gs, 0);
   PG_FREE_IF_COPY(temp, 1);
   if (! result)
@@ -225,7 +225,7 @@ NAI_geo_trgeo(PG_FUNCTION_ARGS)
   PG_RETURN_POINTER(result);
 }
 
-PG_FUNCTION_INFO_V1(NAI_trgeo_tpoint);
+PG_FUNCTION_INFO_V1(NAI_trgeometry_tpoint);
 /**
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the nearest approach instant between the
@@ -233,13 +233,13 @@ PG_FUNCTION_INFO_V1(NAI_trgeo_tpoint);
  * @sqlfn nearestApproachInstant()
  */
 PGDLLEXPORT Datum
-NAI_trgeo_tpoint(PG_FUNCTION_ARGS)
+NAI_trgeometry_tpoint(PG_FUNCTION_ARGS)
 {
   Temporal *temp1 = PG_GETARG_TEMPORAL_P(0);
   Temporal *temp2 = PG_GETARG_TEMPORAL_P(1);
   /* Store fcinfo into a global variable */
   store_fcinfo(fcinfo);
-  TInstant *result = nai_trgeo_tpoint(temp1, temp2);
+  TInstant *result = nai_trgeometry_tpoint(temp1, temp2);
   PG_FREE_IF_COPY(temp1, 0);
   PG_FREE_IF_COPY(temp2, 1);
   if (! result)
@@ -247,7 +247,7 @@ NAI_trgeo_tpoint(PG_FUNCTION_ARGS)
   PG_RETURN_POINTER(result);
 }
 
-PG_FUNCTION_INFO_V1(NAI_tpoint_trgeo);
+PG_FUNCTION_INFO_V1(NAI_tpoint_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the nearest approach instant between the
@@ -255,13 +255,13 @@ PG_FUNCTION_INFO_V1(NAI_tpoint_trgeo);
  * @sqlfn nearestApproachInstant()
  */
 PGDLLEXPORT Datum
-NAI_tpoint_trgeo(PG_FUNCTION_ARGS)
+NAI_tpoint_trgeometry(PG_FUNCTION_ARGS)
 {
   Temporal *temp1 = PG_GETARG_TEMPORAL_P(0);
   Temporal *temp2 = PG_GETARG_TEMPORAL_P(1);
   /* Store fcinfo into a global variable */
   store_fcinfo(fcinfo);
-  TInstant *result = nai_trgeo_tpoint(temp2, temp1);
+  TInstant *result = nai_trgeometry_tpoint(temp2, temp1);
   PG_FREE_IF_COPY(temp1, 0);
   PG_FREE_IF_COPY(temp2, 1);
   if (! result)
@@ -269,7 +269,7 @@ NAI_tpoint_trgeo(PG_FUNCTION_ARGS)
   PG_RETURN_POINTER(result);
 }
 
-PG_FUNCTION_INFO_V1(NAI_trgeo_trgeo);
+PG_FUNCTION_INFO_V1(NAI_trgeometry_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the nearest approach instant between two temporal rigid
@@ -277,13 +277,13 @@ PG_FUNCTION_INFO_V1(NAI_trgeo_trgeo);
  * @sqlfn nearestApproachInstant()
  */
 PGDLLEXPORT Datum
-NAI_trgeo_trgeo(PG_FUNCTION_ARGS)
+NAI_trgeometry_trgeometry(PG_FUNCTION_ARGS)
 {
   Temporal *temp1 = PG_GETARG_TEMPORAL_P(0);
   Temporal *temp2 = PG_GETARG_TEMPORAL_P(1);
   /* Store fcinfo into a global variable */
   store_fcinfo(fcinfo);
-  TInstant *result = nai_trgeo_trgeo(temp1, temp2);
+  TInstant *result = nai_trgeometry_trgeometry(temp1, temp2);
   PG_FREE_IF_COPY(temp1, 0);
   PG_FREE_IF_COPY(temp2, 1);
   if (! result)
@@ -295,7 +295,7 @@ NAI_trgeo_trgeo(PG_FUNCTION_ARGS)
  * Nearest approach distance (NAD)
  *****************************************************************************/
 
-PG_FUNCTION_INFO_V1(NAD_trgeo_geo);
+PG_FUNCTION_INFO_V1(NAD_trgeometry_geo);
 /**
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the nearest approach distance between a temporal rigid
@@ -304,13 +304,13 @@ PG_FUNCTION_INFO_V1(NAD_trgeo_geo);
  * @sqlop @p |=|
  */
 PGDLLEXPORT Datum
-NAD_trgeo_geo(PG_FUNCTION_ARGS)
+NAD_trgeometry_geo(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(1);
   /* Store fcinfo into a global variable */
   store_fcinfo(fcinfo);
-  double result = nad_trgeo_geo(temp, gs);
+  double result = nad_trgeometry_geo(temp, gs);
   PG_FREE_IF_COPY(temp, 0);
   PG_FREE_IF_COPY(gs, 1);
   if (result == DBL_MAX)
@@ -318,7 +318,7 @@ NAD_trgeo_geo(PG_FUNCTION_ARGS)
   PG_RETURN_FLOAT8(result);
 }
 
-PG_FUNCTION_INFO_V1(NAD_geo_trgeo);
+PG_FUNCTION_INFO_V1(NAD_geo_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the nearest approach distance between a geometry and a
@@ -327,13 +327,13 @@ PG_FUNCTION_INFO_V1(NAD_geo_trgeo);
  * @sqlop @p |=|
  */
 PGDLLEXPORT Datum
-NAD_geo_trgeo(PG_FUNCTION_ARGS)
+NAD_geo_trgeometry(PG_FUNCTION_ARGS)
 {
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(0);
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
   /* Store fcinfo into a global variable */
   store_fcinfo(fcinfo);
-  double result = nad_trgeo_geo(temp, gs);
+  double result = nad_trgeometry_geo(temp, gs);
   PG_FREE_IF_COPY(gs, 0);
   PG_FREE_IF_COPY(temp, 1);
   if (result == DBL_MAX)
@@ -341,7 +341,7 @@ NAD_geo_trgeo(PG_FUNCTION_ARGS)
   PG_RETURN_FLOAT8(result);
 }
 
-PG_FUNCTION_INFO_V1(NAD_trgeo_stbox);
+PG_FUNCTION_INFO_V1(NAD_trgeometry_stbox);
 /**
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the nearest approach distance between a temporal rigid
@@ -350,20 +350,20 @@ PG_FUNCTION_INFO_V1(NAD_trgeo_stbox);
  * @sqlop @p |=|
  */
 PGDLLEXPORT Datum
-NAD_trgeo_stbox(PG_FUNCTION_ARGS)
+NAD_trgeometry_stbox(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   STBox *box = PG_GETARG_STBOX_P(1);
   /* Store fcinfo into a global variable */
   store_fcinfo(fcinfo);
-  double result = nad_trgeo_stbox(temp, box);
+  double result = nad_trgeometry_stbox(temp, box);
   PG_FREE_IF_COPY(temp, 0);
   if (result == DBL_MAX)
     PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 
-PG_FUNCTION_INFO_V1(NAD_stbox_trgeo);
+PG_FUNCTION_INFO_V1(NAD_stbox_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the nearest approach distance between a spatiotemporal box and
@@ -372,20 +372,20 @@ PG_FUNCTION_INFO_V1(NAD_stbox_trgeo);
  * @sqlop @p |=|
  */
 PGDLLEXPORT Datum
-NAD_stbox_trgeo(PG_FUNCTION_ARGS)
+NAD_stbox_trgeometry(PG_FUNCTION_ARGS)
 {
   STBox *box = PG_GETARG_STBOX_P(0);
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
   /* Store fcinfo into a global variable */
   store_fcinfo(fcinfo);
-  double result = nad_trgeo_stbox(temp, box);
+  double result = nad_trgeometry_stbox(temp, box);
   PG_FREE_IF_COPY(temp, 1);
   if (result == DBL_MAX)
     PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 
-PG_FUNCTION_INFO_V1(NAD_trgeo_tpoint);
+PG_FUNCTION_INFO_V1(NAD_trgeometry_tpoint);
 /**
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the nearest approach distance between two temporal rigid
@@ -394,13 +394,13 @@ PG_FUNCTION_INFO_V1(NAD_trgeo_tpoint);
  * @sqlop @p |=|
  */
 PGDLLEXPORT Datum
-NAD_trgeo_tpoint(PG_FUNCTION_ARGS)
+NAD_trgeometry_tpoint(PG_FUNCTION_ARGS)
 {
   Temporal *temp1 = PG_GETARG_TEMPORAL_P(0);
   Temporal *temp2 = PG_GETARG_TEMPORAL_P(1);
   /* Store fcinfo into a global variable */
   store_fcinfo(fcinfo);
-  double result = nad_trgeo_tpoint(temp1, temp2);
+  double result = nad_trgeometry_tpoint(temp1, temp2);
   PG_FREE_IF_COPY(temp1, 0);
   PG_FREE_IF_COPY(temp2, 1);
   if (result == DBL_MAX)
@@ -408,7 +408,7 @@ NAD_trgeo_tpoint(PG_FUNCTION_ARGS)
   PG_RETURN_FLOAT8(result);
 }
 
-PG_FUNCTION_INFO_V1(NAD_tpoint_trgeo);
+PG_FUNCTION_INFO_V1(NAD_tpoint_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the nearest approach distance between two temporal rigid
@@ -417,13 +417,13 @@ PG_FUNCTION_INFO_V1(NAD_tpoint_trgeo);
  * @sqlop @p |=|
  */
 PGDLLEXPORT Datum
-NAD_tpoint_trgeo(PG_FUNCTION_ARGS)
+NAD_tpoint_trgeometry(PG_FUNCTION_ARGS)
 {
   Temporal *temp1 = PG_GETARG_TEMPORAL_P(0);
   Temporal *temp2 = PG_GETARG_TEMPORAL_P(1);
   /* Store fcinfo into a global variable */
   store_fcinfo(fcinfo);
-  double result = nad_trgeo_tpoint(temp2, temp1);
+  double result = nad_trgeometry_tpoint(temp2, temp1);
   PG_FREE_IF_COPY(temp1, 0);
   PG_FREE_IF_COPY(temp2, 1);
   if (result == DBL_MAX)
@@ -431,7 +431,7 @@ NAD_tpoint_trgeo(PG_FUNCTION_ARGS)
   PG_RETURN_FLOAT8(result);
 }
 
-PG_FUNCTION_INFO_V1(NAD_trgeo_trgeo);
+PG_FUNCTION_INFO_V1(NAD_trgeometry_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the nearest approach distance between two temporal rigid
@@ -440,13 +440,13 @@ PG_FUNCTION_INFO_V1(NAD_trgeo_trgeo);
  * @sqlop @p |=|
  */
 PGDLLEXPORT Datum
-NAD_trgeo_trgeo(PG_FUNCTION_ARGS)
+NAD_trgeometry_trgeometry(PG_FUNCTION_ARGS)
 {
   Temporal *temp1 = PG_GETARG_TEMPORAL_P(0);
   Temporal *temp2 = PG_GETARG_TEMPORAL_P(1);
   /* Store fcinfo into a global variable */
   store_fcinfo(fcinfo);
-  double result = nad_trgeo_trgeo(temp1, temp2);
+  double result = nad_trgeometry_trgeometry(temp1, temp2);
   PG_FREE_IF_COPY(temp1, 0);
   PG_FREE_IF_COPY(temp2, 1);
   if (result == DBL_MAX)
@@ -458,7 +458,7 @@ NAD_trgeo_trgeo(PG_FUNCTION_ARGS)
  * ShortestLine
  *****************************************************************************/
 
-PG_FUNCTION_INFO_V1(Shortestline_trgeo_geo);
+PG_FUNCTION_INFO_V1(Shortestline_trgeometry_geo);
 /**
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the line connecting the nearest approach point between a
@@ -466,11 +466,11 @@ PG_FUNCTION_INFO_V1(Shortestline_trgeo_geo);
  * @sqlfn shortestLine()
  */
 PGDLLEXPORT Datum
-Shortestline_trgeo_geo(PG_FUNCTION_ARGS)
+Shortestline_trgeometry_geo(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(1);
-  GSERIALIZED *result = shortestline_trgeo_geo(temp, gs);
+  GSERIALIZED *result = shortestline_trgeometry_geo(temp, gs);
   PG_FREE_IF_COPY(temp, 0);
   PG_FREE_IF_COPY(gs, 1);
   if (! result)
@@ -478,7 +478,7 @@ Shortestline_trgeo_geo(PG_FUNCTION_ARGS)
   PG_RETURN_POINTER(result);
 }
 
-PG_FUNCTION_INFO_V1(Shortestline_geo_trgeo);
+PG_FUNCTION_INFO_V1(Shortestline_geo_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the line connecting the nearest approach point between a
@@ -486,11 +486,11 @@ PG_FUNCTION_INFO_V1(Shortestline_geo_trgeo);
  * @sqlfn shortestLine()
  */
 PGDLLEXPORT Datum
-Shortestline_geo_trgeo(PG_FUNCTION_ARGS)
+Shortestline_geo_trgeometry(PG_FUNCTION_ARGS)
 {
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(0);
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
-  GSERIALIZED *result = shortestline_trgeo_geo(temp, gs);
+  GSERIALIZED *result = shortestline_trgeometry_geo(temp, gs);
   PG_FREE_IF_COPY(gs, 0);
   PG_FREE_IF_COPY(temp, 1);
   if (! result)
@@ -498,7 +498,7 @@ Shortestline_geo_trgeo(PG_FUNCTION_ARGS)
   PG_RETURN_POINTER(result);
 }
 
-PG_FUNCTION_INFO_V1(Shortestline_trgeo_tpoint);
+PG_FUNCTION_INFO_V1(Shortestline_trgeometry_tpoint);
 /**
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the line connecting the nearest approach point between two
@@ -506,13 +506,13 @@ PG_FUNCTION_INFO_V1(Shortestline_trgeo_tpoint);
  * @sqlfn shortestLine()
  */
 PGDLLEXPORT Datum
-Shortestline_trgeo_tpoint(PG_FUNCTION_ARGS)
+Shortestline_trgeometry_tpoint(PG_FUNCTION_ARGS)
 {
   Temporal *temp1 = PG_GETARG_TEMPORAL_P(0);
   Temporal *temp2 = PG_GETARG_TEMPORAL_P(1);
   /* Store fcinfo into a global variable */
   store_fcinfo(fcinfo);
-  GSERIALIZED *result = shortestline_trgeo_tpoint(temp1, temp2);
+  GSERIALIZED *result = shortestline_trgeometry_tpoint(temp1, temp2);
   PG_FREE_IF_COPY(temp1, 0);
   PG_FREE_IF_COPY(temp2, 1);
   if (! result)
@@ -520,7 +520,7 @@ Shortestline_trgeo_tpoint(PG_FUNCTION_ARGS)
   PG_RETURN_POINTER(result);
 }
 
-PG_FUNCTION_INFO_V1(Shortestline_tpoint_trgeo);
+PG_FUNCTION_INFO_V1(Shortestline_tpoint_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the line connecting the nearest approach point between two
@@ -528,13 +528,13 @@ PG_FUNCTION_INFO_V1(Shortestline_tpoint_trgeo);
  * @sqlfn shortestLine()
  */
 PGDLLEXPORT Datum
-Shortestline_tpoint_trgeo(PG_FUNCTION_ARGS)
+Shortestline_tpoint_trgeometry(PG_FUNCTION_ARGS)
 {
   Temporal *temp1 = PG_GETARG_TEMPORAL_P(0);
   Temporal *temp2 = PG_GETARG_TEMPORAL_P(1);
   /* Store fcinfo into a global variable */
   store_fcinfo(fcinfo);
-  GSERIALIZED *result = shortestline_trgeo_tpoint(temp2, temp1);
+  GSERIALIZED *result = shortestline_trgeometry_tpoint(temp2, temp1);
   PG_FREE_IF_COPY(temp1, 0);
   PG_FREE_IF_COPY(temp2, 1);
   if (! result)
@@ -542,7 +542,7 @@ Shortestline_tpoint_trgeo(PG_FUNCTION_ARGS)
   PG_RETURN_POINTER(result);
 }
 
-PG_FUNCTION_INFO_V1(Shortestline_trgeo_trgeo);
+PG_FUNCTION_INFO_V1(Shortestline_trgeometry_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the line connecting the nearest approach point between two
@@ -550,13 +550,13 @@ PG_FUNCTION_INFO_V1(Shortestline_trgeo_trgeo);
  * @sqlfn shortestLine()
  */
 PGDLLEXPORT Datum
-Shortestline_trgeo_trgeo(PG_FUNCTION_ARGS)
+Shortestline_trgeometry_trgeometry(PG_FUNCTION_ARGS)
 {
   Temporal *temp1 = PG_GETARG_TEMPORAL_P(0);
   Temporal *temp2 = PG_GETARG_TEMPORAL_P(1);
   /* Store fcinfo into a global variable */
   store_fcinfo(fcinfo);
-  GSERIALIZED *result = shortestline_trgeo_trgeo(temp1, temp2);
+  GSERIALIZED *result = shortestline_trgeometry_trgeometry(temp1, temp2);
   PG_FREE_IF_COPY(temp1, 0);
   PG_FREE_IF_COPY(temp2, 1);
   if (! result)

--- a/mobilitydb/src/rgeo/trgeo_spatialfuncs.c
+++ b/mobilitydb/src/rgeo/trgeo_spatialfuncs.c
@@ -59,7 +59,7 @@ inline Datum
 Trgeometry_traversed_area(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
-  GSERIALIZED *result = trgeo_traversed_area(temp);
+  GSERIALIZED *result = trgeometry_traversed_area(temp);
   PG_FREE_IF_COPY(temp, 0);
   if (! result)
     PG_RETURN_NULL();

--- a/mobilitydb/src/rgeo/trgeo_spatialrels.c
+++ b/mobilitydb/src/rgeo/trgeo_spatialrels.c
@@ -60,28 +60,28 @@
  * Ever/always contains
  *****************************************************************************/
 
-PGDLLEXPORT Datum Econtains_geo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Econtains_geo_trgeo);
+PGDLLEXPORT Datum Econtains_geo_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Econtains_geo_trgeometry);
 /**
  * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if a geometry ever contains a temporal rigid geometry
  * @sqlfn eContains()
  */
 inline Datum
-Econtains_geo_trgeo(PG_FUNCTION_ARGS)
+Econtains_geo_trgeometry(PG_FUNCTION_ARGS)
 {
   return EA_spatialrel_geo_tspatial(fcinfo, &ea_contains_geo_trgeo, EVER);
 }
 
-PGDLLEXPORT Datum Acontains_geo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Acontains_geo_trgeo);
+PGDLLEXPORT Datum Acontains_geo_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Acontains_geo_trgeometry);
 /**
  * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if a geometry always contains a temporal rigid geometry
  * @sqlfn aContains()
  */
 inline Datum
-Acontains_geo_trgeo(PG_FUNCTION_ARGS)
+Acontains_geo_trgeometry(PG_FUNCTION_ARGS)
 {
   return EA_spatialrel_geo_tspatial(fcinfo, &ea_contains_geo_trgeo, ALWAYS);
 }
@@ -90,56 +90,56 @@ Acontains_geo_trgeo(PG_FUNCTION_ARGS)
  * Ever/always covers
  *****************************************************************************/
 
-PGDLLEXPORT Datum Ecovers_geo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Ecovers_geo_trgeo);
+PGDLLEXPORT Datum Ecovers_geo_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Ecovers_geo_trgeometry);
 /**
  * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if a geometry ever covers a temporal rigid geometry
  * @sqlfn eCovers()
  */
 inline Datum
-Ecovers_geo_trgeo(PG_FUNCTION_ARGS)
+Ecovers_geo_trgeometry(PG_FUNCTION_ARGS)
 {
   return EA_spatialrel_geo_tspatial(fcinfo, &ea_covers_geo_trgeo, EVER);
 }
 
-PGDLLEXPORT Datum Acovers_geo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Acovers_geo_trgeo);
+PGDLLEXPORT Datum Acovers_geo_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Acovers_geo_trgeometry);
 /**
  * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if a geometry always covers a temporal rigid geometry
  * @sqlfn aCovers()
  */
 inline Datum
-Acovers_geo_trgeo(PG_FUNCTION_ARGS)
+Acovers_geo_trgeometry(PG_FUNCTION_ARGS)
 {
   return EA_spatialrel_geo_tspatial(fcinfo, &ea_covers_geo_trgeo, ALWAYS);
 }
 
 /*****************************************************************************/
 
-PGDLLEXPORT Datum Ecovers_trgeo_geo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Ecovers_trgeo_geo);
+PGDLLEXPORT Datum Ecovers_trgeometry_geo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Ecovers_trgeometry_geo);
 /**
  * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if a geometry ever covers a temporal rigid geometry
  * @sqlfn eCovers()
  */
 inline Datum
-Ecovers_trgeo_geo(PG_FUNCTION_ARGS)
+Ecovers_trgeometry_geo(PG_FUNCTION_ARGS)
 {
   return EA_spatialrel_tspatial_geo(fcinfo, &ea_covers_trgeo_geo, EVER);
 }
 
-PGDLLEXPORT Datum Acovers_trgeo_geo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Acovers_trgeo_geo);
+PGDLLEXPORT Datum Acovers_trgeometry_geo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Acovers_trgeometry_geo);
 /**
  * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if a geometry always covers a temporal rigid geometry
  * @sqlfn aCovers()
  */
 inline Datum
-Acovers_trgeo_geo(PG_FUNCTION_ARGS)
+Acovers_trgeometry_geo(PG_FUNCTION_ARGS)
 {
   return EA_spatialrel_tspatial_geo(fcinfo, &ea_covers_trgeo_geo, ALWAYS);
 }
@@ -148,8 +148,8 @@ Acovers_trgeo_geo(PG_FUNCTION_ARGS)
  * Ever disjoint (for both geometry and geography)
  *****************************************************************************/
 
-PGDLLEXPORT Datum Edisjoint_geo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Edisjoint_geo_trgeo);
+PGDLLEXPORT Datum Edisjoint_geo_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Edisjoint_geo_trgeometry);
 /**
  * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if a geometry and a temporal rigid geometry are ever
@@ -157,13 +157,13 @@ PG_FUNCTION_INFO_V1(Edisjoint_geo_trgeo);
  * @sqlfn eDisjoint()
  */
 inline Datum
-Edisjoint_geo_trgeo(PG_FUNCTION_ARGS)
+Edisjoint_geo_trgeometry(PG_FUNCTION_ARGS)
 {
   return EA_spatialrel_geo_tspatial(fcinfo, &ea_disjoint_geo_trgeo, EVER);
 }
 
-PGDLLEXPORT Datum Adisjoint_geo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Adisjoint_geo_trgeo);
+PGDLLEXPORT Datum Adisjoint_geo_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Adisjoint_geo_trgeometry);
 /**
  * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if a geometry and a temporal rigid geometry are always
@@ -171,13 +171,13 @@ PG_FUNCTION_INFO_V1(Adisjoint_geo_trgeo);
  * @sqlfn aDisjoint()
  */
 inline Datum
-Adisjoint_geo_trgeo(PG_FUNCTION_ARGS)
+Adisjoint_geo_trgeometry(PG_FUNCTION_ARGS)
 {
   return EA_spatialrel_geo_tspatial(fcinfo, &ea_disjoint_geo_trgeo, ALWAYS);
 }
 
-PGDLLEXPORT Datum Edisjoint_trgeo_geo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Edisjoint_trgeo_geo);
+PGDLLEXPORT Datum Edisjoint_trgeometry_geo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Edisjoint_trgeometry_geo);
 /**
  * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if a temporal rigid geometry and a geometry are ever
@@ -185,13 +185,13 @@ PG_FUNCTION_INFO_V1(Edisjoint_trgeo_geo);
  * @sqlfn eDisjoint()
  */
 inline Datum
-Edisjoint_trgeo_geo(PG_FUNCTION_ARGS)
+Edisjoint_trgeometry_geo(PG_FUNCTION_ARGS)
 {
   return EA_spatialrel_tspatial_geo(fcinfo, &ea_disjoint_trgeo_geo, EVER);
 }
 
-PGDLLEXPORT Datum Adisjoint_trgeo_geo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Adisjoint_trgeo_geo);
+PGDLLEXPORT Datum Adisjoint_trgeometry_geo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Adisjoint_trgeometry_geo);
 /**
  * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if a temporal rigid geometry and a geometry are always
@@ -199,34 +199,34 @@ PG_FUNCTION_INFO_V1(Adisjoint_trgeo_geo);
  * @sqlfn aDisjoint()
  */
 inline Datum
-Adisjoint_trgeo_geo(PG_FUNCTION_ARGS)
+Adisjoint_trgeometry_geo(PG_FUNCTION_ARGS)
 {
   return EA_spatialrel_tspatial_geo(fcinfo, &ea_disjoint_trgeo_geo, ALWAYS);
 }
 
-PGDLLEXPORT Datum Edisjoint_trgeo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Edisjoint_trgeo_trgeo);
+PGDLLEXPORT Datum Edisjoint_trgeometry_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Edisjoint_trgeometry_trgeometry);
 /**
  * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if two temporal rigid geometries are ever disjoint
  * @sqlfn eDisjoint()
  */
 inline Datum
-Edisjoint_trgeo_trgeo(PG_FUNCTION_ARGS)
+Edisjoint_trgeometry_trgeometry(PG_FUNCTION_ARGS)
 {
   return EA_spatialrel_tspatial_tspatial(fcinfo, &ea_disjoint_trgeo_trgeo,
     EVER);
 }
 
-PGDLLEXPORT Datum Adisjoint_trgeo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Adisjoint_trgeo_trgeo);
+PGDLLEXPORT Datum Adisjoint_trgeometry_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Adisjoint_trgeometry_trgeometry);
 /**
  * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if two temporal rigid geometries are ever disjoint
  * @sqlfn aDisjoint()
  */
 inline Datum
-Adisjoint_trgeo_trgeo(PG_FUNCTION_ARGS)
+Adisjoint_trgeometry_trgeometry(PG_FUNCTION_ARGS)
 {
   return EA_spatialrel_tspatial_tspatial(fcinfo, &ea_disjoint_trgeo_trgeo,
     ALWAYS);
@@ -236,8 +236,8 @@ Adisjoint_trgeo_trgeo(PG_FUNCTION_ARGS)
  * Ever intersects (for both geometry and geography)
  *****************************************************************************/
 
-PGDLLEXPORT Datum Eintersects_geo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Eintersects_geo_trgeo);
+PGDLLEXPORT Datum Eintersects_geo_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Eintersects_geo_trgeometry);
 /**
  * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if a geometry and a temporal rigid geometry ever
@@ -245,13 +245,13 @@ PG_FUNCTION_INFO_V1(Eintersects_geo_trgeo);
  * @sqlfn eIntersects()
  */
 inline Datum
-Eintersects_geo_trgeo(PG_FUNCTION_ARGS)
+Eintersects_geo_trgeometry(PG_FUNCTION_ARGS)
 {
   return EA_spatialrel_geo_tspatial(fcinfo, &ea_intersects_geo_trgeo, EVER);
 }
 
-PGDLLEXPORT Datum Aintersects_geo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Aintersects_geo_trgeo);
+PGDLLEXPORT Datum Aintersects_geo_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Aintersects_geo_trgeometry);
 /**
  * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if a geometry and a temporal rigid geometry ever
@@ -259,13 +259,13 @@ PG_FUNCTION_INFO_V1(Aintersects_geo_trgeo);
  * @sqlfn aIntersects()
  */
 inline Datum
-Aintersects_geo_trgeo(PG_FUNCTION_ARGS)
+Aintersects_geo_trgeometry(PG_FUNCTION_ARGS)
 {
   return EA_spatialrel_geo_tspatial(fcinfo, &ea_intersects_geo_trgeo, ALWAYS);
 }
 
-PGDLLEXPORT Datum Eintersects_trgeo_geo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Eintersects_trgeo_geo);
+PGDLLEXPORT Datum Eintersects_trgeometry_geo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Eintersects_trgeometry_geo);
 /**
  * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if a temporal rigid geometry and a geometry ever
@@ -273,13 +273,13 @@ PG_FUNCTION_INFO_V1(Eintersects_trgeo_geo);
  * @sqlfn eIntersects()
  */
 inline Datum
-Eintersects_trgeo_geo(PG_FUNCTION_ARGS)
+Eintersects_trgeometry_geo(PG_FUNCTION_ARGS)
 {
   return EA_spatialrel_tspatial_geo(fcinfo, &ea_intersects_trgeo_geo, EVER);
 }
 
-PGDLLEXPORT Datum Aintersects_trgeo_geo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Aintersects_trgeo_geo);
+PGDLLEXPORT Datum Aintersects_trgeometry_geo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Aintersects_trgeometry_geo);
 /**
  * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if a temporal rigid geometry and a geometry always
@@ -287,34 +287,34 @@ PG_FUNCTION_INFO_V1(Aintersects_trgeo_geo);
  * @sqlfn aIntersects()
  */
 inline Datum
-Aintersects_trgeo_geo(PG_FUNCTION_ARGS)
+Aintersects_trgeometry_geo(PG_FUNCTION_ARGS)
 {
   return EA_spatialrel_tspatial_geo(fcinfo, &ea_intersects_trgeo_geo, ALWAYS);
 }
 
-PGDLLEXPORT Datum Eintersects_trgeo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Eintersects_trgeo_trgeo);
+PGDLLEXPORT Datum Eintersects_trgeometry_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Eintersects_trgeometry_trgeometry);
 /**
  * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if two temporal rigid geometries ever intersect
  * @sqlfn eIntersects()
  */
 inline Datum
-Eintersects_trgeo_trgeo(PG_FUNCTION_ARGS)
+Eintersects_trgeometry_trgeometry(PG_FUNCTION_ARGS)
 {
   return EA_spatialrel_tspatial_tspatial(fcinfo, &ea_intersects_trgeo_trgeo,
     EVER);
 }
 
-PGDLLEXPORT Datum Aintersects_trgeo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Aintersects_trgeo_trgeo);
+PGDLLEXPORT Datum Aintersects_trgeometry_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Aintersects_trgeometry_trgeometry);
 /**
  * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if two temporal rigid geometries ever intersect
  * @sqlfn aIntersects()
  */
 inline Datum
-Aintersects_trgeo_trgeo(PG_FUNCTION_ARGS)
+Aintersects_trgeometry_trgeometry(PG_FUNCTION_ARGS)
 {
   return EA_spatialrel_tspatial_tspatial(fcinfo, &ea_intersects_trgeo_trgeo,
     ALWAYS);
@@ -326,54 +326,54 @@ Aintersects_trgeo_trgeo(PG_FUNCTION_ARGS)
  * ST_Boundary function
  *****************************************************************************/
 
-PGDLLEXPORT Datum Etouches_geo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Etouches_geo_trgeo);
+PGDLLEXPORT Datum Etouches_geo_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Etouches_geo_trgeometry);
 /**
  * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if a geometry and a temporal rigid geometry ever touch
  * @sqlfn eTouches()
  */
 inline Datum
-Etouches_geo_trgeo(PG_FUNCTION_ARGS)
+Etouches_geo_trgeometry(PG_FUNCTION_ARGS)
 {
   return EA_spatialrel_geo_tspatial(fcinfo, &ea_touches_geo_trgeo, EVER);
 }
 
-PGDLLEXPORT Datum Atouches_geo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Atouches_geo_trgeo);
+PGDLLEXPORT Datum Atouches_geo_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Atouches_geo_trgeometry);
 /**
  * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if a geometry and a temporal rigid geometry ever touch
  * @sqlfn aTouches()
  */
 inline Datum
-Atouches_geo_trgeo(PG_FUNCTION_ARGS)
+Atouches_geo_trgeometry(PG_FUNCTION_ARGS)
 {
   return EA_spatialrel_geo_tspatial(fcinfo, &ea_touches_geo_trgeo, ALWAYS);
 }
 
-PGDLLEXPORT Datum Etouches_trgeo_geo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Etouches_trgeo_geo);
+PGDLLEXPORT Datum Etouches_trgeometry_geo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Etouches_trgeometry_geo);
 /**
  * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if a temporal rigid geometry and a geometry ever touch
  * @sqlfn eTouches()
  */
 inline Datum
-Etouches_trgeo_geo(PG_FUNCTION_ARGS)
+Etouches_trgeometry_geo(PG_FUNCTION_ARGS)
 {
   return EA_spatialrel_tspatial_geo(fcinfo, &ea_touches_trgeo_geo, EVER);
 }
 
-PGDLLEXPORT Datum Atouches_trgeo_geo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Atouches_trgeo_geo);
+PGDLLEXPORT Datum Atouches_trgeometry_geo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Atouches_trgeometry_geo);
 /**
  * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if a temporal rigid geometry and a geometry always touch
  * @sqlfn aTouches()
  */
 inline Datum
-Atouches_trgeo_geo(PG_FUNCTION_ARGS)
+Atouches_trgeometry_geo(PG_FUNCTION_ARGS)
 {
   return EA_spatialrel_tspatial_geo(fcinfo, &ea_touches_trgeo_geo, ALWAYS);
 }
@@ -383,8 +383,8 @@ Atouches_trgeo_geo(PG_FUNCTION_ARGS)
  * The function only accepts points and not arbitrary geometries/geographies
  *****************************************************************************/
 
-PGDLLEXPORT Datum Edwithin_geo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Edwithin_geo_trgeo);
+PGDLLEXPORT Datum Edwithin_geo_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Edwithin_geo_trgeometry);
 /**
  * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if a geometry and a temporal rigid geometry are ever
@@ -392,13 +392,13 @@ PG_FUNCTION_INFO_V1(Edwithin_geo_trgeo);
  * @sqlfn eDwithin()
  */
 inline Datum
-Edwithin_geo_trgeo(PG_FUNCTION_ARGS)
+Edwithin_geo_trgeometry(PG_FUNCTION_ARGS)
 {
   return EA_dwithin_geo_tspatial(fcinfo, EVER);
 }
 
-PGDLLEXPORT Datum Adwithin_geo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Adwithin_geo_trgeo);
+PGDLLEXPORT Datum Adwithin_geo_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Adwithin_geo_trgeometry);
 /**
  * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if a geometry and a temporal rigid geometry are always
@@ -406,13 +406,13 @@ PG_FUNCTION_INFO_V1(Adwithin_geo_trgeo);
  * @sqlfn aDwithin()
  */
 inline Datum
-Adwithin_geo_trgeo(PG_FUNCTION_ARGS)
+Adwithin_geo_trgeometry(PG_FUNCTION_ARGS)
 {
   return EA_dwithin_geo_tspatial(fcinfo, ALWAYS);
 }
 
-PGDLLEXPORT Datum Edwithin_trgeo_geo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Edwithin_trgeo_geo);
+PGDLLEXPORT Datum Edwithin_trgeometry_geo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Edwithin_trgeometry_geo);
 /**
  * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if a temporal rigid geometry and a geometry are ever
@@ -420,13 +420,13 @@ PG_FUNCTION_INFO_V1(Edwithin_trgeo_geo);
  * @sqlfn eDwithin()
  */
 inline Datum
-Edwithin_trgeo_geo(PG_FUNCTION_ARGS)
+Edwithin_trgeometry_geo(PG_FUNCTION_ARGS)
 {
   return EA_dwithin_tspatial_geo(fcinfo, EVER);
 }
 
-PGDLLEXPORT Datum Adwithin_trgeo_geo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Adwithin_trgeo_geo);
+PGDLLEXPORT Datum Adwithin_trgeometry_geo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Adwithin_trgeometry_geo);
 /**
  * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if a temporal rigid geometry and a geometry are ever
@@ -434,7 +434,7 @@ PG_FUNCTION_INFO_V1(Adwithin_trgeo_geo);
  * @sqlfn aDwithin()
  */
 inline Datum
-Adwithin_trgeo_geo(PG_FUNCTION_ARGS)
+Adwithin_trgeometry_geo(PG_FUNCTION_ARGS)
 {
   return EA_dwithin_tspatial_geo(fcinfo, ALWAYS);
 }
@@ -445,7 +445,7 @@ Adwithin_trgeo_geo(PG_FUNCTION_ARGS)
  * @sqlfn eDwithin(), aDwithin()
  */
 Datum
-EA_dwithin_trgeo_trgeo(FunctionCallInfo fcinfo, bool ever)
+EA_dwithin_trgeometry_trgeometry(FunctionCallInfo fcinfo, bool ever)
 {
   Temporal *temp1 = PG_GETARG_TEMPORAL_P(0);
   Temporal *temp2 = PG_GETARG_TEMPORAL_P(1);
@@ -458,8 +458,8 @@ EA_dwithin_trgeo_trgeo(FunctionCallInfo fcinfo, bool ever)
   PG_RETURN_BOOL(result);
 }
 
-PGDLLEXPORT Datum Edwithin_trgeo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Edwithin_trgeo_trgeo);
+PGDLLEXPORT Datum Edwithin_trgeometry_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Edwithin_trgeometry_trgeometry);
 /**
  * @ingroup mobilitydb_geo_rel
  * @brief Return true if two temporal rigid geometries are ever within a
@@ -467,13 +467,13 @@ PG_FUNCTION_INFO_V1(Edwithin_trgeo_trgeo);
  * @sqlfn eDwithin()
  */
 inline Datum
-Edwithin_trgeo_trgeo(PG_FUNCTION_ARGS)
+Edwithin_trgeometry_trgeometry(PG_FUNCTION_ARGS)
 {
-  return EA_dwithin_trgeo_trgeo(fcinfo, EVER);
+  return EA_dwithin_trgeometry_trgeometry(fcinfo, EVER);
 }
 
-PGDLLEXPORT Datum Adwithin_trgeo_trgeo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Adwithin_trgeo_trgeo);
+PGDLLEXPORT Datum Adwithin_trgeometry_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Adwithin_trgeometry_trgeometry);
 /**
  * @ingroup mobilitydb_geo_rel
  * @brief Return true if two temporal rigid geometries are always within a
@@ -481,7 +481,7 @@ PG_FUNCTION_INFO_V1(Adwithin_trgeo_trgeo);
  * @sqlfn aDwithin()
  */
 inline Datum
-Adwithin_trgeo_trgeo(PG_FUNCTION_ARGS)
+Adwithin_trgeometry_trgeometry(PG_FUNCTION_ARGS)
 {
   return EA_spatialrel_tspatial_geo(fcinfo, &ea_dwithin_trgeo_geo, ALWAYS);
 }

--- a/mobilitydb/src/temporal/temporal.c
+++ b/mobilitydb/src/temporal/temporal.c
@@ -1135,7 +1135,7 @@ Temporal_start_sequence(PG_FUNCTION_ARGS)
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
 #if RGEO
   TSequence *result = (temp->temptype == T_TRGEOMETRY) ?
-    trgeo_start_sequence(temp) : temporal_start_sequence(temp);
+    trgeometry_start_sequence(temp) : temporal_start_sequence(temp);
 #else
   TSequence *result = temporal_start_sequence(temp);
 #endif /* RGEO */
@@ -1156,7 +1156,7 @@ Temporal_end_sequence(PG_FUNCTION_ARGS)
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
 #if RGEO
   TSequence *result = (temp->temptype == T_TRGEOMETRY) ?
-    trgeo_end_sequence(temp) : temporal_end_sequence(temp);
+    trgeometry_end_sequence(temp) : temporal_end_sequence(temp);
 #else
   TSequence *result = temporal_end_sequence(temp);
 #endif /* RGEO */
@@ -1178,7 +1178,7 @@ Temporal_sequence_n(PG_FUNCTION_ARGS)
   int n = PG_GETARG_INT32(1); /* Assume 1-based */
 #if RGEO
   TSequence *result = (temp->temptype == T_TRGEOMETRY) ?
-    trgeo_sequence_n(temp, n) : temporal_sequence_n(temp, n);
+    trgeometry_sequence_n(temp, n) : temporal_sequence_n(temp, n);
 #else
   TSequence *result = temporal_sequence_n(temp, n);
 #endif /* RGEO */
@@ -1202,7 +1202,7 @@ Temporal_sequences(PG_FUNCTION_ARGS)
   int count;
 #if RGEO
   TSequence **sequences = (temp->temptype == T_TRGEOMETRY) ?
-    trgeo_sequences(temp, &count) : 
+    trgeometry_sequences(temp, &count) : 
     (TSequence **) temporal_sequences_p(temp, &count);
 #else
   const TSequence **sequences = temporal_sequences_p(temp, &count);
@@ -1292,7 +1292,7 @@ Temporal_start_instant(PG_FUNCTION_ARGS)
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
 #if RGEO
   TInstant *result = (temp->temptype == T_TRGEOMETRY) ?
-    trgeo_start_instant(temp) : temporal_start_instant(temp);
+    trgeometry_start_instant(temp) : temporal_start_instant(temp);
 #else
   TInstant *result = temporal_start_instant(temp);
 #endif /* RGEO */
@@ -1313,7 +1313,7 @@ Temporal_end_instant(PG_FUNCTION_ARGS)
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
 #if RGEO
   TInstant *result = (temp->temptype == T_TRGEOMETRY) ?
-    trgeo_end_instant(temp) : temporal_end_instant(temp);
+    trgeometry_end_instant(temp) : temporal_end_instant(temp);
 #else
   TInstant *result = temporal_end_instant(temp);
 #endif /* RGEO */
@@ -1335,7 +1335,7 @@ Temporal_instant_n(PG_FUNCTION_ARGS)
   int n = PG_GETARG_INT32(1); /* Assume 1-based */
 #if RGEO
   TInstant *result = (temp->temptype == T_TRGEOMETRY) ?
-    trgeo_instant_n(temp, n) : temporal_instant_n(temp, n);
+    trgeometry_instant_n(temp, n) : temporal_instant_n(temp, n);
 #else
   TInstant *result = temporal_instant_n(temp, n);
 #endif /* RGEO */
@@ -1359,7 +1359,7 @@ Temporal_instants(PG_FUNCTION_ARGS)
   int count;
 #if RGEO
   TInstant **instants = (temp->temptype == T_TRGEOMETRY) ?
-    trgeo_instants(temp, &count) : 
+    trgeometry_instants(temp, &count) : 
     (TInstant **) temporal_insts_p(temp, &count);
 #else
   const TInstant **instants = temporal_insts_p(temp, &count);
@@ -1520,7 +1520,7 @@ Temporal_round(PG_FUNCTION_ARGS)
   int size = PG_GETARG_INT32(1);
 #if RGEO
   Temporal *result = (temp->temptype == T_TRGEOMETRY) ?
-    trgeo_round(temp, size) : temporal_round(temp, size);
+    trgeometry_round(temp, size) : temporal_round(temp, size);
 #else
   Temporal *result = temporal_round(temp, size);
 #endif /* RGEO */
@@ -1633,7 +1633,7 @@ Temporal_set_interp(PG_FUNCTION_ARGS)
   interpType interp = input_interp_string(fcinfo, 1);
 #if RGEO
   Temporal *result = (temp->temptype == T_TRGEOMETRY) ?
-    trgeo_set_interp(temp, interp) : temporal_set_interp(temp, interp);
+    trgeometry_set_interp(temp, interp) : temporal_set_interp(temp, interp);
 #else
   Temporal *result = temporal_set_interp(temp, interp);
 #endif /* RGEO */
@@ -1884,7 +1884,7 @@ Temporal_append_tinstant(PG_FUNCTION_ARGS)
 
 #if RGEO
   Temporal *result = (temp->temptype == T_TRGEOMETRY) ?
-    trgeo_append_tinstant(temp, inst, interp, 0.0, NULL, false) :
+    trgeometry_append_tinstant(temp, inst, interp, 0.0, NULL, false) :
     temporal_append_tinstant(temp, inst, interp, 0.0, NULL, false);
 #else
   Temporal *result = temporal_append_tinstant(temp, inst, interp, 0.0, NULL,
@@ -1909,7 +1909,7 @@ Temporal_append_tsequence(PG_FUNCTION_ARGS)
   TSequence *seq = PG_GETARG_TSEQUENCE_P(1);
 #if RGEO
   Temporal *result = (temp->temptype == T_TRGEOMETRY) ?
-    trgeo_append_tsequence(temp, seq, false) :
+    trgeometry_append_tsequence(temp, seq, false) :
     temporal_append_tsequence(temp, seq, false);
 #else
   Temporal *result = temporal_append_tsequence(temp, seq, false);
@@ -1977,7 +1977,7 @@ Temporal_restrict_value(FunctionCallInfo fcinfo, bool atfunc)
   MeosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 1));
 #if RGEO
   Temporal *result = (temp->temptype == T_TRGEOMETRY) ?
-    trgeo_restrict_value(temp, value, atfunc) :
+    trgeometry_restrict_value(temp, value, atfunc) :
     temporal_restrict_value(temp, value, atfunc);
 #else
   Temporal *result = temporal_restrict_value(temp, value, atfunc);
@@ -2028,7 +2028,7 @@ Temporal_restrict_values(FunctionCallInfo fcinfo, bool atfunc)
   Set *s = PG_GETARG_SET_P(1);
 #if RGEO
   Temporal *result = (temp->temptype == T_TRGEOMETRY) ?
-    trgeo_restrict_values(temp, s, atfunc) :
+    trgeometry_restrict_values(temp, s, atfunc) :
     temporal_restrict_values(temp, s, atfunc);
 #else
   Temporal *result = temporal_restrict_values(temp, s, atfunc);
@@ -2285,7 +2285,7 @@ Temporal_restrict_timestamptz(FunctionCallInfo fcinfo, bool atfunc)
   TimestampTz t = PG_GETARG_TIMESTAMPTZ(1);
 #if RGEO
   Temporal *result = (temp->temptype == T_TRGEOMETRY) ?
-    trgeo_restrict_timestamptz(temp, t, atfunc) :
+    trgeometry_restrict_timestamptz(temp, t, atfunc) :
     temporal_restrict_timestamptz(temp, t, atfunc);
 #else
   Temporal *result = temporal_restrict_timestamptz(temp, t, atfunc);
@@ -2335,7 +2335,7 @@ Temporal_restrict_tstzset(FunctionCallInfo fcinfo, bool atfunc)
   Set *s = PG_GETARG_SET_P(1);
 #if RGEO
   Temporal *result = (temp->temptype == T_TRGEOMETRY) ?
-    trgeo_restrict_tstzset(temp, s, atfunc) :
+    trgeometry_restrict_tstzset(temp, s, atfunc) :
     temporal_restrict_tstzset(temp, s, atfunc);
 #else
   Temporal *result = temporal_restrict_tstzset(temp, s, atfunc);
@@ -2387,7 +2387,7 @@ Temporal_restrict_tstzspan(FunctionCallInfo fcinfo, bool atfunc)
   Span *s = PG_GETARG_SPAN_P(1);
 #if RGEO
   Temporal *result = (temp->temptype == T_TRGEOMETRY) ?
-    trgeo_restrict_tstzspan(temp, s, atfunc) :
+    trgeometry_restrict_tstzspan(temp, s, atfunc) :
     temporal_restrict_tstzspan(temp, s, atfunc);
 #else
   Temporal *result = temporal_restrict_tstzspan(temp, s, atfunc);
@@ -2438,7 +2438,7 @@ Temporal_restrict_tstzspanset(FunctionCallInfo fcinfo, bool atfunc)
   SpanSet *ss = PG_GETARG_SPANSET_P(1);
 #if RGEO
   Temporal *result = (temp->temptype == T_TRGEOMETRY) ?
-    trgeo_restrict_tstzspanset(temp, ss, atfunc) :
+    trgeometry_restrict_tstzspanset(temp, ss, atfunc) :
     temporal_restrict_tstzspanset(temp, ss, atfunc);
 #else
   Temporal *result = temporal_restrict_tstzspanset(temp, ss, atfunc);
@@ -2492,7 +2492,7 @@ Temporal_before_timestamptz(PG_FUNCTION_ARGS)
   bool strict = PG_GETARG_BOOL(2);
 #if RGEO
   Temporal *result = (temp->temptype == T_TRGEOMETRY) ?
-    trgeo_before_timestamptz(temp, t, strict) :
+    trgeometry_before_timestamptz(temp, t, strict) :
     temporal_before_timestamptz(temp, t, strict);
 #else
   Temporal *result = temporal_before_timestamptz(temp, t, strict);
@@ -2517,7 +2517,7 @@ Temporal_after_timestamptz(PG_FUNCTION_ARGS)
   bool strict = PG_GETARG_BOOL(2);
 #if RGEO
   Temporal *result = (temp->temptype == T_TRGEOMETRY) ?
-    trgeo_after_timestamptz(temp, t, strict) :
+    trgeometry_after_timestamptz(temp, t, strict) :
     temporal_after_timestamptz(temp, t, strict);
 #else
   Temporal *result = temporal_after_timestamptz(temp, t, strict);
@@ -2635,7 +2635,7 @@ Temporal_delete_timestamptz(PG_FUNCTION_ARGS)
   bool connect = PG_GETARG_BOOL(2);
 #if RGEO
   Temporal *result = (temp->temptype == T_TRGEOMETRY) ?
-    trgeo_delete_timestamptz(temp, t, connect) :
+    trgeometry_delete_timestamptz(temp, t, connect) :
     temporal_delete_timestamptz(temp, t, connect);
 #else
   Temporal *result = temporal_delete_timestamptz(temp, t, connect);
@@ -2661,7 +2661,7 @@ Temporal_delete_tstzset(PG_FUNCTION_ARGS)
   bool connect = PG_GETARG_BOOL(2);
 #if RGEO
   Temporal *result = (temp->temptype == T_TRGEOMETRY) ?
-    trgeo_delete_tstzset(temp, s, connect) :
+    trgeometry_delete_tstzset(temp, s, connect) :
     temporal_delete_tstzset(temp, s, connect);
 #else
   Temporal *result = temporal_delete_tstzset(temp, s, connect);
@@ -2688,7 +2688,7 @@ Temporal_delete_tstzspan(PG_FUNCTION_ARGS)
   bool connect = PG_GETARG_BOOL(2);
 #if RGEO
   Temporal *result = (temp->temptype == T_TRGEOMETRY) ?
-    trgeo_delete_tstzspan(temp, s, connect) :
+    trgeometry_delete_tstzspan(temp, s, connect) :
     temporal_delete_tstzspan(temp, s, connect);
 #else
   Temporal *result = temporal_delete_tstzspan(temp, s, connect);
@@ -2714,7 +2714,7 @@ Temporal_delete_tstzspanset(PG_FUNCTION_ARGS)
   bool connect = PG_GETARG_BOOL(2);
 #if RGEO
   Temporal *result = (temp->temptype == T_TRGEOMETRY) ?
-    trgeo_delete_tstzspanset(temp, ss, connect) :
+    trgeometry_delete_tstzspanset(temp, ss, connect) :
     temporal_delete_tstzspanset(temp, ss, connect);
 #else
   Temporal *result = temporal_delete_tstzspanset(temp, ss, connect);


### PR DESCRIPTION
The public trgeometry kernel functions, their MobilityDB wrappers, SQL AS-clauses, and @csqlfn/@sqlfn/@sqlop linkage tags carry the trgeometry type name rather than the trgeo abbreviation, matching the SQL type and the sibling extended types tcbuffer, tnpoint, and tpose. Internal helper functions keep their abbreviated trgeo names. The change renames symbols only and alters no executable code; the sole non-rename edit drops two commented-out duplicate forward declarations.