### PR TITLE
Free intermediate results in distance computation paths

### DIFF
--- a/meos/src/npoint/tnpoint_distance.c
+++ b/meos/src/npoint/tnpoint_distance.c
@@ -56,7 +56,9 @@ datum_npoint_distance(Datum np1, Datum np2)
 {
   Datum geom1 = PointerGetDatum(npoint_to_geompoint(DatumGetNpointP(np1)));
   Datum geom2 = PointerGetDatum(npoint_to_geompoint(DatumGetNpointP(np2)));
-  return datum_pt_distance2d(geom1, geom2);
+  Datum result = datum_pt_distance2d(geom1, geom2);
+  pfree(DatumGetPointer(geom1)); pfree(DatumGetPointer(geom2));
+  return result;
 }
 
 /*****************************************************************************

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -1210,7 +1210,9 @@ pose_distance(Datum pose1, Datum pose2)
 {
   Datum geom1 = PosePGetDatum(pose_to_point(DatumGetPoseP(pose1)));
   Datum geom2 = PosePGetDatum(pose_to_point(DatumGetPoseP(pose2)));
-  return datum_pt_distance2d(geom1, geom2);
+  Datum result = datum_pt_distance2d(geom1, geom2);
+  pfree(DatumGetPointer(geom1)); pfree(DatumGetPointer(geom2));
+  return result;
 }
 
 /**

--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -2065,7 +2065,7 @@ nad_trgeometry_stbox(const Temporal *temp, const STBox *box)
   /* Compute the result */
   Temporal *dist = tdistance_trgeometry_geo(temp, geo);
   double result = DatumGetFloat8(temporal_min_value(dist));
-  pfree(geo);
+  pfree(dist); pfree(geo);
   if (hast)
     pfree(temp1);
   return result;
@@ -2141,6 +2141,7 @@ shortestline_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
   LWGEOM *line = (LWGEOM *) lwline_make(value, PointerGetDatum(gs));
   GSERIALIZED *result = geo_serialize(line);
   lwgeom_free(line);
+  pfree(dist);
   return result;
 }
 


### PR DESCRIPTION
Carved from #992 (the MEOS bug-audit batch) as a single-topic memory-leak fix.

Several distance helpers built temporary geometries or distance temporals and returned without freeing them:

- `datum_npoint_distance` (`tnpoint_distance.c`) — the two temporary geometry points converted from the network points.
- `pose_distance` (`pose.c`) — the two temporary geometry points converted from the poses.
- `nad_trgeometry_stbox` and `shortestline_trgeometry_geo` (`trgeo_distance.c`) — the intermediate distance temporal (distinct functions from the `nai` leak already fixed by #1198, so no double-free).

Validated beyond the build: `geo_test` runs to completion (exit 0) with these changes, and the strict build is green (3 targets, cppcheck-clean, warning-clean). Three files, additive `pfree`s only.
