### PR TITLE
Fix tcbuffer intersects relationships returning the disjoint result

### DIFF
--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -1047,7 +1047,7 @@ int
 ea_intersects_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp,
   bool ever)
 {
-  return ea_disjoint_tcbuffer_geo(temp, gs, ever);
+  return ea_intersects_tcbuffer_geo(temp, gs, ever);
 }
 
 /**

--- a/meos/src/cbuffer/tcbuffer_tempspatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_tempspatialrels.c
@@ -917,14 +917,14 @@ tintersects_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp)
  * @ingroup meos_cbuffer_rel_temp
  * @brief Return a temporal Boolean that states whether a temporal circular
  * buffer and a circular buffer intersect
- * @param[in] temp Temporal circular buffer
  * @param[in] cb Circular buffer
- * @csqlfn #Tdisjoint_tcbuffer_geo()
+ * @param[in] temp Temporal circular buffer
+ * @csqlfn #Tintersects_cbuffer_tcbuffer()
  */
 inline Temporal *
 tintersects_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 {
-  return tinterrel_tcbuffer_cbuffer(temp, cb, TDISJOINT);
+  return tinterrel_tcbuffer_cbuffer(temp, cb, TINTERSECTS);
 }
 
 /**
@@ -933,12 +933,12 @@ tintersects_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
  * buffer and a circular buffer intersect
  * @param[in] temp Temporal circular buffer
  * @param[in] cb Circular buffer
- * @csqlfn #Tdisjoint_tcbuffer_geo()
+ * @csqlfn #Tintersects_tcbuffer_cbuffer()
  */
 inline Temporal *
 tintersects_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
-  return tinterrel_tcbuffer_cbuffer(temp, cb, TDISJOINT);
+  return tinterrel_tcbuffer_cbuffer(temp, cb, TINTERSECTS);
 }
 
 /**


### PR DESCRIPTION
The two tIntersects(tcbuffer, cbuffer) and tIntersects(cbuffer, tcbuffer) forms pass TDISJOINT to the temporal interrelationship engine, and ea_intersects_geo_tcbuffer delegates to ea_disjoint_tcbuffer_geo, so tIntersects(tcbuffer, cbuffer) and eIntersects/aIntersects(geometry, tcbuffer) yield the negation of the relationship. Compute the intersection in all three and correct their @csqlfn tags.