### PR TITLE
Spell the temporal distance tDistance for temporal geos and circular buffers

### DIFF
--- a/mobilitydb/sql/cbuffer/210_tcbuffer_distance.in.sql
+++ b/mobilitydb/sql/cbuffer/210_tcbuffer_distance.in.sql
@@ -93,53 +93,53 @@ CREATE OPERATOR <-> (
  * Temporal distance functions
  *****************************************************************************/
 
-CREATE FUNCTION tdistance(geometry(Point), tcbuffer)
+CREATE FUNCTION tDistance(geometry(Point), tcbuffer)
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tdistance_geo_tcbuffer'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tdistance(cbuffer, tcbuffer)
+CREATE FUNCTION tDistance(cbuffer, tcbuffer)
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tdistance_cbuffer_tcbuffer'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tdistance(tcbuffer, geometry(Point))
+CREATE FUNCTION tDistance(tcbuffer, geometry(Point))
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tdistance_tcbuffer_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tdistance(tcbuffer, cbuffer)
+CREATE FUNCTION tDistance(tcbuffer, cbuffer)
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tdistance_tcbuffer_cbuffer'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tdistance(tcbuffer, tcbuffer)
+CREATE FUNCTION tDistance(tcbuffer, tcbuffer)
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tdistance_tcbuffer_tcbuffer'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <-> (
-  PROCEDURE = tdistance,
+  PROCEDURE = tDistance,
   LEFTARG = geometry,
   RIGHTARG = tcbuffer,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = tdistance,
+  PROCEDURE = tDistance,
   LEFTARG = cbuffer,
   RIGHTARG = tcbuffer,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = tdistance,
+  PROCEDURE = tDistance,
   LEFTARG = tcbuffer,
   RIGHTARG = geometry,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = tdistance,
+  PROCEDURE = tDistance,
   LEFTARG = tcbuffer,
   RIGHTARG = cbuffer,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = tdistance,
+  PROCEDURE = tDistance,
   LEFTARG = tcbuffer,
   RIGHTARG = tcbuffer,
   COMMUTATOR = <->

--- a/mobilitydb/sql/geo/064_tgeo_distance.in.sql
+++ b/mobilitydb/sql/geo/064_tgeo_distance.in.sql
@@ -36,62 +36,62 @@
  * Distance functions
  *****************************************************************************/
 
-CREATE FUNCTION tdistance(geometry, tgeometry)
+CREATE FUNCTION tDistance(geometry, tgeometry)
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tdistance_geo_tgeo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tdistance(tgeometry, geometry)
+CREATE FUNCTION tDistance(tgeometry, geometry)
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tdistance_tgeo_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tdistance(tgeometry, tgeometry)
+CREATE FUNCTION tDistance(tgeometry, tgeometry)
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tdistance_tgeo_tgeo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <-> (
-  PROCEDURE = tdistance,
+  PROCEDURE = tDistance,
   LEFTARG = geometry, RIGHTARG = tgeometry,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = tdistance,
+  PROCEDURE = tDistance,
   LEFTARG = tgeometry, RIGHTARG = geometry,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = tdistance,
+  PROCEDURE = tDistance,
   LEFTARG = tgeometry, RIGHTARG = tgeometry,
   COMMUTATOR = <->
 );
 
 /*****************************************************************************/
 
-CREATE FUNCTION tdistance(geography, tgeography)
+CREATE FUNCTION tDistance(geography, tgeography)
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tdistance_geo_tgeo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tdistance(tgeography, geography)
+CREATE FUNCTION tDistance(tgeography, geography)
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tdistance_tgeo_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tdistance(tgeography, tgeography)
+CREATE FUNCTION tDistance(tgeography, tgeography)
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tdistance_tgeo_tgeo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <-> (
-  PROCEDURE = tdistance,
+  PROCEDURE = tDistance,
   LEFTARG = geography, RIGHTARG = tgeography,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = tdistance,
+  PROCEDURE = tDistance,
   LEFTARG = tgeography, RIGHTARG = geography,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = tdistance,
+  PROCEDURE = tDistance,
   LEFTARG = tgeography, RIGHTARG = tgeography,
   COMMUTATOR = <->
 );

--- a/mobilitydb/sql/geo/064_tpoint_distance.in.sql
+++ b/mobilitydb/sql/geo/064_tpoint_distance.in.sql
@@ -36,62 +36,62 @@
  * Distance functions
  *****************************************************************************/
 
-CREATE FUNCTION tdistance(geometry(Point), tgeompoint)
+CREATE FUNCTION tDistance(geometry(Point), tgeompoint)
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tdistance_geo_tgeo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tdistance(tgeompoint, geometry(Point))
+CREATE FUNCTION tDistance(tgeompoint, geometry(Point))
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tdistance_tgeo_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tdistance(tgeompoint, tgeompoint)
+CREATE FUNCTION tDistance(tgeompoint, tgeompoint)
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tdistance_tgeo_tgeo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <-> (
-  PROCEDURE = tdistance,
+  PROCEDURE = tDistance,
   LEFTARG = geometry, RIGHTARG = tgeompoint,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = tdistance,
+  PROCEDURE = tDistance,
   LEFTARG = tgeompoint, RIGHTARG = geometry,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = tdistance,
+  PROCEDURE = tDistance,
   LEFTARG = tgeompoint, RIGHTARG = tgeompoint,
   COMMUTATOR = <->
 );
 
 /*****************************************************************************/
 
-CREATE FUNCTION tdistance(geography(Point), tgeogpoint)
+CREATE FUNCTION tDistance(geography(Point), tgeogpoint)
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tdistance_geo_tgeo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tdistance(tgeogpoint, geography(Point))
+CREATE FUNCTION tDistance(tgeogpoint, geography(Point))
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tdistance_tgeo_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tdistance(tgeogpoint, tgeogpoint)
+CREATE FUNCTION tDistance(tgeogpoint, tgeogpoint)
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tdistance_tgeo_tgeo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <-> (
-  PROCEDURE = tdistance,
+  PROCEDURE = tDistance,
   LEFTARG = geography, RIGHTARG = tgeogpoint,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = tdistance,
+  PROCEDURE = tDistance,
   LEFTARG = tgeogpoint, RIGHTARG = geography,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = tdistance,
+  PROCEDURE = tDistance,
   LEFTARG = tgeogpoint, RIGHTARG = tgeogpoint,
   COMMUTATOR = <->
 );


### PR DESCRIPTION
The temporal-geo and circular-buffer distances exposed the lower-case `tdistance` as their SQL function name and operator `PROCEDURE`, while their `@sqlfn` catalog tag and every other distance already use the canonical `tDistance` (#1258 did the same for rigid geometries).

PostgreSQL folds unquoted identifiers, so the split is invisible in SQL/pg_regress. But the `@sqlfn` name is taken case-sensitively by the catalog-driven bindings: a case-insensitive engine (Spark SQL) registers `tDistance` and `tdistance` as one UDF, so the lower-case spelling silently shadows the canonical dispatch.

Recase the function definitions and operator `PROCEDURE`s in the temporal-geo, temporal-point, and temporal-circular-buffer distance SQL files to `tDistance`. The C wrappers and implementations are unchanged and the SQL folds identically, so this is a pure binding-canonicalization with no pg_regress output change.
