### PR TITLE
Fix wrong doxygen @ingroup group on tbox/stbox hash_extended

### DIFF
--- a/meos/src/geo/stbox.c
+++ b/meos/src/geo/stbox.c
@@ -2656,7 +2656,7 @@ stbox_hash(const STBox *box)
 }
 
 /**
- * @ingroup meos_setspan_accessor
+ * @ingroup meos_geo_box_accessor
  * @brief Return the 64-bit hash of a spatiotemporal box using a seed
  * @param[in] box Spatiotemporal box
  * @param[in] seed Seed

--- a/meos/src/temporal/tbox.c
+++ b/meos/src/temporal/tbox.c
@@ -1853,7 +1853,7 @@ tbox_hash(const TBox *box)
 }
 
 /**
- * @ingroup meos_setspan_accessor
+ * @ingroup meos_box_accessor
  * @brief Return the 64-bit hash of a temporal box using a seed
  * @param[in] box Temporal box
  * @param[in] seed Seed


### PR DESCRIPTION
`tbox_hash_extended` and `stbox_hash_extended` carried `@ingroup meos_setspan_accessor`, copy-pasted from `span_hash_extended`. They belong with their own `_hash` siblings:

| function | was | should be (matches `*_hash`) |
|---|---|---|
| `tbox_hash_extended` | `meos_setspan_accessor` | `meos_box_accessor` |
| `stbox_hash_extended` | `meos_setspan_accessor` | `meos_geo_box_accessor` |

These two were found by auditing every function's `@ingroup` against the family implied by its name and `@csqlfn` wrapper; they are the only genuine outliers (the rest — e.g. `cbufferset_*` under `meos_cbuffer_set_*` despite a generic `Set_*` wrapper — are correct typed-group conventions).

Doc-only change (no code), so the reference manual and every catalog-driven binding place these functions under their real type.