### PR TITLE
Prune mindistance_tgeo_tgeo by STBox distance and consolidate the box distance helper

### DIFF
--- a/meos/include/meos_geo.h
+++ b/meos/include/meos_geo.h
@@ -891,6 +891,7 @@ extern Temporal *tdistance_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 extern Temporal *tdistance_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2);
 extern double nad_stbox_geo(const STBox *box, const GSERIALIZED *gs);
 extern double nad_stbox_stbox(const STBox *box1, const STBox *box2);
+extern double stbox_spatial_distance(const STBox *box1, const STBox *box2);
 extern double nad_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs);
 extern double nad_tgeo_stbox(const Temporal *temp, const STBox *box);
 extern double nad_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2);

--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -1874,33 +1874,6 @@ mindist_tcbuffer_tcbuffer_threshold(const Temporal *temp1,
 }
 
 /**
- * @brief Return the spatial-only distance between two spatiotemporal boxes,
- * ignoring time entirely
- */
-static double
-tcbuffer_stbox_spatial_distance(const STBox *box1, const STBox *box2)
-{
-  /* Spatial extents overlap → exact minimum is 0 (some pair of points
-   * inside the joined extent has zero distance) */
-  if (box1->xmin <= box2->xmax && box2->xmin <= box1->xmax &&
-      box1->ymin <= box2->ymax && box2->ymin <= box1->ymax)
-    return 0.0;
-
-  /* Spatial extents disjoint → exact bbox-to-bbox euclidean distance.
-   * Drop the time component of each box before serialising to geometry. */
-  datum_func2 func = geo_distance_fn(box1->flags);
-  STBox b1 = *box1, b2 = *box2;
-  MEOS_FLAGS_SET_T(b1.flags, false);
-  MEOS_FLAGS_SET_T(b2.flags, false);
-  Datum g1 = PointerGetDatum(stbox_geo(&b1));
-  Datum g2 = PointerGetDatum(stbox_geo(&b2));
-  double result = DatumGetFloat8(func(g1, g2));
-  pfree(DatumGetPointer(g1));
-  pfree(DatumGetPointer(g2));
-  return result;
-}
-
-/**
  * @ingroup meos_cbuffer_dist
  * @brief Return the minimum spatial distance between two temporal circular
  * buffers, capped at @p threshold
@@ -1932,7 +1905,7 @@ mindistance_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
   {
     const STBox *bbox1 = (const STBox *) temporal_bbox_ptr(temp1);
     const STBox *bbox2 = (const STBox *) temporal_bbox_ptr(temp2);
-    double bbox_dist = tcbuffer_stbox_spatial_distance(bbox1, bbox2);
+    double bbox_dist = stbox_spatial_distance(bbox1, bbox2);
     if (bbox_dist >= threshold)
       return threshold;
   }

--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -795,19 +795,9 @@ nad_stbox_stbox(const STBox *box1, const STBox *box2)
   if (hast && ! overlaps_span_span(&box1->period, &box2->period))
       return DBL_MAX;
 
-  /* If the boxes intersect in the value dimension return 0 */
-  if (box1->xmin <= box2->xmax && box2->xmin <= box1->xmax)
-    return 0.0;
-
-  /* Select the distance function to be applied */
-  datum_func2 func = geo_distance_fn(box1->flags);
-  /* Convert the boxes to geometries */
-  Datum geo1 = PointerGetDatum(stbox_geo(box1));
-  Datum geo2 = PointerGetDatum(stbox_geo(box2));
-  /* Compute the result */
-  double result = DatumGetFloat8(func(geo1, geo2));
-  pfree(DatumGetPointer(geo1)); pfree(DatumGetPointer(geo2));
-  return result;
+  /* The nearest approach distance is the spatial-only distance between the
+   * boxes (time already tested above) */
+  return stbox_spatial_distance(box1, box2);
 }
 
 /**
@@ -993,8 +983,13 @@ shortestline_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
  * Set-set spatial minimum distance
  *****************************************************************************/
 
-/* Spatial-only distance between two STBoxes; ignores time entirely. */
-static double
+/**
+ * @ingroup meos_geo_distance
+ * @brief Return the spatial-only minimum distance between two spatiotemporal
+ * boxes, ignoring the time dimension entirely
+ * @param[in] box1,box2 Spatiotemporal boxes
+ */
+double
 stbox_spatial_distance(const STBox *box1, const STBox *box2)
 {
   /* Spatial extents overlap → exact minimum is 0 (some pair of points

--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -1205,6 +1205,22 @@ mindistance_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2,
       ! ensure_same_dimensionality(temp1->flags, temp2->flags) ||
       ! ensure_same_geodetic(temp1->flags, temp2->flags))
     return DBL_MAX;
+  /* Outer STBox spatial-distance prune: every point on either trajectory
+   * lies within the respective STBox, so the spatial distance between the
+   * boxes is a lower bound on the minimum distance; when it already meets or
+   * exceeds the running threshold the kernels below cannot improve on it, so
+   * short-circuit. Not valid for geodetic inputs (the planar bbox distance is
+   * not a lower bound); TINSTANT inputs have no precomputed bbox
+   * (temporal_bbox_ptr returns NULL) so they are skipped and handled below.
+   * Critical for cross-join aggregations where most pairs are far apart. */
+  if (! MEOS_FLAGS_GET_GEODETIC(temp1->flags) &&
+      temp1->subtype != TINSTANT && temp2->subtype != TINSTANT)
+  {
+    const STBox *bbox1 = (const STBox *) temporal_bbox_ptr(temp1);
+    const STBox *bbox2 = (const STBox *) temporal_bbox_ptr(temp2);
+    if (stbox_spatial_distance(bbox1, bbox2) >= threshold)
+      return threshold;
+  }
   bool inline_eligible =
     ! MEOS_FLAGS_GET_Z(temp1->flags) &&
     ! MEOS_FLAGS_GET_GEODETIC(temp1->flags) &&

--- a/mobilitydb/test/pointcloud/expected/439_tpc_distance_tbl.test.out
+++ b/mobilitydb/test/pointcloud/expected/439_tpc_distance_tbl.test.out
@@ -32,7 +32,7 @@ ORDER BY temp |=| tpcbox_zt(0, 0, 0, 0, 0, 0,
 LIMIT 5;
  k  | finite 
 ----+--------
- 41 | false
+ 41 | true
  22 | true
  19 | true
  17 | true
@@ -53,7 +53,7 @@ ORDER BY temp |=| tpcbox_zt(0, 0, 0, 0, 0, 0,
 LIMIT 5;
  k  | finite 
 ----+--------
- 41 | false
+ 41 | true
  22 | true
  19 | true
  17 | true


### PR DESCRIPTION
Two related changes to the spatiotemporal-box spatial distance.

## 1. Consolidate the STBox spatial distance into one exported function

The spatial-only minimum distance between two STBoxes was implemented twice as identical `static` helpers — one in `tgeo_distance.c`, one in `tcbuffer_distance.c`. This promotes the former to an exported MEOS function `stbox_spatial_distance()` (declared in `meos_geo.h`) and removes the `tcbuffer` duplicate, which now calls the shared one.

`nad_stbox_stbox()` is routed through it as well. Its previous inline computation returned `0` whenever the boxes overlapped on the **X axis alone**, ignoring separation on Y (and Z):

```
nearestApproachDistance(STBOX X((0,0),(10,1)), STBOX X((5,100),(15,101)))  -- returned 0, correct is 99
```

Delegating to `stbox_spatial_distance()`, which tests every spatial axis (and falls back to the exact box-geometry distance when they are disjoint), fixes this. The pointcloud `tpcbox` nearest-approach distance delegates to `nad_stbox_stbox`, so one expected test output is updated where the corrected distance is now positive instead of zero.

## 2. Add an outer STBox spatial-distance prune to `mindistance_tgeo_tgeo`

Every point on either trajectory lies within the respective STBox, so the spatial distance between the two boxes is a lower bound on the minimum distance between the trajectories. When that lower bound already meets or exceeds the running threshold, the segment kernels cannot improve on it, so the computation short-circuits without materialising trajectories or entering the sweep — critical for cross-join aggregations (e.g. BerlinMOD Q5) where most pairs are far apart relative to the running minimum. The prune is skipped for geodetic inputs (whose planar bbox distance is not a valid lower bound) and instant inputs (no precomputed bbox).