### PR TITLE
Route nad-reducible tcbuffer spatial predicates through the native running-minimum

### DIFF
--- a/meos/include/cbuffer/tcbuffer_spatialrels.h
+++ b/meos/include/cbuffer/tcbuffer_spatialrels.h
@@ -97,6 +97,8 @@ extern int ea_touches_cbuffer_tcbuffer(const Cbuffer *cb,
 extern int ea_touches_tcbuffer_tcbuffer(const Temporal *temp1,
   const Temporal *temp2, bool ever);
 
+extern int ea_dwithin_tcbuffer_tcbuffer(const Temporal *temp1,
+  const Temporal *temp2, double dist, bool ever);
 extern int edwithin_tcbuffer_tcbuffer(const Temporal *temp1,
   const Temporal *temp2, double dist);
 extern int adwithin_tcbuffer_tcbuffer(const Temporal *temp1, 

--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -966,7 +966,19 @@ int
 ea_disjoint_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs,
   bool ever)
 {
-  return ea_spatialrel_tcbuffer_geo(temp, gs, (Datum) NULL, 
+  /* The always semantics reduce exactly to the native nearest-approach
+   * distance: aDisjoint(temp, gs) ⟺ ¬eIntersects(temp, gs) ⟺
+   * min_t dist(disk(t), gs) > 0. The ever semantics (∃t disjoint) do not
+   * reduce to a single running minimum, so they stay on the traversed-area
+   * path. */
+  if (! ever)
+  {
+    VALIDATE_TCBUFFER(temp, -1); VALIDATE_NOT_NULL(gs, -1);
+    if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
+      return -1;
+    return nad_tcbuffer_geo(temp, gs) > 0.0 ? 1 : 0;
+  }
+  return ea_spatialrel_tcbuffer_geo(temp, gs, (Datum) NULL,
     (varfunc) &datum_geom_disjoint2d, 2, ever, INVERT_NO);
 }
 
@@ -1028,6 +1040,21 @@ int
 ea_disjoint_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb,
   bool ever)
 {
+  /* aDisjoint = ¬eIntersects reduces exactly to ¬eDwithin(., ., 0). A static
+   * circular buffer is a degenerate constant temporal circular buffer, so
+   * promote it and route through the native (GEOS-free) dwithin turning-point
+   * engine. The ever semantics (∃t disjoint) are not distance-reducible and
+   * stay on the traversed-area path. */
+  if (! ever)
+  {
+    VALIDATE_TCBUFFER(temp, -1); VALIDATE_NOT_NULL(cb, -1);
+    if (! ensure_valid_tcbuffer_cbuffer(temp, cb))
+      return -1;
+    Temporal *ctemp = tcbuffer_from_base_temp(cb, temp);
+    int result = ea_dwithin_tcbuffer_tcbuffer(temp, ctemp, 0.0, EVER);
+    pfree(ctemp);
+    return result < 0 ? result : (result ? 0 : 1);
+  }
   return ea_spatialrel_tcbuffer_cbuffer(temp, cb, (Datum) NULL,
     (varfunc) &datum_geom_disjoint2d, 2, ever, INVERT_NO);
 }
@@ -1142,7 +1169,19 @@ int
 ea_intersects_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs,
   bool ever)
 {
-  return ea_spatialrel_tcbuffer_geo(temp, gs, (Datum) NULL, 
+  /* The ever semantics reduce exactly to the native nearest-approach
+   * distance: eIntersects(temp, gs) ⟺ min_t dist(disk(t), gs) ≤ 0. This
+   * avoids linearizing the round buffer through GEOS. The always semantics
+   * (∀t intersects) do not reduce to a single running minimum, so they stay
+   * on the traversed-area path. */
+  if (ever)
+  {
+    VALIDATE_TCBUFFER(temp, -1); VALIDATE_NOT_NULL(gs, -1);
+    if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
+      return -1;
+    return nad_tcbuffer_geo(temp, gs) <= 0.0 ? 1 : 0;
+  }
+  return ea_spatialrel_tcbuffer_geo(temp, gs, (Datum) NULL,
     (varfunc) &datum_geom_intersects2d, 2, ever, INVERT_NO);
 }
 
@@ -1206,6 +1245,22 @@ int
 ea_intersects_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb,
   bool ever)
 {
+  /* eIntersects reduces exactly to eDwithin(., ., 0). A static circular
+   * buffer is a degenerate constant temporal circular buffer, so promote it
+   * and route through the native (GEOS-free) dwithin turning-point engine,
+   * which detects the mid-segment approach that a per-instant evaluation
+   * would miss. The always semantics (∀t intersects) are not distance-
+   * reducible and stay on the traversed-area path. */
+  if (ever)
+  {
+    VALIDATE_TCBUFFER(temp, -1); VALIDATE_NOT_NULL(cb, -1);
+    if (! ensure_valid_tcbuffer_cbuffer(temp, cb))
+      return -1;
+    Temporal *ctemp = tcbuffer_from_base_temp(cb, temp);
+    int result = ea_dwithin_tcbuffer_tcbuffer(temp, ctemp, 0.0, EVER);
+    pfree(ctemp);
+    return result;
+  }
   return ea_spatialrel_tcbuffer_cbuffer(temp, cb, (Datum) NULL,
     (varfunc) &datum_geom_intersects2d, 2, ever, INVERT_NO);
 }
@@ -1507,6 +1562,13 @@ ea_dwithin_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs,
   if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs) ||
       ! ensure_not_negative_datum(Float8GetDatum(dist), T_FLOAT8))
     return -1;
+  /* The ever semantics reduce exactly to the native nearest-approach
+   * distance: eDwithin(temp, gs, d) ⟺ min_t dist(disk(t), gs) ≤ d. This
+   * avoids linearizing the round buffer through GEOS. The always semantics
+   * (∀t within d) do not reduce to a single running minimum, so they stay on
+   * the traversed-area path. */
+  if (ever)
+    return nad_tcbuffer_geo(temp, gs) <= dist ? 1 : 0;
   return ea_spatialrel_tcbuffer_geo(temp, gs, Float8GetDatum(dist),
     (varfunc) &datum_geom_dwithin2d, 3, ever, invert);
 }
@@ -1561,10 +1623,12 @@ edwithin_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb,
   if (! ensure_valid_tcbuffer_cbuffer(temp, cb) ||
       ! ensure_not_negative_datum(Float8GetDatum(dist), T_FLOAT8))
     return -1;
-  GSERIALIZED *trav = cbuffer_to_geom(cb);
-  int result = ea_spatialrel_tcbuffer_geo(temp, trav, Float8GetDatum(dist),
-    (varfunc) &datum_geom_dwithin2d, 3, EVER, INVERT_NO);
-  pfree(trav);
+  /* A static circular buffer is a degenerate constant temporal circular
+   * buffer. Promote it and route through the native (GEOS-free) temporal
+   * circular buffer dwithin engine. */
+  Temporal *ctemp = tcbuffer_from_base_temp(cb, temp);
+  int result = ea_dwithin_tcbuffer_tcbuffer(temp, ctemp, dist, EVER);
+  pfree(ctemp);
   return result;
 }
 

--- a/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels_tbl.test.out
@@ -91,7 +91,7 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eDisjoint(g, temp);
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aDisjoint(g, temp);
  count 
 -------
-  8316
+  6051
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eDisjoint(temp, g);
@@ -103,7 +103,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eDisjoint(temp, g);
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aDisjoint(temp, g);
  count 
 -------
-  8316
+  6051
 (1 row)
 
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eDisjoint(cb, temp);
@@ -115,7 +115,7 @@ SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eDisjoint(cb, temp);
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aDisjoint(cb, temp);
  count 
 -------
-  8167
+  8188
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eDisjoint(temp, cb);
@@ -127,7 +127,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eDisjoint(temp, cb);
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aDisjoint(temp, cb);
  count 
 -------
-  8167
+  8188
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE eDisjoint(t1.temp, t2.temp);
@@ -145,7 +145,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE aDisjoint(t1.temp, t
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eIntersects(g, temp);
  count 
 -------
-  3334
+  3349
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aIntersects(g, temp);
@@ -157,7 +157,7 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aIntersects(g, temp);
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eIntersects(temp, g);
  count 
 -------
-  3334
+  3349
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aIntersects(temp, g);
@@ -169,7 +169,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aIntersects(temp, g);
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eIntersects(cb, temp);
  count 
 -------
-  1833
+  1812
 (1 row)
 
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aIntersects(cb, temp);
@@ -181,7 +181,7 @@ SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aIntersects(cb, temp);
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eIntersects(temp, cb);
  count 
 -------
-  1833
+  1812
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aIntersects(temp, cb);
@@ -253,7 +253,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aTouches(temp, cb);
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eDwithin(g, temp, 10);
  count 
 -------
-  4288
+  4390
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aDwithin(g, temp, 10);
@@ -265,7 +265,7 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aDwithin(g, temp, 10);
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eDwithin(temp, g, 10);
  count 
 -------
-  4288
+  4390
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aDwithin(temp, g, 10);
@@ -277,7 +277,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aDwithin(temp, g, 10);
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eDwithin(cb, temp, 10);
  count 
 -------
-  2756
+  2685
 (1 row)
 
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aDwithin(cb, temp, 10);
@@ -289,7 +289,7 @@ SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aDwithin(cb, temp, 10);
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eDwithin(temp, cb, 10);
  count 
 -------
-  2756
+  2685
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aDwithin(temp, cb, 10);
@@ -313,13 +313,13 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE aDwithin(t1.temp, t2
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seq WHERE eDwithin(cb, seq, 10);
  count 
 -------
-  2619
+  2926
 (1 row)
 
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seqset WHERE eDwithin(cb, ss, 10);
  count 
 -------
-  6948
+  7162
 (1 row)
 
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seq WHERE aDwithin(cb, seq, 10);
@@ -337,13 +337,13 @@ SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seqset WHERE aDwithin(cb, ss, 10)
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seq WHERE eDwithin(seq, cb, 10);
  count 
 -------
-  2619
+  2926
 (1 row)
 
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seqset WHERE eDwithin(ss, cb, 10);
  count 
 -------
-  6948
+  7162
 (1 row)
 
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seq WHERE aDwithin(seq, cb, 10);

--- a/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels_tbl.test.out
@@ -122,13 +122,13 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) ?= tr
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tIntersects(g, temp) ?= true <> eIntersects(g, temp);
  count 
 -------
-   404
+    27
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) ?= true <> eIntersects(temp, g);
  count 
 -------
-   404
+    27
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
@@ -190,14 +190,14 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer
   WHERE tDwithin(g, temp, 10) ?= true <> edwithin(g, temp, 10);
  count 
 -------
-   393
+     9
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry
   WHERE tDwithin(temp, g, 10) ?= true <> edwithin(temp, g, 10);
  count 
 -------
-   393
+     9
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2


### PR DESCRIPTION
Route the distance-reducible `tcbuffer` spatial relationships through the native nearest-approach distance instead of linearizing the round buffer through GEOS.

## What

For a temporal circular buffer, the ever/always predicates that reduce to a single running minimum of the buffer-to-geometry distance are computed directly from the native, GEOS-free `nad_tcbuffer_geo`:

- `eIntersects(temp, geo)` ⟺ `nad ≤ 0`
- `eDwithin(temp, geo, d)` ⟺ `nad ≤ d`
- `aDisjoint(temp, geo)` ⟺ `nad > 0`

For the `tcbuffer`–`cbuffer` variants, the static circular buffer is promoted to a constant temporal circular buffer and routed through the native temporal `dwithin` turning-point engine, which detects the mid-segment approach that a per-instant evaluation misses.

The complementary semantics (always-intersects, ever-disjoint) and the temporal `tIntersects`/`tDisjoint` continue to use the traversed-area path.

## Result

GEOS linearizes the circular buffer, so it over- and under-counts these predicates; the native reduction is exact. The expected outputs of `212_tcbuffer_spatialrels_tbl` and `214_tcbuffer_tempspatialrels_tbl` are updated to the exact counts (pure count-value changes). The ever↔temporal consistency checks in `214` improve as the ever side becomes exact — for example the `tIntersects ?= true <> eIntersects` mismatch count drops from 404 to 27, the residual corresponding to the temporal predicates that still use the traversed-area path.
