### PR TITLE
Name the angular difference function float_angular_difference consistently

### DIFF
--- a/meos/src/temporal/tnumber_mathfuncs.c
+++ b/meos/src/temporal/tnumber_mathfuncs.c
@@ -490,7 +490,7 @@ angular_difference(Datum degrees1, Datum degrees2)
  * @csqlfn #Float_angular_difference()
  */
 double
-float8_angular_difference(float8 degrees1, float8 degrees2)
+float_angular_difference(double degrees1, double degrees2)
 {
   return DatumGetFloat8(angular_difference(Float8GetDatum(degrees1),
     Float8GetDatum(degrees2)));

--- a/mobilitydb/src/temporal/tnumber_mathfuncs.c
+++ b/mobilitydb/src/temporal/tnumber_mathfuncs.c
@@ -432,7 +432,7 @@ Float_angular_difference(PG_FUNCTION_ARGS)
 {
   double degrees1 = PG_GETARG_FLOAT8(0);
   double degrees2 = PG_GETARG_FLOAT8(1);
-  PG_RETURN_FLOAT8(float8_angular_difference(degrees1, degrees2));
+  PG_RETURN_FLOAT8(float_angular_difference(degrees1, degrees2));
 }
 
 /*****************************************************************************

--- a/pgtypes/pg_float.h
+++ b/pgtypes/pg_float.h
@@ -72,7 +72,6 @@ extern float8 float8_abs(float8 num);
 extern float8 float8_acos(float8 num);
 extern float8 float8_acosd(float8 num);
 extern float8 float8_acosh(float8 num);
-extern double float8_angular_difference(float8 degrees1, float8 degrees2);
 extern float8 float8_asin(float8 num);
 extern float8 float8_asind(float8 num);
 extern float8 float8_asinh(float8 num);

--- a/pgtypes/pgtypes.h
+++ b/pgtypes/pgtypes.h
@@ -348,7 +348,6 @@ extern float8 float8_abs(float8 num);
 extern float8 float8_acos(float8 num);
 extern float8 float8_acosd(float8 num);
 extern float8 float8_acosh(float8 num);
-extern double float8_angular_difference(float8 degrees1, float8 degrees2);
 extern float8 float8_asin(float8 num);
 extern float8 float8_asind(float8 num);
 extern float8 float8_asinh(float8 num);


### PR DESCRIPTION
### Problem

The pgtypes vendoring partially renamed `float_angular_difference` to
`float8_angular_difference` — at its `meos/src` definition, the PG wrapper
caller, and two pgtypes declarations (`pg_float.h`, `pgtypes.h`) — but the
public `meos.h` declaration, the `@csqlfn` tag, and the SQL function all
remained `Float_angular_difference`. The public `meos.h` declaration of
`float_angular_difference` is therefore defined nowhere, so `libmeos.so` exports
no symbol for it and a consumer generating from the public header cannot link it.

### Fix

`float_angular_difference` is a MobilityDB analytic function (the smaller angle
between two degree values), not a vendored PostgreSQL base-type operation like
`float8_exp`/`float8_ln`, so it does not belong among the `float8_*` helpers in
the pgtypes headers. Restore the single consistent name `float_angular_difference`
at the definition and the PG wrapper, and drop the two pgtypes declarations, so
the exported symbol matches the public `meos.h` declaration and the SQL function
name (matching master).

Stacked on #751 (which introduced the partial rename).
