### PR TITLE
Capture the discarded fscanf result in GetProjStringsSPI

### DIFF
--- a/meos/src/geo/tspatial_transform_meos.c
+++ b/meos/src/geo/tspatial_transform_meos.c
@@ -252,8 +252,9 @@ GetProjStringsSPI(int32_t srid)
     return strs;
   }
 
-  /* Read the first line of the file with the headers */
-  (void) fscanf(file, "%1023s\n", header_buffer);
+  /* Read and discard the first line of the file with the headers */
+  int nread = fscanf(file, "%1023s\n", header_buffer);
+  (void) nread;
 
   /* Continue reading the file */
   bool found = false;


### PR DESCRIPTION
`GetProjStringsSPI` intentionally discards the header line of `spatial_ref_sys.csv`, but a `(void) fscanf(...)` cast does not suppress glibc's `warn_unused_result` attribute, leaving a `-Wunused-result` warning under stricter build flags. Capture the return value into a local (mirroring the data-row read in the same loop) so the read is warning-clean; the value remains unused.