### PR TITLE
Add Modifications sections to the network points and circular buffers chapters

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1576,6 +1576,19 @@
 				</itemizedlist>
 			</sect3>
 
+				<sect3>
+					<title>Modifications</title>
+					<itemizedlist>
+						<listitem>
+							<para><link linkend="tnpoint_appendInstant"><varname>appendInstant</varname>, <varname>appendSequence</varname></link>: Agregar un instante temporal o una secuencia temporal</para>
+						</listitem>
+
+						<listitem>
+							<para><link linkend="tnpoint_merge"><varname>merge</varname>, <varname>mergeAgg</varname></link>: Fusionar los puntos de red temporales</para>
+						</listitem>
+					</itemizedlist>
+				</sect3>
+
 			<sect3>
 				<title>Restricciones</title>
 				<itemizedlist>

--- a/doc/es/temporal_network_points.xml
+++ b/doc/es/temporal_network_points.xml
@@ -517,6 +517,47 @@ SELECT round(tnpoint '{[NPoint(1,0.123456789)@2001-01-01, NPoint(1,0.5)@2001-01-
 		</itemizedlist>
 	</sect1>
 
+	<sect1 xml:id="tnpoint_modifications">
+		<title>Modificaciones</title>
+		<itemizedlist>
+			<listitem xml:id="tnpoint_appendInstant">
+				<indexterm significance="normal"><primary><varname>appendInstant</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
+				<para>Agregar un instante temporal o una secuencia temporal</para>
+				<para><varname>appendInstant(tnpoint,tnpointInst) → tnpoint</varname></para>
+				<para><varname>appendSequence(tnpoint,tnpointSeq) → tnpoint</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(appendInstant(tnpoint 'Npoint(1, 0.1)@2001-01-01', 'Npoint(1, 0.2)@2001-01-02'));
+-- [NPoint(1,0.1)@2001-01-01 00:00:00+01, NPoint(1,0.2)@2001-01-02 00:00:00+01]
+SELECT asText(appendSequence(tnpoint '[Npoint(1, 0.1)@2001-01-01]', '[Npoint(1, 0.2)@2001-01-02]'));
+-- {[NPoint(1,0.1)@2001-01-01 00:00:00+01], [NPoint(1,0.2)@2001-01-02 00:00:00+01]}
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="tnpoint_merge">
+				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
+				<para>Fusionar los puntos de red temporales</para>
+				<para><varname>merge(tnpoint,tnpoint) → tnpoint</varname></para>
+				<para><varname>merge(tnpoint[]) → tnpoint</varname></para>
+				<para><varname>mergeAgg(tnpoint) → tnpoint</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(merge(tnpoint '[Npoint(1, 0.1)@2001-01-01, Npoint(1, 0.3)@2001-01-03]',
+  '[Npoint(1, 0.3)@2001-01-03, Npoint(1, 0.5)@2001-01-05]'));
+-- [NPoint(1,0.1)@2001-01-01 00:00:00+01, NPoint(1,0.5)@2001-01-05 00:00:00+01]
+SELECT asText(merge(ARRAY[tnpoint '[Npoint(1, 0.1)@2001-01-01, Npoint(1, 0.2)@2001-01-02]',
+  '[Npoint(1, 0.2)@2001-01-02, Npoint(1, 0.3)@2001-01-03]']));
+-- [NPoint(1,0.1)@2001-01-01 00:00:00+01, NPoint(1,0.3)@2001-01-03 00:00:00+01]
+WITH temp(inst) AS (
+  SELECT tnpoint 'Npoint(1, 0.1)@2001-01-01' UNION
+  SELECT tnpoint 'Npoint(1, 0.2)@2001-01-02' UNION
+  SELECT tnpoint 'Npoint(1, 0.3)@2001-01-03' )
+SELECT asText(mergeAgg(inst)) FROM temp;
+-- {NPoint(1,0.1)@2001-01-01 00:00:00+01, NPoint(1,0.2)@2001-01-02 00:00:00+01, NPoint(1,0.3)@2001-01-03 00:00:00+01}
+</programlisting>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
 	<sect1 xml:id="tnpoint_restrictions">
 		<title>Restricciones</title>
 		<itemizedlist>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1887,6 +1887,19 @@
 				</itemizedlist>
 			</sect3>
 
+				<sect3>
+					<title>Modifications</title>
+					<itemizedlist>
+						<listitem>
+							<para><link linkend="tnpoint_appendInstant"><varname>appendInstant</varname>, <varname>appendSequence</varname></link>: Append a temporal instant or a temporal sequence</para>
+						</listitem>
+
+						<listitem>
+							<para><link linkend="tnpoint_merge"><varname>merge</varname>, <varname>mergeAgg</varname></link>: Merge the temporal network points</para>
+						</listitem>
+					</itemizedlist>
+				</sect3>
+
 			<sect3>
 				<title>Restrictions</title>
 				<itemizedlist>
@@ -2147,6 +2160,19 @@
 					</listitem>
 				</itemizedlist>
 			</sect3>
+
+				<sect3>
+					<title>Modifications</title>
+					<itemizedlist>
+						<listitem>
+							<para><link linkend="tcbuffer_appendInstant"><varname>appendInstant</varname>, <varname>appendSequence</varname></link>: Append a temporal instant or a temporal sequence</para>
+						</listitem>
+
+						<listitem>
+							<para><link linkend="tcbuffer_merge"><varname>merge</varname>, <varname>mergeAgg</varname></link>: Merge the temporal circular buffers</para>
+						</listitem>
+					</itemizedlist>
+				</sect3>
 
 			<sect3>
 				<title>Restrictions</title>

--- a/doc/temporal_circular_buffers.xml
+++ b/doc/temporal_circular_buffers.xml
@@ -556,6 +556,46 @@ SELECT asText(round(tcbuffer '{[Cbuffer(Point(1 1.123456789),0.123456789)@2001-0
 		</itemizedlist>
 	</sect1>
 
+	<sect1 xml:id="tcbuffer_modifications">
+		<title>Modifications</title>
+		<itemizedlist>
+			<listitem xml:id="tcbuffer_appendInstant">
+				<indexterm significance="normal"><primary><varname>appendInstant</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
+				<para>Append a temporal instant or a temporal sequence</para>
+				<para><varname>appendInstant(tcbuffer,tcbufferInst) → tcbuffer</varname></para>
+				<para><varname>appendSequence(tcbuffer,tcbufferSeq) → tcbuffer</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(appendInstant(tcbuffer 'Cbuffer(Point(1 1), 0.1)@2001-01-01', 'Cbuffer(Point(2 2), 0.2)@2001-01-02'));
+-- [Cbuffer(POINT(1 1),0.1)@2001-01-01 00:00:00+01, Cbuffer(POINT(2 2),0.2)@2001-01-02 00:00:00+01]
+SELECT asText(appendSequence(tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01]', '[Cbuffer(Point(2 2), 0.2)@2001-01-02]'));
+-- {[Cbuffer(POINT(1 1),0.1)@2001-01-01 00:00:00+01], [Cbuffer(POINT(2 2),0.2)@2001-01-02 00:00:00+01]}
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="tcbuffer_merge">
+				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
+				<para>Merge the temporal circular buffers</para>
+				<para><varname>merge(tcbuffer,tcbuffer) → tcbuffer</varname></para>
+				<para><varname>merge(tcbuffer[]) → tcbuffer</varname></para>
+				<para><varname>mergeAgg(tcbuffer) → tcbuffer</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(merge(tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01, Cbuffer(Point(1 1), 0.3)@2001-01-03]',
+  '[Cbuffer(Point(1 1), 0.3)@2001-01-03, Cbuffer(Point(1 1), 0.5)@2001-01-05]'));
+-- [Cbuffer(POINT(1 1),0.1)@2001-01-01 00:00:00+01, Cbuffer(POINT(1 1),0.5)@2001-01-05 00:00:00+01]
+SELECT asText(merge(ARRAY[tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01, Cbuffer(Point(1 1), 0.2)@2001-01-02]',
+  '[Cbuffer(Point(1 1), 0.2)@2001-01-02, Cbuffer(Point(1 1), 0.3)@2001-01-03]']));
+-- [Cbuffer(POINT(1 1),0.1)@2001-01-01 00:00:00+01, Cbuffer(POINT(1 1),0.3)@2001-01-03 00:00:00+01]
+WITH temp(inst) AS (
+  SELECT tcbuffer 'Cbuffer(Point(1 1), 0.1)@2001-01-01' UNION
+  SELECT tcbuffer 'Cbuffer(Point(2 2), 0.2)@2001-01-02' )
+SELECT asText(mergeAgg(inst)) FROM temp;
+-- {Cbuffer(POINT(1 1),0.1)@2001-01-01 00:00:00+01, Cbuffer(POINT(2 2),0.2)@2001-01-02 00:00:00+01}
+</programlisting>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
 	<sect1 xml:id="tcbuffer_spatial">
 		<title>Spatial Operations</title>
 		<itemizedlist>

--- a/doc/temporal_network_points.xml
+++ b/doc/temporal_network_points.xml
@@ -535,6 +535,47 @@ SELECT round(tnpoint '{[NPoint(1,0.123456789)@2001-01-01, NPoint(1,0.5)@2001-01-
 		</itemizedlist>
 	</sect1>
 
+	<sect1 xml:id="tnpoint_modifications">
+		<title>Modifications</title>
+		<itemizedlist>
+			<listitem xml:id="tnpoint_appendInstant">
+				<indexterm significance="normal"><primary><varname>appendInstant</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
+				<para>Append a temporal instant or a temporal sequence</para>
+				<para><varname>appendInstant(tnpoint,tnpointInst) → tnpoint</varname></para>
+				<para><varname>appendSequence(tnpoint,tnpointSeq) → tnpoint</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(appendInstant(tnpoint 'Npoint(1, 0.1)@2001-01-01', 'Npoint(1, 0.2)@2001-01-02'));
+-- [NPoint(1,0.1)@2001-01-01 00:00:00+01, NPoint(1,0.2)@2001-01-02 00:00:00+01]
+SELECT asText(appendSequence(tnpoint '[Npoint(1, 0.1)@2001-01-01]', '[Npoint(1, 0.2)@2001-01-02]'));
+-- {[NPoint(1,0.1)@2001-01-01 00:00:00+01], [NPoint(1,0.2)@2001-01-02 00:00:00+01]}
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="tnpoint_merge">
+				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
+				<para>Merge the temporal network points</para>
+				<para><varname>merge(tnpoint,tnpoint) → tnpoint</varname></para>
+				<para><varname>merge(tnpoint[]) → tnpoint</varname></para>
+				<para><varname>mergeAgg(tnpoint) → tnpoint</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(merge(tnpoint '[Npoint(1, 0.1)@2001-01-01, Npoint(1, 0.3)@2001-01-03]',
+  '[Npoint(1, 0.3)@2001-01-03, Npoint(1, 0.5)@2001-01-05]'));
+-- [NPoint(1,0.1)@2001-01-01 00:00:00+01, NPoint(1,0.5)@2001-01-05 00:00:00+01]
+SELECT asText(merge(ARRAY[tnpoint '[Npoint(1, 0.1)@2001-01-01, Npoint(1, 0.2)@2001-01-02]',
+  '[Npoint(1, 0.2)@2001-01-02, Npoint(1, 0.3)@2001-01-03]']));
+-- [NPoint(1,0.1)@2001-01-01 00:00:00+01, NPoint(1,0.3)@2001-01-03 00:00:00+01]
+WITH temp(inst) AS (
+  SELECT tnpoint 'Npoint(1, 0.1)@2001-01-01' UNION
+  SELECT tnpoint 'Npoint(1, 0.2)@2001-01-02' UNION
+  SELECT tnpoint 'Npoint(1, 0.3)@2001-01-03' )
+SELECT asText(mergeAgg(inst)) FROM temp;
+-- {NPoint(1,0.1)@2001-01-01 00:00:00+01, NPoint(1,0.2)@2001-01-02 00:00:00+01, NPoint(1,0.3)@2001-01-03 00:00:00+01}
+</programlisting>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
 	<sect1 xml:id="tnpoint_restrictions">
 		<title>Restrictions</title>
 		<itemizedlist>


### PR DESCRIPTION
The temporal network points chapter documents the type-specific appendInstant, appendSequence and merge functions and the mergeAgg aggregate in a Modifications section with tnpoint examples, so the chapter presents its full modification surface. The English and Spanish chapters and the reference index carry the section. It builds on the mergeAgg name from #828.