### PR TITLE
Link tpose_to_tpoint and name the rgeo seqset SQL functions canonically

### DIFF
--- a/mobilitydb/src/rgeo/trgeo.c
+++ b/mobilitydb/src/rgeo/trgeo.c
@@ -336,7 +336,7 @@ PG_FUNCTION_INFO_V1(Trgeometry_seqset_constructor_gaps);
  * @brief Construct a temporal rigid geometry sequence set from an array of
  * temporal instants accounting for potential gaps
  * @note The SQL function is not strict
- * @sqlfn trgeoSeqsetGaps()
+ * @sqlfn trgeometrySeqSetGaps()
  */
 Datum
 Trgeometry_seqset_constructor_gaps(PG_FUNCTION_ARGS)
@@ -579,7 +579,7 @@ PG_FUNCTION_INFO_V1(Trgeometry_to_tsequenceset);
  * @brief Return a temporal rigid geometry transformed into a temporal sequence
  * set
  * @note The SQL function is not strict
- * @sqlfn trgeoSeqSet()
+ * @sqlfn trgeometrySeqSet()
  */
 Datum
 Trgeometry_to_tsequenceset(PG_FUNCTION_ARGS)


### PR DESCRIPTION
The MEOS tpose_to_tpoint conversion declares the @csqlfn link to its Tpose_to_tgeompoint PostgreSQL wrapper, and the rigid-geometry sequence-set constructor and conversion wrappers name their SQL functions trgeometrySeqSetGaps and trgeometrySeqSet to match the catalog. Doxygen comments only, with no change to code or behaviour.