### PR TITLE
Restore the temporal_merge_transfn/combinefn MEOS export

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -1726,6 +1726,8 @@ extern SkipList *tnumber_wavg_transfn(SkipList *state, const Temporal *temp, con
 extern SkipList *tstzset_tcount_transfn(SkipList *state, const Set *s);
 extern SkipList *tstzspan_tcount_transfn(SkipList *state, const Span *s);
 extern SkipList *tstzspanset_tcount_transfn(SkipList *state, const SpanSet *ss);
+extern SkipList *temporal_merge_transfn(SkipList *state, const Temporal *temp);
+extern SkipList *temporal_merge_combinefn(SkipList *state1, SkipList *state2);
 extern SkipList *ttext_tmax_transfn(SkipList *state, const Temporal *temp);
 extern SkipList *ttext_tmin_transfn(SkipList *state, const Temporal *temp);
 

--- a/meos/src/temporal/temporal_aggfuncs_meos.c
+++ b/meos/src/temporal/temporal_aggfuncs_meos.c
@@ -277,6 +277,34 @@ ttext_tmax_transfn(SkipList *state, const Temporal *temp)
   return temporal_tagg_transfn(state, temp, &datum_max_text, CROSSINGS_NO);
 }
 
+/**
+ * @ingroup meos_temporal_agg
+ * @brief Transition function for the merge aggregate of temporal values
+ * @param[in,out] state Current aggregate state
+ * @param[in] temp Temporal value to aggregate
+ * @csqlfn #Temporal_merge_transfn()
+ */
+SkipList *
+temporal_merge_transfn(SkipList *state, const Temporal *temp)
+{
+  /* Null temporal: return state */
+  if (! temp)
+    return state;
+  return temporal_tagg_transfn(state, temp, NULL, CROSSINGS_NO);
+}
+
+/**
+ * @ingroup meos_temporal_agg
+ * @brief Combine function for the merge aggregate of temporal values
+ * @param[in,out] state1, state2 Current aggregate states
+ * @csqlfn #Temporal_merge_combinefn()
+ */
+SkipList *
+temporal_merge_combinefn(SkipList *state1, SkipList *state2)
+{
+  return temporal_tagg_combinefn(state1, state2, NULL, CROSSINGS_NO);
+}
+
 #endif /* MEOS */
 
 /*****************************************************************************


### PR DESCRIPTION
The merge variant is the only temporal aggregate whose `transfn` and `combinefn` are not part of the public MEOS surface, which blocks external consumers from exposing a SQL `merge(temporal)` aggregate without reimplementing the skiplist machinery. Both functions delegate to `temporal_tagg_transfn` / `temporal_tagg_combinefn` with a NULL combiner, matching the PG-side `Temporal_merge_transfn` dispatch.

These two exports were present in the MEOS public header until the PostgreSQL-18 base-type vendoring landed on a pre-export base and dropped them; this restores them.