### PR TITLE
Fix mis-tagged @sqlfn/@sqlop catalog annotations and the floatspanset accessor

### DIFF
--- a/meos/src/temporal/spanset_meos.c
+++ b/meos/src/temporal/spanset_meos.c
@@ -400,7 +400,7 @@ floatspanset_lower(const SpanSet *ss)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_FLOATSPANSET(ss, DBL_MAX);
-  return Float8GetDatum(ss->elems[0].lower);
+  return DatumGetFloat8(ss->elems[0].lower);
 }
 
 /**
@@ -462,7 +462,7 @@ floatspanset_upper(const SpanSet *ss)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_FLOATSPANSET(ss, DBL_MAX);
-  return Float8GetDatum(ss->elems[ss->count - 1].upper);
+  return DatumGetFloat8(ss->elems[ss->count - 1].upper);
 }
 
 /**

--- a/meos/src/temporal/tnumber_mathfuncs.c
+++ b/meos/src/temporal/tnumber_mathfuncs.c
@@ -861,7 +861,7 @@ tfloat_log10_turnpt(Datum start, Datum end,
 
 /**
  * @ingroup meos_temporal_math
- * @brief Return the natural logarithm of a double
+ * @brief Return the base 10 logarithm of a double
  * @param[in] temp Temporal value
  * @csqlfn #Tfloat_log10()
  */

--- a/mobilitydb/src/geo/stbox.c
+++ b/mobilitydb/src/geo/stbox.c
@@ -1167,7 +1167,7 @@ PG_FUNCTION_INFO_V1(Contains_stbox_stbox);
  * @ingroup mobilitydb_geo_box_topo
  * @brief Return true if the first spatiotemporal box contains the second one
  * @sqlfn contains()
- * @sqlop @p \@>
+ * @sqlop @p @>
  */
 Datum
 Contains_stbox_stbox(PG_FUNCTION_ARGS)
@@ -1254,7 +1254,7 @@ PG_FUNCTION_INFO_V1(Left_stbox_stbox);
  * @brief Return true if the first spatiotemporal box is to the left of the
  * second one
  * @sqlfn left()
- * @sqlop @p >>
+ * @sqlop @p <<
  */
 Datum
 Left_stbox_stbox(PG_FUNCTION_ARGS)
@@ -1271,7 +1271,7 @@ PG_FUNCTION_INFO_V1(Overleft_stbox_stbox);
  * @brief Return true if the first spatiotemporal box does not extend to the
  * right of the second one
  * @sqlfn overleft()
- * @sqlop @p &>
+ * @sqlop @p &<
  */
 Datum
 Overleft_stbox_stbox(PG_FUNCTION_ARGS)
@@ -1288,7 +1288,7 @@ PG_FUNCTION_INFO_V1(Right_stbox_stbox);
  * @brief Return true if the first spatiotemporal box is to the right of the
  * second one
  * @sqlfn right()
- * @sqlop @p <<
+ * @sqlop @p >>
  */
 Datum
 Right_stbox_stbox(PG_FUNCTION_ARGS)
@@ -1305,7 +1305,7 @@ PG_FUNCTION_INFO_V1(Overright_stbox_stbox);
  * @brief Return true if the first spatio temporal box does not extend to the
  * left of the second one
  * @sqlfn overright()
- * @sqlop @p &<
+ * @sqlop @p &>
  */
 Datum
 Overright_stbox_stbox(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/geo/tgeo_boxops.c
+++ b/mobilitydb/src/geo/tgeo_boxops.c
@@ -311,7 +311,7 @@ PG_FUNCTION_INFO_V1(Contains_stbox_tspatial);
  * @brief Return true if a spatiotemporal box contains the one of a temporal
  * point
  * @sqlfn contains_bbox()
- * @sqlop @p <@
+ * @sqlop @p @>
  */
 inline Datum
 Contains_stbox_tspatial(PG_FUNCTION_ARGS)
@@ -326,7 +326,7 @@ PG_FUNCTION_INFO_V1(Contains_tspatial_stbox);
  * @brief Return true if the spatiotemporal box of a spatiotemporal value
  * contains a spatiotemporal box
  * @sqlfn contains_bbox()
- * @sqlop @p <@
+ * @sqlop @p @>
  */
 inline Datum
 Contains_tspatial_stbox(PG_FUNCTION_ARGS)
@@ -341,7 +341,7 @@ PG_FUNCTION_INFO_V1(Contains_tspatial_tspatial);
  * @brief Return true if the spatiotemporal box of the first spatiotemporal
  * value contains the one of the second spatiotemporal value
  * @sqlfn contains_bbox()
- * @sqlop @p <@
+ * @sqlop @p @>
  */
 inline Datum
 Contains_tspatial_tspatial(PG_FUNCTION_ARGS)
@@ -360,7 +360,7 @@ PG_FUNCTION_INFO_V1(Contained_stbox_tspatial);
  * @brief Return true if a spatiotemporal box is contained in the
  * spatiotemporal box of a spatiotemporal value
  * @sqlfn contained_bbox()
- * @sqlop @p \@>
+ * @sqlop @p <@
  */
 inline Datum
 Contained_stbox_tspatial(PG_FUNCTION_ARGS)
@@ -375,7 +375,7 @@ PG_FUNCTION_INFO_V1(Contained_tspatial_stbox);
  * @brief Return true if the spatiotemporal box of a spatiotemporal value is
  * contained in the spatiotemporal box
  * @sqlfn contained_bbox()
- * @sqlop @p \@>
+ * @sqlop @p <@
  */
 inline Datum
 Contained_tspatial_stbox(PG_FUNCTION_ARGS)
@@ -390,7 +390,7 @@ PG_FUNCTION_INFO_V1(Contained_tspatial_tspatial);
  * @brief Return true if the spatiotemporal box of the first spatiotemporal
  * value is contained in the one of the second spatiotemporal value
  * @sqlfn contained_bbox()
- * @sqlop @p \@>
+ * @sqlop @p <@
  */
 inline Datum
 Contained_tspatial_tspatial(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/temporal/set_ops.c
+++ b/mobilitydb/src/temporal/set_ops.c
@@ -105,7 +105,7 @@ PG_FUNCTION_INFO_V1(Contains_set_value);
  * @ingroup mobilitydb_setspan_topo
  * @brief Return true if a set contains a value
  * @sqlfn contains()
- * @sqlop @p \@>
+ * @sqlop @p @>
  */
 inline Datum
 Contains_set_value(PG_FUNCTION_ARGS)
@@ -119,7 +119,7 @@ PG_FUNCTION_INFO_V1(Contains_set_set);
  * @ingroup mobilitydb_setspan_topo
  * @brief Return true if the first set contains the second one
  * @sqlfn contains()
- * @sqlop @p \@>
+ * @sqlop @p @>
  */
 inline Datum
 Contains_set_set(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/temporal/span_ops.c
+++ b/mobilitydb/src/temporal/span_ops.c
@@ -52,7 +52,7 @@ PG_FUNCTION_INFO_V1(Contains_span_value);
  * @ingroup mobilitydb_setspan_topo
  * @brief Return true if a span contains a value
  * @sqlfn contains()
- * @sqlop @p \@>
+ * @sqlop @p @>
  */
 Datum
 Contains_span_value(PG_FUNCTION_ARGS)
@@ -68,7 +68,7 @@ PG_FUNCTION_INFO_V1(Contains_span_span);
  * @ingroup mobilitydb_setspan_topo
  * @brief Return true if the first span contains the second one
  * @sqlfn contains()
- * @sqlop @p \@>
+ * @sqlop @p @>
  */
 Datum
 Contains_span_span(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/temporal/spanset_ops.c
+++ b/mobilitydb/src/temporal/spanset_ops.c
@@ -142,7 +142,7 @@ PG_FUNCTION_INFO_V1(Contains_spanset_value);
  * @ingroup mobilitydb_setspan_topo
  * @brief Return true if a span contains a value
  * @sqlfn contains()
- * @sqlop @p \@>
+ * @sqlop @p @>
  */
 inline Datum
 Contains_spanset_value(PG_FUNCTION_ARGS)
@@ -156,7 +156,7 @@ PG_FUNCTION_INFO_V1(Contains_spanset_span);
  * @ingroup mobilitydb_setspan_topo
  * @brief Return true if a span set contains a span
  * @sqlfn contains()
- * @sqlop @p \@>
+ * @sqlop @p @>
  */
 inline Datum
 Contains_spanset_span(PG_FUNCTION_ARGS)
@@ -170,7 +170,7 @@ PG_FUNCTION_INFO_V1(Contains_span_spanset);
  * @ingroup mobilitydb_setspan_topo
  * @brief Return true if a span contains a span set
  * @sqlfn contains()
- * @sqlop @p \@>
+ * @sqlop @p @>
  */
 inline Datum
 Contains_span_spanset(PG_FUNCTION_ARGS)
@@ -184,7 +184,7 @@ PG_FUNCTION_INFO_V1(Contains_spanset_spanset);
  * @ingroup mobilitydb_setspan_topo
  * @brief Return true if the first span set contains the second one
  * @sqlfn contains()
- * @sqlop @p \@>
+ * @sqlop @p @>
  */
 inline Datum
 Contains_spanset_spanset(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/temporal/temporal_boxops.c
+++ b/mobilitydb/src/temporal/temporal_boxops.c
@@ -258,7 +258,7 @@ PG_FUNCTION_INFO_V1(Contains_tstzspan_temporal);
  * @brief Return true if a timestamptz span contains the time span of a
  * temporal value
  * @sqlfn contains_bbox()
- * @sqlop @p \@>
+ * @sqlop @p @>
  */
 inline Datum
 Contains_tstzspan_temporal(PG_FUNCTION_ARGS)
@@ -273,7 +273,7 @@ PG_FUNCTION_INFO_V1(Contains_temporal_tstzspan);
  * @brief Return true if the time span of a temporal value contains a
  * timestamptz span
  * @sqlfn contains_bbox()
- * @sqlop @p \@>
+ * @sqlop @p @>
  */
 inline Datum
 Contains_temporal_tstzspan(PG_FUNCTION_ARGS)
@@ -288,7 +288,7 @@ PG_FUNCTION_INFO_V1(Contains_temporal_temporal);
  * @brief Return true if the time span of the first temporal value
  * contains the one of the second one
  * @sqlfn contains_bbox()
- * @sqlop @p \@>
+ * @sqlop @p @>
  */
 inline Datum
 Contains_temporal_temporal(PG_FUNCTION_ARGS)
@@ -581,7 +581,7 @@ PG_FUNCTION_INFO_V1(Contains_numspan_tnumber);
  * @brief Return true if a number span contains the value span of a temporal
  * number
  * @sqlfn contains_bbox()
- * @sqlop @p \@>
+ * @sqlop @p @>
  */
 inline Datum
 Contains_numspan_tnumber(PG_FUNCTION_ARGS)
@@ -596,7 +596,7 @@ PG_FUNCTION_INFO_V1(Contains_tnumber_numspan);
  * @brief Return true if the value span of a temporal number contains
  * a number span
  * @sqlfn contains_bbox()
- * @sqlop @p \@>
+ * @sqlop @p @>
  */
 inline Datum
 Contains_tnumber_numspan(PG_FUNCTION_ARGS)
@@ -611,7 +611,7 @@ PG_FUNCTION_INFO_V1(Contains_tbox_tnumber);
  * @brief Return true if a temporal box contains the bounding box of a
  * temporal number
  * @sqlfn contains_bbox()
- * @sqlop @p \@>
+ * @sqlop @p @>
  */
 inline Datum
 Contains_tbox_tnumber(PG_FUNCTION_ARGS)
@@ -626,7 +626,7 @@ PG_FUNCTION_INFO_V1(Contains_tnumber_tbox);
  * @brief Return true if the bounding box of a temporal number contains a
  * temporal box
  * @sqlfn contains_bbox()
- * @sqlop @p \@>
+ * @sqlop @p @>
  */
 inline Datum
 Contains_tnumber_tbox(PG_FUNCTION_ARGS)
@@ -641,7 +641,7 @@ PG_FUNCTION_INFO_V1(Contains_tnumber_tnumber);
  * @brief Return true if the bounding box of the first temporal number contains
  * the one of the second temporal number
  * @sqlfn contains_bbox()
- * @sqlop @p \@>
+ * @sqlop @p @>
  */
 inline Datum
 Contains_tnumber_tnumber(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/temporal/tnumber_mathfuncs.c
+++ b/mobilitydb/src/temporal/tnumber_mathfuncs.c
@@ -487,8 +487,8 @@ PGDLLEXPORT Datum Tfloat_exp(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Tfloat_exp);
 /**
  * @ingroup mobilitydb_temporal_math
- * @brief Return the natural logarithm of a temporal number
- * @sqlfn ln()
+ * @brief Return the exponential of a temporal number
+ * @sqlfn exp()
  */
 Datum
 Tfloat_exp(PG_FUNCTION_ARGS)
@@ -523,8 +523,8 @@ PGDLLEXPORT Datum Tfloat_log10(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Tfloat_log10);
 /**
  * @ingroup mobilitydb_temporal_math
- * @brief Return the natural logarithm of a temporal number
- * @sqlfn ln()
+ * @brief Return the base 10 logarithm of a temporal number
+ * @sqlfn log10()
  */
 Datum
 Tfloat_log10(PG_FUNCTION_ARGS)


### PR DESCRIPTION
Several catalog tags and one typed accessor diverged from their bindings/siblings. Verified against `CREATE FUNCTION`/`CREATE OPERATOR` in `mobilitydb/sql/**` and the correct `tbox`/`tnumber`/`int`-`bigint` siblings.

**Tags (comment-only):**
- `Tfloat_exp`, `Tfloat_log10` carried `@sqlfn ln()` + a "natural logarithm" brief copied from `Tfloat_ln`; their bindings are `exp(tfloat)→Tfloat_exp` and `log10(tfloat)→Tfloat_log10`, now tagged `exp()`/`log10()` with matching briefs (incl. the MEOS `Tfloat_log10` brief).
- `Left`/`Right`/`Overleft`/`Overright_stbox_stbox` had `@sqlop` swapped (`>>`/`<<`, `&>`/`&<`) vs the operators that back them (e.g. `CREATE OPERATOR << PROCEDURE = stbox_left`) and the correct `*_tbox_tbox` siblings.
- `Contains_*`/`Contained_*` bbox functions had `@sqlop` `@>`/`<@` swapped vs their `CREATE OPERATOR` bindings.
- Normalized the redundant Doxygen escape `@sqlop @p \@>` → bare `@sqlop @p @>` across the source (the `@p` already renders the next token literally), so the operator is consistent and clean when read by the catalog extractor.

**Accessor (behavioral):**
- `floatspanset_lower`/`floatspanset_upper` used `Float8GetDatum` (double→Datum, wrong direction) where the span bound is already a `Datum`, returning reinterpreted bits. Now `DatumGetFloat8`, mirroring `intspanset_lower` (`DatumGetInt32`) / `bigintspanset_lower` (`DatumGetInt64`). MobilityDB SQL `upper(floatspanset)` binds the generic `Spanset_upper` and is unaffected; the typed accessor is consumed by bindings.