### PR TITLE
Restore the aCovers(tgeometry) always-covers surface

### DIFF
--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -829,6 +829,20 @@ ecovers_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
 
 /**
  * @ingroup meos_geo_rel_ever
+ * @brief Return 1 if a geometry always covers a temporal geo,
+ * 0 if not, and -1 on error or if the geometry is empty
+ * @param[in] gs Geometry
+ * @param[in] temp Temporal geo
+ * @csqlfn #Acovers_geo_tgeo()
+ */
+int
+acovers_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
+{
+  return ea_covers_tgeo_geo_int(temp, gs, ALWAYS, INVERT);
+}
+
+/**
+ * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a temporal geometry ever covers a geo, 0 if not, and
  * -1 on error or if the geometry is empty
  * @param[in] temp Temporal geo
@@ -839,6 +853,20 @@ int
 ecovers_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_covers_tgeo_geo_int(temp, gs, EVER, INVERT_NO);
+}
+
+/**
+ * @ingroup meos_geo_rel_ever
+ * @brief Return 1 if a geometry always covers a temporal geo,
+ * 0 if not, and -1 on error or if the geometry is empty
+ * @param[in] temp Temporal geo
+ * @param[in] gs Geometry
+ * @csqlfn #Acovers_tgeo_geo()
+ */
+int
+acovers_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
+{
+  return ea_covers_tgeo_geo_int(temp, gs, ALWAYS, INVERT_NO);
 }
 #endif /* MEOS */
 
@@ -880,6 +908,19 @@ inline int
 ecovers_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 {
   return ea_covers_tgeo_tgeo(temp1, temp2, EVER);
+}
+
+/**
+ * @ingroup meos_geo_rel_ever
+ * @brief Return 1 if a temporal geometry always covers another one, 0 if not,
+ * and -1 on error
+ * @param[in] temp1,temp2 Temporal geos
+ * @csqlfn #Acovers_tgeo_tgeo()
+ */
+inline int
+acovers_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
+{
+  return ea_covers_tgeo_tgeo(temp1, temp2, ALWAYS);
 }
 #endif /* MEOS */
 

--- a/mobilitydb/sql/geo/070_tgeo_spatialrels.in.sql
+++ b/mobilitydb/sql/geo/070_tgeo_spatialrels.in.sql
@@ -72,7 +72,7 @@ CREATE FUNCTION aContains(tgeometry, tgeometry)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************
- * eCovers
+ * eCovers, aCovers
  *****************************************************************************/
 
 CREATE FUNCTION eCovers(geometry, tgeometry)
@@ -88,6 +88,22 @@ CREATE FUNCTION eCovers(tgeometry, geometry)
 CREATE FUNCTION eCovers(tgeometry, tgeometry)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Ecovers_tgeo_tgeo'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION aCovers(geometry, tgeometry)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Acovers_geo_tgeo'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION aCovers(tgeometry, geometry)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Acovers_tgeo_geo'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION aCovers(tgeometry, tgeometry)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Acovers_tgeo_tgeo'
   SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 

--- a/mobilitydb/src/geo/tgeo_spatialrels.c
+++ b/mobilitydb/src/geo/tgeo_spatialrels.c
@@ -264,6 +264,19 @@ Ecovers_geo_tgeo(PG_FUNCTION_ARGS)
   return EA_spatialrel_geo_tspatial(fcinfo, &ea_covers_geo_tgeo, EVER);
 }
 
+PGDLLEXPORT Datum Acovers_geo_tgeo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Acovers_geo_tgeo);
+/**
+ * @ingroup mobilitydb_geo_rel_ever
+ * @brief Return true if a geometry always covers a temporal geometry
+ * @sqlfn aCovers()
+ */
+inline Datum
+Acovers_geo_tgeo(PG_FUNCTION_ARGS)
+{
+  return EA_spatialrel_geo_tspatial(fcinfo, &ea_covers_geo_tgeo, ALWAYS);
+}
+
 PGDLLEXPORT Datum Ecovers_tgeo_geo(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Ecovers_tgeo_geo);
 /**
@@ -277,6 +290,19 @@ Ecovers_tgeo_geo(PG_FUNCTION_ARGS)
   return EA_spatialrel_tspatial_geo(fcinfo, &ea_covers_tgeo_geo, EVER);
 }
 
+PGDLLEXPORT Datum Acovers_tgeo_geo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Acovers_tgeo_geo);
+/**
+ * @ingroup mobilitydb_geo_rel_ever
+ * @brief Return true if a temporal geometry always covers a geometry
+ * @sqlfn aCovers()
+ */
+inline Datum
+Acovers_tgeo_geo(PG_FUNCTION_ARGS)
+{
+  return EA_spatialrel_tspatial_geo(fcinfo, &ea_covers_tgeo_geo, ALWAYS);
+}
+
 PGDLLEXPORT Datum Ecovers_tgeo_tgeo(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Ecovers_tgeo_tgeo);
 /**
@@ -288,6 +314,19 @@ inline Datum
 Ecovers_tgeo_tgeo(PG_FUNCTION_ARGS)
 {
   return EA_spatialrel_tspatial_tspatial(fcinfo, &ea_covers_tgeo_tgeo, EVER);
+}
+
+PGDLLEXPORT Datum Acovers_tgeo_tgeo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Acovers_tgeo_tgeo);
+/**
+ * @ingroup mobilitydb_geo_rel_ever
+ * @brief Return true if a temporal geometry always covers another one
+ * @sqlfn aCovers()
+ */
+inline Datum
+Acovers_tgeo_tgeo(PG_FUNCTION_ARGS)
+{
+  return EA_spatialrel_tspatial_tspatial(fcinfo, &ea_covers_tgeo_tgeo, ALWAYS);
 }
 
 /*****************************************************************************

--- a/mobilitydb/test/geo/expected/070_tgeo_spatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/070_tgeo_spatialrels_tbl.test.out
@@ -40,16 +40,34 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE eCovers(g, temp);
    574
 (1 row)
 
+SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE aCovers(g, temp);
+ count 
+-------
+    35
+(1 row)
+
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE eCovers(temp, g);
  count 
 -------
    439
 (1 row)
 
+SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE aCovers(temp, g);
+ count 
+-------
+    31
+(1 row)
+
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE eCovers(t1.temp, t2.temp);
  count 
 -------
    100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE aCovers(t1.temp, t2.temp);
+ count 
+-------
+    33
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE eDisjoint(g, temp);

--- a/mobilitydb/test/geo/queries/070_tgeo_spatialrels_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/070_tgeo_spatialrels_tbl.test.sql
@@ -49,10 +49,13 @@ SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE aContains(t1.temp,
 -------------------------------------------------------------------------------
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE eCovers(g, temp);
+SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE aCovers(g, temp);
 
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE eCovers(temp, g);
+SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE aCovers(temp, g);
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE eCovers(t1.temp, t2.temp);
+SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE aCovers(t1.temp, t2.temp);
 
 -------------------------------------------------------------------------------
 -- eDisjoint, aDisjoint


### PR DESCRIPTION
PR #837 exposed the public MEOS functions `acovers_geo_tgeo`, `acovers_tgeo_geo`, and `acovers_tgeo_tgeo`, but a later spatial-surface rework (#1162) removed their implementations at every layer while leaving the declarations in `meos_geo.h` orphaned — declared in the public header yet exported by neither `libmeos` nor the extension. A North-Star symbol-verification gate (bindings generate from the `libmeos` surface) flagged the three as declared-but-absent.

## Restored (mirroring the `ecovers_*` siblings, `EVER`→`ALWAYS`)
- **MEOS API** (`meos/src/geo/tgeo_spatialrels.c`): the three public `#if MEOS` wrappers with `@csqlfn` links. The underlying `ea_covers_*` kernels already take a `bool ever` arg and were never removed.
- **Extension** (`mobilitydb/src/geo/tgeo_spatialrels.c`): the `Acovers_*` `PG_FUNCTION` wrappers.
- **SQL** (`070_tgeo_spatialrels.in.sql`): the `aCovers()` functions.
- **Tests**: the dropped `aCovers` table queries + expected output.

## Correctness
The always-covers counts are strictly smaller than ever-covers (35/31/33 vs 574/439/100), consistent with `always ⊆ ever`. The previous golden values equated always with ever (the pre-fix always-quantifier signature); the restored expected reflects the corrected behavior. Full regression test green.

## North Star
The SQL→PG→MEOS derivation chain is regular and complete across all layers (decl / `@csqlfn` / `libmeos` symbol / `@sqlfn` / SQL), a faithful mirror of `ecovers_*` with zero hand special-cases — so a MEOS-API catalog regeneration reproduces `acovers_*` as regular public symbols.