### PR TITLE
Provide a single temporal-first instantiation for the commutative bbox predicates

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -1628,14 +1628,11 @@ extern TBox *tnumber_tboxes(const Temporal *temp, int *count);
 
 /* Topological functions for temporal types */
 
-extern bool adjacent_numspan_tnumber(const Span *s, const Temporal *temp);
-extern bool adjacent_tbox_tnumber(const TBox *box, const Temporal *temp);
 extern bool adjacent_temporal_temporal(const Temporal *temp1, const Temporal *temp2);
 extern bool adjacent_temporal_tstzspan(const Temporal *temp, const Span *s);
 extern bool adjacent_tnumber_numspan(const Temporal *temp, const Span *s);
 extern bool adjacent_tnumber_tbox(const Temporal *temp, const TBox *box);
 extern bool adjacent_tnumber_tnumber(const Temporal *temp1, const Temporal *temp2);
-extern bool adjacent_tstzspan_temporal(const Span *s, const Temporal *temp);
 extern bool contained_numspan_tnumber(const Span *s, const Temporal *temp);
 extern bool contained_tbox_tnumber(const TBox *box, const Temporal *temp);
 extern bool contained_temporal_temporal(const Temporal *temp1, const Temporal *temp2);
@@ -1652,22 +1649,16 @@ extern bool contains_tnumber_numspan(const Temporal *temp, const Span *s);
 extern bool contains_tnumber_tbox(const Temporal *temp, const TBox *box);
 extern bool contains_tnumber_tnumber(const Temporal *temp1, const Temporal *temp2);
 extern bool contains_tstzspan_temporal(const Span *s, const Temporal *temp);
-extern bool overlaps_numspan_tnumber(const Span *s, const Temporal *temp);
-extern bool overlaps_tbox_tnumber(const TBox *box, const Temporal *temp);
 extern bool overlaps_temporal_temporal(const Temporal *temp1, const Temporal *temp2);
 extern bool overlaps_temporal_tstzspan(const Temporal *temp, const Span *s);
 extern bool overlaps_tnumber_numspan(const Temporal *temp, const Span *s);
 extern bool overlaps_tnumber_tbox(const Temporal *temp, const TBox *box);
 extern bool overlaps_tnumber_tnumber(const Temporal *temp1, const Temporal *temp2);
-extern bool overlaps_tstzspan_temporal(const Span *s, const Temporal *temp);
-extern bool same_numspan_tnumber(const Span *s, const Temporal *temp);
-extern bool same_tbox_tnumber(const TBox *box, const Temporal *temp);
 extern bool same_temporal_temporal(const Temporal *temp1, const Temporal *temp2);
 extern bool same_temporal_tstzspan(const Temporal *temp, const Span *s);
 extern bool same_tnumber_numspan(const Temporal *temp, const Span *s);
 extern bool same_tnumber_tbox(const Temporal *temp, const TBox *box);
 extern bool same_tnumber_tnumber(const Temporal *temp1, const Temporal *temp2);
-extern bool same_tstzspan_temporal(const Span *s, const Temporal *temp);
 
 /*****************************************************************************/
 

--- a/meos/include/meos_geo.h
+++ b/meos/include/meos_geo.h
@@ -735,7 +735,6 @@ extern STBox *tgeo_split_n_stboxes(const Temporal *temp, int box_count, int *cou
 
 /* Topological functions */
 
-extern bool adjacent_stbox_tspatial(const STBox *box, const Temporal *temp);
 extern bool adjacent_tspatial_stbox(const Temporal *temp, const STBox *box);
 extern bool adjacent_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2);
 extern bool contained_stbox_tspatial(const STBox *box, const Temporal *temp);
@@ -744,10 +743,8 @@ extern bool contained_tspatial_tspatial(const Temporal *temp1, const Temporal *t
 extern bool contains_stbox_tspatial(const STBox *box, const Temporal *temp);
 extern bool contains_tspatial_stbox(const Temporal *temp, const STBox *box);
 extern bool contains_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2);
-extern bool overlaps_stbox_tspatial(const STBox *box, const Temporal *temp);
 extern bool overlaps_tspatial_stbox(const Temporal *temp, const STBox *box);
 extern bool overlaps_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2);
-extern bool same_stbox_tspatial(const STBox *box, const Temporal *temp);
 extern bool same_tspatial_stbox(const Temporal *temp, const STBox *box);
 extern bool same_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2);
 

--- a/meos/src/geo/tspatial_topops_meos.c
+++ b/meos/src/geo/tspatial_topops_meos.c
@@ -55,20 +55,6 @@
 
 /**
  * @ingroup meos_geo_bbox_topo
- * @brief Return true if a spatiotemporal box and the spatiotemporal box of a
- * spatiotemporal value overlap
- * @param[in] box Spatiotemporal box
- * @param[in] temp Spatiotemporal value
- * @csqlfn #Overlaps_stbox_tspatial()
- */
-inline bool
-overlaps_stbox_tspatial(const STBox *box, const Temporal *temp)
-{
-  return boxop_tspatial_stbox(temp, box, &overlaps_stbox_stbox, INVERT);
-}
-
-/**
- * @ingroup meos_geo_bbox_topo
  * @brief Return true if the spatiotemporal box of a spatiotemporal value and
  * a spatiotemporal box overlap
  * @param[in] temp Spatiotemporal value
@@ -190,20 +176,6 @@ contained_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 
 /**
  * @ingroup meos_geo_bbox_topo
- * @brief Return true if a spatiotemporal box and the spatiotemporal box of a
- * spatiotemporal value are equal in the common dimensions
- * @param[in] box Spatiotemporal box
- * @param[in] temp Spatiotemporal value
- * @csqlfn #Same_stbox_tspatial()
- */
-inline bool
-same_stbox_tspatial(const STBox *box, const Temporal *temp)
-{
-  return boxop_tspatial_stbox(temp, box, &same_stbox_stbox, INVERT);
-}
-
-/**
- * @ingroup meos_geo_bbox_topo
  * @brief Return true if the spatiotemporal box of a spatiotemporal value and
  * a spatiotemporal box are equal in the common dimensions
  * @param[in] temp Spatiotemporal value
@@ -232,20 +204,6 @@ same_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
 /*****************************************************************************
  * adjacent
  *****************************************************************************/
-
-/**
- * @ingroup meos_geo_bbox_topo
- * @brief Return true if a spatiotemporal box and the spatiotemporal box of a
- * spatiotemporal value are adjacent
- * @param[in] box Spatiotemporal box
- * @param[in] temp Spatiotemporal value
- * @csqlfn #Adjacent_stbox_tspatial()
- */
-inline bool
-adjacent_stbox_tspatial(const STBox *box, const Temporal *temp)
-{
-  return boxop_tspatial_stbox(temp, box, &adjacent_stbox_stbox, INVERT);
-}
 
 /**
  * @ingroup meos_geo_bbox_topo

--- a/meos/src/temporal/temporal_boxops_meos.c
+++ b/meos/src/temporal/temporal_boxops_meos.c
@@ -158,22 +158,6 @@ contained_temporal_temporal(const Temporal *temp1, const Temporal *temp2)
 
 /**
  * @ingroup meos_temporal_bbox_topo
- * @brief Return true if a timestamptz span and the time span of a
- * temporal value overlap
- * @param[in] s Span
- * @param[in] temp Temporal value
- * @csqlfn #Overlaps_tstzspan_temporal()
- */
-bool
-overlaps_tstzspan_temporal(const Span *s, const Temporal *temp)
-{
-  /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_TSTZSPAN(s, NULL);
-  return boxop_temporal_tstzspan(temp, s, &overlaps_span_span, INVERT);
-}
-
-/**
- * @ingroup meos_temporal_bbox_topo
  * @brief Return true if the time span of a temporal value and a
  * timestamptz span overlap
  * @param[in] temp Temporal value
@@ -206,22 +190,6 @@ overlaps_temporal_temporal(const Temporal *temp1, const Temporal *temp2)
 
 /**
  * @ingroup meos_temporal_bbox_topo
- * @brief Return true if a timestamptz span and the time span of a
- * temporal value are equal
- * @param[in] s Span
- * @param[in] temp Temporal value
- * @csqlfn #Same_tstzspan_temporal()
- */
-bool
-same_tstzspan_temporal(const Span *s, const Temporal *temp)
-{
-  /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_TSTZSPAN(s, NULL);
-  return boxop_temporal_tstzspan(temp, s, &span_eq, INVERT);
-}
-
-/**
- * @ingroup meos_temporal_bbox_topo
  * @brief Return true if the time span of a temporal value and a timestamptz
  * span are equal
  * @param[in] temp Temporal value
@@ -251,22 +219,6 @@ same_temporal_temporal(const Temporal *temp1, const Temporal *temp2)
 }
 
 /*****************************************************************************/
-
-/**
- * @ingroup meos_temporal_bbox_topo
- * @brief Return true if a timestamptz span and the time span of a temporal
- * value are adjacent
- * @param[in] s Span
- * @param[in] temp Temporal value
- * @csqlfn #Adjacent_tstzspan_temporal()
- */
-bool
-adjacent_tstzspan_temporal(const Span *s, const Temporal *temp)
-{
-  /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_TSTZSPAN(s, NULL);
-  return boxop_temporal_tstzspan(temp, s, &adjacent_span_span, INVERT);
-}
 
 /**
  * @ingroup meos_temporal_bbox_topo
@@ -476,23 +428,6 @@ contained_tnumber_tnumber(const Temporal *temp1, const Temporal *temp2)
 
 /**
  * @ingroup meos_temporal_bbox_topo
- * @brief Return true if a number span and the value span of a temporal number
- * overlap
- * @param[in] s Span
- * @param[in] temp Temporal value
- * @csqlfn #Overlaps_numspan_tnumber()
- */
-bool
-overlaps_numspan_tnumber(const Span *s, const Temporal *temp)
-{
-  /* Ensure the validity of the arguments */
-  if (! ensure_valid_tnumber_numspan(temp, s))
-    return NULL;
-  return boxop_tnumber_numspan(temp, s, &overlaps_span_span, INVERT);
-}
-
-/**
- * @ingroup meos_temporal_bbox_topo
  * @brief Return true if the value span of a temporal number and the number
  * span overlap
  * @param[in] temp Temporal value
@@ -506,23 +441,6 @@ overlaps_tnumber_numspan(const Temporal *temp, const Span *s)
   if (! ensure_valid_tnumber_numspan(temp, s))
     return NULL;
   return boxop_tnumber_numspan(temp, s, &overlaps_span_span, INVERT_NO);
-}
-
-/**
- * @ingroup meos_temporal_bbox_topo
- * @brief Return true if a temporal box and the bounding box of a temporal
- * number overlap
- * @param[in] box Bounding box
- * @param[in] temp Temporal value
- * @csqlfn #Overlaps_tbox_tnumber()
- */
-bool
-overlaps_tbox_tnumber(const TBox *box, const Temporal *temp)
-{
-  /* Ensure the validity of the arguments */
-  if (! ensure_valid_tnumber_tbox(temp, box))
-    return NULL;
-  return boxop_tnumber_tbox(temp, box, &overlaps_tbox_tbox, INVERT);
 }
 
 /**
@@ -561,23 +479,6 @@ overlaps_tnumber_tnumber(const Temporal *temp1, const Temporal *temp2)
 
 /**
  * @ingroup meos_temporal_bbox_topo
- * @brief Return true if a number span and the value span of a temporal number
- * are equal
- * @param[in] s Span
- * @param[in] temp Temporal value
- * @csqlfn #Same_numspan_tnumber()
- */
-bool
-same_numspan_tnumber(const Span *s, const Temporal *temp)
-{
-  /* Ensure the validity of the arguments */
-  if (! ensure_valid_tnumber_numspan(temp, s))
-    return NULL;
-  return boxop_tnumber_numspan(temp, s, &span_eq, INVERT);
-}
-
-/**
- * @ingroup meos_temporal_bbox_topo
  * @brief Return true if the value span of a temporal number and a number span
  * are equal
  * @param[in] temp Temporal value
@@ -591,23 +492,6 @@ same_tnumber_numspan(const Temporal *temp, const Span *s)
   if (! ensure_valid_tnumber_numspan(temp, s))
     return NULL;
   return boxop_tnumber_numspan(temp, s, &span_eq, INVERT_NO);
-}
-
-/**
- * @ingroup meos_temporal_bbox_topo
- * @brief Return true if a temporal box and the bounding box of a temporal
- * number are equal in the common dimensions
- * @param[in] box Bounding box
- * @param[in] temp Temporal value
- * @csqlfn #Same_tbox_tnumber()
- */
-bool
-same_tbox_tnumber(const TBox *box, const Temporal *temp)
-{
-  /* Ensure the validity of the arguments */
-  if (! ensure_valid_tnumber_tbox(temp, box))
-    return NULL;
-  return boxop_tnumber_tbox(temp, box, &same_tbox_tbox, INVERT);
 }
 
 /**
@@ -646,23 +530,6 @@ same_tnumber_tnumber(const Temporal *temp1, const Temporal *temp2)
 
 /**
  * @ingroup meos_temporal_bbox_topo
- * @brief Return true if a number span and the value span of a temporal number
- * are adjacent
- * @param[in] s Span
- * @param[in] temp Temporal value
- * @csqlfn #Adjacent_numspan_tnumber()
- */
-bool
-adjacent_numspan_tnumber(const Span *s, const Temporal *temp)
-{
-  /* Ensure the validity of the arguments */
-  if (! ensure_valid_tnumber_numspan(temp, s))
-    return NULL;
-  return boxop_tnumber_numspan(temp, s, &adjacent_span_span, INVERT);
-}
-
-/**
- * @ingroup meos_temporal_bbox_topo
  * @brief Return true if the value span of a temporal number and a number span
  * are adjacent
  * @param[in] temp Temporal value
@@ -676,23 +543,6 @@ adjacent_tnumber_numspan(const Temporal *temp, const Span *s)
   if (! ensure_valid_tnumber_numspan(temp, s))
     return NULL;
   return boxop_tnumber_numspan(temp, s, &adjacent_span_span, INVERT_NO);
-}
-
-/**
- * @ingroup meos_temporal_bbox_topo
- * @brief Return true if a temporal box and the bounding box of a temporal
- * number are adjacent
- * @param[in] box Bounding box
- * @param[in] temp Temporal value
- * @csqlfn #Adjacent_tbox_tnumber()
- */
-bool
-adjacent_tbox_tnumber(const TBox *box, const Temporal *temp)
-{
-  /* Ensure the validity of the arguments */
-  if (! ensure_valid_tnumber_tbox(temp, box))
-    return NULL;
-  return boxop_tnumber_tbox(temp, box, &adjacent_tbox_tbox, INVERT);
 }
 
 /**

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -2059,9 +2059,6 @@ int main(void)
   /* Topological functions */
   printf("****************************************************************\n");
 
-  /* bool adjacent_stbox_tspatial(const STBox *box, const Temporal *temp); */
-  bool_result = adjacent_stbox_tspatial(stbox1, tgeompt1);
-  printf("adjacent_stbox_tspatial(%s, %s): %c\n", stbox1_out, tgeompt1_out, bool_result ? 't' : 'n');
 
   /* bool adjacent_tspatial_stbox(const Temporal *temp, const STBox *box); */
   bool_result = adjacent_tspatial_stbox(tgeompt1, stbox1);
@@ -2095,9 +2092,6 @@ int main(void)
   bool_result = contains_tspatial_tspatial(tgeompt1, tgeompt2);
   printf("contains_tspatial_tspatial(%s, %s): %c\n", tgeompt1_out, tgeompt2_out, bool_result ? 't' : 'n');
 
-  /* bool overlaps_stbox_tspatial(const STBox *box, const Temporal *temp); */
-  bool_result = overlaps_stbox_tspatial(stbox1, tgeompt1);
-  printf("overlaps_stbox_tspatial(%s, %s): %c\n", stbox1_out, tgeompt1_out, bool_result ? 't' : 'n');
 
   /* bool overlaps_tspatial_stbox(const Temporal *temp, const STBox *box); */
   bool_result = overlaps_tspatial_stbox(tgeompt1, stbox1);
@@ -2107,9 +2101,6 @@ int main(void)
   bool_result = overlaps_tspatial_tspatial(tgeompt1, tgeompt2);
   printf("overlaps_tspatial_tspatial(%s, %s): %c\n", tgeompt1_out, tgeompt2_out, bool_result ? 't' : 'n');
 
-  /* bool same_stbox_tspatial(const STBox *box, const Temporal *temp); */
-  bool_result = same_stbox_tspatial(stbox1, tgeompt1);
-  printf("same_stbox_tspatial(%s, %s): %c\n", stbox1_out, tgeompt1_out, bool_result ? 't' : 'n');
 
   /* bool same_tspatial_stbox(const Temporal *temp, const STBox *box); */
   bool_result = same_tspatial_stbox(tgeompt1, stbox1);

--- a/meos/test/temporal_test.c
+++ b/meos/test/temporal_test.c
@@ -2466,14 +2466,6 @@ int main(void)
 
   /* Topological functions for temporal types */
 
-  /* bool adjacent_numspan_tnumber(const Span *s, const Temporal *temp); */
-  bool_result = adjacent_numspan_tnumber(fspan1, tfloat1);
-  printf("adjacent_numspan_tnumber(%s, %s): %c\n", fspan1_out, tfloat1_out, bool_result ? 't' : 'n');
-
-  /* bool adjacent_tbox_tnumber(const TBox *box, const Temporal *temp); */
-  bool_result = adjacent_tbox_tnumber(tbox1, tfloat1);
-  printf("adjacent_tbox_tnumber(%s, %s): %c\n", tbox1_out, tfloat1_out, bool_result ? 't' : 'n');
-
   /* bool adjacent_temporal_temporal(const Temporal *temp1, const Temporal *temp2); */
   bool_result = adjacent_temporal_temporal(tfloat1, tfloat2);
   printf("adjacent_temporal_temporal(%s, %s): %c\n", tfloat1_out, tfloat2_out, bool_result ? 't' : 'n');
@@ -2493,10 +2485,6 @@ int main(void)
   /* bool adjacent_tnumber_tnumber(const Temporal *temp1, const Temporal *temp2); */
   bool_result = adjacent_tnumber_tnumber(tfloat1, tfloat2);
   printf("adjacent_tnumber_tnumber(%s, %s): %c\n", tfloat1_out, tfloat2_out, bool_result ? 't' : 'n');
-
-  /* bool adjacent_tstzspan_temporal(const Span *s, const Temporal *temp); */
-  bool_result = adjacent_tstzspan_temporal(tstzspan1, tfloat1);
-  printf("adjacent_tstzspan_temporal(%s, %s): %c\n", tstzspan1_out, tstzspan1_out, bool_result ? 't' : 'n');
 
   /* bool contained_numspan_tnumber(const Span *s, const Temporal *temp); */
   bool_result = contained_numspan_tnumber(fspan1, tfloat1);
@@ -2562,14 +2550,6 @@ int main(void)
   bool_result = contains_tstzspan_temporal(tstzspan1, tfloat1);
   printf("contains_tstzspan_temporal(%s, %s): %c\n", tstzspan1_out, tfloat1_out, bool_result ? 't' : 'n');
 
-  /* bool overlaps_numspan_tnumber(const Span *s, const Temporal *temp); */
-  bool_result = overlaps_numspan_tnumber(fspan1, tfloat1);
-  printf("overlaps_numspan_tnumber(%s, %s): %c\n", fspan1_out, tfloat1_out, bool_result ? 't' : 'n');
-
-  /* bool overlaps_tbox_tnumber(const TBox *box, const Temporal *temp); */
-  bool_result = overlaps_tbox_tnumber(tbox1, tfloat1);
-  printf("overlaps_tbox_tnumber(%s, %s): %c\n", tbox1_out, tfloat1_out, bool_result ? 't' : 'n');
-
   /* bool overlaps_temporal_temporal(const Temporal *temp1, const Temporal *temp2); */
   bool_result = overlaps_temporal_temporal(tfloat1, tfloat2);
   printf("overlaps_temporal_temporal(%s, %s): %c\n", tfloat1_out, tfloat2_out, bool_result ? 't' : 'n');
@@ -2590,18 +2570,6 @@ int main(void)
   bool_result = overlaps_tnumber_tnumber(tfloat1, tfloat2);
   printf("overlaps_tnumber_tnumber(%s, %s): %c\n", tfloat1_out, tfloat2_out, bool_result ? 't' : 'n');
 
-  /* bool overlaps_tstzspan_temporal(const Span *s, const Temporal *temp); */
-  bool_result = overlaps_tstzspan_temporal(tstzspan1, tfloat1);
-  printf("overlaps_tstzspan_temporal(%s, %s): %c\n", tstzspan1_out, tfloat1_out, bool_result ? 't' : 'n');
-
-  /* bool same_numspan_tnumber(const Span *s, const Temporal *temp); */
-  bool_result = same_numspan_tnumber(fspan1, tfloat1);
-  printf("same_numspan_tnumber(%s, %s): %c\n", fspan1_out, tfloat1_out, bool_result ? 't' : 'n');
-
-  /* bool same_tbox_tnumber(const TBox *box, const Temporal *temp); */
-  bool_result = same_tbox_tnumber(tbox1, tfloat1);
-  printf("same_tbox_tnumber(%s, %s): %c\n", tbox1_out, tfloat1_out, bool_result ? 't' : 'n');
-
   /* bool same_temporal_temporal(const Temporal *temp1, const Temporal *temp2); */
   bool_result = same_temporal_temporal(tfloat1, tfloat2);
   printf("same_temporal_temporal(%s, %s): %c\n", tfloat1_out, tfloat2_out, bool_result ? 't' : 'n');
@@ -2621,10 +2589,6 @@ int main(void)
   /* bool same_tnumber_tnumber(const Temporal *temp1, const Temporal *temp2); */
   bool_result = same_tnumber_tnumber(tfloat1, tfloat2);
   printf("same_tnumber_tnumber(%s, %s): %c\n", tfloat1_out, tfloat2_out, bool_result ? 't' : 'n');
-
-  /* bool same_tstzspan_temporal(const Span *s, const Temporal *temp); */
-  bool_result = same_tstzspan_temporal(tstzspan1, tfloat1);
-  printf("same_tstzspan_temporal(%s, %s): %c\n", tstzspan1_out, tfloat1_out, bool_result ? 't' : 'n');
 
   /*****************************************************************************/
   /* Position functions for temporal types */


### PR DESCRIPTION
The topological predicates same, overlaps and adjacent between a temporal value and a bounding box (tbox, stbox) or a span (numeric span, tstzspan) are commutative, so one temporal-first typed function covers both argument orders: same_tspatial_stbox, same_tnumber_tbox, same_tnumber_numspan, same_temporal_tstzspan and the overlaps and adjacent counterparts. The PostgreSQL operators ~=, && and -|- expose both argument directions through the generic Boxop dispatchers together with the operator COMMUTATOR, which is what GiST and SP-GiST index access uses; these typed functions are MEOS binding API outside the index path, so index access on either side is unaffected.