### PR TITLE
Remove the redundant dangling geo_get_srid declaration

### DIFF
--- a/meos/include/postgis_ext_defs.in.h
+++ b/meos/include/postgis_ext_defs.in.h
@@ -393,10 +393,6 @@ typedef struct
 }
 LWTIN;
 
-/* Functions */
-
-extern int32 geo_get_srid(const GSERIALIZED *g);
-
 /* PROJ */
 
 struct PJconsts;


### PR DESCRIPTION
### Problem

`geo_get_srid(const GSERIALIZED *)` is declared in the public `postgis_ext_defs`
header but defined nowhere, so `libmeos.so` exports no symbol for it and a
consumer linking against the shared library cannot resolve it.

It is also redundant and inconsistently named: the public accessor for a
geometry's SRID is **`geo_srid`** (a thin wrapper over the internal liblwgeom
`gserialized_get_srid`), which follows the uniform SRID accessor convention used
across the API — `geo_set_srid`/`geo_srid`, `stbox_set_srid`/`stbox_srid`,
`tspatial_set_srid`/`tspatial_srid`. `geo_get_srid` was the only `_get_srid`
name in the public surface and had no callers anywhere.

### Fix

Drop the dangling declaration. `geo_srid` remains the user-facing accessor, so
no functionality is lost — the public surface becomes fully linkable and the
SRID accessor naming stays uniform.
