### PR TITLE
Add a pluggable allocator hook to the MEOS API

### DIFF
--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -60,6 +60,9 @@ jobs:
         run: |
           cd meos/test
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+          # SIBLING-FROM bool_test (same compile+run idiom)
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o allocator_test allocator_test.c -L/usr/local/lib -lmeos
+          ./allocator_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o bool_test bool_test.c -L/usr/local/lib -lmeos
           ./bool_test
           # The tcbuffer test program is generated from the installed headers

--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -351,6 +351,18 @@ extern int rtree_search_temporal_dedup(const RTree *rtree, RTreeSearchOp op, con
 typedef void (*error_handler_fn)(int, int, const char *);
 
 extern void meos_initialize_error_handler(error_handler_fn err_handler);
+
+/* Definition of the optional allocator hook functions. When installed, MEOS
+ * routes its working-memory allocations through these hooks so that an
+ * embedder can account for and bound them with its own memory manager. They
+ * are plain C function pointers so that JNR/cffi/cgo closures can implement
+ * them, exactly like error_handler_fn. */
+typedef void *(*meos_malloc_fn)(size_t size);
+typedef void *(*meos_realloc_fn)(void *ptr, size_t size);
+typedef void  (*meos_free_fn)(void *ptr);
+
+extern void meos_initialize_allocator(meos_malloc_fn malloc_fn,
+  meos_realloc_fn realloc_fn, meos_free_fn free_fn);
 extern void meos_initialize_noexit_error_handler(void);
 extern void meos_initialize_timezone(const char *name);
 extern void meos_initialize_collation(void);

--- a/meos/src/temporal/meos.c
+++ b/meos/src/temporal/meos.c
@@ -624,6 +624,8 @@ extern void init_database_collation(void);
 void
 meos_initialize(void)
 {
+  /* Install the default (libc) allocator before anything else can allocate */
+  meos_initialize_allocator(NULL, NULL, NULL);
   meos_initialize_error_handler(NULL);
   meos_initialize_timezone(NULL);
   /* Initialize collation */

--- a/meos/test/allocator_test.c
+++ b/meos/test/allocator_test.c
@@ -1,0 +1,167 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief A program that tests the pluggable allocator hook of the MEOS API.
+ *
+ * It installs a counting allocator via #meos_initialize_allocator, builds and
+ * frees a temporal value, and verifies that (a) the custom allocator was
+ * actually invoked (interposition) and (b) the tracked live bytes return to
+ * zero after freeing (no leak, so free routes through the hook too). Finally it
+ * reinstalls the default (libc) allocator.
+ *
+ * The program can be build as follows
+ * @code
+ * gcc -Wall -g -I/usr/local/include -o allocator_test allocator_test.c -L/usr/local/lib -lmeos
+ * @endcode
+ */
+
+#include <assert.h>
+#include <malloc.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <meos.h>
+
+/* The palloc/pfree entry points route MEOS working-memory allocations through
+ * the hook. They are exported by libmeos but are not part of the typed API, so
+ * declare them here. */
+extern void *palloc(size_t size);
+extern void pfree(void *ptr);
+
+/*
+ * Counting allocator. It is pointer-preserving (as a real embedder such as
+ * DuckDB is), tracking the live byte count through malloc_usable_size so that
+ * a value allocated through it can be released either with the hook (pfree) or
+ * with libc free.
+ */
+static size_t live_bytes = 0;
+static long n_malloc = 0;
+static long n_realloc = 0;
+static long n_free = 0;
+
+static void *
+counting_malloc(size_t size)
+{
+  void *p = malloc(size);
+  if (p)
+  {
+    live_bytes += malloc_usable_size(p);
+    n_malloc++;
+  }
+  return p;
+}
+
+static void *
+counting_realloc(void *ptr, size_t size)
+{
+  size_t old = ptr ? malloc_usable_size(ptr) : 0;
+  void *p = realloc(ptr, size);
+  if (p)
+  {
+    live_bytes += malloc_usable_size(p);
+    live_bytes -= old;
+    n_realloc++;
+  }
+  return p;
+}
+
+static void
+counting_free(void *ptr)
+{
+  if (ptr)
+  {
+    live_bytes -= malloc_usable_size(ptr);
+    n_free++;
+    free(ptr);
+  }
+}
+
+/* Main program */
+int main(void)
+{
+  const char *tint_str = "[1@2000-01-01, 2@2000-01-02, 3@2000-01-03]";
+
+  /* Initialize MEOS (which installs the default libc allocator) */
+  meos_initialize();
+  meos_initialize_timezone("UTC");
+
+  /* Warm up the lazily-initialized global caches (type cache, timezone and
+   * collation) under the default allocator, so that they do not leave residual
+   * live bytes once the counting allocator is installed. */
+  Temporal *warm = tint_in(tint_str);
+  char *warm_out = tint_out(warm);
+  pfree(warm_out);
+  pfree(warm);
+
+  printf("****************************************************************\n");
+  printf("* Allocator hook *\n");
+  printf("****************************************************************\n");
+
+  /* Install the counting allocator */
+  meos_initialize_allocator(counting_malloc, counting_realloc, counting_free);
+
+  /* Nothing has been allocated through the hook yet */
+  assert(live_bytes == 0);
+
+  /* Build a temporal value: its working memory now routes through the hook */
+  Temporal *temp = tint_in(tint_str);
+  assert(n_malloc > 0);         /* interposition: the custom malloc ran */
+  assert(live_bytes > 0);       /* the value's memory is tracked by the hook */
+  size_t peak = live_bytes;
+
+  /* Exercise more of the allocation path */
+  char *temp_out = tint_out(temp);
+  assert(temp_out != NULL);
+
+  printf("custom malloc calls: %ld\n", n_malloc);
+  printf("custom realloc calls: %ld\n", n_realloc);
+  printf("live bytes after building a tint value: %zu\n", peak);
+
+  /* Free everything through the hook (pfree routes to the custom free) */
+  pfree(temp_out);
+  pfree(temp);
+
+  printf("custom free calls: %ld\n", n_free);
+  printf("live bytes after freeing: %zu\n", live_bytes);
+
+  /* Interposition of free + zero-leak: every hook allocation was released
+   * through the hook, so the tracked live bytes return to zero */
+  assert(n_free > 0);
+  assert(live_bytes == 0);
+
+  printf("Allocator hook interposition and zero-leak: OK\n");
+  printf("****************************************************************\n");
+
+  /* Reinstall the default allocator and finalize MEOS */
+  meos_initialize_allocator(NULL, NULL, NULL);
+  meos_finalize();
+
+  return 0;
+}

--- a/pgtypes/common/fe_memutils.c
+++ b/pgtypes/common/fe_memutils.c
@@ -16,6 +16,58 @@
 #include "postgres.h"
 #include "common/fe_memutils.h"
 
+#if MEOS
+#include "meos.h"
+
+/*
+ * Optional allocator hook. When unset the hooks are libc malloc/realloc/free,
+ * so the allocation path is byte-identical to a plain libc build; an embedder
+ * may install its own allocator via meos_initialize_allocator to make MEOS
+ * working-memory visible to its memory manager. SIBLING-FROM the error-handler
+ * hook (MEOS_ERROR_HANDLER in meos/src/temporal/error.c), including its atomic
+ * publish/consume discipline for thread-safety.
+ */
+static meos_malloc_fn  MEOS_MALLOC  = &malloc;
+static meos_realloc_fn MEOS_REALLOC = &realloc;
+static meos_free_fn    MEOS_FREE    = &free;
+
+void
+meos_initialize_allocator(meos_malloc_fn malloc_fn,
+	meos_realloc_fn realloc_fn, meos_free_fn free_fn)
+{
+	/* Publish with release semantics so a thread that acquire-loads a hook on
+	 * the allocation path sees a fully-published value; a NULL argument resets
+	 * that hook to the libc default. Mirror of meos_initialize_error_handler. */
+	__atomic_store_n(&MEOS_MALLOC, malloc_fn ? malloc_fn : &malloc,
+		__ATOMIC_RELEASE);
+	__atomic_store_n(&MEOS_REALLOC, realloc_fn ? realloc_fn : &realloc,
+		__ATOMIC_RELEASE);
+	__atomic_store_n(&MEOS_FREE, free_fn ? free_fn : &free, __ATOMIC_RELEASE);
+	return;
+}
+
+static inline void *
+meos_hook_malloc(size_t size)
+{
+	meos_malloc_fn fn = __atomic_load_n(&MEOS_MALLOC, __ATOMIC_ACQUIRE);
+	return fn(size);
+}
+
+static inline void *
+meos_hook_realloc(void *ptr, size_t size)
+{
+	meos_realloc_fn fn = __atomic_load_n(&MEOS_REALLOC, __ATOMIC_ACQUIRE);
+	return fn(ptr, size);
+}
+
+static inline void
+meos_hook_free(void *ptr)
+{
+	meos_free_fn fn = __atomic_load_n(&MEOS_FREE, __ATOMIC_ACQUIRE);
+	fn(ptr);
+}
+#endif /* MEOS */
+
 static inline void *
 pg_malloc_internal(size_t size, int flags)
 {
@@ -24,7 +76,11 @@ pg_malloc_internal(size_t size, int flags)
 	/* Avoid unportable behavior of malloc(0) */
 	if (size == 0)
 		size = 1;
+#if MEOS
+	tmp = meos_hook_malloc(size);	/* MEOS SIBLING-FROM error.c */
+#else
 	tmp = malloc(size);
+#endif
 	if (tmp == NULL)
 	{
 		if ((flags & MCXT_ALLOC_NO_OOM) == 0)
@@ -66,7 +122,11 @@ pg_realloc(void *ptr, size_t size)
 	/* Avoid unportable behavior of realloc(NULL, 0) */
 	if (ptr == NULL && size == 0)
 		size = 1;
+#if MEOS
+	tmp = meos_hook_realloc(ptr, size);	/* MEOS SIBLING-FROM error.c */
+#else
 	tmp = realloc(ptr, size);
+#endif
 	if (!tmp)
 	{
 		fprintf(stderr, _("out of memory\n"));
@@ -89,7 +149,19 @@ pg_strdup(const char *in)
 				_("cannot duplicate null pointer (internal error)\n"));
 		exit(EXIT_FAILURE);
 	}
+#if MEOS
+	/* MEOS SIBLING-FROM error.c: libc strdup would bypass the allocator hook,
+	 * so duplicate through the hook explicitly. */
+	{
+		size_t		len = strlen(in) + 1;
+
+		tmp = meos_hook_malloc(len);
+		if (tmp)
+			memcpy(tmp, in, len);
+	}
+#else
 	tmp = strdup(in);
+#endif
 	if (!tmp)
 	{
 		fprintf(stderr, _("out of memory\n"));
@@ -101,7 +173,11 @@ pg_strdup(const char *in)
 void
 pg_free(void *ptr)
 {
+#if MEOS
+	meos_hook_free(ptr);	/* MEOS SIBLING-FROM error.c */
+#else
 	free(ptr);
+#endif
 }
 
 /*
@@ -152,7 +228,11 @@ pnstrdup(const char *in, Size size)
 	}
 
 	len = strnlen(in, size);
+#if MEOS
+	tmp = meos_hook_malloc(len + 1);	/* MEOS SIBLING-FROM error.c */
+#else
 	tmp = malloc(len + 1);
+#endif
 	if (tmp == NULL)
 	{
 		fprintf(stderr, _("out of memory\n"));


### PR DESCRIPTION
## What

Adds an optional allocator hook to the MEOS API so an embedder can route MEOS working-memory allocations through its own allocator, closing #1224.

In the MEOS build, working memory is allocated with libc `malloc`/`realloc`/`free` through the vendored `palloc`/`pfree` path, with no way for a host to interpose its own allocator. A host that runs its own memory manager (for example DuckDB via MobilityDuck) therefore cannot see MEOS allocations: they escape its memory limit and cause an OOM-kill instead of a catchable out-of-memory error.

## How

`meos_initialize_allocator` installs three plain C function pointers (`malloc`/`realloc`/`free`) that the `palloc`/`pfree` path reads on the allocation hot path. It is exactly analogous to the existing `meos_initialize_error_handler` hook, and uses the same `__atomic` release/acquire discipline for thread-safety.

```c
typedef void *(*meos_malloc_fn)(size_t size);
typedef void *(*meos_realloc_fn)(void *ptr, size_t size);
typedef void  (*meos_free_fn)(void *ptr);
extern void meos_initialize_allocator(meos_malloc_fn malloc_fn,
  meos_realloc_fn realloc_fn, meos_free_fn free_fn);
```

- `meos_initialize` installs the libc default first, and a `NULL` argument resets a hook to that default, so the unset behaviour is byte-identical libc allocation.
- The whole mechanism is guarded by `#if MEOS`, so the PostgreSQL-extension build is unchanged.
- Because it is a plain MEOS function, every binding (PyMEOS, JMEOS, MobilitySpark, MobilityDuck, …) picks it up through the normal generation and installs its allocator at initialization, exactly as it already installs the error handler.

## Test

`meos/test/allocator_test.c` installs a counting allocator, builds and frees a temporal value, and asserts that the custom allocator was actually invoked (interposition) and that the tracked live bytes return to zero after freeing (free routes through the hook too, no leak). It is wired into the MEOS test workflow.