### PR TITLE
Free the validity-check array on error paths in ensure_valid_tinstarr_gaps

### DIFF
--- a/meos/src/temporal/tsequenceset.c
+++ b/meos/src/temporal/tsequenceset.c
@@ -467,11 +467,17 @@ ensure_valid_tinstarr_gaps(TInstant **instants, int count, bool merge,
     if (! ensure_increasing_timestamps(instants[i - 1], instants[i], merge) ||
         ! ensure_spatial_validity((Temporal *) instants[i - 1],
           (Temporal *) instants[i]))
+    {
+      pfree(result);
       return NULL;
+    }
 #if NPOINT
     if (instants[i]->temptype == T_TNPOINT &&
         ! ensure_same_rid_tnpointinst(instants[i - 1], instants[i]))
+    {
+      pfree(result);
       return NULL;
+    }
 #endif
     /* Determine if there should be a split */
     bool split = false;


### PR DESCRIPTION
Carved from #992 (the MEOS bug-audit batch) as a single-topic memory-leak fix.

`ensure_valid_tinstarr_gaps` `palloc0`'s a `result` array and returns it on success, but two early-return error paths — non-increasing timestamps, and (under `#if NPOINT`) a mismatched `tnpoint` route id — returned `NULL` without freeing it, leaking the array on every rejected input.

Fix: `pfree(result)` before those two `return NULL`s.

Validated beyond the build: `geo_test` runs to completion (exit 0), and the strict build is green (3 targets, cppcheck-clean, warning-clean). Single file.
