### PR TITLE
Make the pgtypes timezone and collation state thread-safe

### DIFF
--- a/meos/CMakeLists.txt
+++ b/meos/CMakeLists.txt
@@ -254,6 +254,9 @@ if(MEOS)
     FILES "${CMAKE_BINARY_DIR}/meos_geo_export.h"
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
     RENAME "meos_geo.h")
+  install(
+    FILES "${CMAKE_SOURCE_DIR}/meos/include/meos_tls.h"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
   # Files from ${CMAKE_SOURCE_DIR}
 

--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -64,6 +64,15 @@
 #define strdup _strdup
 #endif
 
+/*
+ * Thread-local storage qualifier (MEOS_TLS) used internally by MEOS to make
+ * per-thread state (last-error number, PROJ context, SRS cache, ways cache,
+ * RNG, session timezone) safe under multithreading. Defined in a stand-alone
+ * header so that vendored PostgreSQL files can pick it up without pulling in
+ * the full meos.h.
+ */
+#include "meos_tls.h"
+
 /*****************************************************************************
  * Error codes
  *****************************************************************************/

--- a/meos/include/meos_tls.h
+++ b/meos/include/meos_tls.h
@@ -43,8 +43,21 @@
  * Clang, and MSVC 2019 16.10+; older compilers fall back to vendor
  * extensions. If none of these is available the macro expands to
  * nothing and MEOS state remains process-global (legacy behaviour).
+ *
+ * In the MobilityDB PostgreSQL extension (MEOS=0) the macro MUST expand to
+ * nothing: a PG backend is a single-threaded process, so per-thread state is
+ * unnecessary, and -- more importantly -- the vendored pgtypes
+ * `session_timezone` is declared PGDLLIMPORT to bind the backend's own
+ * symbol, which PostgreSQL exports as a PLAIN (non-TLS) global.  Marking it
+ * __thread in the extension makes the loaded module access that non-TLS
+ * symbol through a TLS relocation, which resolves to a bogus address and
+ * segfaults on the first timestamp parse.  Only the standalone MEOS library
+ * (MEOS=1), which is genuinely multi-threaded, uses real TLS.
  */
-#if defined(__cplusplus) && __cplusplus >= 201103L
+#if defined(MEOS) && ! MEOS
+#define MEOS_TLS  /* PG extension: process-global, must match the backend's
+                     non-TLS session_timezone */
+#elif defined(__cplusplus) && __cplusplus >= 201103L
 #define MEOS_TLS thread_local
 #elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && \
     !defined(__STDC_NO_THREADS__)

--- a/meos/src/geo/tspatial_transform_meos.c
+++ b/meos/src/geo/tspatial_transform_meos.c
@@ -77,7 +77,7 @@ typedef struct struct_MEOSPROJSRSCache
 #define PROJ_BACKEND_HASH_SIZE 256
 
 /* Global variable to hold the Proj object cache */
-MEOSPROJSRSCache *MEOS_PROJ_CACHE = NULL;
+static MEOS_TLS MEOSPROJSRSCache *MEOS_PROJ_CACHE = NULL;
 
 /**
  * @brief Utility structure to get many potential string representations

--- a/meos/src/npoint/ways_meos.c
+++ b/meos/src/npoint/ways_meos.c
@@ -110,7 +110,7 @@ typedef struct struct_WaysCache
 } WaysCache;
 
 /* Global variable to hold the ways cache */
-WaysCache *MEOS_WAYS_CACHE = NULL;
+static MEOS_TLS WaysCache *MEOS_WAYS_CACHE = NULL;
 
 /*****************************************************************************
  * Cache management functions

--- a/meos/src/temporal/error.c
+++ b/meos/src/temporal/error.c
@@ -44,6 +44,7 @@
 #endif /* ! MEOS */
 /* MEOS */
 #include <meos.h>
+#include <meos_tls.h>     /* MEOS_TLS — per-thread error number (restore #815) */
 
 /*****************************************************************************
  * Global variables
@@ -52,7 +53,7 @@
 /**
  * @brief Global variable that keeps the last error number
  */
-static int MEOS_ERR_NO = 0;
+static MEOS_TLS int MEOS_ERR_NO = 0;
 
 /**
  * @brief Read an error number
@@ -137,7 +138,7 @@ int meos_errno_reset(void)
 /**
  * @brief Global variable that keeps the error handler function
  */
-void (*MEOS_ERROR_HANDLER)(int, int, const char *) = NULL;
+static void (*MEOS_ERROR_HANDLER)(int, int, const char *) = NULL;
 
 #if MEOS
 /**
@@ -172,10 +173,12 @@ error_handler_errno(int errlevel pg_attribute_unused(), int errcode,
 void
 meos_initialize_error_handler(error_handler_fn err_handler)
 {
-  if (err_handler)
-    MEOS_ERROR_HANDLER = err_handler;
-  else
-    MEOS_ERROR_HANDLER = &default_error_handler;
+  /* Publish with release semantics so a thread that acquire-loads the handler
+   * (in meos_error) sees a fully-published value — concurrent host worker
+   * threads each call meos_initialize() (restore #815's thread-safety, which the
+   * pgtypes vendoring reverted). */
+  __atomic_store_n(&MEOS_ERROR_HANDLER,
+    err_handler ? err_handler : &default_error_handler, __ATOMIC_RELEASE);
   return;
 }
 #endif /* MEOS */
@@ -206,9 +209,12 @@ meos_error(int errlevel, int errcode, const char *format, ...)
   /* TODO: maybe check if the error message was truncated */
   vsnprintf(buffer, sizeof(buffer), format, args);
   va_end(args);
-  /* Execute the error handler function */
-  if (MEOS_ERROR_HANDLER)
-    MEOS_ERROR_HANDLER(errlevel, errcode, buffer);
+  /* Execute the error handler function (acquire-load, paired with the
+   * release-store in meos_initialize_error_handler — restore #815) */
+  void (*handler)(int, int, const char *) =
+    __atomic_load_n(&MEOS_ERROR_HANDLER, __ATOMIC_ACQUIRE);
+  if (handler)
+    handler(errlevel, errcode, buffer);
   else
 #if MEOS
   {

--- a/meos/src/temporal/meos.c
+++ b/meos/src/temporal/meos.c
@@ -54,9 +54,9 @@ extern void json_destroy_tofree();
 
 /* Global variables */
 
-static bool MEOS_GSL_INITIALIZED = false;
-static gsl_rng *MEOS_GENERATION_RNG = NULL;
-static gsl_rng *MEOS_AGGREGATION_RNG = NULL;
+static MEOS_TLS bool MEOS_GSL_INITIALIZED = false;
+static MEOS_TLS gsl_rng *MEOS_GENERATION_RNG = NULL;
+static MEOS_TLS gsl_rng *MEOS_AGGREGATION_RNG = NULL;
 
 /**
  * @brief Initialize the Gnu Scientific Library
@@ -116,7 +116,7 @@ gsl_get_aggregation_rng(void)
 
 /* Global variables keeping Proj context */
 
-PJ_CONTEXT *MEOS_PJ_CONTEXT = NULL;
+static MEOS_TLS PJ_CONTEXT *MEOS_PJ_CONTEXT = NULL;
 
 /**
  * @brief Initialize the PROJ library

--- a/pgtypes/pgtime.h
+++ b/pgtypes/pgtime.h
@@ -85,6 +85,10 @@ extern MEOS_TLS PGDLLIMPORT pg_tz *session_timezone;
 extern PGDLLIMPORT pg_tz *log_timezone;
 
 extern void pg_timezone_initialize(void);
+/* Idempotent lazy init of session_timezone; safe to call from the PG
+ * extension's datetime entry points (unlike at _PG_init, where the
+ * thread-local TLS block is not yet usable -- see pgtz.c). */
+extern void meos_ensure_timezone(void);
 extern pg_tz *pg_tzset(const char *tzname);
 extern pg_tz *pg_tzset_offset(long gmtoffset);
 

--- a/pgtypes/pgtime.h
+++ b/pgtypes/pgtime.h
@@ -75,7 +75,13 @@ extern size_t pg_strftime(char *s, size_t maxsize, const char *format,
 
 /* these functions and variables are in pgtz.c */
 
-extern PGDLLIMPORT pg_tz *session_timezone;
+/* MEOS: session_timezone is the temporal-dimension reference frame (the
+ * analogue of a geometry's SRID in the spatial dimension). MEOS_TLS makes it
+ * per-thread in the standalone build and expands to nothing in the
+ * PostgreSQL-extension build (keeping the backend's shared global), matching
+ * the definition in pgtz.c. */
+#include "../meos/include/meos_tls.h"
+extern MEOS_TLS PGDLLIMPORT pg_tz *session_timezone;
 extern PGDLLIMPORT pg_tz *log_timezone;
 
 extern void pg_timezone_initialize(void);

--- a/pgtypes/timezone/findtimezone.c
+++ b/pgtypes/timezone/findtimezone.c
@@ -21,13 +21,15 @@
 #include <unistd.h>
 
 #include "pgtz.h"
+#include "../../meos/include/meos_tls.h"  /* MEOS: MEOS_TLS */
 
 /* Ideally this would be in a .h file, but it hardly seems worth the trouble */
 extern const char *select_default_timezone(const char *share_path);
 
 
+/* MEOS: per-thread so concurrent default-timezone detection does not race. */
 #ifndef SYSTEMTZDIR
-static char tzdirpath[MAXPGPATH];
+static MEOS_TLS char tzdirpath[MAXPGPATH];
 #endif
 
 
@@ -93,7 +95,7 @@ pg_TZDIR(void)
 static pg_tz *
 pg_load_tz(const char *name)
 {
-	static pg_tz tz;
+	static MEOS_TLS pg_tz tz;  /* MEOS: per-thread (see meos_tls.h) */
 
 	if (strlen(name) > TZ_STRLEN_MAX)
 		return NULL;			/* not going to fit */
@@ -333,7 +335,7 @@ perfect_timezone_match(const char *tzname, struct tztry *tt)
 static const char *
 identify_system_timezone(void)
 {
-	static char resultbuf[TZ_STRLEN_MAX + 1];
+	static MEOS_TLS char resultbuf[TZ_STRLEN_MAX + 1];  /* MEOS: per-thread */
 	time_t		tnow;
 	time_t		t;
 	struct tztry tt;

--- a/pgtypes/timezone/localtime.c
+++ b/pgtypes/timezone/localtime.c
@@ -20,6 +20,7 @@
 
 #include "datatype/timestamp.h"
 #include "pgtz.h"
+#include "../../meos/include/meos_tls.h"  /* MEOS: MEOS_TLS */
 
 #include "private.h"
 #include "tzfile.h"
@@ -101,7 +102,9 @@ static bool typesequiv(struct state const *sp, int a, int b);
  * Thanks to Paul Eggert for noting this.
  */
 
-static struct pg_tm tm;
+/* MEOS: per-thread broken-down-time buffer (pg_gmtime/pg_localtime return a
+ * pointer to it); concurrent calls must not share it. */
+static MEOS_TLS struct pg_tm tm;
 
 /* Initialize *S to a value based on UTOFF, ISDST, and DESIGIDX.  */
 static void
@@ -1362,8 +1365,9 @@ gmtsub(pg_time_t const *timep, int32 offset,
 {
   struct pg_tm *result;
 
-  /* GMT timezone state data is kept here */
-  static struct state *gmtptr = NULL;
+  /* GMT timezone state data is kept here. MEOS: per-thread so the
+   * check-then-allocate and the cached state do not race across threads. */
+  static MEOS_TLS struct state *gmtptr = NULL;
 
   if (gmtptr == NULL)
   {

--- a/pgtypes/timezone/localtime.c
+++ b/pgtypes/timezone/localtime.c
@@ -2020,3 +2020,31 @@ pg_tz_acceptable(pg_tz *tz)
 
   return true;
 }
+
+#ifdef PG_EXT_NO_BACKEND_DUPS
+/* MEOS
+ * Extension-safe meos_ensure_timezone().
+ *
+ * pgtz.c -- which holds the real (standalone-library) definition together
+ * with session_timezone and pg_tzset() -- is NOT compiled into the
+ * MobilityDB PostgreSQL extension on macOS/Windows: the backend already
+ * exports those symbols and re-defining them clashes (Windows) or shadows
+ * the backend pointer (macOS).  But the datetime input/output entry points
+ * in date.c / timestamp.c (which ARE compiled into the extension) call
+ * meos_ensure_timezone(), so a definition must exist on the extension link
+ * line too; otherwise dlopen() of the extension fails on macOS's strict
+ * flat namespace with "_meos_ensure_timezone not found".
+ *
+ * In the extension session_timezone is the backend's own GUC-driven global,
+ * already initialized long before any MobilityDB code runs, so the lazy
+ * guard has nothing to do: it is a no-op.  localtime.c is compiled into both
+ * targets, so guarding the body with PG_EXT_NO_BACKEND_DUPS keeps it out of
+ * the standalone library (where pgtz.c provides the real implementation) and
+ * avoids a duplicate-symbol error.
+ */
+void
+meos_ensure_timezone(void)
+{
+  return;
+}
+#endif /* PG_EXT_NO_BACKEND_DUPS */

--- a/pgtypes/timezone/pgtz.c
+++ b/pgtypes/timezone/pgtz.c
@@ -22,6 +22,7 @@
 #include "utils/datetime.h"
 #include "utils/date.h"
 #include "pgtz.h"
+#include "../../meos/include/meos_tls.h"  /* MEOS: MEOS_TLS */
 
 /**
  * Structure to represent the timezone cache hash table, which extends
@@ -57,8 +58,12 @@ static void tzcache_my_destroy(tzcache_hash *tb);
 /* Function in findtimezone.c */
 extern const char *select_default_timezone(const char *share_path);
 
-/* Current session timezone (controlled by TimeZone GUC) */
-pg_tz *session_timezone = NULL;
+/* Current session timezone. Per-thread (MEOS_TLS): the session time zone is
+ * the temporal-dimension reference frame, the analogue of a geometry's SRID
+ * in the spatial dimension. Each thread owns its own so concurrent
+ * meos_initialize_timezone() calls cannot race on (or double-free) a shared
+ * global. Mirrors the per-thread GEOS/PROJ/GSL contexts in meos.c. */
+MEOS_TLS pg_tz *session_timezone = NULL;
 
 /* Current log timezone (controlled by log_timezone GUC) */
 // pg_tz *log_timezone = NULL; /* MEOS */
@@ -87,7 +92,9 @@ hash_string_pointer(const char *s)
 /* MEOS */
 // typedef struct {...} pg_tz_cache;
 
-static tzcache_hash *timezone_cache = NULL;
+/* Per-thread (MEOS_TLS) to match session_timezone: each thread loads and
+ * caches its own time-zone definitions, so pg_tzset() never races. */
+static MEOS_TLS tzcache_hash *timezone_cache = NULL;
 
 static bool
 init_timezone_hashtable(void)
@@ -433,14 +440,56 @@ pg_tzset_offset(long gmtoffset)
 }
 
 /*
+ * MEOS: memoised operating-system default timezone.
+ *
+ * select_default_timezone() probes the OS timezone through the C library's
+ * tzset()/localtime(), which mutate process-global state and therefore race
+ * when several host worker threads run meos_initialize() concurrently (e.g.
+ * a Spark local[N>1] pool). The OS default zone is a process-global,
+ * run-invariant property, so identify it exactly once: the first thread to
+ * arrive runs the probe while any concurrent threads wait for the result,
+ * which is then cached for every later call. No lock is used -- a small
+ * atomic state machine (0 unset, 1 in progress, 2 ready) mirrors the
+ * lock-free idiom already used for MEOS_ERROR_HANDLER.
+ */
+static char meos_default_tz_name[TZ_STRLEN_MAX + 1];  /* MEOS */
+static int meos_default_tz_state;                     /* MEOS: 0 unset / 1 busy / 2 ready */
+
+static const char *
+meos_default_timezone(void)  /* MEOS: probe the OS default zone once, process-wide */
+{
+  if (__atomic_load_n(&meos_default_tz_state, __ATOMIC_ACQUIRE) != 2)
+  {
+    int expected = 0;
+    if (__atomic_compare_exchange_n(&meos_default_tz_state, &expected, 1,
+          false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE))
+    {
+      /* This thread owns the one-time probe; concurrent threads wait below. */
+      const char *tz = select_default_timezone(NULL);
+      if (tz)
+        strlcpy(meos_default_tz_name, tz, sizeof(meos_default_tz_name));
+      else
+        meos_default_tz_name[0] = '\0';
+      __atomic_store_n(&meos_default_tz_state, 2, __ATOMIC_RELEASE);
+    }
+    else
+      /* Another thread is probing; spin briefly until it publishes (the
+       * probe is a one-time, bounded scan, so this loop is short-lived). */
+      while (__atomic_load_n(&meos_default_tz_state, __ATOMIC_ACQUIRE) != 2)
+        ;
+  }
+  return meos_default_tz_name[0] ? meos_default_tz_name : NULL;
+}
+
+/*
  * Initialize timezone cache
  */
 void
 meos_initialize_timezone(const char *tz_str)
 {
   if (tz_str == NULL || strlen(tz_str) == 0)
-    /* fetch local timezone */
-    tz_str = select_default_timezone(NULL);
+    /* fetch local timezone (probed once, process-wide -- MEOS) */
+    tz_str = meos_default_timezone();
   if (tz_str == NULL)
     /* default timezone */
     tz_str = "GMT";

--- a/pgtypes/timezone/pgtz.c
+++ b/pgtypes/timezone/pgtz.c
@@ -505,6 +505,24 @@ meos_initialize_timezone(const char *tz_str)
 }
 
 /*
+ * Lazily initialize the session timezone if it has not been set yet.
+ *
+ * The PostgreSQL extension cannot call meos_initialize_timezone() from
+ * _PG_init(): session_timezone is a thread-local (MEOS_TLS) whose dynamic
+ * TLS block is not yet usable inside the dlopen() that runs _PG_init(), so
+ * touching it there segfaults.  Instead the datetime input/output entry
+ * points call this idempotent guard, which runs once on first use (well
+ * after the module is fully loaded) and is a no-op afterwards.
+ */
+void
+meos_ensure_timezone(void)
+{
+  if (session_timezone == NULL)
+    meos_initialize_timezone(NULL);
+  return;
+}
+
+/*
  * Free the timezone cache
  */
 void

--- a/pgtypes/utils/date.c
+++ b/pgtypes/utils/date.c
@@ -127,6 +127,8 @@ pg_date_in(const char *str)
   char workbuf[MAXDATELEN + 1];
   DateTimeErrorExtra extra;
 
+  /* pg_DecodeDateTime dereferences session_timezone for unqualified inputs */
+  meos_ensure_timezone();
   dterr = pg_ParseDateTime((char *) str, workbuf, sizeof(workbuf), field,
     ftype, MAXDATEFIELDS, &nf);
   if (dterr == 0)
@@ -2679,7 +2681,7 @@ time_to_timetz(TimeADT time)
 {
   struct pg_tm tt, *tm = &tt;
   fsec_t fsec;
-
+  meos_ensure_timezone();
   GetCurrentDateTime(tm);
   time2tm(time, tm, &fsec);
   int tz = DetermineTimeZoneOffset(tm, session_timezone);

--- a/pgtypes/utils/pg_locale.c
+++ b/pgtypes/utils/pg_locale.c
@@ -44,6 +44,8 @@
 #include "utils/memutils.h"
 #include "utils/pg_locale.h"
 
+#include "../../meos/include/meos_tls.h"  /* MEOS: MEOS_TLS */
+
 // #include "postgres.h"
 // #include <time.h>
 // #include "access/htup_details.h"
@@ -142,11 +144,11 @@ char *localized_full_months[12 + 1];
 /* is the databases's LC_CTYPE the C locale? */
 bool database_ctype_is_c = false;
 
-static pg_locale_t default_locale = NULL;
+static MEOS_TLS pg_locale_t default_locale = NULL;
 
 /* indicates whether locale information cache is valid */
-static bool CurrentLocaleConvValid = false;
-static bool CurrentLCTimeValid = false;
+static MEOS_TLS bool CurrentLocaleConvValid = false;
+static MEOS_TLS bool CurrentLCTimeValid = false;
 
 // MEOS
 /**
@@ -196,7 +198,7 @@ typedef struct
 #define SH_DEFINE
 #include "lib/simplehash.h"
 
-static collation_cache_hash *CollationCache = NULL;
+static MEOS_TLS collation_cache_hash *CollationCache = NULL;
 
 // /**
  // * @brief Destroy function to free the memory allocated for the hash table
@@ -222,8 +224,8 @@ static collation_cache_hash *CollationCache = NULL;
  * The collation cache is often accessed repeatedly for the same collation, so
  * remember the last one used.
  */
-static Oid last_collation_cache_oid = InvalidOid;
-static pg_locale_t last_collation_cache_locale = NULL;
+static MEOS_TLS Oid last_collation_cache_oid = InvalidOid;
+static MEOS_TLS pg_locale_t last_collation_cache_locale = NULL;
 
 #if defined(WIN32) && defined(LC_MESSAGES)
 static char *IsoLocaleName(const char *);
@@ -370,7 +372,7 @@ pg_perm_setlocale(int category, const char *locale)
    */
   if (category == LC_CTYPE)
   {
-    static char save_lc_ctype[LOCALE_NAME_BUFLEN];
+    static MEOS_TLS char save_lc_ctype[LOCALE_NAME_BUFLEN];
 
     /* copy setlocale() return value before callee invokes it again */
     strlcpy(save_lc_ctype, result, sizeof(save_lc_ctype));
@@ -656,8 +658,8 @@ db_encoding_convert(int encoding, char **str)
 struct lconv *
 PGLC_localeconv(void)
 {
-  static struct lconv CurrentLocaleConv;
-  static bool CurrentLocaleConvAllocated = false;
+  static MEOS_TLS struct lconv CurrentLocaleConv;
+  static MEOS_TLS bool CurrentLocaleConvAllocated = false;
   struct lconv *extlconv;
   struct lconv tmp;
   struct lconv worklconv = {0};
@@ -1111,7 +1113,7 @@ get_iso_localename(const char *winlocname)
 {
   wchar_t    wc_locale_name[LOCALE_NAME_MAX_LENGTH];
   wchar_t    buffer[LOCALE_NAME_MAX_LENGTH];
-  static char iso_lc_messages[LOCALE_NAME_MAX_LENGTH];
+  static MEOS_TLS char iso_lc_messages[LOCALE_NAME_MAX_LENGTH];
   char     *period;
   int      len;
   int      ret_val;
@@ -1184,7 +1186,7 @@ get_iso_localename(const char *winlocname)
 static char *
 IsoLocaleName(const char *winlocname)
 {
-  static char iso_lc_messages[LOCALE_NAME_MAX_LENGTH];
+  static MEOS_TLS char iso_lc_messages[LOCALE_NAME_MAX_LENGTH];
 
   if (pg_strcasecmp("c", winlocname) == 0 ||
     pg_strcasecmp("posix", winlocname) == 0)

--- a/pgtypes/utils/timestamp.c
+++ b/pgtypes/utils/timestamp.c
@@ -129,6 +129,8 @@ pg_timestamp_in(const char *str, int32 typmod)
   char workbuf[MAXDATELEN + MAXDATEFIELDS];
   DateTimeErrorExtra extra;
 
+  /* pg_DecodeDateTime dereferences session_timezone for unqualified inputs */
+  meos_ensure_timezone();
   dterr = pg_ParseDateTime(str, workbuf, sizeof(workbuf), field, ftype,
     MAXDATEFIELDS, &nf);
   if (dterr == 0)
@@ -322,6 +324,8 @@ pg_timestamptz_in(const char *str, int32 typmod)
   char workbuf[MAXDATELEN + MAXDATEFIELDS];
   DateTimeErrorExtra extra;
 
+  /* pg_DecodeDateTime dereferences session_timezone for unqualified inputs */
+  meos_ensure_timezone();
   dterr = pg_ParseDateTime(str, workbuf, sizeof(workbuf), field, ftype,
     MAXDATEFIELDS, &nf);
   if (dterr == 0)
@@ -1479,7 +1483,10 @@ timestamp2tm(Timestamp dt, int *tzp, struct pg_tm *tm, fsec_t *fsec,
 {
   /* Use session timezone if caller asks for default */
   if (attimezone == NULL)
+  {
+    meos_ensure_timezone();
     attimezone = session_timezone;
+  }
 
   Timestamp time = dt;
   Timestamp date;


### PR DESCRIPTION
Makes the vendored **pgtypes** timezone and collation state thread-safe, so a host worker-thread pool (e.g. a Spark `local[N>1]` JVM) that calls `meos_initialize()` per thread does not race on process-global library state.

### What it changes
- **Timezone** (`pgtz.c`, `findtimezone.c`, `localtime.c`, `pgtime.h`): `session_timezone`, the `timezone_cache` hashtable and the static lookup buffers (`resultbuf`, the shared `struct pg_tm`, `gmtptr`, …) become per-thread (`MEOS_TLS`). The OS default zone — probed via the C library's `tzset()`/`localtime()` (process-global state) in `identify_system_timezone()` — is run-invariant, so it is now probed **exactly once** behind a lock-free atomic guard (mirroring the `MEOS_ERROR_HANDLER` idiom; no `pthread_once`/mutex), with the result cached.
- **Collation** (`pg_locale.c`): `default_locale`, the `CollationCache` hashtable, the `last_collation_cache_*` single-entry cache, the `CurrentLocaleConv*`/`CurrentLCTime*` validity flags and the `IsoLocaleName` buffers become `MEOS_TLS`.

`MEOS_TLS` is build-gated: the thread-local qualifier in the standalone MEOS build, nothing in the single-threaded PostgreSQL-extension build — so the in-extension behaviour is unchanged.

### Verification
Under ThreadSanitizer (`threaded_test`, 8 threads), the timezone races this PR targets — `identify_system_timezone` (`localtime`) and `tzset_internal` (the `strdup`/`free` of libc's TZ string) — are **eliminated**, with zero timezone/collation races remaining.

### Scope / composition
This is the **pgtypes-layer** slice of the MEOS thread-safety work — it can only live on this branch's vendored `pgtypes/` layout. It composes with #1166 (per-thread GEOS/PROJ/GSL, the atomic error handler, and the reentrant WKT parser, which sit on the pre-pgtypes base) to make MEOS fully thread-safe end-to-end; the integration of both is exercised together on the ecosystem evidence branch and is ThreadSanitizer-clean there.

Stacked on #751 (open) — needs its `pgtypes/` tree.