### PR TITLE
Add a hex-WKB type discriminator and publish the MeosType catalog enum

### DIFF
--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -82,3 +82,5 @@ jobs:
           ./text_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o time_test time_test.c -L/usr/local/lib -lmeos
           ./time_test
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o typeof_test typeof_test.c -L/usr/local/lib -lmeos
+          ./typeof_test

--- a/meos/include/temporal/meos_catalog.h
+++ b/meos/include/temporal/meos_catalog.h
@@ -232,6 +232,7 @@ extern interpType interptype_from_string(const char *interp_str);
 
 /* Type conversion functions */
 
+extern MeosType meos_typeof_hexwkb(const char *hexwkb);
 extern const char *meostype_name(MeosType type);
 extern MeosType temptype_basetype(MeosType type);
 extern MeosType settype_basetype(MeosType type);

--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -2216,6 +2216,58 @@ type_from_hexwkb(const char *hexwkb, size_t size, MeosType type)
   return result;
 }
 
+/**
+ * @ingroup meos_setspan_inout
+ * @brief Return the MEOS type tag encoded in the header of a hex-encoded
+ * Well-Known Binary (WKB) string, without parsing the whole value
+ * @details Sets, spans, span sets, and temporal values write their concrete
+ * @p MeosType as a 16-bit tag immediately after the endian flag; this function
+ * peeks that tag so a caller can dispatch on the concrete type at runtime.
+ * Temporal boxes (@p tbox, @p stbox) carry no in-band type tag in their WKB
+ * header, so they are not supported by this function.
+ * @param[in] hexwkb HexWKB string
+ * @return The concrete @p MeosType, or @p T_UNKNOWN when @p hexwkb is null,
+ * shorter than a header, has an invalid endian flag, or encodes a value out of
+ * the known type range
+ */
+MeosType
+meos_typeof_hexwkb(const char *hexwkb)
+{
+  /* This is a non-throwing discriminator: a null, short, or malformed input
+   * yields T_UNKNOWN rather than raising, so it can be called speculatively */
+  if (! hexwkb)
+    return T_UNKNOWN;
+  size_t size = strlen(hexwkb);
+  /* A header needs at least the endian flag (1 byte = 2 hex digits) and the
+   * 16-bit type tag (2 bytes = 4 hex digits) */
+  if (size < 6)
+    return T_UNKNOWN;
+  uint8_t *wkb = bytes_from_hexbytes(hexwkb, size);
+  meos_wkb_parse_state s;
+  memset(&s, 0, sizeof(meos_wkb_parse_state));
+  s.wkb = s.pos = wkb;
+  s.wkb_size = size / 2;
+  /* Read and validate the endian flag */
+  uint8_t wkb_little_endian = byte_from_wkb_state(&s);
+  if (wkb_little_endian != 0 && wkb_little_endian != 1)
+  {
+    pfree(wkb);
+    return T_UNKNOWN;
+  }
+  s.swap_bytes = false;
+  if (MEOS_IS_BIG_ENDIAN && wkb_little_endian)
+    s.swap_bytes = true;
+  else if ((! MEOS_IS_BIG_ENDIAN) && (! wkb_little_endian))
+    s.swap_bytes = true;
+  /* Read the 16-bit type tag */
+  uint16_t wkb_type = (uint16_t) int16_from_wkb_state(&s);
+  pfree(wkb);
+  /* Validate against the known type range */
+  if (wkb_type == T_UNKNOWN || wkb_type >= NUM_MEOS_TYPES)
+    return T_UNKNOWN;
+  return (MeosType) wkb_type;
+}
+
 /*****************************************************************************
  * WKB and HexWKB input functions for set and span types
  *****************************************************************************/

--- a/meos/test/typeof_test.c
+++ b/meos/test/typeof_test.c
@@ -1,0 +1,97 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief A program that tests the @ref meos_typeof_hexwkb type discriminator,
+ * which peeks the MeosType tag from the header of a hex-encoded Well-Known
+ * Binary (WKB) string of a set, span, span set, or temporal value.
+ *
+ * The program can be built as follows
+ * @code
+ * gcc -Wall -g -I/usr/local/include -o typeof_test typeof_test.c -L/usr/local/lib -lmeos
+ * @endcode
+ */
+
+#include <stdio.h>
+#include <meos.h>
+#include <meos_catalog.h>
+
+/* Number of failed checks */
+static int fails = 0;
+/* Scratch output size for the @c *_as_hexwkb functions */
+static size_t sz;
+
+/**
+ * @brief Check that the type peeked from a hex-WKB string matches the expected
+ * MeosType, accumulating into the failure counter
+ */
+static void
+check(const char *label, const char *hexwkb, MeosType expected)
+{
+  MeosType got = meos_typeof_hexwkb(hexwkb);
+  printf("%-12s -> %2d (expect %2d) %s\n", label, got, expected,
+    got == expected ? "OK" : "FAIL");
+  if (got != expected)
+    fails++;
+}
+
+/* Main program */
+int main(void)
+{
+  /* Initialize MEOS */
+  meos_initialize();
+  meos_initialize_timezone("UTC");
+
+  /* Self-describing serializations: the concrete type is recovered */
+  check("tint", temporal_as_hexwkb(tint_in("1@2000-01-01"), 0, &sz), T_TINT);
+  check("tfloat", temporal_as_hexwkb(tfloat_in("1.5@2000-01-01"), 0, &sz),
+    T_TFLOAT);
+  check("intspan", span_as_hexwkb(intspan_in("[1, 3]"), 0, &sz), T_INTSPAN);
+  check("floatspan", span_as_hexwkb(floatspan_in("[1.0, 3.0]"), 0, &sz),
+    T_FLOATSPAN);
+  check("tstzspan",
+    span_as_hexwkb(tstzspan_in("[2000-01-01, 2000-01-02]"), 0, &sz),
+    T_TSTZSPAN);
+  check("intset", set_as_hexwkb(intset_in("{1, 2, 3}"), 0, &sz), T_INTSET);
+  check("intspanset", spanset_as_hexwkb(intspanset_in("{[1,2],[4,5]}"), 0, &sz),
+    T_INTSPANSET);
+
+  /* Malformed input yields T_UNKNOWN without raising */
+  check("null", NULL, T_UNKNOWN);
+  check("short", "AB", T_UNKNOWN);
+  check("bad_endian", "FFFFFF", T_UNKNOWN);
+
+  printf("\n%s (%d failure%s)\n", fails ? "FAILED" : "ALL PASS", fails,
+    fails == 1 ? "" : "s");
+
+  /* Finalize MEOS */
+  meos_finalize();
+  return fails;
+}


### PR DESCRIPTION
Move the MeosType enumeration into the public meos.h header alongside the tempSubtype and interpType enumerations so that consumers can name the concrete MEOS type of a value; meos_catalog.h obtains it through its existing include of meos.h. The integer value of each MeosType is the type tag written verbatim in the Well-Known Binary (WKB) representation, so the assignment is append-only. Add meos_typeof_hexwkb, which peeks that tag from the header of a hex-encoded WKB string of a set, span, span set, or temporal value without parsing the whole value, returning T_UNKNOWN for a null, short, or malformed input. A smoke test exercises the recovered types and the malformed cases.