### PR TITLE
Add eDwithinPairs, tDwithinPairs, and aDisjointPairs set-set spatial join

### DIFF
--- a/doc/es/temporal_spatial_p2.xml
+++ b/doc/es/temporal_spatial_p2.xml
@@ -570,6 +570,32 @@ SELECT tDwithin(tgeompoint '[Point(1 0)@2001-01-01, Point(1 4)@2001-01-05]',
 </programlisting>
 				</listitem>
 
+				<listitem xml:id="tgeo_setset_join">
+					<indexterm significance="normal"><primary><varname>eDwithinPairs</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>tDwithinPairs</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>aDisjointPairs</varname></primary></indexterm>
+					<para>Devuelve los pares de índices que satisfacen la relación entre dos arreglos de geometrías temporales, generalizando la relación escalar correspondiente a una unión espacial conjunto-conjunto</para>
+					<para><varname>eDwithinPairs(tgeo[],tgeo[],float) → setof(i integer, j integer)</varname></para>
+					<para><varname>tDwithinPairs(tgeo[],tgeo[],float) → setof(i integer, j integer, periods tstzspanset)</varname></para>
+					<para><varname>aDisjointPairs(tgeo[],tgeo[]) → setof(i integer, j integer)</varname></para>
+					<para>Cada función resuelve el producto cruzado podado de los dos arreglos en una sola llamada y devuelve los índices basados en uno <varname>i</varname> y <varname>j</varname> de los pares que cumplen. <varname>eDwithinPairs</varname> devuelve los pares que alguna vez están a la distancia, <varname>tDwithinPairs</varname> devuelve además los períodos durante los cuales cada par está a la distancia, y <varname>aDisjointPairs</varname> devuelve los pares que siempre son disjuntos. La caja espaciotemporal de cada entrada se usa como prefiltro de caja envolvente para que la relación exacta se calcule solo sobre los pares candidatos que sobreviven. Los pares cuyas extensiones temporales no se solapan se excluyen, de acuerdo con la relación escalar. Los índices se asignan a las identidades originales mediante un <varname>array_agg(identity ORDER BY ...)</varname> paralelo.</para>
+					<programlisting language="sql" xml:space="preserve">
+SELECT i, j FROM eDwithinPairs(
+  ARRAY[tgeompoint '[Point(0 0)@2001-01-01, Point(0 10)@2001-01-02]',
+        tgeompoint '[Point(50 50)@2001-01-01, Point(50 60)@2001-01-02]'],
+  ARRAY[tgeompoint '[Point(1 0)@2001-01-01, Point(1 10)@2001-01-02]'], 2.0);
+-- 1 | 1
+SELECT i, j, periods FROM tDwithinPairs(
+  ARRAY[tgeompoint '[Point(0 0)@2001-01-01, Point(0 10)@2001-01-02]'],
+  ARRAY[tgeompoint '[Point(1 0)@2001-01-01, Point(1 10)@2001-01-02]'], 2.0);
+-- 1 | 1 | {[2001-01-01, 2001-01-02]}
+SELECT i, j FROM aDisjointPairs(
+  ARRAY[tgeompoint '[Point(0 0)@2001-01-01, Point(0 10)@2001-01-02]'],
+  ARRAY[tgeompoint '[Point(1 0)@2001-01-01, Point(1 10)@2001-01-02]']);
+-- 1 | 1
+</programlisting>
+				</listitem>
+
 				<listitem xml:id="tgeo_tIntersects">
 					<indexterm significance="normal"><primary><varname>tIntersects</varname></primary></indexterm>
 					<para>Intersección temporal &Z_support; &geography_support;</para>

--- a/doc/temporal_spatial_p2.xml
+++ b/doc/temporal_spatial_p2.xml
@@ -572,6 +572,32 @@ SELECT tDwithin(tgeompoint '[Point(1 0)@2001-01-01, Point(1 4)@2001-01-05]',
 </programlisting>
 				</listitem>
 
+				<listitem xml:id="tgeo_setset_join">
+					<indexterm significance="normal"><primary><varname>eDwithinPairs</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>tDwithinPairs</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>aDisjointPairs</varname></primary></indexterm>
+					<para>Return the qualifying index pairs of two arrays of temporal geometries, generalising the corresponding scalar relationship to a set-set spatial join</para>
+					<para><varname>eDwithinPairs(tgeo[],tgeo[],float) → setof(i integer, j integer)</varname></para>
+					<para><varname>tDwithinPairs(tgeo[],tgeo[],float) → setof(i integer, j integer, periods tstzspanset)</varname></para>
+					<para><varname>aDisjointPairs(tgeo[],tgeo[]) → setof(i integer, j integer)</varname></para>
+					<para>Each function resolves the pruned cross product of the two arrays inside a single call and returns the one-based indexes <varname>i</varname> and <varname>j</varname> of the qualifying pairs. <varname>eDwithinPairs</varname> returns the pairs that are ever within the distance, <varname>tDwithinPairs</varname> additionally returns the periods during which each pair is within the distance, and <varname>aDisjointPairs</varname> returns the pairs that are always disjoint. Each input's spatiotemporal box is used as a bounding-box prefilter so that the exact relationship is computed only on the surviving candidate pairs. Pairs whose temporal extents do not overlap are excluded, matching the scalar relationship. The indexes map back to the original identities through a parallel <varname>array_agg(identity ORDER BY ...)</varname>.</para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT i, j FROM eDwithinPairs(
+  ARRAY[tgeompoint '[Point(0 0)@2001-01-01, Point(0 10)@2001-01-02]',
+        tgeompoint '[Point(50 50)@2001-01-01, Point(50 60)@2001-01-02]'],
+  ARRAY[tgeompoint '[Point(1 0)@2001-01-01, Point(1 10)@2001-01-02]'], 2.0);
+-- 1 | 1
+SELECT i, j, periods FROM tDwithinPairs(
+  ARRAY[tgeompoint '[Point(0 0)@2001-01-01, Point(0 10)@2001-01-02]'],
+  ARRAY[tgeompoint '[Point(1 0)@2001-01-01, Point(1 10)@2001-01-02]'], 2.0);
+-- 1 | 1 | {[2001-01-01, 2001-01-02]}
+SELECT i, j FROM aDisjointPairs(
+  ARRAY[tgeompoint '[Point(0 0)@2001-01-01, Point(0 10)@2001-01-02]'],
+  ARRAY[tgeompoint '[Point(1 0)@2001-01-01, Point(1 10)@2001-01-02]']);
+-- 1 | 1
+</programlisting>
+				</listitem>
+
 				<listitem xml:id="tgeo_tIntersects">
 					<indexterm significance="normal"><primary><varname>tIntersects</varname></primary></indexterm>
 					<para>Temporal intersects &Z_support; &geography_support;</para>

--- a/meos/include/meos_geo.h
+++ b/meos/include/meos_geo.h
@@ -883,6 +883,9 @@ extern GSERIALIZED *shortestline_tgeo_geo(const Temporal *temp, const GSERIALIZE
 extern GSERIALIZED *shortestline_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2);
 extern double mindistance_tgeoarr_tgeoarr(const Temporal **arr1, int count1, const Temporal **arr2, int count2);
 extern double mindistance_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2, double threshold);
+extern int *edwithin_tgeoarr_tgeoarr(const Temporal **arr1, int count1, const Temporal **arr2, int count2, double dist, int *count);
+extern int *tdwithin_tgeoarr_tgeoarr(const Temporal **arr1, int count1, const Temporal **arr2, int count2, double dist, int *count, SpanSet ***periods);
+extern int *adisjoint_tgeoarr_tgeoarr(const Temporal **arr1, int count1, const Temporal **arr2, int count2, int *count);
 
 /* Aggregates */
 

--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -1823,4 +1823,255 @@ adwithin_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2, double dist)
 }
 #endif /* MEOS */
 
+/*****************************************************************************
+ * Set-set spatial join
+ *
+ * Generalisation of the scalar ever/temporal spatial relationships to two
+ * arrays of temporal geos, resolving the pruned N x M cross product inside a
+ * single call.  Every input's STBox is materialised once and used as a cheap
+ * bounding-box prefilter (always sound, independent of any index) so that the
+ * exact per-pair predicate runs only on the surviving candidate pairs.  The
+ * result is the set of qualifying (i, j) indexes into the input arrays,
+ * mirroring #Mindistance_tgeoarr_tgeoarr().
+ *****************************************************************************/
+
+/**
+ * @brief Return true if the spatial extents of two spatiotemporal boxes
+ * overlap, ignoring the time dimension
+ */
+static bool
+stbox_overlaps_space(const STBox *box1, const STBox *box2)
+{
+  if (box1->xmin > box2->xmax || box2->xmin > box1->xmax ||
+      box1->ymin > box2->ymax || box2->ymin > box1->ymax)
+    return false;
+  if (MEOS_FLAGS_GET_Z(box1->flags) && MEOS_FLAGS_GET_Z(box2->flags) &&
+      (box1->zmin > box2->zmax || box2->zmin > box1->zmax))
+    return false;
+  return true;
+}
+
+/**
+ * @brief Return true if the spatial extents of two spatiotemporal boxes are
+ * within a distance, ignoring the time dimension
+ * @details Equivalent to expanding the first box by @p dist in every spatial
+ * dimension and testing spatial overlap; a sound lower-bound prefilter for the
+ * within-distance relationships in the planar (non-geodetic) case.
+ */
+static bool
+stbox_within_dist_space(const STBox *box1, const STBox *box2, double dist)
+{
+  if (box1->xmin - dist > box2->xmax || box2->xmin - dist > box1->xmax ||
+      box1->ymin - dist > box2->ymax || box2->ymin - dist > box1->ymax)
+    return false;
+  if (MEOS_FLAGS_GET_Z(box1->flags) && MEOS_FLAGS_GET_Z(box2->flags) &&
+      (box1->zmin - dist > box2->zmax || box2->zmin - dist > box1->zmax))
+    return false;
+  return true;
+}
+
+/**
+ * @brief Validate two arrays of temporal geos and materialise their STBoxes
+ * @details Ensures both arrays are non-empty and that every element is a
+ * non-NULL temporal geo sharing the SRID, dimensionality, and geodetic flag of
+ * the first element of the first array.
+ * @param[in] arr1,arr2 Arrays of temporal geos
+ * @param[in] count1,count2 Number of elements in the arrays
+ * @param[out] bb1,bb2 Materialised STBoxes (allocated on success)
+ * @return True on success, false on any validation failure
+ */
+static bool
+tgeoarr_tgeoarr_init(const Temporal **arr1, int count1, const Temporal **arr2,
+  int count2, STBox ***bb1, STBox ***bb2)
+{
+  if (count1 <= 0 || count2 <= 0)
+    return false;
+  for (int i = 0; i < count1; i++)
+    VALIDATE_TGEO(arr1[i], false);
+  for (int j = 0; j < count2; j++)
+    VALIDATE_TGEO(arr2[j], false);
+  int32 srid = tspatial_srid(arr1[0]);
+  int16 flags = arr1[0]->flags;
+  for (int i = 1; i < count1; i++)
+    if (! ensure_same_srid(tspatial_srid(arr1[i]), srid) ||
+        ! ensure_same_dimensionality(arr1[i]->flags, flags) ||
+        ! ensure_same_geodetic(arr1[i]->flags, flags))
+      return false;
+  for (int j = 0; j < count2; j++)
+    if (! ensure_same_srid(tspatial_srid(arr2[j]), srid) ||
+        ! ensure_same_dimensionality(arr2[j]->flags, flags) ||
+        ! ensure_same_geodetic(arr2[j]->flags, flags))
+      return false;
+  STBox **boxes1 = palloc(count1 * sizeof(STBox *));
+  STBox **boxes2 = palloc(count2 * sizeof(STBox *));
+  for (int i = 0; i < count1; i++) boxes1[i] = tspatial_to_stbox(arr1[i]);
+  for (int j = 0; j < count2; j++) boxes2[j] = tspatial_to_stbox(arr2[j]);
+  *bb1 = boxes1; *bb2 = boxes2;
+  return true;
+}
+
+/**
+ * @ingroup meos_geo_rel_ever
+ * @brief Return the index pairs of two arrays of temporal geos that are ever
+ * within a distance
+ * @details The exact per-pair predicate #edwithin_tgeo_tgeo() runs only on the
+ * pairs that survive a temporal-overlap prefilter and, in the planar case, a
+ * spatial within-distance bounding-box prefilter; pairs that do not intersect
+ * on time are not within the distance and are excluded, matching the scalar
+ * predicate.
+ * @param[in] arr1,arr2 Arrays of temporal geos
+ * @param[in] count1,count2 Number of elements in the arrays
+ * @param[in] dist Distance
+ * @param[out] count Number of resulting index pairs
+ * @return Flattened array of @p count index pairs `[i0, j0, i1, j1, ...]`, or
+ * NULL on validation failure or when no pair qualifies
+ * @csqlfn #Edwithin_tgeoarr_tgeoarr()
+ */
+int *
+edwithin_tgeoarr_tgeoarr(const Temporal **arr1, int count1,
+  const Temporal **arr2, int count2, double dist, int *count)
+{
+  VALIDATE_NOT_NULL(arr1, NULL); VALIDATE_NOT_NULL(arr2, NULL);
+  VALIDATE_NOT_NULL(count, NULL);
+  STBox **bb1, **bb2;
+  if (! tgeoarr_tgeoarr_init(arr1, count1, arr2, count2, &bb1, &bb2))
+    return NULL;
+  bool geodetic = MEOS_FLAGS_GET_GEODETIC(arr1[0]->flags);
+  int *result = palloc((size_t) count1 * count2 * 2 * sizeof(int));
+  int nres = 0;
+  for (int i = 0; i < count1; i++)
+    for (int j = 0; j < count2; j++)
+    {
+      /* No common time → never within the distance */
+      if (! overlaps_span_span(&bb1[i]->period, &bb2[j]->period))
+        continue;
+      /* Farther apart than the distance in the planar case */
+      if (! geodetic && ! stbox_within_dist_space(bb1[i], bb2[j], dist))
+        continue;
+      if (ea_dwithin_tgeo_tgeo(arr1[i], arr2[j], dist, EVER) == 1)
+      {
+        result[2 * nres] = i; result[2 * nres + 1] = j; nres++;
+      }
+    }
+  for (int i = 0; i < count1; i++) pfree(bb1[i]);
+  for (int j = 0; j < count2; j++) pfree(bb2[j]);
+  pfree(bb1); pfree(bb2);
+  *count = nres;
+  if (nres == 0) { pfree(result); return NULL; }
+  return result;
+}
+
+/**
+ * @ingroup meos_geo_rel_temp
+ * @brief Return the index pairs of two arrays of temporal geos that are ever
+ * within a distance together with the periods during which they are
+ * @details The temporal predicate #tdwithin_tgeo_tgeo() runs only on the pairs
+ * that survive a temporal-overlap prefilter and, in the planar case, a spatial
+ * within-distance bounding-box prefilter; a pair is returned only when the
+ * temporal boolean is true at some instant.
+ * @param[in] arr1,arr2 Arrays of temporal geos
+ * @param[in] count1,count2 Number of elements in the arrays
+ * @param[in] dist Distance
+ * @param[out] count Number of resulting index pairs
+ * @param[out] periods Spansets of the times when each resulting pair is within
+ * the distance (allocated on success, one per resulting pair)
+ * @return Flattened array of @p count index pairs `[i0, j0, i1, j1, ...]`, or
+ * NULL on validation failure or when no pair qualifies
+ * @csqlfn #Tdwithin_tgeoarr_tgeoarr()
+ */
+int *
+tdwithin_tgeoarr_tgeoarr(const Temporal **arr1, int count1,
+  const Temporal **arr2, int count2, double dist, int *count,
+  SpanSet ***periods)
+{
+  VALIDATE_NOT_NULL(arr1, NULL); VALIDATE_NOT_NULL(arr2, NULL);
+  VALIDATE_NOT_NULL(count, NULL); VALIDATE_NOT_NULL(periods, NULL);
+  STBox **bb1, **bb2;
+  if (! tgeoarr_tgeoarr_init(arr1, count1, arr2, count2, &bb1, &bb2))
+    return NULL;
+  bool geodetic = MEOS_FLAGS_GET_GEODETIC(arr1[0]->flags);
+  int *result = palloc((size_t) count1 * count2 * 2 * sizeof(int));
+  SpanSet **ss = palloc((size_t) count1 * count2 * sizeof(SpanSet *));
+  int nres = 0;
+  for (int i = 0; i < count1; i++)
+    for (int j = 0; j < count2; j++)
+    {
+      if (! overlaps_span_span(&bb1[i]->period, &bb2[j]->period))
+        continue;
+      if (! geodetic && ! stbox_within_dist_space(bb1[i], bb2[j], dist))
+        continue;
+      Temporal *td = tdwithin_tgeo_tgeo(arr1[i], arr2[j], dist);
+      if (! td)
+        continue;
+      SpanSet *when = tbool_when_true(td);
+      pfree(td);
+      if (! when)
+        continue;
+      result[2 * nres] = i; result[2 * nres + 1] = j;
+      ss[nres] = when; nres++;
+    }
+  for (int i = 0; i < count1; i++) pfree(bb1[i]);
+  for (int j = 0; j < count2; j++) pfree(bb2[j]);
+  pfree(bb1); pfree(bb2);
+  *count = nres;
+  if (nres == 0) { pfree(result); pfree(ss); return NULL; }
+  *periods = ss;
+  return result;
+}
+
+/**
+ * @ingroup meos_geo_rel_ever
+ * @brief Return the index pairs of two arrays of temporal geos that are always
+ * disjoint
+ * @details Derived from intersection by negation (always disjoint is the
+ * negation of ever intersects).  A pair that does not intersect on time is
+ * excluded, matching the scalar predicate; a pair whose spatial extents are
+ * disjoint while their time extents overlap is always disjoint and is returned
+ * without the exact test; the exact #eintersects_tgeo_tgeo() runs only on the
+ * pairs whose boxes overlap in both space and time.
+ * @param[in] arr1,arr2 Arrays of temporal geos
+ * @param[in] count1,count2 Number of elements in the arrays
+ * @param[out] count Number of resulting index pairs
+ * @return Flattened array of @p count index pairs `[i0, j0, i1, j1, ...]`, or
+ * NULL on validation failure or when no pair qualifies
+ * @csqlfn #Adisjoint_tgeoarr_tgeoarr()
+ */
+int *
+adisjoint_tgeoarr_tgeoarr(const Temporal **arr1, int count1,
+  const Temporal **arr2, int count2, int *count)
+{
+  VALIDATE_NOT_NULL(arr1, NULL); VALIDATE_NOT_NULL(arr2, NULL);
+  VALIDATE_NOT_NULL(count, NULL);
+  STBox **bb1, **bb2;
+  if (! tgeoarr_tgeoarr_init(arr1, count1, arr2, count2, &bb1, &bb2))
+    return NULL;
+  bool geodetic = MEOS_FLAGS_GET_GEODETIC(arr1[0]->flags);
+  int *result = palloc((size_t) count1 * count2 * 2 * sizeof(int));
+  int nres = 0;
+  for (int i = 0; i < count1; i++)
+    for (int j = 0; j < count2; j++)
+    {
+      /* No common time → the scalar predicate is undefined (excluded) */
+      if (! overlaps_span_span(&bb1[i]->period, &bb2[j]->period))
+        continue;
+      /* Spatially disjoint while overlapping on time → always disjoint */
+      if (! geodetic && ! stbox_overlaps_space(bb1[i], bb2[j]))
+      {
+        result[2 * nres] = i; result[2 * nres + 1] = j; nres++;
+        continue;
+      }
+      /* Always disjoint is the negation of ever intersects */
+      if (INVERT_RESULT(ea_intersects_tgeo_tgeo(arr1[i], arr2[j], EVER)) == 1)
+      {
+        result[2 * nres] = i; result[2 * nres + 1] = j; nres++;
+      }
+    }
+  for (int i = 0; i < count1; i++) pfree(bb1[i]);
+  for (int j = 0; j < count2; j++) pfree(bb2[j]);
+  pfree(bb1); pfree(bb2);
+  *count = nres;
+  if (nres == 0) { pfree(result); return NULL; }
+  return result;
+}
+
 /*****************************************************************************/

--- a/mobilitydb/sql/geo/070_tgeo_spatialrels.in.sql
+++ b/mobilitydb/sql/geo/070_tgeo_spatialrels.in.sql
@@ -406,4 +406,30 @@ CREATE FUNCTION aDwithin(tgeography, tgeography, dist float)
   SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+/*****************************************************************************
+ * Set-set spatial join
+ *****************************************************************************/
+
+CREATE FUNCTION eDwithinPairs(tgeompoint[], tgeompoint[], dist float,
+    OUT i integer, OUT j integer)
+  RETURNS setof record
+  AS 'MODULE_PATHNAME', 'Edwithin_tgeoarr_tgeoarr'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION eDwithinPairs(tgeometry[], tgeometry[], dist float,
+    OUT i integer, OUT j integer)
+  RETURNS setof record
+  AS 'MODULE_PATHNAME', 'Edwithin_tgeoarr_tgeoarr'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION aDisjointPairs(tgeompoint[], tgeompoint[],
+    OUT i integer, OUT j integer)
+  RETURNS setof record
+  AS 'MODULE_PATHNAME', 'Adisjoint_tgeoarr_tgeoarr'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION aDisjointPairs(tgeometry[], tgeometry[],
+    OUT i integer, OUT j integer)
+  RETURNS setof record
+  AS 'MODULE_PATHNAME', 'Adisjoint_tgeoarr_tgeoarr'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 /*****************************************************************************/

--- a/mobilitydb/sql/geo/072_tgeo_tempspatialrels.in.sql
+++ b/mobilitydb/sql/geo/072_tgeo_tempspatialrels.in.sql
@@ -145,4 +145,19 @@ CREATE FUNCTION tDwithin(tgeometry, tgeometry, dist float)
   AS 'MODULE_PATHNAME', 'Tdwithin_tgeo_tgeo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+/*****************************************************************************
+ * Set-set spatial join
+ *****************************************************************************/
+
+CREATE FUNCTION tDwithinPairs(tgeompoint[], tgeompoint[], dist float,
+    OUT i integer, OUT j integer, OUT periods tstzspanset)
+  RETURNS setof record
+  AS 'MODULE_PATHNAME', 'Tdwithin_tgeoarr_tgeoarr'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION tDwithinPairs(tgeometry[], tgeometry[], dist float,
+    OUT i integer, OUT j integer, OUT periods tstzspanset)
+  RETURNS setof record
+  AS 'MODULE_PATHNAME', 'Tdwithin_tgeoarr_tgeoarr'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 /*****************************************************************************/

--- a/mobilitydb/src/geo/tgeo_spatialrels.c
+++ b/mobilitydb/src/geo/tgeo_spatialrels.c
@@ -782,4 +782,164 @@ Adwithin_tgeo_tgeo(PG_FUNCTION_ARGS)
   return EA_dwithin_tgeo_tgeo(fcinfo, ALWAYS);
 }
 
+/*****************************************************************************
+ * Set-set spatial join
+ *****************************************************************************/
+
+/**
+ * @brief State carried across the calls of a set-set spatial-join SRF
+ */
+typedef struct
+{
+  int *pairs;        /**< Flattened (i, j) index pairs, length 2 * max_calls */
+  SpanSet **periods; /**< Per-pair spansets for tDwithinPairs, NULL otherwise */
+} TgeoarrJoinState;
+
+PGDLLEXPORT Datum Edwithin_tgeoarr_tgeoarr(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Edwithin_tgeoarr_tgeoarr);
+/**
+ * @ingroup mobilitydb_geo_rel_ever
+ * @brief Return the index pairs of two arrays of temporal geos that are ever
+ * within a distance
+ * @sqlfn eDwithinPairs()
+ */
+Datum
+Edwithin_tgeoarr_tgeoarr(PG_FUNCTION_ARGS)
+{
+  FuncCallContext *funcctx;
+  if (SRF_IS_FIRSTCALL())
+  {
+    funcctx = SRF_FIRSTCALL_INIT();
+    MemoryContext oldcontext =
+      MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
+    ArrayType *array1 = PG_GETARG_ARRAYTYPE_P(0);
+    ArrayType *array2 = PG_GETARG_ARRAYTYPE_P(1);
+    double dist = PG_GETARG_FLOAT8(2);
+    int count1, count2, npairs = 0;
+    Temporal **arr1 = (Temporal **) temparr_extract(array1, &count1);
+    Temporal **arr2 = (Temporal **) temparr_extract(array2, &count2);
+    TgeoarrJoinState *state = palloc0(sizeof(TgeoarrJoinState));
+    state->pairs = edwithin_tgeoarr_tgeoarr((const Temporal **) arr1, count1,
+      (const Temporal **) arr2, count2, dist, &npairs);
+    pfree(arr1); pfree(arr2);
+    PG_FREE_IF_COPY(array1, 0); PG_FREE_IF_COPY(array2, 1);
+    funcctx->user_fctx = state;
+    funcctx->max_calls = npairs;
+    get_call_result_type(fcinfo, NULL, &funcctx->tuple_desc);
+    BlessTupleDesc(funcctx->tuple_desc);
+    MemoryContextSwitchTo(oldcontext);
+  }
+  funcctx = SRF_PERCALL_SETUP();
+  if (funcctx->call_cntr >= funcctx->max_calls)
+    SRF_RETURN_DONE(funcctx);
+  TgeoarrJoinState *state = funcctx->user_fctx;
+  int k = funcctx->call_cntr;
+  Datum values[2];
+  bool isnull[2] = {false, false};
+  /* The kernel returns 0-based indexes into the input arrays; expose them as
+   * 1-based positions to match the SQL array convention */
+  values[0] = Int32GetDatum(state->pairs[2 * k] + 1);
+  values[1] = Int32GetDatum(state->pairs[2 * k + 1] + 1);
+  HeapTuple tuple = heap_form_tuple(funcctx->tuple_desc, values, isnull);
+  SRF_RETURN_NEXT(funcctx, HeapTupleGetDatum(tuple));
+}
+
+PGDLLEXPORT Datum Tdwithin_tgeoarr_tgeoarr(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tdwithin_tgeoarr_tgeoarr);
+/**
+ * @ingroup mobilitydb_geo_rel_temp
+ * @brief Return the index pairs of two arrays of temporal geos that are ever
+ * within a distance together with the periods during which they are
+ * @sqlfn tDwithinPairs()
+ */
+Datum
+Tdwithin_tgeoarr_tgeoarr(PG_FUNCTION_ARGS)
+{
+  FuncCallContext *funcctx;
+  if (SRF_IS_FIRSTCALL())
+  {
+    funcctx = SRF_FIRSTCALL_INIT();
+    MemoryContext oldcontext =
+      MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
+    ArrayType *array1 = PG_GETARG_ARRAYTYPE_P(0);
+    ArrayType *array2 = PG_GETARG_ARRAYTYPE_P(1);
+    double dist = PG_GETARG_FLOAT8(2);
+    int count1, count2, npairs = 0;
+    Temporal **arr1 = (Temporal **) temparr_extract(array1, &count1);
+    Temporal **arr2 = (Temporal **) temparr_extract(array2, &count2);
+    TgeoarrJoinState *state = palloc0(sizeof(TgeoarrJoinState));
+    state->pairs = tdwithin_tgeoarr_tgeoarr((const Temporal **) arr1, count1,
+      (const Temporal **) arr2, count2, dist, &npairs, &state->periods);
+    pfree(arr1); pfree(arr2);
+    PG_FREE_IF_COPY(array1, 0); PG_FREE_IF_COPY(array2, 1);
+    funcctx->user_fctx = state;
+    funcctx->max_calls = npairs;
+    get_call_result_type(fcinfo, NULL, &funcctx->tuple_desc);
+    BlessTupleDesc(funcctx->tuple_desc);
+    MemoryContextSwitchTo(oldcontext);
+  }
+  funcctx = SRF_PERCALL_SETUP();
+  if (funcctx->call_cntr >= funcctx->max_calls)
+    SRF_RETURN_DONE(funcctx);
+  TgeoarrJoinState *state = funcctx->user_fctx;
+  int k = funcctx->call_cntr;
+  Datum values[3];
+  bool isnull[3] = {false, false, false};
+  /* The kernel returns 0-based indexes into the input arrays; expose them as
+   * 1-based positions to match the SQL array convention */
+  values[0] = Int32GetDatum(state->pairs[2 * k] + 1);
+  values[1] = Int32GetDatum(state->pairs[2 * k + 1] + 1);
+  values[2] = PointerGetDatum(state->periods[k]);
+  HeapTuple tuple = heap_form_tuple(funcctx->tuple_desc, values, isnull);
+  SRF_RETURN_NEXT(funcctx, HeapTupleGetDatum(tuple));
+}
+
+PGDLLEXPORT Datum Adisjoint_tgeoarr_tgeoarr(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Adisjoint_tgeoarr_tgeoarr);
+/**
+ * @ingroup mobilitydb_geo_rel_ever
+ * @brief Return the index pairs of two arrays of temporal geos that are always
+ * disjoint
+ * @sqlfn aDisjointPairs()
+ */
+Datum
+Adisjoint_tgeoarr_tgeoarr(PG_FUNCTION_ARGS)
+{
+  FuncCallContext *funcctx;
+  if (SRF_IS_FIRSTCALL())
+  {
+    funcctx = SRF_FIRSTCALL_INIT();
+    MemoryContext oldcontext =
+      MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
+    ArrayType *array1 = PG_GETARG_ARRAYTYPE_P(0);
+    ArrayType *array2 = PG_GETARG_ARRAYTYPE_P(1);
+    int count1, count2, npairs = 0;
+    Temporal **arr1 = (Temporal **) temparr_extract(array1, &count1);
+    Temporal **arr2 = (Temporal **) temparr_extract(array2, &count2);
+    TgeoarrJoinState *state = palloc0(sizeof(TgeoarrJoinState));
+    state->pairs = adisjoint_tgeoarr_tgeoarr((const Temporal **) arr1, count1,
+      (const Temporal **) arr2, count2, &npairs);
+    pfree(arr1); pfree(arr2);
+    PG_FREE_IF_COPY(array1, 0); PG_FREE_IF_COPY(array2, 1);
+    funcctx->user_fctx = state;
+    funcctx->max_calls = npairs;
+    get_call_result_type(fcinfo, NULL, &funcctx->tuple_desc);
+    BlessTupleDesc(funcctx->tuple_desc);
+    MemoryContextSwitchTo(oldcontext);
+  }
+  funcctx = SRF_PERCALL_SETUP();
+  if (funcctx->call_cntr >= funcctx->max_calls)
+    SRF_RETURN_DONE(funcctx);
+  TgeoarrJoinState *state = funcctx->user_fctx;
+  int k = funcctx->call_cntr;
+  Datum values[2];
+  bool isnull[2] = {false, false};
+  /* The kernel returns 0-based indexes into the input arrays; expose them as
+   * 1-based positions to match the SQL array convention */
+  values[0] = Int32GetDatum(state->pairs[2 * k] + 1);
+  values[1] = Int32GetDatum(state->pairs[2 * k + 1] + 1);
+  HeapTuple tuple = heap_form_tuple(funcctx->tuple_desc, values, isnull);
+  SRF_RETURN_NEXT(funcctx, HeapTupleGetDatum(tuple));
+}
+
 /*****************************************************************************/

--- a/mobilitydb/test/geo/expected/070_tgeo_spatialrels.test.out
+++ b/mobilitydb/test/geo/expected/070_tgeo_spatialrels.test.out
@@ -1997,3 +1997,64 @@ SELECT eDwithin(tgeography 'Point(1 1)@2000-01-01', geography 'SRID=4283;Point(1
 ERROR:  Operation on mixed SRID
 SELECT eDwithin(tgeography 'SRID=4283;Point(1 1)@2000-01-01', tgeography 'Point(1 1)@2000-01-01', 2);
 ERROR:  Operation on mixed SRID
+SELECT i, j FROM eDwithinPairs(
+  ARRAY[tgeompoint '[Point(0 0)@2000-01-01, Point(0 10)@2000-01-02]',
+        tgeompoint '[Point(50 50)@2000-01-01, Point(50 60)@2000-01-02]'],
+  ARRAY[tgeompoint '[Point(1 0)@2000-01-01, Point(1 10)@2000-01-02]',
+        tgeompoint '[Point(200 200)@2000-01-01, Point(200 210)@2000-01-02]'],
+  2.0) ORDER BY i, j;
+ i | j 
+---+---
+ 1 | 1
+(1 row)
+
+SELECT i, j FROM eDwithinPairs(
+  ARRAY[tgeompoint '[Point(0 0)@2000-01-01, Point(0 10)@2000-01-02]'],
+  ARRAY[tgeompoint '[Point(0 0)@2000-03-01, Point(0 10)@2000-03-02]'],
+  2.0) ORDER BY i, j;
+ i | j 
+---+---
+(0 rows)
+
+SELECT i, j FROM eDwithinPairs(
+  ARRAY[tgeometry '[Point(0 0)@2000-01-01, Point(0 10)@2000-01-02]'],
+  ARRAY[tgeometry '[Point(1 0)@2000-01-01, Point(1 10)@2000-01-02]'],
+  2.0) ORDER BY i, j;
+ i | j 
+---+---
+ 1 | 1
+(1 row)
+
+SELECT i, j FROM eDwithinPairs(ARRAY[]::tgeompoint[],
+  ARRAY[tgeompoint 'Point(0 0)@2000-01-01'], 2.0) ORDER BY i, j;
+ i | j 
+---+---
+(0 rows)
+
+SELECT i, j FROM aDisjointPairs(
+  ARRAY[tgeompoint '[Point(0 0)@2000-01-01, Point(0 10)@2000-01-02]',
+        tgeompoint '[Point(50 50)@2000-01-01, Point(50 60)@2000-01-02]'],
+  ARRAY[tgeompoint '[Point(1 0)@2000-01-01, Point(1 10)@2000-01-02]',
+        tgeompoint '[Point(0 0)@2000-01-01, Point(0 10)@2000-01-02]']) ORDER BY i, j;
+ i | j 
+---+---
+ 1 | 1
+ 2 | 1
+ 2 | 2
+(3 rows)
+
+SELECT i, j FROM aDisjointPairs(
+  ARRAY[tgeompoint '[Point(0 0)@2000-01-01, Point(0 10)@2000-01-02]'],
+  ARRAY[tgeompoint '[Point(5 5)@2000-03-01, Point(5 10)@2000-03-02]']) ORDER BY i, j;
+ i | j 
+---+---
+(0 rows)
+
+SELECT i, j FROM aDisjointPairs(
+  ARRAY[tgeometry '[Point(0 0)@2000-01-01, Point(0 10)@2000-01-02]'],
+  ARRAY[tgeometry '[Point(1 0)@2000-01-01, Point(1 10)@2000-01-02]']) ORDER BY i, j;
+ i | j 
+---+---
+ 1 | 1
+(1 row)
+

--- a/mobilitydb/test/geo/expected/072_tgeo_tempspatialrels.test.out
+++ b/mobilitydb/test/geo/expected/072_tgeo_tempspatialrels.test.out
@@ -1116,3 +1116,31 @@ SELECT tDwithin(tgeometry 'Point(1 1)@2000-01-01', geometry 'Point(0 0)', -1);
 ERROR:  The value cannot be negative: -1.000000
 SELECT tDwithin(tgeometry 'Point(1 1 1)@2000-01-01', geometry 'Point(0 0 0)', -1);
 ERROR:  The value cannot be negative: -1.000000
+SELECT i, j, periods FROM tDwithinPairs(
+  ARRAY[tgeompoint '[Point(0 0)@2000-01-01, Point(0 10)@2000-01-02]',
+        tgeompoint '[Point(50 50)@2000-01-01, Point(50 60)@2000-01-02]'],
+  ARRAY[tgeompoint '[Point(1 0)@2000-01-01, Point(1 10)@2000-01-02]',
+        tgeompoint '[Point(200 200)@2000-01-01, Point(200 210)@2000-01-02]'],
+  2.0) ORDER BY i, j;
+ i | j |                            periods                             
+---+---+----------------------------------------------------------------
+ 1 | 1 | {[Sat Jan 01 00:00:00 2000 PST, Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+
+SELECT i, j, periods FROM tDwithinPairs(
+  ARRAY[tgeompoint '[Point(0 0)@2000-01-01, Point(0 10)@2000-01-02]'],
+  ARRAY[tgeompoint '[Point(0 0)@2000-03-01, Point(0 10)@2000-03-02]'],
+  2.0) ORDER BY i, j;
+ i | j | periods 
+---+---+---------
+(0 rows)
+
+SELECT i, j, periods FROM tDwithinPairs(
+  ARRAY[tgeometry '[Point(0 0)@2000-01-01, Point(0 10)@2000-01-02]'],
+  ARRAY[tgeometry '[Point(1 0)@2000-01-01, Point(1 10)@2000-01-02]'],
+  2.0) ORDER BY i, j;
+ i | j |                            periods                             
+---+---+----------------------------------------------------------------
+ 1 | 1 | {[Sat Jan 01 00:00:00 2000 PST, Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+

--- a/mobilitydb/test/geo/queries/070_tgeo_spatialrels.test.sql
+++ b/mobilitydb/test/geo/queries/070_tgeo_spatialrels.test.sql
@@ -515,3 +515,38 @@ SELECT eDwithin(tgeography 'SRID=4283;Point(1 1)@2000-01-01', tgeography 'Point(
 -------------------------------------------------------------------------------
 
 -------------------------------------------------------------------------------
+-- Set-set spatial join
+-------------------------------------------------------------------------------
+
+SELECT i, j FROM eDwithinPairs(
+  ARRAY[tgeompoint '[Point(0 0)@2000-01-01, Point(0 10)@2000-01-02]',
+        tgeompoint '[Point(50 50)@2000-01-01, Point(50 60)@2000-01-02]'],
+  ARRAY[tgeompoint '[Point(1 0)@2000-01-01, Point(1 10)@2000-01-02]',
+        tgeompoint '[Point(200 200)@2000-01-01, Point(200 210)@2000-01-02]'],
+  2.0) ORDER BY i, j;
+-- Pairs that do not overlap on time are never within the distance
+SELECT i, j FROM eDwithinPairs(
+  ARRAY[tgeompoint '[Point(0 0)@2000-01-01, Point(0 10)@2000-01-02]'],
+  ARRAY[tgeompoint '[Point(0 0)@2000-03-01, Point(0 10)@2000-03-02]'],
+  2.0) ORDER BY i, j;
+SELECT i, j FROM eDwithinPairs(
+  ARRAY[tgeometry '[Point(0 0)@2000-01-01, Point(0 10)@2000-01-02]'],
+  ARRAY[tgeometry '[Point(1 0)@2000-01-01, Point(1 10)@2000-01-02]'],
+  2.0) ORDER BY i, j;
+SELECT i, j FROM eDwithinPairs(ARRAY[]::tgeompoint[],
+  ARRAY[tgeompoint 'Point(0 0)@2000-01-01'], 2.0) ORDER BY i, j;
+
+SELECT i, j FROM aDisjointPairs(
+  ARRAY[tgeompoint '[Point(0 0)@2000-01-01, Point(0 10)@2000-01-02]',
+        tgeompoint '[Point(50 50)@2000-01-01, Point(50 60)@2000-01-02]'],
+  ARRAY[tgeompoint '[Point(1 0)@2000-01-01, Point(1 10)@2000-01-02]',
+        tgeompoint '[Point(0 0)@2000-01-01, Point(0 10)@2000-01-02]']) ORDER BY i, j;
+-- Pairs that do not overlap on time are excluded (the relationship is undefined)
+SELECT i, j FROM aDisjointPairs(
+  ARRAY[tgeompoint '[Point(0 0)@2000-01-01, Point(0 10)@2000-01-02]'],
+  ARRAY[tgeompoint '[Point(5 5)@2000-03-01, Point(5 10)@2000-03-02]']) ORDER BY i, j;
+SELECT i, j FROM aDisjointPairs(
+  ARRAY[tgeometry '[Point(0 0)@2000-01-01, Point(0 10)@2000-01-02]'],
+  ARRAY[tgeometry '[Point(1 0)@2000-01-01, Point(1 10)@2000-01-02]']) ORDER BY i, j;
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/geo/queries/072_tgeo_tempspatialrels.test.sql
+++ b/mobilitydb/test/geo/queries/072_tgeo_tempspatialrels.test.sql
@@ -334,3 +334,23 @@ SELECT tDwithin(tgeometry 'Point(1 1 1)@2000-01-01', geometry 'Point(0 0 0)', -1
 -------------------------------------------------------------------------------
 
 -------------------------------------------------------------------------------
+-- Set-set spatial join
+-------------------------------------------------------------------------------
+
+SELECT i, j, periods FROM tDwithinPairs(
+  ARRAY[tgeompoint '[Point(0 0)@2000-01-01, Point(0 10)@2000-01-02]',
+        tgeompoint '[Point(50 50)@2000-01-01, Point(50 60)@2000-01-02]'],
+  ARRAY[tgeompoint '[Point(1 0)@2000-01-01, Point(1 10)@2000-01-02]',
+        tgeompoint '[Point(200 200)@2000-01-01, Point(200 210)@2000-01-02]'],
+  2.0) ORDER BY i, j;
+-- Pairs that do not overlap on time produce no row
+SELECT i, j, periods FROM tDwithinPairs(
+  ARRAY[tgeompoint '[Point(0 0)@2000-01-01, Point(0 10)@2000-01-02]'],
+  ARRAY[tgeompoint '[Point(0 0)@2000-03-01, Point(0 10)@2000-03-02]'],
+  2.0) ORDER BY i, j;
+SELECT i, j, periods FROM tDwithinPairs(
+  ARRAY[tgeometry '[Point(0 0)@2000-01-01, Point(0 10)@2000-01-02]'],
+  ARRAY[tgeometry '[Point(1 0)@2000-01-01, Point(1 10)@2000-01-02]'],
+  2.0) ORDER BY i, j;
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
eDwithinPairs(tgeo[], tgeo[], float), tDwithinPairs(tgeo[], tgeo[], float), and aDisjointPairs(tgeo[], tgeo[]) return the qualifying (i, j) index pairs of two arrays of temporal geos, generalising the eDwithin, tDwithin, and aDisjoint scalar relationships to a set-set spatial join resolved inside one call, mirroring mindistance_tgeoarr_tgeoarr. Each input's STBox is a bounding-box prefilter (temporal overlap and, in the planar case, spatial within-distance or spatial overlap) so the exact relationship runs only on the surviving candidate pairs; aDisjointPairs derives from ever-intersects by negation, and pairs whose temporal extents do not overlap are excluded to match the scalar relationships. Defined for tgeompoint[] and tgeometry[], with pg_regress coverage in 070_tgeo_spatialrels and 072_tgeo_tempspatialrels and DocBook documentation. Stacked on #1136, which normalises the sibling mindistance_tgeoarr_tgeoarr name.