### PR TITLE
Spell the split-spans @sqlfn tags splitNSpans, like the SQL

### DIFF
--- a/mobilitydb/src/temporal/span.c
+++ b/mobilitydb/src/temporal/span.c
@@ -303,7 +303,7 @@ PG_FUNCTION_INFO_V1(Set_split_n_spans);
 /**
  * @ingroup mobilitydb_setspan_conversion
  * @brief Return an array of N spans from the elements of a set
- * @sqlfn splitNspans()
+ * @sqlfn splitNSpans()
  */
 Datum
 Set_split_n_spans(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/temporal/spanset.c
+++ b/mobilitydb/src/temporal/spanset.c
@@ -1049,7 +1049,7 @@ PG_FUNCTION_INFO_V1(Spanset_split_n_spans);
 /**
  * @ingroup mobilitydb_temporal_bbox_topo
  * @brief Return an array of N spans from the spans of a spanset
- * @sqlfn splitNspans()
+ * @sqlfn splitNSpans()
  */
 Datum
 Spanset_split_n_spans(PG_FUNCTION_ARGS)
@@ -1070,7 +1070,7 @@ PG_FUNCTION_INFO_V1(Spanset_split_each_n_spans);
  * @ingroup mobilitydb_temporal_bbox_topo
  * @brief Return an array of spans from a spanset obtained by merging a given
  * number of successive composing spans
- * @sqlfn splitEachNspans()
+ * @sqlfn splitEachNSpans()
  */
 Datum
 Spanset_split_each_n_spans(PG_FUNCTION_ARGS)


### PR DESCRIPTION
The SQL functions are declared `splitNSpans` / `splitEachNSpans` (capital S) for every type — set, span, spanset, temporal, and geo — and the canonical doc tag in `temporal_boxops.c` reads `@sqlfn splitNSpans()`. Three `@sqlfn` tags on the set, spanset, and spanset-each wrappers (`span.c`, `spanset.c`) lagged at the lower-case `splitNspans` / `splitEachNspans`.

They fold to the same SQL identifier, so this is invisible in PostgreSQL, but a case-sensitive binding catalog records two distinct names and a case-insensitive engine (Spark SQL) lets one shadow the other. Recasing the three tags so the catalog carries one canonical spelling.

Doxygen-comment-only change — no SQL, no code, no behavioral change. Sibling of #1258 (the rgeo `tDistance` casing straggler).