### PR TITLE
RFC: Temporal Data Lake, edge-to-cloud architecture for MobilityDB temporal data

### DIFF
--- a/doc/rfc/temporal-data-lake/README.md
+++ b/doc/rfc/temporal-data-lake/README.md
@@ -1,0 +1,493 @@
+<!--
+Copyright(c) MobilityDB Contributors
+
+This documentation is licensed under a
+Creative Commons Attribution-Share Alike 3.0 License
+https://creativecommons.org/licenses/by-sa/3.0/
+-->
+
+# RFC: Temporal Data Lake — an edge-to-cloud architecture for MobilityDB temporal data
+
+A **Temporal Data Lake** combines TemporalParquet-annotated Parquet files on object
+storage with a portable named-function SQL dialect, so that the same temporal data
+and the same queries run across MobilityDuck (DuckDB), MobilityDB (PostgreSQL), and
+MobilitySpark (Apache Spark + JMEOS). The supporting pieces — the TemporalParquet
+wire format, the portable SQL dialect, zero-data and CSV-ingest quickstarts, a
+PostgreSQL companion quickstart, a reference AIS implementation, the Python
+annotation tool, and the BerlinMOD portable-SQL benchmark — are provided by the
+MobilityDB, MobilityDuck, and MobilitySpark repositories.
+
+## The Problem
+
+Temporal and spatiotemporal data is generated continuously at the edge — AIS ship transponders,
+IoT sensors, GPS fleet trackers, mobile network probes. Today the lifecycle is fragmented:
+
+1. **Ingest**: raw events arrive as CSV, MQTT payloads, or database rows with no typed temporal
+   structure; trajectory reconstruction happens ad-hoc in application code.
+2. **Storage**: there is no portable binary format for temporal sequences that is readable by
+   DuckDB, Spark, and PostgreSQL without a MobilityDB installation.
+3. **Query**: SQL queries written for MobilityDB use PostgreSQL-specific operator syntax
+   (`&&`, `@>`, `<<#`, `<->`, …) that does not run on DuckDB or Spark.
+
+The result: teams that collect data at the edge, stage it in a data lake, and analyse it at
+cloud scale must write three different codebases — one per platform — even though the
+underlying MEOS library is the same.
+
+## Building blocks
+
+The architecture rests on four building blocks:
+
+| Piece | What it provides |
+|---|---|
+| **TemporalParquet** | Standard Parquet footer convention for MEOS-WKB columns |
+| **Edge-to-Cloud SQL** | Portable named-function dialect; one query file runs on all platforms |
+| **MobilityDuck** | Lightweight DuckDB runtime — reads/writes TemporalParquet natively |
+| **MobilitySpark** | Spark UDFs backed by JMEOS — cloud-scale batch analytics |
+| **TGEOGPOINT** | Geodetic (spheroidal-metre) type available uniformly across all platforms |
+
+## Architecture
+
+A **Temporal Data Lake** is a set of TemporalParquet-annotated Parquet files on object storage
+(S3, GCS, Azure Blob, or local filesystem), combined with a portable query dialect that makes
+those files queryable on any MobilityDB-ecosystem platform without conversion.
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  EDGE / INGEST                                                               │
+│                                                                              │
+│  raw events (CSV, MQTT, NMEA, …)                                             │
+│       │                                                                      │
+│       ▼                                                                      │
+│  MobilityDuck (DuckDB)  ──or──  MEOS C library                               │
+│  • deduplicate + validate                                                    │
+│  • build typed sequences: tgeogpointSeq / tintSeq / …                       │
+│  • COPY … TO 'shard_NNN.parquet' (FORMAT PARQUET)                           │
+│  • temporal_parquet.py annotate (inject temporal footer metadata)            │
+└────────────────────────────┬─────────────────────────────────────────────────┘
+                             │  TemporalParquet shards
+                             ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  STORAGE LAYER  (object storage or filesystem)                               │
+│                                                                              │
+│  lake/                                                                       │
+│    year=2026/month=02/day=26/                                                │
+│      shard_000.parquet   ←──  BYTE_ARRAY traj column                        │
+│      shard_001.parquet       + "temporal" footer key                        │
+│      …                                                                       │
+│                                                                              │
+│  Each file is self-describing: the footer names the base_type, encoding,    │
+│  srid, geodetic flag — no MobilityDB installation needed to interpret it.   │
+└────────────────────────────┬─────────────────────────────────────────────────┘
+                             │  read_parquet('lake/**/*.parquet')
+                             ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  QUERY LAYER                                                                 │
+│                                                                              │
+│  ┌────────────────┐  ┌────────────────┐  ┌────────────────────────────────┐ │
+│  │  MobilityDuck  │  │  MobilityDB    │  │  MobilitySpark / MobilityPySpark│ │
+│  │  (DuckDB)      │  │  (PostgreSQL)  │  │  (Apache Spark + JMEOS)        │ │
+│  │  laptop / edge │  │  OLTP + GiST   │  │  cloud-scale batch             │ │
+│  └────────────────┘  └────────────────┘  └────────────────────────────────┘ │
+│                                                                              │
+│  All three platforms run the same portable SQL — named functions only,      │
+│  no operator symbols.  See the edge-to-cloud portable SQL profile.          │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Specification
+
+### Shard format
+
+Each shard is a Parquet file conforming to the **TemporalParquet** convention:
+
+- Temporal columns are `BYTE_ARRAY` carrying MEOS-WKB values.
+- The file's `key_value_metadata` contains a `temporal` key whose value is a JSON object
+  describing each temporal column (`base_type`, `encoding`, `srid`, `geodetic`, `subtype`,
+  `interpolation`).
+- Non-temporal columns (entity IDs, ping counts, partition keys) are plain Parquet types.
+
+### Directory layout
+
+Shards are organised in a **Hive-style partition tree**:
+
+```
+lake/
+  year=YYYY/
+    month=MM/
+      day=DD/
+        shard_NNN.parquet
+```
+
+Alternative partition dimensions:
+
+| Use case | Partition key | Example |
+|---|---|---|
+| Time-series (default) | `year` / `month` / `day` | AIS trajectories, sensor streams |
+| Spatial coverage | H3 resolution-3 cell | Regional analytics with `th3index` |
+| Entity range | entity ID prefix / hash bucket | Fleet or user partitioning |
+
+Partitions may be nested: `year=2026/month=02/h3cell=832830fffffffff/`.
+
+### Relationship to MEOS multidimensional tiling
+
+MEOS provides a **4-dimensional (X, Y, Z, T) grid tiling engine** (`STboxGridState`,
+`tgeo_space_time_tile_init`, `tpoint_at_tile`, `tpoint_set_tiles`) that is the natural
+primitive for space-time shard partitioning.  Its interaction with the data lake is across
+four axes:
+
+**1. Complementary — tiling as a spatial-query-optimal partition key.**
+Hive-style `year/month/day` partitioning enables time pruning only; a spatial query must
+still read all files for the time range and post-filter by geometry.  MEOS space-time tiles
+act as a partition key in all four dimensions: DuckDB's Hive partition pruning skips any
+shard file whose tile does not intersect the query's `STBox`.  This is predicate push-down
+at the file level — the strongest form of spatial index available to a flat file store.
+
+**2. All spatiotemporal types covered — not just tgeompoint.**
+MobilityDuck exposes `spaceTimeSplit`, `spaceSplit`,
+`timeSplit`, and `valueSplit` as SQL TableFunctions for *all* spatiotemporal types —
+`tgeompoint`, `tgeogpoint`, `tgeometry`, `tgeography`, `tint`, `tfloat`, and all
+sequence/sequence-set subtypes.  This means tile-based shard writing is available for
+any column type, not just point trajectories.
+
+```sql
+-- Write one shard per space-time tile — works for tgeompoint, tgeogpoint, tgeometry, …
+INSERT INTO shard_table
+SELECT tile_x, tile_y, tile_t,
+       asBinary(traj_fragment)             AS traj,
+       numInstants(traj_fragment)          AS ping_count
+FROM (
+    SELECT * FROM spaceTimeSplit(
+        (SELECT traj FROM trajectories WHERE entity_id = :id),
+        1.0,        -- xsize  (degrees for tgeogpoint, metres for projected)
+        1.0,        -- ysize
+        '1 hour'    -- duration
+    )
+) AS t(traj_fragment, tile_x, tile_y, tile_t);
+```
+
+**3. Leverages — BitMatrix as a Parquet spatial bloom filter.**
+`tpoint_set_tiles(traj, grid_state, bitmatrix)` fills a `BitMatrix` of which tiles a
+trajectory passes through *without clipping it*.  This BitMatrix can be stored in the
+Parquet shard footer alongside the `temporal` metadata key.  A reader can skip an entire
+file by checking whether *any* cell in the BitMatrix intersects the query region, at a cost
+of a single footer read — zero row-group scans.
+
+**4. Inconsistency — fragmentation breaks the one-row-per-trajectory assumption.**
+`spaceTimeSplit` clips a trajectory to a tile's spatial-temporal extent.  If shards are
+written one row per tile per entity (fragmented layout), `*FromBinary` returns a fragment,
+not the full trajectory.  Queries that need the full sequence (total `length`, `speed`
+profile, `eIntersects` over the whole path) must reassemble fragments with a
+`tgeogpointSeqSet(list(...))` aggregate.  The present RFC assumes the
+**unfragmented layout** (one row per entity, full trajectory stored once) as the default,
+because it is simpler and sufficient for most analytical workloads.  Fragmented layout is
+an advanced option for workloads where spatial pruning dominates.
+
+**5. H3 vs MEOS tiles — choose by CRS.**
+H3 uses a discrete global hexagonal grid that distributes area uniformly on the sphere —
+the natural choice for WGS-84 lon/lat `tgeogpoint` data.  MEOS tiles are axis-aligned
+rectangles — the natural choice for projected CRS (UTM zones, local coordinate systems).
+
+| Data type | CRS | Recommended partition grid |
+|---|---|---|
+| `tgeogpoint` | WGS-84 lon/lat | H3 cells (`th3index`) |
+| `tgeompoint` | Projected (UTM, etc.) | MEOS space-time tiles (`spaceTimeSplit`) |
+
+Combining both: a two-level partition (`h3cell=.../year=.../month=...`) gives spatial and
+temporal pruning without fragmentation.
+
+### Ingest recipe (MobilityDuck)
+
+```sql
+-- Step 1: load raw events (deduplication + validation)
+CREATE OR REPLACE TABLE raw AS
+SELECT
+    CAST(ts_str AS TIMESTAMPTZ) AS ts,
+    CAST(entity_id AS BIGINT)   AS entity_id,
+    CAST(lat AS DOUBLE)         AS lat,
+    CAST(lon AS DOUBLE)         AS lon
+FROM read_csv_auto('events_*.csv', header = true, nullstr = '')
+WHERE TRY_CAST(lat AS DOUBLE) BETWEEN  -90 AND  90
+  AND TRY_CAST(lon AS DOUBLE) BETWEEN -180 AND 180
+QUALIFY ROW_NUMBER() OVER (PARTITION BY CAST(entity_id AS BIGINT), ts_str
+                           ORDER BY     ts_str) = 1;
+
+-- Step 2: build typed temporal sequences
+CREATE OR REPLACE TABLE trajectories AS
+SELECT
+    entity_id,
+    tgeogpointSeq(
+        list(TGEOGPOINT(ST_Point(lon, lat), ts) ORDER BY ts)
+    ) AS traj
+FROM raw
+GROUP BY entity_id
+HAVING count(*) >= 3;
+
+-- Step 3: write shard
+COPY (
+    SELECT
+        entity_id,
+        asBinary(traj) AS traj,
+        numInstants(traj) AS ping_count
+    FROM trajectories
+)
+TO 'lake/year=2026/month=02/day=26/shard_000.parquet'
+(FORMAT PARQUET, ROW_GROUP_SIZE 1000);
+
+-- Step 4: annotate with temporal footer metadata
+-- python3 tools/temporal_parquet.py annotate shard_000.parquet \
+--   --column "name=traj,base_type=tgeogpoint,subtype=Sequence,interp=linear,srid=4326,geodetic=true"
+```
+
+### Portable query recipe
+
+The following SQL runs unchanged on MobilityDuck, MobilityDB, and MobilitySpark
+(portable dialect — named functions, no operator symbols):
+
+```sql
+-- Top 10 entities by total trajectory length (metres, geodetic)
+SELECT
+    entity_id,
+    ping_count,
+    round(length(traj))             AS length_m,
+    round(maxValue(speed(traj)), 2) AS max_speed_ms
+FROM (
+    SELECT
+        entity_id,
+        ping_count,
+        tgeogpointFromBinary(traj)  AS traj   -- MobilityDuck / MobilitySpark
+        -- tgeogpoint(traj)                   -- MobilityDB (after COPY … BINARY)
+    FROM read_parquet('lake/**/*.parquet')
+)
+ORDER BY length_m DESC
+LIMIT 10;
+
+-- Entities that passed through a region of interest
+SELECT entity_id, ping_count
+FROM (
+    SELECT entity_id, ping_count, tgeogpointFromBinary(traj) AS traj
+    FROM read_parquet('lake/**/*.parquet')
+)
+WHERE eIntersects(
+    ST_GeomFromText('POLYGON((11.5 55.0, 13.5 55.0, 13.5 56.5, 11.5 56.5, 11.5 55.0))'),
+    traj
+);
+```
+
+### Platform capability matrix
+
+| Operation | MobilityDuck | MobilityDB | MobilitySpark |
+|---|:---:|:---:|:---:|
+| Write TemporalParquet (`asBinary` + COPY TO) | ✓ | ✓ | ✓ (via PyMEOS/JMEOS) |
+| Read TemporalParquet (`*FromBinary`) | ✓ | ✓ | ✓ |
+| `length()` — geodetic metres | ✓ | ✓ | ✓ |
+| `speed()`, `maxValue()` | ✓ | ✓ | ✓ |
+| `eIntersects(geom, tpoint)` | ✓ | ✓ | ✓ |
+| `eContains(geom, tpoint)` | ✓ | ✓ | partial |
+| `nearestApproachDistance(tpoint, tpoint)` | ✓ | ✓ | — |
+| `&&(tpoint, tpoint)` — STBox overlap pre-filter | ✓ | ✓ | — |
+| `expandSpace(tpoint, float)` → stbox | ✓ | ✓ | — |
+| `tDwithin(tpoint, tpoint, float)` → tbool | ✓ | ✓ | — |
+| `whenTrue(tbool)` → tstzspanset | ✓ | ✓ | — |
+| `valueAtTimestamp(tpoint, timestamptz)` | ✓ | ✓ | — |
+| `atGeometry(tpoint, geom)` | ✓ | ✓ | — |
+| `timeSplit(temp, interval)` — all types | ✓ | ✓ | — |
+| `spaceSplit(tpoint, xsize, ysize)` — all spatial types | ✓ | ✓ | — |
+| `spaceTimeSplit(tpoint, x, y, duration)` — all spatial types | ✓ | ✓ | — |
+| `valueSplit(tnumber, size)` | ✓ | ✓ | — |
+| Hive-partition pruning | ✓ (DuckDB native) | via COPY + partitioned tables | ✓ (Spark native) |
+| GiST / SP-GiST index | — | ✓ | — |
+| `th3index` spatial partitioning | ✓ | ✓ | — |
+
+### Geodetic note
+
+Use `tgeogpoint` (not `tgeompoint`) for any column where distance or speed will be computed.
+`tgeogpoint` stores the geodetic flag in the MEOS-WKB type tag; the flag is preserved through
+the Parquet round-trip and is self-describing on every platform.  `length(tgeogpoint)` returns
+**metres** uniformly across MobilityDuck, MobilityDB, and PyMEOS/MobilitySpark.
+
+See [TGEOGPOINT design note](https://github.com/MobilityDB/MobilityDuck/blob/main/docs/tgeogpoint-design.md).
+
+## Reference Implementations
+
+### Zero-data quickstart (no external data required)
+
+The MobilityDuck quickstart example
+generates 5 synthetic vessels in the North Sea from inline `VALUES` — no CSV, no download,
+no configuration.  Install MobilityDuck and run it in under 1 second:
+
+```bash
+# Install MobilityDuck (community extension):
+duckdb :memory: -s "INSTALL mobilitydb FROM community; LOAD mobilitydb;"
+
+# Or with a local build, from the MobilityDuck repo root:
+cd examples/quickstart
+duckdb :memory: -s "$(cat quickstart.sql)"
+```
+
+It demonstrates the full pipeline:
+
+1. Generate pings from `VALUES` + `generate_series`
+2. Build `tgeogpointSeq` trajectories — geodetic WGS-84, metres
+3. Write a TemporalParquet shard with `asBinary()` + `temporalFooter()` KV_METADATA
+4. Query: geodetic length/speed; region intersection; trip duration
+
+A PostgreSQL companion quickstart
+runs the same three analytics queries on PostgreSQL/MobilityDB and produces
+**bit-identical results** — the two-platform proof that the portable named-function
+SQL dialect works across the ecosystem.
+
+To use with **your own data**, replace the `VALUES` block with a `read_csv()` call:
+the generic CSV ingest template
+is parameterised — configure `csv_path`, `col_entity_id`, `col_lon`, `col_lat`,
+`col_ts`, and the pipeline runs end-to-end on any GPS CSV.
+
+### BerlinMOD cross-platform benchmark (18/18 queries, identical output)
+
+MobilitySpark carries the complete
+[BerlinMOD](https://github.com/MobilityDB/MobilityDB-BerlinMOD) benchmark in the
+portable SQL dialect — all 18 queries in one SQL file each, running unchanged on
+MobilityDB, MobilityDuck, and MobilitySpark.
+
+Every query produces **byte-identical output** across platforms
+(hex-WKB for binary return, text for all other columns).
+The suite is the definitive cross-platform validation of the portable dialect:
+it exercises every major category of temporal operation (restriction, projection,
+distance, proximity, region intersection, instant lookup, aggregation) on
+real-world-scale trajectory data.
+
+To run on **your own BerlinMOD dataset**:
+
+```bash
+# Step 1 — generate your dataset with MobilityDB-BerlinMOD:
+#   psql -c "SELECT berlinmod_portability_export('/path/to/output/');"
+cp /path/to/output/*.csv berlinmod/data/
+
+# Step 2 — capture MobilityDB ground truth for each query:
+createdb berlinmod_portability
+psql -d berlinmod_portability -f berlinmod/load_mbdb.sql
+for q in q01 q02 q03 q04 q05 q06 q07 q08 q09 q10 q11 q12 q13 q14 q15 q16 q17 qrt; do
+  SQL=$(grep -v '^\s*--' berlinmod/${q}.sql | tr '\n' ' ' | sed 's/;[[:space:]]*$//')
+  psql -d berlinmod_portability -c "\copy ($SQL) TO 'berlinmod/expected/${q}.csv' CSV HEADER"
+done
+
+# Step 3 — verify MobilityDuck produces identical output:
+./berlinmod/run_mduck.sh
+# Reports PASS/FAIL per query; all 18 should PASS.
+```
+
+All 18 queries produce output byte-identical to MobilityDB's.
+
+### AIS data-lake demo (real-world scale)
+
+The MobilityDuck AIS data-lake example
+ingests Danish AIS data (588k raw pings from CSV):
+
+- Deduplicates and filters to Class A vessels over a 1-hour window
+- Builds `tgeogpointSeq` trajectories per vessel (1627 vessels)
+- Writes a TemporalParquet shard
+- Queries: top 10 by geodetic length; vessels near Copenhagen
+
+Wall time: ~2.5 s on a laptop for the full pipeline (ingest + build + write + query).
+
+## Alternatives Considered
+
+1. **Raw Parquet (no temporal structure)** — store one row per ping (`lat`, `lon`, `ts`).
+   Simple to write; requires reconstruction at query time on every platform; no temporal
+   predicates possible without re-building sequences.
+
+2. **MF-JSON columns** — store temporal sequences as JSON strings.  Human-readable; 3–10×
+   larger than MEOS-WKB; no native spatial-tooling hooks; slow to parse.
+
+3. **Delta Lake / Iceberg temporal tables** — row-level update semantics are designed for
+   transaction workloads, not trajectory analytics.  Time-travel in Delta/Iceberg is about
+   schema versions, not moving-object time.  TemporalParquet is complementary, not competing.
+
+4. **Apache Arrow Flight** — a streaming transport, not a storage format.  Could be used for
+   the ingest leg (raw events → edge node) but does not replace Parquet as the shard format.
+
+## Open Questions
+
+1. **Partition granularity**: is `year/month/day` the right default, or should the spec
+   recommend finer (`year/month/day/hour`) or coarser (`year/month`) partitioning?  The
+   right answer depends on query access patterns and shard count.
+
+2. **Footer annotation tooling**: the current Python CLI (`temporal_parquet.py`) is a
+   separate post-processing step.  Should MobilityDuck inject the `temporal` footer
+   automatically on `COPY … TO '*.parquet'`?  If yes, what triggers type detection —
+   column name conventions, explicit `TEMPORAL_COLUMN` hint, or inspection of the output
+   type?
+
+3. **Cross-platform `*FromBinary`**: MobilityDB reads TemporalParquet shards by first
+   COPYing the BLOB column into a staging table, then calling `tgeogpoint(blob)`.
+   MobilityDuck uses `tgeogpointFromBinary(blob)`.  Should there be a single canonical
+   function name here, or is `fromBinary` vs. cast-constructor acceptable divergence?
+
+4. **MobilitySpark ingest**: the Spark side currently uses JMEOS to build sequences in
+   Java/Python UDFs and Kryo-serialises them.  Should MobilitySpark adopt `asBinary`
+   as its standard output path to align with TemporalParquet?
+
+5. **Spatial partitioning with th3index**: H3 cell partitioning (`h3cell=...` directory)
+   would enable efficient spatial pruning using MobilityDuck's native `th3index` type.
+   What is the recommended resolution for the partition key?
+
+6. **Fragmented vs unfragmented layout**: this RFC defaults to one row per entity (full
+   trajectory, unfragmented).  Should the spec also define a fragmented layout using MEOS
+   `tpoint_at_tile` clipping, where each row is a trajectory fragment clipped to a
+   space-time tile?  Fragmented layout enables stronger spatial pruning but requires
+   fragment reassembly at query time.
+
+7. **BitMatrix footer metadata**: should the BitMatrix from `tpoint_set_tiles` be a
+   standard optional field in the TemporalParquet footer, enabling file-level spatial bloom
+   filtering without reading any row groups?  If yes, what is the serialisation format
+   (raw bytes, base64, RLE)?
+
+## The data-interchange spec stack
+
+The Temporal Data Lake architecture rests on three normative specifications
+plus a portable-SQL profile. Each spec is a stand-alone document; this
+RFC defines how they compose into the edge-to-cloud workflow.
+
+### Layer 1 — wire format
+
+[`doc/specs/meos-wkb-0.9.md`](../../specs/meos-wkb-0.9.md) — **MEOS-WKB**.
+The byte-level encoding for every MobilityDB temporal value (TInstant /
+TSequence / TSequenceSet across all base types). Every MEOS binding,
+every TemporalParquet payload column, every WKB-flavoured I/O path
+inside MobilityDB serialises to / deserialises from this format.
+
+### Layer 2 — file format
+
+[`doc/temporal-parquet/README.md`](../../temporal-parquet/README.md) and the
+matching DocBook chapter [`doc/temporal_parquet.xml`](../../temporal_parquet.xml)
+— **TemporalParquet**. Standardises the Parquet footer convention, the
+payload column (MEOS-WKB BYTE_ARRAY), and the spatial / temporal min-max
+statistics needed for predicate pushdown.
+
+### Layer 3 — function registry
+
+[`doc/specs/meos-api-0.1-draft.md`](../../specs/meos-api-0.1-draft.md) —
+**MEOS-API**. The cross-binding contract: every MobilityDB function name
++ signature + JSON-schema-validated argument set that PyMEOS, JMEOS,
+MobilityDuck, and MobilitySpark are expected to expose. The portable-SQL
+named-function dialect sources its function set from this registry.
+
+### Layer 4 — query dialect
+
+**Edge-to-Cloud portable SQL**. The named-function SQL profile (covered
+above in the *Portable query recipe* section) that runs unchanged on
+DuckDB, PostgreSQL, and Spark by binding to MEOS-API function names
+rather than dialect-specific operators.
+
+The four layers compose: a MobilityDuck `COPY trips TO '...' (FORMAT
+PARQUET)` writes MEOS-WKB-encoded rows under the TemporalParquet footer
+convention; a portable-SQL `SELECT eIntersects(region, trip_h3) FROM ...`
+binds via MEOS-API to the same kernel on whichever platform reads the
+shard.
+
+## Related — implementations and supporting docs
+
+- [doc/edge-to-cloud/](../edge-to-cloud/README.md) — portable SQL operator mapping
+- [MobilityDuck](https://github.com/MobilityDB/MobilityDuck) — DuckDB ingest/query engine
+- [MobilitySpark](https://github.com/MobilityDB/MobilitySpark) — Apache Spark analytics engine
+- [MEOS-API repo](https://github.com/MobilityDB/MEOS-API) — function-registry implementation (parsed from MEOS headers; consumed by all bindings)
+- AIS reference dataset: Danish Maritime Authority open data

--- a/doc/specs/_template.md
+++ b/doc/specs/_template.md
@@ -1,0 +1,53 @@
+<!--
+   ****************************************************************************
+    MobilityDB / MEOS Specification — <Title>
+    Copyright(c) MobilityDB Contributors
+
+    This documentation is licensed under a Creative Commons Attribution-Share
+    Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
+   ****************************************************************************
+-->
+
+# <Spec title> — Format Specification
+
+| | |
+|---|---|
+| Version | vX.Y.Z |
+| Scope | <one-line scope> |
+| Reference | <authoritative source files> |
+
+## 1. Scope and intent
+
+<What this document describes; descriptive vs. prescriptive; what's in scope.>
+
+## 2. Notation
+
+<Bytes-and-bits conventions used in the document.>
+
+## 3+. <Body sections>
+
+<Per-family or per-topic sections.>
+
+## N. Versioning and stability
+
+<Bump rules.>
+
+## N+1. Out of scope
+
+<What is deliberately not specified and why.>
+
+## N+2. References
+
+<Source files, sister specifications, prior art.>
+
+## N+3. Consumers
+
+<Who produces/consumes the format. Comparison points for new implementers.>
+
+## N+4. Outlook — integration scenarios
+
+<Classes of system this format suits beyond the current consumers. Frame by class, not by named project, so the spec ages cleanly.>
+
+## N+5. References to the implementation
+
+<Authoritative source note; how to file corrections.>

--- a/doc/specs/meos-api-0.1-draft.md
+++ b/doc/specs/meos-api-0.1-draft.md
@@ -1,0 +1,304 @@
+<!--
+   ****************************************************************************
+    MEOS-API Specification
+    Copyright(c) MobilityDB Contributors
+
+    This documentation is licensed under a Creative Commons Attribution-Share
+    Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
+   ****************************************************************************
+-->
+
+# MEOS-API — Machine-Readable Description of the MEOS C Library API
+
+| | |
+|---|---|
+| Version | v0.1.0 |
+| Scope | The public C API surface of the MEOS library (functions, structs, enums) as exposed by `meos.h` |
+| Reference | This document, paired with the JSON Schema at `schemas/meos-api-0.1-draft.json` and the reference generator at [`MobilityDB/MEOS-API`](https://github.com/MobilityDB/MEOS-API) |
+
+## 1. Scope and intent
+
+MEOS-API is a JSON catalog format describing the public C API of the MEOS library so that downstream language bindings (PyMEOS, JMEOS, meos-rs, GoMEOS, MEOS.NET, MEOS.js, …) can generate their wrapper code from a single shared description rather than each maintaining a hand-rolled mirror of `meos.h`.
+
+The specification is **descriptive of the MEOS C API**, not prescriptive of new behaviour. Any divergence between this document, the JSON Schema, and the reference generator's output is a defect to be reconciled — the C headers are the underlying truth.
+
+## 2. Notation
+
+| Term | Meaning |
+|---|---|
+| `meos-api.json` | An instance document describing one MEOS release. |
+| `cType` | A C type spelling exactly as it appears in the header (e.g. `TInstant **`). |
+| `canonical` | A normalised form of a `cType`, used by binding-generators that prefer a uniform type vocabulary (e.g. `[TInstant *]` for an array of pointers). For v0.1, `canonical` may equal `cType` — the field is reserved for future normalisation rules. |
+| `Doxygen block` | A C comment of the form `/** … */` immediately preceding a declaration; the source-of-truth for annotations (§5). |
+| GIR-style annotation | A parenthesised tag inside a Doxygen block, e.g. `(transfer full)`, `(nullable)`, `(array length=count)`. Vocabulary borrowed verbatim from [GObject Introspection](https://gi.readthedocs.io/en/latest/annotations/giannotations.html). |
+
+JSON examples in this document follow standard JSONC conventions (comments allowed for illustrative purposes only — actual `meos-api.json` files are strict JSON).
+
+## 3. Document shape
+
+A `meos-api.json` document is a JSON object with five top-level keys:
+
+```jsonc
+{
+  "version": "0.1.0-draft",
+  "meos_version": "1.4.0",
+  "generated_at": "2026-05-01T12:00:00Z",
+  "functions": [ /* …function entries… */ ],
+  "structs":   [ /* …struct entries…   */ ],
+  "enums":     [ /* …enum entries…     */ ]
+}
+```
+
+| Key | Type | Required | Meaning |
+|---|---|---|---|
+| `version` | string | yes | The schema version this document conforms to. For v0.1, the literal string `"0.1.0-draft"`. |
+| `meos_version` | string | yes | The version of the MEOS C library this document was generated from, in `MAJOR.MINOR.PATCH` form. |
+| `generated_at` | string | yes | ISO 8601 UTC timestamp; the moment the document was emitted. |
+| `functions` | array | yes | Public functions declared in `meos.h`. May be empty. |
+| `structs` | array | yes | Public struct types declared in `meos.h`. May be empty. |
+| `enums` | array | yes | Public enum types declared in `meos.h`. May be empty. |
+
+## 4. Function entries
+
+A function entry describes one public function. Required fields are marked `★`; optional fields are present only when meaningful.
+
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `name` ★ | string | yes | Function name as declared in the header. |
+| `file` ★ | string | yes | Header file in which the declaration appears, relative to the MEOS include root (`meos.h`, `meos_internal.h`, `meos_catalog.h`, …). |
+| `returnType` ★ | object | yes | `{ "c": "<cType>", "canonical": "<canonical>" }`. |
+| `params` ★ | array | yes | Ordered array of parameter entries. Empty array if the function takes no parameters (the C `(void)` declaration). |
+| `ownership` | string | optional | `"caller"`, `"callee"`, or `"none"`. From the `(transfer …)` annotation on the return type. See §5. |
+| `nullable` | boolean | optional | `true` if the return value may legitimately be `NULL`. From the `(nullable)` annotation on the return type. |
+| `doc` | string | optional | The free-form description from the Doxygen block, with annotation tags stripped. |
+
+Each parameter entry has the shape:
+
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `name` ★ | string | yes | Parameter name. |
+| `cType` ★ | string | yes | C type as declared. |
+| `canonical` ★ | string | yes | Canonical form (may equal `cType`). |
+| `direction` | string | optional | `"in"` (default), `"out"`, or `"inout"`. From `(out)` / `(inout)` annotations. |
+| `nullable` | boolean | optional | `true` if `NULL` is an accepted input. |
+| `array` | object | optional | Present if the parameter is an array. `{ "lengthFrom": "<param-name>" }` (length carried in another parameter) or `{ "zeroTerminated": true }`. From `(array length=…)` / `(array zero-terminated=1)`. |
+| `closure` | object | optional | Present if the parameter is a callback. `{ "userData": "<param-name>", "destroy": "<param-name>" }`. From `(scope …)` / `(closure …)` / `(destroy …)`. |
+| `doc` | string | optional | Per-parameter description. |
+
+Example:
+
+```jsonc
+{
+  "name": "tpointseq_make",
+  "file": "meos.h",
+  "returnType": { "c": "TSequence *", "canonical": "TSequence *" },
+  "params": [
+    {
+      "name": "instants",
+      "cType": "TInstant **",
+      "canonical": "TInstant **",
+      "array": { "lengthFrom": "count" }
+    },
+    { "name": "count", "cType": "int", "canonical": "int" }
+  ],
+  "ownership": "caller",
+  "nullable": true,
+  "doc": "Creates a temporal point sequence from an array of instants."
+}
+```
+
+## 5. Annotations and source-of-truth
+
+Annotations on functions, parameters, and return types live **in the C header as part of the Doxygen block**, never in a sidecar file. The reference generator parses the headers + annotations and emits `meos-api.json` as a derived artefact.
+
+```c
+/**
+ * tpointseq_make: (transfer full) (nullable)
+ * @instants: (array length=count): array of instants — caller retains ownership
+ * @count: number of instants; must be ≥ 1
+ *
+ * Creates a temporal point sequence from an array of instants.
+ */
+TSequence *tpointseq_make(TInstant **instants, int count);
+```
+
+The annotation vocabulary follows [GObject Introspection's annotations](https://gi.readthedocs.io/en/latest/annotations/giannotations.html) verbatim. Adopting the GIR vocabulary lets us inherit ~15 years of corner-case work — closures, destroy-notifiers, out-parameter sizing, zero-terminated arrays — instead of rediscovering them.
+
+The annotation tags MEOS-API consumes in v0.1:
+
+| GIR annotation | Maps to JSON field | Notes |
+|---|---|---|
+| `(transfer full\|none\|container)` | `ownership` | `full` → `"caller"`, `none` → `"callee"`, `container` → currently mapped as `"caller"` with a future-extension note. |
+| `(nullable)` | `nullable: true` | Applied to either the return type or to a parameter. |
+| `(array length=name)` | `array.lengthFrom: name` | Length comes from another parameter of the same function. |
+| `(array zero-terminated=1)` | `array.zeroTerminated: true` | NULL-terminated array. |
+| `(out)`, `(inout)` | `direction` | Defaults to `"in"` if absent. |
+| `(scope async\|notified\|call)` | `closure.scope` | Reserved annotation for callback-lifetime scope. |
+| `(closure name)` | `closure.userData` | The parameter that carries the callback's user-data pointer. |
+| `(destroy name)` | `closure.destroy` | The parameter that carries the callback's destroy-notify function. |
+
+**Why header-resident, not sidecar:** sidecar metadata files drift the moment a header is changed without the corresponding sidecar update. Header-resident annotations are caught by ordinary PR review on any signature change, since the reviewer is already looking at the same file. GIR's project history documents the sidecar→header migration explicitly; we adopt the lesson without paying the cost.
+
+The reference generator includes a CI check that fails if any public function in `meos.h` is missing required annotations (see §11).
+
+## 6. Struct entries
+
+A struct entry describes one public struct.
+
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `name` ★ | string | yes | Struct tag/typedef name. |
+| `file` ★ | string | yes | Header file. |
+| `fields` ★ | array | yes | Ordered field list. May be empty for opaque types (see §8). |
+| `opaque` | boolean | optional | `true` if the struct is forward-declared in the public header but has no field list (clients use it only via opaque pointer). |
+| `doc` | string | optional | Free-form description. |
+
+Each field entry has the shape:
+
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `name` ★ | string | yes | Field name. |
+| `cType` ★ | string | yes | C type as declared. |
+| `nullable` | boolean | optional | `true` if the field may legitimately be `NULL`. |
+| `doc` | string | optional | Per-field description. |
+
+Example:
+
+```jsonc
+{
+  "name": "TInstant",
+  "file": "temporal.h",
+  "fields": [
+    { "name": "subtype",  "cType": "uint8" },
+    { "name": "flags",    "cType": "uint16" },
+    { "name": "temptype", "cType": "uint8" },
+    { "name": "value",    "cType": "Datum" },
+    { "name": "t",        "cType": "TimestampTz" }
+  ],
+  "doc": "An instant value of a temporal type."
+}
+```
+
+## 7. Enum entries
+
+An enum entry describes one public C enum.
+
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `name` ★ | string | yes | Enum tag/typedef name. |
+| `file` ★ | string | yes | Header file. |
+| `values` ★ | array | yes | Ordered list of named values. |
+| `doc` | string | optional | Free-form description. |
+
+Each value entry: `{ "name": "<NAME>", "value": <integer>, "doc": "<optional>" }`.
+
+Example:
+
+```jsonc
+{
+  "name": "interpType",
+  "file": "temporal.h",
+  "values": [
+    { "name": "INTERP_NONE", "value": 0 },
+    { "name": "DISCRETE",    "value": 1 },
+    { "name": "STEP",        "value": 2 },
+    { "name": "LINEAR",      "value": 3 }
+  ],
+  "doc": "Interpolation type for a temporal sequence."
+}
+```
+
+## 8. Opaque types
+
+C structs declared in the public header without a field list (`typedef struct Foo Foo;`) are exposed in `meos-api.json` with `opaque: true` and an empty `fields` array. Bindings are expected to wrap them as opaque handles; clients of the binding manipulate them only by passing them back to MEOS functions.
+
+```jsonc
+{
+  "name": "Temporal",
+  "file": "temporal.h",
+  "opaque": true,
+  "fields": [],
+  "doc": "Generic opaque handle for any temporal value."
+}
+```
+
+## 9. Public vs. internal split
+
+MEOS exposes two header tiers:
+
+- **Public** — `meos.h` and the headers it transitively includes, intended for external bindings and end-user C consumers.
+- **Internal** — `meos_internal.h` and similar, intended for MobilityDB's own use of MEOS.
+
+A `meos-api.json` document records **public symbols only**. The `file` field on each entry records the originating header so consumers can verify the public-only invariant. Internal symbols (§9) are not part of the schema.
+
+## 10. Versioning and stability
+
+The schema follows `MAJOR.MINOR.PATCH`, distinct from the MEOS C-library version (which is carried in the `meos_version` field of every instance document). A binding consuming the catalog pins to an exact schema version and regenerates when it upgrades to a different shape. The reference generator at `MobilityDB/MEOS-API` tracks the schema version.
+
+Schema changes follow `MAJOR.MINOR.PATCH` discipline:
+
+| Bump | Triggers |
+|---|---|
+| **Patch** | Editorial clarifications. Bindings already generated against patch-N stay valid against patch-N+k. |
+| **Minor** | Additive schema changes — new optional fields on existing entries, new entry types. Bindings that ignore unknown fields stay forward-compatible. |
+| **Major** | Breaking schema changes. Bindings must explicitly upgrade. |
+
+Compatibility constraints follow the model of [Protobuf's update rules](https://protobuf.dev/programming-guides/proto3/#updating).
+
+The schema expresses the full public surface, including function-pointer typedefs as struct fields and parameter types, opaque pointer types (§8), conditional compilation guards (`CBUFFER`, `NPOINT`, `POSE`, `RGEO` — see [`MobilityDB/CMakeLists.txt`](https://github.com/MobilityDB/MobilityDB/blob/master/CMakeLists.txt)), the public-vs-internal split (§9), and `va_list` / varargs callbacks. GIR annotation coverage uses the GIR vocabulary; any MEOS construct not expressible in GIR's terms is documented with its alternative annotation in this spec.
+
+## 11. Validation tooling
+
+Two artefacts ship alongside this document:
+
+- `schemas/meos-api-0.1-draft.json` — a JSON Schema document describing the shape of a `meos-api.json` instance. Consumers can validate received documents with any standard JSON-Schema tool (`ajv`, `python-jsonschema`, etc.).
+- A round-trip CI lane in [`MobilityDB/MEOS-API`](https://github.com/MobilityDB/MEOS-API): generate from a snapshot of MEOS, validate against the JSON Schema, and assert that a real-binding consumer (PyMEOS-CFFI) regenerates successfully.
+
+The reference generator additionally enforces an **annotation-coverage gate**: any public function in `meos.h` that lacks a return-type ownership annotation is reported as a CI failure. This is the primary mechanism by which annotations stay in sync with header changes.
+
+## 12. Out of scope
+
+- **Internal symbols** (`meos_internal.h`) — see §9.
+- **Optional subsystems** behind `#ifdef` (cbuffer, npoint, pose, rgeo) — the schema expresses conditional availability so that a binding consuming a `meos-api.json` generated with `-DCBUFFER=ON` declares conditional compatibility.
+- **Function-pointer typedefs** as standalone catalog entries — they appear inline in `cType` fields; lifting them to top-level entries depends on binding-generator needs.
+- **Variadic functions** and `va_list` parameters — MEOS uses these sparingly.
+- **C macros** that bindings mirror as constants (boundary values, default flags) — bindings re-derive these from the headers.
+
+## 13. References
+
+- [`MobilityDB/MEOS-API`](https://github.com/MobilityDB/MEOS-API) — reference implementation (libclang-based generator).
+- [GObject Introspection annotations](https://gi.readthedocs.io/en/latest/annotations/giannotations.html) — the annotation vocabulary adopted verbatim.
+- [`g-ir-scanner`](https://gi.readthedocs.io/en/latest/tools/g-ir-scanner.html) — reference parser for header-resident GIR annotations; instructive even though our generator uses libclang directly.
+- [GIR format spec](https://gi.readthedocs.io/en/latest/gir-1.2.rnc.html) — XML schema GIR's `.gir` files conform to; useful for cross-checking that our JSON shape covers the same conceptual space.
+- [WIT format](https://component-model.bytecodealliance.org/design/wit.html) — modern IDL design reference whose ownership types and resource-type vocabulary inform §5.
+- [`bindgen`](https://rust-lang.github.io/rust-bindgen/) — what [meos-rs](https://github.com/MobilityDB/meos-rs) currently uses; instructive for what a catalog-consuming generator still needs to hand-customise per binding.
+- [Protobuf update rules](https://protobuf.dev/programming-guides/proto3/#updating) — the model for the schema's mechanical compatibility constraints.
+- [MEOS-WKB byte-format specification](./meos-wkb-0.9.md) — the sister specification covering MEOS's binary serialisation format.
+
+## 14. Consumers
+
+The primary consumers of `meos-api.json` are language bindings that produce wrapper code over MEOS:
+
+| Binding | Binding mechanism |
+|---|---|
+| [PyMEOS](https://github.com/MobilityDB/PyMEOS) / [PyMEOS-CFFI](https://github.com/MobilityDB/PyMEOS-CFFI) | CFFI |
+| [JMEOS](https://github.com/MobilityDB/JMEOS) | JNR-FFI |
+| [meos-rs](https://github.com/MobilityDB/meos-rs) | `bindgen` + MEOS-specific patches |
+| [GoMEOS](https://github.com/MobilityDB/GoMEOS) | CGO |
+| [MEOS.NET](https://github.com/MobilityDB/MEOS.NET) | P/Invoke |
+| [MEOS.js](https://github.com/MobilityDB/MEOS.js) | emscripten / embind |
+
+## 15. Outlook — integration scenarios
+
+Beyond the bindings ecosystem, a stable machine-readable API description suits several classes of system:
+
+- **Documentation generators** that need richer type information than what a Doxygen build extracts (e.g. ownership-aware cross-references between functions and the structs they return).
+- **Static analysis / migration tooling** for users upgrading across MEOS major releases — diff two `meos-api.json` snapshots to enumerate breaking changes.
+- **Composition frameworks** (e.g. WebAssembly Component Model bindings, GraalVM native-image, Roc) that need a normalised description of foreign-language interfaces.
+- **API-stability badges** and CI gates: a project depending on MEOS can pin to a specific `meos-api.json` snapshot and fail the build if a new MEOS release breaks against it.
+
+These integrations are framed by class, not by named project, deliberately — the spec is intended to outlive any one consumer.
+
+## 16. Coordinated artefacts
+
+The spec, the JSON Schema (`schemas/meos-api-0.1-draft.json`), and the reference generator at `MobilityDB/MEOS-API` form a coordinated triple — a change to any one carries a corresponding update to the others.

--- a/doc/specs/meos-wkb-0.9.md
+++ b/doc/specs/meos-wkb-0.9.md
@@ -1,0 +1,475 @@
+<!--
+   ****************************************************************************
+    MEOS-WKB Specification
+    Copyright(c) MobilityDB Contributors
+
+    This documentation is licensed under a Creative Commons Attribution-Share
+    Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
+   ****************************************************************************
+-->
+
+# MEOS Well-Known Binary (MEOS-WKB) — Format Specification
+
+| | |
+|---|---|
+| Version | v0.9.0 |
+| Scope | Temporal types and supporting data types defined in `meos/src/temporal/` and `meos/src/geo/` |
+| Reference | `meos/src/temporal/type_out.c` (writer) and `meos/src/temporal/type_in.c` (reader) define the authoritative byte output |
+
+## 1. Scope and intent
+
+MEOS-WKB is the binary serialisation format that the MEOS C library uses to encode temporal and supporting values for storage and inter-process exchange. This document specifies that format as an independent reference.
+
+The specification is **descriptive of the MEOS C library's byte output**, not prescriptive of new behaviour. Any divergence between this document and the library's actual byte output is a defect in this document; the implementation is authoritative.
+
+The format covers the temporal scalar types (including `tbigint`), the span / span-set and set families, the temporal boxes `tbox` / `stbox` / `tpcbox`, the spatial-temporal types (`tgeompoint`, `tgeogpoint`, `tgeometry`, `tgeography`), and the optional spatial subsystems `tcbuffer`, `tnpoint`, `tpose`, `trgeometry`, `th3index`, and the temporal point-cloud types `tpcpoint` / `tpcpatch`.
+
+## 2. Notation
+
+| Term | Meaning |
+|---|---|
+| `byte` | Unsigned 8-bit integer. |
+| `int16` | Signed 16-bit integer; endianness as declared by the leading endian byte. |
+| `int32` | Signed 32-bit integer; endianness as declared. |
+| `int64` | Signed 64-bit integer; endianness as declared. |
+| `double` | IEEE 754 binary64 (8 bytes); endianness as declared. |
+| `date` | `int32` representing days since the PostgreSQL date epoch (`2000-01-01`). |
+| `timestamp` | `int64` representing microseconds since `2000-01-01 00:00:00 UTC`. |
+| `text` | `int8`-prefixed byte string. The prefix is the byte-length of the UTF-8 payload (8 bytes), then the payload, then a single `\0` terminator byte. |
+
+Endianness is declared per encoded value by a leading byte: `0x00` = big-endian (XDR), `0x01` = little-endian (NDR). Readers MUST honour the declared endianness for all multi-byte integer and floating-point fields in the value.
+
+This document presents hex examples in **little-endian** form, which is the predominant form in practice.
+
+## 3. Type catalog
+
+Each top-level encoded value carries a 16-bit type tag drawn from MEOS's internal type enumeration. The tag values for the v0.9 scope are:
+
+| Type tag (decimal) | Hex (little-endian on the wire) | MEOS name | Family |
+|---|---|---|---|
+| 12 | `0C 00` | `floatset` | Set |
+| 13 | `0D 00` | `floatspan` | Span |
+| 14 | `0E 00` | `floatspanset` | Span set |
+| 18 | `12 00` | `intset` | Set |
+| 19 | `13 00` | `intspan` | Span |
+| 20 | `14 00` | `intspanset` | Span set |
+| 25 | — *(see §6.5)* | `stbox` | Box |
+| 26 | `1A 00` | `tbool` | Temporal scalar |
+| 27 | — *(see §6.5)* | `tbox` | Box |
+| 33 | `21 00` | `tfloat` | Temporal scalar |
+| 35 | `23 00` | `tint` | Temporal scalar |
+| 39 | `27 00` | `tstzspan` | Span (time) |
+| 40 | `28 00` | `tstzspanset` | Span set (time) |
+| 41 | `29 00` | `ttext` | Temporal scalar |
+| 46 | `2E 00` | `tgeompoint` | Temporal spatial |
+| 47 | `2F 00` | `tgeogpoint` | Temporal spatial |
+| 51 | `33 00` | `tnpoint` | Temporal spatial (network) |
+| 56 | `38 00` | `tpose` | Temporal spatial (pose) |
+| 59 | `3B 00` | `tcbuffer` | Temporal spatial (circular buffer) |
+| 60 | `3C 00` | `tgeometry` | Temporal spatial |
+| 61 | `3D 00` | `tgeography` | Temporal spatial |
+| 62 | `3E 00` | `trgeometry` | Temporal spatial (rigid geometry) |
+| 63 | `3F 00` | `tbigint` | Temporal scalar |
+| 64 | `40 00` | `h3index` | Set base (H3 cell) |
+| 65 | `41 00` | `h3indexset` | Set |
+| 66 | `42 00` | `th3index` | Temporal spatial (H3 cell) |
+| 67 | `43 00` | `pcpoint` | Set base (point cloud) |
+| 68 | `44 00` | `pcpointset` | Set |
+| 69 | `45 00` | `tpcpoint` | Temporal point cloud |
+| 70 | `46 00` | `pcpatch` | Set base (point cloud patch) |
+| 71 | `47 00` | `pcpatchset` | Set |
+| 72 | `48 00` | `tpcpatch` | Temporal point cloud |
+| 73 | — *(see §6.5)* | `tpcbox` | Box |
+
+Set tags `intset` / `floatset` / `dateset` / `tstzset` / `textset` / `geomset` / `geogset` and span / spanset tags for date / timestamptz / bigint families follow the same pattern; consult `meos/include/temporal/meos_catalog.h` for the full enumeration.
+
+## 4. Common building blocks
+
+### 4.1 Endian byte
+
+```
+byte 0:    endian   (0x00 = big-endian, 0x01 = little-endian)
+```
+
+Every top-level encoded value begins with an endian byte. All multi-byte fields that follow are encoded in the declared endianness.
+
+### 4.2 Type tag (`int16`)
+
+```
+bytes 1-2: type     (int16, in declared endianness)
+```
+
+Set, span, span-set, and temporal values immediately follow the endian byte with their type tag from §3. **Box values (`tbox`, `stbox`) omit the type tag** — see §6.5.
+
+### 4.3 Flag byte
+
+The byte immediately following the type tag carries the *variation flags*. The flag-bit layout differs per family; see the per-family sections (§6).
+
+### 4.4 SRID
+
+For spatial-temporal values, spatial sets, and spatiotemporal boxes that carry a non-default SRID, the SRID is written as an `int32` immediately after the flag byte (or after the flag byte's natural successor for boxes). The presence of an SRID is signalled by bit 6 of the flag byte (the `MEOS_WKB_SRIDFLAG`).
+
+### 4.5 Bounds byte
+
+For span values (and for sequences of temporal values), a *bounds byte* encodes whether the lower and upper bounds of the interval are inclusive:
+
+```
+bit 0: L = lower-inclusive
+bit 1: U = upper-inclusive
+bits 2-7: unused (must be 0)
+```
+
+| Hex | Lower-inc | Upper-inc | Notation |
+|---|---|---|---|
+| `0x00` | no | no | `(lower, upper)` |
+| `0x01` | yes | no | `[lower, upper)` |
+| `0x02` | no | yes | `(lower, upper]` |
+| `0x03` | yes | yes | `[lower, upper]` |
+
+### 4.6 Base-value encoding
+
+A scalar base value's encoding depends only on its base type. The encodings are:
+
+| Base type | Wire format |
+|---|---|
+| `bool` | 1 byte: `0x00` = false, `0x01` = true |
+| `int4` | `int32` |
+| `int8` (`bigint`) | `int64` |
+| `float8` | `double` |
+| `date` | `date` (`int32`) |
+| `timestamptz` | `timestamp` (`int64`) |
+| `text` | `int64` payload-byte-length, then payload bytes, then `\0` terminator |
+| `geometry` / `geography` | PostGIS WKB payload, embedded inline (see §5) |
+
+These encodings are the building blocks used everywhere a "base value" appears in the higher-level layouts of §6.
+
+## 5. Spatial value embedding
+
+When a base-value field is a `geometry` or `geography`, MEOS-WKB embeds the spatial value in PostGIS Extended-WKB form (EWKB). The embedded form preserves the SRID alongside the geometry's coordinates and dimensions. MEOS does not re-encode the spatial value; the EWKB bytes from PostGIS travel through unchanged.
+
+For temporal types whose base type is a *point* (`tgeompoint`, `tgeogpoint`), each per-instant value is a single embedded EWKB POINT.
+
+For temporal types whose base type is an arbitrary geometry (`tgeometry`, `tgeography`), each per-instant value is an embedded EWKB of whatever geometry kind the instant carries (LINESTRING, POLYGON, MULTI*, GEOMETRYCOLLECTION).
+
+## 6. Per-family layouts
+
+### 6.1 Sets (e.g. `intset`, `floatset`, `geomset`)
+
+```
+endian (1 byte)
+type   (int16)
+flags  (1 byte)         bit 0: O (ordered, always 1 in v0.9)
+                        bit 4: Z       (spatial sets only)
+                        bit 5: G       (geodetic; geog set only)
+                        bit 6: SRID    (spatial sets only)
+[ srid (int32) ]        present if bit 6 of flags is set
+count  (int32)          number of values that follow
+values (count × base)   per-value encoding from §4.6 / §5
+```
+
+#### Example — `intset '{1, 3, 5}'`
+
+```
+01 12 00 01 03 00 00 00 01 00 00 00 03 00 00 00 05 00 00 00
+│  │     │  │           │           │           │
+│  │     │  │           value 1     value 3     value 5
+│  │     │  count = 3
+│  │     flags = 0x01 (ordered)
+│  type = 0x0012 (intset)
+endian = 0x01 (little)
+```
+
+### 6.2 Spans (e.g. `intspan`, `floatspan`, `tstzspan`)
+
+```
+endian (1 byte)
+type   (int16)
+bounds (1 byte)         §4.5
+lower  (base)           per-base-type encoding
+upper  (base)
+```
+
+#### Example — `intspan '[5, 10)'`
+
+```
+01 13 00 01 05 00 00 00 0A 00 00 00
+│  │     │  │           │
+│  │     │  │           upper = 10
+│  │     │  lower = 5
+│  │     bounds = 0x01 (lower-inclusive)
+│  type = 0x0013 (intspan)
+endian = little
+```
+
+#### Example — `tstzspan '[2026-01-01, 2026-01-02)'`
+
+```
+01 27 00 01 00 BC 54 34 46 EA 02 00 00 1C 2C 52 5A EA 02 00
+│  │     │  │                       │
+│  │     │  lower = 2026-01-01      upper = 2026-01-02
+│  │     bounds = 0x01
+│  type = 0x0027 (tstzspan)
+endian = little
+```
+
+### 6.3 Span sets (e.g. `intspanset`)
+
+A span set is an ordered set of disjoint spans. The component spans omit their endian byte (the parent's endian declaration applies); they keep their own bounds byte and lower/upper values:
+
+```
+endian (1 byte)
+type   (int16)         span-set type tag
+count  (int32)         number of component spans
+spans  (count of:)
+  bounds (1 byte)
+  lower  (base)
+  upper  (base)
+```
+
+Note: in v0.9 the component spans inside a span set do **not** carry their own type tag — the parent's `intspanset` tag implies `intspan` components, etc.
+
+#### Example — `intspanset '{[1, 3), [5, 7)}'`
+
+```
+01 14 00 02 00 00 00 01 01 00 00 00 03 00 00 00 01 05 00 00 00 07 00 00 00
+│  │     │           │  │           │           │  │           │
+│  │     │           │  │           upper=3     │  │           upper=7
+│  │     │           │  lower=1                 │  lower=5
+│  │     │           bounds=0x01                bounds=0x01
+│  │     count = 2
+│  type = 0x0014 (intspanset)
+endian = little
+```
+
+### 6.4 Temporal types (Instant, Sequence, Sequence Set)
+
+Every temporal value follows the same opening:
+
+```
+endian (1 byte)
+type   (int16)         temporal type tag
+flags  (1 byte)
+[ srid (int32) ]       spatial-temporal types only, if SRID flag set
+```
+
+The flag byte for a temporal value is:
+
+```
+bits 0-1: TT  subtype  (0b01=Instant, 0b10=Sequence, 0b11=SequenceSet)
+bits 2-3: II  interpolation  (0=none, 1=Discrete, 2=Step, 3=Linear)
+bit 4:    Z   has Z         (spatial-temporal only)
+bit 5:    G   geodetic      (spatial-temporal only)
+bit 6:    S   SRID flag     (spatial-temporal only)
+bit 7:    unused
+```
+
+The body that follows depends on the subtype.
+
+#### 6.4.1 Instant subtype
+
+```
+[ opening as above ]
+value     (base)
+timestamp (timestamp)
+```
+
+##### Example — `tint '5@2026-01-01'`
+
+```
+01 23 00 01 05 00 00 00 00 BC 54 34 46 EA 02 00
+│  │     │  │           │
+│  │     │  │           timestamp = 2026-01-01 UTC
+│  │     │  value = 5
+│  │     flags = 0x01 (subtype=Instant, interp=none, no spatial)
+│  type = 0x0023 (tint)
+endian = little
+```
+
+##### Example — `tgeompoint 'SRID=4326;Point(1 2)@2026-01-01'`
+
+```
+01 2E 00 41 E6 10 00 00 │ 01 01 00 00 20 E6 10 00 00 …point body… │ 00 BC 54 34 46 EA 02 00
+│  │     │  │            │                                          │
+│  │     │  srid=4326    embedded EWKB POINT (with SRID=4326,        timestamp
+│  │     flags = 0x41    little-endian, no Z)
+│  │     (subtype=Instant, SRID flag set)
+│  type = 0x002E (tgeompoint)
+endian = little
+```
+
+#### 6.4.2 Sequence subtype
+
+```
+[ opening as above ]
+count   (int32)            number of instants in the sequence
+bounds  (1 byte)           §4.5 — applies to the sequence's time interval
+instants (count of:)
+  value     (base)
+  timestamp (timestamp)
+```
+
+##### Example — `tfloat '[1.5@2026-01-01, 2.5@2026-01-02]'` (linear interp by default)
+
+```
+01 21 00 0E │ 02 00 00 00 │ 03 │
+│  │     │  │              │
+│  │     │  count=2        bounds=0x03 (both inclusive)
+│  │     flags = 0x0E (subtype=Sequence, interp=Linear)
+│  type = 0x0021 (tfloat)
+endian = little
+
+…then 2 (value, timestamp) tuples:
+00 00 00 00 00 00 F8 3F  00 BC 54 34 46 EA 02 00   (value=1.5, ts=2026-01-01)
+00 00 00 00 00 00 04 40  00 1C 2C 52 5A EA 02 00   (value=2.5, ts=2026-01-02)
+```
+
+##### Example — `tfloat 'Interp=Step;[1.5@…, 2.5@…]'` (step interp)
+
+Identical to the above with **flag byte = `0x0A`** (subtype=Sequence, interp=Step).
+
+#### 6.4.3 Sequence set subtype
+
+A sequence set is an ordered collection of sequences sharing the same temporal type, interpolation, SRID, etc. The opening (endian / type / flags / SRID) is written once for the whole sequence set; the component sequences omit their endian / type / flags / SRID and contain only their `count`, `bounds`, and per-instant body.
+
+```
+endian (1 byte)
+type   (int16)
+flags  (1 byte)
+[ srid (int32) ]
+count  (int32)              number of sequences
+sequences (count of:)
+  count   (int32)           instants in this sequence
+  bounds  (1 byte)
+  instants (count of:)
+    value     (base)
+    timestamp (timestamp)
+```
+
+##### Example — `tfloat '{[1.5@2026-01-01, 2.5@2026-01-02], [3.5@2026-01-03, 4.5@2026-01-04]}'`
+
+```
+01 21 00 0F │ 02 00 00 00 │ … two sequence bodies …
+│  │     │  │
+│  │     │  count = 2 sequences
+│  │     flags = 0x0F (subtype=SequenceSet=3, interp=Linear=3)
+│  type = 0x0021 (tfloat)
+endian = little
+```
+
+The two sequence bodies are each `count(int32) bounds(byte) instant₁ instant₂` and are concatenated.
+
+### 6.5 Boxes — `tbox`, `stbox`
+
+**Box values do not carry a 16-bit type tag.** The discriminator between `tbox` and `stbox` is the `tbox` / `stbox` SQL type the value already lives inside; the byte stream itself starts with the endian byte and goes directly to the flag byte.
+
+#### `tbox`
+
+```
+endian (1 byte)
+flags  (1 byte)         bit 0: X (value dimension present)
+                        bit 1: T (time dimension present)
+                        all other bits: unused / reserved
+[ tstzspan ]            present if bit T is set; encoded as a span body:
+                        type(int16) + bounds(byte) + lower(int64) + upper(int64)
+[ valuespan ]           present if bit X is set; encoded as a span body:
+                        type(int16) + bounds(byte) + lower(base) + upper(base)
+                        — type tag is intspan / floatspan as appropriate
+```
+
+##### Example — `tbox 'TBOXFLOAT XT([1.0, 5.0], [2026-01-01, 2026-01-02])'`
+
+```
+01 03 │ 27 00 03 00 BC 54 34 46 EA 02 00 00 1C 2C 52 5A EA 02 00 │ 0D 00 03 00 00 00 00 00 00 F0 3F 00 00 00 00 00 00 14 40
+│  │  │                                                          │
+│  │  embedded tstzspan: type=0x27, bounds=0x03, lower, upper    embedded floatspan: type=0x0D, bounds=0x03, 1.0, 5.0
+│  flags = 0x03 (X + T)
+endian = little
+```
+
+#### `stbox`
+
+```
+endian (1 byte)
+flags  (1 byte)         bit 0: X     (spatial dimension present)
+                        bit 1: T     (time dimension present)
+                        bit 4: Z     (3D spatial extent)
+                        bit 5: G     (geodetic)
+                        bit 6: SRID  (carries an SRID)
+[ srid (int32) ]        present if SRID flag set
+[ tstzspan ]            present if bit T is set; same span-body form as tbox
+[ doubles ]             present if bit X is set:
+                        xmin, xmax, ymin, ymax  (4 × double)
+                        + zmin, zmax            (2 × double, if Z set)
+```
+
+##### Example — `stbox 'SRID=4326;STBOX XT(((0,0),(10,10)), [2026-01-01, 2026-01-02])'`
+
+```
+01 43 │ E6 10 00 00 │ 27 00 03 00 BC 54 34 46 EA 02 00 00 1C 2C 52 5A EA 02 00 │ …4 doubles…
+│  │  │              │                                                          │
+│  │  srid=4326      embedded tstzspan                                          xmin=0, xmax=10, ymin=0, ymax=10
+│  flags = 0x43 (X + T + SRID)
+endian = little
+```
+
+## 7. Versioning and stability
+
+This document uses semantic versioning:
+
+| Bump | Triggers |
+|---|---|
+| **Patch** (`0.9.x` → `0.9.y`) | Editorial clarifications. No byte-layout changes. |
+| **Minor** (`0.9.x` → `0.10.0`, eventually `1.1.0`) | Additive changes only — new type tags, new optional flag bits, new optional fields. Producers MAY emit them; readers of the new minor MUST tolerate the absence of new optional fields (i.e. consumers of `0.9` continue to work against producers of `0.10` for any value that doesn't use new features). |
+| **Major** (`0.x` → `1.0`, `1.x` → `2.0`) | Layout changes that older readers cannot accept. |
+
+The MEOS implementation is the authoritative reference: conflicts between this document and implementation behaviour are resolved in favour of the implementation. The byte format is emitted by the MEOS C library and consumed by every binding (PyMEOS, JMEOS, meos-rs, GoMEOS, MEOS.NET, MEOS.js, MobilityDB, MobilityDuck) for wire-level interchange.
+
+## 8. Out of scope
+
+- Higher-level container formats that *embed* MEOS-WKB blobs (for example the TemporalParquet footer convention). Those are separate specifications layered over this one.
+- Encoding negotiation and version-tag wrapping. MEOS-WKB values do not carry a self-declared format version on the wire; consumers know the version from out-of-band context (the MEOS library version they link against, or a higher-level container's declared `encoding_version` field).
+
+## 9. References
+
+- `meos/include/temporal/temporal.h` — flag-bit definitions, integer-size constants, subtype enumeration.
+- `meos/include/temporal/meos_catalog.h` — type-tag enumeration.
+- `meos/src/temporal/type_out.c` — reference encoder.
+- `meos/src/temporal/type_in.c` — reference decoder.
+- `meos/include/meos.h` — public API entry-points: `temporal_as_wkb`, `temporal_from_wkb`, and analogous functions per family.
+- PostGIS Extended Well-Known Binary (EWKB) — used unmodified for the embedded spatial values referenced in §5. See PostGIS source `liblwgeom/lwout_wkb.c`.
+- ISO 19141:2008 — *Geographic information — Schema for moving features*. Conceptual model that MEOS extends.
+- OGC 19-045r3 — *Moving Features JSON*. Sister encoding to MEOS-WKB; values round-trip cleanly between the two.
+
+## 10. Consumers
+
+The following components produce or consume MEOS-WKB at the byte level. Each is a useful comparison point for an implementer verifying conformance:
+
+| Consumer | Role | Repository |
+|---|---|---|
+| MEOS C library | Reference encoder and decoder. | https://github.com/MobilityDB/MobilityDB (under `meos/`) |
+| MobilityDB | PostgreSQL extension built on MEOS; uses MEOS-WKB as the on-the-wire representation of temporal values exchanged with clients. | https://github.com/MobilityDB/MobilityDB |
+| MobilityDuck | DuckDB extension built on MEOS; uses MEOS-WKB for inter-process exchange and as the payload form embedded in TemporalParquet. | https://github.com/MobilityDB/MobilityDuck |
+| PyMEOS | Python binding (CFFI). | https://github.com/MobilityDB/PyMEOS |
+| JMEOS | Java / JVM binding (JNR-FFI). | https://github.com/MobilityDB/JMEOS |
+| meos-rs | Rust binding. | https://github.com/MobilityDB/meos-rs |
+| GoMEOS | Go binding (CGO). | https://github.com/MobilityDB/GoMEOS |
+| MEOS.NET | .NET binding (P/Invoke). | https://github.com/MobilityDB/MEOS.NET |
+| MEOS.js | JavaScript / WebAssembly binding. | https://github.com/MobilityDB/MEOS.js |
+
+A new implementation can validate against any of the above by encoding the same value and comparing bytes. The MEOS C reference is authoritative when implementations diverge.
+
+## 11. Outlook — integration scenarios
+
+MEOS-WKB is the canonical binary form for MEOS temporal values. Beyond the consumers in §10, the format is suited to a range of system contexts where temporal values need to travel between processes:
+
+- **Relational databases** with user-defined-type extensibility — PostgreSQL via MobilityDB; in principle, other RDBMSes with similar UDT mechanisms.
+- **Columnar query engines** treating MEOS values as opaque BLOBs with a metadata footer convention — DuckDB via MobilityDuck; the TemporalParquet convention standardises the Parquet footer for this case.
+- **Streaming and event-flow engines** — carrying MEOS values as serialised payloads on a stream, with the format's self-contained framing (per-value endian byte + type tag) making per-message decoding straightforward.
+- **Graph databases** — representing trajectories as edges with MEOS-encoded temporal attributes.
+- **Time-series engines** — embedding temporal-of-temporal values where a per-row time-series of values benefits from MEOS's geometry- and span-aware encodings.
+
+The format itself does not encode any database-specific details; it is designed to be embedded uniformly across these contexts. Each integration scenario carries its own wrapping convention (such as TemporalParquet) describing how MEOS-WKB blobs travel over that transport, without re-specifying the byte layout.
+
+## 12. References to the implementation
+
+The MEOS reference implementation is authoritative for the byte layout specified here. The TemporalParquet convention references this document for the byte layout it carries in the Parquet payload column.

--- a/doc/temporal-parquet/README.md
+++ b/doc/temporal-parquet/README.md
@@ -1,0 +1,191 @@
+<!--
+Copyright(c) MobilityDB Contributors
+
+This documentation is licensed under a
+Creative Commons Attribution-Share Alike 3.0 License
+https://creativecommons.org/licenses/by-sa/3.0/
+-->
+
+# RFC: TemporalParquet — a Parquet footer convention for MobilityDB temporal types
+
+TemporalParquet is the Parquet footer-metadata convention that makes MobilityDB
+temporal columns self-describing and portable across the ecosystem. The convention
+is documented here and in the DocBook chapter (`doc/temporal_parquet.xml`, wired as
+an appendix of the manual). MobilityDuck provides the reference implementation: the
+Python annotation tool, the round-trip regression test, the `asBinary()` /
+`*FromBinary()` and `temporalFooter()` functions, the geodetic `TGEOGPOINT` type
+with the full set of `(GEOMETRY, temporal)` spatial predicates, the zero-data and
+generic-CSV quickstarts, the PostgreSQL companion quickstart, and the end-to-end
+AIS data-lake demo. The `th3index` cross-platform port carries the same BerlinMOD
+prefilter SQL unchanged on MobilityDB, MobilityDuck, and MobilitySpark (see
+[Worked example: `th3index`](#worked-example-th3index)).
+
+## The Problem
+
+MobilityDB has two well-tested binary-interchange surfaces for its temporal types:
+
+| Surface | Where it lives | What it produces |
+|---|---|---|
+| EWKB / MEOS-WKB | `temporal_as_wkb` / `temporal_from_wkb` | A length-prefixed self-describing binary blob carrying subtype, interpolation, base-type tag, instants array, geometry payload |
+| MF-JSON | `*_as_mfjson` / `*_from_mfjson` (OGC Moving Features JSON) | A verbose self-describing JSON document |
+
+Neither is a "Parquet ingest format". Exporting a MobilityDB table to Parquet today means either dropping every temporal column to text via MF-JSON (verbose, ~3–10× larger, no spatial-tooling hooks) or to opaque hex via `asHexEWKB` (compact but unparseable by anything except MobilityDB / MEOS). There is no Parquet convention that lets `tgeompoint`, `tint`, `tfloat`, and friends survive an export→import round-trip with structure intact.
+
+## Motivation
+
+Three forces make a Parquet convention the natural interchange story:
+
+1. **MobilityDuck** makes Parquet a natural interchange concern. DuckDB's primary on-disk format is Parquet; MobilityDuck users round-trip temporal values without losing structure.
+2. **The binding ecosystem** (PyMEOS / JMEOS / meos-rs / MobilityPandas / MEOS.NET) all share the same interchange story — one format on the C-library side gives meaningful leverage across all of them.
+3. **GeoParquet 1.x** is the established standard for spatial-Parquet interchange and is **architecturally identical** to what MobilityDB needs: a `BYTE_ARRAY` (BLOB) column carrying WKB-encoded values, with a JSON metadata object in the Parquet file footer that describes each column's encoding, CRS, and type pattern. MobilityDB's MEOS-WKB encoder is battle-tested; the convention defines the metadata schema, not the encoding.
+
+## Proposal
+
+Define **TemporalParquet**: a Parquet footer-metadata convention for files containing MobilityDB temporal columns, modelled directly on GeoParquet.
+
+### File structure
+
+For every column carrying a MobilityDB temporal type, the column is `BYTE_ARRAY` with logical-type `NONE`; each row value is the MEOS-WKB encoding of the temporal value; nulls are encoded as Parquet nulls.
+
+The Parquet file's `key_value_metadata` carries an entry with key `temporal` whose value is a JSON document:
+
+```jsonc
+{
+  "version": "1.0.0",
+  "primary_temporal_column": "traj",
+  "columns": {
+    "traj": {
+      "encoding": "MEOS-WKB",
+      "encoding_version": "1.0",
+      "base_type": "tgeompoint",
+      "subtype": "Sequence",
+      "interpolation": "linear",
+      "srid": 4326,
+      "geodetic": false,
+      "has_z": false
+    }
+    /* one entry per temporal column */
+  }
+}
+```
+
+The `temporal` object coexists with GeoParquet's `geo` object: a single file can have both.
+
+### Type coverage
+
+| MobilityDB type | `base_type` value | Notes |
+|---|---|---|
+| `tbool`, `tint`, `tfloat`, `tbigint`, `ttext` | `tbool` / `tint` / `tfloat` / `tbigint` / `ttext` | scalar temporals |
+| `tgeompoint`, `tgeogpoint` | `tgeompoint` / `tgeogpoint` | spatial-temporal; `srid` + `geodetic` + `has_z` populated |
+| `tgeometry`, `tgeography` | `tgeometry` / `tgeography` | general spatial-temporal |
+| `th3index` | `th3index` | spatial via `h3_resolution`, see [Worked example](#worked-example-th3index) |
+| `tpcpoint`, `tpcpatch` | `tpcpoint` / `tpcpatch` | temporal point-cloud types |
+| `tcbuffer`, `tnpoint`, `tpose`, `trgeometry` | each as its own `base_type` | extended temporal types |
+| `stbox`, `tbox`, `tpcbox` | `stbox` / `tbox` / `tpcbox` | bounding boxes |
+| `intspan`, `floatspan`, `tstzspan`, spansets, sets | each as its own `base_type` | spans, spansets, sets |
+
+The `subtype` field applies only to lifted temporal types (Instant / Sequence / SequenceSet); span/set/box columns omit it.
+
+#### Type-specific optional fields
+
+Some `base_type` values may carry optional metadata that helps consumers decide whether the column is usable for a given workload **without decoding any row**:
+
+| Field | Applies to | Semantics |
+|---|---|---|
+| `srid` | `tgeompoint`, `tgeogpoint`, `tgeometry`, `tgeography` | EPSG code of the column's CRS; required for spatial-temporal types |
+| `geodetic` | `tgeogpoint`, `tgeography` | `true` ⇒ spheroidal-metre math (Haversine / Vincenty); see [Geodetic Distances](#geodetic-distances) |
+| `has_z` | spatial-temporal types | column carries a Z dimension throughout |
+| `h3_resolution` | `th3index` | **optional**; integer in `[0, 15]` declaring that every cell in the column was produced at this resolution. Consumers MAY rely on this for cell-membership prefilters (e.g. cross-join probes via `ever_eq(h3index, th3index)` only make sense when both sides share a resolution) |
+
+### Encoding versioning
+
+`encoding_version` is `MAJOR.MINOR` of the WKB schema. New WKB tags (e.g. when a future temporal type lands) bump MINOR; breaking layout changes bump MAJOR. Readers MUST refuse files with a higher MAJOR than they support.
+
+### Geodetic distances
+
+`tgeompoint` stores coordinates in the input CRS (e.g. lon/lat WGS-84) and computes **Euclidean** distances in that coordinate space.  `length(tgeompoint)` over a WGS-84 trajectory therefore returns degrees, not kilometres.
+
+`tgeogpoint` is the geodetically-correct variant: it carries the same MEOS-WKB bytes but with the geodetic flag set in the type tag, causing MEOS to route all spatial math through the spheroidal Haversine / Vincenty engine — lengths and speeds are in **metres**.
+
+When writing TemporalParquet files that consumers will use for distance or speed analytics, prefer `tgeogpoint` (set `"geodetic": true` in the column metadata).  The geodetic flag is self-describing in MEOS-WKB: a file written with `asBinary(tgeogpointSeq(...))` will reconstruct as a geodetic sequence on any platform that calls `tgeogpointFromBinary(blob)`.
+
+*Implementation note*: DuckDB does not have a native GEOGRAPHY type in its core (the community `duckdb-geography` extension uses Google S2's spherical model, which is incompatible with MEOS's spheroidal Vincenty engine). MobilityDuck's `TGEOGPOINT` therefore accepts the same `GEOMETRY` (lon/lat) input as `TGEOMPOINT` and sets the geodetic flag internally — all geodetic math lives exclusively in MEOS. This is the uniform pattern across MobilityDB, MobilityDuck, and PyMEOS.
+
+### Worked example: `th3index`
+
+`th3index` ships a cross-platform binding across MobilityDB, MobilityDuck (full H3 cell index API), and MobilitySpark (H3 spatial-prefilter UDFs covering the BerlinMOD-relevant subset). All three execute the same H3-prefiltered BerlinMOD `.sql` files without per-engine rewrites.
+
+A `th3index` column in TemporalParquet uses the same `BYTE_ARRAY` carrier as every other temporal type — the MEOS-WKB encoder handles th3index payload identically to tbigint (both lift over an `int64`). The metadata `base_type` is the discriminator. Example footer entry for a BerlinMOD trips table:
+
+```jsonc
+{
+  "version": "1.0.0",
+  "primary_temporal_column": "trip",
+  "columns": {
+    "trip": {
+      "encoding": "MEOS-WKB",
+      "encoding_version": "1.0",
+      "base_type": "tgeompoint",
+      "subtype": "Sequence",
+      "interpolation": "linear",
+      "srid": 4326,
+      "geodetic": false,
+      "has_z": false
+    },
+    "trip_h3": {
+      "encoding": "MEOS-WKB",
+      "encoding_version": "1.0",
+      "base_type": "th3index",
+      "subtype": "Sequence",
+      "interpolation": "step",
+      "h3_resolution": 7
+    }
+  }
+}
+```
+
+The companion `trip_h3` column is produced once at load time via `tgeompoint_to_th3index(trip, 7)` and acts as a cheap cell-membership prefilter on subsequent cross-join queries:
+
+```sql
+-- BerlinMOD Q5 (nearest-approach), runs unchanged on PG / DuckDB / Spark
+SELECT t1.licence AS licence1, t2.licence AS licence2,
+       nearestApproachDistance(t1.trip, t2.trip) AS d
+FROM   Trips t1 JOIN Trips t2 ON t1.vehId < t2.vehId
+WHERE  everEqTh3IndexTh3Index(t1.trip_h3, t2.trip_h3)        -- h3-cell prefilter
+  AND  nearestApproachDistance(t1.trip, t2.trip) IS NOT NULL;
+```
+
+`interpolation` is always `step` for th3index (a vehicle is in exactly one cell at a time); `subtype` follows the source `tgeompoint`'s subtype after the lifted conversion. The `h3_resolution` field is the consumer-side hint that lets a reader gate the prefilter without decoding any row.
+
+> **Soundness note.** A `th3index` column produced by densifying a `tgeompoint` covers the cells the trajectory passes through at the densification resolution. The `trip_h3` prefilter is a candidate filter: a consumer that needs strict semantic correctness evaluates the underlying `tgeompoint` predicate rather than relying on the prefilter alone as a `WHERE` clause. The metadata schema is independent of how the column was produced — `base_type: "th3index"` and `h3_resolution` describe the bytes regardless.
+
+### Components
+
+1. **The convention spec** — this document and the DocBook chapter `doc/temporal_parquet.xml`.
+2. **Reference exporter / importer** — a Python CLI in MobilityDuck that writes and reads files conforming to the spec (PyArrow only; `annotate` / `describe` / `verify` subcommands).
+3. **Round-trip regression test** — proves a fixture survives DuckDB → Parquet → DuckDB with value parity; covers tgeompoint, tint, tfloat, tbool, ttext, and mixed-type shards.
+4. **MobilityDuck hook** — the DuckDB-side `asBinary()` / `*FromBinary()` functions for MEOS-WKB export / import, plus `temporalFooter()` for embedding the `temporal` footer key in `COPY … TO '*.parquet'` via `KV_METADATA`.
+
+The MEOS-WKB encoders and decoders are part of the MEOS C library; TemporalParquet adds no byte-level encoding of its own.
+
+## Alternatives Considered
+
+1. **MF-JSON-on-Parquet (VARCHAR column)** — already works; 3–10× larger; no GeoParquet coherence; useful stopgap but inferior as the official answer.
+2. **Struct-of-arrays encoding** — `STRUCT(timestamps ARRAY<TIMESTAMP>, points ARRAY<…>)`. Would enable predicate pushdown but deviates strongly from the GeoParquet pattern and is hard to evolve. Deferred unless the broader spatial-Parquet ecosystem moves that way first.
+3. **Opaque hex-EWKB-in-VARCHAR** — same bytes as WKB but 2× larger (hex encoding) and no structure for non-MobilityDB tools. Strictly worse.
+4. **GeoParquet extension proposal** — extend GeoParquet's `geo` metadata to cover temporal types. Would require a multi-month upstream RFC we don't control. Better to ship our own sibling convention now and contribute back if GeoParquet wants to absorb it later.
+
+## Open Questions
+
+- **Directional sign-off** on the BLOB-plus-footer approach over MF-JSON / struct-of-arrays.
+- **Naming**: is `TemporalParquet` the right name? Alternatives: `MovingParquet`, `MFParquet`. Naming carefully matters because the convention may outlive any one tool.
+- **Footer schema completeness**: does the proposed per-column object cover everything PyMEOS / JMEOS / meos-rs / MobilityDuck / MobilityPandas need? Anything missing?
+- **Footer self-injection**: whether a writer should inject the `temporal` footer automatically on `COPY … TO '*.parquet'`, or keep it as an explicit `temporalFooter()` / `KV_METADATA` step.
+
+## Related
+
+- [MEOS-WKB byte-format specification](../specs/meos-wkb-0.9.md) — the encoding that TemporalParquet columns carry
+- [MEOS-API specification](../specs/meos-api-0.1-draft.md) — the machine-readable function registry that bindings consuming TemporalParquet files also use
+- [Temporal Data Lake RFC](../rfc/temporal-data-lake/README.md) — edge-to-cloud architecture; TemporalParquet is its file-format substrate
+- [GeoParquet specification](https://geoparquet.org/) — the spatial-Parquet standard this convention is modelled on
+- [MobilityDuck](https://github.com/MobilityDB/MobilityDuck) — DuckDB extension; primary consumer of TemporalParquet on the read/write path

--- a/doc/temporal-parquet/beta-testing.md
+++ b/doc/temporal-parquet/beta-testing.md
@@ -1,0 +1,232 @@
+<!--
+Copyright(c) MobilityDB Contributors
+
+This documentation is licensed under a
+Creative Commons Attribution-Share Alike 3.0 License
+https://creativecommons.org/licenses/by-sa/3.0/
+-->
+
+# Beta-Testing Guide: TemporalParquet
+
+This guide covers what to install, what to run, what to check, and where to send
+feedback.
+
+### What you are testing
+
+**TemporalParquet**: a Parquet footer-metadata convention modelled on
+[GeoParquet](https://geoparquet.org/). MobilityDB temporal columns
+(`tgeompoint`, `tgeogpoint`, `tfloat`, `tint`, …) are stored as
+`BYTE_ARRAY` columns carrying MEOS-WKB values. The file's
+`key_value_metadata` carries a `temporal` JSON object that describes
+each column's `base_type`, `subtype`, `interpolation`, SRID, and
+encoding version — making the file self-describing and readable by any
+tool that implements the convention.
+
+The two concrete claims you are asked to verify:
+
+1. **MobilityDB-side round-trip**: Export a MobilityDB table to a
+   TemporalParquet file; inspect the footer; re-import into a fresh
+   table; confirm byte-level identity.
+2. **Cross-platform portability**: A file written by MobilityDuck's
+   `temporalFooter()` function can be imported by MobilityDB's Python
+   importer, and vice versa.
+
+### Time budget
+
+Scenario A (MobilityDB PoC only): **~20 minutes** including the Python setup.
+Scenario B (cross-platform round-trip): add ~15 minutes for the MobilityDuck build.
+
+---
+
+### Scenario A — MobilityDB Python PoC
+
+#### Prerequisites
+
+```bash
+# Python 3.10+
+python3 -m pip install --user pyarrow psycopg2-binary
+```
+
+MobilityDB + PostgreSQL must be running.  Any recent MobilityDB 1.x is sufficient.
+
+#### Step 1 — Get the scripts
+
+The export / import / inspect scripts live under `scripts/parquet/` in the
+MobilityDB repository:
+
+```bash
+git clone https://github.com/MobilityDB/MobilityDB.git
+cd MobilityDB/scripts/parquet
+```
+
+#### Step 2 — Seed a test table
+
+```sql
+-- In psql, connected to a database with CREATE EXTENSION mobilitydb CASCADE
+CREATE TABLE test_trips (
+  tripId  INT,
+  vehId   INT,
+  trip    tgeompoint,
+  speed   tfloat
+);
+
+INSERT INTO test_trips VALUES
+  (1, 1,
+   tgeompoint '[POINT(0 0)@2020-01-01, POINT(100 0)@2020-01-01 00:10:00]',
+   tfloat '[0.0@2020-01-01, 10.0@2020-01-01 00:10:00]'),
+  (2, 2,
+   tgeompoint '[POINT(0 5)@2020-01-01, POINT(100 5)@2020-01-01 00:10:00]',
+   tfloat '[0.0@2020-01-01, 12.5@2020-01-01 00:10:00]');
+```
+
+#### Step 3 — Export, inspect, re-import
+
+```bash
+# Export
+python3 poc_export.py --dsn "dbname=mydb" --table test_trips \
+  --columns trip,speed --out trips.parquet
+
+# Inspect footer
+python3 poc_inspect.py trips.parquet
+```
+
+**Expected footer** (abbreviated):
+```json
+{
+  "version": "1.0",
+  "columns": {
+    "trip":  { "base_type": "tgeompoint",  "subtype": "Sequence",
+               "interpolation": "linear",  "srid": 0 },
+    "speed": { "base_type": "tfloat",      "subtype": "Sequence",
+               "interpolation": "linear" }
+  }
+}
+```
+
+```bash
+# Re-import into a fresh table
+python3 poc_import.py --dsn "dbname=mydb" \
+  --table test_trips_rt --input trips.parquet
+
+# Verify byte-level identity
+psql -d mydb -c "
+  SELECT bool_and(a.trip IS NOT DISTINCT FROM b.trip
+               AND a.speed IS NOT DISTINCT FROM b.speed)
+  FROM test_trips a JOIN test_trips_rt b USING (tripId);"
+```
+
+**Expected result:** `t` (all values identical after round-trip).
+
+#### Third-party reader test
+
+The Parquet file must be readable by any Parquet-capable tool:
+
+```python
+import pyarrow.parquet as pq
+f = pq.read_table("trips.parquet")
+print(f.schema)
+# trip and speed columns are BYTE_ARRAY — opaque to Arrow but readable by MEOS
+```
+
+```python
+# DuckDB (no MobilityDB extension needed):
+import duckdb
+duckdb.sql("SELECT * FROM read_parquet('trips.parquet')").show()
+```
+
+---
+
+### Scenario B — Cross-platform round-trip with MobilityDuck
+
+#### Step 1 — Build MobilityDuck
+
+```bash
+git clone --recurse-submodules https://github.com/MobilityDB/MobilityDuck.git
+cd MobilityDuck
+make   # 5–10 min on first build
+```
+
+#### Step 2 — Write a TemporalParquet file from DuckDB
+
+```bash
+TZ=UTC ./build/release/duckdb
+```
+
+```sql
+LOAD mobilitydb;
+
+-- Build a tgeompoint sequence
+CREATE OR REPLACE TABLE trips AS
+SELECT 1 AS tripId,
+       tgeompoint('[POINT(0 0)@2020-01-01, POINT(100 0)@2020-01-01 00:10:00]') AS trip;
+
+-- Write to TemporalParquet (with footer)
+COPY trips TO 'trips_duck.parquet' (
+  FORMAT PARQUET,
+  KV_METADATA {
+    'temporal': temporalFooter({'trip': first(trip)})
+  }
+);
+```
+
+#### Step 3 — Inspect from MobilityDB
+
+```bash
+python3 poc_inspect.py trips_duck.parquet
+```
+
+The `temporal` footer key must be present and consistent with Scenario A's output.
+
+#### Step 4 — Import into MobilityDB
+
+```bash
+python3 poc_import.py --dsn "dbname=mydb" \
+  --table trips_from_duck --input trips_duck.parquet
+psql -d mydb -c "SELECT * FROM trips_from_duck;"
+```
+
+The `trip` column must deserialize correctly as `tgeompoint`.
+
+---
+
+### How to report feedback
+
+Open a comment on the beta thread:
+<https://github.com/MobilityDB/MobilityDB/discussions/870>
+
+Please include:
+- Platform + OS + Python version
+- Output of `poc_inspect.py` when results look wrong
+- For build failures: last 20 lines of `make` output (Scenario B)
+- Any ergonomic friction or gaps in the spec
+
+---
+
+## `th3index` cross-platform round-trip
+
+A TemporalParquet shard with both a `tgeompoint` trajectory column and a `th3index`
+companion column round-trips losslessly across MobilityDB, MobilityDuck, and
+MobilitySpark — the bytes, the metadata, and the `base_type` / `h3_resolution`
+recovery produce identical answers on all three engines:
+
+```sql
+-- Export from MobilityDB:
+COPY (SELECT vehId, trip, tgeompoint_to_th3index(trip, 7) AS trip_h3 FROM Trips)
+TO 'trips.parquet' (FORMAT PARQUET);
+
+-- Annotate the footer (Python tool):
+python3 scripts/parquet/tp_export.py annotate trips.parquet \
+    --column trip:tgeompoint --column 'trip_h3:th3index;h3_resolution=7'
+
+-- Re-import on MobilityDuck or MobilitySpark, then run Q5 against the
+-- semantic predicate:
+SELECT t1.licence, t2.licence,
+       nearestApproachDistance(t1.trip, t2.trip) AS d
+FROM   Trips t1 JOIN Trips t2 ON t1.vehId < t2.vehId
+WHERE  nearestApproachDistance(t1.trip, t2.trip) IS NOT NULL;
+```
+
+The `trip_h3` column is a candidate filter for cell-membership prefiltering: a
+consumer that needs strict semantic correctness evaluates the underlying
+`tgeompoint` predicate rather than relying on the prefilter alone as a `WHERE`
+clause. The metadata schema is independent of how the column is produced.

--- a/doc/temporal_parquet.xml
+++ b/doc/temporal_parquet.xml
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   ****************************************************************************
+    MobilityDB Manual
+    Copyright(c) MobilityDB Contributors
+
+    This documentation is licensed under a Creative Commons Attribution-Share
+    Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
+   ****************************************************************************
+-->
+<appendix xml:id="temporal_parquet">
+	<title>TemporalParquet: a Parquet Footer Convention for Temporal Types</title>
+	<para>
+		Apache Parquet has become the de-facto interchange format for columnar analytics data on object storage. Geospatial data has had a documented Parquet convention — <ulink url="https://geoparquet.org/">GeoParquet</ulink> — since 2022; mobility data (trajectories, temporal types, spans, sets) has not. This appendix documents <emphasis>TemporalParquet</emphasis>, the convention MobilityDB adopts for storing temporal columns in Parquet files: a <varname>BYTE_ARRAY</varname> column carrying MEOS-WKB encoded values, with a JSON metadata object in the Parquet file footer that describes each column's encoding, base type, subtype, and (where applicable) SRID, geodetic flag, or H3 resolution.
+	</para>
+
+	<para>
+		The convention is the file-format substrate of the <emphasis>Temporal Data Lake</emphasis> architecture and is consumed by MobilityDuck (DuckDB extension) and MobilitySpark (Apache Spark binding). The same <varname>.parquet</varname> shard written by one platform reads back losslessly on the other two.
+	</para>
+
+	<sect1>
+		<title>File Structure</title>
+		<para>
+			For every column carrying a MobilityDB temporal type, the column is <varname>BYTE_ARRAY</varname> with logical-type <varname>NONE</varname>; each row value is the MEOS-WKB encoding of the temporal value; NULLs are encoded as Parquet NULLs.
+		</para>
+		<para>
+			The Parquet file's <varname>key_value_metadata</varname> carries an entry with key <varname>temporal</varname> whose value is a JSON document:
+		</para>
+<programlisting>
+{
+  "version": "1.0.0",
+  "primary_temporal_column": "traj",
+  "columns": {
+    "traj": {
+      "encoding": "MEOS-WKB",
+      "encoding_version": "1.0",
+      "base_type": "tgeompoint",
+      "subtype": "Sequence",
+      "interpolation": "linear",
+      "srid": 4326,
+      "geodetic": false,
+      "has_z": false
+    }
+  }
+}
+</programlisting>
+		<para>
+			The <varname>temporal</varname> object coexists with GeoParquet's <varname>geo</varname> object: a single file can have both.
+		</para>
+	</sect1>
+
+	<sect1>
+		<title>Type Coverage</title>
+		<informaltable frame="all">
+			<tgroup cols="3">
+				<thead>
+					<row>
+						<entry>MobilityDB type</entry>
+						<entry><varname>base_type</varname> value</entry>
+						<entry>Notes</entry>
+					</row>
+				</thead>
+				<tbody>
+					<row>
+						<entry><varname>tbool</varname>, <varname>tint</varname>, <varname>tfloat</varname>, <varname>tbigint</varname>, <varname>ttext</varname></entry>
+						<entry>same</entry>
+						<entry>Scalar temporals.</entry>
+					</row>
+					<row>
+						<entry><varname>tgeompoint</varname>, <varname>tgeogpoint</varname></entry>
+						<entry>same</entry>
+						<entry><varname>srid</varname>, <varname>geodetic</varname>, <varname>has_z</varname> populated.</entry>
+					</row>
+					<row>
+						<entry><varname>tgeometry</varname>, <varname>tgeography</varname></entry>
+						<entry>same</entry>
+						<entry>General spatial-temporal.</entry>
+					</row>
+					<row>
+						<entry><varname>th3index</varname></entry>
+						<entry><varname>th3index</varname></entry>
+						<entry>Carries optional <varname>h3_resolution</varname>; see <xref linkend="tp_th3index"/>.</entry>
+					</row>
+					<row>
+						<entry><varname>tpcpoint</varname>, <varname>tpcpatch</varname></entry>
+						<entry>each as its own <varname>base_type</varname></entry>
+						<entry>Temporal point-cloud types.</entry>
+					</row>
+					<row>
+						<entry><varname>tcbuffer</varname>, <varname>tnpoint</varname>, <varname>tpose</varname>, <varname>trgeometry</varname></entry>
+						<entry>each as its own <varname>base_type</varname></entry>
+						<entry>Extended temporal types.</entry>
+					</row>
+					<row>
+						<entry><varname>stbox</varname>, <varname>tbox</varname>, <varname>tpcbox</varname></entry>
+						<entry>same</entry>
+						<entry>Bounding boxes.</entry>
+					</row>
+					<row>
+						<entry><varname>intspan</varname>, <varname>floatspan</varname>, <varname>tstzspan</varname>, spansets, sets</entry>
+						<entry>each as its own <varname>base_type</varname></entry>
+						<entry>Spans, spansets, sets.</entry>
+					</row>
+				</tbody>
+			</tgroup>
+		</informaltable>
+		<para>
+			The <varname>subtype</varname> field applies only to lifted temporal types (<varname>Instant</varname> / <varname>Sequence</varname> / <varname>SequenceSet</varname>); span / set / box columns omit it.
+		</para>
+
+		<sect2>
+			<title>Type-Specific Optional Fields</title>
+			<para>
+				Some <varname>base_type</varname> values may carry optional metadata that lets consumers decide whether the column is usable for a given workload <emphasis>without decoding any row</emphasis>:
+			</para>
+			<itemizedlist>
+				<listitem>
+					<para><varname>srid</varname> — EPSG code of the column's CRS. Required for spatial-temporal types.</para>
+				</listitem>
+				<listitem>
+					<para><varname>geodetic</varname> — <varname>true</varname> ⇒ spheroidal-metre math (Haversine / Vincenty); see <xref linkend="tp_geodetic"/>.</para>
+				</listitem>
+				<listitem>
+					<para><varname>has_z</varname> — column carries a Z dimension throughout.</para>
+				</listitem>
+				<listitem>
+					<para><varname>h3_resolution</varname> — applies to <varname>th3index</varname>. Optional integer in <varname>[0, 15]</varname> declaring every cell in the column was produced at this resolution. Consumers MAY rely on it to gate cell-membership prefilters (cross-join probes via <varname>everEqH3IndexTh3Index</varname>) without decoding any row.</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2 xml:id="tp_geodetic">
+			<title>Geodetic Distances</title>
+			<para>
+				<varname>tgeompoint</varname> stores coordinates in the input CRS (e.g. lon/lat WGS-84) and computes <emphasis>Euclidean</emphasis> distances in that coordinate space; <varname>length(tgeompoint)</varname> over a WGS-84 trajectory therefore returns degrees, not kilometres.
+			</para>
+			<para>
+				<varname>tgeogpoint</varname> is the geodetically-correct variant: it carries the same MEOS-WKB bytes but with the geodetic flag set in the type tag, causing MEOS to route all spatial math through the spheroidal Haversine / Vincenty engine — lengths and speeds are in <emphasis>metres</emphasis>.
+			</para>
+			<para>
+				When writing TemporalParquet files that consumers will use for distance or speed analytics, prefer <varname>tgeogpoint</varname> (set <varname>"geodetic": true</varname> in the column metadata). The geodetic flag is self-describing in MEOS-WKB: a file written with <varname>asBinary(tgeogpointSeq(...))</varname> reconstructs as a geodetic sequence on any platform that calls <varname>tgeogpointFromBinary(blob)</varname>.
+			</para>
+		</sect2>
+	</sect1>
+
+	<sect1 xml:id="tp_th3index">
+		<title>Worked Example: <varname>th3index</varname></title>
+		<para>
+			<varname>th3index</varname> ships a cross-platform binding across MobilityDB, MobilityDuck, and MobilitySpark. The MEOS-WKB encoder handles the <varname>th3index</varname> payload identically to <varname>tbigint</varname> (both lift over an <varname>int64</varname>); the metadata <varname>base_type</varname> is the discriminator. The companion <varname>h3_resolution</varname> field declares uniform resolution per column so consumers can gate cell-membership prefilters without scanning the data.
+		</para>
+		<para>
+			Example footer entry for a BerlinMOD trips table:
+		</para>
+<programlisting>
+{
+  "version": "1.0.0",
+  "primary_temporal_column": "trip",
+  "columns": {
+    "trip": {
+      "encoding": "MEOS-WKB",
+      "encoding_version": "1.0",
+      "base_type": "tgeompoint",
+      "subtype": "Sequence",
+      "interpolation": "linear",
+      "srid": 4326,
+      "geodetic": false,
+      "has_z": false
+    },
+    "trip_h3": {
+      "encoding": "MEOS-WKB",
+      "encoding_version": "1.0",
+      "base_type": "th3index",
+      "subtype": "Sequence",
+      "interpolation": "step",
+      "h3_resolution": 7
+    }
+  }
+}
+</programlisting>
+		<para>
+			The companion <varname>trip_h3</varname> column is produced once at load time via <varname>tgeompoint_to_th3index(trip, 7)</varname> and acts as a cheap cell-membership prefilter on subsequent cross-join queries that runs unchanged on MobilityDB, MobilityDuck and MobilitySpark:
+		</para>
+<programlisting>
+-- BerlinMOD Q5 (nearest-approach) with the th3index prefilter
+SELECT t1.licence AS licence1, t2.licence AS licence2,
+       nearestApproachDistance(t1.trip, t2.trip) AS d
+FROM   Trips t1 JOIN Trips t2 ON t1.vehId &lt; t2.vehId
+WHERE  everEqTh3IndexTh3Index(t1.trip_h3, t2.trip_h3)
+  AND  nearestApproachDistance(t1.trip, t2.trip) IS NOT NULL;
+</programlisting>
+		<para>
+			<varname>interpolation</varname> is always <varname>step</varname> for <varname>th3index</varname> (a vehicle is in exactly one cell at a time); <varname>subtype</varname> follows the source <varname>tgeompoint</varname>'s subtype after the lifted conversion. The <varname>h3_resolution</varname> field is the consumer-side hint that lets a reader gate the prefilter without decoding any row.
+		</para>
+		<note>
+			<title>Soundness note</title>
+			<para>
+				A <varname>th3index</varname> column produced by densifying a <varname>tgeompoint</varname> covers the cells the trajectory passes through at the densification resolution. The <varname>trip_h3</varname> prefilter is a candidate filter for cell-membership pruning.
+			</para>
+			<para>
+				The TemporalParquet metadata schema is independent of how the column is produced — <varname>base_type: "th3index"</varname> and <varname>h3_resolution</varname> describe the bytes regardless. A consumer that needs strict semantic correctness evaluates the underlying <varname>tgeompoint</varname> predicate rather than relying on the prefilter alone as a <varname>WHERE</varname> clause.
+			</para>
+		</note>
+	</sect1>
+
+	<sect1>
+		<title>Encoding Versioning</title>
+		<para>
+			<varname>encoding_version</varname> is <varname>MAJOR.MINOR</varname> of the MEOS-WKB schema. New WKB tags (e.g. when a future temporal type lands) bump <varname>MINOR</varname>; breaking layout changes bump <varname>MAJOR</varname>. Readers MUST refuse files with a higher <varname>MAJOR</varname> than they support; readers MAY accept higher <varname>MINOR</varname> by skipping the unrecognised tags.
+		</para>
+	</sect1>
+
+	<sect1>
+		<title>Reference Implementation</title>
+		<para>
+			A Python reference implementation ships in <varname>scripts/parquet/</varname>: <varname>tp_export.py</varname> writes annotated TemporalParquet files, <varname>tp_import.py</varname> reads them back, and <varname>tp_inspect.py</varname> dumps the footer metadata. A round-trip regression test exercises export, footer inspection, and re-import with value parity.
+		</para>
+		<para>
+			The convention spec and the beta-testing guide live in <varname>doc/temporal-parquet/</varname>; this appendix is the user-facing summary.
+		</para>
+	</sect1>
+
+	<sect1>
+		<title>Related</title>
+		<itemizedlist>
+			<listitem>
+				<para>Temporal Data Lake RFC — edge-to-cloud architecture; this convention is the file-format substrate.</para>
+			</listitem>
+			<listitem>
+				<para>MEOS-WKB byte-format specification — the encoding TemporalParquet columns carry.</para>
+			</listitem>
+			<listitem>
+				<para><ulink url="https://geoparquet.org/">GeoParquet specification</ulink> — the spatial-Parquet standard this convention is modelled on.</para>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+</appendix>


### PR DESCRIPTION
Define the Temporal Data Lake architecture pattern for the MobilityDB ecosystem: edge ingest writes TemporalParquet shards to object storage with Hive-style partitioning (year/month/day, spatial H3 cell, entity range), and the query layer (MobilityDuck, MobilityDB, MobilitySpark) reads the shards using the portable named-function SQL dialect. Document the ingest recipe via MobilityDuck SQL (deduplicate, build `tgeogpointSeq`, COPY TO Parquet, annotate footer), the platform capability matrix, and the geodetic note (use `tgeogpoint` for distance and speed to preserve spheroidal-metre semantics through the Parquet round-trip). The reference implementation lives in MobilityDuck `examples/ais-data-lake/ais_data_lake.sql`.
