### PR TITLE
Remove the invalid span analyze from the quadbin and h3 set types

### DIFF
--- a/mobilitydb/sql/h3/251_h3indexset.in.sql
+++ b/mobilitydb/sql/h3/251_h3indexset.in.sql
@@ -71,8 +71,8 @@ CREATE TYPE h3indexset (
   receive = h3indexset_recv,
   send = h3indexset_send,
   alignment = double,
-  storage = extended,
-  analyze = span_analyze
+  storage = extended
+  -- , analyze = geoset_analyze
 );
 
 /******************************************************************************

--- a/mobilitydb/sql/quadbin/351_quadbinset.in.sql
+++ b/mobilitydb/sql/quadbin/351_quadbinset.in.sql
@@ -71,8 +71,8 @@ CREATE TYPE quadbinset (
   receive = quadbinset_recv,
   send = quadbinset_send,
   alignment = double,
-  storage = extended,
-  analyze = span_analyze
+  storage = extended
+  -- , analyze = geoset_analyze
 );
 
 /******************************************************************************


### PR DESCRIPTION
## Problem

PostgreSQL autoanalyze fails once per minute on any table holding a `quadbinset` or `h3indexset` column:

```
ERROR:  type quadbin is not a span type
CONTEXT:  automatic analyze of table "...public.tbl_quadbinset"
```

(and the analogous `type h3index is not a span type` for `h3indexset`).

## Cause

`quadbin` and `h3index` are backed by `int8` but are **spatial cell-index types**, not number types — their element type has no span type. The set types were created with `analyze = span_analyze`, copied from the numeric-set template. `span_analyze` looks up the element's span type, does not find one, and errors during autoanalyze.

## Fix

Drop the custom analyze from `quadbinset` and `h3indexset`, matching the other non-geo spatial set types (`cbufferset`, `npointset`, `poseset`), which likewise omit it because they are not registered as spatial set types — `spatialset_type()` covers only `geomset`/`geogset`/`cbufferset`/`npointset`/`poseset`. The pure geo set (`geoset`) keeps `spatialset_analyze`; the cell-index sets use the default, which does not error.

Two-line change; regression baselines are unaffected.