### PR TITLE
Index the hex-decode table with the unsigned byte value

### DIFF
--- a/postgis/liblwgeom/lwin_wkb.c
+++ b/postgis/liblwgeom/lwin_wkb.c
@@ -105,8 +105,8 @@ uint8_t* bytes_from_hexbytes(const char *hexbuf, size_t hexsize)
 
 	for( i = 0; i < hexsize/2; i++ )
 	{
-		h1 = hex2char[(int)hexbuf[2*i]];
-		h2 = hex2char[(int)hexbuf[2*i+1]];
+		h1 = hex2char[(uint8_t) hexbuf[2*i]]; /* MEOS */
+		h2 = hex2char[(uint8_t) hexbuf[2*i+1]]; /* MEOS */
 		if( h1 > 15 )
 			lwerror("Invalid hex character (%c) encountered", hexbuf[2*i]);
 		if( h2 > 15 )


### PR DESCRIPTION
bytes_from_hexbytes indexes the 256-entry hex2char lookup with a hex character cast to int from a plain char. On platforms where char is signed a byte with the high bit set casts to a negative index and reads out of bounds, so a hex-WKB string carrying such a byte is decoded through undefined behavior instead of being rejected cleanly. Cast the character to uint8_t so the index is the unsigned byte value on every platform.