### PR TITLE
Name the span set operations with the spanset prefix

### DIFF
--- a/doc/portable_sql.xml
+++ b/doc/portable_sql.xml
@@ -11,9 +11,11 @@
 <chapter xml:id="portable_sql">
 	<title>Portable Named-Function Dialect</title>
 
-	<para>Every MobilityDB operator is also callable as a bare named function. A query written with named functions only, using no operator symbols, is portable: the same SQL runs unchanged on MobilityDB (PostgreSQL), MobilityDuck (DuckDB) and MobilitySpark (Apache Spark), which cannot register PostgreSQL operator symbols. Each named alias reuses the operator's own implementation, so it returns exactly the same result as the operator.</para>
+	<para>Every MobilityDB operator is also callable as a bare named function. A query written with named functions only, using no operator symbols, is portable: the same SQL runs unchanged across the MobilityDB ecosystem — the database engines MobilityDB (PostgreSQL), MobilityDuck (DuckDB) and MobilitySpark (Apache Spark), and the streaming engines — several of which cannot register PostgreSQL operator symbols. Each named alias reuses the operator's own implementation, so it returns exactly the same result as the operator.</para>
 
-	<para>The spatial-relationship functions (<varname>eIntersects</varname>, <varname>aIntersects</varname>, <varname>eTouches</varname>, <varname>eDwithin</varname>, …), the restriction functions (<varname>atTime</varname>, <varname>atGeometry</varname>, <varname>atValue</varname>, …), the distance functions <varname>tDistance</varname> and <varname>nearestApproachDistance</varname>, and the ever/always comparison functions (<varname>eEq</varname>, <varname>aEq</varname>, …) are already named functions and need no mapping. The remaining operators map to bare names as follows.</para>
+	<para>This chapter is the canonical, ecosystem-wide reference for that mapping. An engine that does not accept a given operator can look it up here and use the function form instead. For example, DuckDB does not accept any operator containing <literal>#</literal> (it reserves <literal>#</literal> for positional column references), so on MobilityDuck the temporal comparisons (<literal>#=</literal>, …) are written <varname>tEq</varname>, … and the time-position tests (<literal>&lt;&lt;#</literal>, <literal>#&gt;&gt;</literal>, <literal>&amp;&lt;#</literal>, <literal>#&amp;&gt;</literal>) are written <varname>before</varname>, <varname>after</varname>, <varname>overbefore</varname>, <varname>overafter</varname>, while the operators it does accept may be used directly.</para>
+
+	<para>The spatial-relationship functions (<varname>eIntersects</varname>, <varname>aIntersects</varname>, <varname>eTouches</varname>, <varname>eDwithin</varname>, …) and the restriction functions (<varname>atTime</varname>, <varname>atGeometry</varname>, <varname>atValue</varname>, …) are only ever named functions (they have no operator). The B-tree ordering comparator is likewise the named function <varname>cmp(a, b)</varname>, which returns <literal>-1</literal>, <literal>0</literal> or <literal>1</literal> and has no operator. Every operator maps to a bare name as follows; for the arithmetic and set-theoretic operators the function name carries the operand's type-family prefix (<varname>set</varname>, <varname>span</varname> or <varname>spanset</varname>, and <varname>t</varname> for temporal numbers).</para>
 
 	<informaltable frame="all" colsep="1" rowsep="1">
 		<?dblatex table-width="autowidth.column: 1 2 3"?>
@@ -55,6 +57,31 @@
 				<row><entry>Distance</entry><entry>&lt;-&gt;</entry><entry>tDistance(a, b)</entry></row>
 				<row><entry></entry><entry>|=|</entry><entry>nearestApproachDistance(a, b)</entry></row>
 				<row><entry>Same</entry><entry>~=</entry><entry>same(a, b)</entry></row>
+				<row><entry>Traditional comparison</entry><entry>=</entry><entry>eq(a, b)</entry></row>
+				<row><entry></entry><entry>&lt;&gt;</entry><entry>ne(a, b)</entry></row>
+				<row><entry></entry><entry>&lt;</entry><entry>lt(a, b)</entry></row>
+				<row><entry></entry><entry>&lt;=</entry><entry>le(a, b)</entry></row>
+				<row><entry></entry><entry>&gt;</entry><entry>gt(a, b)</entry></row>
+				<row><entry></entry><entry>&gt;=</entry><entry>ge(a, b)</entry></row>
+				<row><entry>Ever comparison</entry><entry>?=</entry><entry>eEq(a, b)</entry></row>
+				<row><entry></entry><entry>?&lt;&gt;</entry><entry>eNe(a, b)</entry></row>
+				<row><entry></entry><entry>?&lt;</entry><entry>eLt(a, b)</entry></row>
+				<row><entry></entry><entry>?&lt;=</entry><entry>eLe(a, b)</entry></row>
+				<row><entry></entry><entry>?&gt;</entry><entry>eGt(a, b)</entry></row>
+				<row><entry></entry><entry>?&gt;=</entry><entry>eGe(a, b)</entry></row>
+				<row><entry>Always comparison</entry><entry>%=</entry><entry>aEq(a, b)</entry></row>
+				<row><entry></entry><entry>%&lt;&gt;</entry><entry>aNe(a, b)</entry></row>
+				<row><entry></entry><entry>%&lt;</entry><entry>aLt(a, b)</entry></row>
+				<row><entry></entry><entry>%&lt;=</entry><entry>aLe(a, b)</entry></row>
+				<row><entry></entry><entry>%&gt;</entry><entry>aGt(a, b)</entry></row>
+				<row><entry></entry><entry>%&gt;=</entry><entry>aGe(a, b)</entry></row>
+				<row><entry>Arithmetic (temporal numbers)</entry><entry>+</entry><entry>tAdd(a, b)</entry></row>
+				<row><entry></entry><entry>-</entry><entry>tSub(a, b)</entry></row>
+				<row><entry></entry><entry>*</entry><entry>tMul(a, b)</entry></row>
+				<row><entry></entry><entry>/</entry><entry>tDiv(a, b)</entry></row>
+				<row><entry>Union (set / span / span set)</entry><entry>+</entry><entry>setUnion / spanUnion / spansetUnion (a, b)</entry></row>
+				<row><entry>Intersection (set / span / span set)</entry><entry>*</entry><entry>setIntersection / spanIntersection / spansetIntersection (a, b)</entry></row>
+				<row><entry>Difference (set / span / span set)</entry><entry>-</entry><entry>setMinus / spanMinus / spansetMinus (a, b)</entry></row>
 			</tbody>
 		</tgroup>
 	</informaltable>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -407,7 +407,7 @@
 				</listitem>
 
 				<listitem>
-					<para><link linkend="setspan_union_agg"><varname>setUnion</varname>, <varname>spanUnion</varname></link>: Aggregate union</para>
+					<para><link linkend="setspan_union_agg"><varname>setUnion</varname>, <varname>spanUnion</varname>, <varname>spansetUnion</varname></link>: Aggregate union</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/set_span_types.xml
+++ b/doc/set_span_types.xml
@@ -1301,7 +1301,7 @@ SELECT cmp(intspanset '{[1, 4)}', intspanset '{[1, 5), [6, 7)}');
 
 		<itemizedlist>
 			<listitem><para>Function <varname>extent</varname> returns a bounding span that encloses a set of set or span values.</para></listitem>
-			<listitem><para>Union is a very useful operation for set and span types. As we have seen in <xref linkend="setspan_set_ops"/>, we can compute the union of two set or span values using the <varname>+</varname> operator. However, it is also very useful to have an aggregate version of the union operator for combining an arbitrary number of values. Functions <varname>setUnion</varname> and <varname>spanUnion</varname> can be used for this purpose.</para></listitem>
+			<listitem><para>Union is a very useful operation for set and span types. As we have seen in <xref linkend="setspan_set_ops"/>, we can compute the union of two set or span values using the <varname>+</varname> operator. However, it is also very useful to have an aggregate version of the union operator for combining an arbitrary number of values. Functions <varname>setUnion</varname>, <varname>spanUnion</varname>, and <varname>spansetUnion</varname> can be used for this purpose.</para></listitem>
 			<listitem><para>Function <varname>tCount</varname> generalizes the traditional aggregate function <varname>count</varname>. The temporal count can be used to compute at each point in time the number of available objects (for example, number of spans). Function <varname>tCount</varname> returns a temporal integer (see <xref linkend="ttype_p1"/>). The function has two optional parameters that specify the granularity (an <varname>interval</varname>) and the origin of time (a <varname>timestamptz</varname>). When these parameters are given, the temporal count is computed at time bins of the given granularity (see <xref linkend="ttype_tiling"/>).</para></listitem>
 		</itemizedlist>
 
@@ -1337,6 +1337,7 @@ SELECT extent(ps) FROM periods;
 				<para>Aggregate union</para>
 				<para><varname>setUnion({value,set}) → set</varname></para>
 				<para><varname>spanUnion(spans) → spanset</varname></para>
+					<para><varname>spansetUnion(spansets) → spanset</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH times(ts) AS (
   SELECT tstzset '{2001-01-01, 2001-01-03, 2001-01-05}' UNION
@@ -1348,7 +1349,7 @@ WITH periods(ps) AS (
   SELECT tstzspanset '{[2001-01-01, 2001-01-02], [2001-01-03, 2001-01-04]}' UNION
   SELECT tstzspanset '{[2001-01-02, 2001-01-03], [2001-01-05, 2001-01-06]}' UNION
   SELECT tstzspanset '{[2001-01-07, 2001-01-08]}' )
-SELECT spanUnion(ps) FROM periods;
+SELECT spansetUnion(ps) FROM periods;
 -- {[2001-01-01, 2001-01-04], [2001-01-05, 2001-01-06], [2001-01-07, 2001-01-08]}
 </programlisting>
 			</listitem>

--- a/mobilitydb/sql/temporal/009_spanset_ops.in.sql
+++ b/mobilitydb/sql/temporal/009_spanset_ops.in.sql
@@ -1903,7 +1903,7 @@ CREATE OPERATOR -|- (
 
 /*****************************************************************************/
 
-CREATE FUNCTION spanUnion(integer, intspanset)
+CREATE FUNCTION spansetUnion(integer, intspanset)
   RETURNS intspanset
   AS 'MODULE_PATHNAME', 'Union_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -1911,21 +1911,21 @@ CREATE FUNCTION spanUnion(intspan, intspanset)
   RETURNS intspanset
   AS 'MODULE_PATHNAME', 'Union_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanUnion(intspanset, integer)
+CREATE FUNCTION spansetUnion(intspanset, integer)
   RETURNS intspanset
   AS 'MODULE_PATHNAME', 'Union_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanUnion(intspanset, intspan)
+CREATE FUNCTION spansetUnion(intspanset, intspan)
   RETURNS intspanset
   AS 'MODULE_PATHNAME', 'Union_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanUnion(intspanset, intspanset)
+CREATE FUNCTION spansetUnion(intspanset, intspanset)
   RETURNS intspanset
   AS 'MODULE_PATHNAME', 'Union_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR + (
-  PROCEDURE = spanUnion,
+  PROCEDURE = spansetUnion,
   LEFTARG = integer, RIGHTARG = intspanset,
   COMMUTATOR = +
 );
@@ -1935,22 +1935,22 @@ CREATE OPERATOR + (
   COMMUTATOR = +
 );
 CREATE OPERATOR + (
-  PROCEDURE = spanUnion,
+  PROCEDURE = spansetUnion,
   LEFTARG = intspanset, RIGHTARG = integer,
   COMMUTATOR = +
 );
 CREATE OPERATOR + (
-  PROCEDURE = spanUnion,
+  PROCEDURE = spansetUnion,
   LEFTARG = intspanset, RIGHTARG = intspan,
   COMMUTATOR = +
 );
 CREATE OPERATOR + (
-  PROCEDURE = spanUnion,
+  PROCEDURE = spansetUnion,
   LEFTARG = intspanset, RIGHTARG = intspanset,
   COMMUTATOR = +
 );
 
-CREATE FUNCTION spanUnion(bigint, bigintspanset)
+CREATE FUNCTION spansetUnion(bigint, bigintspanset)
   RETURNS bigintspanset
   AS 'MODULE_PATHNAME', 'Union_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -1958,21 +1958,21 @@ CREATE FUNCTION spanUnion(bigintspan, bigintspanset)
   RETURNS bigintspanset
   AS 'MODULE_PATHNAME', 'Union_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanUnion(bigintspanset, bigint)
+CREATE FUNCTION spansetUnion(bigintspanset, bigint)
   RETURNS bigintspanset
   AS 'MODULE_PATHNAME', 'Union_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanUnion(bigintspanset, bigintspan)
+CREATE FUNCTION spansetUnion(bigintspanset, bigintspan)
   RETURNS bigintspanset
   AS 'MODULE_PATHNAME', 'Union_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanUnion(bigintspanset, bigintspanset)
+CREATE FUNCTION spansetUnion(bigintspanset, bigintspanset)
   RETURNS bigintspanset
   AS 'MODULE_PATHNAME', 'Union_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR + (
-  PROCEDURE = spanUnion,
+  PROCEDURE = spansetUnion,
   LEFTARG = bigint, RIGHTARG = bigintspanset,
   COMMUTATOR = +
 );
@@ -1982,22 +1982,22 @@ CREATE OPERATOR + (
   COMMUTATOR = +
 );
 CREATE OPERATOR + (
-  PROCEDURE = spanUnion,
+  PROCEDURE = spansetUnion,
   LEFTARG = bigintspanset, RIGHTARG = bigint,
   COMMUTATOR = +
 );
 CREATE OPERATOR + (
-  PROCEDURE = spanUnion,
+  PROCEDURE = spansetUnion,
   LEFTARG = bigintspanset, RIGHTARG = bigintspan,
   COMMUTATOR = +
 );
 CREATE OPERATOR + (
-  PROCEDURE = spanUnion,
+  PROCEDURE = spansetUnion,
   LEFTARG = bigintspanset, RIGHTARG = bigintspanset,
   COMMUTATOR = +
 );
 
-CREATE FUNCTION spanUnion(float, floatspanset)
+CREATE FUNCTION spansetUnion(float, floatspanset)
   RETURNS floatspanset
   AS 'MODULE_PATHNAME', 'Union_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -2005,21 +2005,21 @@ CREATE FUNCTION spanUnion(floatspan, floatspanset)
   RETURNS floatspanset
   AS 'MODULE_PATHNAME', 'Union_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanUnion(floatspanset, float)
+CREATE FUNCTION spansetUnion(floatspanset, float)
   RETURNS floatspanset
   AS 'MODULE_PATHNAME', 'Union_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanUnion(floatspanset, floatspan)
+CREATE FUNCTION spansetUnion(floatspanset, floatspan)
   RETURNS floatspanset
   AS 'MODULE_PATHNAME', 'Union_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanUnion(floatspanset, floatspanset)
+CREATE FUNCTION spansetUnion(floatspanset, floatspanset)
   RETURNS floatspanset
   AS 'MODULE_PATHNAME', 'Union_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR + (
-  PROCEDURE = spanUnion,
+  PROCEDURE = spansetUnion,
   LEFTARG = float, RIGHTARG = floatspanset,
   COMMUTATOR = +
 );
@@ -2029,22 +2029,22 @@ CREATE OPERATOR + (
   COMMUTATOR = +
 );
 CREATE OPERATOR + (
-  PROCEDURE = spanUnion,
+  PROCEDURE = spansetUnion,
   LEFTARG = floatspanset, RIGHTARG = float,
   COMMUTATOR = +
 );
 CREATE OPERATOR + (
-  PROCEDURE = spanUnion,
+  PROCEDURE = spansetUnion,
   LEFTARG = floatspanset, RIGHTARG = floatspan,
   COMMUTATOR = +
 );
 CREATE OPERATOR + (
-  PROCEDURE = spanUnion,
+  PROCEDURE = spansetUnion,
   LEFTARG = floatspanset, RIGHTARG = floatspanset,
   COMMUTATOR = +
 );
 
-CREATE FUNCTION spanUnion(date, datespanset)
+CREATE FUNCTION spansetUnion(date, datespanset)
   RETURNS datespanset
   AS 'MODULE_PATHNAME', 'Union_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -2052,21 +2052,21 @@ CREATE FUNCTION spanUnion(datespan, datespanset)
   RETURNS datespanset
   AS 'MODULE_PATHNAME', 'Union_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanUnion(datespanset, date)
+CREATE FUNCTION spansetUnion(datespanset, date)
   RETURNS datespanset
   AS 'MODULE_PATHNAME', 'Union_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanUnion(datespanset, datespan)
+CREATE FUNCTION spansetUnion(datespanset, datespan)
   RETURNS datespanset
   AS 'MODULE_PATHNAME', 'Union_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanUnion(datespanset, datespanset)
+CREATE FUNCTION spansetUnion(datespanset, datespanset)
   RETURNS datespanset
   AS 'MODULE_PATHNAME', 'Union_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR + (
-  PROCEDURE = spanUnion,
+  PROCEDURE = spansetUnion,
   LEFTARG = date, RIGHTARG = datespanset,
   COMMUTATOR = +
 );
@@ -2076,22 +2076,22 @@ CREATE OPERATOR + (
   COMMUTATOR = +
 );
 CREATE OPERATOR + (
-  PROCEDURE = spanUnion,
+  PROCEDURE = spansetUnion,
   LEFTARG = datespanset, RIGHTARG = date,
   COMMUTATOR = +
 );
 CREATE OPERATOR + (
-  PROCEDURE = spanUnion,
+  PROCEDURE = spansetUnion,
   LEFTARG = datespanset, RIGHTARG = datespan,
   COMMUTATOR = +
 );
 CREATE OPERATOR + (
-  PROCEDURE = spanUnion,
+  PROCEDURE = spansetUnion,
   LEFTARG = datespanset, RIGHTARG = datespanset,
   COMMUTATOR = +
 );
 
-CREATE FUNCTION spanUnion(timestamptz, tstzspanset)
+CREATE FUNCTION spansetUnion(timestamptz, tstzspanset)
   RETURNS tstzspanset
   AS 'MODULE_PATHNAME', 'Union_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -2099,21 +2099,21 @@ CREATE FUNCTION spanUnion(tstzspan, tstzspanset)
   RETURNS tstzspanset
   AS 'MODULE_PATHNAME', 'Union_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanUnion(tstzspanset, timestamptz)
+CREATE FUNCTION spansetUnion(tstzspanset, timestamptz)
   RETURNS tstzspanset
   AS 'MODULE_PATHNAME', 'Union_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanUnion(tstzspanset, tstzspan)
+CREATE FUNCTION spansetUnion(tstzspanset, tstzspan)
   RETURNS tstzspanset
   AS 'MODULE_PATHNAME', 'Union_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanUnion(tstzspanset, tstzspanset)
+CREATE FUNCTION spansetUnion(tstzspanset, tstzspanset)
   RETURNS tstzspanset
   AS 'MODULE_PATHNAME', 'Union_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR + (
-  PROCEDURE = spanUnion,
+  PROCEDURE = spansetUnion,
   LEFTARG = timestamptz, RIGHTARG = tstzspanset,
   COMMUTATOR = +
 );
@@ -2123,24 +2123,24 @@ CREATE OPERATOR + (
   COMMUTATOR = +
 );
 CREATE OPERATOR + (
-  PROCEDURE = spanUnion,
+  PROCEDURE = spansetUnion,
   LEFTARG = tstzspanset, RIGHTARG = timestamptz,
   COMMUTATOR = +
 );
 CREATE OPERATOR + (
-  PROCEDURE = spanUnion,
+  PROCEDURE = spansetUnion,
   LEFTARG = tstzspanset, RIGHTARG = tstzspan,
   COMMUTATOR = +
 );
 CREATE OPERATOR + (
-  PROCEDURE = spanUnion,
+  PROCEDURE = spansetUnion,
   LEFTARG = tstzspanset, RIGHTARG = tstzspanset,
   COMMUTATOR = +
 );
 
 /*****************************************************************************/
 
-CREATE FUNCTION spanMinus(integer, intspanset)
+CREATE FUNCTION spansetMinus(integer, intspanset)
   RETURNS intspanset
   AS 'MODULE_PATHNAME', 'Minus_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -2148,21 +2148,21 @@ CREATE FUNCTION spanMinus(intspan, intspanset)
   RETURNS intspanset
   AS 'MODULE_PATHNAME', 'Minus_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanMinus(intspanset, integer)
+CREATE FUNCTION spansetMinus(intspanset, integer)
   RETURNS intspanset
   AS 'MODULE_PATHNAME', 'Minus_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanMinus(intspanset, intspan)
+CREATE FUNCTION spansetMinus(intspanset, intspan)
   RETURNS intspanset
   AS 'MODULE_PATHNAME', 'Minus_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanMinus(intspanset, intspanset)
+CREATE FUNCTION spansetMinus(intspanset, intspanset)
   RETURNS intspanset
   AS 'MODULE_PATHNAME', 'Minus_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR - (
-  PROCEDURE = spanMinus,
+  PROCEDURE = spansetMinus,
   LEFTARG = integer, RIGHTARG = intspanset
 );
 CREATE OPERATOR - (
@@ -2170,19 +2170,19 @@ CREATE OPERATOR - (
   LEFTARG = intspan, RIGHTARG = intspanset
 );
 CREATE OPERATOR - (
-  PROCEDURE = spanMinus,
+  PROCEDURE = spansetMinus,
   LEFTARG = intspanset, RIGHTARG = integer
 );
 CREATE OPERATOR - (
-  PROCEDURE = spanMinus,
+  PROCEDURE = spansetMinus,
   LEFTARG = intspanset, RIGHTARG = intspan
 );
 CREATE OPERATOR - (
-  PROCEDURE = spanMinus,
+  PROCEDURE = spansetMinus,
   LEFTARG = intspanset, RIGHTARG = intspanset
 );
 
-CREATE FUNCTION spanMinus(bigint, bigintspanset)
+CREATE FUNCTION spansetMinus(bigint, bigintspanset)
   RETURNS bigintspanset
   AS 'MODULE_PATHNAME', 'Minus_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -2190,21 +2190,21 @@ CREATE FUNCTION spanMinus(bigintspan, bigintspanset)
   RETURNS bigintspanset
   AS 'MODULE_PATHNAME', 'Minus_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanMinus(bigintspanset, bigint)
+CREATE FUNCTION spansetMinus(bigintspanset, bigint)
   RETURNS bigintspanset
   AS 'MODULE_PATHNAME', 'Minus_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanMinus(bigintspanset, bigintspan)
+CREATE FUNCTION spansetMinus(bigintspanset, bigintspan)
   RETURNS bigintspanset
   AS 'MODULE_PATHNAME', 'Minus_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanMinus(bigintspanset, bigintspanset)
+CREATE FUNCTION spansetMinus(bigintspanset, bigintspanset)
   RETURNS bigintspanset
   AS 'MODULE_PATHNAME', 'Minus_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR - (
-  PROCEDURE = spanMinus,
+  PROCEDURE = spansetMinus,
   LEFTARG = bigint, RIGHTARG = bigintspanset
 );
 CREATE OPERATOR - (
@@ -2212,19 +2212,19 @@ CREATE OPERATOR - (
   LEFTARG = bigintspan, RIGHTARG = bigintspanset
 );
 CREATE OPERATOR - (
-  PROCEDURE = spanMinus,
+  PROCEDURE = spansetMinus,
   LEFTARG = bigintspanset, RIGHTARG = bigint
 );
 CREATE OPERATOR - (
-  PROCEDURE = spanMinus,
+  PROCEDURE = spansetMinus,
   LEFTARG = bigintspanset, RIGHTARG = bigintspan
 );
 CREATE OPERATOR - (
-  PROCEDURE = spanMinus,
+  PROCEDURE = spansetMinus,
   LEFTARG = bigintspanset, RIGHTARG = bigintspanset
 );
 
-CREATE FUNCTION spanMinus(float, floatspanset)
+CREATE FUNCTION spansetMinus(float, floatspanset)
   RETURNS floatspanset
   AS 'MODULE_PATHNAME', 'Minus_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -2232,21 +2232,21 @@ CREATE FUNCTION spanMinus(floatspan, floatspanset)
   RETURNS floatspanset
   AS 'MODULE_PATHNAME', 'Minus_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanMinus(floatspanset, float)
+CREATE FUNCTION spansetMinus(floatspanset, float)
   RETURNS floatspanset
   AS 'MODULE_PATHNAME', 'Minus_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanMinus(floatspanset, floatspan)
+CREATE FUNCTION spansetMinus(floatspanset, floatspan)
   RETURNS floatspanset
   AS 'MODULE_PATHNAME', 'Minus_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanMinus(floatspanset, floatspanset)
+CREATE FUNCTION spansetMinus(floatspanset, floatspanset)
   RETURNS floatspanset
   AS 'MODULE_PATHNAME', 'Minus_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR - (
-  PROCEDURE = spanMinus,
+  PROCEDURE = spansetMinus,
   LEFTARG = float, RIGHTARG = floatspanset
 );
 CREATE OPERATOR - (
@@ -2254,19 +2254,19 @@ CREATE OPERATOR - (
   LEFTARG = floatspan, RIGHTARG = floatspanset
 );
 CREATE OPERATOR - (
-  PROCEDURE = spanMinus,
+  PROCEDURE = spansetMinus,
   LEFTARG = floatspanset, RIGHTARG = float
 );
 CREATE OPERATOR - (
-  PROCEDURE = spanMinus,
+  PROCEDURE = spansetMinus,
   LEFTARG = floatspanset, RIGHTARG = floatspan
 );
 CREATE OPERATOR - (
-  PROCEDURE = spanMinus,
+  PROCEDURE = spansetMinus,
   LEFTARG = floatspanset, RIGHTARG = floatspanset
 );
 
-CREATE FUNCTION spanMinus(date, datespanset)
+CREATE FUNCTION spansetMinus(date, datespanset)
   RETURNS datespanset
   AS 'MODULE_PATHNAME', 'Minus_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -2274,21 +2274,21 @@ CREATE FUNCTION spanMinus(datespan, datespanset)
   RETURNS datespanset
   AS 'MODULE_PATHNAME', 'Minus_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanMinus(datespanset, date)
+CREATE FUNCTION spansetMinus(datespanset, date)
   RETURNS datespanset
   AS 'MODULE_PATHNAME', 'Minus_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanMinus(datespanset, datespan)
+CREATE FUNCTION spansetMinus(datespanset, datespan)
   RETURNS datespanset
   AS 'MODULE_PATHNAME', 'Minus_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanMinus(datespanset, datespanset)
+CREATE FUNCTION spansetMinus(datespanset, datespanset)
   RETURNS datespanset
   AS 'MODULE_PATHNAME', 'Minus_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR - (
-  PROCEDURE = spanMinus,
+  PROCEDURE = spansetMinus,
   LEFTARG = date, RIGHTARG = datespanset
 );
 CREATE OPERATOR - (
@@ -2296,19 +2296,19 @@ CREATE OPERATOR - (
   LEFTARG = datespan, RIGHTARG = datespanset
 );
 CREATE OPERATOR - (
-  PROCEDURE = spanMinus,
+  PROCEDURE = spansetMinus,
   LEFTARG = datespanset, RIGHTARG = date
 );
 CREATE OPERATOR - (
-  PROCEDURE = spanMinus,
+  PROCEDURE = spansetMinus,
   LEFTARG = datespanset, RIGHTARG = datespan
 );
 CREATE OPERATOR - (
-  PROCEDURE = spanMinus,
+  PROCEDURE = spansetMinus,
   LEFTARG = datespanset, RIGHTARG = datespanset
 );
 
-CREATE FUNCTION spanMinus(timestamptz, tstzspanset)
+CREATE FUNCTION spansetMinus(timestamptz, tstzspanset)
   RETURNS tstzspanset
   AS 'MODULE_PATHNAME', 'Minus_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -2316,21 +2316,21 @@ CREATE FUNCTION spanMinus(tstzspan, tstzspanset)
   RETURNS tstzspanset
   AS 'MODULE_PATHNAME', 'Minus_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanMinus(tstzspanset, timestamptz)
+CREATE FUNCTION spansetMinus(tstzspanset, timestamptz)
   RETURNS tstzspanset
   AS 'MODULE_PATHNAME', 'Minus_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanMinus(tstzspanset, tstzspan)
+CREATE FUNCTION spansetMinus(tstzspanset, tstzspan)
   RETURNS tstzspanset
   AS 'MODULE_PATHNAME', 'Minus_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanMinus(tstzspanset, tstzspanset)
+CREATE FUNCTION spansetMinus(tstzspanset, tstzspanset)
   RETURNS tstzspanset
   AS 'MODULE_PATHNAME', 'Minus_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR - (
-  PROCEDURE = spanMinus,
+  PROCEDURE = spansetMinus,
   LEFTARG = timestamptz, RIGHTARG = tstzspanset
 );
 CREATE OPERATOR - (
@@ -2338,21 +2338,21 @@ CREATE OPERATOR - (
   LEFTARG = tstzspan, RIGHTARG = tstzspanset
 );
 CREATE OPERATOR - (
-  PROCEDURE = spanMinus,
+  PROCEDURE = spansetMinus,
   LEFTARG = tstzspanset, RIGHTARG = timestamptz
 );
 CREATE OPERATOR - (
-  PROCEDURE = spanMinus,
+  PROCEDURE = spansetMinus,
   LEFTARG = tstzspanset, RIGHTARG = tstzspan
 );
 CREATE OPERATOR - (
-  PROCEDURE = spanMinus,
+  PROCEDURE = spansetMinus,
   LEFTARG = tstzspanset, RIGHTARG = tstzspanset
 );
 
 /*****************************************************************************/
 
-CREATE FUNCTION spanIntersection(integer, intspanset)
+CREATE FUNCTION spansetIntersection(integer, intspanset)
   RETURNS intspanset
   AS 'MODULE_PATHNAME', 'Intersection_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -2360,21 +2360,21 @@ CREATE FUNCTION spanIntersection(intspan, intspanset)
   RETURNS intspanset
   AS 'MODULE_PATHNAME', 'Intersection_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanIntersection(intspanset, integer)
+CREATE FUNCTION spansetIntersection(intspanset, integer)
   RETURNS intspanset
   AS 'MODULE_PATHNAME', 'Intersection_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanIntersection(intspanset, intspan)
+CREATE FUNCTION spansetIntersection(intspanset, intspan)
   RETURNS intspanset
   AS 'MODULE_PATHNAME', 'Intersection_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanIntersection(intspanset, intspanset)
+CREATE FUNCTION spansetIntersection(intspanset, intspanset)
   RETURNS intspanset
   AS 'MODULE_PATHNAME', 'Intersection_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR * (
-  PROCEDURE = spanIntersection,
+  PROCEDURE = spansetIntersection,
   LEFTARG = integer, RIGHTARG = intspanset,
   COMMUTATOR = *
 );
@@ -2384,22 +2384,22 @@ CREATE OPERATOR * (
   COMMUTATOR = *
 );
 CREATE OPERATOR * (
-  PROCEDURE = spanIntersection,
+  PROCEDURE = spansetIntersection,
   LEFTARG = intspanset, RIGHTARG = integer,
   COMMUTATOR = *
 );
 CREATE OPERATOR * (
-  PROCEDURE = spanIntersection,
+  PROCEDURE = spansetIntersection,
   LEFTARG = intspanset, RIGHTARG = intspan,
   COMMUTATOR = *
 );
 CREATE OPERATOR * (
-  PROCEDURE = spanIntersection,
+  PROCEDURE = spansetIntersection,
   LEFTARG = intspanset, RIGHTARG = intspanset,
   COMMUTATOR = *
 );
 
-CREATE FUNCTION spanIntersection(bigint, bigintspanset)
+CREATE FUNCTION spansetIntersection(bigint, bigintspanset)
   RETURNS bigintspanset
   AS 'MODULE_PATHNAME', 'Intersection_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -2407,21 +2407,21 @@ CREATE FUNCTION spanIntersection(bigintspan, bigintspanset)
   RETURNS bigintspanset
   AS 'MODULE_PATHNAME', 'Intersection_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanIntersection(bigintspanset, bigint)
+CREATE FUNCTION spansetIntersection(bigintspanset, bigint)
   RETURNS bigintspanset
   AS 'MODULE_PATHNAME', 'Intersection_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanIntersection(bigintspanset, bigintspan)
+CREATE FUNCTION spansetIntersection(bigintspanset, bigintspan)
   RETURNS bigintspanset
   AS 'MODULE_PATHNAME', 'Intersection_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanIntersection(bigintspanset, bigintspanset)
+CREATE FUNCTION spansetIntersection(bigintspanset, bigintspanset)
   RETURNS bigintspanset
   AS 'MODULE_PATHNAME', 'Intersection_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR * (
-  PROCEDURE = spanIntersection,
+  PROCEDURE = spansetIntersection,
   LEFTARG = bigint, RIGHTARG = bigintspanset,
   COMMUTATOR = *
 );
@@ -2431,22 +2431,22 @@ CREATE OPERATOR * (
   COMMUTATOR = *
 );
 CREATE OPERATOR * (
-  PROCEDURE = spanIntersection,
+  PROCEDURE = spansetIntersection,
   LEFTARG = bigintspanset, RIGHTARG = bigint,
   COMMUTATOR = *
 );
 CREATE OPERATOR * (
-  PROCEDURE = spanIntersection,
+  PROCEDURE = spansetIntersection,
   LEFTARG = bigintspanset, RIGHTARG = bigintspan,
   COMMUTATOR = *
 );
 CREATE OPERATOR * (
-  PROCEDURE = spanIntersection,
+  PROCEDURE = spansetIntersection,
   LEFTARG = bigintspanset, RIGHTARG = bigintspanset,
   COMMUTATOR = *
 );
 
-CREATE FUNCTION spanIntersection(float, floatspanset)
+CREATE FUNCTION spansetIntersection(float, floatspanset)
   RETURNS floatspanset
   AS 'MODULE_PATHNAME', 'Intersection_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -2454,21 +2454,21 @@ CREATE FUNCTION spanIntersection(floatspan, floatspanset)
   RETURNS floatspanset
   AS 'MODULE_PATHNAME', 'Intersection_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanIntersection(floatspanset, float)
+CREATE FUNCTION spansetIntersection(floatspanset, float)
   RETURNS floatspanset
   AS 'MODULE_PATHNAME', 'Intersection_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanIntersection(floatspanset, floatspan)
+CREATE FUNCTION spansetIntersection(floatspanset, floatspan)
   RETURNS floatspanset
   AS 'MODULE_PATHNAME', 'Intersection_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanIntersection(floatspanset, floatspanset)
+CREATE FUNCTION spansetIntersection(floatspanset, floatspanset)
   RETURNS floatspanset
   AS 'MODULE_PATHNAME', 'Intersection_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR * (
-  PROCEDURE = spanIntersection,
+  PROCEDURE = spansetIntersection,
   LEFTARG = float, RIGHTARG = floatspanset,
   COMMUTATOR = *
 );
@@ -2478,22 +2478,22 @@ CREATE OPERATOR * (
   COMMUTATOR = *
 );
 CREATE OPERATOR * (
-  PROCEDURE = spanIntersection,
+  PROCEDURE = spansetIntersection,
   LEFTARG = floatspanset, RIGHTARG = float,
   COMMUTATOR = *
 );
 CREATE OPERATOR * (
-  PROCEDURE = spanIntersection,
+  PROCEDURE = spansetIntersection,
   LEFTARG = floatspanset, RIGHTARG = floatspan,
   COMMUTATOR = *
 );
 CREATE OPERATOR * (
-  PROCEDURE = spanIntersection,
+  PROCEDURE = spansetIntersection,
   LEFTARG = floatspanset, RIGHTARG = floatspanset,
   COMMUTATOR = *
 );
 
-CREATE FUNCTION spanIntersection(date, datespanset)
+CREATE FUNCTION spansetIntersection(date, datespanset)
   RETURNS datespanset
   AS 'MODULE_PATHNAME', 'Intersection_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -2501,21 +2501,21 @@ CREATE FUNCTION spanIntersection(datespan, datespanset)
   RETURNS datespanset
   AS 'MODULE_PATHNAME', 'Intersection_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanIntersection(datespanset, date)
+CREATE FUNCTION spansetIntersection(datespanset, date)
   RETURNS date
   AS 'MODULE_PATHNAME', 'Intersection_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanIntersection(datespanset, datespan)
+CREATE FUNCTION spansetIntersection(datespanset, datespan)
   RETURNS datespanset
   AS 'MODULE_PATHNAME', 'Intersection_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanIntersection(datespanset, datespanset)
+CREATE FUNCTION spansetIntersection(datespanset, datespanset)
   RETURNS datespanset
   AS 'MODULE_PATHNAME', 'Intersection_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR * (
-  PROCEDURE = spanIntersection,
+  PROCEDURE = spansetIntersection,
   LEFTARG = date, RIGHTARG = datespanset,
   COMMUTATOR = *
 );
@@ -2525,22 +2525,22 @@ CREATE OPERATOR * (
   COMMUTATOR = *
 );
 CREATE OPERATOR * (
-  PROCEDURE = spanIntersection,
+  PROCEDURE = spansetIntersection,
   LEFTARG = datespanset, RIGHTARG = date,
   COMMUTATOR = *
 );
 CREATE OPERATOR * (
-  PROCEDURE = spanIntersection,
+  PROCEDURE = spansetIntersection,
   LEFTARG = datespanset, RIGHTARG = datespan,
   COMMUTATOR = *
 );
 CREATE OPERATOR * (
-  PROCEDURE = spanIntersection,
+  PROCEDURE = spansetIntersection,
   LEFTARG = datespanset, RIGHTARG = datespanset,
   COMMUTATOR = *
 );
 
-CREATE FUNCTION spanIntersection(timestamptz, tstzspanset)
+CREATE FUNCTION spansetIntersection(timestamptz, tstzspanset)
   RETURNS tstzspanset
   AS 'MODULE_PATHNAME', 'Intersection_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -2548,21 +2548,21 @@ CREATE FUNCTION spanIntersection(tstzspan, tstzspanset)
   RETURNS tstzspanset
   AS 'MODULE_PATHNAME', 'Intersection_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanIntersection(tstzspanset, timestamptz)
+CREATE FUNCTION spansetIntersection(tstzspanset, timestamptz)
   RETURNS tstzspanset
   AS 'MODULE_PATHNAME', 'Intersection_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanIntersection(tstzspanset, tstzspan)
+CREATE FUNCTION spansetIntersection(tstzspanset, tstzspan)
   RETURNS tstzspanset
   AS 'MODULE_PATHNAME', 'Intersection_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanIntersection(tstzspanset, tstzspanset)
+CREATE FUNCTION spansetIntersection(tstzspanset, tstzspanset)
   RETURNS tstzspanset
   AS 'MODULE_PATHNAME', 'Intersection_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR * (
-  PROCEDURE = spanIntersection,
+  PROCEDURE = spansetIntersection,
   LEFTARG = timestamptz, RIGHTARG = tstzspanset,
   COMMUTATOR = *
 );
@@ -2572,17 +2572,17 @@ CREATE OPERATOR * (
   COMMUTATOR = *
 );
 CREATE OPERATOR * (
-  PROCEDURE = spanIntersection,
+  PROCEDURE = spansetIntersection,
   LEFTARG = tstzspanset, RIGHTARG = timestamptz,
   COMMUTATOR = *
 );
 CREATE OPERATOR * (
-  PROCEDURE = spanIntersection,
+  PROCEDURE = spansetIntersection,
   LEFTARG = tstzspanset, RIGHTARG = tstzspan,
   COMMUTATOR = *
 );
 CREATE OPERATOR * (
-  PROCEDURE = spanIntersection,
+  PROCEDURE = spansetIntersection,
   LEFTARG = tstzspanset, RIGHTARG = tstzspanset,
   COMMUTATOR = *
 );

--- a/mobilitydb/sql/temporal/015_span_aggfuncs.in.sql
+++ b/mobilitydb/sql/temporal/015_span_aggfuncs.in.sql
@@ -379,7 +379,7 @@ CREATE FUNCTION spanset_union_transfn(internal, tstzspanset)
   AS 'MODULE_PATHNAME', 'Spanset_union_transfn'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
-CREATE AGGREGATE spanUnion(intspanset) (
+CREATE AGGREGATE spansetUnion(intspanset) (
   SFUNC = spanset_union_transfn,
   STYPE = internal,
 #if POSTGRESQL_VERSION_NUMBER >= 160000
@@ -390,7 +390,7 @@ CREATE AGGREGATE spanUnion(intspanset) (
   FINALFUNC = intspan_union_finalfn,
   PARALLEL = safe
 );
-CREATE AGGREGATE spanUnion(bigintspanset) (
+CREATE AGGREGATE spansetUnion(bigintspanset) (
   SFUNC = spanset_union_transfn,
   STYPE = internal,
 #if POSTGRESQL_VERSION_NUMBER >= 160000
@@ -401,7 +401,7 @@ CREATE AGGREGATE spanUnion(bigintspanset) (
   FINALFUNC = bigintspan_union_finalfn,
   PARALLEL = safe
 );
-CREATE AGGREGATE spanUnion(floatspanset) (
+CREATE AGGREGATE spansetUnion(floatspanset) (
   SFUNC = spanset_union_transfn,
   STYPE = internal,
 #if POSTGRESQL_VERSION_NUMBER >= 160000
@@ -412,7 +412,7 @@ CREATE AGGREGATE spanUnion(floatspanset) (
   FINALFUNC = floatspan_union_finalfn,
   PARALLEL = safe
 );
-CREATE AGGREGATE spanUnion(datespanset) (
+CREATE AGGREGATE spansetUnion(datespanset) (
   SFUNC = spanset_union_transfn,
   STYPE = internal,
 #if POSTGRESQL_VERSION_NUMBER >= 160000
@@ -423,7 +423,7 @@ CREATE AGGREGATE spanUnion(datespanset) (
   FINALFUNC = datespan_union_finalfn,
   PARALLEL = safe
 );
-CREATE AGGREGATE spanUnion(tstzspanset) (
+CREATE AGGREGATE spansetUnion(tstzspanset) (
   SFUNC = spanset_union_transfn,
   STYPE = internal,
 #if POSTGRESQL_VERSION_NUMBER >= 160000

--- a/mobilitydb/src/temporal/spanset_ops.c
+++ b/mobilitydb/src/temporal/spanset_ops.c
@@ -776,7 +776,7 @@ PG_FUNCTION_INFO_V1(Union_value_spanset);
 /**
  * @ingroup mobilitydb_setspan_set
  * @brief Return the union of a value and a span set
- * @sqlfn spanUnion()
+ * @sqlfn spansetUnion()
  * @sqlop @p +
  */
 inline Datum
@@ -804,7 +804,7 @@ PG_FUNCTION_INFO_V1(Union_spanset_value);
 /**
  * @ingroup mobilitydb_setspan_set
  * @brief Return the union of a span set and a value
- * @sqlfn spanUnion()
+ * @sqlfn spansetUnion()
  * @sqlop @p +
  */
 inline Datum
@@ -818,7 +818,7 @@ PG_FUNCTION_INFO_V1(Union_spanset_span);
 /**
  * @ingroup mobilitydb_setspan_set
  * @brief Return the union of a span set and a span
- * @sqlfn spanUnion()
+ * @sqlfn spansetUnion()
  * @sqlop @p +
  */
 inline Datum
@@ -832,7 +832,7 @@ PG_FUNCTION_INFO_V1(Union_spanset_spanset);
 /**
  * @ingroup mobilitydb_setspan_set
  * @brief Return the union of two span sets
- * @sqlfn spanUnion()
+ * @sqlfn spansetUnion()
  * @sqlop @p +
  */
 inline Datum
@@ -850,7 +850,7 @@ PG_FUNCTION_INFO_V1(Intersection_value_spanset);
 /**
  * @ingroup mobilitydb_setspan_set
  * @brief Return the intersection of a value and a span set
- * @sqlfn spanIntersection()
+ * @sqlfn spansetIntersection()
  * @sqlop @p *
  */
 inline Datum
@@ -878,7 +878,7 @@ PG_FUNCTION_INFO_V1(Intersection_spanset_value);
 /**
  * @ingroup mobilitydb_setspan_set
  * @brief Return the intersection of a span set and a value
- * @sqlfn spanIntersection()
+ * @sqlfn spansetIntersection()
  * @sqlop @p *
  */
 inline Datum
@@ -892,7 +892,7 @@ PG_FUNCTION_INFO_V1(Intersection_spanset_span);
 /**
  * @ingroup mobilitydb_setspan_set
  * @brief Return the intersection of a span set and a span
- * @sqlfn spanIntersection()
+ * @sqlfn spansetIntersection()
  * @sqlop @p *
  */
 inline Datum
@@ -906,7 +906,7 @@ PG_FUNCTION_INFO_V1(Intersection_spanset_spanset);
 /**
  * @ingroup mobilitydb_setspan_set
  * @brief Return the intersection of two span sets
- * @sqlfn spanIntersection()
+ * @sqlfn spansetIntersection()
  * @sqlop @p *
  */
 inline Datum
@@ -925,7 +925,7 @@ PG_FUNCTION_INFO_V1(Minus_value_spanset);
 /**
  * @ingroup mobilitydb_setspan_set
  * @brief Return the difference of a value and a span set
- * @sqlfn spanMinus()
+ * @sqlfn spansetMinus()
  * @sqlop @p -
  */
 inline Datum
@@ -953,7 +953,7 @@ PG_FUNCTION_INFO_V1(Minus_spanset_value);
 /**
  * @ingroup mobilitydb_setspan_set
  * @brief Return the difference of a span set and a value
- * @sqlfn spanMinus()
+ * @sqlfn spansetMinus()
  * @sqlop @p -
  */
 inline Datum
@@ -967,7 +967,7 @@ PG_FUNCTION_INFO_V1(Minus_spanset_span);
 /**
  * @ingroup mobilitydb_setspan_set
  * @brief Return the difference of a span set and a span
- * @sqlfn spanMinus()
+ * @sqlfn spansetMinus()
  * @sqlop @p -
  */
 inline Datum
@@ -981,7 +981,7 @@ PG_FUNCTION_INFO_V1(Minus_spanset_spanset);
 /**
  * @ingroup mobilitydb_setspan_set
  * @brief Return the difference of two span sets
- * @sqlfn spanMinus()
+ * @sqlfn spansetMinus()
  * @sqlop @p -
  */
 inline Datum

--- a/mobilitydb/test/temporal/expected/015_span_aggfuncs.test.out
+++ b/mobilitydb/test/temporal/expected/015_span_aggfuncs.test.out
@@ -328,23 +328,23 @@ SELECT spanUnion(temp) FROM (VALUES
  {[Sat Jan 01 00:00:00 2000 PST, Sun Jan 02 00:00:00 2000 PST]}
 (1 row)
 
-SELECT spanUnion(temp) FROM (VALUES
+SELECT spansetUnion(temp) FROM (VALUES
 (NULL::tstzspanset),(NULL::tstzspanset)) t(temp);
- spanunion 
------------
+ spansetunion 
+--------------
  
 (1 row)
 
-SELECT spanUnion(temp) FROM (VALUES
+SELECT spansetUnion(temp) FROM (VALUES
 (NULL::tstzspanset),('{[2000-01-01, 2000-01-02]}'::tstzspanset)) t(temp);
-                           spanunion                            
+                          spansetunion                          
 ----------------------------------------------------------------
  {[Sat Jan 01 00:00:00 2000 PST, Sun Jan 02 00:00:00 2000 PST]}
 (1 row)
 
-SELECT spanUnion(temp) FROM (VALUES
+SELECT spansetUnion(temp) FROM (VALUES
 ('{[2000-01-01, 2000-01-02]}'::tstzspanset),(NULL::tstzspanset)) t(temp);
-                           spanunion                            
+                          spansetunion                          
 ----------------------------------------------------------------
  {[Sat Jan 01 00:00:00 2000 PST, Sun Jan 02 00:00:00 2000 PST]}
 (1 row)
@@ -365,10 +365,10 @@ SELECT spanUnion(temp) FROM (VALUES
  {[Sat Jan 01 00:00:00 2000 PST, Thu Jan 06 00:00:00 2000 PST]}
 (1 row)
 
-SELECT spanUnion(temp) FROM (VALUES
+SELECT spansetUnion(temp) FROM (VALUES
 ('{[2000-01-01, 2000-01-03]}'::tstzspanset),
 ('{[2000-01-02, 2000-01-06]}'::tstzspanset)) t(temp);
-                           spanunion                            
+                          spansetunion                          
 ----------------------------------------------------------------
  {[Sat Jan 01 00:00:00 2000 PST, Thu Jan 06 00:00:00 2000 PST]}
 (1 row)
@@ -414,7 +414,7 @@ SELECT numSpans(spanUnion(t)) FROM tbl_tstzspan;
        99
 (1 row)
 
-SELECT numSpans(spanUnion(t)) FROM tbl_tstzspanset;
+SELECT numSpans(spansetUnion(t)) FROM tbl_tstzspanset;
  numspans 
 ----------
       479

--- a/mobilitydb/test/temporal/queries/015_span_aggfuncs.test.sql
+++ b/mobilitydb/test/temporal/queries/015_span_aggfuncs.test.sql
@@ -124,11 +124,11 @@ SELECT spanUnion(temp) FROM (VALUES
 SELECT spanUnion(temp) FROM (VALUES
 ('[2000-01-01, 2000-01-02]'::tstzspan),(NULL::tstzspan)) t(temp);
 
-SELECT spanUnion(temp) FROM (VALUES
+SELECT spansetUnion(temp) FROM (VALUES
 (NULL::tstzspanset),(NULL::tstzspanset)) t(temp);
-SELECT spanUnion(temp) FROM (VALUES
+SELECT spansetUnion(temp) FROM (VALUES
 (NULL::tstzspanset),('{[2000-01-01, 2000-01-02]}'::tstzspanset)) t(temp);
-SELECT spanUnion(temp) FROM (VALUES
+SELECT spansetUnion(temp) FROM (VALUES
 ('{[2000-01-01, 2000-01-02]}'::tstzspanset),(NULL::tstzspanset)) t(temp);
 
 -------------------------------------------------------------------------------
@@ -141,7 +141,7 @@ SELECT spanUnion(temp) FROM (VALUES
 ('[2000-01-01, 2000-01-03]'::tstzspan),
 ('[2000-01-02, 2000-01-06]'::tstzspan)) t(temp);
 
-SELECT spanUnion(temp) FROM (VALUES
+SELECT spansetUnion(temp) FROM (VALUES
 ('{[2000-01-01, 2000-01-03]}'::tstzspanset),
 ('{[2000-01-02, 2000-01-06]}'::tstzspanset)) t(temp);
 
@@ -165,6 +165,6 @@ SELECT startValue(setUnion(t)) FROM Temp;
 SELECT numValues(setUnion(t)) FROM tbl_timestamptz;
 SELECT numValues(setUnion(t)) FROM tbl_tstzset;
 SELECT numSpans(spanUnion(t)) FROM tbl_tstzspan;
-SELECT numSpans(spanUnion(t)) FROM tbl_tstzspanset;
+SELECT numSpans(spansetUnion(t)) FROM tbl_tstzspanset;
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
The set-theoretic operations whose subject operand is a span set are renamed from the overloaded span-prefixed names to the spanset-prefixed canonical names: `spanUnion`/`spanIntersection`/`spanMinus` become `spansetUnion`/`spansetIntersection`/`spansetMinus` for the span-set binary operators and for the span-set aggregate, while the span-subject overloads keep the `spanUnion`/`spanIntersection`/`spanMinus` names.

This aligns the SQL surface with the MEOS C source, whose functions already distinguish the operand families (`union_spanset_spanset` versus `union_span_span`), and completes the `set` / `span` / `spanset` prefix family alongside `setUnion` and `spanUnion`. It follows the template-type naming North Star: a `Set<T>` / `Span<T>` / `SpanSet<T>` operation carries its template prefix rather than overloading a single name.

The backing C symbols are unchanged; only the SQL function name, the operator `PROCEDURE` reference, the aggregate name, and the `@sqlfn` tag change.

The **Portable Named-Function Dialect** manual chapter is extended into the complete, ecosystem-wide operator-to-function reference: it now covers the traditional comparison (`=` -> `eq`, ...), ever/always comparison, arithmetic (`+` -> `tAdd`, ...) and set/span/spanset union/intersection/difference tiers, and explains that an engine which cannot register a given operator (for example DuckDB, which reserves `#` for positional column references) can look up the function form here. The related documentation pages are updated accordingly.