### PR TITLE
[rename-only] Rename trgeoinst_make to trgeometryinst_make for API naming uniformity

### DIFF
--- a/doc/contributing/new_temporal_type.md
+++ b/doc/contributing/new_temporal_type.md
@@ -512,12 +512,12 @@ These bite contributors who didn't read this doc. Worth reading even if you're n
   The rule: any C function that **returns** a TInstant, TSequence, or TSequenceSet of a type with auxiliary embedded data must use the type-specific constructors:
   ```c
   /* trgeometry example */
-  outinsts[i] = trgeoinst_make(ref_geom, DatumGetPoseP(value), t);
+  outinsts[i] = trgeometryinst_make(ref_geom, DatumGetPoseP(value), t);
   result = trgeoseq_make_free(ref_geom, outinsts, n, lower_inc, upper_inc, interp, NORMALIZE);
   ```
   Internal intermediate computations that only read the bare value datum (never touching bbox or type-specific accessors) may still use `tinstant_make` — but only if those instants are never returned to a caller. The typical pattern is an intermediate `TSequence *seq1` built inside an analytics helper (`tsequence_tprecision`, `tsequence_tsample`) solely to extract a scalar result via generic lifting; as soon as it is reused for output, switch to the type-specific path.
 
-  This pitfall recurs when porting analytics functions (tprecision, tsample, temporal_simplify) and aggregate finalizers from generic temporal machinery to a type-specific implementation. When adding a type that follows this pattern, add a constructor helper analogous to `trgeoinst_make` / `trgeoseq_make_free` before wiring up any analytics.
+  This pitfall recurs when porting analytics functions (tprecision, tsample, temporal_simplify) and aggregate finalizers from generic temporal machinery to a type-specific implementation. When adding a type that follows this pattern, add a constructor helper analogous to `trgeometryinst_make` / `trgeoseq_make_free` before wiring up any analytics.
 
 ---
 

--- a/meos/include/meos_rgeo.h
+++ b/meos/include/meos_rgeo.h
@@ -80,7 +80,7 @@ extern char *trgeometry_out(const Temporal *temp);
  * Constructor functions
  *****************************************************************************/
 
-extern TInstant *trgeoinst_make(const GSERIALIZED *geom, const Pose *pose, TimestampTz t);
+extern TInstant *trgeometryinst_make(const GSERIALIZED *geom, const Pose *pose, TimestampTz t);
 extern Temporal *geo_tpose_to_trgeometry(const GSERIALIZED *gs, const Temporal *temp);
 
 /*****************************************************************************

--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -345,7 +345,7 @@ geo_tposeinst_to_trgeo(const GSERIALIZED *gs, const TInstant *inst)
   if (! ensure_not_empty(gs) || ! ensure_has_not_M_geo(gs))
     return NULL;
 
-  return trgeoinst_make(gs, DatumGetPoseP(tinstant_value_p(inst)), inst->t);
+  return trgeometryinst_make(gs, DatumGetPoseP(tinstant_value_p(inst)), inst->t);
 }
 
 /**

--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -1926,7 +1926,7 @@ nai_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
       /* The closest point may be at an exclusive bound. */
       Datum value;
       temporal_value_at_timestamptz(temp, min->t, false, &value);
-      result = trgeoinst_make(trgeo_geom_p(temp), DatumGetPoseP(value), 
+      result = trgeometryinst_make(trgeo_geom_p(temp), DatumGetPoseP(value), 
         min->t);
       pfree(dist); pfree(DatumGetPointer(value));
     }
@@ -1955,7 +1955,7 @@ nai_trgeometry_tpoint(const Temporal *temp1, const Temporal *temp2)
     /* The closest point may be at an exclusive bound */
     Datum value;
     temporal_value_at_timestamptz(temp1, min->t, false, &value);
-    result = trgeoinst_make(trgeo_geom_p(temp1), DatumGetPoseP(value),
+    result = trgeometryinst_make(trgeo_geom_p(temp1), DatumGetPoseP(value),
       min->t);
     pfree(dist); pfree(DatumGetPointer(value));
   }
@@ -1983,7 +1983,7 @@ nai_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2)
     /* The closest point may be at an exclusive bound. */
     Datum value;
     temporal_value_at_timestamptz(temp1, min->t, false, &value);
-      result = trgeoinst_make(trgeo_geom_p(temp1), DatumGetPoseP(value),
+      result = trgeometryinst_make(trgeo_geom_p(temp1), DatumGetPoseP(value),
         min->t);
     pfree(dist); pfree(DatumGetPointer(value));
   }

--- a/meos/src/rgeo/trgeo_inst.c
+++ b/meos/src/rgeo/trgeo_inst.c
@@ -194,7 +194,7 @@ trgeoinst_make1(const GSERIALIZED *geom, const Pose *pose, TimestampTz t)
  * @param t Timestamp
  */
 TInstant *
-trgeoinst_make(const GSERIALIZED *geom, const Pose *pose, TimestampTz t)
+trgeometryinst_make(const GSERIALIZED *geom, const Pose *pose, TimestampTz t)
 {
   VALIDATE_NOT_NULL(geom, NULL); VALIDATE_NOT_NULL(pose, NULL);
   if (! trgeoinst_make_valid(geom, pose))
@@ -222,7 +222,7 @@ trgeoseq_to_tinstant(const TSequence *seq)
     return NULL;
   }
   const TInstant *inst = TSEQUENCE_INST_N(seq, 0);
-  return trgeoinst_make(trgeoseq_geom_p(seq),
+  return trgeometryinst_make(trgeoseq_geom_p(seq),
     DatumGetPoseP(tinstant_value_p(inst)), inst->t);
 }
 
@@ -243,7 +243,7 @@ trgeoseqset_to_tinstant(const TSequenceSet *ss)
   }
   const TSequence *seq = TSEQUENCESET_SEQ_N(ss, 0);
   const TInstant *inst = TSEQUENCE_INST_N(seq, 0);
-  return trgeoinst_make(trgeoseqset_geom_p(ss),
+  return trgeometryinst_make(trgeoseqset_geom_p(ss),
     DatumGetPoseP(tinstant_value_p(inst)), inst->t);
 }
 

--- a/meos/src/rgeo/trgeo_parser.c
+++ b/meos/src/rgeo/trgeo_parser.c
@@ -76,7 +76,7 @@ trgeoinst_parse(const char **str, MeosType temptype, bool end,
     return NULL;
   }
 
-  TInstant *result = trgeoinst_make(geom, pose, t);
+  TInstant *result = trgeometryinst_make(geom, pose, t);
   pfree(pose);
   return result;
 }

--- a/mobilitydb/src/rgeo/trgeo.c
+++ b/mobilitydb/src/rgeo/trgeo.c
@@ -265,7 +265,7 @@ Trgeometry_inst_constructor(PG_FUNCTION_ARGS)
   ensure_not_empty(gs);
   ensure_has_not_M_geo(gs);
   TimestampTz t = PG_GETARG_TIMESTAMPTZ(2);
-  TInstant *result = trgeoinst_make(gs, pose, t);
+  TInstant *result = trgeometryinst_make(gs, pose, t);
   PG_FREE_IF_COPY(gs, 0);
   PG_RETURN_POINTER(result);
 }


### PR DESCRIPTION
The public temporal-rigid-geometry instant constructor is the last function in `meos_rgeo.h` still on the old abbreviated `trgeo` prefix. Every other public `trgeometry` function (`trgeometry_start_instant`, `trgeometry_instants`, `trgeometry_rotation`, …) uses the canonical `trgeometry` prefix that equals the SQL type name; this brings the constructor in line.

**Rename-only, no behavioural change.**

| old | new | occurrences | scope |
|---|---|---|---|
| `trgeoinst_make` | `trgeometryinst_make` | 12 | user-facing (public `meos_rgeo.h`) |

Touches the declaration (`meos_rgeo.h`), definition + internal callers (`trgeo_inst.c`), the `trgeo.c` / `trgeo_distance.c` / `trgeo_parser.c` callers, the MobilityDB PG wrapper, and the `new_temporal_type.md` doc example.

The internal `trgeoinst_*` / `trgeoseq_*` / `trgeoseqset_*` helpers (declared in the internal `rgeo/` headers, **not** in the public API) keep their abbreviated names — verified net-zero change. MEOS standalone and the PG extension both build with `-DRGEO=ON`.