### PR TITLE
Expose base-geometry portability helpers: transform() and asEWKT()

### DIFF
--- a/mobilitydb/sql/geo/053_tpoint_inout.in.sql
+++ b/mobilitydb/sql/geo/053_tpoint_inout.in.sql
@@ -140,6 +140,20 @@ CREATE FUNCTION asEWKT(tgeogpoint[], maxdecimaldigits int4 DEFAULT 15)
   AS 'MODULE_PATHNAME', 'Spatialarr_as_ewkt'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+-- Single base geometry/geography EWKT. In the PostgreSQL extension this rewrites
+-- to PostGIS ST_AsEWKT; the standalone MEOS library and the generated bindings
+-- back the same asEWKT(geometry) surface with the geo_as_ewkt() kernel. Together
+-- with transform(geometry, integer) this lets one portable generator/suite use
+-- MobilityDB names (asEWKT, transform) instead of PostGIS-only ST_AsEWKT/ST_Transform.
+CREATE FUNCTION asEWKT(geometry, maxdecimaldigits int4 DEFAULT 15)
+  RETURNS text
+  AS 'SELECT @extschema@.ST_AsEWKT($1, $2)'
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION asEWKT(geography, maxdecimaldigits int4 DEFAULT 15)
+  RETURNS text
+  AS 'SELECT @extschema@.ST_AsEWKT($1, $2)'
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE FUNCTION asEWKT(geometry[], maxdecimaldigits int4 DEFAULT 15)
   RETURNS text[]
   AS 'MODULE_PATHNAME', 'Spatialarr_as_ewkt'

--- a/mobilitydb/sql/geo/056_tpoint_spatialfuncs.in.sql
+++ b/mobilitydb/sql/geo/056_tpoint_spatialfuncs.in.sql
@@ -51,6 +51,21 @@ CREATE FUNCTION round(geography, integer DEFAULT 0)
   AS 'MODULE_PATHNAME', 'Geo_round'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+-- Base geometry/geography SRID reprojection. In the PostgreSQL extension this
+-- delegates to PostGIS ST_Transform (its SPI-backed proj cache); the standalone
+-- MEOS library and the generated bindings provide the same transform(geometry,
+-- integer) surface backed by the MEOS geo_transform() kernel. Exposing it under
+-- the MobilityDB transform() name (matching transform(geomset)/transform(tgeometry)/
+-- ...) lets portable SQL call one name across PostgreSQL, DuckDB and Spark.
+CREATE FUNCTION transform(geometry, integer)
+  RETURNS geometry
+  AS 'SELECT @extschema@.ST_Transform($1, $2)'
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION transform(geography, integer)
+  RETURNS geography
+  AS 'SELECT @extschema@.ST_Transform($1::geometry, $2)::geography'
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
+
 /*****************************************************************************/
 
 CREATE FUNCTION SRID(stbox)

--- a/mobilitydb/test/geo/expected/056_tgeo_spatialfuncs.test.out
+++ b/mobilitydb/test/geo/expected/056_tgeo_spatialfuncs.test.out
@@ -778,6 +778,53 @@ POLYHEDRALSURFACE Z (
   ((1 1 1, 1 1 0, 0 1 0, 0 1 1, 1 1 1))
 ))', 1);
 ERROR:  Unsupported geometry type in round function: PolyhedralSurface
+SELECT ST_AsText(transform(geometry 'SRID=4326;Point(4.35 50.85)', 3812)) =
+       ST_AsText(ST_Transform(geometry 'SRID=4326;Point(4.35 50.85)', 3812));
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT ST_AsText(transform(geometry 'SRID=4326;Linestring(4.35 50.85,4.40 50.90)', 3812)) =
+       ST_AsText(ST_Transform(geometry 'SRID=4326;Linestring(4.35 50.85,4.40 50.90)', 3812));
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT ST_SRID(transform(geometry 'SRID=3812;Point(150000 170000)', 4326));
+ st_srid 
+---------
+    4326
+(1 row)
+
+SELECT ST_SRID(transform(geography 'SRID=4326;Point(4.35 50.85)', 4326));
+ st_srid 
+---------
+    4326
+(1 row)
+
+SELECT asEWKT(geometry 'SRID=4326;Point(4.35 50.85)') =
+       ST_AsEWKT(geometry 'SRID=4326;Point(4.35 50.85)');
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT asEWKT(geometry 'SRID=3812;Linestring(150000 170000,160000 180000)', 2) =
+       ST_AsEWKT(geometry 'SRID=3812;Linestring(150000 170000,160000 180000)', 2);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT asEWKT(geography 'SRID=4326;Point(4.35 50.85)') =
+       ST_AsEWKT(geography 'SRID=4326;Point(4.35 50.85)');
+ ?column? 
+----------
+ t
+(1 row)
+
 SELECT asText(round(tgeometry 'Point(1.12345 1.12345)@2000-01-01', 2));
                     astext                     
 -----------------------------------------------

--- a/mobilitydb/test/geo/queries/056_tgeo_spatialfuncs.test.sql
+++ b/mobilitydb/test/geo/queries/056_tgeo_spatialfuncs.test.sql
@@ -295,6 +295,29 @@ POLYHEDRALSURFACE Z (
 ))', 1);
 
 --------------------------------------------------------
+-- transform(geometry, integer) / transform(geography, integer)
+-- MobilityDB name for base-geometry SRID reprojection; in the extension it
+-- delegates to PostGIS ST_Transform, so it must agree with it exactly.
+--------------------------------------------------------
+
+SELECT ST_AsText(transform(geometry 'SRID=4326;Point(4.35 50.85)', 3812)) =
+       ST_AsText(ST_Transform(geometry 'SRID=4326;Point(4.35 50.85)', 3812));
+SELECT ST_AsText(transform(geometry 'SRID=4326;Linestring(4.35 50.85,4.40 50.90)', 3812)) =
+       ST_AsText(ST_Transform(geometry 'SRID=4326;Linestring(4.35 50.85,4.40 50.90)', 3812));
+SELECT ST_SRID(transform(geometry 'SRID=3812;Point(150000 170000)', 4326));
+-- geography stays in a lon/lat system (projected targets are correctly rejected
+-- by the underlying ST_Transform); a same-system reprojection is a no-op
+SELECT ST_SRID(transform(geography 'SRID=4326;Point(4.35 50.85)', 4326));
+
+-- asEWKT(geometry/geography): MobilityDB EWKT serialization, must equal ST_AsEWKT
+SELECT asEWKT(geometry 'SRID=4326;Point(4.35 50.85)') =
+       ST_AsEWKT(geometry 'SRID=4326;Point(4.35 50.85)');
+SELECT asEWKT(geometry 'SRID=3812;Linestring(150000 170000,160000 180000)', 2) =
+       ST_AsEWKT(geometry 'SRID=3812;Linestring(150000 170000,160000 180000)', 2);
+SELECT asEWKT(geography 'SRID=4326;Point(4.35 50.85)') =
+       ST_AsEWKT(geography 'SRID=4326;Point(4.35 50.85)');
+
+--------------------------------------------------------
 
 -- 2D
 SELECT asText(round(tgeometry 'Point(1.12345 1.12345)@2000-01-01', 2));


### PR DESCRIPTION
## What

Adds `transform(geometry, integer)` and `transform(geography, integer)` for SRID reprojection of base geometry/geography.

## Why

Every *derived* spatial type already has it — `transform(geomset, …)`, `transform(tgeometry, …)`, `transform(stbox, …)`, `transform(tgeompoint, …)`, `transform(pose, …)`, `transform(cbuffer, …)`, … — but the **base** `geometry`/`geography` types did not, so callers had to drop to PostGIS `ST_Transform`. This closes that parity gap.

## How

In the PostgreSQL extension `transform()` delegates to PostGIS `ST_Transform` (its SPI-backed proj cache), following the existing `@extschema@`-passthrough precedent in `076_tpoint_analytics`. The standalone MEOS library and the generated bindings expose the same `transform(geometry, integer)` surface via the existing `geo_transform()` kernel (`meos_geo.h`).

The motivating use case: portable BerlinMOD SQL needs lon/lat (4326) input for the H3 cell prefilter while the trip data is in a projected metric SRID (Brussels Lambert 2008 / 3812, for true-metre distances). With a single `transform()` name available across PostgreSQL, DuckDB and Spark, the suite no longer needs a platform-specific `ST_Transform` — which DuckDB Spatial does not even provide.

## Tests

`056_tgeo_spatialfuncs` extended: `transform(geometry, …)` is asserted byte-identical to `ST_Transform` (Point + Linestring), plus SRID checks for geometry and geography. Suite green.

## Notes

- `transformPipeline(geometry/geography, …)` is intentionally **not** added here: PostGIS `ST_TransformPipeline` has different forward/inverse semantics than the MEOS `geo_transform_pipeline(…, is_forward)`, so it warrants its own change.
- Binding follow-up (separate repos): the DuckDB/Spark generators should emit `transform(geometry, integer)` from the MEOS `geo_transform` catalog entry so the portable suite resolves the same name everywhere.