### PR TITLE
Prefix the vendored PostGIS and backend symbols to avoid host symbol collision

### DIFF
--- a/meos/include/geo/postgis_funcs.h
+++ b/meos/include/geo/postgis_funcs.h
@@ -36,6 +36,24 @@
 #ifndef __POSTGIS_FUNCS_H__
 #define __POSTGIS_FUNCS_H__
 
+/* MEOS: Prefix these vendored PostGIS symbols so they cannot be interposed by a
+ * PostGIS loaded through shared_preload_libraries. Without the prefix the
+ * preloaded PostGIS interposes these definitions and routes the geometry to
+ * GEOS conversion through PostGIS's non-reentrant global GEOS context rather
+ * than the per-thread context. */
+#define POSTGIS2GEOS MEOS_POSTGIS2GEOS
+#define GEOS2POSTGIS MEOS_GEOS2POSTGIS
+#define cart_to_lwpoint meos_cart_to_lwpoint
+#define lonlat_to_cart meos_lonlat_to_cart
+#define geography_centroid_from_mline meos_geography_centroid_from_mline
+#define geography_centroid_from_mpoly meos_geography_centroid_from_mpoly
+#define geography_centroid_from_wpoints meos_geography_centroid_from_wpoints
+#define geography_valid_type meos_geography_valid_type
+#define postgis_valid_typmod meos_postgis_valid_typmod
+#define itree_pip_contains meos_itree_pip_contains
+#define itree_pip_covers meos_itree_pip_covers
+#define itree_pip_intersects meos_itree_pip_intersects
+
 /*****************************************************************************/
 
 /* GEOS */

--- a/pgtypes/utils/date.c
+++ b/pgtypes/utils/date.c
@@ -535,7 +535,7 @@ minus_date_int(DateADT date, int32 days)
  * datatypes have the same lower bound, Julian day zero.
  */
 Timestamp
-date2timestamp_opt_overflow(DateADT date, int *overflow)
+meos_date2timestamp_opt_overflow(DateADT date, int *overflow)
 {
   if (overflow)
     *overflow = 0;
@@ -576,7 +576,7 @@ date2timestamp_opt_overflow(DateADT date, int *overflow)
 static TimestampTz
 date2timestamp(DateADT date)
 {
-  return date2timestamp_opt_overflow(date, NULL);
+  return meos_date2timestamp_opt_overflow(date, NULL);
 }
 
 /*
@@ -712,7 +712,7 @@ int32
 date_cmp_timestamp_internal(DateADT date, Timestamp dt2)
 {
   int overflow;
-  Timestamp dt1 = date2timestamp_opt_overflow(date, &overflow);
+  Timestamp dt1 = meos_date2timestamp_opt_overflow(date, &overflow);
   if (overflow > 0)
   {
     /* dt1 is larger than any finite timestamp, but less than infinity */

--- a/pgtypes/utils/date.h
+++ b/pgtypes/utils/date.h
@@ -98,7 +98,8 @@ TimeTzADTPGetDatum(const TimeTzADT *X)
 /* date.c */
 extern int32 anytime_typmod_check(bool istz, int32 typmod);
 extern double date2timestamp_no_overflow(DateADT dateVal);
-extern Timestamp date2timestamp_opt_overflow(DateADT dateVal, int *overflow);
+/* MEOS: prefixed to avoid interposition by a host backend symbol */
+extern Timestamp meos_date2timestamp_opt_overflow(DateADT dateVal, int *overflow);
 extern TimestampTz date2timestamptz_opt_overflow(DateADT dateVal, int *overflow);
 extern int32 date_cmp_timestamp_internal(DateADT dateVal, Timestamp dt2);
 extern int32 date_cmp_timestamptz_internal(DateADT dateVal, TimestampTz dt2);


### PR DESCRIPTION
Prefix the vendored PostGIS conversion and helper symbols (POSTGIS2GEOS, GEOS2POSTGIS, the geography and interval-tree helpers) and the backend date2timestamp_opt_overflow so a PostGIS loaded through shared_preload_libraries cannot interpose the module's own definitions. The interposed PostGIS POSTGIS2GEOS routes the geometry to GEOS conversion through PostGIS's non-reentrant global GEOS context, which aborts during planning-time constant folding on hosts where that context is not yet initialized. The prefix is applied through a marked define shim in postgis_funcs.h, matching the existing meos_pg_* convention.