### PR TITLE
Use MEOS_EPSILON for the network point snapping tolerance

### DIFF
--- a/meos/examples/geom_npoint.c
+++ b/meos/examples/geom_npoint.c
@@ -141,7 +141,7 @@ int main(void)
 
     /* We need to implement the following SQL query for a given geo
      *   SELECT npoint(gid, ST_LineLocatePoint(the_geom, geo))
-     *   FROM public.ways WHERE ST_DWithin(the_geom, geo, DIST_EPSILON)
+     *   FROM public.ways WHERE ST_DWithin(the_geom, geo, MEOS_EPSILON)
      *   ORDER BY ST_Distance(the_geom, geo) LIMIT 1;
      */
     

--- a/meos/include/temporal/temporal.h
+++ b/meos/include/temporal/temporal.h
@@ -68,11 +68,6 @@
 #define MEOS_FP_GT(A, B) (((A) - MEOS_EPSILON) > (B))
 #define MEOS_FP_GE(A, B) (((A) + MEOS_EPSILON) >= (B))
 
-/**
- * Precision for distance operations
- */
-#define DIST_EPSILON    1.0e-06
-
 #define UNUSED          __attribute__((unused))
 
 /** Symbolic constants for lifting */

--- a/meos/src/npoint/ways.c
+++ b/meos/src/npoint/ways.c
@@ -243,7 +243,7 @@ geompoint_to_npoint(const GSERIALIZED *gs)
     "SELECT npoint(gid, ST_LineLocatePoint(the_geom, '%s')) "
     "FROM public.ways WHERE ST_DWithin(the_geom, '%s', %lf) "
     "ORDER BY ST_Distance(the_geom, '%s') LIMIT 1", geomstr, geomstr,
-    DIST_EPSILON, geomstr);
+    MEOS_EPSILON, geomstr);
   pfree(geomstr);
   Npoint *result = palloc(sizeof(Npoint));
   bool isNull = true;

--- a/meos/src/npoint/ways_meos.c
+++ b/meos/src/npoint/ways_meos.c
@@ -411,7 +411,7 @@ geompoint_to_npoint(const GSERIALIZED *gs)
   {
     /* We need to reproduce the following SQL query for a given geometry geo
      *   SELECT npoint(gid, ST_LineLocatePoint(the_geom, geo))
-     *   FROM public.ways WHERE ST_DWithin(the_geom, geo, DIST_EPSILON)
+     *   FROM public.ways WHERE ST_DWithin(the_geom, geo, MEOS_EPSILON)
      *   ORDER BY ST_Distance(the_geom, geo) LIMIT 1;
      */
     /* Buffer for reading the geometry string */


### PR DESCRIPTION
The network point constructor snaps a geometry to the nearest way using ST_DWithin with the floating point precision epsilon. Use MEOS_EPSILON, the kernel-wide floating point precision constant defined in temporal.h, for this tolerance, the same constant the kernel's distance comparisons already use.