### PR TITLE
Support PostgreSQL 14 and 15 in the extension build

### DIFF
--- a/.github/workflows/pgversion.yml
+++ b/.github/workflows/pgversion.yml
@@ -1,8 +1,8 @@
 name: Main Build
 
 # Test for supported PostgreSQL/PostGIS versions.
-# Minimum supported PG is 16 (see mobilitydb/CMakeLists.txt PG_MIN_MAJOR_VERSION).
-# 3 (PostgreSQL) * 1 (PostGIS) * 1 (Linux) + 1 (coverage) = 4 jobs are triggered.
+# Minimum supported PG is 14 (see mobilitydb/CMakeLists.txt PG_MIN_MAJOR_VERSION).
+# 5 (PostgreSQL) * 1 (PostGIS) * 1 (Linux) + 1 (coverage) = 6 jobs are triggered.
 # Allow manual trigger
 
 on:
@@ -34,7 +34,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          psql: [16, 17, 18]
+          psql: [14, 15, 16, 17, 18]
           postgis: [3]
           os: ["ubuntu-24.04"]
           coverage: [0]

--- a/mobilitydb/CMakeLists.txt
+++ b/mobilitydb/CMakeLists.txt
@@ -46,13 +46,9 @@ endif()
 #-------------------------------------
 
 # Find PostgreSQL
-# Minimum supported version is 16. Older versions (14, 15) carry an
-# accumulating maintenance burden (per-version conditional code, allocator
-# differences exposed by the PG14/15 backend in load_jsonb_tables) that no
-# longer pays off; PostgreSQL 14 reaches end-of-life on 2026-11-12. Build
-# fails clearly here rather than letting the host pretend to be supported
-# and crashing later in fixtures.
-set(PG_MIN_MAJOR_VERSION "16")
+# Minimum supported version is 14. Build fails clearly here rather than letting
+# the host pretend to be supported and crashing later in fixtures.
+set(PG_MIN_MAJOR_VERSION "14")
 find_package(POSTGRESQL ${PG_MIN_MAJOR_VERSION} REQUIRED)
 if(POSTGRESQL_VERSION_MAJOR VERSION_LESS PG_MIN_MAJOR_VERSION)
   message(FATAL_ERROR

--- a/mobilitydb/src/temporal/meos_catalog.c
+++ b/mobilitydb/src/temporal/meos_catalog.c
@@ -58,6 +58,9 @@
 #include <access/heapam.h>
 #include <access/htup_details.h>
 #include <access/tableam.h>
+#if POSTGRESQL_VERSION_NUMBER < 140000
+#include <catalog/indexing.h>
+#endif
 #include <catalog/namespace.h>
 #include <catalog/pg_extension.h>
 #include <commands/extension.h>
@@ -191,6 +194,39 @@ RelnameNspGetRelid(const char *relname, Oid nsp_oid)
   return GetSysCacheOid2(RELNAMENSP, Anum_pg_class_oid,
     PointerGetDatum(relname), ObjectIdGetDatum(nsp_oid));
 }
+
+#if POSTGRESQL_VERSION_NUMBER < 160000
+/*
+ * get_extension_schema - given an extension OID, fetch its extnamespace
+ *
+ * Returns InvalidOid if no such extension.
+ */
+static Oid
+get_extension_schema(Oid ext_oid)
+{
+  Relation rel = table_open(ExtensionRelationId, AccessShareLock);
+
+  ScanKeyData entry[1];
+  ScanKeyInit(&entry[0], Anum_pg_extension_oid, BTEqualStrategyNumber, F_OIDEQ,
+  ObjectIdGetDatum(ext_oid));
+
+  SysScanDesc scandesc = systable_beginscan(rel, ExtensionOidIndexId, true,
+    NULL, 1, entry);
+
+  HeapTuple tuple = systable_getnext(scandesc);
+
+  /* We assume that there can be at most one matching tuple */
+  Oid result;
+  if (HeapTupleIsValid(tuple))
+    result = ((Form_pg_extension) GETSTRUCT(tuple))->extnamespace;
+  else
+    result = InvalidOid;
+
+  systable_endscan(scandesc);
+  table_close(rel, AccessShareLock);
+  return result;
+}
+#endif
 
 /**
  * @brief Return namespace Oid for the extension

--- a/mobilitydb/test/geo/expected/064_tpoint_distance.test.out
+++ b/mobilitydb/test/geo/expected/064_tpoint_distance.test.out
@@ -4003,11 +4003,11 @@ SELECT minDistance(t1, t2) FROM (
 
 WITH pairs(t1, t2) AS (VALUES
   (tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
-   tgeompoint '[Point(10 10)@2000-01-01, Point(11 11)@2000-01-02]'),  -- ~12.7
+   tgeompoint '[Point(10 10)@2000-01-01, Point(11 11)@2000-01-02]'),
   (tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
-   tgeompoint '[Point(0 5)@2000-01-01, Point(1 5)@2000-01-02]'),       -- 4
+   tgeompoint '[Point(0 5)@2000-01-01, Point(1 5)@2000-01-02]'),
   (tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
-   tgeompoint '[Point(2 1)@2000-01-01, Point(2 2)@2000-01-02]'))       -- ~1
+   tgeompoint '[Point(2 1)@2000-01-01, Point(2 2)@2000-01-02]'))
 SELECT round(minDistance(t1, t2)::numeric, 6) FROM pairs;
   round   
 ----------

--- a/mobilitydb/test/geo/queries/064_tpoint_distance.test.sql
+++ b/mobilitydb/test/geo/queries/064_tpoint_distance.test.sql
@@ -891,13 +891,14 @@ SELECT minDistance(t1, t2) FROM (
          tgeompoint '[Point(5 0)@2000-01-01, Point(15 0)@2000-01-02]'  AS t2) v;
 
 -- Aggregate over multiple rows: minimum across all per-pair distances
+-- (per-pair values are approximately 12.7, 4, and 1)
 WITH pairs(t1, t2) AS (VALUES
   (tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
-   tgeompoint '[Point(10 10)@2000-01-01, Point(11 11)@2000-01-02]'),  -- ~12.7
+   tgeompoint '[Point(10 10)@2000-01-01, Point(11 11)@2000-01-02]'),
   (tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
-   tgeompoint '[Point(0 5)@2000-01-01, Point(1 5)@2000-01-02]'),       -- 4
+   tgeompoint '[Point(0 5)@2000-01-01, Point(1 5)@2000-01-02]'),
   (tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
-   tgeompoint '[Point(2 1)@2000-01-01, Point(2 2)@2000-01-02]'))       -- ~1
+   tgeompoint '[Point(2 1)@2000-01-01, Point(2 2)@2000-01-02]'))
 SELECT round(minDistance(t1, t2)::numeric, 6) FROM pairs;
 
 -- Grouped: per-group minimum equivalent to MIN over the array form


### PR DESCRIPTION
Set the minimum supported PostgreSQL major version to 14 and cover 14 through 18 in the version CI matrix. Compile the local get_extension_schema fallback for hosts below PostgreSQL 16 (the symbol is provided by the core backend from 16 onward) and include catalog/indexing.h for hosts below PostgreSQL 14.