### PR TITLE
Export the public catalog type predicates instead of defining them inline

### DIFF
--- a/meos/src/temporal/meos_catalog.c
+++ b/meos/src/temporal/meos_catalog.c
@@ -301,7 +301,7 @@ static const temptype_catalog_struct MEOS_TEMPTYPE_CATALOG[] =
 /**
  * @brief Return the string representation of the MEOS type
  */
-inline const char *
+const char *
 meostype_name(MeosType type)
 {
   return MEOS_TYPE_NAMES[type];
@@ -313,7 +313,7 @@ meostype_name(MeosType type)
  * @brief Return the string representation of the subtype of the temporal type
  * corresponding to the enum value
  */
-inline const char *
+const char *
 tempsubtype_name(tempSubtype subtype)
 {
   return MEOS_TEMPSUBTYPE_NAMES[subtype];
@@ -402,7 +402,7 @@ temptype_subtype_all(tempSubtype subtype)
 /**
  * @brief Return the string name from a MEOS operator number
  */
-inline const char *
+const char *
 meosoper_name(MeosOper oper)
 {
   return MEOS_OPER_NAMES[oper];
@@ -430,7 +430,7 @@ meosoper_from_string(const char *str)
  * @brief Return the string representation of the subtype of the temporal type
  * corresponding to the enum value
  */
-inline const char *
+const char *
 interptype_name(interpType interp)
 {
   return MEOS_INTERPTYPE_NAMES[interp];
@@ -623,7 +623,7 @@ meos_basetype(MeosType type)
 /**
  * @brief Return true if the values of the base type are passed by value
  */
-inline bool
+bool
 basetype_byvalue(MeosType type)
 {
   return (type == T_BOOL || type == T_INT4 || type == T_INT8 || type == T_FLOAT8 ||
@@ -633,7 +633,7 @@ basetype_byvalue(MeosType type)
 /**
  * @brief Return true if the values of the base type are of variable length
  */
-inline bool
+bool
 basetype_varlength(MeosType type)
 {
   return (type == T_TEXT || type == T_GEOMETRY || type == T_GEOGRAPHY
@@ -723,7 +723,7 @@ alphanum_temptype(MeosType type)
 /**
  * @brief Return true if the type is a geo base type
  */
-inline bool
+bool
 geo_basetype(MeosType type)
 {
   return (type == T_GEOMETRY || type == T_GEOGRAPHY);
@@ -732,7 +732,7 @@ geo_basetype(MeosType type)
 /**
  * @brief Return true if the type is a spatial base type
  */
-inline bool
+bool
 spatial_basetype(MeosType type)
 {
   return (type == T_GEOMETRY || type == T_GEOGRAPHY 
@@ -753,7 +753,7 @@ spatial_basetype(MeosType type)
 /**
  * @brief Return true if the type is a time type
  */
-inline bool
+bool
 time_type(MeosType type)
 {
   return (type == T_DATE || type == T_DATESET || type == T_DATESPAN ||
@@ -793,7 +793,7 @@ set_basetype(MeosType type)
 /**
  * @brief Return true if the type is a set type
  */
-inline bool
+bool
 set_type(MeosType type)
 {
   return (type == T_TSTZSET || type == T_DATESET || type == T_INTSET ||
@@ -817,7 +817,7 @@ set_type(MeosType type)
 /**
  * @brief Return true if the type is a number set type
  */
-inline bool
+bool
 numset_type(MeosType type)
 {
   return (type == T_INTSET || type == T_BIGINTSET || type == T_FLOATSET ||
@@ -843,7 +843,7 @@ ensure_numset_type(MeosType type)
 /**
  * @brief Return true if the type is a time set type
  */
-inline bool
+bool
 timeset_type(MeosType type)
 {
   return (type == T_DATESET || type == T_TSTZSET);
@@ -852,7 +852,7 @@ timeset_type(MeosType type)
 /**
  * @brief Return true if the type is a set type with a span as a bounding box
  */
-inline bool
+bool
 set_spantype(MeosType type)
 {
   return (type == T_INTSET || type == T_BIGINTSET || type == T_FLOATSET ||
@@ -875,7 +875,7 @@ ensure_set_spantype(MeosType type)
 /**
  * @brief Return true if the type is a set type
  */
-inline bool
+bool
 alphanumset_type(MeosType type)
 {
   return (type == T_TSTZSET || type == T_DATESET || type == T_INTSET ||
@@ -890,7 +890,7 @@ alphanumset_type(MeosType type)
 /**
  * @brief Return true if the type is a geo set type
  */
-inline bool
+bool
 geoset_type(MeosType type)
 {
   return (type == T_GEOMSET || type == T_GEOGSET);
@@ -913,7 +913,7 @@ ensure_geoset_type(MeosType type)
 /**
  * @brief Return true if the type is a geo set type
  */
-inline bool
+bool
 spatialset_type(MeosType type)
 {
   return (type == T_GEOMSET || type == T_GEOGSET
@@ -949,7 +949,7 @@ ensure_spatialset_type(MeosType type)
 /**
  * @brief Return true if the type is a span base type
  */
-inline bool
+bool
 span_basetype(MeosType type)
 {
   return (type == T_TIMESTAMPTZ || type == T_DATE || type == T_INT4 ||
@@ -959,7 +959,7 @@ span_basetype(MeosType type)
 /**
  * @brief Return true if the type is a canonical base type of a span type
  */
-inline bool
+bool
 span_canon_basetype(MeosType type)
 {
   return (type == T_DATE || type == T_INT4 || type == T_INT8);
@@ -979,7 +979,7 @@ span_type(MeosType type)
  * @brief Return true if the type has a span type as bounding box
  * @note This function is only used in the asserts
  */
-inline bool
+bool
 type_span_bbox(MeosType type)
 {
   return (set_spantype(type) || span_type(type) || spanset_type(type) ||
@@ -990,7 +990,7 @@ type_span_bbox(MeosType type)
  * @brief Return true if the type can be converted to a temporal box
  * @note This function is only used in the asserts
  */
-inline bool
+bool
 span_tbox_type(MeosType type)
 {
   return (type == T_INTSPAN || type == T_FLOATSPAN || type == T_TSTZSPAN);
@@ -1013,7 +1013,7 @@ ensure_span_tbox_type(MeosType type)
 /**
  * @brief Return true if the type is a number span type
  */
-inline bool
+bool
 numspan_basetype(MeosType type)
 {
   return (type == T_INT4 || type == T_INT8 || type == T_FLOAT8 ||
@@ -1024,7 +1024,7 @@ numspan_basetype(MeosType type)
 /**
  * @brief Return true if the type is a number span type
  */
-inline bool
+bool
 numspan_type(MeosType type)
 {
   return (type == T_INTSPAN || type == T_BIGINTSPAN || type == T_FLOATSPAN ||
@@ -1047,7 +1047,7 @@ ensure_numspan_type(MeosType type)
 /**
  * @brief Return true if the type is a time span type
  */
-inline bool
+bool
 timespan_basetype(MeosType type)
 {
   return (type == T_TIMESTAMPTZ || type == T_DATE);
@@ -1056,7 +1056,7 @@ timespan_basetype(MeosType type)
 /**
  * @brief Return true if the type is a time span type
  */
-inline bool
+bool
 timespan_type(MeosType type)
 {
   return (type == T_TSTZSPAN || type == T_DATESPAN);
@@ -1067,7 +1067,7 @@ timespan_type(MeosType type)
 /**
  * @brief Return true if the type is a span set type
  */
-inline bool
+bool
 spanset_type(MeosType type)
 {
   return (type == T_TSTZSPANSET || type == T_DATESPANSET ||
@@ -1077,7 +1077,7 @@ spanset_type(MeosType type)
 /**
  * @brief Return true if the type is a time span type
  */
-inline bool
+bool
 timespanset_type(MeosType type)
 {
   return (type == T_TSTZSPANSET || type == T_DATESPANSET);
@@ -1104,7 +1104,7 @@ ensure_timespanset_type(MeosType type)
  * @brief Return true if the type is an @b external temporal type
  * @note Function used in particular in the indexes
  */
-inline bool
+bool
 temporal_type(MeosType type)
 {
   return (type == T_TBOOL || type == T_TINT || type == T_TFLOAT ||
@@ -1167,7 +1167,7 @@ temporal_basetype(MeosType type)
  * subset whose values can vary linearly between samples (as opposed to
  * STEP-only types like tbool, tint, ttext, tgeometry, tgeography, th3index).
  */
-inline bool
+bool
 temptype_supports_linear(MeosType type)
 {
   bool result = (type == T_TFLOAT || type == T_TDOUBLE2 || type == T_TDOUBLE3 ||
@@ -1220,7 +1220,7 @@ ensure_talphanum_type(MeosType type)
  * @brief Return true if the type is a temporal alpha type (i.e., those whose
  * bounding box is a timestamptz span)
  */
-inline bool
+bool
 talpha_type(MeosType type)
 {
   return (type == T_TBOOL || type == T_TTEXT || type == T_TDOUBLE2 ||
@@ -1234,7 +1234,7 @@ talpha_type(MeosType type)
 /**
  * @brief Return true if the type is a temporal number type
  */
-inline bool
+bool
 tnumber_type(MeosType type)
 {
   return (type == T_TINT || type == T_TFLOAT);
@@ -1296,7 +1296,7 @@ tnumber_spantype(MeosType type)
  * types, in particular, all of them use the same bounding box @ STBox.
  * Therefore, it is used for the indexes and selectivity functions.
  */
-inline bool
+bool
 tspatial_type(MeosType type)
 {
   return (type == T_TGEOMPOINT || type == T_TGEOGPOINT || 
@@ -1334,7 +1334,7 @@ ensure_tspatial_type(MeosType type)
 /**
  * @brief Return true if a type is a temporal point type
  */
-inline bool
+bool
 tpoint_type(MeosType type)
 {
   return (type == T_TGEOMPOINT || type == T_TGEOGPOINT);
@@ -1356,7 +1356,7 @@ ensure_tpoint_type(MeosType type)
 /**
  * @brief Return true if a type is a temporal geo type
  */
-inline bool
+bool
 tgeo_type(MeosType type)
 {
   return (type == T_TGEOMETRY || type == T_TGEOGRAPHY);
@@ -1381,7 +1381,7 @@ ensure_tgeo_type(MeosType type)
  * @brief Return true if a type is a temporal type with geometry/geography as
  * base type
  */
-inline bool
+bool
 tgeo_type_all(MeosType type)
 {
   return (type == T_TGEOMETRY || type == T_TGEOGRAPHY ||
@@ -1406,7 +1406,7 @@ ensure_tgeo_type_all(MeosType type)
 /**
  * @brief Return true if a type is a temporal geometry type
  */
-inline bool
+bool
 tgeometry_type(MeosType type)
 {
   return (type == T_TGEOMPOINT || type == T_TGEOMETRY);
@@ -1429,7 +1429,7 @@ ensure_tgeometry_type(MeosType type)
 /**
  * @brief Return true if a type is a temporal geodetic type
  */
-inline bool
+bool
 tgeodetic_type(MeosType type)
 {
   return (type == T_TGEOGPOINT || type == T_TGEOGRAPHY);


### PR DESCRIPTION
### Problem

The `MeosType` type-introspection predicates in `meos/src/temporal/meos_catalog.c`
are declared `extern` in the public `meos_catalog.h` but defined with the
`inline` specifier. Under C99 inline semantics a plain `inline` definition
provides no external definition, so `libmeos.so` exports no symbol for them and
a consumer linking against the shared library gets an undefined reference. This
is the export-side complement to making `meos_catalog.h` public: the
declarations are visible but the symbols are not linkable.

### Fix

Drop the `inline` specifier from the 36 public catalog predicates so each emits
an exported symbol matching its `extern` declaration, consistent with the
neighbouring `temptype_basetype` / `settype_basetype` accessors that are already
plain exported functions. No behaviour changes — only linkage.

Verified on an all-families build (`-DCBUFFER -DNPOINT -DPOSE -DRGEO -DH3
-DQUADBIN -DPOINTCLOUD`): all 36 predicates now appear as `T` symbols in
`nm -D libmeos.so`, where previously they were absent.

### Out of scope (intentionally left `inline`)

The predicates guarded by `#ifndef NDEBUG` — `meos_basetype`, `set_basetype`,
`temporal_basetype`, `talphanum_type`, `alphanum_basetype`, `alphanum_temptype`,
`temptype_subtype`, `temptype_subtype_all` — exist only in assertion-enabled
builds (their declarations and definitions are both `NDEBUG`-guarded). They are
not part of the released shared-library surface, so they are deliberately
unchanged.
