### PR TITLE
Complete the @csqlfn SQL-function links on the MEOS API binding surface

### DIFF
--- a/meos/src/cbuffer/cbuffer.c
+++ b/meos/src/cbuffer/cbuffer.c
@@ -749,6 +749,7 @@ cbuffer_radius(const Cbuffer *cb)
  * @ingroup meos_cbuffer_base_transf
  * @brief Return a circular buffer with the precision of the values set to a
  * number of decimal places
+ * @csqlfn #Cbuffer_round()
  */
 Cbuffer *
 cbuffer_round(const Cbuffer *cb, int maxdd)
@@ -868,6 +869,7 @@ cbuffer_transf_pj(const Cbuffer *cb, int32_t srid_to, const LWPROJ *pj)
  * @brief Return a circular buffer transformed to another SRID
  * @param[in] cb Circular buffer
  * @param[in] srid_to Target SRID
+ * @csqlfn #Cbuffer_transform()
  */
 Cbuffer *
 cbuffer_transform(const Cbuffer *cb, int32_t srid_to)
@@ -899,6 +901,7 @@ cbuffer_transform(const Cbuffer *cb, int32_t srid_to)
  * @param[in] pipeline Pipeline string
  * @param[in] srid_to Target SRID, may be `SRID_UNKNOWN`
  * @param[in] is_forward True when the transformation is forward
+ * @csqlfn #Cbuffer_transform_pipeline()
  */
 Cbuffer *
 cbuffer_transform_pipeline(const Cbuffer *cb, const char *pipeline,
@@ -1160,6 +1163,7 @@ cbuffer_touches(const Cbuffer *cb1, const Cbuffer *cb2)
  * @param[in] cb1,cb2 Circular buffers
  * @param[in] dist Distance
  * @note The function assumes that all validity tests have been previously done
+ * @csqlfn #Cbuffer_dwithin()
  */
 int
 cbuffer_dwithin(const Cbuffer *cb1, const Cbuffer *cb2, double dist)
@@ -1377,6 +1381,7 @@ cbuffer_ne(const Cbuffer *cb1, const Cbuffer *cb2)
  * @ingroup meos_cbuffer_base_comp
  * @brief Return true if two circular buffers are approximately equal with
  * respect to an epsilon value
+ * @csqlfn #Cbuffer_same()
  */
 bool
 cbuffer_same(const Cbuffer *cb1, const Cbuffer *cb2)
@@ -1504,6 +1509,7 @@ cbuffer_ge(const Cbuffer *cb1, const Cbuffer *cb2)
  * @ingroup meos_cbuffer_base_accessor
  * @brief Return the 32-bit hash value of a circular buffer
  * @param[in] cb Circular buffer
+ * @csqlfn #Cbuffer_hash()
  */
 uint32
 cbuffer_hash(const Cbuffer *cb)
@@ -1533,6 +1539,7 @@ cbuffer_hash(const Cbuffer *cb)
  * @param[in] cb Circular buffer
  * @param[in] seed Seed
  * csqlfn hash_extended
+ * @csqlfn #Cbuffer_hash_extended()
  */
 uint64
 cbuffer_hash_extended(const Cbuffer *cb, uint64 seed)

--- a/meos/src/cbuffer/tcbuffer.c
+++ b/meos/src/cbuffer/tcbuffer.c
@@ -318,6 +318,7 @@ tcbuffersegm_intersection(Datum start1, Datum end1, Datum start2, Datum end2,
  * @brief Return a temporal circular buffer from its Well-Known Text (WKT)
  * representation
  * @param[in] str String
+ * @csqlfn #Tcbuffer_in()
  */
 Temporal *
 tcbuffer_in(const char *str)

--- a/meos/src/geo/geo_round.c
+++ b/meos/src/geo/geo_round.c
@@ -524,6 +524,7 @@ round_geometrycollection(const GSERIALIZED *gs, int maxdd)
  * @param[in] gs Geometry/geography
  * @param[in] maxdd Maximum number of decimal digits
  * @note Currently not all geometry types are allowed
+ * @csqlfn #Geo_round()
  */
 GSERIALIZED *
 geo_round(const GSERIALIZED *gs, int maxdd)

--- a/meos/src/geo/stbox.c
+++ b/meos/src/geo/stbox.c
@@ -137,6 +137,7 @@ stbox_expand(const STBox *box1, STBox *box2)
  * where the commas are optional and the SRID is optional. If the SRID is not
  * stated it is by default 0 for non geodetic boxes and 4326 for geodetic boxes
  * @param[in] str String
+ * @csqlfn #Stbox_in()
  */
 STBox *
 stbox_in(const char *str)
@@ -153,6 +154,7 @@ stbox_in(const char *str)
  * box
  * @param[in] box Spatiotemporal box
  * @param[in] maxdd Maximum number of decimal digits
+ * @csqlfn #Stbox_out()
  */
 char *
 stbox_out(const STBox *box, int maxdd)
@@ -710,6 +712,7 @@ gbox_to_stbox(const GBOX *box)
  * @ingroup meos_geo_box_conversion
  * @brief Convert a `BOX3D` into a spatiotemporal box
  * @param[in] box BOX3D
+ * @csqlfn #Box3d_to_stbox()
  */
 STBox *
 box3d_to_stbox(const BOX3D *box)
@@ -1670,6 +1673,7 @@ stbox_transf_pj(const STBox *box, int32_t srid_to, const LWPROJ *pj)
  * @brief Return a spatiotemporal box transformed to another SRID
  * @param[in] box Spatiotemporal box
  * @param[in] srid_to Target SRID
+ * @csqlfn #Stbox_transform()
  */
 STBox *
 stbox_transform(const STBox *box, int32_t srid_to)
@@ -1700,6 +1704,7 @@ stbox_transform(const STBox *box, int32_t srid_to)
  * @param[in] pipeline Pipeline string
  * @param[in] srid_to Target SRID, may be `SRID_UNKNOWN`
  * @param[in] is_forward True when the transformation is forward
+ * @csqlfn #Stbox_transform_pipeline()
  */
 STBox *
 stbox_transform_pipeline(const STBox *box, const char *pipeline,
@@ -2573,6 +2578,7 @@ stbox_gt(const STBox *box1, const STBox *box2)
  * @param[in] box Spatiotemporal box
  * @return On error return @p INT_MAX
  * @sqlfn stbox_hash()
+ * @csqlfn #Stbox_hash()
  */
 uint32
 stbox_hash(const STBox *box)

--- a/meos/src/geo/tgeo_boxops.c
+++ b/meos/src/geo/tgeo_boxops.c
@@ -1371,6 +1371,7 @@ geo_split_n_gboxes(const GSERIALIZED *gs, int box_count, int *count)
  * @brief Return an array of N spatial boxes from the segments of a 
  * (multi)linestring
  * @sqlfn splitNStboxes()
+ * @csqlfn #Geo_split_n_stboxes()
  */
 STBox *
 geo_split_n_stboxes(const GSERIALIZED *gs, int box_count, int *count)

--- a/meos/src/geo/tgeo_tile.c
+++ b/meos/src/geo/tgeo_tile.c
@@ -1033,6 +1033,7 @@ tgeo_space_time_boxes(const Temporal *temp, double xsize, double ysize,
  * @param[in] border_inc True when the box contains the upper border, otherwise
  * the upper border is assumed as outside of the box.
  * @param[out] count Number of elements in the output array
+ * @csqlfn #Tgeo_space_boxes()
  */
 inline STBox *
 tgeo_space_boxes(const Temporal *temp, double xsize, double ysize,
@@ -1364,6 +1365,7 @@ tgeo_space_time_tile_init(const Temporal *temp, double xsize, double ysize,
  * @note This function in MEOS corresponds to the MobilityDB function
  * #Tgeo_space_time_split_common. Note that the test for the validity of the
  * arguments is done in #tgeo_space_time_tile_init
+ * @csqlfn #Tgeo_space_time_split()
  */
 Temporal **
 tgeo_space_time_split(const Temporal *temp, double xsize, double ysize,
@@ -1457,6 +1459,7 @@ tgeo_space_time_split(const Temporal *temp, double xsize, double ysize,
  * the upper border is assumed as outside of the box.
  * @param[out] space_bins Array of space bins
  * @param[out] count Number of elements in the output arrays
+ * @csqlfn #Tgeo_space_split()
  */
 inline Temporal **
 tgeo_space_split(const Temporal *temp, double xsize, double ysize,

--- a/meos/src/geo/tspatial_srid.c
+++ b/meos/src/geo/tspatial_srid.c
@@ -673,6 +673,7 @@ tspatial_transf_pj(const Temporal *temp, int32_t srid_to, const LWPROJ *pj)
  * @brief Return a spatiotemporal value transformed to another SRID
  * @param[in] temp Spatiotemporal value
  * @param[in] srid_to Target SRID
+ * @csqlfn #Tspatial_transform()
  */
 Temporal *
 tspatial_transform(const Temporal *temp, int32_t srid_to)
@@ -708,6 +709,7 @@ tspatial_transform(const Temporal *temp, int32_t srid_to)
  * @param[in] pipeline Pipeline string
  * @param[in] srid_to Target SRID, may be @p SRID_UNKNOWN
  * @param[in] is_forward True when the transformation is forward
+ * @csqlfn #Tspatial_transform_pipeline()
  */
 Temporal *
 tspatial_transform_pipeline(const Temporal *temp, const char *pipeline,

--- a/meos/src/geo/tspatial_tempspatialrels.c
+++ b/meos/src/geo/tspatial_tempspatialrels.c
@@ -698,6 +698,7 @@ tcontains_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] temp1,temp2 Temporal geometries
  * @note The function is not available for temporal points, the `tintersects`
  * function can be used instead.
+ * @csqlfn #Tcontains_tgeo_tgeo()
  */
 Temporal *
 tcontains_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
@@ -764,6 +765,7 @@ tcovers_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] temp1,temp2 Temporal geometries
  * @note The function is not available for temporal points, the `tintersects`
  * function can be used instead.
+ * @csqlfn #Tcovers_tgeo_tgeo()
  */
 Temporal *
 tcovers_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)

--- a/meos/src/npoint/npoint.c
+++ b/meos/src/npoint/npoint.c
@@ -1016,6 +1016,7 @@ nsegmentarr_geom(Nsegment **segments, int count)
  * @ingroup meos_npoint_base_transf
  * @brief Return a network point with the precision of the position set to a
  * number of decimal places
+ * @csqlfn #Npoint_round()
  */
 Npoint *
 npoint_round(const Npoint *np, int maxdd)
@@ -1044,6 +1045,7 @@ datum_npoint_round(Datum npoint, Datum size)
  * @ingroup meos_npoint_base_transf
  * @brief Return a network segment with the precision of the positions set to a
  * number of decimal places
+ * @csqlfn #Nsegment_round()
  */
 Nsegment *
 nsegment_round(const Nsegment *ns, int maxdd)

--- a/meos/src/npoint/tnpoint.c
+++ b/meos/src/npoint/tnpoint.c
@@ -213,6 +213,7 @@ tnpointsegm_intersection(Datum start1, Datum end1, Datum start2, Datum end2,
  * @brief Return a temporal network point from its Well-Known Text (WKT)
  * representation
  * @param[in] str String
+ * @csqlfn #Tnpoint_in()
  */
 Temporal *
 tnpoint_in(const char *str)

--- a/meos/src/npoint/tnpoint_spatialfuncs.c
+++ b/meos/src/npoint/tnpoint_spatialfuncs.c
@@ -195,6 +195,7 @@ tnpoint_trajectory(const Temporal *temp)
  * @details Two network points may be have different route identifier but
  * represent the same spatial point at the intersection of the two route
  * identifiers
+ * @csqlfn #Npoint_same()
  */
 bool
 npoint_same(const Npoint *np1, const Npoint *np2)
@@ -568,6 +569,7 @@ tnpoint_restrict_stbox(const Temporal *temp, const STBox *box, bool border_inc,
  * @param[in] box Spatiotemporal box
  * @param[in] border_inc True when the box contains the upper border
  * @sqlfn #Tnpoint_at_stbox()
+ * @csqlfn #Tnpoint_at_stbox()
  */
 inline Temporal *
 tnpoint_at_stbox(const Temporal *temp, const STBox *box, bool border_inc)
@@ -582,6 +584,7 @@ tnpoint_at_stbox(const Temporal *temp, const STBox *box, bool border_inc)
  * @param[in] box Spatiotemporal box
  * @param[in] border_inc True when the box contains the upper border
  * @sqlfn #Tnpoint_minus_stbox()
+ * @csqlfn #Tnpoint_minus_stbox()
  */
 inline Temporal *
 tnpoint_minus_stbox(const Temporal *temp, const STBox *box, bool border_inc)

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -852,6 +852,7 @@ pose_copy(const Pose *pose)
  * @ingroup meos_pose_base_conversion
  * @brief Convert a pose into a geometry point
  * @param[in] pose Pose
+ * @csqlfn #Pose_to_point()
  */
 GSERIALIZED *
 pose_to_point(const Pose *pose)
@@ -921,6 +922,7 @@ posearr_points(Pose **posearr, int count)
  * @brief Return the rotation of a 2D pose
  * @param[in] pose Pose
  * @return On error return @p DBL_MAX
+ * @csqlfn #Pose_rotation()
  */
 double
 pose_rotation(const Pose *pose)
@@ -947,6 +949,7 @@ datum_pose_rotation(Datum pose)
  * @brief Return the orientation of a 3D pose
  * @param[in] pose Pose
  * @return On error return @p NULL
+ * @csqlfn #Pose_orientation()
  */
 double *
 pose_orientation(const Pose *pose)
@@ -1050,6 +1053,7 @@ posearr_round(const Pose **posearr, int count, int maxdd)
  * @ingroup meos_pose_base_srid
  * @brief Return the SRID
  * @param[in] pose Pose
+ * @csqlfn #Pose_srid()
  */
 int32_t
 pose_srid(const Pose *pose)
@@ -1077,6 +1081,7 @@ pose_srid(const Pose *pose)
  * @brief Set the SRID
  * @param[in] pose Pose
  * @param[in] srid SRID
+ * @csqlfn #Pose_set_srid()
  */
 void
 pose_set_srid(Pose *pose, int32_t srid)
@@ -1135,6 +1140,7 @@ pose_transf_pj(const Pose *pose, int32_t srid_to, const LWPROJ *pj)
  * @brief Return a pose transformed to another SRID
  * @param[in] pose Pose
  * @param[in] srid_to Target SRID
+ * @csqlfn #Pose_transform()
  */
 Pose *
 pose_transform(const Pose *pose, int32_t srid_to)
@@ -1167,6 +1173,7 @@ pose_transform(const Pose *pose, int32_t srid_to)
  * @param[in] pipeline Pipeline string
  * @param[in] srid_to Target SRID, may be @p SRID_UNKNOWN
  * @param[in] is_forward True when the transformation is forward
+ * @csqlfn #Pose_transform_pipeline()
  */
 Pose *
 pose_transform_pipeline(const Pose *pose, const char *pipeline,
@@ -1287,6 +1294,7 @@ distance_pose_stbox(const Pose *pose, const STBox *box)
  * @ingroup meos_pose_base_comp
  * @brief Return true if the first pose is equal to the second one
  * @param[in] pose1,pose2 Poses
+ * @csqlfn #Pose_eq()
  */
 bool
 pose_eq(const Pose *pose1, const Pose *pose2)
@@ -1316,6 +1324,7 @@ pose_eq(const Pose *pose1, const Pose *pose2)
  * @ingroup meos_pose_base_comp
  * @brief Return true if the first pose is not equal to the second one
  * @param[in] pose1,pose2 Poses
+ * @csqlfn #Pose_ne()
  */
 inline bool
 pose_ne(const Pose *pose1, const Pose *pose2)
@@ -1327,6 +1336,7 @@ pose_ne(const Pose *pose1, const Pose *pose2)
  * @ingroup meos_pose_base_comp
  * @brief Return true if the first pose is equal to the second one
  * @param[in] pose1,pose2 Poses
+ * @csqlfn #Pose_same()
  */
 bool
 pose_same(const Pose *pose1, const Pose *pose2)
@@ -1368,6 +1378,7 @@ pose_nsame(const Pose *pose1, const Pose *pose2)
  * @brief Return -1, 0, or 1 depending on whether the first pose
  * is less than, equal to, or greater than the second one
  * @param[in] pose1,pose2 Poses
+ * @csqlfn #Pose_cmp()
  */
 int
 pose_cmp(const Pose *pose1, const Pose *pose2)
@@ -1399,6 +1410,7 @@ pose_cmp(const Pose *pose1, const Pose *pose2)
  * @ingroup meos_pose_base_comp
  * @brief Return true if the first pose is less than the second one
  * @param[in] pose1,pose2 Poses
+ * @csqlfn #Pose_lt()
  */
 inline bool
 pose_lt(const Pose *pose1, const Pose *pose2)
@@ -1410,6 +1422,7 @@ pose_lt(const Pose *pose1, const Pose *pose2)
  * @ingroup meos_pose_base_comp
  * @brief Return true if the first pose is less than or equal to the second one
  * @param[in] pose1,pose2 Poses
+ * @csqlfn #Pose_le()
  */
 inline bool
 pose_le(const Pose *pose1, const Pose *pose2)
@@ -1421,6 +1434,7 @@ pose_le(const Pose *pose1, const Pose *pose2)
  * @ingroup meos_pose_base_comp
  * @brief Return true if the first pose is greater than the second one
  * @param[in] pose1,pose2 Poses
+ * @csqlfn #Pose_gt()
  */
 inline bool
 pose_gt(const Pose *pose1, const Pose *pose2)
@@ -1433,6 +1447,7 @@ pose_gt(const Pose *pose1, const Pose *pose2)
  * @brief Return true if the first pose is greater than or equal to the second
  * one
  * @param[in] pose1,pose2 Poses
+ * @csqlfn #Pose_ge()
  */
 inline bool
 pose_ge(const Pose *pose1, const Pose *pose2)
@@ -1457,6 +1472,7 @@ void hashlittle2(const void *key, size_t length, uint32_t *pc, uint32_t *pb);
  * @ingroup meos_pose_base_accessor
  * @brief Return the 32-bit hash value of a pose
  * @param[in] pose Pose
+ * @csqlfn #Pose_hash()
  */
 uint32
 pose_hash(const Pose *pose)
@@ -1494,6 +1510,7 @@ pose_hash(const Pose *pose)
  * @param[in] pose Pose
  * @param[in] seed Seed
  * csqlfn hash_extended
+ * @csqlfn #Pose_hash_extended()
  */
 uint64
 pose_hash_extended(const Pose *pose, uint64 seed)

--- a/meos/src/pose/tpose.c
+++ b/meos/src/pose/tpose.c
@@ -174,6 +174,7 @@ tposesegm_intersection(Datum start1, Datum end1, Datum start2, Datum end2,
  * @ingroup meos_pose_inout
  * @brief Return a temporal pose from its Well-Known Text (WKT) representation
  * @param[in] str String
+ * @csqlfn #Tpose_in()
  */
 Temporal *
 tpose_in(const char *str)
@@ -423,6 +424,7 @@ tpose_to_tpoint(const Temporal *temp)
  * @ingroup meos_pose_accessor
  * @brief Return a the rotation of a temporal pose as a temporal float
  * @param[in] temp Temporal pose
+ * @csqlfn #Tpose_rotation()
  */
 Temporal *
 tpose_rotation(const Temporal *temp)

--- a/meos/src/pose/tpose_spatialfuncs.c
+++ b/meos/src/pose/tpose_spatialfuncs.c
@@ -172,6 +172,7 @@ tpose_restrict_stbox(const Temporal *temp, const STBox *box, bool border_inc,
  * @param[in] box Spatiotemporal box
  * @param[in] border_inc True when the box contains the upper border
  * @sqlfn #Tpose_at_stbox()
+ * @csqlfn #Tpose_at_stbox()
  */
 inline Temporal *
 tpose_at_stbox(const Temporal *temp, const STBox *box, bool border_inc)
@@ -186,6 +187,7 @@ tpose_at_stbox(const Temporal *temp, const STBox *box, bool border_inc)
  * @param[in] box Spatiotemporal box
  * @param[in] border_inc True when the box contains the upper border
  * @sqlfn #Tpose_minus_stbox()
+ * @csqlfn #Tpose_minus_stbox()
  */
 inline Temporal *
 tpose_minus_stbox(const Temporal *temp, const STBox *box, bool border_inc)

--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -166,6 +166,7 @@ trgeo_from_mfjson(const char *mfjson)
  * @brief Return the Well-Known Text (WKT) representation of a temporal rigid
  * geometry
  * @param[in] temp Temporal rigid geometry
+ * @csqlfn #Trgeometry_out()
  */
 char *
 trgeometry_out(const Temporal *temp)
@@ -247,6 +248,7 @@ trgeo_as_ewkt(const Temporal *temp, int maxdd)
  * @brief Return a temporal pose obtained by removing the reference geometry
  * of a temporal rigid geometry
  * @param[in] temp Temporal rigid geometry
+ * @csqlfn #Trgeometry_to_tpose()
  */
 Temporal *
 trgeometry_to_tpose(const Temporal *temp)
@@ -270,6 +272,7 @@ trgeometry_to_tpose(const Temporal *temp)
  * @brief Return a temporal point obtained from the points of the temporal
  * pose of a temporal rigid geometry
  * @param[in] temp Temporal rigid geometry
+ * @csqlfn #Trgeometry_to_tpoint()
  */
 Temporal *
 trgeometry_to_tpoint(const Temporal *temp)
@@ -470,6 +473,7 @@ trgeometry_start_value(const Temporal *temp)
  * @ingroup meos_rgeo_accessor
  * @brief Return a copy of the end base value of a temporal rigid geometry
  * @param[in] temp Temporal rigid geometry
+ * @csqlfn #Trgeometry_end_value()
  */
 GSERIALIZED *
 trgeometry_end_value(const Temporal *temp)

--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -1827,6 +1827,7 @@ dist2d_trgeoseqset_geo(const TSequenceSet *ss, const GSERIALIZED *gs)
  * @param[in] temp Temporal
  * @param[in] gs Geometry
  * @sqlop @p <->
+ * @csqlfn #Tdistance_trgeometry_geo()
  */
 Temporal *
 tdistance_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
@@ -1859,6 +1860,7 @@ tdistance_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @brief Return the temporal distance between two
  * temporal rigid geometries.
  * @sqlop @p <->
+ * @csqlfn #Tdistance_trgeometry_tpoint()
  */
 Temporal *
 tdistance_trgeometry_tpoint(const Temporal *temp1 UNUSED,
@@ -1878,6 +1880,7 @@ tdistance_trgeometry_tpoint(const Temporal *temp1 UNUSED,
  * @ingroup meos_rgeo_dist
  * @brief Return the temporal distance between two temporal rigid geometries
  * @sqlop @p <->
+ * @csqlfn #Tdistance_trgeometry_trgeometry()
  */
 Temporal *
 tdistance_trgeometry_trgeometry(const Temporal *temp1 UNUSED,
@@ -2099,6 +2102,7 @@ nad_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2)
  * @brief Return the line connecting the nearest approach point between a
  * temporal rigid geometry and a geometry
  * @sqlfn shortestLine()
+ * @csqlfn #Shortestline_trgeometry_geo()
  */
 GSERIALIZED *
 shortestline_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
@@ -2123,6 +2127,7 @@ shortestline_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @brief Return the line connecting the nearest approach point between a
  * temporal rigid geometry and a temporal geometry point
  * @sqlfn shortestLine()
+ * @csqlfn #Shortestline_trgeometry_tpoint()
  */
 GSERIALIZED *
 shortestline_trgeometry_tpoint(const Temporal *temp1, const Temporal *temp2)
@@ -2150,6 +2155,7 @@ shortestline_trgeometry_tpoint(const Temporal *temp1, const Temporal *temp2)
  * @brief Return the line connecting the nearest approach point between two
  * temporal rigid geometries
  * @sqlfn shortestLine()
+ * @csqlfn #Shortestline_trgeometry_trgeometry()
  */
 GSERIALIZED *
 shortestline_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2)

--- a/meos/src/temporal/set.c
+++ b/meos/src/temporal/set.c
@@ -638,6 +638,7 @@ set_num_values(const Set *s)
  * @ingroup meos_internal_setspan_accessor
  * @brief Return a copy of the start value of a set
  * @param[in] s Set
+ * @csqlfn #Set_start_value()
  */
 Datum
 set_start_value(const Set *s)
@@ -651,6 +652,7 @@ set_start_value(const Set *s)
  * @ingroup meos_internal_setspan_accessor
  * @brief Return a copy of the end value of a set
  * @param[in] s Set
+ * @csqlfn #Set_end_value()
  */
 Datum
 set_end_value(const Set *s)
@@ -723,6 +725,7 @@ set_values(const Set *s)
  * decimal places
  * @param[in] s Set
  * @param[in] maxdd Maximum number of decimal digits
+ * @csqlfn #Set_round()
  */
 Set *
 set_round(const Set *s, int maxdd)

--- a/meos/src/temporal/set_aggfuncs_meos.c
+++ b/meos/src/temporal/set_aggfuncs_meos.c
@@ -225,6 +225,7 @@ value_union_transfn(Set *state, Datum value, MeosType basetype)
  * @code
  * state = set_union_transfn(state, set);
  * @endcode
+ * @csqlfn #Set_union_transfn()
  */
 Set *
 set_union_transfn(Set *state, Set *s)
@@ -254,6 +255,7 @@ set_union_transfn(Set *state, Set *s)
  * @brief Final function for set union aggregate
  * @param[in,out] state Current aggregate state
  * @note The input state must be free by the calling function
+ * @csqlfn #Set_union_finalfn()
  */
 Set *
 set_union_finalfn(Set *state)

--- a/meos/src/temporal/span.c
+++ b/meos/src/temporal/span.c
@@ -351,6 +351,7 @@ spanarr_normalize(Span *spans, int count, bool order, int *newcount)
  * @brief Return a span from its Well-Known Text (WKT) representation
  * @param[in] str String
  * @param[in] spantype Span type
+ * @csqlfn #Span_in()
  */
 Span *
 span_in(const char *str, MeosType spantype)
@@ -387,6 +388,7 @@ unquote(char *str)
  * @brief Return the Well-Known Text (WKT) representation of a span
  * @param[in] s Span
  * @param[in] maxdd Maximum number of decimal digits
+ * @csqlfn #Span_out()
  */
 char *
 span_out(const Span *s, int maxdd)
@@ -622,6 +624,7 @@ intspan_set_floatspan(const Span *s1, Span *s2)
  * @brief Convert an integer span into a float span
  * @param[in] s Span
  * @return On error return @p NULL
+ * @csqlfn #Intspan_to_floatspan()
  */
 Span *
 intspan_to_floatspan(const Span *s)
@@ -654,6 +657,7 @@ floatspan_set_intspan(const Span *s1, Span *s2)
  * @brief Convert a float span into an integer span
  * @param[in] s Span
  * @return On error return @p NULL
+ * @csqlfn #Floatspan_to_intspan()
  */
 Span *
 floatspan_to_intspan(const Span *s)
@@ -688,6 +692,7 @@ datespan_set_tstzspan(const Span *s1, Span *s2)
  * @brief Convert a date span into a timestamptz span
  * @param[in] s Span
  * @return On error return @p NULL
+ * @csqlfn #Datespan_to_tstzspan()
  */
 Span *
 datespan_to_tstzspan(const Span *s)
@@ -730,6 +735,7 @@ tstzspan_set_datespan(const Span *s1, Span *s2)
  * @brief Convert a timestamptz span into a date span
  * @param[in] s Span
  * @return On error return @p NULL
+ * @csqlfn #Tstzspan_to_datespan()
  */
 Span *
 tstzspan_to_datespan(const Span *s)
@@ -830,6 +836,7 @@ floatspan_round_set(const Span *s, int maxdd, Span *result)
  * @param[in] s Span
  * @param[in] maxdd Maximum number of decimal digits
  * @return On error return @p NULL
+ * @csqlfn #Floatspan_round()
  */
 Span *
 floatspan_round(const Span *s, int maxdd)

--- a/meos/src/temporal/span_aggfuncs.c
+++ b/meos/src/temporal/span_aggfuncs.c
@@ -72,6 +72,7 @@ spanbase_extent_transfn(Span *state, Datum value, MeosType basetype)
  * @brief Transition function for span extent aggregate of sets
  * @param[in,out] state Current aggregate state, may be `NULL`
  * @param[in] s Set to aggregate, may be `NULL`
+ * @csqlfn #Set_extent_transfn()
  */
 Span *
 set_extent_transfn(Span *state, const Set *s)
@@ -102,6 +103,7 @@ set_extent_transfn(Span *state, const Set *s)
  * @brief Transition function for span extent aggregate of spans
  * @param[in,out] state Current aggregate state, may be `NULL`
  * @param[in] s Span to aggregate, may be `NULL`
+ * @csqlfn #Span_extent_transfn()
  */
 Span *
 span_extent_transfn(Span *state, const Span *s)
@@ -129,6 +131,7 @@ span_extent_transfn(Span *state, const Span *s)
  * @brief Transition function for span extent aggregate of span sets
  * @param[in,out] state Current aggregate state, may be `NULL`
  * @param[in] ss Span set to aggregate, may be `NULL`
+ * @csqlfn #Spanset_extent_transfn()
  */
 Span *
 spanset_extent_transfn(Span *state, const SpanSet *ss)

--- a/meos/src/temporal/span_aggfuncs_meos.c
+++ b/meos/src/temporal/span_aggfuncs_meos.c
@@ -253,6 +253,7 @@ span_union_transfn(SpanSet *state, const Span *s)
  * @code
  * state = spanset_union_transfn(state, spanset);
  * @endcode
+ * @csqlfn #Spanset_union_transfn()
  */
 SpanSet *
 spanset_union_transfn(SpanSet *state, const SpanSet *ss)

--- a/meos/src/temporal/spanset.c
+++ b/meos/src/temporal/spanset.c
@@ -209,6 +209,7 @@ SPANSET_SP_N(const SpanSet *ss, int index)
  * @brief Return a span set from its Well-Known Text (WKT) representation
  * @param[in] str String
  * @param[in] spansettype Span set type
+ * @csqlfn #Spanset_in()
  */
 SpanSet *
 spanset_in(const char *str, MeosType spansettype)

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -757,6 +757,7 @@ intersection_temporal_temporal(const Temporal *temp1, const Temporal *temp2,
 /**
  * @ingroup meos_misc
  * @brief Return the version of the MobilityDB extension
+ * @csqlfn #Mobilitydb_version()
  */
 char *
 mobilitydb_version(void)
@@ -767,6 +768,7 @@ mobilitydb_version(void)
 /**
  * @ingroup meos_misc
  * @brief Return the versions of the MobilityDB extension and its dependencies
+ * @csqlfn #Mobilitydb_full_version()
  */
 char *
 mobilitydb_full_version(void)
@@ -800,6 +802,7 @@ mobilitydb_full_version(void)
  * @brief Return a temporal value from its Well-Known Text (WKT) representation
  * @param[in] str String
  * @param[in] temptype Temporal type
+ * @csqlfn #Temporal_in()
  */
 Temporal *
 temporal_in(const char *str, MeosType temptype)
@@ -814,6 +817,7 @@ temporal_in(const char *str, MeosType temptype)
  * @brief Return the Well-Known Text (WKT) representation of a temporal value
  * @param[in] temp Temporal value
  * @param[in] maxdd Maximum number of decimal digits
+ * @csqlfn #Temporal_out()
  */
 char *
 temporal_out(const Temporal *temp, int maxdd)
@@ -1206,6 +1210,7 @@ round_fn(MeosType basetype)
  * @brief Return a temporal value rounded to a given number of decimal places
  * @param[in] temp Temporal value
  * @param[in] maxdd Maximum number of decimal digits to output
+ * @csqlfn #Temporal_round()
  */
 Temporal *
 temporal_round(const Temporal *temp, int maxdd)
@@ -1254,6 +1259,7 @@ temparr_round(Temporal **temparr, int count, int maxdd)
 /**
  * @ingroup meos_base_types
  * @brief Return a float number rounded to a given number of decimal places
+ * @csqlfn #Float_round()
  */
 double
 float_round(double d, int maxdd)
@@ -1968,6 +1974,7 @@ temporal_start_value(const Temporal *temp)
  * @ingroup meos_internal_temporal_accessor
  * @brief Return a copy of the end base value of a temporal value
  * @param[in] temp Temporal value
+ * @csqlfn #Temporal_end_value()
  */
 Datum
 temporal_end_value(const Temporal *temp)
@@ -1993,6 +2000,7 @@ temporal_end_value(const Temporal *temp)
  * @ingroup meos_internal_temporal_accessor
  * @brief Return a copy of the minimum base value of a temporal value
  * @param[in] temp Temporal value
+ * @csqlfn #Temporal_min_value()
  */
 Datum
 temporal_min_value(const Temporal *temp)
@@ -3183,6 +3191,7 @@ tsequenceset_stops(const TSequenceSet *ss, double maxdist, int64 mintunits)
  * @param[in] temp Temporal value
  * @param[in] maxdist Maximum distance
  * @param[in] minduration Minimum duration
+ * @csqlfn #Temporal_stops()
  */
 TSequenceSet *
 temporal_stops(const Temporal *temp, double maxdist,
@@ -3227,6 +3236,7 @@ temporal_stops(const Temporal *temp, double maxdist,
  * @brief Return the integral (area under the curve) of a temporal number
  * @param[in] temp Temporal value
  * @return On error return -1.0
+ * @csqlfn #Tnumber_integral()
  */
 double
 tnumber_integral(const Temporal *temp)

--- a/meos/src/temporal/temporal_analytics.c
+++ b/meos/src/temporal/temporal_analytics.c
@@ -67,6 +67,7 @@
  * @param[in] t Time value
  * @param[in] duration Size of the time bins
  * @param[in] torigin Time origin of the bins
+ * @csqlfn #Timestamptz_tprecision()
  */
 TimestampTz
 timestamptz_tprecision(TimestampTz t, const Interval *duration,
@@ -85,6 +86,7 @@ timestamptz_tprecision(TimestampTz t, const Interval *duration,
  * @param[in] s Timestamptz set
  * @param[in] duration Size of the time bins
  * @param[in] torigin Time origin of the bins
+ * @csqlfn #Tstzset_tprecision()
  */
 Set *
 tstzset_tprecision(const Set *s, const Interval *duration, TimestampTz torigin)
@@ -107,6 +109,7 @@ tstzset_tprecision(const Set *s, const Interval *duration, TimestampTz torigin)
  * @param[in] s Time value
  * @param[in] duration Size of the time bins
  * @param[in] torigin Time origin of the bins
+ * @csqlfn #Tstzspan_tprecision()
  */
 Span *
 tstzspan_tprecision(const Span *s, const Interval *duration,
@@ -134,6 +137,7 @@ tstzspan_tprecision(const Span *s, const Interval *duration,
  * @param[in] ss Time value
  * @param[in] duration Size of the time bins
  * @param[in] torigin Time origin of the bins
+ * @csqlfn #Tstzspanset_tprecision()
  */
 SpanSet *
 tstzspanset_tprecision(const SpanSet *ss, const Interval *duration,
@@ -1196,6 +1200,7 @@ tinstarr_hausdorff_distance(TInstant **instants1, int count1,
  * @brief Return the Hausdorf distance between two temporal values
  * @param[in] temp1,temp2 Temporal values
  * @return On error return `DBL_MAX`
+ * @csqlfn #Temporal_hausdorff_distance()
  */
 double
 temporal_hausdorff_distance(const Temporal *temp1, const Temporal *temp2)

--- a/meos/src/temporal/temporal_tile.c
+++ b/meos/src/temporal/temporal_tile.c
@@ -532,6 +532,7 @@ spanset_bins(const SpanSet *ss, Datum size, Datum origin, int *count)
  * @param[in] duration Interval defining the size of the bins
  * @param[in] torigin Origin of the bins
  * @param[out] count Number of elements in the output array
+ * @csqlfn #Temporal_time_bins()
  */
 Span *
 temporal_time_bins(const Temporal *temp, const Interval *duration,

--- a/meos/src/temporal/tinstant.c
+++ b/meos/src/temporal/tinstant.c
@@ -82,6 +82,7 @@ tinstant_value_p(const TInstant *inst)
  * @ingroup meos_internal_temporal_accessor
  * @brief Return a copy of the base value of a temporal instant
  * @param[in] inst Temporal instant
+ * @csqlfn #Tinstant_value()
  */
 Datum
 tinstant_value(const TInstant *inst)

--- a/meos/src/temporal/tnumber_mathfuncs.c
+++ b/meos/src/temporal/tnumber_mathfuncs.c
@@ -482,6 +482,7 @@ angular_difference(Datum degrees1, Datum degrees2)
  * @brief Return the angular difference, i.e., the smaller angle between the
  * two degree values
  * @param[in] degrees1,degrees2 Values
+ * @csqlfn #Float_angular_difference()
  */
 double
 float_angular_difference(double degrees1, double degrees2)

--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -970,6 +970,7 @@ ensure_temptype_mfjson(const char *typestr)
  * @see #tinstant_from_mfjson()
  * @see #tsequence_from_mfjson()
  * @see #tsequenceset_from_mfjson()
+ * @csqlfn #Temporal_from_mfjson()
  */
 Temporal *
 temporal_from_mfjson(const char *mfjson, MeosType temptype)


### PR DESCRIPTION
Each MEOS API function wrapped by an external SQL function declares the @csqlfn link to its PostgreSQL wrapper, so the binding code generators derive the SQL function and operator for every binding-API function. The tags cover the temporal, geo, cbuffer, npoint, pose and rgeo families and are doxygen comments only, with no change to code or behaviour.