### PR TITLE
Silence the residual compiler warnings in the MEOS build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,12 +215,20 @@ add_compile_definitions(_USE_MATH_DEFINES)
 
 # Set default compile flags and code coverage for GCC
 if(CMAKE_COMPILER_IS_GNUCC)
-  # MobilityDB compiler flags
-  add_definitions(-Wall -Wextra -std=gnu1x -Wunused-parameter -Wno-strict-aliasing)
-  # Treat an implicit function declaration as an error: it silently assumes an
-  # int return, truncating any 64-bit pointer the callee actually returns and
-  # producing a hard-to-trace crash at runtime rather than at build time.
-  add_definitions(-Werror=implicit-function-declaration -Werror=implicit-int)
+  # MobilityDB compiler flags valid for both C and C++
+  add_compile_options(-Wall -Wextra -Wunused-parameter -Wno-strict-aliasing)
+  # The following flags are C-only: the C++ compiler rejects -std=gnu1x and an
+  # implicit function declaration is a C-specific construct. Gating them to the
+  # C language keeps the C++ translation units (PostGIS/GEOS wrappers and the
+  # linked shared module) free of cc1plus command-line option warnings.
+  # Treating an implicit function declaration as an error matters because it
+  # silently assumes an int return, truncating any 64-bit pointer the callee
+  # actually returns and producing a hard-to-trace crash at runtime rather than
+  # at build time.
+  add_compile_options(
+    "$<$<COMPILE_LANGUAGE:C>:-std=gnu1x>"
+    "$<$<COMPILE_LANGUAGE:C>:-Werror=implicit-function-declaration>"
+    "$<$<COMPILE_LANGUAGE:C>:-Werror=implicit-int>")
   # -Wno-strict-aliasing was removed to access directly PostGIS points
   # See file tpoint_spatialfuncs.h
   # add_definitions(-Wall -Wextra -std=gnu1x -Wno-unused-parameter)

--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -196,6 +196,7 @@ ea_spatialrel_tcbufferseq_discstep_geo(const TSequence *seq,
   assert(seq); assert(gs); assert(seq->temptype == T_TCBUFFER);
   interpType interp = MEOS_FLAGS_GET_INTERP(seq->flags);
   assert(interp == DISCRETE || interp == STEP);
+  (void) interp;
   bool result;
   for (int i = 0; i < seq->count; i++)
   {

--- a/pgtypes/timezone/findtimezone.c
+++ b/pgtypes/timezone/findtimezone.c
@@ -182,6 +182,7 @@ get_timezone_offset(struct tm *tm)
 #if defined(HAVE_STRUCT_TM_TM_ZONE)
 	return tm->tm_gmtoff;
 #elif defined(HAVE_INT_TIMEZONE)
+	(void) tm; /* MEOS: tm is unused on this branch; silence -Wunused-parameter */
 	return -TIMEZONE_GLOBAL;
 #else
 #error No way to determine TZ? Can this happen?


### PR DESCRIPTION
Build the MEOS library cleanly under `-Wall -Wextra` with no compiler warnings.

- **`tcbuffer_spatialrels.c`**: the interpolation flag is read only for an `assert`, which the release build compiles out, leaving the variable unused. Mark it consumed so the release build no longer warns.
- **`findtimezone.c`**: on the `HAVE_INT_TIMEZONE` branch the `struct tm` argument is unused. Discard it explicitly (vendored code, marked with `/* MEOS */`).
- **`CMakeLists.txt`**: the C-only flags `-std=gnu1x`, `-Werror=implicit-function-declaration` and `-Werror=implicit-int` were added for every language, so the C++ translation units emitted `cc1plus` command-line option warnings. Gate them to the C language so they keep guarding the C sources without reaching the C++ compiler.

Verified: an all-families MEOS build (`CBUFFER`/`NPOINT`/`POSE`/`RGEO`/`JSON`) compiles with zero source warnings and zero `cc1plus` notices; the C-only flags remain on the C translation units and are absent from the C++ ones.