### PR TITLE
Define the temporal rigid geometry accessors missing from libmeos

### DIFF
--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -836,6 +836,77 @@ trgeometry_sequences(const Temporal *temp, int *count)
   return result;
 }
 
+/*****************************************************************************/
+
+/**
+ * @ingroup meos_rgeo_accessor
+ * @brief Return the set of distinct points seen along a temporal rigid
+ * geometry's antenna trajectory
+ * @param[in] temp Temporal rigid geometry
+ * @csqlfn #Trgeometry_points()
+ */
+Set *
+trgeometry_points(const Temporal *temp)
+{
+  VALIDATE_TRGEOMETRY(temp, NULL);
+  Temporal *tpose = trgeometry_to_tpose(temp);
+  if (! tpose)
+    return NULL;
+  Set *result = tpose_points(tpose);
+  pfree(tpose);
+  return result;
+}
+
+/**
+ * @ingroup meos_rgeo_accessor
+ * @brief Return the rotation of a temporal rigid geometry as a temporal float
+ * @param[in] temp Temporal rigid geometry
+ * @csqlfn #Trgeometry_rotation()
+ */
+Temporal *
+trgeometry_rotation(const Temporal *temp)
+{
+  VALIDATE_TRGEOMETRY(temp, NULL);
+  Temporal *tpose = trgeometry_to_tpose(temp);
+  if (! tpose)
+    return NULL;
+  Temporal *result = tpose_rotation(tpose);
+  pfree(tpose);
+  return result;
+}
+
+/**
+ * @ingroup meos_rgeo_accessor
+ * @brief Return the array of inter-instant segments of a temporal rigid
+ * geometry — one TSequence per consecutive pair of instants
+ * @param[in] temp Temporal rigid geometry
+ * @param[out] count Number of resulting segments
+ * @csqlfn #Temporal_segments()
+ */
+TSequence **
+trgeometry_segments(const Temporal *temp, int *count)
+{
+  VALIDATE_TRGEOMETRY(temp, NULL); VALIDATE_NOT_NULL(count, NULL);
+  if (! ensure_continuous(temp))
+    return NULL;
+  const GSERIALIZED *geo = trgeo_geom_p(temp);
+  Temporal *tpose = trgeometry_to_tpose(temp);
+  if (! tpose)
+    return NULL;
+  TSequence **segs = temporal_segments(tpose, count);
+  pfree(tpose);
+  if (! segs)
+    return NULL;
+  TSequence **result = palloc(sizeof(TSequence *) * (*count));
+  for (int i = 0; i < *count; i++)
+  {
+    result[i] = geo_tposeseq_to_trgeo(geo, segs[i]);
+    pfree(segs[i]);
+  }
+  pfree(segs);
+  return result;
+}
+
 /*****************************************************************************
  * Transformation functions
  *****************************************************************************/

--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -2073,6 +2073,18 @@ nad_trgeometry_stbox(const Temporal *temp, const STBox *box)
 
 /**
  * @ingroup meos_rgeo_dist
+ * @brief Return the nearest approach distance between a spatiotemporal box and
+ * a temporal rigid geometry
+ * @sqlop @p |=|
+ */
+double
+nad_stbox_trgeometry(const STBox *box, const Temporal *temp)
+{
+  return nad_trgeometry_stbox(temp, box);
+}
+
+/**
+ * @ingroup meos_rgeo_dist
  * @brief Return the nearest approach distance between two temporal rigid
  * geometries
  * @sqlop @p |=|


### PR DESCRIPTION
The public header `meos_rgeo.h` declares `trgeometry_points`, `trgeometry_rotation`, `trgeometry_segments` and `nad_stbox_trgeometry`, but the library defines none of them. The advertised public surface therefore fails to link for any consumer built against `libmeos` (the MEOS public-export invariant: every `extern` in a public header must export a symbol).

This defines all four so the declared API is fully linkable:

- `trgeometry_points`, `trgeometry_rotation`, `trgeometry_segments` — the point-set, rotation and inter-instant-segment views of the underlying temporal pose, mirroring the existing `trgeometry_sequences` (thin wrappers over `trgeometry_to_tpose` + `tpose_points`/`tpose_rotation`/`temporal_segments`, all already present).
- `nad_stbox_trgeometry` — the box-first companion of the existing `nad_trgeometry_stbox`, so both argument orders of the symmetric nearest-approach distance are available.

Verified: an all-families MEOS build exports `T trgeometry_points`, `T trgeometry_rotation`, `T trgeometry_segments`, `T nad_stbox_trgeometry`; a smoke run exercises the three accessors (`trgeometry_points`/`rotation`/`segments` return correctly) and the distance swapper.