### PR TITLE
Fix the under-sized memset of the skiplist update array

### DIFF
--- a/meos/src/temporal/skiplist.c
+++ b/meos/src/temporal/skiplist.c
@@ -441,7 +441,7 @@ keyval_skiplist_common(SkipList *list, void **keys, void **values, int count,
   void *max_value = values[count - 1];
 
   /* Find the list values that are strictly before the span of new values */
-  memset(update, 0, sizeof(&update));
+  memset(update, 0, sizeof(int) * SKIPLIST_MAXLEVEL);
   int height = list->elems[0].height;
   SkipListElem *elem = &list->elems[0];
   int cur = 0;

--- a/meos/src/temporal/temporal_aggfuncs.c
+++ b/meos/src/temporal/temporal_aggfuncs.c
@@ -290,7 +290,7 @@ temporal_skiplist_common(SkipList *list, void **values, int count,
   }
 
   /* Find the list values that are strictly before the span of new values */
-  memset(update, 0, sizeof(&update));
+  memset(update, 0, sizeof(int) * SKIPLIST_MAXLEVEL);
   int height = list->elems[0].height;
   SkipListElem *elem = &list->elems[0];
   int cur = 0;


### PR DESCRIPTION
Carved from #992 (the MEOS bug-audit batch) as a single-topic, low-risk correctness fix.

Both skiplist splice helpers — `keyval_skiplist_common` (`skiplist.c`) and `temporal_skiplist_common` (`temporal_aggfuncs.c`) — zeroed the level-tracking `update[]` array with `sizeof(&update)`: the size of a **pointer** (8 bytes), not the array. Since `update` is `int update[SKIPLIST_MAXLEVEL]` (decaying to `int *`), only the first two levels were zeroed; the rest kept stack garbage, which is then used to index `list->elems[update[level]]` for higher levels — an under-initialisation bug.

Fix: `memset(update, 0, sizeof(int) * SKIPLIST_MAXLEVEL)` in both.

This is the clearly-correct, ownership-neutral part of the skiplist work (the riskier keyval-ownership changes were withdrawn in #1242 after they caused a crash). Validated: `geo_test` **and** `setspan_test` both run to completion (exit 0), strict build green (3 targets, cppcheck-clean, warning-clean).
