### PR TITLE
Rename the meosOper enum to MeosOper

### DIFF
--- a/meos/include/temporal/meos_catalog.h
+++ b/meos/include/temporal/meos_catalog.h
@@ -169,7 +169,7 @@ typedef enum
   ALWAYSLE_OP     = 40, /**< Alwaysle `%<=` operator */
   ALWAYSGT_OP     = 41, /**< Alwaysgt `%>` operator */
   ALWAYSGE_OP     = 42, /**< Alwaysge `%>=` operator */
-} meosOper;
+} MeosOper;
 
 /**
  * Structure to represent the temporal type cache array.
@@ -215,8 +215,8 @@ extern bool temptype_subtype_all(tempSubtype subtype);
 #endif
 extern const char *tempsubtype_name(tempSubtype subtype);
 extern bool tempsubtype_from_string(const char *str, int16 *subtype);
-extern const char *meosoper_name(meosOper oper);
-extern meosOper meosoper_from_string(const char *name);
+extern const char *meosoper_name(MeosOper oper);
+extern MeosOper meosoper_from_string(const char *name);
 extern const char *interptype_name(interpType interp);
 extern interpType interptype_from_string(const char *interp_str);
 

--- a/meos/src/temporal/meos_catalog.c
+++ b/meos/src/temporal/meos_catalog.c
@@ -128,7 +128,7 @@ static const char *MEOS_TYPE_NAMES[] =
 
 /**
  * @brief Global constant array containing the operator names corresponding to
- * the enumeration meosOper defined in file `meos_catalog.h`
+ * the enumeration MeosOper defined in file `meos_catalog.h`
  */
 static const char *MEOS_OPER_NAMES[] =
 {
@@ -387,7 +387,7 @@ temptype_subtype_all(tempSubtype subtype)
  * @brief Return the string name from a MEOS operator number
  */
 inline const char *
-meosoper_name(meosOper oper)
+meosoper_name(MeosOper oper)
 {
   return MEOS_OPER_NAMES[oper];
 }
@@ -396,7 +396,7 @@ meosoper_name(meosOper oper)
  * @brief Fetch the operator number from its name
  * @arg[in] str Name of the type
  */
-meosOper
+MeosOper
 meosoper_from_string(const char *str)
 {
   int n = sizeof(MEOS_OPER_NAMES) / sizeof(char *);

--- a/mobilitydb/pg_include/pg_geo/tspatial_selfuncs.h
+++ b/mobilitydb/pg_include/pg_geo/tspatial_selfuncs.h
@@ -98,7 +98,7 @@ extern ND_STATS *pg_get_nd_stats(const Oid tableid, AttrNumber att_num,
   int mode, bool only_parent);
 
 extern float8 geo_sel(VariableStatData *vardata, const STBox *box,
-  meosOper oper);
+  MeosOper oper);
 extern float8 geo_joinsel(const ND_STATS *s1, const ND_STATS *s2);
 
 /*****************************************************************************/

--- a/mobilitydb/pg_include/pg_temporal/meos_catalog.h
+++ b/mobilitydb/pg_include/pg_temporal/meos_catalog.h
@@ -45,9 +45,9 @@
 /* MobilityDB functions */
 
 extern Oid meostype_oid(MeosType type);
-extern Oid meosoper_oid(meosOper op, MeosType l, MeosType r);
+extern Oid meosoper_oid(MeosOper op, MeosType l, MeosType r);
 extern MeosType oid_meostype(Oid typid);
-extern meosOper oid_meosoper(Oid operOid, MeosType *l, MeosType *r);
+extern MeosOper oid_meosoper(Oid operOid, MeosType *l, MeosType *r);
 
 extern bool range_basetype(MeosType type);
 extern bool ensure_range_basetype(MeosType type);

--- a/mobilitydb/pg_include/pg_temporal/span_selfuncs.h
+++ b/mobilitydb/pg_include/pg_temporal/span_selfuncs.h
@@ -43,17 +43,17 @@
 
 /*****************************************************************************/
 
-extern float8 span_sel_default(meosOper oper);
-extern float8 span_joinsel_default(meosOper oper);
+extern float8 span_sel_default(MeosOper oper);
+extern float8 span_joinsel_default(MeosOper oper);
 
 extern void span_const_to_span(Node *other, Span *span);
 
 extern double span_sel_hist(VariableStatData *vardata, const Span *constval,
-  meosOper oper, bool value);
+  MeosOper oper, bool value);
 extern float8 span_sel(PlannerInfo *root, Oid operid, List *args,
   int varRelid);
 
-extern float8 span_joinsel(PlannerInfo *root, bool value, meosOper oper,
+extern float8 span_joinsel(PlannerInfo *root, bool value, MeosOper oper,
   List *args, JoinType jointype, SpecialJoinInfo *sjinfo);
 
 /*****************************************************************************/

--- a/mobilitydb/pg_include/pg_temporal/temporal_selfuncs.h
+++ b/mobilitydb/pg_include/pg_temporal/temporal_selfuncs.h
@@ -61,7 +61,7 @@
 extern Selectivity scalarineqsel(PlannerInfo *root, Oid operid, bool isgt,
   bool iseq, VariableStatData *vardata, Datum constval, Oid consttypid);
 extern Selectivity temporal_sel_tstzspan(VariableStatData *vardata, Span *s,
-  meosOper oper);
+  MeosOper oper);
 
 /*****************************************************************************
  * Some other helper functions.

--- a/mobilitydb/src/geo/tspatial_selfuncs.c
+++ b/mobilitydb/src/geo/tspatial_selfuncs.c
@@ -414,7 +414,7 @@ nd_box_ratio_overback(const ND_BOX *b1, const ND_BOX *b2)
  * @brief Dispatch function for the position operators
  */
 static double
-nd_box_ratio_position(const ND_BOX *b1, const ND_BOX *b2, meosOper oper)
+nd_box_ratio_position(const ND_BOX *b1, const ND_BOX *b2, MeosOper oper)
 {
   if (oper == LEFT_OP)
     return nd_box_ratio_left(b1, b2);
@@ -485,7 +485,7 @@ nd_box_from_stbox(const STBox *box, ND_BOX *nd_box)
  * file gserialized_estimate.c
  */
 Selectivity
-geo_sel(VariableStatData *vardata, const STBox *box, meosOper oper)
+geo_sel(VariableStatData *vardata, const STBox *box, MeosOper oper)
 {
   ND_STATS *nd_stats;
   AttStatsSlot sslot;

--- a/mobilitydb/src/temporal/meos_catalog.c
+++ b/mobilitydb/src/temporal/meos_catalog.c
@@ -104,7 +104,7 @@ typedef struct
 typedef struct
 {
   Oid oproid;        /**< Oid of the operator (hashtable key) */
-  meosOper oper;     /**< Operator type number */
+  MeosOper oper;     /**< Operator type number */
   MeosType ltype;    /**< Type number of the left argument */
   MeosType rtype;    /**< Type number of the right argument */
   char status;       /* hash status */
@@ -135,8 +135,8 @@ typedef struct
  * @details
  * - Global array that enables the mapping MeosType -> Oid
  * - Global hash table that enables the mapping Oid -> MeosType
- * - Global hash table that enables the mapping meosOper -> Oid
- * - Global 3-dimensional array that enables the mapping meosOper -> Oid
+ * - Global hash table that enables the mapping MeosOper -> Oid
+ * - Global 3-dimensional array that enables the mapping MeosOper -> Oid
  *   in MobilityDB.
  *   The first dimension corresponds to the operator class (e.g., <=), the
  *   second and third dimensions correspond, respectively, to the left and
@@ -358,7 +358,7 @@ oid_meostype(Oid typid)
  * @arg[in] rt Type number for the right argument
  */
 Oid
-meosoper_oid(meosOper oper, MeosType lt, MeosType rt)
+meosoper_oid(MeosOper oper, MeosType lt, MeosType rt)
 {
   mobilitydb_initialize_cache();
 
@@ -377,7 +377,7 @@ meosoper_oid(meosOper oper, MeosType lt, MeosType rt)
  * @arg[in] oproid Operator oid
  * @arg[out] ltype,rtype Type number of the left/right argument
  */
-meosOper
+MeosOper
 oid_meosoper(Oid oproid, MeosType *ltype, MeosType *rtype)
 {
   mobilitydb_initialize_cache();
@@ -471,7 +471,7 @@ fill_oid_cache(PG_FUNCTION_ARGS)
     Oid oprright = DatumGetInt32(heap_getattr(tuple, oprright_n, tupDesc_pg,
       &isnull));
     /* Get the type and operator numbers */
-    meosOper oper = meosoper_from_string(oprname);
+    MeosOper oper = meosoper_from_string(oprname);
     MeosType ltype = oid_meostype(oprleft);
     MeosType rtype = oid_meostype(oprright);
     /* Fill the cache if the operator and all its types are recognized */

--- a/mobilitydb/src/temporal/span_selfuncs.c
+++ b/mobilitydb/src/temporal/span_selfuncs.c
@@ -61,7 +61,7 @@
  * don't have statistics or cannot use them for some reason
  */
 float8
-span_sel_default(meosOper oper UNUSED)
+span_sel_default(MeosOper oper UNUSED)
 {
   // TODO take care of the operator
   return DEFAULT_TEMP_SEL;
@@ -72,7 +72,7 @@ span_sel_default(meosOper oper UNUSED)
  * we don't have statistics or cannot use them for some reason
  */
 float8
-span_joinsel_default(meosOper oper UNUSED)
+span_joinsel_default(MeosOper oper UNUSED)
 {
   // TODO take care of the operator
   return DEFAULT_TEMP_JOINSEL;
@@ -97,7 +97,7 @@ value_oper_sel(Oid operid UNUSED, MeosType ltype,
  * @brief Determine whether we can estimate selectivity for the operator
  */
 bool
-time_oper_sel(meosOper oper UNUSED, MeosType ltype,
+time_oper_sel(MeosOper oper UNUSED, MeosType ltype,
   MeosType rtype)
 {
   if ((timeset_type(ltype) || timespan_basetype(ltype) || timespan_type(ltype) ||
@@ -610,7 +610,7 @@ span_sel_contains(SpanBound *const_lower, SpanBound *const_upper,
  */
 static Selectivity
 span_sel_hist1(AttStatsSlot *hslot, AttStatsSlot *lslot, const Span *constval,
-  meosOper oper)
+  MeosOper oper)
 {
   SpanBound *hist_lower, *hist_upper;
   SpanBound const_lower, const_upper;
@@ -702,7 +702,7 @@ span_sel_hist1(AttStatsSlot *hslot, AttStatsSlot *lslot, const Span *constval,
  * @note This estimate is for the portion of values that are not NULL
  */
 Selectivity
-span_sel_hist(VariableStatData *vardata, const Span *constval, meosOper oper,
+span_sel_hist(VariableStatData *vardata, const Span *constval, MeosOper oper,
   bool value)
 {
   AttStatsSlot hslot, lslot;
@@ -864,7 +864,7 @@ span_sel(PlannerInfo *root, Oid operid, List *args, int varRelid)
   span_const_to_span(other, &span);
   /* Determine whether we can estimate selectivity for the operator */
   MeosType ltype, rtype;
-  meosOper oper = oid_meosoper(operid, &ltype, &rtype);
+  MeosOper oper = oid_meosoper(operid, &ltype, &rtype);
   bool value = value_oper_sel(oper, ltype, rtype);
   if (! value)
   {
@@ -980,7 +980,7 @@ _mobdb_span_sel(PG_FUNCTION_ARGS)
   bool value = (s->basetype != T_TIMESTAMPTZ);
   /* Determine whether we can estimate selectivity for the operator */
   MeosType ltype, rtype;
-  meosOper oper = oid_meosoper(operid, &ltype, &rtype);
+  MeosOper oper = oid_meosoper(operid, &ltype, &rtype);
   bool found = value ?
     value_oper_sel(oper, ltype, rtype) : time_oper_sel(oper, ltype, rtype);
   if (! found)
@@ -1155,7 +1155,7 @@ span_joinsel_scalar(const SpanBound *hist1, int nhist1, const SpanBound *hist2,
 static Selectivity
 span_joinsel_oper(SpanBound *lower1, SpanBound *upper1, int nhist1,
   SpanBound *lower2, SpanBound *upper2, int nhist2, Datum *length,
-  int length_nvalues, meosOper oper)
+  int length_nvalues, MeosOper oper)
 {
   /* If the spans do not overlap return 0.0 */
   if (span_bound_cmp(&lower1[0], &upper2[nhist2 - 1]) > 0 ||
@@ -1191,7 +1191,7 @@ span_joinsel_oper(SpanBound *lower1, SpanBound *upper1, int nhist1,
  */
 static Selectivity
 span_joinsel_hist1(AttStatsSlot *hslot1, AttStatsSlot *hslot2,
-  AttStatsSlot *lslot, meosOper oper)
+  AttStatsSlot *lslot, MeosOper oper)
 {
   int nhist1, nhist2;
   SpanBound *lower1, *upper1, *lower2, *upper2;
@@ -1290,7 +1290,7 @@ span_joinsel_hist1(AttStatsSlot *hslot1, AttStatsSlot *hslot2,
  */
 static Selectivity
 span_joinsel_hist(VariableStatData *vardata1, VariableStatData *vardata2,
-  bool value, meosOper oper)
+  bool value, MeosOper oper)
 {
   /* There is only one lslot, see explanation below */
   AttStatsSlot hslot1, hslot2, lslot;
@@ -1410,7 +1410,7 @@ span_joinsel_hist(VariableStatData *vardata1, VariableStatData *vardata2,
  * @brief Estimate join selectivity for spans
  */
 Selectivity
-span_joinsel(PlannerInfo *root, bool value, meosOper oper, List *args,
+span_joinsel(PlannerInfo *root, bool value, MeosOper oper, List *args,
   JoinType jointype UNUSED, SpecialJoinInfo *sjinfo)
 {
   VariableStatData vardata1, vardata2;
@@ -1466,7 +1466,7 @@ Span_joinsel(PG_FUNCTION_ARGS)
 
   /* Determine whether we can estimate selectivity for the operator */
   MeosType ltype, rtype;
-  meosOper oper = oid_meosoper(operid, &ltype, &rtype);
+  MeosOper oper = oid_meosoper(operid, &ltype, &rtype);
   bool value = value_oper_sel(oper, ltype, rtype);
   if (! value)
   {
@@ -1529,7 +1529,7 @@ _mobdb_span_joinsel(PG_FUNCTION_ARGS)
 
   /* Determine whether we can estimate selectivity for the operator */
   MeosType ltype, rtype;
-  meosOper oper = oid_meosoper(operid, &ltype, &rtype);
+  MeosOper oper = oid_meosoper(operid, &ltype, &rtype);
   bool value = value_oper_sel(oper, ltype, rtype);
   if (! value)
   {

--- a/mobilitydb/src/temporal/temporal_selfuncs.c
+++ b/mobilitydb/src/temporal/temporal_selfuncs.c
@@ -165,7 +165,7 @@ tspatial_const_to_stbox(Node *other, STBox *box)
  * have statistics or cannot use them for some reason
  */
 static double
-temporal_sel_default(meosOper oper)
+temporal_sel_default(MeosOper oper)
 {
   switch (oper)
   {
@@ -202,7 +202,7 @@ temporal_sel_default(meosOper oper)
  * have statistics or cannot use them for some reason
  */
 float8
-tnumber_sel_default(meosOper operator)
+tnumber_sel_default(MeosOper operator)
 {
   switch (operator)
   {
@@ -243,7 +243,7 @@ tnumber_sel_default(meosOper operator)
  * operator, when we don't have statistics or cannot use them for some reason
  */
 static float8
-tspatial_sel_default(meosOper oper)
+tspatial_sel_default(MeosOper oper)
 {
   switch (oper)
   {
@@ -300,7 +300,7 @@ temporal_joinsel_default(Oid operid UNUSED)
  * we don't have statistics or cannot use them for some reason
  */
 float8
-tnumber_joinsel_default(meosOper oper UNUSED)
+tnumber_joinsel_default(MeosOper oper UNUSED)
 {
   // TODO take care of the operators
   return 0.001;
@@ -311,7 +311,7 @@ tnumber_joinsel_default(meosOper oper UNUSED)
  * when we don't have statistics or cannot use them for some reason
  */
 static float8
-tspatial_joinsel_default(meosOper oper)
+tspatial_joinsel_default(MeosOper oper)
 {
   switch (oper)
   {
@@ -356,7 +356,7 @@ tspatial_joinsel_default(meosOper oper)
  * @brief Return the enum value associated to the operator
  */
 static bool
-temporal_oper_sel(meosOper oper UNUSED, MeosType ltype,
+temporal_oper_sel(MeosOper oper UNUSED, MeosType ltype,
   MeosType rtype)
 {
   if ((timespan_basetype(ltype) || timeset_type(ltype) ||
@@ -408,7 +408,7 @@ tspatial_oper_sel(Oid operid UNUSED, MeosType ltype,
  * family
  */
 static bool
-temporal_oper_sel_family(meosOper oper UNUSED, MeosType ltype,
+temporal_oper_sel_family(MeosOper oper UNUSED, MeosType ltype,
   MeosType rtype, TemporalFamily tempfamily)
 {
   /* Get enumeration value associated to the operator */
@@ -435,7 +435,7 @@ temporal_oper_sel_family(meosOper oper UNUSED, MeosType ltype,
  * <> are eqsel and neqsel, respectively.
  */
 Selectivity
-temporal_sel_tstzspan(VariableStatData *vardata, Span *s, meosOper oper)
+temporal_sel_tstzspan(VariableStatData *vardata, Span *s, MeosOper oper)
 {
   Selectivity selec;
 
@@ -481,7 +481,7 @@ temporal_sel_tstzspan(VariableStatData *vardata, Span *s, meosOper oper)
  */
 Selectivity
 tnumber_sel_span_tstzspan(VariableStatData *vardata, Span *span, Span *period,
-  meosOper oper)
+  MeosOper oper)
 {
   /* Enable the multiplication of the selectivity of the value and time
    * dimensions since either may be missing */
@@ -564,7 +564,7 @@ temporal_sel(PlannerInfo *root, Oid operid, List *args, int varRelid,
 
   /* Determine whether we can estimate selectivity for the operator */
   MeosType ltype, rtype;
-  meosOper oper = oid_meosoper(operid, &ltype, &rtype);
+  MeosOper oper = oid_meosoper(operid, &ltype, &rtype);
   if (! temporal_oper_sel_family(oper, ltype, rtype, tempfamily))
     /* In the case of unknown operator */
     return DEFAULT_TEMP_SEL;
@@ -768,7 +768,7 @@ Tspatial_sel(PG_FUNCTION_ARGS)
  * the join selectivity
  */
 static bool
-tnumber_joinsel_components(meosOper oper, MeosType oprleft,
+tnumber_joinsel_components(MeosOper oper, MeosType oprleft,
   MeosType oprright, bool *value, bool *time)
 {
   /* Get the argument which may not a temporal number */
@@ -811,7 +811,7 @@ tnumber_joinsel_components(meosOper oper, MeosType oprleft,
  * join selectivity
  */
 static bool
-tspatial_joinsel_components(meosOper oper, MeosType oprleft,
+tspatial_joinsel_components(MeosOper oper, MeosType oprleft,
   MeosType oprright, bool *space, bool *time)
 {
   /* Get the argument which may not be a temporal point */
@@ -881,7 +881,7 @@ temporal_joinsel(PlannerInfo *root, Oid operid, List *args, JoinType jointype,
 
   /* Determine whether we can estimate selectivity for the operator */
   MeosType ltype, rtype;
-  meosOper oper = oid_meosoper(operid, &ltype, &rtype);
+  MeosOper oper = oid_meosoper(operid, &ltype, &rtype);
   if (! temporal_oper_sel_family(oper, ltype, rtype, tempfamily))
     /* In the case of unknown operator */
     return DEFAULT_TEMP_SEL;


### PR DESCRIPTION
The MEOS operator enum uses the PascalCase form MeosOper, matching the MeosType and SkipListType enums. Type identifier only; the meosoper_name accessor and the enum constants are unchanged.