### PR TITLE
Default the traversedArea unary union argument to false for temporal circular buffers

### DIFF
--- a/doc/temporal_circular_buffers.xml
+++ b/doc/temporal_circular_buffers.xml
@@ -605,7 +605,7 @@ FROM test;
 			<listitem xml:id="tcbuffer_traversedArea">
 				<indexterm significance="normal"><primary><varname>traversedArea</varname></primary></indexterm>
 				<para>Return the area traversed by the temporal circular buffer</para>
-				<para><varname>traversedArea(tcbuffer) → geometry</varname></para>
+				<para><varname>traversedArea(tcbuffer, unary_union=false) → geometry</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(traversedArea(tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01, 
   Cbuffer(Point(1 1), 0.5)@2001-01-02]'));

--- a/mobilitydb/sql/cbuffer/155_tcbuffer_spatialfuncs.in.sql
+++ b/mobilitydb/sql/cbuffer/155_tcbuffer_spatialfuncs.in.sql
@@ -61,7 +61,7 @@ CREATE FUNCTION transformPipeline(tcbuffer, text, srid integer DEFAULT 0,
  * Traversed area
  *****************************************************************************/
 
-CREATE FUNCTION traversedArea(tcbuffer, bool DEFAULT true)
+CREATE FUNCTION traversedArea(tcbuffer, bool DEFAULT FALSE)
   RETURNS geometry
   AS 'MODULE_PATHNAME', 'Tcbuffer_traversed_area'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;


### PR DESCRIPTION
The traversedArea function for tcbuffer takes a Boolean argument that, when true, applies a spatial union to the per-segment geometries to return a single geometry. Its default of false matches the traversedArea functions for tgeometry and tgeography, which leave the per-segment geometries unmerged. The DocBook signature for the temporal circular buffers chapter records the argument and its default.