### PR TITLE
Remove duplicate and dead constant definitions

### DIFF
--- a/meos/include/temporal/temporal_tile.h
+++ b/meos/include/temporal/temporal_tile.h
@@ -34,8 +34,6 @@
 #include <meos.h>
 #include "temporal/meos_catalog.h"
 
-#define MAXDIMS 4
-
 /*****************************************************************************/
 
 /**

--- a/meos/src/npoint/npoint.c
+++ b/meos/src/npoint/npoint.c
@@ -72,8 +72,6 @@
 #define NPOINT_MAXLEN     128
 #define NSEGMENT_MAXLEN   128
 
-#define SQL_ROUTE_MAXLEN  64
-
 /*****************************************************************************
  * Collinear and interpolation function
  *****************************************************************************/

--- a/meos/src/npoint/ways.c
+++ b/meos/src/npoint/ways.c
@@ -103,8 +103,6 @@ get_srid_ways()
   return result;
 }
 
-#define SQL_ROUTE_MAXLEN 64
-
 /**
  * @ingroup meos_npoint_base_route
  * @brief Return true if the edge table contains a route with the route


### PR DESCRIPTION
MAXDIMS is defined in tgeo_tile.h, the only header whose structures and the tiling code use it. SQL_ROUTE_MAXLEN is defined in ways.c, the only file that uses it for the route query buffer size.