### PR TITLE
Reconcile component SRIDs in the rigid-geometry constructor

### DIFF
--- a/meos/include/geo/tgeo_spatialfuncs.h
+++ b/meos/include/geo/tgeo_spatialfuncs.h
@@ -100,6 +100,7 @@ extern bool ensure_same_geodetic_tspatial_base(const Temporal *temp,
   Datum base);
 extern bool ensure_srid_known(int32_t srid);
 extern bool ensure_same_srid(int32_t srid1, int32_t srid2);
+extern bool ensure_srid_reconcile(int32_t srid1, int32_t srid2, int32_t *result);
 extern bool ensure_same_dimensionality(int16 flags1, int16 flags2);
 extern bool same_spatial_dimensionality(int16 flags1, int16 flags2);
 extern bool ensure_same_spatial_dimensionality(int16 flags1, int16 flags2);

--- a/meos/src/geo/tgeo_spatialfuncs.c
+++ b/meos/src/geo/tgeo_spatialfuncs.c
@@ -588,6 +588,35 @@ ensure_same_srid(int32_t srid1, int32_t srid2)
 }
 
 /**
+ * @brief Reconcile the SRID of two spatial components: copy the known SRID onto
+ * the one that is unknown, and ensure that two known SRIDs are equal
+ * @details This is the single construction-time SRID resolution used by the
+ * parsers and the constructors: an unknown (`SRID_UNKNOWN`) component adopts the
+ * SRID of the other, while two known but different SRIDs are rejected. By
+ * convention @p srid1 is the geometry SRID and @p srid2 the temporal type SRID.
+ * @param[in] srid1,srid2 SRIDs to reconcile
+ * @param[out] result Common SRID (the known one, or `SRID_UNKNOWN` if both are
+ * unknown)
+ * @return On error (two different known SRIDs) return false
+ */
+bool
+ensure_srid_reconcile(int32_t srid1, int32_t srid2, int32_t *result)
+{
+  if (srid1 == SRID_UNKNOWN)
+    *result = srid2;
+  else if (srid2 == SRID_UNKNOWN || srid2 == srid1)
+    *result = srid1;
+  else
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "SRID of geometry (%d) and temporal type (%d) must correspond", srid1,
+      srid2);
+    return false;
+  }
+  return true;
+}
+
+/**
  * @brief Ensure that two temporal points have the same dimensionality as given
  * by their flags
  */

--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -407,13 +407,43 @@ geo_tpose_to_trgeometry(const GSERIALIZED *gs, const Temporal *temp)
   if (! ensure_not_empty(gs) || ! ensure_has_not_M_geo(gs))
     return NULL;
 
-  assert(temptype_subtype(temp->subtype));
-  if (temp->subtype == TINSTANT)
-    return (Temporal *) geo_tposeinst_to_trgeo(gs, (TInstant *) temp);
-  else if (temp->subtype == TSEQUENCE)
-    return (Temporal *) geo_tposeseq_to_trgeo(gs, (TSequence *) temp);
-  else /* temp->subtype == TSEQUENCESET */
-    return (Temporal *) geo_tposeseqset_to_trgeo(gs, (TSequenceSet *) temp);
+  /* Reconcile the SRID of the reference geometry and the temporal pose: copy the
+   * known SRID onto the one that is unknown, and error if both are known and
+   * differ. This mirrors the text parser (trgeo_parse_geom) so that programmatic
+   * and parsed construction agree, and guarantees that the resulting value is
+   * SRID-consistent across its reference geometry and its pose. */
+  int32_t srid_geom = gserialized_get_srid(gs);
+  int32_t srid_temp = tspatial_srid(temp);
+  int32_t srid;
+  if (! ensure_srid_reconcile(srid_geom, srid_temp, &srid))
+    return NULL;
+  GSERIALIZED *gs1 = (GSERIALIZED *) gs;
+  Temporal *temp1 = (Temporal *) temp;
+  bool free_gs = false, free_temp = false;
+  if (srid_geom == SRID_UNKNOWN && srid != SRID_UNKNOWN)
+  {
+    gs1 = geo_copy(gs);
+    gserialized_set_srid(gs1, srid);
+    free_gs = true;
+  }
+  else if (srid_temp == SRID_UNKNOWN && srid != SRID_UNKNOWN)
+  {
+    temp1 = tspatial_set_srid(temp, srid);
+    free_temp = true;
+  }
+
+  Temporal *result;
+  assert(temptype_subtype(temp1->subtype));
+  if (temp1->subtype == TINSTANT)
+    result = (Temporal *) geo_tposeinst_to_trgeo(gs1, (TInstant *) temp1);
+  else if (temp1->subtype == TSEQUENCE)
+    result = (Temporal *) geo_tposeseq_to_trgeo(gs1, (TSequence *) temp1);
+  else /* temp1->subtype == TSEQUENCESET */
+    result = (Temporal *) geo_tposeseqset_to_trgeo(gs1, (TSequenceSet *) temp1);
+
+  if (free_gs) pfree(gs1);
+  if (free_temp) pfree(temp1);
+  return result;
 }
 
 /*****************************************************************************

--- a/meos/src/rgeo/trgeo_parser.c
+++ b/meos/src/rgeo/trgeo_parser.c
@@ -282,23 +282,18 @@ trgeo_parse_geom(const char **str, int32_t temp_srid)
   GSERIALIZED *result = DatumGetGserializedP(geom);
   ensure_not_empty(result);
   ensure_has_not_M_geo(result);
-  /* If one of the SRID of the temporal rigid geometry and of the geometry
-   * is SRID_UNKNOWN and the other not, copy the SRID */
+  /* Reconcile the SRID of the geometry and the temporal rigid geometry: copy
+   * the known SRID onto the one that is unknown, and error if both are known and
+   * differ */
   int32_t geo_srid = gserialized_get_srid(result);
-  if (temp_srid == SRID_UNKNOWN && geo_srid != SRID_UNKNOWN)
-    temp_srid = geo_srid;
-  else if (temp_srid != SRID_UNKNOWN && geo_srid == SRID_UNKNOWN)
-    gserialized_set_srid(result, temp_srid);
-  /* If the SRID of the temporal rigid geometry and of the geometry do not match */
-  else if (temp_srid != SRID_UNKNOWN && geo_srid != SRID_UNKNOWN &&
-    temp_srid != geo_srid)
+  int32_t srid;
+  if (! ensure_srid_reconcile(geo_srid, temp_srid, &srid))
   {
-    meos_error(ERROR, MEOS_ERR_TEXT_INPUT,
-      "Geometry SRID (%d) does not match temporal type SRID (%d)",
-      geo_srid, temp_srid);
     pfree(result);
     return NULL;
   }
+  if (geo_srid == SRID_UNKNOWN && srid != SRID_UNKNOWN)
+    gserialized_set_srid(result, srid);
   return result;
 }
 


### PR DESCRIPTION
## Problem

A temporal rigid geometry carries **two** SRID-bearing components: its reference geometry and its temporal pose. The text parser reconciles them (an unknown SRID adopts the known one; two different known SRIDs are rejected), but the programmatic constructor `geo_tpose_to_trgeometry` dispatched straight to the per-subtype builders **without any reconciliation**. As a result, a value built from a known-SRID geometry and an unknown-SRID pose (or vice versa) was left internally inconsistent — e.g. `geo_tpose_to_trgeometry(<SRID 4326 geometry>, <SRID-unknown pose>)` produced a value whose reference geometry was 4326 while its pose stayed 0.

The reconciliation logic was also **duplicated inline** in the parsers (`geo_parse`, `trgeo_parse_geom`) with no shared helper, and the two copies had already drifted (different error messages).

## Fix

- Extract the construction-time SRID resolution into a single shared helper `ensure_srid_reconcile(srid1, srid2, *result)` next to `ensure_same_srid`: an unknown SRID adopts the known one, and two different known SRIDs are rejected.
- Use it in **both** `geo_tpose_to_trgeometry` (the constructor — the actual bug) and `trgeo_parse_geom` (de-duplicating the parser's inline block).

The constructor now copies the known SRID onto the unknown component and rejects a genuine mismatch, exactly as the parser does, so programmatic and parsed construction agree and the result is always SRID-consistent.

## Verification

- MEOS library and PostgreSQL extension both build clean.
- The rigid-geometry regression group passes (`151_trgeo_inout`, `156_trgeo_topops`, `157_trgeo_posops`, + table variants): 12/12.
- Direct check of `geo_tpose_to_trgeometry`: `(geom 4326, pose 0)` and `(geom 0, pose 4326)` now both yield a consistent 4326 value; `(geom 0, pose 0)` stays consistent at 0; `(geom 4326, pose 3812)` is rejected with `SRID of geometry (4326) and temporal type (3812) must correspond`.
