### PR TITLE
Export per-operation SkipList combine functions for temporal aggregation in MEOS

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -1797,34 +1797,46 @@ extern int nad_tint_tint(const Temporal *temp1, const Temporal *temp2);
  *****************************************************************************/
 
 extern SkipList *tbool_tand_transfn(SkipList *state, const Temporal *temp);
+extern SkipList *tbool_tand_combinefn(SkipList *state1, SkipList *state2);
 extern SkipList *tbool_tor_transfn(SkipList *state, const Temporal *temp);
+extern SkipList *tbool_tor_combinefn(SkipList *state1, SkipList *state2);
 extern Span *temporal_extent_transfn(Span *s, const Temporal *temp);
 extern SkipList *temporal_merge_transfn(SkipList *state, const Temporal *temp);
 extern SkipList *temporal_merge_combinefn(SkipList *state1, SkipList *state2);
 extern Temporal *temporal_tagg_finalfn(SkipList *state);
 extern SkipList *temporal_tcount_transfn(SkipList *state, const Temporal *temp);
+extern SkipList *temporal_tcount_combinefn(SkipList *state1, SkipList *state2);
 extern SkipList *tfloat_tmax_transfn(SkipList *state, const Temporal *temp);
+extern SkipList *tfloat_tmax_combinefn(SkipList *state1, SkipList *state2);
 extern SkipList *tfloat_tmin_transfn(SkipList *state, const Temporal *temp);
+extern SkipList *tfloat_tmin_combinefn(SkipList *state1, SkipList *state2);
 extern SkipList *tfloat_tsum_transfn(SkipList *state, const Temporal *temp);
+extern SkipList *tfloat_tsum_combinefn(SkipList *state1, SkipList *state2);
 extern SkipList *tfloat_wmax_transfn(SkipList *state, const Temporal *temp, const Interval *interv);
 extern SkipList *tfloat_wmin_transfn(SkipList *state, const Temporal *temp, const Interval *interv);
 extern SkipList *tfloat_wsum_transfn(SkipList *state, const Temporal *temp, const Interval *interv);
 extern SkipList *timestamptz_tcount_transfn(SkipList *state, TimestampTz t);
 extern SkipList *tint_tmax_transfn(SkipList *state, const Temporal *temp);
+extern SkipList *tint_tmax_combinefn(SkipList *state1, SkipList *state2);
 extern SkipList *tint_tmin_transfn(SkipList *state, const Temporal *temp);
+extern SkipList *tint_tmin_combinefn(SkipList *state1, SkipList *state2);
 extern SkipList *tint_tsum_transfn(SkipList *state, const Temporal *temp);
+extern SkipList *tint_tsum_combinefn(SkipList *state1, SkipList *state2);
 extern SkipList *tint_wmax_transfn(SkipList *state, const Temporal *temp, const Interval *interv);
 extern SkipList *tint_wmin_transfn(SkipList *state, const Temporal *temp, const Interval *interv);
 extern SkipList *tint_wsum_transfn(SkipList *state, const Temporal *temp, const Interval *interv);
 extern TBox *tnumber_extent_transfn(TBox *box, const Temporal *temp);
 extern Temporal *tnumber_tavg_finalfn(SkipList *state);
 extern SkipList *tnumber_tavg_transfn(SkipList *state, const Temporal *temp);
+extern SkipList *tnumber_tavg_combinefn(SkipList *state1, SkipList *state2);
 extern SkipList *tnumber_wavg_transfn(SkipList *state, const Temporal *temp, const Interval *interv);
 extern SkipList *tstzset_tcount_transfn(SkipList *state, const Set *s);
 extern SkipList *tstzspan_tcount_transfn(SkipList *state, const Span *s);
 extern SkipList *tstzspanset_tcount_transfn(SkipList *state, const SpanSet *ss);
 extern SkipList *ttext_tmax_transfn(SkipList *state, const Temporal *temp);
+extern SkipList *ttext_tmax_combinefn(SkipList *state1, SkipList *state2);
 extern SkipList *ttext_tmin_transfn(SkipList *state, const Temporal *temp);
+extern SkipList *ttext_tmin_combinefn(SkipList *state1, SkipList *state2);
 
 /*****************************************************************************
  * Analytics functions for temporal types

--- a/meos/src/temporal/temporal_aggfuncs_meos.c
+++ b/meos/src/temporal/temporal_aggfuncs_meos.c
@@ -306,6 +306,153 @@ temporal_merge_combinefn(SkipList *state1, SkipList *state2)
   return temporal_tagg_combinefn(state1, state2, NULL, CROSSINGS_NO);
 }
 
+/**
+ * @ingroup meos_temporal_agg
+ * @brief Combine function for the temporal count aggregate of temporal values
+ * @param[in,out] state1, state2 Current aggregate states
+ * @csqlfn #Temporal_tcount_combinefn()
+ */
+SkipList *
+temporal_tcount_combinefn(SkipList *state1, SkipList *state2)
+{
+  return temporal_tagg_combinefn(state1, state2, &datum_sum_int32, CROSSINGS_NO);
+}
+
+/**
+ * @ingroup meos_temporal_agg
+ * @brief Combine function for the temporal and aggregate of temporal booleans
+ * @param[in,out] state1, state2 Current aggregate states
+ * @csqlfn #Tbool_tand_combinefn()
+ */
+SkipList *
+tbool_tand_combinefn(SkipList *state1, SkipList *state2)
+{
+  return temporal_tagg_combinefn(state1, state2, &datum_and, CROSSINGS_NO);
+}
+
+/**
+ * @ingroup meos_temporal_agg
+ * @brief Combine function for the temporal or aggregate of temporal booleans
+ * @param[in,out] state1, state2 Current aggregate states
+ * @csqlfn #Tbool_tor_combinefn()
+ */
+SkipList *
+tbool_tor_combinefn(SkipList *state1, SkipList *state2)
+{
+  return temporal_tagg_combinefn(state1, state2, &datum_or, CROSSINGS_NO);
+}
+
+/**
+ * @ingroup meos_temporal_agg
+ * @brief Combine function for the temporal minimum aggregate of temporal
+ * integers
+ * @param[in,out] state1, state2 Current aggregate states
+ * @csqlfn #Tint_tmin_combinefn()
+ */
+SkipList *
+tint_tmin_combinefn(SkipList *state1, SkipList *state2)
+{
+  return temporal_tagg_combinefn(state1, state2, &datum_min_int32, CROSSINGS_NO);
+}
+
+/**
+ * @ingroup meos_temporal_agg
+ * @brief Combine function for the temporal minimum aggregate of temporal floats
+ * @param[in,out] state1, state2 Current aggregate states
+ * @csqlfn #Tfloat_tmin_combinefn()
+ */
+SkipList *
+tfloat_tmin_combinefn(SkipList *state1, SkipList *state2)
+{
+  return temporal_tagg_combinefn(state1, state2, &datum_min_float8, CROSSINGS);
+}
+
+/**
+ * @ingroup meos_temporal_agg
+ * @brief Combine function for the temporal maximum aggregate of temporal
+ * integers
+ * @param[in,out] state1, state2 Current aggregate states
+ * @csqlfn #Tint_tmax_combinefn()
+ */
+SkipList *
+tint_tmax_combinefn(SkipList *state1, SkipList *state2)
+{
+  return temporal_tagg_combinefn(state1, state2, &datum_max_int32, CROSSINGS_NO);
+}
+
+/**
+ * @ingroup meos_temporal_agg
+ * @brief Combine function for the temporal maximum aggregate of temporal floats
+ * @param[in,out] state1, state2 Current aggregate states
+ * @csqlfn #Tfloat_tmax_combinefn()
+ */
+SkipList *
+tfloat_tmax_combinefn(SkipList *state1, SkipList *state2)
+{
+  return temporal_tagg_combinefn(state1, state2, &datum_max_float8, CROSSINGS);
+}
+
+/**
+ * @ingroup meos_temporal_agg
+ * @brief Combine function for the temporal sum aggregate of temporal integers
+ * @param[in,out] state1, state2 Current aggregate states
+ * @csqlfn #Tint_tsum_combinefn()
+ */
+SkipList *
+tint_tsum_combinefn(SkipList *state1, SkipList *state2)
+{
+  return temporal_tagg_combinefn(state1, state2, &datum_sum_int32, CROSSINGS_NO);
+}
+
+/**
+ * @ingroup meos_temporal_agg
+ * @brief Combine function for the temporal sum aggregate of temporal floats
+ * @param[in,out] state1, state2 Current aggregate states
+ * @csqlfn #Tfloat_tsum_combinefn()
+ */
+SkipList *
+tfloat_tsum_combinefn(SkipList *state1, SkipList *state2)
+{
+  return temporal_tagg_combinefn(state1, state2, &datum_sum_float8, CROSSINGS_NO);
+}
+
+/**
+ * @ingroup meos_temporal_agg
+ * @brief Combine function for the temporal minimum aggregate of temporal texts
+ * @param[in,out] state1, state2 Current aggregate states
+ * @csqlfn #Ttext_tmin_combinefn()
+ */
+SkipList *
+ttext_tmin_combinefn(SkipList *state1, SkipList *state2)
+{
+  return temporal_tagg_combinefn(state1, state2, &datum_min_text, CROSSINGS_NO);
+}
+
+/**
+ * @ingroup meos_temporal_agg
+ * @brief Combine function for the temporal maximum aggregate of temporal texts
+ * @param[in,out] state1, state2 Current aggregate states
+ * @csqlfn #Ttext_tmax_combinefn()
+ */
+SkipList *
+ttext_tmax_combinefn(SkipList *state1, SkipList *state2)
+{
+  return temporal_tagg_combinefn(state1, state2, &datum_max_text, CROSSINGS_NO);
+}
+
+/**
+ * @ingroup meos_temporal_agg
+ * @brief Combine function for the temporal average aggregate of temporal
+ * numbers
+ * @param[in,out] state1, state2 Current aggregate states
+ * @csqlfn #Tnumber_tavg_combinefn()
+ */
+SkipList *
+tnumber_tavg_combinefn(SkipList *state1, SkipList *state2)
+{
+  return temporal_tagg_combinefn(state1, state2, &datum_sum_double2, CROSSINGS_NO);
+}
+
 #endif /* MEOS */
 
 /*****************************************************************************


### PR DESCRIPTION
The MEOS aggregate surface exposes the per-operation transition and final functions but only a single combine function, temporal_merge_combinefn, which concatenates states. Add the per-operation combine functions tint_tsum_combinefn, tfloat_tsum_combinefn, tint_tmin_combinefn, tfloat_tmin_combinefn, tint_tmax_combinefn, tfloat_tmax_combinefn, ttext_tmin_combinefn, ttext_tmax_combinefn, tbool_tand_combinefn, tbool_tor_combinefn, temporal_tcount_combinefn and tnumber_tavg_combinefn, each delegating to the generic temporal_tagg_combinefn with the same aggregation function and crossings flag as the matching transition function. They let a MEOS consumer merge partial aggregation states across parallel or windowed slices for every temporal-aggregate operation, not only merge; the window variants combine with the same functions, so these symbols cover them as well.