### PR TITLE
Add box3d_in and gbox_in parsers for the PostGIS box types

### DIFF
--- a/meos/include/meos_geo.h
+++ b/meos/include/meos_geo.h
@@ -328,10 +328,12 @@ typedef enum
 extern BOX3D *box3d_from_gbox(const GBOX *box);
 extern BOX3D *box3d_make(double xmin, double xmax, double ymin, double ymax,
   double zmin, double zmax, int32_t srid);
+extern BOX3D *box3d_in(const char *str);
 extern char *box3d_out(const BOX3D *box, int maxdd);
 extern GBOX *gbox_make(bool hasz, bool hasm, bool geodetic, double xmin,
   double xmax, double ymin, double ymax, double zmin, double zmax, double mmin,
   double mmax);
+extern GBOX *gbox_in(const char *str);
 extern char *gbox_out(const GBOX *box, int maxdd);
 extern uint8_t *geo_as_ewkb(const GSERIALIZED *gs, const char *endian, size_t *size);
 extern char *geo_as_ewkt(const GSERIALIZED *gs, int precision);

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -138,6 +138,32 @@ gbox_out(const GBOX *box, int maxdd)
 
 /**
  * @ingroup meos_geo_base_inout
+ * @brief Return a PostGIS GBOX from its string representation
+ * @param[in] str String
+ * @details The format is `GBOX((xmin,ymin),(xmax,ymax))` for two dimensions
+ * or `GBOX((xmin,ymin,zmin),(xmax,ymax,zmax))` for three dimensions, the
+ * inverse of #gbox_out
+ */
+GBOX *
+gbox_in(const char *str)
+{
+  VALIDATE_NOT_NULL(str, NULL);
+
+  double xmin, ymin, zmin, xmax, ymax, zmax;
+  if (sscanf(str, " GBOX((%lf,%lf,%lf),(%lf,%lf,%lf))",
+      &xmin, &ymin, &zmin, &xmax, &ymax, &zmax) == 6)
+    return gbox_make(true, false, false, xmin, xmax, ymin, ymax, zmin, zmax,
+      0, 0);
+  if (sscanf(str, " GBOX((%lf,%lf),(%lf,%lf))",
+      &xmin, &ymin, &xmax, &ymax) == 4)
+    return gbox_make(false, false, false, xmin, xmax, ymin, ymax, 0, 0, 0, 0);
+  meos_error(ERROR, MEOS_ERR_TEXT_INPUT,
+    "Could not parse GBOX value: %s", str);
+  return NULL;
+}
+
+/**
+ * @ingroup meos_geo_base_inout
  * @brief Return a PostGIS BOX3D from the arguments
  * @param[in] xmin,ymin,zmin Minimum bounds for the spatial dimension
  * @param[in] xmax,ymax,zmax Maximum bounds for the spatial dimension
@@ -204,6 +230,45 @@ box3d_out(const BOX3D *box, int maxdd)
   pfree(ymin); pfree(ymax);
   pfree(zmin); pfree(zmax);
   return strdup(buf);
+}
+
+/**
+ * @ingroup meos_geo_base_inout
+ * @brief Return a PostGIS BOX3D from its string representation
+ * @param[in] str String
+ * @details The format is `[SRID=#;]BOX3D((xmin,ymin,zmin),(xmax,ymax,zmax))`,
+ * the inverse of #box3d_out
+ */
+BOX3D *
+box3d_in(const char *str)
+{
+  VALIDATE_NOT_NULL(str, NULL);
+
+  int32 srid = SRID_UNKNOWN;
+  const char *ptr = str;
+  /* Optional "SRID=#;" prefix */
+  if (pg_strncasecmp(ptr, "SRID=", 5) == 0)
+  {
+    char *end;
+    srid = (int32) strtol(ptr + 5, &end, 10);
+    if (end == ptr + 5 || *end != ';')
+    {
+      meos_error(ERROR, MEOS_ERR_TEXT_INPUT,
+        "Could not parse BOX3D value: %s", str);
+      return NULL;
+    }
+    ptr = end + 1;
+  }
+
+  double xmin, ymin, zmin, xmax, ymax, zmax;
+  if (sscanf(ptr, " BOX3D((%lf,%lf,%lf),(%lf,%lf,%lf))",
+      &xmin, &ymin, &zmin, &xmax, &ymax, &zmax) != 6)
+  {
+    meos_error(ERROR, MEOS_ERR_TEXT_INPUT,
+      "Could not parse BOX3D value: %s", str);
+    return NULL;
+  }
+  return box3d_make(xmin, xmax, ymin, ymax, zmin, zmax, srid);
 }
 #endif /* MEOS */
 

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -1523,6 +1523,18 @@ int main(void)
   printf("gbox_to_stbox(%s): %s\n", gbox1_out, char_result);
   free(stbox_result); free(char_result);
 
+  /* BOX3D *box3d_in(const char *str); */
+  box3d_result = box3d_in(box3d1_out);
+  char_result = box3d_out(box3d_result, 6);
+  printf("box3d_in(%s): %s\n", box3d1_out, char_result);
+  free(box3d_result); free(char_result);
+
+  /* GBOX *gbox_in(const char *str); */
+  gbox_result = gbox_in(gbox1_out);
+  char_result = gbox_out(gbox_result, 6);
+  printf("gbox_in(%s): %s\n", gbox1_out, char_result);
+  free(gbox_result); free(char_result);
+
   /* Temporal *geomeas_to_tpoint(const GSERIALIZED *gs); */
   (void) tpoint_tfloat_to_geomeas(tgeompt1_step, tfloat1, true, &geom_result);
   tgeompt_result = geomeas_to_tpoint(geom_result);


### PR DESCRIPTION
box3d_in and gbox_in are the inverses of box3d_out and gbox_out: box3d_in parses [SRID=#;]BOX3D((xmin,ymin,zmin),(xmax,ymax,zmax)), and gbox_in parses the two- and three-dimensional GBOX representations. They unblock the reverse box conversions box3d_to_stbox and gbox_to_stbox from a string. The geo smoke test round-trips both for 2D and 3D.