### PR TITLE
Rename tdistance_tnpoint_point / tdistance_tpose_point to *_geo

### DIFF
--- a/meos/include/meos_npoint.h
+++ b/meos/include/meos_npoint.h
@@ -281,7 +281,7 @@ extern Temporal *tnpoint_minus_stbox(const Temporal *temp, const STBox *box, boo
  *****************************************************************************/
 
 extern Temporal *tdistance_tnpoint_npoint(const Temporal *temp, const Npoint *np);
-extern Temporal *tdistance_tnpoint_point(const Temporal *temp, const GSERIALIZED *gs);
+extern Temporal *tdistance_tnpoint_geo(const Temporal *temp, const GSERIALIZED *gs);
 extern Temporal *tdistance_tnpoint_tnpoint(const Temporal *temp1, const Temporal *temp2);
 extern double nad_tnpoint_geo(const Temporal *temp, const GSERIALIZED *gs);
 extern double nad_tnpoint_npoint(const Temporal *temp, const Npoint *np);

--- a/meos/include/meos_pose.h
+++ b/meos/include/meos_pose.h
@@ -251,7 +251,7 @@ extern Temporal *tpose_minus_stbox(const Temporal *temp, const STBox *box, bool 
  *****************************************************************************/
 
 extern Temporal *tdistance_tpose_pose(const Temporal *temp, const Pose *pose);
-extern Temporal *tdistance_tpose_point(const Temporal *temp, const GSERIALIZED *gs);
+extern Temporal *tdistance_tpose_geo(const Temporal *temp, const GSERIALIZED *gs);
 extern Temporal *tdistance_tpose_tpose(const Temporal *temp1, const Temporal *temp2);
 extern double nad_tpose_geo(const Temporal *temp, const GSERIALIZED *gs);
 extern double nad_tpose_pose(const Temporal *temp, const Pose *pose);

--- a/meos/src/npoint/tnpoint_distance.c
+++ b/meos/src/npoint/tnpoint_distance.c
@@ -69,10 +69,10 @@ datum_npoint_distance(Datum np1, Datum np2)
  * @ingroup meos_npoint_dist
  * @brief Return the temporal distance between a geometry point and a temporal
  * network point
- * @csqlfn #Tdistance_tnpoint_point()
+ * @csqlfn #Tdistance_tnpoint_geo()
  */
 Temporal *
-tdistance_tnpoint_point(const Temporal *temp, const GSERIALIZED *gs)
+tdistance_tnpoint_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tnpoint_geo(temp, gs) || gserialized_is_empty(gs) || 

--- a/meos/src/pose/tpose_distance.c
+++ b/meos/src/pose/tpose_distance.c
@@ -51,10 +51,10 @@
  * @brief Return the temporal distance between a geometry and a temporal pose
  * @param[in] temp Temporal pose
  * @param[in] gs Geometry
- * @csqlfn #Tdistance_tpose_point()
+ * @csqlfn #Tdistance_tpose_geo()
  */
 Temporal *
-tdistance_tpose_point(const Temporal *temp, const GSERIALIZED *gs)
+tdistance_tpose_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tpose_geo(temp, gs) || gserialized_is_empty(gs))

--- a/meos/test/npoint_test.c
+++ b/meos/test/npoint_test.c
@@ -759,10 +759,10 @@ int main(void)
   printf("tdistance_tnpoint_npoint(%s, %s): %s\n", tnpoint1_out, npoint1_out, char_result);
   free(tfloat_result); free(char_result);
 
-  /* Temporal *tdistance_tnpoint_point(const Temporal *temp, const GSERIALIZED *gs); */
-  tfloat_result = tdistance_tnpoint_point(tnpoint1, geom1);
+  /* Temporal *tdistance_tnpoint_geo(const Temporal *temp, const GSERIALIZED *gs); */
+  tfloat_result = tdistance_tnpoint_geo(tnpoint1, geom1);
   char_result = tfloat_out(tfloat_result, 6);
-  printf("tdistance_tnpoint_point(%s, %s): %s\n", tnpoint1_out, geom1_out, char_result);
+  printf("tdistance_tnpoint_geo(%s, %s): %s\n", tnpoint1_out, geom1_out, char_result);
   free(tfloat_result); free(char_result);
 
   /* Temporal *tdistance_tnpoint_tnpoint(const Temporal *temp1, const Temporal *temp2); */

--- a/mobilitydb/sql/npoint/312_tnpoint_distance.in.sql
+++ b/mobilitydb/sql/npoint/312_tnpoint_distance.in.sql
@@ -46,7 +46,7 @@ CREATE FUNCTION tDistance(npoint, tnpoint)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION tDistance(tnpoint, geometry(Point))
   RETURNS tfloat
-  AS 'MODULE_PATHNAME', 'Tdistance_tnpoint_point'
+  AS 'MODULE_PATHNAME', 'Tdistance_tnpoint_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION tDistance(tnpoint, npoint)
   RETURNS tfloat

--- a/mobilitydb/sql/pose/113_tpose_distance.in.sql
+++ b/mobilitydb/sql/pose/113_tpose_distance.in.sql
@@ -42,7 +42,7 @@ CREATE FUNCTION tDistance(pose, tpose)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION tDistance(tpose, geometry(Point))
   RETURNS tfloat
-  AS 'MODULE_PATHNAME', 'Tdistance_tpose_point'
+  AS 'MODULE_PATHNAME', 'Tdistance_tpose_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION tDistance(tpose, pose)
   RETURNS tfloat

--- a/mobilitydb/src/npoint/tnpoint_distance.c
+++ b/mobilitydb/src/npoint/tnpoint_distance.c
@@ -62,7 +62,7 @@ Tdistance_point_tnpoint(PG_FUNCTION_ARGS)
 {
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(0);
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
-  Temporal *result = tdistance_tnpoint_point(temp, gs);
+  Temporal *result = tdistance_tnpoint_geo(temp, gs);
   PG_FREE_IF_COPY(gs, 0);
   PG_FREE_IF_COPY(temp, 1);
   if (! result)
@@ -70,8 +70,8 @@ Tdistance_point_tnpoint(PG_FUNCTION_ARGS)
   PG_RETURN_TEMPORAL_P(result);
 }
 
-PGDLLEXPORT Datum Tdistance_tnpoint_point(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Tdistance_tnpoint_point);
+PGDLLEXPORT Datum Tdistance_tnpoint_geo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tdistance_tnpoint_geo);
 /**
  * @ingroup mobilitydb_npoint_dist
  * @brief Return the temporal distance between a temporal network point and
@@ -80,11 +80,11 @@ PG_FUNCTION_INFO_V1(Tdistance_tnpoint_point);
  * @sqlop @p <->
  */
 Datum
-Tdistance_tnpoint_point(PG_FUNCTION_ARGS)
+Tdistance_tnpoint_geo(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(1);
-  Temporal *result = tdistance_tnpoint_point(temp, gs);
+  Temporal *result = tdistance_tnpoint_geo(temp, gs);
   PG_FREE_IF_COPY(temp, 0);
   PG_FREE_IF_COPY(gs, 1);
   if (! result)

--- a/mobilitydb/src/pose/tpose_distance.c
+++ b/mobilitydb/src/pose/tpose_distance.c
@@ -61,7 +61,7 @@ Tdistance_point_tpose(PG_FUNCTION_ARGS)
 {
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(0);
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
-  Temporal *result = tdistance_tpose_point(temp, gs);
+  Temporal *result = tdistance_tpose_geo(temp, gs);
   PG_FREE_IF_COPY(gs, 0);
   PG_FREE_IF_COPY(temp, 1);
   if (! result)
@@ -69,8 +69,8 @@ Tdistance_point_tpose(PG_FUNCTION_ARGS)
   PG_RETURN_TEMPORAL_P(result);
 }
 
-PGDLLEXPORT Datum Tdistance_tpose_point(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Tdistance_tpose_point);
+PGDLLEXPORT Datum Tdistance_tpose_geo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tdistance_tpose_geo);
 /**
  * @ingroup mobilitydb_pose_dist
  * @brief Return the temporal distance between a temporal pose and a geometry
@@ -79,11 +79,11 @@ PG_FUNCTION_INFO_V1(Tdistance_tpose_point);
  * @sqlop @p <->
  */
 Datum
-Tdistance_tpose_point(PG_FUNCTION_ARGS)
+Tdistance_tpose_geo(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(1);
-  Temporal *result = tdistance_tpose_point(temp, gs);
+  Temporal *result = tdistance_tpose_geo(temp, gs);
   PG_FREE_IF_COPY(temp, 0);
   PG_FREE_IF_COPY(gs, 1);
   if (! result)


### PR DESCRIPTION
`tdistance_tnpoint_point` and `tdistance_tpose_point` take a `GSERIALIZED` geometry argument, for which the canonical operand suffix is `_geo` (as in `tdistance_tgeo_geo`), not `_point`.

This renames the two MEOS functions to `tdistance_tnpoint_geo` / `tdistance_tpose_geo` and their PG wrappers `Tdistance_*_point` → `Tdistance_*_geo` (declaration + definition + `@csqlfn` + `MODULE_PATHNAME` + test), giving a consistent distance surface across families. The user-facing SQL function name (`tDistance`) is unchanged — a pure internal rename; both targets build clean with all families enabled.

A focused, mechanical rename-only PR suitable for an atomic merge.
