### PR TITLE
Free the borrowed-value array in temporal_values

### DIFF
--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -1908,6 +1908,10 @@ temporal_values(const Temporal *temp, int *count)
   Datum *result = palloc(sizeof(Datum) * newcount);
   for (int i = 0; i < newcount; i++)
     result[i] = datum_copy(values[i], basetype);
+  /* temporal_values_p returns a palloc'd array of borrowed value pointers (the
+   * elements are views into temp). result holds owned copies, so free the
+   * array only — never its elements. */
+  pfree(values);
   *count = newcount;
   return result;
 }


### PR DESCRIPTION
Carved from #992 (the "MEOS bug audit" batch) as a single-topic fix.

`temporal_values` calls `temporal_values_p`, which returns a palloc'd array of **borrowed** value pointers (views into `temp`). It then builds an owned-copy array into `result` but never frees the borrowed-pointer array — a leak in the `valueSet` path shared by every temporal type.

Fix: `pfree(values)` after the copies are built (the elements are views, so only the array is freed). Verified present-on-master-and-unfixed; strict build green (3 targets, cppcheck-clean, warning-clean).

First of the per-topic splits of #992.
