### PR TITLE
[rename-only] Normalize the cbuffer traversed-area naming to traversed_area

### DIFF
--- a/meos/include/cbuffer/tcbuffer_spatialfuncs.h
+++ b/meos/include/cbuffer/tcbuffer_spatialfuncs.h
@@ -44,10 +44,10 @@
 
 /* Traversed area functions */
 
-extern GSERIALIZED *tcbufferinst_trav_area(const TInstant *inst);
-extern GSERIALIZED *tcbufferseq_trav_area(const TSequence *seq);
-extern GSERIALIZED *tcbufferseqset_trav_area(const TSequenceSet *ss);
-extern GSERIALIZED *tcbuffersegm_trav_area(const TInstant *inst1,
+extern GSERIALIZED *tcbufferinst_traversed_area(const TInstant *inst);
+extern GSERIALIZED *tcbufferseq_traversed_area(const TSequence *seq);
+extern GSERIALIZED *tcbufferseqset_traversed_area(const TSequenceSet *ss);
+extern GSERIALIZED *tcbuffersegm_traversed_area(const TInstant *inst1,
   const TInstant *inst2);
 
 /* Restriction functions */

--- a/meos/include/meos_cbuffer.h
+++ b/meos/include/meos_cbuffer.h
@@ -231,7 +231,7 @@ extern Temporal *tcbuffer_make(const Temporal *tpoint, const Temporal *tfloat);
 
 extern Set *tcbuffer_points(const Temporal *temp);
 extern Set *tcbuffer_radius(const Temporal *temp);
-extern GSERIALIZED *tcbuffer_trav_area(const Temporal *temp, bool merge_union);
+extern GSERIALIZED *tcbuffer_traversed_area(const Temporal *temp, bool merge_union);
 
 /*****************************************************************************
  * Conversion functions

--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -536,7 +536,7 @@ nad_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
   if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
     return -1.0;
 
-  GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
+  GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
   double result = geom_distance2d(trav, gs);
   pfree(trav);
   return result;
@@ -557,7 +557,7 @@ nad_tcbuffer_stbox(const Temporal *temp, const STBox *box)
   if (! ensure_valid_tcbuffer_stbox(temp, box))
     return -1.0;
 
-  GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
+  GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
   GSERIALIZED *geo = stbox_geo(box);
   double result = geom_distance2d(trav, geo);
   pfree(trav); pfree(geo);
@@ -580,7 +580,7 @@ nad_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
     return -1.0;
 
   GSERIALIZED *geom = cbuffer_to_geom(cb);
-  GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
+  GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
   double result = geom_distance2d(trav, geom);
   pfree(trav); pfree(geom);
   return result;
@@ -626,7 +626,7 @@ shortestline_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
   if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
     return NULL;
 
-  GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
+  GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
   GSERIALIZED *result = geom_shortestline2d(trav, gs);
   pfree(trav);
   return result;
@@ -648,7 +648,7 @@ shortestline_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
     return NULL;
 
   GSERIALIZED *geom = cbuffer_to_geom(cb);
-  GSERIALIZED *trav = tcbuffer_trav_area(temp, false);
+  GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
   GSERIALIZED *result = geom_shortestline2d(trav, geom);
   pfree(geom); pfree(trav);
   return result;

--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -243,7 +243,7 @@ ea_spatialrel_tcbufferseq_linear_geo(const TSequence *seq,
   for (int i = 1; i < seq->count; i++)
   {
     const TInstant *inst2 = TSEQUENCE_INST_N(seq, i);
-    GSERIALIZED *trav = tcbuffersegm_trav_area(inst1, inst2);
+    GSERIALIZED *trav = tcbuffersegm_traversed_area(inst1, inst2);
     result = spatialrel_geo_geo(trav, gs, param, func, numparam, invert);
     pfree(trav);
     if (result == 1 && ever)

--- a/meos/src/cbuffer/tcbuffer_tempspatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_tempspatialrels.c
@@ -131,7 +131,7 @@ tinterrel_tcbufferinst_geom(const TInstant *inst, const GSERIALIZED *gs,
 {
   assert(inst); assert(gs); assert(! gserialized_is_empty(gs));
   assert(inst->temptype == T_TCBUFFER);
-  GSERIALIZED *trav = tcbufferinst_trav_area(inst);
+  GSERIALIZED *trav = tcbufferinst_traversed_area(inst);
   GSERIALIZED *inter = geom_intersection2d_coll(trav, gs);
   pfree(trav);
   Datum datum_true = tinter ? BoolGetDatum(true) : BoolGetDatum(false);
@@ -160,7 +160,7 @@ tinterrel_tcbufferseq_disc_geom(const TSequence *seq, const GSERIALIZED *gs,
   assert(MEOS_FLAGS_GET_INTERP(seq->flags) == DISCRETE);
   /* Compute the intersection of the traversed area of a temporal circular
    * buffer and the geometry */
-  GSERIALIZED *trav = tcbufferseq_trav_area(seq);
+  GSERIALIZED *trav = tcbufferseq_traversed_area(seq);
   GSERIALIZED *inter = geom_intersection2d_coll(trav, gs);
   pfree(trav);
   /* If there is no intersection */
@@ -176,7 +176,7 @@ tinterrel_tcbufferseq_disc_geom(const TSequence *seq, const GSERIALIZED *gs,
   for (int i = 0; i < seq->count; i++)
   {
     const TInstant *inst = TSEQUENCE_INST_N(seq, i);
-    GSERIALIZED *circle = tcbufferinst_trav_area(inst);
+    GSERIALIZED *circle = tcbufferinst_traversed_area(inst);
     /* Loop for each point in the intersection */
     bool found = false;
     for (int j = 0; j < npoints; j++)
@@ -249,7 +249,7 @@ tinterrel_tcbufferseq_step_geom(const TSequence *seq, const GSERIALIZED *gs,
   assert(MEOS_FLAGS_GET_INTERP(seq->flags) == STEP);
   /* Compute the intersection of the traversed area of a temporal circular
    * buffer and the geometry */
-  GSERIALIZED *trav = tcbufferseq_trav_area(seq);
+  GSERIALIZED *trav = tcbufferseq_traversed_area(seq);
   GSERIALIZED *inter = geom_intersection2d_coll(trav, gs);
   pfree(trav);
   /* If there is no intersection */
@@ -269,7 +269,7 @@ tinterrel_tcbufferseq_step_geom(const TSequence *seq, const GSERIALIZED *gs,
       TSEQUENCE_INST_N(seq, i + 1) : inst;
     TimestampTz mint = DT_NOEND, maxt = DT_NOBEGIN;
     bool upper_inc = (i == seq->count - 1) ? false : seq->period.upper_inc;
-    GSERIALIZED *circle = tcbufferinst_trav_area(inst);
+    GSERIALIZED *circle = tcbufferinst_traversed_area(inst);
     /* Loop for each point in the intersection */
     bool found = false;
     for (int j = 0; j < npoints; j++)
@@ -361,7 +361,7 @@ tinterrel_tcbufferseq_linear_geom(const TSequence *seq, const GSERIALIZED *gs,
   assert(MEOS_FLAGS_LINEAR_INTERP(seq->flags));
   /* Compute the intersection of the traversed area of a temporal circular
    * buffer and the geometry */
-  GSERIALIZED *trav = tcbufferseq_trav_area(seq);
+  GSERIALIZED *trav = tcbufferseq_traversed_area(seq);
   GSERIALIZED *inter = geom_intersection2d_coll(trav, gs);
   pfree(trav);
   /* If there is no intersection */

--- a/meos/test/cbuffer_test.c
+++ b/meos/test/cbuffer_test.c
@@ -556,10 +556,10 @@ int main(void)
   printf("tcbuffer_points(%s, 6): %s", tcbuffer1_out, char_result);
   free(floatset_result); free(char_result);
 
-  /* GSERIALIZED *tcbuffer_trav_area(const Temporal *temp, bool merge_union); */
-  geom_result = tcbuffer_trav_area(tcbuffer1, true);
+  /* GSERIALIZED *tcbuffer_traversed_area(const Temporal *temp, bool merge_union); */
+  geom_result = tcbuffer_traversed_area(tcbuffer1, true);
   char_result = geo_as_text(geom_result, 6);
-  printf("tcbuffer_trav_area(%s, true): %s\n", tcbuffer1_out, char_result);
+  printf("tcbuffer_traversed_area(%s, true): %s\n", tcbuffer1_out, char_result);
   free(geom_result); free(char_result);
 
   /*****************************************************************************

--- a/mobilitydb/src/cbuffer/tcbuffer.c
+++ b/mobilitydb/src/cbuffer/tcbuffer.c
@@ -295,7 +295,7 @@ Tcbuffer_traversed_area(PG_FUNCTION_ARGS)
   bool unary_union = false;
   if (PG_NARGS() > 1 && ! PG_ARGISNULL(1))
     unary_union = PG_GETARG_BOOL(1);
-  GSERIALIZED *result = tcbuffer_trav_area(temp, unary_union);
+  GSERIALIZED *result = tcbuffer_traversed_area(temp, unary_union);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_TEMPORAL_P(result);
 }


### PR DESCRIPTION
The MEOS-level temporal circular buffer functions spell the traversed area as `trav_area`, while the temporal geometry and rigid-geometry equivalents (`tgeo_traversed_area`, `trgeometry_traversed_area`) and the SQL wrapper `Tcbuffer_traversed_area` use the full `traversed_area` spelling.

This renames the cbuffer functions to `traversed_area` so the spelling is uniform across the spatial types. It is a pure rename with no behavioural change: 46 symmetric line changes across 8 files, covering the public `tcbuffer_traversed_area` and the internal per-subtype helpers.