### PR TITLE
Align the tcbuffer NAD and distance failure sentinel with DBL_MAX

### DIFF
--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -32,6 +32,8 @@
  * @brief Temporal distance for temporal circular buffers
  */
 
+/* C */
+#include <float.h>
 /* MEOS */
 #include <meos.h>
 #include <meos_internal.h>
@@ -510,7 +512,7 @@ nad_cbuffer_stbox(const Cbuffer *cb, const STBox *box)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_cbuffer_stbox(cb, box))
-    return -1.0;
+    return DBL_MAX;
 
   Datum geocbuf = PointerGetDatum(cbuffer_to_geom(cb));
   Datum geobox = PointerGetDatum(stbox_geo(box));
@@ -534,7 +536,7 @@ nad_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
-    return -1.0;
+    return DBL_MAX;
 
   GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
   double result = geom_distance2d(trav, gs);
@@ -555,7 +557,7 @@ nad_tcbuffer_stbox(const Temporal *temp, const STBox *box)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tcbuffer_stbox(temp, box))
-    return -1.0;
+    return DBL_MAX;
 
   GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
   GSERIALIZED *geo = stbox_geo(box);
@@ -577,7 +579,7 @@ nad_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tcbuffer_cbuffer(temp, cb))
-    return -1.0;
+    return DBL_MAX;
 
   GSERIALIZED *geom = cbuffer_to_geom(cb);
   GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
@@ -597,11 +599,11 @@ nad_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tcbuffer_tcbuffer(temp1, temp2))
-    return -1.0;
+    return DBL_MAX;
 
   Temporal *dist = tdistance_tcbuffer_tcbuffer(temp1, temp2);
   if (dist == NULL)
-    return -1.0;
+    return DBL_MAX;
   double result = DatumGetFloat8(temporal_min_value(dist));
   pfree(dist);
   return result;


### PR DESCRIPTION
The temporal circular buffer nearest-approach-distance functions (`nad_cbuffer_stbox`, `nad_tcbuffer_geo`, `nad_tcbuffer_stbox`, `nad_tcbuffer_cbuffer`, `nad_tcbuffer_tcbuffer`) returned `-1.0` on invalid/empty/no-overlap inputs, whereas the canonical failure sentinel across the distance surface is `DBL_MAX` (the sibling `nad_tgeo_*` functions all return `DBL_MAX`).

A `-1.0` sentinel sorts smaller than any real distance, so a KNN search using the `|=|` operator over a GiST/SP-GiST index returns the can't-compute entries first and reports `-1` instead of the true nearest distance; `DBL_MAX` sorts them last so the genuinely nearest rows are returned. The PostgreSQL wrappers already test `if (result == DBL_MAX) PG_RETURN_NULL();`, so the MEOS layer returning `-1.0` left that conversion as dead code.

Return `DBL_MAX` from these paths, matching the temporal geometry family. The base `distance_cbuffer_*` functions are unchanged.

Verified: full cbuffer regression suite green (incl. `166_tcbuffer_indexes_tbl` and `210_tcbuffer_distance`).