### PR TITLE
Use SQL lookup for MF-JSON SRS names

### DIFF
--- a/mobilitydb/pg_include/pg_geo/postgis.h
+++ b/mobilitydb/pg_include/pg_geo/postgis.h
@@ -65,7 +65,6 @@
 /*****************************************************************************/
 
 int32_t getSRIDbySRS(FunctionCallInfo fcinfo, const char *srs);
-char *getSRSbySRID(FunctionCallInfo fcinfo, int32_t srid, bool short_crs);
 
 /* PostGIS functions called by MobilityDB */
 

--- a/mobilitydb/src/temporal/type_out.c
+++ b/mobilitydb/src/temporal/type_out.c
@@ -35,9 +35,13 @@
 
 /* PostgreSQL */
 #include <postgres.h>
+#include <catalog/pg_type.h>
+#include <executor/spi.h>
 #include <pgtypes.h>
+#include <utils/memutils.h>
 /* PostGIS */
 #include <liblwgeom_internal.h>
+#include "lwgeom_pg.h"
 /* MEOS */
 #include <meos.h>
 #include <meos_internal.h>
@@ -114,6 +118,104 @@ Temporalarr_as_text(PG_FUNCTION_ARGS)
  * Output in Moving Features JSON MF-JSON representation
  *****************************************************************************/
 
+typedef struct
+{
+  int32_t srid;
+  bool short_crs;
+  char *srs;
+} MFSrsCache;
+
+/**
+ * @brief Return the SRS name associated to a SRID
+ */
+static char *
+get_srs_by_srid(FunctionCallInfo fcinfo, int32_t srid, bool short_crs)
+{
+  MemoryContext oldcontext;
+  const uint16_t max_query_size = 512;
+  char query[512];
+  Oid argtypes[1] = {INT4OID};
+  Datum values[1] = {Int32GetDatum(srid)};
+  char *srs, *srscopy;
+
+  postgis_initialize_cache();
+
+  if (SPI_connect() != SPI_OK_CONNECT)
+    elog(ERROR, "%s: could not connect to SPI manager", __func__);
+
+  if (short_crs)
+    snprintf(query, max_query_size,
+      "SELECT auth_name || ':' || auth_srid "
+      "FROM %s WHERE srid = $1",
+      postgis_spatial_ref_sys());
+  else
+    snprintf(query, max_query_size,
+      "SELECT 'urn:ogc:def:crs:' || auth_name || '::' || auth_srid "
+      "FROM %s WHERE srid = $1",
+      postgis_spatial_ref_sys());
+
+  if (SPI_execute_with_args(query, 1, argtypes, values, NULL, true, 1) !=
+      SPI_OK_SELECT)
+  {
+    SPI_finish();
+    elog(ERROR, "%s: error executing spatial_ref_sys lookup", __func__);
+  }
+
+  if (SPI_processed <= 0)
+  {
+    SPI_finish();
+    return NULL;
+  }
+
+  srs = SPI_getvalue(SPI_tuptable->vals[0], SPI_tuptable->tupdesc, 1);
+  if (! srs)
+  {
+    SPI_finish();
+    return NULL;
+  }
+
+  oldcontext = MemoryContextSwitchTo(fcinfo->flinfo->fn_mcxt);
+  srscopy = pstrdup(srs);
+  MemoryContextSwitchTo(oldcontext);
+
+  SPI_finish();
+  return srscopy;
+}
+
+/**
+ * @brief Return the cached SRS name associated to a SRID
+ */
+static char *
+get_srs_cache_by_srid(FunctionCallInfo fcinfo, int32_t srid, bool short_crs)
+{
+  MFSrsCache *cache = fcinfo->flinfo->fn_extra;
+  MemoryContext oldcontext;
+  char *srs;
+
+  if (cache && cache->srid == srid && cache->short_crs == short_crs &&
+      cache->srs)
+    return cache->srs;
+
+  srs = get_srs_by_srid(fcinfo, srid, short_crs);
+  if (! srs)
+    return NULL;
+
+  oldcontext = MemoryContextSwitchTo(fcinfo->flinfo->fn_mcxt);
+  if (! cache)
+  {
+    cache = palloc0(sizeof(MFSrsCache));
+    fcinfo->flinfo->fn_extra = cache;
+  }
+  else if (cache->srs)
+    pfree(cache->srs);
+  cache->srid = srid;
+  cache->short_crs = short_crs;
+  cache->srs = srs;
+  MemoryContextSwitchTo(oldcontext);
+
+  return cache->srs;
+}
+
 PGDLLEXPORT Datum Temporal_as_mfjson(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Temporal_as_mfjson);
 /**
@@ -156,9 +258,9 @@ Temporal_as_mfjson(PG_FUNCTION_ARGS)
     if (srid != SRID_UNKNOWN)
     {
       if (option & 2)
-        srs = getSRSbySRID(fcinfo, srid, true);
+        srs = get_srs_cache_by_srid(fcinfo, srid, true);
       else if (option & 4)
-        srs = getSRSbySRID(fcinfo, srid, false);
+        srs = get_srs_cache_by_srid(fcinfo, srid, false);
       if (! srs)
       {
         elog(ERROR, "SRID %i unknown in spatial_ref_sys table", srid);


### PR DESCRIPTION
## Summary

- replace the direct `getSRSbySRID` call in `Temporal_as_mfjson` with a MobilityDB-owned SPI lookup against PostGIS `spatial_ref_sys`
- cache the last SRID/CRS-mode result in the `asMFJSON` function `fn_extra` context
- bind the SRID lookup as a typed SPI argument instead of interpolating it into the query text
- remove the now-unused `getSRSbySRID` declaration from the PostGIS shim header

## Rationale

`asMFJSON` only needs the CRS name text for MF-JSON output. Looking it up through SQL keeps that behavior local to MobilityDB and avoids depending on a private PostGIS C helper symbol for SRID-to-SRS conversion.

## Validation

- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build --target pg_temporal -j32`
- `git diff --check`
- `git diff HEAD^..HEAD --check`
- `rg -n "getSRSbySRID" mobilitydb meos -g "*.[ch]"` returned no matches

Full local `cmake --build build --target MobilityDB-1.4 -j32` still fails before linking MobilityDB in the existing `pgtypes` target: `pgtypes/libpq/pqformat.h` calls `elog` without a visible declaration under this local PostgreSQL 18/GCC 16 setup. The touched `pg_temporal` target builds successfully.
