### PR TITLE
Complete the topops template so it reproduces its reference

### DIFF
--- a/.github/workflows/check-codegen.yml
+++ b/.github/workflows/check-codegen.yml
@@ -42,3 +42,6 @@ jobs:
                  "'python3 tools/codegen/inherited/generate.py' and commit the result."
             exit 1
           fi
+
+      - name: Validate the reference family reproduces from the template
+        run: python3 tools/codegen/inherited/generate.py --validate

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -37,6 +37,7 @@ subtypes:
     category: tspatial
     # A cell-index (like h3) has NO scalar base::stbox cast — drop that block.
     scalar_stbox_cast: false
+    stboxes: false
     # compops/posops/topops are generic (topops' scalar cast stripped via the flag
     # above). spatialrels delegates to the geo spatial relationships via the
     # cell→boundary tgeometry conversion (quadbin_cell_to_boundary), the cell-index
@@ -56,6 +57,7 @@ subtypes:
     category: tspatial
     # A cell-index has NO scalar base::stbox cast — same as tquadbin.
     scalar_stbox_cast: false
+    stboxes: false
     files: [compops, posops, topops, spatialrels, gist, spgist]
 
   # ---- reference families (validate self-regeneration == committed; not new) ----

--- a/tools/codegen/inherited/templates/topops.sql.tmpl
+++ b/tools/codegen/inherited/templates/topops.sql.tmpl
@@ -65,6 +65,25 @@ CREATE CAST ({TEMP} AS stbox) WITH FUNCTION stbox({TEMP});
 
 /*****************************************************************************/
 
+-- @IF stboxes
+CREATE FUNCTION stboxes({TEMP})
+  RETURNS stbox[]
+  AS 'MODULE_PATHNAME', 'Tgeo_stboxes'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION splitNStboxes({TEMP}, integer)
+  RETURNS stbox[]
+  AS 'MODULE_PATHNAME', 'Tgeo_split_n_stboxes'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION splitEachNStboxes({TEMP}, integer)
+  RETURNS stbox[]
+  AS 'MODULE_PATHNAME', 'Tgeo_split_each_n_stboxes'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/*****************************************************************************/
+
+-- @ENDIF
 CREATE FUNCTION expandSpace({TEMP}, float)
   RETURNS stbox
   AS 'SELECT @extschema@.expandSpace($1::stbox, $2)'


### PR DESCRIPTION
### Summary

The inherited-behaviour generator's `topops` template did not emit the
`stboxes` / `splitNStboxes` / `splitEachNStboxes` trajectory-tiling functions,
so `generate.py --validate` could not reproduce its `tcbuffer` reference
(`208_tcbuffer_topops.in.sql`) — a latent template/reference drift.

### Change

- Add the three functions to `topops.sql.tmpl`, gated behind an `stboxes`
  flag. They apply to the continuous spatial families (cbuffer, pose, rgeo,
  npoint) but not to the discrete cell indexes (h3, quadbin), so the two cell
  families set `stboxes: false` in the manifest. Regenerating h3/quadbin
  leaves their files byte-for-byte unchanged.
- With the reference now reproduced exactly (`--validate` is green for all
  four cbuffer reference files), add `generate.py --validate` to the
  `Check codegen` workflow, so template/reference drift is caught as well as
  drift in the emitted families.

No emitted SQL changes (the template only gains content that its reference
already had); this is a generator/CI-only change.
