### PR TITLE
Add geometry/geography KNN order-by members to tpoint indexes

### DIFF
--- a/meos/src/geo/tspatial_spgist.c
+++ b/meos/src/geo/tspatial_spgist.c
@@ -679,6 +679,10 @@ tspatial_spgist_get_stbox(Datum value, MeosType type, STBox *result)
   {
     memcpy(result, DatumGetSTboxP(value), sizeof(STBox));
   }
+  else if (geo_basetype(type))
+  {
+    geo_set_stbox(DatumGetGserializedP(value), result);
+  }
   else if (tspatial_type(type))
   {
     const Temporal *temp = DatumGetTemporalP(value);

--- a/mobilitydb/sql/geo/073_tpoint_gist.in.sql
+++ b/mobilitydb/sql/geo/073_tpoint_gist.in.sql
@@ -88,6 +88,8 @@ CREATE OPERATOR CLASS stbox_rtree_ops
   OPERATOR  25    |=| (stbox, stbox) FOR ORDER BY pg_catalog.float_ops,
   OPERATOR  25    |=| (stbox, tgeompoint) FOR ORDER BY pg_catalog.float_ops,
   OPERATOR  25    |=| (stbox, tgeogpoint) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25    |=| (stbox, geometry) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25    |=| (stbox, geography) FOR ORDER BY pg_catalog.float_ops,
   -- overlaps or before
   OPERATOR  28    &<# (stbox, stbox),
   OPERATOR  28    &<# (stbox, tgeompoint),
@@ -185,6 +187,7 @@ CREATE OPERATOR CLASS tgeompoint_rtree_ops
   -- nearest approach distance
   OPERATOR  25    |=| (tgeompoint, stbox) FOR ORDER BY pg_catalog.float_ops,
   OPERATOR  25    |=| (tgeompoint, tgeompoint) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25    |=| (tgeompoint, geometry) FOR ORDER BY pg_catalog.float_ops,
   -- overlaps or before
   OPERATOR  28    &<# (tgeompoint, tstzspan),
   OPERATOR  28    &<# (tgeompoint, stbox),
@@ -248,6 +251,7 @@ CREATE OPERATOR CLASS tgeogpoint_rtree_ops
   -- distance
   OPERATOR  25    |=| (tgeogpoint, stbox) FOR ORDER BY pg_catalog.float_ops,
   OPERATOR  25    |=| (tgeogpoint, tgeogpoint) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25    |=| (tgeogpoint, geography) FOR ORDER BY pg_catalog.float_ops,
   -- overlaps or before
   OPERATOR  28    &<# (tgeogpoint, tstzspan),
   OPERATOR  28    &<# (tgeogpoint, stbox),

--- a/mobilitydb/sql/geo/074_tpoint_spgist.in.sql
+++ b/mobilitydb/sql/geo/074_tpoint_spgist.in.sql
@@ -249,6 +249,7 @@ CREATE OPERATOR CLASS tgeompoint_quadtree_ops
   -- nearest approach distance
   OPERATOR  25    |=| (tgeompoint, stbox) FOR ORDER BY pg_catalog.float_ops,
   OPERATOR  25    |=| (tgeompoint, tgeompoint) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25    |=| (tgeompoint, geometry) FOR ORDER BY pg_catalog.float_ops,
   -- overlaps or before
   OPERATOR  28    &<# (tgeompoint, tstzspan),
   OPERATOR  28    &<# (tgeompoint, stbox),
@@ -336,6 +337,7 @@ CREATE OPERATOR CLASS tgeompoint_kdtree_ops
   -- nearest approach distance
   OPERATOR  25    |=| (tgeompoint, stbox) FOR ORDER BY pg_catalog.float_ops,
   OPERATOR  25    |=| (tgeompoint, tgeompoint) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25    |=| (tgeompoint, geometry) FOR ORDER BY pg_catalog.float_ops,
   -- overlaps or before
   OPERATOR  28    &<# (tgeompoint, tstzspan),
   OPERATOR  28    &<# (tgeompoint, stbox),
@@ -399,6 +401,7 @@ CREATE OPERATOR CLASS tgeogpoint_quadtree_ops
   -- nearest approach distance
   OPERATOR  25    |=| (tgeogpoint, stbox) FOR ORDER BY pg_catalog.float_ops,
   OPERATOR  25    |=| (tgeogpoint, tgeogpoint) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25    |=| (tgeogpoint, geography) FOR ORDER BY pg_catalog.float_ops,
   -- overlaps or before
   OPERATOR  28    &<# (tgeogpoint, tstzspan),
   OPERATOR  28    &<# (tgeogpoint, stbox),
@@ -449,6 +452,7 @@ CREATE OPERATOR CLASS tgeogpoint_kdtree_ops
   -- nearest approach distance
   OPERATOR  25    |=| (tgeogpoint, stbox) FOR ORDER BY pg_catalog.float_ops,
   OPERATOR  25    |=| (tgeogpoint, tgeogpoint) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25    |=| (tgeogpoint, geography) FOR ORDER BY pg_catalog.float_ops,
   -- overlaps or before
   OPERATOR  28    &<# (tgeogpoint, tstzspan),
   OPERATOR  28    &<# (tgeogpoint, stbox),

--- a/mobilitydb/src/geo/tspatial_gist.c
+++ b/mobilitydb/src/geo/tspatial_gist.c
@@ -49,6 +49,8 @@
 #include "geo/stbox.h"
 #include "geo/stbox_index.h"
 /* MobilityDB */
+#include "pg_geo/postgis.h"
+/* MobilityDB */
 #include "pg_temporal/meos_catalog.h"
 #include "pg_temporal/temporal.h"
 #include "pg_temporal/tnumber_gist.h"
@@ -75,6 +77,14 @@ tspatial_gist_get_stbox(FunctionCallInfo fcinfo, STBox *result, MeosType type)
     if (! box)
       return false;
     memcpy(result, box, sizeof(STBox));
+  }
+  else if (geo_basetype(type))
+  {
+    if (PG_ARGISNULL(1))
+      return false;
+    GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(1);
+    if (! geo_set_stbox(gs, result))
+      return false;
   }
   else if (tspatial_type(type))
   {


### PR DESCRIPTION
### Summary

`nearestApproachDistance` (`|=|`) is defined between a temporal point and a
static `geometry`/`geography`, and its result is the **time-agnostic spatial
distance** (the temporal test in `nad_stbox_stbox` is skipped when one side
carries no time dimension). However, the GiST and SP-GiST opclasses only
registered `|=| ... FOR ORDER BY` for the `tgeompoint`/`tgeogpoint`/`stbox`
right operands, **not** `geometry`/`geography`.

As a result, a nearest-neighbour query against a static geometry probe,

```sql
SELECT * FROM Trips ORDER BY trip |=| <geometry> LIMIT k;
```

could not use the spatial index for the ordering and fell back to a full scan
plus sort, even though the `|=| (tgeompoint, geometry)` operator already
existed.

### Change

- Register the `geometry`/`geography` `|=|` operators as `FOR ORDER BY` members
  in the `tgeompoint`, `tgeogpoint` and `stbox` GiST (`073_tpoint_gist`) and
  SP-GiST (`074_tpoint_spgist`) opclasses.
- Teach the query-to-box transforms (`tspatial_gist_get_stbox`,
  `tspatial_spgist_get_stbox`) to accept a `geometry`/`geography` query operand
  by converting it to its `STBox` via `geo_set_stbox`.

No new operators are introduced — the operators already existed; this makes
them index-accelerated. With the change, `ORDER BY tpoint |=| geometry LIMIT k`
uses an index KNN scan:

```
Index Scan using trips_trip_gist on trips
  Order By: (trip |=| ...)
```

### Notes

- The KNN benefit scales with the selectivity of the probe's bounding box: a
  compact probe (point / small region) prunes tightly, while a probe with a
  very large bounding box (e.g. a whole trajectory) overlaps most candidates
  and gains little.
- `pg_regress` is unchanged (the added opclass members do not alter any
  existing result).
