### PR TITLE
Spell the temporal rigid-geometry distance tDistance, like tgeo

### DIFF
--- a/mobilitydb/sql/rgeo/161_trgeo_distance.in.sql
+++ b/mobilitydb/sql/rgeo/161_trgeo_distance.in.sql
@@ -36,49 +36,49 @@
  * Distance functions
  *****************************************************************************/
 
-CREATE FUNCTION tdistance(trgeometry, geometry)
+CREATE FUNCTION tDistance(trgeometry, geometry)
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tdistance_trgeometry_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tdistance(geometry, trgeometry)
+CREATE FUNCTION tDistance(geometry, trgeometry)
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tdistance_geo_trgeometry'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tdistance(trgeometry, tgeompoint)
+CREATE FUNCTION tDistance(trgeometry, tgeompoint)
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tdistance_trgeometry_tpoint'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tdistance(tgeompoint, trgeometry)
+CREATE FUNCTION tDistance(tgeompoint, trgeometry)
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tdistance_tpoint_trgeometry'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tdistance(trgeometry, trgeometry)
+CREATE FUNCTION tDistance(trgeometry, trgeometry)
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tdistance_trgeometry_trgeometry'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <-> (
-  PROCEDURE = tdistance,
+  PROCEDURE = tDistance,
   LEFTARG = trgeometry, RIGHTARG = geometry,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = tdistance,
+  PROCEDURE = tDistance,
   LEFTARG = geometry, RIGHTARG = trgeometry,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = tdistance,
+  PROCEDURE = tDistance,
   LEFTARG = trgeometry, RIGHTARG = tgeompoint,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = tdistance,
+  PROCEDURE = tDistance,
   LEFTARG = tgeompoint, RIGHTARG = trgeometry,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = tdistance,
+  PROCEDURE = tDistance,
   LEFTARG = trgeometry, RIGHTARG = trgeometry,
   COMMUTATOR = <->
 );

--- a/mobilitydb/src/rgeo/trgeo_distance.c
+++ b/mobilitydb/src/rgeo/trgeo_distance.c
@@ -70,7 +70,7 @@ PG_FUNCTION_INFO_V1(Tdistance_trgeometry_geo);
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the temporal distance between a temporal rigid geometry and a
  * geometry
- * @sqlfn tdistance()
+ * @sqlfn tDistance()
  * @sqlop @p <->
  */
 PGDLLEXPORT Datum
@@ -93,7 +93,7 @@ PG_FUNCTION_INFO_V1(Tdistance_geo_trgeometry);
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the temporal distance between a geometry and a temporal rigid
  * geometry
- * @sqlfn tdistance()
+ * @sqlfn tDistance()
  * @sqlop @p <->
  */
 PGDLLEXPORT Datum
@@ -115,7 +115,7 @@ PG_FUNCTION_INFO_V1(Tdistance_trgeometry_tpoint);
 /**
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the temporal distance between two temporal rigid geometries
- * @sqlfn tdistance()
+ * @sqlfn tDistance()
  * @sqlop @p <->
  */
 PGDLLEXPORT Datum
@@ -137,7 +137,7 @@ PG_FUNCTION_INFO_V1(Tdistance_tpoint_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the temporal distance between two temporal rigid geometries
- * @sqlfn tdistance()
+ * @sqlfn tDistance()
  * @sqlop @p <->
  */
 PGDLLEXPORT Datum
@@ -159,7 +159,7 @@ PG_FUNCTION_INFO_V1(Tdistance_trgeometry_trgeometry);
 /**
  * @ingroup mobilitydb_rgeo_dist
  * @brief Return the temporal distance between two temporal rigid geometries
- * @sqlfn tdistance()
+ * @sqlfn tDistance()
  * @sqlop @p <->
  */
 PGDLLEXPORT Datum


### PR DESCRIPTION
The rigid-geometry temporal distance exposed the lower-case `tdistance` as its SQL function name, operator `PROCEDURE`, and `@sqlfn` doc tag, while the geometry temporal distance (`mobilitydb/src/geo/tgeo_distance.c`) and every other distance use the canonical `tDistance`.

PostgreSQL folds unquoted identifiers, so the split is invisible in SQL/pg_regress. But the `@sqlfn` name is taken **case-sensitively** by the catalog-driven bindings: a case-insensitive engine (Spark SQL) registers `tDistance` and `tdistance` as one UDF, so the rigid-geometry-only spelling silently shadows the geometry-distance dispatch and `<->`(tgeompoint, tgeompoint) returns NULL.

Recase the five function definitions, operator `PROCEDURE`s, and `@sqlfn` tags in `mobilitydb/sql/rgeo/161_trgeo_distance.in.sql` + `mobilitydb/src/rgeo/trgeo_distance.c` to `tDistance`. The C wrappers (`Tdistance_*`) and implementations (`tdistance_trgeometry_*`) are unchanged; the SQL folds identically (pure binding-canonicalization). Surfaced by the new MEOS-API `@sqlfn` case-collision lint.