### PR TITLE
Correct the @csqlfn tag on the WKB serialization output functions

### DIFF
--- a/meos/src/cbuffer/cbuffer.c
+++ b/meos/src/cbuffer/cbuffer.c
@@ -435,7 +435,7 @@ cbuffer_from_hexwkb(const char *hexwkb)
  * @param[in] cb Circular buffer
  * @param[in] variant Output variant
  * @param[out] size_out Size of the output
- * @csqlfn #Cbuffer_recv(), #Cbuffer_as_wkb()
+ * @csqlfn #Cbuffer_send(), #Cbuffer_as_wkb()
  */
 uint8_t *
 cbuffer_as_wkb(const Cbuffer *cb, uint8_t variant, size_t *size_out)

--- a/meos/src/geo/stbox.c
+++ b/meos/src/geo/stbox.c
@@ -286,7 +286,7 @@ stbox_from_hexwkb(const char *hexwkb)
  * @param[in] box Spatiotemporal box
  * @param[in] variant Output variant
  * @param[out] size_out Size of the output
- * @csqlfn #Stbox_recv(), #Stbox_as_wkb()
+ * @csqlfn #Stbox_send(), #Stbox_as_wkb()
  */
 uint8_t *
 stbox_as_wkb(const STBox *box, uint8_t variant, size_t *size_out)

--- a/meos/src/npoint/npoint.c
+++ b/meos/src/npoint/npoint.c
@@ -560,7 +560,7 @@ npoint_from_hexwkb(const char *hexwkb)
  * @param[in] np Network point
  * @param[in] variant Output variant
  * @param[out] size_out Size of the output
- * @csqlfn #Npoint_recv(), #Npoint_as_wkb()
+ * @csqlfn #Npoint_send(), #Npoint_as_wkb()
  */
 uint8_t *
 npoint_as_wkb(const Npoint *np, uint8_t variant, size_t *size_out)

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -652,7 +652,7 @@ pose_from_hexwkb(const char *hexwkb)
  * @param[in] pose Pose
  * @param[in] variant Output variant
  * @param[out] size_out Size of the output
- * @csqlfn #Pose_recv(), #Pose_as_wkb()
+ * @csqlfn #Pose_send(), #Pose_as_wkb()
  */
 uint8_t *
 pose_as_wkb(const Pose *pose, uint8_t variant, size_t *size_out)

--- a/meos/src/temporal/type_out.c
+++ b/meos/src/temporal/type_out.c
@@ -2591,7 +2591,7 @@ tbox_as_hexwkb(const TBox *box, uint8_t variant, size_t *size_out)
  * @param[in] temp Temporal value
  * @param[in] variant Output variant
  * @param[out] size_out Size of the output
- * @csqlfn #Temporal_recv(), #Temporal_as_wkb()
+ * @csqlfn #Temporal_send(), #Temporal_as_wkb()
  */
 uint8_t *
 temporal_as_wkb(const Temporal *temp, uint8_t variant, size_t *size_out)


### PR DESCRIPTION
The `*_as_wkb` WKB-output functions (`temporal_as_wkb`, `cbuffer_as_wkb`, `stbox_as_wkb`, `pose_as_wkb`, `npoint_as_wkb`) carry a `@csqlfn #*_recv()` link copied from their `*_from_wkb` input sibling, where `recv` (read WKB) correctly belongs. `recv` is an input function, so an output function cannot back it.

`temporal_as_wkb` / `cbuffer_as_wkb` / `stbox_as_wkb` / `pose_as_wkb` back the `*_send` wrapper (whose body calls `*_as_wkb`), so they carry `#*_send()`. `npoint_as_wkb` backs only the `Npoint_as_wkb` wrapper (`Npoint_send` delegates to a separate `npoint_send`), so its spurious `#Npoint_recv()` is removed.

This attaches the `*_send` SQL names to the MEOS-API catalog (previously unreachable) and drops the wrong link, so the binding generators expose the WKB-output surface correctly.