### PR TITLE
Set the varlena size of the pose instant in trgeoinst_tposeinst

### DIFF
--- a/meos/src/rgeo/trgeo_inst.c
+++ b/meos/src/rgeo/trgeo_inst.c
@@ -99,6 +99,7 @@ trgeoinst_tposeinst(const TInstant *inst)
   size_t inst_size = trgeoinst_pose_varsize(inst);
   TInstant *result = palloc(inst_size);
   memcpy(((char *)result), ((char *)inst), inst_size);
+  SET_VARSIZE(result, inst_size);
   MEOS_FLAGS_SET_GEOM(result->flags, false);
   result->temptype = T_TPOSE;
   return result;


### PR DESCRIPTION
`trgeoinst_tposeinst` builds a temporal pose instant from a temporal rigid geometry instant by allocating the pose-only size, copying that many bytes, and clearing the geometry flag. The copy carries over the source instant's varlena header, which spans the appended reference geometry, so the result reports a larger size than it occupies. A later `tsequence_make` reads `VARSIZE()` bytes from the instant and runs past the allocation (a heap over-read).

Recording the pose-only size with `SET_VARSIZE` fixes it, matching the sibling `trgeoseq_tposeseq` and `trgeoseqset_tposeseqset`, which already set their own size.
