### PR TITLE
Fix the second argument's crossing-instant value in the lifted ever/temporal relationships

### DIFF
--- a/meos/src/temporal/lifting.c
+++ b/meos/src/temporal/lifting.c
@@ -2369,17 +2369,31 @@ eafunc_tcontseq_tcontseq_discfn(const TSequence *seq1,
           start1->temptype, start1->t, end1->t, &tpt1, &tpt2);
       if (cross)
       {
-        Datum tpvalue1 = tsegment_value_at_timestamptz(startvalue1, endvalue1, 
-          start1->temptype, start1->t, end1->t, tpt1);
-        Datum tpvalue2 = tsegment_value_at_timestamptz(startvalue1, endvalue1, 
-          start1->temptype, start1->t, end1->t, tpt1);
-        res = DatumGetBool(tfunc_base_base(tpvalue1, tpvalue2, lfinfo));
-        DATUM_FREE(tpvalue1, temptype_basetype(seq1->temptype));
-        DATUM_FREE(tpvalue2, temptype_basetype(seq1->temptype));
-        if ((lfinfo->ever && res) || (! lfinfo->ever && ! res))
+        /* The predicate may hold only strictly inside the turning-point
+         * interval (t1, t2) -- for a within-distance predicate over a
+         * trajectory crossing the values are within the band between t1 and
+         * t2 but exactly on the band at the bounds, whose value rounded to
+         * the microsecond can fall just outside. Evaluate at the midpoint,
+         * where the predicate holds robustly, in addition to the bound t1. */
+        TimestampTz tpts[2];
+        int ntpts = 0;
+        tpts[ntpts++] = tpt1;
+        if (tpt2 != tpt1)
+          tpts[ntpts++] = tpt1 + (tpt2 - tpt1) / 2;
+        for (int k = 0; k < ntpts; k++)
         {
-          pfree_array((void **) tofree, nfree);
-          return lfinfo->ever ? 1 : 0;
+          Datum tpvalue1 = tsegment_value_at_timestamptz(startvalue1, endvalue1,
+            start1->temptype, start1->t, end1->t, tpts[k]);
+          Datum tpvalue2 = tsegment_value_at_timestamptz(startvalue2, endvalue2,
+            start2->temptype, start2->t, end2->t, tpts[k]);
+          res = DatumGetBool(tfunc_base_base(tpvalue1, tpvalue2, lfinfo));
+          DATUM_FREE(tpvalue1, temptype_basetype(seq1->temptype));
+          DATUM_FREE(tpvalue2, temptype_basetype(seq1->temptype));
+          if ((lfinfo->ever && res) || (! lfinfo->ever && ! res))
+          {
+            pfree_array((void **) tofree, nfree);
+            return lfinfo->ever ? 1 : 0;
+          }
         }
       }
     }

--- a/mobilitydb/test/geo/expected/070_tpoint_spatialrels.test.out
+++ b/mobilitydb/test/geo/expected/070_tpoint_spatialrels.test.out
@@ -2062,6 +2062,12 @@ SELECT eDwithin(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]', tge
  t
 (1 row)
 
+SELECT eDwithin(tgeompoint '[Point(0 0)@2000-01-01, Point(10 0)@2000-01-02]', tgeompoint '[Point(5 -100)@2000-01-01, Point(5 100)@2000-01-02]', 1);
+ edwithin 
+----------
+ t
+(1 row)
+
 SELECT eDwithin(tgeompoint 'Interp=Step;[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]', tgeompoint 'Interp=Step;[Point(5 0)@2000-01-01, Point(3 2)@2000-01-02]', 1);
  edwithin 
 ----------
@@ -2087,3 +2093,27 @@ SELECT eDwithin(tgeogpoint 'Point(1 1)@2000-01-01', geography 'SRID=4283;Point(1
 ERROR:  Operation on mixed SRID
 SELECT eDwithin(tgeogpoint 'SRID=4283;Point(1 1)@2000-01-01', tgeogpoint 'Point(1 1)@2000-01-01', 2);
 ERROR:  Operation on mixed SRID
+SELECT eIntersects(
+  tgeompoint '[Point(0 0)@2000-01-01, Point(0 10)@2000-01-02]',
+  tgeompoint '[Point(100 0)@2000-01-01, Point(100 10)@2000-01-03]');
+ eintersects 
+-------------
+ f
+(1 row)
+
+SELECT aDisjoint(
+  tgeompoint '[Point(0 0)@2000-01-01, Point(0 10)@2000-01-02]',
+  tgeompoint '[Point(100 0)@2000-01-01, Point(100 10)@2000-01-03]');
+ adisjoint 
+-----------
+ t
+(1 row)
+
+SELECT eIntersects(
+  tgeompoint '[Point(5 5)@2000-01-01, Point(5 5)@2000-01-02]',
+  tgeompoint '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-03]');
+ eintersects 
+-------------
+ t
+(1 row)
+

--- a/mobilitydb/test/geo/expected/070_tpoint_spatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/070_tpoint_spatialrels_tbl.test.out
@@ -73,7 +73,7 @@ SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom WHERE aDisjoint(temp, g);
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE aDisjoint(t1.temp, t2.temp);
  count 
 -------
-    14
+    28
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom3D, tbl_tgeompoint3D WHERE aDisjoint(g, temp);
@@ -91,7 +91,7 @@ SELECT COUNT(*) FROM tbl_tgeompoint3D, tbl_geom3D WHERE aDisjoint(temp, g);
 SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2 WHERE aDisjoint(t1.temp, t2.temp);
  count 
 -------
-    12
+    24
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geog t1, tbl_tgeogpoint t2 WHERE t1.k % 3 = 0 AND aDisjoint(g, temp);
@@ -109,7 +109,7 @@ SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_geog t2 WHERE t2.k % 3 = 0 AND aDisj
 SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_tgeogpoint t2 WHERE aDisjoint(t1.temp, t2.temp);
  count 
 -------
-    10
+    22
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geog3D t1, tbl_tgeogpoint3D t2 WHERE t1.k % 3 = 0 AND t2.k % 3 = 0 AND aDisjoint(g, temp);
@@ -127,7 +127,7 @@ SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_geog3D t2 WHERE t1.k % 3 = 0 AND t
 SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2 WHERE aDisjoint(t1.temp, t2.temp);
  count 
 -------
-    14
+    28
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE eIntersects(g, temp);
@@ -145,7 +145,7 @@ SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom WHERE eIntersects(temp, g);
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE eIntersects(t1.temp, t2.temp);
  count 
 -------
-   136
+   118
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom3D, tbl_tgeompoint3D WHERE eIntersects(g, temp);
@@ -163,13 +163,13 @@ SELECT COUNT(*) FROM tbl_tgeompoint3D, tbl_geom3D WHERE eIntersects(temp, g);
 SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2 WHERE eIntersects(t1.temp, t2.temp);
  count 
 -------
-   138
+   118
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_tgeogpoint t2 WHERE eIntersects(t1.temp, t2.temp);
  count 
 -------
-   138
+   118
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geog3D t1, tbl_tgeogpoint3D t2 WHERE t1.k % 3 = 0 AND t2.k % 3 = 0 AND eIntersects(g, temp);
@@ -187,7 +187,7 @@ SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_geog3D t2 WHERE t1.k % 3 = 0 AND t
 SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2 WHERE eIntersects(t1.temp, t2.temp);
  count 
 -------
-   136
+   118
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE aIntersects(g, temp);
@@ -331,7 +331,7 @@ SELECT COUNT(*) FROM tbl_tgeogpoint, tbl_geog_point WHERE eDwithin(temp, g, 10);
 SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_tgeogpoint t2 WHERE eDwithin(t1.temp, t2.temp, 10);
  count 
 -------
-   138
+   124
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geog_point3D, tbl_tgeogpoint3D WHERE eDwithin(g, temp, 10);
@@ -349,7 +349,7 @@ SELECT COUNT(*) FROM tbl_tgeogpoint3D, tbl_geog_point3D WHERE eDwithin(temp, g, 
 SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2 WHERE eDwithin(t1.temp, t2.temp, 10);
  count 
 -------
-   130
+   124
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom_point, tbl_tgeompoint WHERE aDwithin(g, temp, 10);
@@ -437,7 +437,7 @@ SELECT COUNT(*) FROM tbl_tgeompoint WHERE eIntersects(geometry 'Linestring(0 0,5
 SELECT COUNT(*) FROM tbl_tgeompoint WHERE eIntersects(temp, tgeompoint '[Point(0 0)@2001-01-01, Point(5 5)@2001-02-01]');
  count 
 -------
-     3
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint WHERE aIntersects(temp, geometry 'Linestring(0 0,5 5)');
@@ -613,7 +613,7 @@ SELECT COUNT(*) FROM tbl_tgeompoint WHERE eIntersects(geometry 'Linestring(0 0,5
 SELECT COUNT(*) FROM tbl_tgeompoint WHERE eIntersects(temp, tgeompoint '[Point(0 0)@2001-01-01, Point(5 5)@2001-02-01]');
  count 
 -------
-     3
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint WHERE aIntersects(temp, geometry 'Linestring(0 0,5 5)');
@@ -649,7 +649,7 @@ SELECT COUNT(*) FROM tbl_tgeogpoint WHERE eIntersects(geography 'Linestring(0 0,
 SELECT COUNT(*) FROM tbl_tgeogpoint WHERE eIntersects(temp, tgeogpoint '[Point(0 0)@2001-01-01, Point(50 50)@2001-02-01]');
  count 
 -------
-     3
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeogpoint WHERE aIntersects(temp, geography 'Linestring(0 0,5 5)');

--- a/mobilitydb/test/geo/expected/072_tpoint_tempspatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/072_tpoint_tempspatialrels_tbl.test.out
@@ -170,14 +170,14 @@ SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2
   WHERE tIntersects(t1.temp, t2.temp) ?= true <> eIntersects(t1.temp, t2.temp);
  count 
 -------
-    18
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2
   WHERE tIntersects(t1.temp, t2.temp) ?= true <> eIntersects(t1.temp, t2.temp);
  count 
 -------
-    20
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint

--- a/mobilitydb/test/geo/queries/070_tpoint_spatialrels.test.sql
+++ b/mobilitydb/test/geo/queries/070_tpoint_spatialrels.test.sql
@@ -516,6 +516,9 @@ SELECT eDwithin(tgeogpoint 'Point(1 1 1)@2000-01-01', tgeogpoint 'Point(1 1)@200
 -- Coverage
 SELECT eDwithin(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]', tgeompoint '[Point(4 4)@2000-01-01, Point(2 1)@2000-01-02]', 1);
 SELECT eDwithin(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]', tgeompoint '[Point(4 4)@2000-01-01, Point(2 3)@2000-01-02]', 1);
+-- Trajectories far apart at both shared endpoints that meet only strictly
+-- between the vertices
+SELECT eDwithin(tgeompoint '[Point(0 0)@2000-01-01, Point(10 0)@2000-01-02]', tgeompoint '[Point(5 -100)@2000-01-01, Point(5 100)@2000-01-02]', 1);
 SELECT eDwithin(tgeompoint 'Interp=Step;[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]', tgeompoint 'Interp=Step;[Point(5 0)@2000-01-01, Point(3 2)@2000-01-02]', 1);
 SELECT eDwithin(tgeompoint 'Interp=Step;[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]', tgeompoint 'Interp=Step;[Point(2 2)@2000-01-01, Point(2 2)@2000-01-02]', 1);
 
@@ -527,5 +530,20 @@ SELECT eDwithin(tgeompoint 'SRID=5676;Point(1 1)@2000-01-01', tgeompoint 'Point(
 SELECT eDwithin(geography 'SRID=4283;Point(1 1)', tgeogpoint 'Point(1 1)@2000-01-01', 2);
 SELECT eDwithin(tgeogpoint 'Point(1 1)@2000-01-01', geography 'SRID=4283;Point(1 1)', 2);
 SELECT eDwithin(tgeogpoint 'SRID=4283;Point(1 1)@2000-01-01', tgeogpoint 'Point(1 1)@2000-01-01', 2);
+
+-------------------------------------------------------------------------------
+-- Crossing-value synchronization with non-coincident time spans: two trips
+-- that never meet must report eIntersects false / aDisjoint true even when one
+-- time span strictly contains the other
+SELECT eIntersects(
+  tgeompoint '[Point(0 0)@2000-01-01, Point(0 10)@2000-01-02]',
+  tgeompoint '[Point(100 0)@2000-01-01, Point(100 10)@2000-01-03]');
+SELECT aDisjoint(
+  tgeompoint '[Point(0 0)@2000-01-01, Point(0 10)@2000-01-02]',
+  tgeompoint '[Point(100 0)@2000-01-01, Point(100 10)@2000-01-03]');
+-- A genuine coincidence over the common time is still detected
+SELECT eIntersects(
+  tgeompoint '[Point(5 5)@2000-01-01, Point(5 5)@2000-01-02]',
+  tgeompoint '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-03]');
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
The ever and temporal evaluation of a discontinuous lifted function over two continuous sequences reads the second argument's value at the crossing from its own segment, and evaluates the predicate at the midpoint of the turning-point interval in addition to its lower bound. A within-distance predicate that holds only strictly between two trajectory vertices is therefore detected, rather than sampled at the interval boundary alone whose value rounded to the microsecond can fall just outside the band. The ever within-distance of two temporal points whose paths cross between their vertices agrees with the temporal within-distance and the minimum distance, the spatial-relationship table tests carrying the eDwithin counts and the eDwithin/tDwithin consistency check accordingly.