### PR TITLE
Add bare geom_intersects and geom_dwithin (planar 2D defaults)

### DIFF
--- a/meos/include/meos_geo.h
+++ b/meos/include/meos_geo.h
@@ -419,8 +419,10 @@ extern bool geog_intersects(const GSERIALIZED *gs1, const GSERIALIZED *gs2, bool
 extern bool geom_contains(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
 extern bool geom_covers(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
 extern bool geom_disjoint2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
+extern bool geom_dwithin(const GSERIALIZED *gs1, const GSERIALIZED *gs2, double tolerance);
 extern bool geom_dwithin2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2, double tolerance);
 extern bool geom_dwithin3d(const GSERIALIZED *gs1, const GSERIALIZED *gs2, double tolerance);
+extern bool geom_intersects(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
 extern bool geom_intersects2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
 extern bool geom_intersects3d(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
 extern bool geom_relate_pattern(const GSERIALIZED *gs1, const GSERIALIZED *gs2, char *patt);

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -936,6 +936,22 @@ geom_dwithin2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2,
 /**
  * @ingroup meos_geo_base_rel
  * @brief Return true if two geometries are within a distance
+ * @details Bare name for the planar (2D) distance-within test, the portable
+ * counterpart of @ref geog_dwithin() for geometry; equivalent to PostGIS
+ * @p ST_DWithin.
+ * @param[in] gs1,gs2 Geometries
+ * @param[in] tolerance Tolerance
+ * @note PostGIS function: @p LWGEOM_dwithin(PG_FUNCTION_ARGS)
+ */
+inline bool
+geom_dwithin(const GSERIALIZED *gs1, const GSERIALIZED *gs2, double tolerance)
+{
+  return geom_dwithin2d(gs1, gs2, tolerance);
+}
+
+/**
+ * @ingroup meos_geo_base_rel
+ * @brief Return true if two geometries are within a distance
  * @param[in] gs1,gs2 Geometries
  * @param[in] tolerance Tolerance
  * @note PostGIS function: @p LWGEOM_dwithin3d(PG_FUNCTION_ARGS)
@@ -1538,6 +1554,21 @@ inline bool
 geom_intersects2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 {
   return geom_spatialrel(gs1, gs2, INTERSECTS);
+}
+
+/**
+ * @ingroup meos_geo_base_rel
+ * @brief Return true if two geometries intersect
+ * @details Bare name for the planar (2D) intersection test, the portable
+ * counterpart of @ref geog_intersects() for geometry; equivalent to PostGIS
+ * @p ST_Intersects.
+ * @param[in] gs1,gs2 Geometries
+ * @note PostGIS function: @p ST_Intersects(PG_FUNCTION_ARGS)
+ */
+inline bool
+geom_intersects(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
+{
+  return geom_intersects2d(gs1, gs2);
 }
 
 #if MEOS


### PR DESCRIPTION
Adds the bare planar names `geom_intersects(gs1, gs2)` and `geom_dwithin(gs1, gs2, tolerance)` as thin inline wrappers over the existing 2D implementations (`geom_intersects2d` / `geom_dwithin2d`).

### Why
The geometry-geometry intersection and distance-within predicates were only exposed under the `2d`/`3d`-suffixed names, mirroring the PostGIS `ST_Intersects`/`ST_3DIntersects` split — while the sibling predicates with no 3D form (`geom_contains`, `geom_covers`, `geom_touches`) and the **geography** forms (`geog_intersects`, `geog_dwithin`) are already bare. This completes that asymmetry: every binding generated from the MEOS surface now gets a clean planar `intersects`/`dwithin` for geometry that matches the geography forms — the GEOS-backed predicate names a non-PostGIS host (e.g. MobilitySpark) binds so a canonical `ST_Intersects`/`ST_DWithin` resolves to the same GEOS implementation PostGIS and `duckdb_spatial` use.

`aliases-reuse-backing`: the bare names call the existing 2D functions; no behavioural second path.

### Verified
Standalone MEOS and the PostgreSQL extension both build; `nm -D` shows `geom_intersects`/`geom_dwithin` exported; functional check (crossing/disjoint linestrings, dwithin thresholds) passes.
