### PR TITLE
Support the ever semantics for tcbuffer contains and covers

### DIFF
--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -431,14 +431,11 @@ ea_spatialrel_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
  * @param[in] temp Temporal circular buffer
  * @param[in] ever True for the ever semantics, false for the always semantics
  * @csqlfn #Acontains_geo_tcbuffer()
- * @note The function is not supported for the `ever` semantics
  */
 int
 ea_contains_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp,
   bool ever)
 {
-  /* This function is not provided for the ever semantics */
-  assert(! ever);
   return ea_spatialrel_tcbuffer_geo(temp, gs, (Datum) NULL,
       (varfunc) &datum_geom_contains, 2, ever, INVERT);
 }
@@ -624,14 +621,11 @@ acontains_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @param[in] gs Geometry
  * @param[in] temp Temporal circular buffer
  * @param[in] ever True for the ever semantics, false for the always semantics
- * @note The function is not supported for the `ever` semantics
  * @csqlfn #Acovers_geo_tcbuffer()
  */
 int
 ea_covers_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp, bool ever)
 {
-  /* This function is not provided for the ever semantics */
-  assert(! ever);
   return ea_spatialrel_tcbuffer_geo(temp, gs, (Datum) NULL,
       (varfunc) &datum_geom_covers, 2, ever, INVERT);
 }


### PR DESCRIPTION
ea_contains_geo_tcbuffer and ea_covers_geo_tcbuffer compute the ever and always semantics through the generic tcbuffer/geometry relationship machinery, which evaluates the predicate per segment for both semantics, so ecovers/econtains over a temporal circular buffer return the per-instant result rather than aborting on a Debug build.