### PR TITLE
Fix aTouches(tgeometry, tgeometry) computing ever instead of always

### DIFF
--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -1433,7 +1433,7 @@ etouches_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 int
 atouches_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
-  return ea_touches_tgeo_tgeo(temp1, temp2, EVER);
+  return ea_touches_tgeo_tgeo(temp1, temp2, ALWAYS);
 }
 #endif /* MEOS */
 


### PR DESCRIPTION
`atouches_tgeo_tgeo` (the **always** variant) passed `EVER` to `ea_touches_tgeo_tgeo()`, so `aTouches(tgeometry, tgeometry)` returned the *ever*-touches result.

**Why it's a real, user-reachable bug:**
- `ea_touches_tgeo_tgeo(temp1, temp2, ever)` honours the flag — it forwards `ever` to `ea_spatialrel_tspatial_tspatial(...)`. So `EVER` vs `ALWAYS` genuinely changes the result.
- Every sibling always-wrapper passes `ALWAYS` (`acontains_tgeo_tgeo`, `acovers_tgeo_tgeo`, `adisjoint_tgeo_geo`, `atouches_tgeo_geo`, …). `atouches_tgeo_tgeo` was the lone outlier — a copy-paste from `etouches_tgeo_tgeo` with the `EVER` left in.
- It is reachable: `PG_FUNCTION_INFO_V1(Atouches_tgeo_tgeo)` + SQL `aTouches(tgeometry, tgeometry)` → `Atouches_tgeo_tgeo`.

**Fix:** pass `ALWAYS`.

**Tests:** the `070_tgeo_spatialrels_tbl` regress did not catch this — `eTouches` and `aTouches` over `tbl_tgeometry × tbl_tgeometry` both count 0 (no pair ever touches, so none always touch), so the data doesn't distinguish the two semantics. Verified locally that the fix introduces **zero** new regress diffs: the build is clean and the `070_tgeo_spatialrels_tbl` output is byte-identical with and without the change (the `aTouches(t1,t2)` count stays 0; the only local diffs are a pre-existing GEOS/PROJ-version environment mismatch on unrelated `aContains`/`aDwithin` rows, identical in the unmodified-master baseline). Expected output is therefore unchanged.