### PR TITLE
Allow T_INT8 in the temporal number arithmetic base type assertion

### DIFF
--- a/mobilitydb/src/temporal/tnumber_mathfuncs.c
+++ b/mobilitydb/src/temporal/tnumber_mathfuncs.c
@@ -99,7 +99,7 @@ Arithop_tnumber_tnumber(FunctionCallInfo fcinfo, TArithmetic oper,
   Temporal *temp1 = PG_GETARG_TEMPORAL_P(0);
   Temporal *temp2 = PG_GETARG_TEMPORAL_P(1);
   MeosType basetype = temptype_basetype(temp1->temptype);
-  assert(basetype == T_INT4 || basetype == T_FLOAT8);
+  assert(basetype == T_INT4 || basetype == T_INT8 || basetype == T_FLOAT8);
   Temporal *result;
   if (basetype == T_FLOAT8 && (oper == MUL || oper == DIV))
     result = arithop_tnumber_tnumber(temp1, temp2, oper, func,


### PR DESCRIPTION
The PostgreSQL wrapper `Arithop_tnumber_tnumber` (`mobilitydb/src/temporal/tnumber_mathfuncs.c`) asserts that the temporal number base type is `T_INT4` or `T_FLOAT8`, but the temporal big integer type `tbigint` (base type `T_INT8`) is also a valid temporal number. The MEOS-side `arithop_tnumber_tnumber` (`meos/src/temporal/tnumber_mathfuncs.c`) already permits `T_INT8`; the wrapper assertion was not updated when `tbigint` was added, so any `tbigint` arithmetic (`+`, `-`, `*`, `/`) aborts (`signal 6`) in an assert-enabled (Debug) build. For example:

```
SELECT tbigint '1@2000-01-01' + tbigint '1@2000-01-01';
-- Debug build: Assertion `basetype == T_INT4 || basetype == T_FLOAT8' failed -> backend aborts
```

This is not caught by CI because the extension regression suite runs in `Release` (asserts compiled out), so the behaviour only surfaces in a Debug extension build (the default for local development).

The fix makes the wrapper assertion match the MEOS-side one (`T_INT4 || T_INT8 || T_FLOAT8`). Verified: the `026_tnumber_mathfuncs` regression test now passes in a Debug build (it aborted on the first `tbigint` arithmetic query before this change); the expected output is unchanged.