### PR TITLE
Add a CI check that the inherited SQL generator is up to date

### DIFF
--- a/.github/workflows/check-codegen.yml
+++ b/.github/workflows/check-codegen.yml
@@ -1,0 +1,44 @@
+name: Check codegen
+
+# Verifies that the SQL emitted by the inherited-behaviour generator
+# (tools/codegen/inherited) is in sync with its template + manifest, so a
+# hand edit to an emitted file — or a template change that was not
+# re-emitted — cannot land unnoticed. The generator is deterministic, so
+# regenerating and diffing is enough.
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/check-codegen.yml'
+      - 'tools/codegen/inherited/**'
+      - 'mobilitydb/sql/**'
+  pull_request:
+    paths:
+      - '.github/workflows/check-codegen.yml'
+      - 'tools/codegen/inherited/**'
+      - 'mobilitydb/sql/**'
+
+permissions:
+  contents: read
+
+jobs:
+  check-codegen:
+    name: Inherited SQL generator is up to date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Regenerate the inherited SQL
+        run: python3 tools/codegen/inherited/generate.py
+
+      - name: Fail if the emitted SQL is out of date
+        run: |
+          if ! git diff --exit-code; then
+            echo "::error::Emitted SQL is out of date. Run" \
+                 "'python3 tools/codegen/inherited/generate.py' and commit the result."
+            exit 1
+          fi


### PR DESCRIPTION
### Summary

The SQL files under `mobilitydb/sql` that are emitted by the
inherited-behaviour generator (`tools/codegen/inherited`) are deterministic
projections of a shared template plus a manifest. Until now nothing verified
that a checked-in file still matched what the generator produces, so a hand
edit to an emitted file — or a template change that was not re-emitted — could
drift silently.

### Change

Add a `Check codegen` workflow that installs PyYAML, runs the generator, and
fails if the working tree then differs (`git diff --exit-code`). It runs on
pushes and pull requests that touch the generator, its templates/manifest, or
`mobilitydb/sql`. The generator is deterministic, so regenerating and diffing
is a complete check for the emitted subtypes.

### Notes

- This enforces the emitted (non-reference) subtypes. The generator also has a
  `--validate` mode that checks the template still reproduces its hand-written
  reference family; that is not wired here yet because the `topops` template
  currently lags its `tcbuffer` reference. Reconciling that drift and adding
  `--validate` to this workflow is a follow-up.
