### PR TITLE
Make the tpoint_geom_clip.c accumulator arrays per-thread (MEOS_TLS)

### DIFF
--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -60,11 +60,13 @@
  * Data structures
  *****************************************************************************/
 
-/* Global static arrays for accumulating the results of the clipping process */
-static MeosArray *events = NULL;
-static MeosArray *intervals = NULL;
-static MeosArray *periods = NULL;
-static int *rtree_results = NULL;
+/* Per-thread arrays for accumulating the results of the clipping process.
+ * MEOS_TLS is required: concurrent callers from different threads would
+ * otherwise race on these file-scope pointers, causing heap corruption. */
+static MEOS_TLS MeosArray *events = NULL;
+static MEOS_TLS MeosArray *intervals = NULL;
+static MEOS_TLS MeosArray *periods = NULL;
+static MEOS_TLS int *rtree_results = NULL;
 
 /**
  * @brief Enumeration defining the edge types 


### PR DESCRIPTION
Four file-scope static pointers (`events`, `intervals`, `periods`, `rtree_results`) accumulate intermediate state across calls to the clipping algorithm in `tpoint_clip_edges`. In a multi-threaded environment (e.g. DuckDB parallel executor), two threads entering the function simultaneously race on these shared pointers: one thread overwrites the pointer while the other is reading through it, causing heap corruption that manifests as a SIGSEGV on the next allocation. Annotate all four with `MEOS_TLS` so each thread owns its own copy. `MEOS_TLS` is already available via `meos.h` → `meos_tls.h`.