### PR TITLE
Seed the random generator once so the test data generation is reproducible

### DIFF
--- a/mobilitydb/datagen/header.in.sql
+++ b/mobilitydb/datagen/header.in.sql
@@ -38,3 +38,7 @@
 
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION mobilitydb_datagen" to load this file. \quit
+
+-- Set a fixed seed once so that every create_test_tables_* call in this session
+-- produces reproducible tables for a given PostgreSQL version
+SELECT setseed(0.5);


### PR DESCRIPTION
Set a fixed seed at the top of the data generation extension so that every create_test_tables_* call in the same session produces reproducible tables for a given PostgreSQL version.