### PR TITLE
Resolve INT64_FORMAT/UINT64_FORMAT for the cppcheck CI via a library cfg

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -84,6 +84,7 @@ jobs:
             --suppress='*:clipper2/*' \
             --suppress='missingIncludeSystem' \
             --suppress='unmatchedSuppression' \
+            --library=cppcheck-mobilitydb.cfg \
             --xml --xml-version=2 \
             -j "$(nproc)" \
             2> cppcheck.xml || true

--- a/cppcheck-mobilitydb.cfg
+++ b/cppcheck-mobilitydb.cfg
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!--
+  cppcheck library for MobilityDB/MEOS.
+
+  Declares the PostgreSQL fixed-width integer format macros so static
+  analysis resolves them the way the real build does. The build defines
+  them in pgtypes/c.h as `"%" PRId64` / `"%" PRIu64`; cppcheck does not
+  parse the system <inttypes.h> that provides PRId64/PRIu64, so it reports
+  a spurious `unknownMacro` on any code that uses INT64_FORMAT/UINT64_FORMAT.
+
+  The values below mirror that expansion on LP64 platforms and are used
+  ONLY for cppcheck's macro resolution and printf-format checking; they are
+  never seen at build or run time (pgtypes/c.h remains the single source).
+-->
+<def format="2">
+  <define name="INT64_FORMAT" value="&quot;%ld&quot;"/>
+  <define name="UINT64_FORMAT" value="&quot;%lu&quot;"/>
+</def>


### PR DESCRIPTION
cppcheck reports a spurious `unknownMacro` ("If INT64_FORMAT is a macro then please configure it") on code using the `INT64_FORMAT` / `UINT64_FORMAT` PostgreSQL format macros: it does not parse the system `<inttypes.h>` that defines `PRId64`/`PRIu64`, which `pgtypes/c.h` uses (`#define INT64_FORMAT "%" PRId64`). The finding is a false positive — the real build resolves the macros — but it fails the **Cppcheck** check on any PR whose changed lines use them.

Add `cppcheck-mobilitydb.cfg`, a cppcheck library that declares the two macros, and load it with `--library` (the canonical cppcheck mechanism for project macros) instead of hardcoding a format value in the workflow. `pgtypes/c.h` remains the single source for the real build; the cfg values are used only for static-analysis macro resolution.

Verified locally (cppcheck 2.13): a TU using the macros reports `unknownMacro` without the cfg and is clean with `--library=cppcheck-mobilitydb.cfg` (no format-mismatch warning).