### PR TITLE
Fix a heap-buffer-overflow read in tinstant_make

### DIFF
--- a/meos/src/temporal/tinstant.c
+++ b/meos/src/temporal/tinstant.c
@@ -240,6 +240,7 @@ tinstant_make(Datum value, MeosType temptype, TimestampTz t)
   size_t size = value_offset;
   /* Create the temporal instant */
   size_t value_size;
+  size_t value_copy_size;
   void *value_from;
   MeosType basetype = temptype_basetype(temptype);
   bool typbyval = basetype_byvalue(basetype);
@@ -248,6 +249,7 @@ tinstant_make(Datum value, MeosType temptype, TimestampTz t)
   {
     /* For base types passed by value */
     value_size = DOUBLE_PAD(sizeof(Datum));
+    value_copy_size = sizeof(Datum);
     value_from = &value;
   }
   else
@@ -255,13 +257,24 @@ tinstant_make(Datum value, MeosType temptype, TimestampTz t)
     /* For base types passed by reference */
     int16 typlen = meostype_length(basetype);
     value_from = DatumGetPointer(value);
-    value_size = (typlen != -1) ? DOUBLE_PAD((unsigned int) typlen) :
-      DOUBLE_PAD(VARSIZE(value_from));
+    if (typlen != -1)
+    {
+      value_size = DOUBLE_PAD((unsigned int) typlen);
+      value_copy_size = (unsigned int) typlen;
+    }
+    else
+    {
+      value_copy_size = VARSIZE(value_from);
+      value_size = DOUBLE_PAD(value_copy_size);
+    }
   }
   size += value_size;
   TInstant *result = palloc0(size);
   void *value_to = ((char *) result) + value_offset;
-  memcpy(value_to, value_from, value_size);
+  /* Copy only the actual value bytes; palloc0 already zeroed any DOUBLE_PAD
+   * trailing bytes in the destination, so reading past the source object
+   * (which may be a tightly-allocated varlena) is unnecessary and unsafe. */
+  memcpy(value_to, value_from, value_copy_size);
   /* Initialize fixed-size values */
   result->temptype = temptype;
   result->subtype = TINSTANT;


### PR DESCRIPTION
Carved from #992 (the MEOS bug-audit batch) as a single-topic fix.

**Heap-buffer-overflow read in `tinstant_make`.** For a by-reference base type, the function copied `value_size` bytes — the `DOUBLE_PAD`-rounded *allocation* size — from the source value. But the source is a tightly-allocated varlena that may be smaller than its padded size, so `memcpy` read past the end of the source object (a heap-buffer-overflow read; catchable by ASan/valgrind).

Fix: copy only the actual value bytes (`value_copy_size`). The destination padding is already zeroed by `palloc0`, so there is nothing to gain from over-reading the source.

Verified not-on-master; strict build green (3 targets, cppcheck-clean, warning-clean). Single file, single function.
