### PR TITLE
Validate the WKB type code in the span/set/spanset/temporal readers

### DIFF
--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -2083,7 +2083,18 @@ type_from_wkb(const uint8_t *wkb, size_t size, MeosType type)
   if (span_type(type))
   {
     Span *span = palloc(sizeof(Span));
+    /* Unlike the pointer-returning readers, span_from_wkb_state returns a
+     * Span by value, so on a foreign type code it can only return a zeroed
+     * struct (non-NULL once wrapped). Honour the same NULL contract as the
+     * other families: reset the error state, parse, and fail if the reader
+     * raised an error (the type-code guard in span_from_wkb_state). */
+    meos_errno_reset();
     *span = span_from_wkb_state(&s);
+    if (meos_errno() != 0)
+    {
+      pfree(span);
+      return (Datum) 0;
+    }
     return PointerGetDatum(span);
   }
   if (spanset_type(type))

--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -2087,8 +2087,13 @@ type_from_wkb(const uint8_t *wkb, size_t size, MeosType type)
      * Span by value, so on a foreign type code it can only return a zeroed
      * struct (non-NULL once wrapped). Honour the same NULL contract as the
      * other families: reset the error state, parse, and fail if the reader
-     * raised an error (the type-code guard in span_from_wkb_state). */
+     * raised an error (the type-code guard in span_from_wkb_state). The
+     * meos_errno reset API is only built under MEOS; in the PostgreSQL
+     * extension a foreign type code is raised via ereport (longjmp), so the
+     * reset is unnecessary there and meos_errno() stays 0. */
+#if MEOS
     meos_errno_reset();
+#endif /* MEOS */
     *span = span_from_wkb_state(&s);
     if (meos_errno() != 0)
     {

--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -1627,9 +1627,18 @@ span_from_wkb_state(meos_wkb_parse_state *s)
 {
   /* Read the span type */
   uint16_t wkb_spantype = int16_from_wkb_state(s);
+  Span result;
+  /* Ensure the WKB type code belongs to the span family before trusting it;
+   * a valid-hex buffer of another family would otherwise corrupt memory */
+  if (! span_type(wkb_spantype))
+  {
+    meos_error(ERROR, MEOS_ERR_WKB_INPUT,
+      "Invalid span type code in WKB string: %d", wkb_spantype);
+    memset(&result, 0, sizeof(Span));
+    return result;
+  }
   s->spantype = (uint8_t) wkb_spantype;
   s->basetype = spantype_basetype(wkb_spantype);
-  Span result;
   span_from_wkb_state_iter(s, &result);
   return result;
 }
@@ -1644,6 +1653,13 @@ spanset_from_wkb_state(meos_wkb_parse_state *s)
 {
   /* Read the span type */
   uint16_t wkb_spansettype = int16_from_wkb_state(s);
+  /* Ensure the WKB type code belongs to the span set family before trusting it */
+  if (! spanset_type(wkb_spansettype))
+  {
+    meos_error(ERROR, MEOS_ERR_WKB_INPUT,
+      "Invalid span set type code in WKB string: %d", wkb_spansettype);
+    return NULL;
+  }
   /* For template classes it is necessary to store the specific type */
   s->type = (uint8_t) wkb_spansettype;
   s->spantype = spansettype_spantype(s->type);
@@ -1693,6 +1709,13 @@ set_from_wkb_state(meos_wkb_parse_state *s)
 {
   /* Read the set type */
   uint16_t wkb_settype = int16_from_wkb_state(s);
+  /* Ensure the WKB type code belongs to the set family before trusting it */
+  if (! set_type(wkb_settype))
+  {
+    meos_error(ERROR, MEOS_ERR_WKB_INPUT,
+      "Invalid set type code in WKB string: %d", wkb_settype);
+    return NULL;
+  }
   /* For template classes it is necessary to store the specific type */
   s->type = (uint8_t) wkb_settype;
   s->basetype = settype_basetype(s->type);
@@ -1959,6 +1982,15 @@ temporal_from_wkb_state(meos_wkb_parse_state *s)
 {
   /* Read the temporal type */
   uint16_t wkb_temptype = int16_from_wkb_state(s);
+  /* Ensure the WKB type code is a temporal type before trusting it; a valid-hex
+   * buffer of another family (e.g. a tstzspan) would otherwise be parsed as a
+   * temporal structure and corrupt memory */
+  if (! temporal_type(wkb_temptype))
+  {
+    meos_error(ERROR, MEOS_ERR_WKB_INPUT,
+      "Invalid temporal type code in WKB string: %d", wkb_temptype);
+    return NULL;
+  }
   s->temptype = (uint8_t) wkb_temptype;
   s->basetype = temptype_basetype(s->temptype);
 


### PR DESCRIPTION
**Crash / robustness defect.** The WKB readers (`span_from_wkb_state`, `set_from_wkb_state`, `spanset_from_wkb_state`, `temporal_from_wkb_state` in `type_in.c`) read a 2-byte type code and **trusted it** — assigning it into the parse state and looking up its base type. A valid-hex buffer of a *different* family (e.g. feeding a `tstzspan` hex to `temporal_from_hexwkb`) was parsed as the wrong structure, reading over the buffer and **SIGSEGV**-ing the host process instead of returning NULL.

Repro (confirmed via JMEOS + the Spark BerlinMOD probe):
```
p    = temporal_from_hexwkb("…")        // a tint
hex  = span_as_hexwkb(temporal_to_tstzspan(p), …)   // a tstzspan WKB
temporal_from_hexwkb(hex)               // ← SIGSEGV, not NULL
```
Real trigger: the canonical BerlinMOD NxN — `overlaps(timeSpan(t1.trip), timeSpan(t2.trip))` hands a `tstzspan` WKB to the temporal reader.

**Fix:** one guard per reader — after reading the code, verify it belongs to the expected family via the existing `span_type`/`set_type`/`spanset_type`/`temporal_type` classifiers; otherwise raise `MEOS_ERR_WKB_INPUT` and return NULL (graceful null under the no-exit handler) **before** any base-type lookup or structure parse. Fixes it at the source so every untyped-hex consumer (Spark/Duck/PyMEOS/Nebula) is protected without a per-binding workaround. Complements #1172 (the hex-WKB type *discriminator*); this is the defensive read path.