### PR TITLE
Fix the compiler-only -Wall -Wextra warnings cppcheck cannot catch

### DIFF
--- a/meos/src/temporal/temporal_rtree.c
+++ b/meos/src/temporal/temporal_rtree.c
@@ -720,7 +720,10 @@ node_search(const RTree *rtree, const RTreeNode *node, RTreeSearchOp op,
     if (node->node_type == RTREE_LEAF)
     {
       if (leaf_consistent(rtree, RTREE_NODE_BBOX_N(node, i), query, op))
-        meos_array_add(result, &node->ids[i]);
+      {
+        int id = node->ids[i];
+        meos_array_add(result, &id);
+      }
     }
     else
     {

--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -1973,7 +1973,7 @@ temporal_from_wkb_state(meos_wkb_parse_state *s)
     s->srid = SRID_DEFAULT;
 
 #if RGEO
-  GSERIALIZED *gs;
+  GSERIALIZED *gs = NULL;
   MeosType temptype_orig = SRID_UNKNOWN;
   if (s->temptype == T_TRGEOMETRY)
   {


### PR DESCRIPTION
Two MEOS warnings under `-Wall -Wextra` are compiler diagnostics that the cppcheck cleanup (#1222 / #1008) structurally does not emit. This fixes them as the complement to that pass, so the library builds clean under `-Wall -Wextra`:

- **`type_in.c`** — initialize `gs` to `NULL` in the WKB reader. It is only read on the `T_TRGEOMETRY` path that also assigns it, but the compiler cannot prove that correlation (`-Wmaybe-uninitialized`).
- **`temporal_rtree.c`** — copy the node id into a local before adding it to the result array instead of passing a pointer into the `const` node, which discarded the `const` qualifier (`-Wdiscarded-qualifiers`). The array copies fixed-size elements, so a local copy is equivalent.

Scope is deliberately limited to these two: the `state` (`-Wmaybe-uninitialized`) and `fscanf` (`-Wunused-result`) warnings are owned by the cppcheck cleanup PR, so they are not duplicated here.
