### PR TITLE
Remove the superseded tCentroid stub and the phantom tcbuffer centroid entry

### DIFF
--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -2254,7 +2254,6 @@
 					</listitem>
 
 					<listitem>
-						<para><link linkend="tcbuffer_tCentroid"><varname>tCentroid</varname></link>: Temporal centroid</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/temporal_circular_buffers.xml
+++ b/doc/temporal_circular_buffers.xml
@@ -946,25 +946,6 @@ FROM Temp;
    1@2001-01-06)} */
 </programlisting>
 			</listitem>
-
-			<listitem xml:id="tcbuffer_tCentroid">
-				<indexterm significance="normal"><primary><varname>tCentroid</varname></primary></indexterm>
-				<para>TODO Temporal centroid</para>
-				<para><varname>tCentroid(tcbuffer) → tgeompoint</varname></para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
-WITH Temp(temp) AS (
-SELECT tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01, 
-  Cbuffer(Point(1 1), 0.3)@2001-01-03)' UNION
-SELECT tcbuffer '[Cbuffer(Point(1 1), 0.2)@2001-01-01, 
-  Cbuffer(Point(1 1), 0.4)@2001-01-03)' UNION
-SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01, 
-  Cbuffer(Point(1 1), 0.5)@2001-01-03)' )
-SELECT astext(tCentroid(Temp))
-FROM Temp;
-/* {[POINT(72.451531682218 76.5231414472853)@2001-01-01,
-   POINT(55.7001249027598 72.9552602410653)@2001-01-03)} */
-</programlisting>
-			</listitem>
 		</itemizedlist>
 	</sect1>
 

--- a/mobilitydb/sql/geo/056_tgeo_spatialfuncs.in.sql
+++ b/mobilitydb/sql/geo/056_tgeo_spatialfuncs.in.sql
@@ -152,10 +152,6 @@ CREATE FUNCTION convexHull(tgeometry)
   AS 'MODULE_PATHNAME', 'Tgeo_convex_hull'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
--- CREATE FUNCTION tCentroid(tgeometry)
-  -- RETURNS tgeometry
-  -- AS 'MODULE_PATHNAME', 'Tgeo_tcentroid'
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************/
 


### PR DESCRIPTION
The temporal centroid of a temporal geometry is the scalar centroid(tgeometry) backed by the Tgeo_centroid kernel; the commented tCentroid declaration named a nonexistent symbol and is removed. The circular-buffers chapter documented a tCentroid(tcbuffer) aggregate that does not exist — the temporal centroid is a point aggregate provided for tgeompoint and tnpoint — so that entry and its reference link are removed.