### PR TITLE
Add missing circular-buffer sections and reference index to the Spanish manual

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -2047,6 +2047,305 @@
 	</sect1>
 
 	<sect1>
+		<title>Búferes circulares temporales</title>
+
+		<sect2>
+			<title>Búferes circulares estáticos</title>
+
+			<sect3>
+				<title>Constructores</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="cbuffer"><varname>cbuffer</varname></link>: Constructor para búferes circulares</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Conversiones de tipo</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="cbuffer_geometry"><varname>cbuffer::geometry</varname>, <varname>geometry::cbuffer</varname></link>: Convertir entre un búfer circular y un punto de geometría</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="cbuffer_stbox"><varname>stbox</varname></link>: Convertir un búfer circular y, opcionalmente, una marca de tiempo o un período, en un cuadro espaciotemporal</para>
+					</listitem>
+
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Accesores</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="cbuffer_point"><varname>point</varname></link>: Devuelve el punto</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="cbuffer_radius"><varname>radius</varname></link>: Devuelve el radio</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Transformaciones</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="cbuffer_round"><varname>round</varname></link>: Redondea el punto y el radio del búfer circular al número de decimales</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Operaciones espaciales</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="cbuffer_SRID"><varname>SRID</varname>, <varname>setSRID</varname></link>: Devuelve o establece el identificador de referencia espacial</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="cbuffer_transform"><varname>transform</varname>, <varname>transformPipeline</varname></link>: Transforma a un identificador de referencia espacial</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Comparaciones</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="cbuffer_comp"><varname>=</varname>, <varname>&lt;&gt;</varname>, <varname>&lt;</varname>, <varname>&gt;</varname>, <varname>&lt;=</varname>, <varname>&gt;=</varname></link>: Comparaciones tradicionales</para>
+						</listitem>
+				</itemizedlist>
+			</sect3>
+		</sect2>
+
+		<sect2>
+			<title>Búferes circulares temporales</title>
+
+			<sect3>
+				<title>Entrada y salida</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tcbuffer_asText"><varname>asText</varname>, <varname>asEWKT</varname></link>: Devuelve la representación en texto conocido (WKT) o en texto conocido extendido (EWKT)</para>
+					</listitem>
+
+						<listitem>
+						<para><link linkend="tcbuffer_asMFJSON"><varname>asMFJSON</varname></link>: Devuelve la representación en JSON de entidades móviles (MF-JSON)</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tcbuffer_asBinary"><varname>asBinary</varname>, <varname>asEWKB</varname></link>: Devuelve la representación en binario conocido (WKB), en binario conocido extendido (EWKB) o en binario conocido extendido hexadecimal (HexEWKB) como texto</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tcbufferFromText"><varname>tcbufferFromText</varname>, <varname>tcbufferFromEWKT</varname></link>: Entrada desde la representación en texto conocido (WKT) o en texto conocido extendido (EWKT)</para>
+					</listitem>
+
+						<listitem>
+						<para><link linkend="tcbufferFromMFJSON"><varname>tcbufferFromMFJSON</varname></link>: Entrada desde la representación en JSON de entidades móviles (MF-JSON)</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tcbufferFromBinary"><varname>tcbufferFromBinary</varname>, <varname>tcbufferFromEWKB</varname>, <varname>tcbufferFromHexEWKB</varname></link>: Entrada desde la representación en binario conocido (WKB), en binario conocido extendido (EWKB) o en binario conocido extendido hexadecimal (HexEWKB)</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Constructores</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tcbuffer_const"><varname>tcbuffer</varname></link>: Constructor para búferes circulares temporales con un valor constante</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tcbufferSeq"><varname>tcbufferSeq</varname></link>: Constructores para búferes circulares temporales del subtipo secuencia</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tcbufferSeqSet"><varname>tcbufferSeqSet</varname>, <varname>tcbufferSeqSetGaps</varname></link>: Constructor para búferes circulares temporales del subtipo conjunto de secuencias</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tgeompoint_tfloat_tcbuffer"><varname>tcbuffer</varname></link>: Construye un búfer circular temporal a partir de un punto de geometría temporal y un flotante temporal</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Conversiones de tipo</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tcbuffer_tgeompoint"><varname>tcbuffer::tgeompoint</varname></link>: Convertir un búfer circular temporal a un punto de geometría temporal</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tcbuffer_tfloat"><varname>tcbuffer::tfloat</varname></link>: Convertir un búfer circular temporal a un flotante temporal</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Accesores</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tcbuffer_getValues"><varname>getValues</varname></link>: Devuelve los valores</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tcbuffer_points"><varname>points</varname>, <varname>radius</varname></link>: Devuelve los puntos o los radios</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tcbuffer_valueAtTimestamp"><varname>valueAtTimestamp</varname></link>: Devuelve el valor en una marca de tiempo</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Transformaciones</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tcbuffer_subtype"><varname>tcbufferInst</varname>, <varname>tcbufferSeq</varname>, <varname>tcbufferSeqSet</varname></link>: Transforma un búfer circular temporal a otro subtipo</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tcbuffer_setInterp"><varname>setInterp</varname></link>: Transforma un búfer circular temporal a otra interpolación</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tcbuffer_round"><varname>round</varname></link>: Redondea los puntos y los radios del búfer circular temporal al número de decimales</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+				<sect3>
+					<title>Modificaciones</title>
+					<itemizedlist>
+						<listitem>
+							<para><link linkend="tcbuffer_appendInstant"><varname>appendInstant</varname>, <varname>appendSequence</varname></link>: Añade un instante temporal o una secuencia temporal</para>
+						</listitem>
+
+						<listitem>
+							<para><link linkend="tcbuffer_merge"><varname>merge</varname>, <varname>mergeAgg</varname></link>: Combina los búferes circulares temporales</para>
+						</listitem>
+					</itemizedlist>
+				</sect3>
+
+			<sect3>
+				<title>Restricciones</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tcbuffer_atValues"><varname>atValues</varname>, <varname>minusValue</varname></link>: Restringe a (el complemento de) un conjunto de valores</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tcbuffer_atGeometry"><varname>atGeometry</varname>, <varname>minusGeometry</varname></link>: Restringe a (el complemento de) una geometría</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Operaciones de distancia</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tcbuffer_nearestApproachDistance"><varname>|=|</varname></link>: Devuelve la menor distancia que existió en algún momento entre los dos argumentos</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tcbuffer_nearestApproachInstant"><varname>nearestApproachInstant</varname></link>: Devuelve el instante del primer búfer circular temporal en el que los dos argumentos están a la menor distancia</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tcbuffer_shortestLine"><varname>shortestLine</varname></link>: Devuelve la línea que conecta el punto de aproximación más cercana entre los dos argumentos</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tcbuffer_tdistance"><varname>&lt;-&gt;</varname></link>: Devuelve la distancia temporal</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Operaciones espaciales</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tcbuffer_SRID"><varname>SRID</varname>, <varname>setSRID</varname></link>: Devuelve o establece el identificador de referencia espacial</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tcbuffer_transform"><varname>transform</varname>, <varname>transformPipeline</varname></link>: Transforma a un identificador de referencia espacial</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tcbuffer_traversedArea"><varname>traversedArea</varname></link>: Devuelve el área recorrida por el búfer circular temporal</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Operaciones de cuadro delimitador</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tcbuffer_topo"><varname>&amp;&amp;, &lt;@, @&gt;, ~=, -|-</varname></link>: Operadores topológicos</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tcbuffer_pos"><varname>&lt;&lt;, &amp;&lt;, &gt;&gt;, &amp;&gt;, &lt;&lt;|, &amp;&lt;|, |&gt;&gt;, |&amp;&gt;, &lt;&lt;#, &amp;&lt;#, #&gt;&gt;, |&amp;&gt;</varname></link>: Operadores de posición</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Relaciones espaciales</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tcbuffer_espatialrels"><varname>eContains, eDisjoint, eIntersects, eTouches, eDwithin</varname></link>: Relaciones espaciales posibles</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tcbuffer_tspatialrels"><varname>tContains, tDisjoint, tIntersects, tTouches, tDwithin</varname></link>: Relaciones espaciotemporales</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Comparaciones</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tcbuffer_comp"><varname>=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=</varname></link>: Comparaciones tradicionales</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tcbuffer_ever_always"><varname>?=, &amp;=</varname></link>: Comparaciones siempre y alguna vez</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tcbuffer_tcomp"><varname>#=, #&lt;&gt;</varname></link>: Comparaciones temporales</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Agregaciones</title>
+
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tcbuffer_tCount"><varname>tCount</varname></link>: Conteo temporal</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tcbuffer_wCount"><varname>wCount</varname></link>: Conteo de ventana</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tcbuffer_centroid"><varname>tCentroid</varname></link>: Centroide temporal</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+		</sect2>
+	</sect1>
+
+	<sect1>
 		<title>Geometrías rígidas temporales</title>
 
 		<sect2>

--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -2003,6 +2003,210 @@
 	</sect1>
 
 	<sect1>
+		<title>JSON temporal</title>
+
+		<sect2>
+		<title>Entrada y salida</title>
+			<itemizedlist>
+				<listitem>
+					<para><link linkend="tjsonb_asText"><varname>asText</varname></link>: Devuelve la representación Well-Known Text (WKT)</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tjsonb_asBinary"><varname>asBinary</varname>, <varname>asWKB</varname></link>: Devuelve la representación Well-Known Binary (WKB) o la representación Hexadecimal Well-Known Binary (HexEWKB) como texto</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tjsonb_asMFJSON"><varname>asMFJSON</varname></link>: Devuelve la representación Moving Features JSON (MF-JSON) como texto</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tjsonbFromText"><varname>tjsonbFromText</varname>, <varname>tjsonbFromWKT</varname></link>: Entrar a partir de la representación Well-Known Text (WKT)</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tjsonbFromBinary"><varname>tjsonbFromBinary</varname>, <varname>tjsonbFromHexWKB</varname></link>: Entrar a partir de la representación Well-Known Binary (WKB) o a partir de la representación Hexadecimal Well-Known Binary (HexEWKB)</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tjsonbFromMFJSON"><varname>tjsonbFromMFJSON</varname></link>: Entrar a partir de la representación Moving Features JSON (MF-JSON)</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2>
+		<title>Constructores</title>
+			<itemizedlist>
+				<listitem>
+					<para><link linkend="tjsonb_const"><varname>tjsonb</varname></link>: Constructor para un JSONB temporal con un valor constante</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tjsonbSeq"><varname>tjsonbSeq</varname></link>: Constructores para un JSONB temporal de subtipo secuencia</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tjsonbSeqSet"><varname>tjsonbSeqSet</varname>, <varname>tjsonbSeqSetGaps</varname></link>: Constructor para un JSONB temporal de subtipo conjunto de secuencias</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2>
+		<title>Conversiones de tipo</title>
+			<itemizedlist>
+				<listitem>
+					<para><link linkend="tjsonb_tstzspan"><varname>tjsonb::tstzspan</varname></link>: Convertir un JSONB temporal a un punto geométrico temporal</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tjsonb_text"><varname>tjsonb::ttext</varname></link>: Convertir un JSONB temporal a un texto temporal</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2>
+		<title>Accesores</title>
+			<itemizedlist>
+				<listitem>
+					<para><link linkend="tjsonb_getValues"><varname>getValues</varname></link>: Devuelve los valores</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tjsonb_valueAtTimestamp"><varname>valueAtTimestamp</varname></link>: Devuelve el valor en una marca de tiempo</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2>
+		<title>Transformaciones</title>
+			<itemizedlist>
+				<listitem>
+					<para><link linkend="tjsonb_subtype"><varname>tjsonbInst</varname>, <varname>tjsonbSeq</varname>, <varname>tjsonbSeqSet</varname></link>: Transformar un JSONB temporal en otro subtipo</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tjsonb_setInterp"><varname>setInterp</varname></link>: Transformar un JSONB temporal a otra interpolación</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2>
+			<title>Operaciones JSON temporales</title>
+
+			<itemizedlist>
+				<listitem>
+					<para><link linkend="tjson_object_field"><varname>-></varname>, <varname>->></varname>, <varname>tjson_object_field</varname>, <varname>tjsonb_object_field</varname>, <varname>tjsonb_object_field_text</varname></link>: Extraer un campo de un valor JSON temporal especificado por una clave</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tjson_extract_path"><varname>#></varname>, <varname>#>></varname></link>: Extraer un campo de un valor JSON temporal especificado por una ruta</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tjson_array_element"><varname>tjson_array_element</varname>, <varname>tjsonb_array_element</varname>, <varname>tjsonb_array_element_text</varname></link>: Extraer un elemento de un arreglo JSON temporal</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tjsonb_concat"><varname>||</varname></link>: Concatenación de JSONB temporal</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tjsonb_delete"><varname>-</varname>, <varname>#-</varname></link>: Eliminación de JSONB temporal</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tjsonb_set"><varname>tjsonb_set</varname>, <varname>tjsonb_set_lax</varname></link>: Asignación de JSONB temporal</para>
+				</listitem>
+
+				<listitem>
+					<indexterm significance="normal"><primary><varname>?</varname></primary></indexterm>
+					<para><link linkend="tjsonb_exists"><varname>?</varname>, <varname>?|</varname>, <varname>?&amp;</varname></link>: Existencia de JSONB temporal</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tjsonb_contains"><varname>@&gt;</varname>, <varname>&lt;@</varname></link>: JSONB temporal contiene/contenido</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tjsonb_talphanum"><varname>tbool</varname>, <varname>tint</varname>, <varname>tfloat</varname>, <varname>ttext</varname></link>: Extraer un valor alfanumérico temporal de un valor JSONB temporal dado por una clave</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tjson_strip_nulls"><varname>tjson_strip_nulls</varname>, <varname>tjsonb_strip_nulls</varname></link>: Devuelve un valor JSON temporal sin valores nulos</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tjsonb_path_exists"><varname>@?</varname>, <varname>tjsonb_path_exists</varname>, <varname>tjsonb_path_exists_tz</varname></link>: ¿Devuelve la expresión de ruta JSON algún elemento del valor JSONB?</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tjsonb_path_match"><varname>@@</varname>, <varname>tjsonb_path_match</varname>, <varname>tjsonb_path_match_tz</varname></link>: Devuelve el resultado de la comprobación de una expresión de ruta JSON para un valor JSONB temporal.</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tjsonb_path_query_array"><varname>tjsonb_path_query</varname>, <varname>tjsonb_path_query_tz</varname></link>: Devuelve todos los elementos retornados por una expresión de ruta JSON de un valor JSONB temporal, como un arreglo JSON</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tjsonb_path_query_first"><varname>tjsonb_path_query_first</varname>, <varname>tjsonb_path_query_first_tz</varname></link>: Devuelve el primer elemento retornado por una expresión de ruta JSON de un valor JSONB temporal</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2>
+		<title>Restricciones</title>
+			<itemizedlist>
+				<listitem>
+					<para><link linkend="tjsonb_atValues"><varname>atValues</varname>, <varname>minusValue</varname></link>: Restringir a (al complemento de) un conjunto de valores</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2>
+		<title>Operaciones de cuadro delimitador</title>
+			<itemizedlist>
+				<listitem>
+					<para><link linkend="tjsonb_topo"><varname>&amp;&amp;, &lt;@, @&gt;, ~=, -|-</varname></link>: Operadores topológicos</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tjsonb_pos"><varname>&lt;&lt;#, &amp;&lt;#, #&gt;&gt;, |&amp;&gt;</varname></link>: Operadores de posición relativa</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2>
+		<title>Comparaciones</title>
+			<itemizedlist>
+				<listitem>
+					<para><link linkend="tjsonb_comp"><varname>=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=</varname></link>: Comparaciones tradicionales</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tjsonb_ever_always"><varname>?=, &amp;=</varname></link>: Comparaciones siempre y alguna vez</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tjsonb_tcomp"><varname>#=, #&lt;&gt;</varname></link>: Comparaciones temporales</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2>
+		<title>Agregaciones</title>
+			<itemizedlist>
+				<listitem>
+					<para><link linkend="tjsonb_tCount"><varname>tCount</varname></link>: Conteo temporal</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tjsonb_wCount"><varname>wCount</varname></link>: Conteo de ventana</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+	</sect1>
+
+	<sect1>
 		<title>Índices de celda H3 temporales</title>
 
 		<sect2>

--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1472,6 +1472,314 @@
 	</sect1>
 
 	<sect1>
+		<title>Poses temporales</title>
+
+		<sect2>
+			<title>Poses estáticas</title>
+
+			<sect3>
+				<title>Entrada y salida</title>
+				<itemizedlist>
+
+					<listitem>
+						<para><link linkend="pose_asText"><varname>asText</varname>, <varname>asEWKT</varname></link>: Devuelve la representación en texto conocido (WKT) o en texto conocido extendido (EWKT)</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="pose_asBinary"><varname>asBinary</varname>, <varname>asEWKB</varname>, <varname>asHexEWKB</varname></link>: Devuelve la representación en binario conocido (WKB), en binario conocido extendido (EWKB) o en binario conocido extendido hexadecimal (HexEWKB)</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="poseFromText"><varname>poseFromText</varname>, <varname>poseFromEWKT</varname></link>: Entrada desde la representación en texto conocido (WKT) o en texto conocido extendido (EWKT)</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="poseFromBinary"><varname>poseFromBinary</varname>, <varname>poseFromEWKB</varname>, <varname>poseFromHexEWKB</varname></link>: Entrada desde la representación en binario conocido (WKB), en binario conocido extendido (EWKB) o en binario conocido extendido hexadecimal (HexEWKB)</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Constructores</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="pose"><varname>pose</varname></link>: Constructores para poses</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Conversiones de tipo</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="pose_stbox"><varname>pose::stbox</varname>, <varname>stbox(pose)</varname></link>: Convertir una pose y, opcionalmente, una marca de tiempo o un período, en un cuadro espaciotemporal</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="pose_geometry"><varname>pose::geometry</varname></link>: Convertir una pose en un punto de geometría</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Accesores</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="pose_point"><varname>point</varname></link>: Devuelve el punto</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="pose_rotation"><varname>rotation</varname></link>: Devuelve la rotación</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="pose_orientation"><varname>orientation</varname></link>: Devuelve la orientación</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Transformaciones</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="pose_round"><varname>round</varname></link>: Redondea el punto y la orientación de la pose al número de decimales</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Sistema de referencia espacial</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="pose_srid"><varname>SRID</varname>, <varname>setSRID</varname></link>: Devuelve o establece el identificador de referencia espacial</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="pose_transform"><varname>transform</varname>, <varname>transformPipeline</varname></link>: Transforma a un identificador de referencia espacial</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="pose_same"><varname>same</varname></link>: Similitud espacial</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Comparaciones</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="pose_comp"><varname>=</varname>, <varname>&lt;&gt;</varname>, <varname>&lt;</varname>, <varname>&gt;</varname>, <varname>&lt;=</varname>, <varname>&gt;=</varname></link>: Comparaciones tradicionales</para>
+						</listitem>
+				</itemizedlist>
+			</sect3>
+		</sect2>
+
+		<sect2>
+			<title>Poses temporales</title>
+			<sect3>
+				<title>Entrada y salida</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpose_asText"><varname>asText</varname>, <varname>asEWKT</varname></link>: Devuelve la representación en texto conocido (WKT) o en texto conocido extendido (EWKT)</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tpose_asMFJSON"><varname>asMFJSON</varname></link>: Devuelve la representación en JSON de características móviles (MF-JSON)</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tpose_asBinary"><varname>asBinary</varname>, <varname>asEWKB</varname>, <varname>asHexEWKB</varname></link>: Devuelve la representación en binario conocido (WKB), en binario conocido extendido (EWKB) o en binario conocido extendido hexadecimal (HexEWKB)</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tposeFromText"><varname>tposeFromText</varname>, <varname>tposeFromEWKT</varname></link>: Entrada desde la representación en texto conocido (WKT) o en texto conocido extendido (EWKT)</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tposeFromMFJSON"><varname>tposeFromMFJSON</varname></link>: Entrada desde la representación en JSON de características móviles (MF-JSON)</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tposeFromBinary"><varname>tposeFromBinary</varname>, <varname>tposeFromEWKB </varname>, <varname>tposeFromHexEWKB</varname></link>: Entrada desde la representación en binario conocido (WKB), en binario conocido extendido (EWKB) o en binario conocido extendido hexadecimal (HexEWKB)</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Constructores</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpose_const"><varname>tpose</varname></link>: Constructor para poses temporales a partir de un valor base y un valor de tiempo</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tposeSeq"><varname>tposeSeq</varname></link>: Constructores para poses temporales del subtipo secuencia</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tposeSeqSet"><varname>tposeSeqSet</varname>, <varname>tposeSeqSetGaps</varname></link>: Constructor para poses temporales del subtipo conjunto de secuencias</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tgeompoint_tfloat_tpose"><varname>tpose</varname></link>: Construye una pose temporal 2D a partir de un punto de geometría temporal y un flotante temporal</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Conversiones de tipo</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpose_tgeompoint"><varname>tpose::tgeompoint</varname></link>: Convertir una pose temporal en un punto de geometría temporal</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Accesores</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpose_getValues"><varname>getValues</varname></link>: Devuelve los valores</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tpose_points"><varname>points</varname></link>: Devuelve los puntos</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tpose_rotation"><varname>rotation</varname></link>: Devuelve la rotación</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tpose_valueAtTimestamp"><varname>valueAtTimestamp</varname></link>: Devuelve el valor en una marca de tiempo</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Transformaciones</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpose_subtype"><varname>tposeInst</varname>, <varname>tposeSeq </varname>, <varname>tposeSeqSet</varname></link>: Transforma a otro subtipo</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tpose_setInterp"><varname>setInterp</varname></link>: Transforma a otra interpolación</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="pose_round"><varname>round</varname></link>: Redondea los puntos y las orientaciones de la pose temporal al número de decimales</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Modificaciones</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpose_appendInstant"><varname>appendInstant</varname>, <varname>appendInstantAgg</varname>, <varname>appendSequence</varname>, <varname>appendSequenceAgg</varname></link>: Añade un instante temporal o una secuencia temporal</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tpose_merge"><varname>merge</varname>, <varname>mergeAgg</varname></link>: Combina las poses temporales</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Restricciones</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpose_atValues"><varname>atValues</varname>, <varname>minusValues</varname></link>: Restringe a (el complemento de) un conjunto de valores</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tpose_atGeometry"><varname>atGeometry</varname>, <varname>minusGeometry</varname></link>: Restringe a (el complemento de) una geometría</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Sistema de referencia espacial</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpose_SRID"><varname>SRID</varname>, <varname>setSRID</varname></link>: Devuelve o establece el identificador de referencia espacial</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tpose_transform"><varname>transform</varname>, <varname>transformPipeline</varname></link>: Transforma a un identificador de referencia espacial</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Operaciones de cuadro delimitador</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpose_topo"><varname>&amp;&amp;, &lt;@, @&gt;, ~=, -|-</varname></link>: Operadores topológicos</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tpose_pos"><varname>&lt;&lt;, &amp;&lt;, &gt;&gt;, &amp;&gt;, &lt;&lt;|, &amp;&lt;|, |&gt;&gt;, |&amp;&gt;, &lt;&lt;#, &amp;&lt;#, #&gt;&gt;, |&amp;&gt;</varname></link>: Operadores de posición</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Operadores de distancia</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpose_nearestApproachDistance"><varname>|=|</varname></link>: Devuelve la menor distancia en cualquier momento</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tpose_nearestApproachInstant"><varname>nearestApproachInstant</varname></link>: Devuelve el instante de la primera pose temporal en el que los dos argumentos están a la distancia más cercana</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tpose_shortestLine"><varname>shortestLine</varname></link>: Devuelve la línea que conecta el punto de aproximación más cercano</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tpose_tdistance"><varname>&lt;-&gt;</varname></link>: Devuelve la distancia temporal</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Comparaciones</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpose_comp"><varname>=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=</varname></link>: Comparaciones tradicionales</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tpose_ever_always"><varname>?=, &amp;=</varname></link>: Comparaciones siempre y en algún momento</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tpose_tcomp"><varname>#=, #&lt;&gt;</varname></link>: Comparaciones temporales</para>
+					</listitem>
+
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Agregaciones</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpose_tCount"><varname>tCount</varname></link>: Cuenta temporal</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tpose_wCount"><varname>wCount</varname></link>: Cuenta de ventana</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+		</sect2>
+	</sect1>
+
+	<sect1>
 		<title>Operaciones para puntos de red temporales</title>
 
 		<sect2>

--- a/doc/es/temporal_circular_buffers.xml
+++ b/doc/es/temporal_circular_buffers.xml
@@ -700,6 +700,22 @@ SELECT ST_AsText(traversedArea(tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
 -- CURVEPOLYGON(CIRCULARSTRING(0.7 1,1.3 1,0.7 1))
 </programlisting>
 			</listitem>
+			<listitem xml:id="tcbuffer_centroid">
+				<indexterm significance="normal"><primary><varname>centroid</varname></primary></indexterm>
+				<para>Devuelve el punto geométrico temporal dado por los centros de un búfer circular temporal</para>
+				<para><varname>centroid(tcbuffer) → tgeompoint</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(centroid(tcbuffer '[Cbuffer(Point(1 1), 0.5)@2001-01-01,
+  Cbuffer(Point(3 3), 0.5)@2001-01-03]'));
+-- [POINT(1 1)@2001-01-01 00:00:00+01, POINT(3 3)@2001-01-03 00:00:00+01]
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="tcbuffer_convexHull">
+				<indexterm significance="normal"><primary><varname>convexHull</varname></primary></indexterm>
+				<para>Devuelve la envolvente convexa del área atravesada por el búfer circular temporal</para>
+				<para><varname>convexHull(tcbuffer) → geometry</varname></para>
+			</listitem>
 		</itemizedlist>
 	</sect1>
 
@@ -767,6 +783,25 @@ SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
 -- [2.34988300875063@2001-01-02 00:00:00+01, 2.34988300875063@2001-01-03 00:00:00+01]
 </programlisting>
 			</listitem>
+			<listitem xml:id="tcbuffer_minDistance">
+				<indexterm significance="normal"><primary><varname>minDistance</varname></primary></indexterm>
+				<para>Devuelve la distancia espacial mínima, ignorando el tiempo</para>
+				<para><varname>minDistance(tcbuffer,{geo,cbuffer}) → float</varname></para>
+				<para><varname>minDistance(tcbuffer,tcbuffer) → float</varname> (agregado)</para>
+				<para>El resultado es la distancia espacial entre las áreas barridas por los dos argumentos durante toda su vida útil, igual a <varname>ST_Distance(traversedArea(...), traversedArea(...))</varname>. La forma de dos argumentos de búfer circular temporal es un agregado, de modo que una combinación cruzada agrupada por una clave produce el mínimo sobre cada par del grupo.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT minDistance(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2001-01-01,
+  Cbuffer(Point(10 0), 0.5)@2001-01-02]', geometry 'Point(5 5)');
+-- 4.5
+SELECT minDistance(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2001-01-01,
+  Cbuffer(Point(10 0), 0.5)@2001-01-02]', cbuffer 'Cbuffer(Point(5 5), 1)');
+-- 3.5
+SELECT g, minDistance(t1.Noise, t2.Noise)
+FROM Vessel v1, VesselTrip t1, Vessel v2, VesselTrip t2
+WHERE v1.MMSI = t1.MMSI AND v2.MMSI = t2.MMSI
+GROUP BY t1.ShipTypeLabel, t2.ShipTypeLabel;
+</programlisting>
+			</listitem>
 		</itemizedlist>
 	</sect1>
 
@@ -804,6 +839,18 @@ SELECT asText(minusGeometry(tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,
   Cbuffer(Point(2 2), 0.7)@2001-01-03]', 'Polygon((0 0,0 2,2 2,2 0,0 0))'));
 /* {(Cbuffer(Point(2 2),0.342593)@2001-01-01 05:06:40.364673+01,
    Cbuffer(Point(2 2),0.7)@2001-01-03 00:00:00+01]} */
+</programlisting>
+			</listitem>
+			<listitem xml:id="tcbuffer_atStbox">
+				<indexterm significance="normal"><primary><varname>atStbox</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>minusStbox</varname></primary></indexterm>
+				<para>Restringir un búfer circular temporal a (el complemento de) una caja espaciotemporal</para>
+				<para><varname>atStbox(tcbuffer,stbox,borderInc bool=true) → tcbuffer</varname></para>
+				<para><varname>minusStbox(tcbuffer,stbox,borderInc bool=true) → tcbuffer</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(atStbox(tcbuffer '[Cbuffer(Point(1 1), 0.5)@2000-01-01,
+  Cbuffer(Point(3 3), 0.5)@2000-01-03]', stbox 'STBOX X((0,0),(2,2))'));
+-- {[Cbuffer(POINT(1 1),0.5)@2000-01-01 00:00:00+01, Cbuffer(POINT(2 2),0.5)@2000-01-02 00:00:00+01)}
 </programlisting>
 			</listitem>
 		</itemizedlist>
@@ -1051,6 +1098,35 @@ SELECT astext(tCentroid(Temp))
 FROM Temp;
 /* {[POINT(72.451531682218 76.5231414472853)@2001-01-01,
    POINT(55.7001249027598 72.9552602410653)@2001-01-03)} */
+</programlisting>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
+	<sect1 xml:id="tcbuffer_simplification">
+		<title>Simplificación</title>
+		<itemizedlist>
+			<listitem xml:id="tcbuffer_minDistSimplify">
+				<indexterm significance="normal"><primary><varname>minDistSimplify</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>minTimeDeltaSimplify</varname></primary></indexterm>
+				<para>Devuelve un búfer circular temporal simplificado asegurándose de que los centros consecutivos estén al menos separados por una cierta distancia o intervalo de tiempo</para>
+				<para><varname>minDistSimplify(tcbuffer,mindist float) → tcbuffer</varname></para>
+				<para><varname>minTimeDeltaSimplify(tcbuffer,mint interval) → tcbuffer</varname></para>
+				<para>La simplificación opera sobre la trayectoria de los centros del búfer circular temporal y conserva el radio en cada instante que sobrevive. La simplificación se aplica sólo a secuencias temporales o conjuntos de secuencias con interpolación lineal. En todos los demás casos, se devuelve una copia del valor dado.</para>
+			</listitem>
+
+			<listitem xml:id="tcbuffer_douglasPeuckerSimplify">
+				<indexterm significance="normal"><primary><varname>maxDistSimplify</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>douglasPeuckerSimplify</varname></primary></indexterm>
+				<para>Devuelve un búfer circular temporal simplificado usando el <ulink url="https://es.wikipedia.org/wiki/Algoritmo_de_Ramer%E2%80%93Douglas%E2%80%93Peucker">algoritmo de Douglas-Peucker</ulink></para>
+				<para><varname>maxDistSimplify(tcbuffer,maxdist float,syncdist=true) → tcbuffer</varname></para>
+				<para><varname>douglasPeuckerSimplify(tcbuffer,maxdist float,syncdist=true) → tcbuffer</varname></para>
+				<para>La diferencia entre las dos funciones es que <varname>maxDistSimplify</varname> utiliza una versión de un solo paso del algoritmo mientras que <varname>douglasPeuckerSimplify</varname> utiliza el algoritmo recursivo estándar. Al igual que las funciones anteriores, la simplificación opera sobre la trayectoria de los centros y conserva el radio en cada instante que sobrevive.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(douglasPeuckerSimplify(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01,
+  Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(3 1),0.5)@2000-01-03,
+  Cbuffer(Point(4 4),0.5)@2000-01-04]', 2.0));
+-- {Cbuffer(POINT(1 1),0.5)@2000-01-01 00:00:00+01, Cbuffer(POINT(4 4),0.5)@2000-01-04 00:00:00+01}
 </programlisting>
 			</listitem>
 		</itemizedlist>

--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -363,6 +363,217 @@ SELECT pose 'Pose(SRID=5676;Point(1 1), 0.3)' ~=
 
 			</itemizedlist>
 		</sect2>
+		<sect2 xml:id="pose_ogc_geopose">
+			<title>Soporte de OGC GeoPose v1.0</title>
+			<para>El tipo <varname>pose</varname> de MobilityDB implementa el modelo de datos que subyace al <ulink url="https://www.ogc.org/standards/geopose/">estándar OGC GeoPose v1.0</ulink> (<ulink url="https://docs.ogc.org/is/21-056r10/21-056r10.html">21-056r10</ulink>): una <varname>position</varname> más una <varname>orientation</varname> en un marco de referencia conocido, donde la orientación es un cuaternión unitario en la convención de Hamilton o, de forma equivalente, una terna yaw / pitch / roll bajo la convención Tait-Bryan intrínseca ZYX. Esta sección agrupa la superficie SQL que expone esa interoperabilidad: E/S JSON para las clases de conformidad Basic del estándar, una función auxiliar de renormalización explícita para quienes ejecutan composiciones largas, y los accesores de ángulos de Euler que esperan los consumidores Basic-YPR.</para>
+
+			<sect3 xml:id="pose_geopose_io">
+				<title>Entrada y salida JSON</title>
+				<itemizedlist>
+					<listitem xml:id="pose_geopose_funcs">
+						<indexterm significance="normal"><primary><varname>asGeoPose</varname></primary></indexterm>
+						<indexterm significance="normal"><primary><varname>poseFromGeoPose</varname></primary></indexterm>
+						<para>Convertir hacia o desde la codificación JSON de OGC GeoPose v1.0 (clase de conformidad Basic-Quaternion o Basic-YPR)</para>
+						<para><varname>asGeoPose(pose,conformance int4=0,maxdecimaldigits int4=-1) → text</varname></para>
+						<para><varname>poseFromGeoPose(text) → pose</varname></para>
+						<para>El argumento <varname>conformance</varname> selecciona la clase de salida: <varname>0</varname> = Basic-Quaternion (predeterminado, sin pérdida), <varname>1</varname> = Basic-YPR (yaw, pitch, roll en grados, Tait-Bryan intrínseco ZYX). El argumento <varname>maxdecimaldigits</varname> es el número de dígitos significativos que se conservan en los números JSON; <varname>-1</varname> utiliza el valor predeterminado sin pérdida de json-c. La función de entrada detecta automáticamente la clase de conformidad a partir de las claves JSON (el miembro <varname>quaternion</varname> → Basic-Quaternion, el miembro <varname>angles</varname> → Basic-YPR). Las clases de conformidad Basic exigen un marco exterior geográfico; la implementación acepta el SRID 4326 (o 0, tratado como geográfico) y rechaza los SRID proyectados en el límite de la conversión.</para>
+						<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asGeoPose(pose 'Pose(Point(8 47 1500), 0.7071067811865476, 0, 0, 0.7071067811865475)', 0, 6);
+-- {"position":{"lat":47,"lon":8,"h":1500},"quaternion":{"x":0,"y":0,"z":0.707107,"w":0.707107}}
+SELECT asGeoPose(pose 'Pose(Point(8 47 1500), 0.7071067811865476, 0, 0, 0.7071067811865475)', 1, 6);
+-- {"position":{"lat":47,"lon":8,"h":1500},"angles":{"yaw":90,"pitch":0,"roll":0}}
+SELECT asEWKT(poseFromGeoPose(
+  '{"position":{"lat":47,"lon":8,"h":1500},"angles":{"yaw":90,"pitch":0,"roll":0}}'));
+-- Pose(POINT Z (8 47 1500),0.7071067811865476,0,0,0.7071067811865475)
+</programlisting>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3 xml:id="pose_geopose_normalize">
+				<title>Renormalización de cuaterniones</title>
+				<itemizedlist>
+					<listitem xml:id="pose_normalize">
+						<indexterm significance="normal"><primary><varname>poseNormalize</varname></primary></indexterm>
+						<para>Devuelve una pose cuyo cuaternión de orientación se ha llevado de nuevo a la norma unitaria. Una pose 2D se devuelve sin cambios, ya que su orientación es un único ángulo que no deriva. A una pose 3D se le divide el cuaternión por su norma euclidiana, de modo que composiciones largas de SLERP (o cualquier otra vía que acumule deriva de punto flotante en <varname>|q|</varname>) pueden restaurarse al invariante <varname>|q| = 1</varname> que requiere el código de SLERP y de descomposición de Euler.</para>
+						<para><varname>poseNormalize(pose) → pose</varname></para>
+						<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(poseNormalize(pose 'Pose(Point(1 1 1), 0.5, 0.5, 0.5, 0.5)'));
+-- Pose(POINT Z (1 1 1),0.5,0.5,0.5,0.5)
+</programlisting>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3 xml:id="pose_geopose_ypr">
+				<title>Accesores de ángulos de Euler</title>
+				<itemizedlist>
+					<listitem xml:id="pose_yaw_pitch_roll">
+						<indexterm significance="normal"><primary><varname>yaw</varname></primary></indexterm>
+						<indexterm significance="normal"><primary><varname>pitch</varname></primary></indexterm>
+						<indexterm significance="normal"><primary><varname>roll</varname></primary></indexterm>
+						<para>Devuelve el ángulo yaw, pitch o roll de una pose, en radianes, bajo la convención Tait-Bryan intrínseca ZYX que exige la clase de conformidad Basic-YPR de OGC GeoPose</para>
+						<para><varname>yaw(pose) → float</varname></para>
+						<para><varname>pitch(pose) → float</varname></para>
+						<para><varname>roll(pose) → float</varname></para>
+						<para>Para una pose 2D, <varname>yaw</varname> devuelve la rotación almacenada <varname>theta</varname> —por convención, el yaw del marco del cuerpo— y <varname>pitch</varname> y <varname>roll</varname> devuelven <varname>0</varname>. Para una pose 3D, los tres valores provienen de la descomposición Tait-Bryan intrínseca ZYX del cuaternión de orientación. El término de pitch <varname>asin</varname> se acota a <varname>[-1, 1]</varname> para absorber la pequeña deriva numérica que pueden introducir las composiciones largas de cuaterniones.</para>
+						<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT yaw(pose 'Pose(Point(1 1), 0.5)');
+-- 0.5
+SELECT pitch(pose 'Pose(Point(1 1), 0.5)');
+-- 0
+SELECT roll(pose 'Pose(Point(0 0 0), 0.7071067811865476, 0, 0, 0.7071067811865475)');
+-- 0
+SELECT yaw(pose 'Pose(Point(0 0 0), 0.7071067811865476, 0, 0, 0.7071067811865475)');
+-- 1.5707963267948966
+</programlisting>
+					</listitem>
+
+					<listitem xml:id="tpose_yaw_pitch_roll">
+						<indexterm significance="normal"><primary><varname>yaw</varname></primary></indexterm>
+						<indexterm significance="normal"><primary><varname>pitch</varname></primary></indexterm>
+						<indexterm significance="normal"><primary><varname>roll</varname></primary></indexterm>
+						<para>Eleva los accesores de ángulos de Euler a través de una pose temporal, devolviendo un flotante temporal (radianes) por cada instante bajo la convención Tait-Bryan intrínseca ZYX</para>
+						<para><varname>yaw(tpose) → tfloat</varname></para>
+						<para><varname>pitch(tpose) → tfloat</varname></para>
+						<para><varname>roll(tpose) → tfloat</varname></para>
+						<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(yaw(tpose '[Pose(Point(0 0), 0.0)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02]'));
+-- [0@2000-01-01, 0.5@2000-01-02]
+</programlisting>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3 xml:id="pose_geopose_frames">
+				<title>Registro de metadatos de marcos</title>
+				<para>El estándar OGC GeoPose v1.0 distingue el <emphasis>marco exterior</emphasis> (la referencia global, por ejemplo, WGS-84 geográfico o ECEF) del <emphasis>marco interior</emphasis> (el marco del cuerpo cuya orientación es el cuaternión de la pose). Las clases de conformidad Basic exigen WGS-84 geográfico como marco exterior y un marco interior implícito de ejes de cuerpo dextrógiros; la clase Advanced admite pilas de marcos con nombre.</para>
+				<para>En MobilityDB v1, el tipo <varname>pose</varname> codifica el marco exterior de forma implícita mediante su SRID y utiliza el marco interior convencional de ejes de cuerpo dextrógiros. La tabla <varname>geopose_frames</varname> documenta esta correspondencia y siembra un registro paralelo a la tabla <varname>pointcloud_formats</varname> de pgPointCloud, de modo que el soporte futuro de la clase Advanced solo necesite ampliar el catálogo en lugar de rediseñarlo.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT frame_id, authority, code, name, is_geographic
+FROM geopose_frames ORDER BY frame_id;
+-- 1 | EPSG | 4326 | WGS-84 geographic (lat/lon/h)                | t
+-- 2 | EPSG | 4978 | WGS-84 ECEF (Earth-Centred Earth-Fixed)      | f
+-- 3 | OGC  | LTP  | Local Tangent Plane (East-North-Up)          | f
+-- 4 | OGC  | BODY | Right-handed body axes (default inner frame) | f
+</programlisting>
+				<para>Tres funciones auxiliares SQL proporcionan una interfaz de consulta estable para el código que no quiere codificar de forma rígida la disposición de la tabla:</para>
+				<itemizedlist>
+					<listitem><para><varname>geopose_frame_srid(int) → int</varname> — el SRID de PostGIS de un marco, o <varname>NULL</varname> si el marco es paramétrico (LTP, BODY).</para></listitem>
+					<listitem><para><varname>geopose_frame_name(int) → text</varname> — el nombre legible del marco.</para></listitem>
+					<listitem><para><varname>geopose_frame_is_geographic(int) → boolean</varname> — <varname>true</varname> para los marcos lat/lon/h, <varname>false</varname> para los cartesianos o proyectados.</para></listitem>
+				</itemizedlist>
+				<para>Los usuarios pueden registrar marcos personalizados insertándolos en <varname>geopose_frames</varname>; el catálogo está marcado como una tabla de configuración, por lo que <varname>pg_dump</varname> preserva las filas del usuario.</para>
+			</sect3>
+
+			<sect3 xml:id="pose_geopose_apply">
+				<title>Transformación rígida cuerpo↔mundo</title>
+				<para>La función <varname>applyPose</varname> aplica la transformación de cuerpo rígido codificada por una pose (la correspondencia <emphasis>cuerpo→mundo</emphasis> de OGC GeoPose) a una geometría en el marco del cuerpo, produciendo la geometría correspondiente en el marco del mundo. La transformación es</para>
+				<programlisting xml:space="preserve" format="linespecific">
+world = R(q) · body + p
+</programlisting>
+				<para>donde <varname>(p, q)</varname> son la posición y la orientación de la pose. La forma estática toma una única pose y una geometría estática; la forma temporal eleva la transformación rígida por instante de una <varname>tpose</varname> a lo largo de sus instantes, produciendo una trayectoria <varname>tgeompoint</varname> en el marco del mundo de la geometría del cuerpo. La versión v1 admite geometrías de cuerpo de tipo punto y multipunto; las líneas y los polígonos quedan aplazados. La interpolación lineal de la trayectoria resultante es la cuerda de cada segmento, que aproxima la verdadera trayectoria de cuerpo rígido (un arco circular bajo SLERP), la misma concesión que MobilityDB ya adopta para las trayectorias espaciales.</para>
+				<para><varname>applyPose(geometry, pose) → geometry</varname></para>
+				<para><varname>applyPose(geometry, tpose) → tgeompoint</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- A body sensor offset 1 unit along the body X axis, traced through a
+-- tpose that ends 90 degrees yawed and translated to (10, 20).
+SELECT asText(applyPose(ST_Point(1,0),
+  tpose '[Pose(Point(0 0), 0)@2026-01-01,
+          Pose(Point(10 20), 1.5707963267948966)@2026-01-02]'));
+-- [POINT(1 0)@2026-01-01, POINT(10 21)@2026-01-02]
+</programlisting>
+			</sect3>
+
+			<sect3 xml:id="pose_geopose_transform">
+				<title>Transformaciones de marco entre SRID</title>
+				<para>La función <varname>transform(pose, srid)</varname> lleva los valores de pose de un SRID a otro. El flujo de trabajo n.º 6 del plan de GeoPose temporal amplía el comportamiento preexistente de <emphasis>solo posición</emphasis> con la corrección de orientación necesaria cuando el marco de origen y el de destino tienen bases distintas en el punto de la pose. La versión v1 implementa el caso canónico de OGC GeoPose —WGS-84 geográfico (EPSG:4326) ↔ WGS-84 ECEF (EPSG:4978)— utilizando la base estándar Este-Norte-Arriba en el punto geográfico como pivote de rotación. Para los pares de SRID cuya corrección de orientación aún no está definida, <varname>transform</varname> emite un <varname>NOTICE</varname> y deja pasar la orientación sin cambios.</para>
+				<para>Un viaje de ida y vuelta a través de ECEF y de regreso aterriza exactamente en la pose de entrada:</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asEWKT(round(
+  transform(transform(pose 'SRID=4326;Pose(Point(8 47 0), 1, 0, 0, 0)', 4978),
+            4326), 6));
+-- SRID=4326;Pose(POINT Z (8 47 0),1,0,0,0)
+
+-- At the equator-meridian (lat=lon=0), the body identity quaternion in
+-- the ECEF basis becomes the canonical ENU->ECEF rotation:
+SELECT asEWKT(round(
+  transform(pose 'SRID=4326;Pose(Point(0 0 0), 1, 0, 0, 0)', 4978), 6));
+-- SRID=4978;Pose(POINT Z (6378137 0 0),0.5,-0.5,-0.5,-0.5)
+</programlisting>
+				<para>La implementación también corrige un error preexistente de solo posición en el que <varname>transform</varname> no actualizaba el campo SRID del resultado, de modo que la pose devuelta ahora lleva el SRID de destino como se espera.</para>
+			</sect3>
+
+			<sect3 xml:id="pose_geopose_temporal_io">
+				<title>E/S JSON temporal</title>
+				<itemizedlist>
+					<listitem xml:id="tpose_geopose_funcs">
+						<indexterm significance="normal"><primary><varname>asGeoPose</varname></primary></indexterm>
+						<indexterm significance="normal"><primary><varname>tposeFromGeoPose</varname></primary></indexterm>
+						<para>Convierte una pose temporal hacia o desde una envoltura JSON TemporalGeoPose. Cada carga útil por instante es un documento GeoPose de clase Basic estrictamente válido según OGC más un miembro <varname>validTime</varname>; la envoltura registra la clase de conformidad, la interpolación y (para secuencias y conjuntos de secuencias) la inclusión de los límites del período. Un consumidor GeoPose ajeno a MEOS puede iterar sobre <varname>instants[]</varname> (o cada <varname>sequences[].instants[]</varname>) y consumir cada elemento como un documento GeoPose estático.</para>
+						<para><varname>asGeoPose(tpose,conformance int4=0,maxdecimaldigits int4=-1) → text</varname></para>
+						<para><varname>tposeFromGeoPose(text) → tpose</varname></para>
+						<para>La forma de la envoltura es</para>
+						<programlisting xml:space="preserve" format="linespecific">
+{
+  "type":          "TemporalGeoPose",
+  "version":       "1.0",
+  "conformance":   "Basic-Quaternion" | "Basic-YPR",
+  "interpolation": "None" | "Discrete" | "Step" | "Linear",
+  "instants":      [...]                  // for TInstant + TSequence
+  "lower_inc":     true|false,            // for TSequence only
+  "upper_inc":     true|false,            // for TSequence only
+  "sequences":     [{...}, ...]           // for TSequenceSet only
+}
+</programlisting>
+						<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asGeoPose(tpose '[Pose(Point(8 47), 0)@2026-01-01,
+                         Pose(Point(9 48), 0.5)@2026-01-02]',
+                 1, 4);
+-- {"type":"TemporalGeoPose","version":"1.0","conformance":"Basic-YPR",
+--  "interpolation":"Linear","lower_inc":true,"upper_inc":true,
+--  "instants":[
+--    {"position":{"lat":47,"lon":8,"h":0},
+--     "angles":{"yaw":0,"pitch":0,"roll":0},
+--     "validTime":"2026-01-01 00:00:00+01"},
+--    {"position":{"lat":48,"lon":9,"h":0},
+--     "angles":{"yaw":28.65,"pitch":0,"roll":0},
+--     "validTime":"2026-01-02 00:00:00+01"}]}
+</programlisting>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3 xml:id="pose_geopose_speed">
+				<title>Velocidad y velocidad angular</title>
+				<itemizedlist>
+					<listitem xml:id="tpose_speed">
+						<indexterm significance="normal"><primary><varname>speed</varname></primary></indexterm>
+						<para>Devuelve la velocidad de una pose temporal como un flotante temporal: la magnitud de la velocidad de la componente de posición (distancia recorrida por unidad de tiempo). La orientación no forma parte de este escalar; para la velocidad angular véase <varname>angularSpeed</varname>.</para>
+						<para><varname>speed(tpose) → tfloat</varname></para>
+						<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(speed(tpose '[Pose(Point(0 0), 0)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02]'));
+-- Interp=Step;[1.6368e-5@2000-01-01, 1.6368e-5@2000-01-02]
+-- (sqrt(2) units / 86400 seconds — units depend on the SRID's CRS)
+</programlisting>
+					</listitem>
+
+					<listitem xml:id="tpose_angular_speed">
+						<indexterm significance="normal"><primary><varname>angularSpeed</varname></primary></indexterm>
+						<para>Devuelve la velocidad angular de una pose temporal como un flotante temporal con interpolación por pasos (radianes por unidad de tiempo). Para las poses 2D es el delta theta del arco más corto por segmento dividido por la duración del segmento; para las poses 3D es el ángulo de arco de SLERP <varname>2 · acos(|q1 · q2|)</varname> dividido por la duración del segmento. SLERP tiene por construcción velocidad angular constante a lo largo de un segmento, por lo que el resultado es constante a trozos.</para>
+						<para><varname>angularSpeed(tpose) → tfloat</varname></para>
+						<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- 90-degree yaw rotation over one day -> pi/2 rad / 86400 s
+SELECT asText(angularSpeed(tpose
+  '[Pose(Point(0 0 0), 1, 0, 0, 0)@2000-01-01,
+    Pose(Point(0 0 0), 0.7071067811865476, 0, 0, 0.7071067811865475)@2000-01-02]'));
+-- Interp=Step;[1.8181e-5@2000-01-01, 1.8181e-5@2000-01-02]
+</programlisting>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+		</sect2>
+
 	</sect1>
 
 	<sect1 xml:id="temp_poses">
@@ -636,6 +847,17 @@ SELECT asText((tpose '[Pose(Point(1 1), 0.2)@2001-01-01,
 SELECT asEWKT((tpose '[Pose(Point Z(1 1 1), 0.5, 0.5, 0.5, 0.5)@2001-01-01,
   Pose(Point Z(2 2 2), 1, 0, 0, 0)@2001-01-02)')::tgeompoint);
 -- [POINT Z (1 1 1)@2001-01-01, POINT Z (2 2 2)@2001-01-02)
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="tpose_tgeogpoint">
+				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
+				<para>Convertir una pose temporal geodésica en un punto geográfico temporal</para>
+				<para><varname>tpose::tgeogpoint</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText((tpose '[GeodPose(Point(1 1), 0.2)@2001-01-01,
+  GeodPose(Point(1 1), 0.3)@2001-01-02)')::tgeogpoint);
+-- [POINT(1 1)@2001-01-01, POINT(1 1)@2001-01-02)
 </programlisting>
 			</listitem>
 		</itemizedlist>


### PR DESCRIPTION
The Spanish circular-buffer chapter (`doc/es/temporal_circular_buffers.xml`) lagged the English one: it lacked the `centroid` and `convexHull` spatial functions, the `minDistance` operator, the `atStbox` restriction, and the whole Simplification section (`minDistSimplify`, `douglasPeuckerSimplify`) — 7 anchors.

This translates them, bringing the Spanish chapter to anchor parity with the English one. With every circular-buffer anchor now present in Spanish, it also adds the Temporal Circular Buffers section to the Spanish reference index (`doc/es/reference.xml`).

Every `linkend` resolves to an existing anchor and the Spanish manual builds cleanly.