### PR TITLE
Include <assert.h> in meos_internal.h for standalone debug builds

### DIFF
--- a/meos/include/meos_internal.h
+++ b/meos/include/meos_internal.h
@@ -35,6 +35,7 @@
 #define __MEOS_INTERNAL_H__
 
 /* C */
+#include <assert.h>
 #include <stddef.h>
 /* JSON-C */
 #include <json-c/json.h>


### PR DESCRIPTION
The `VALIDATE_*SPAN`/`VALIDATE_*SPANSET` macros' non-MEOS (`#else`) branch calls bare `assert()`, but `meos_internal.h` never includes `<assert.h>`.

- The **PG-extension** build gets it transitively via the `postgres.h` chain.
- **Release** consumer builds are masked by `-DNDEBUG` (assert is a no-op).

So it was latent. But a **standalone** consumer that does not define `MEOS` (MobilityDuck/JMEOS/Nebula — they can't take the `#if MEOS` branch, whose `return (ret)` breaks their non-pointer-returning callers) building in **debug or under ASan** (no `NDEBUG`) takes the `assert()` branch and fails with `'assert' was not declared in this scope`.

One line — make the header self-contained so debug/ASan builds work for every standalone consumer.