### PR TITLE
Fix the analytic nearest-approach distance for tcbuffer against multi-segment geometries

### DIFF
--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -556,6 +556,14 @@ tcbuffer_minfun(double A, double B, double C, double R0, double DR, double lo,
   }
   else if (fabs(a1) > 1e-18)
     cand[nc++] = -a0 / a1;
+  /* Vertex of the quadratic under the root. In the perpendicular regime that
+   * quadratic is a perfect square, so the stationarity discriminant above is a
+   * rounding-noise negative and its double root -B/(2A) is dropped; that root
+   * is the instant the moving centre crosses the edge's supporting line (an
+   * exact zero distance, i.e. an overlap), so add it explicitly to never miss
+   * it. */
+  if (fabs(A) > 1e-18)
+    cand[nc++] = -B / (2.0 * A);
   double best = DBL_MAX;
   for (int i = 0; i < nc; i++)
   {
@@ -800,6 +808,11 @@ tcbuffer_minfun_w(double A, double B, double C, double R0, double DR, double lo,
   }
   else if (fabs(a1) > 1e-18)
     cand[nc++] = -a0 / a1;
+  /* Vertex of the quadratic under the root; in the perpendicular regime it is a
+   * perfect square whose stationarity double root -B/(2A) rounds out above, so
+   * add it explicitly (the instant the centre crosses the edge line). */
+  if (fabs(A) > 1e-18)
+    cand[nc++] = -B / (2.0 * A);
   double best = DBL_MAX, bt = lo;
   for (int i = 0; i < nc; i++)
   {
@@ -1310,7 +1323,7 @@ tcbuffer_seq_nad(const TSequence *seq, const TcbGeom *g, double *best)
  * buffer and a geometry
  */
 static double
-tcbuffer_geo_nad_analytic(const Temporal *temp, const GSERIALIZED *gs)
+nad_tcbuffer_geo_analytic(const Temporal *temp, const GSERIALIZED *gs)
 {
   LWGEOM *lw = lwgeom_from_gserialized(gs);
   TcbSeg *segs = NULL;
@@ -1411,7 +1424,7 @@ nad_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
   if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
     return DBL_MAX;
 
-  return tcbuffer_geo_nad_analytic(temp, gs);
+  return nad_tcbuffer_geo_analytic(temp, gs);
 }
 
 /**

--- a/mobilitydb/test/cbuffer/expected/210_tcbuffer_distance.test.out
+++ b/mobilitydb/test/cbuffer/expected/210_tcbuffer_distance.test.out
@@ -459,6 +459,12 @@ SELECT round(nearestApproachDistance(tcbuffer '{Cbuffer(Point(0 0), 1)@2000-01-0
  0.236068
 (1 row)
 
+SELECT round(tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(141.4213562373095 173.20508075688772), 1)@2000-01-02]' |=| geometry 'Linestring(173.20508075688772 0, 0 141.4213562373095)', 6);
+ round 
+-------
+     0
+(1 row)
+
 SELECT geometrytype(shortestLine(tcbuffer 'Cbuffer(Point(0 0), 1)@2000-01-01', geometry 'Polygon((5 5,5 8,8 8,8 5,5 5))'));
  geometrytype 
 --------------

--- a/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels_tbl.test.out
@@ -91,7 +91,7 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eDisjoint(g, temp);
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aDisjoint(g, temp);
  count 
 -------
-  6051
+  6041
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eDisjoint(temp, g);
@@ -103,7 +103,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eDisjoint(temp, g);
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aDisjoint(temp, g);
  count 
 -------
-  6051
+  6041
 (1 row)
 
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eDisjoint(cb, temp);
@@ -145,7 +145,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE aDisjoint(t1.temp, t
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eIntersects(g, temp);
  count 
 -------
-  3349
+  3359
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aIntersects(g, temp);
@@ -157,7 +157,7 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aIntersects(g, temp);
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eIntersects(temp, g);
  count 
 -------
-  3349
+  3359
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aIntersects(temp, g);
@@ -253,7 +253,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aTouches(temp, cb);
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eDwithin(g, temp, 10);
  count 
 -------
-  4390
+  4391
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aDwithin(g, temp, 10);
@@ -265,7 +265,7 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aDwithin(g, temp, 10);
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eDwithin(temp, g, 10);
  count 
 -------
-  4390
+  4391
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aDwithin(temp, g, 10);

--- a/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels_tbl.test.out
@@ -122,13 +122,13 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) ?= tr
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tIntersects(g, temp) ?= true <> eIntersects(g, temp);
  count 
 -------
-    27
+    17
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) ?= true <> eIntersects(temp, g);
  count 
 -------
-    27
+    17
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
@@ -190,14 +190,14 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer
   WHERE tDwithin(g, temp, 10) ?= true <> edwithin(g, temp, 10);
  count 
 -------
-     9
+     8
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry
   WHERE tDwithin(temp, g, 10) ?= true <> edwithin(temp, g, 10);
  count 
 -------
-     9
+     8
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2

--- a/mobilitydb/test/cbuffer/queries/210_tcbuffer_distance.test.sql
+++ b/mobilitydb/test/cbuffer/queries/210_tcbuffer_distance.test.sql
@@ -187,6 +187,13 @@ SELECT round(nearestApproachDistance(tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-0
 SELECT round(nearestApproachDistance(geometry 'Linestring(4 -3,4 6)', tcbuffer 'Cbuffer(Point(0 0), 1)@2000-01-01'), 6);
 SELECT round(nearestApproachDistance(tcbuffer '{Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(8 3), 2)@2000-01-02}', geometry 'Multipolygon(((200 200,200 210,210 210,210 200,200 200)),((9 -1,9 1,12 1,12 -1,9 -1)))'), 6);
 
+-- Perpendicular perfect-square crossing: the buffer centre sweeps across the
+-- edge's supporting line at an interior projection, so the squared
+-- perpendicular distance is a perfect square whose stationarity discriminant
+-- rounds to a small negative; the crossing (overlap) instant must still be
+-- taken, giving 0 rather than the edge-endpoint distance.
+SELECT round(tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(141.4213562373095 173.20508075688772), 1)@2000-01-02]' |=| geometry 'Linestring(173.20508075688772 0, 0 141.4213562373095)', 6);
+
 -------------------------------------------------------------------------------
 
 -- Analytic shortestLine: its length equals the nearest-approach distance;


### PR DESCRIPTION
The analytic nearest-approach distance between a temporal circular buffer and a geometry (`nearestApproachDistance`, and the distance-reducible predicates wired to it — `eIntersects`, `eDwithin`, `aDisjoint`) over-estimated the distance for multi-segment geometries, reporting a positive value when the moving buffer actually overlaps a linestring or polygon.

## Cause

The per-segment minimiser considers the interval endpoints and the roots of the squared stationarity equation. When the moving centre crosses a boundary edge's supporting line, the quadratic under the square root is a perfect square, so the stationarity discriminant evaluates to a small negative rounding value and its double root `-B/(2A)` is discarded. That root is exactly the instant of zero distance, so the true minimum was missed.

## Fix

Add the quadratic vertex `-B/(2A)` as an explicit candidate in both minimisers (`tcbuffer_minfun`, `tcbuffer_minfun_w`); it is clamped to the segment domain and evaluated like the other candidates, so it can only tighten the minimum. The analytic result now matches `ST_Distance(traversedArea(temp), geom)` across the full test dataset.

Also renames the helper `tcbuffer_geo_nad_analytic` to `nad_tcbuffer_geo_analytic` for the canonical operator-first name.

Expected outputs for `210_tcbuffer_distance`, `212_tcbuffer_spatialrels_tbl`, and `214_tcbuffer_tempspatialrels_tbl` are updated to the corrected values, and a regression case is added.