### PR TITLE
Use xml:id for section anchors in the Spanish box and set/span chapters

### DIFF
--- a/doc/es/box_types.xml
+++ b/doc/es/box_types.xml
@@ -438,7 +438,7 @@ SELECT perimeter(stbox 'GEODSTBOX XT(((1,1),(3,3)),[2001-01-01,2001-01-03))', fa
 		</itemizedlist>
 	</sect1>
 
-	<sect1 id ="box_transformations">
+	<sect1 xml:id="box_transformations">
 		<title>Transformaciones</title>
 
 		<itemizedlist>
@@ -565,7 +565,7 @@ SELECT round(tstzspan '[2000-01-01, 2001-01-02]'::tbox);
 			</itemizedlist>
 		</sect1>
 
-	<sect1 id ="box_srid">
+	<sect1 xml:id="box_srid">
 		<title>Sistema de referencia espacial</title>
 
 		<itemizedlist>
@@ -616,7 +616,7 @@ FROM test;
 		</itemizedlist>
 	</sect1>
 
-	<sect1 id ="box_splitting">
+	<sect1 xml:id="box_splitting">
 		<title>Operaciones de división</title>
 
 		<itemizedlist>
@@ -921,7 +921,7 @@ SELECT tbox 'TBOXFLOAT XT([1,1],[2001-01-01,2001-01-04])' &gt;=
 		</itemizedlist>
 	</sect1>
 
-	<sect1 id ="box_aggregations">
+	<sect1 xml:id="box_aggregations">
 		<title>Aggregaciones</title>
 
 		<itemizedlist>
@@ -947,7 +947,7 @@ SELECT extent(b) FROM boxes;
 		</itemizedlist>
 	</sect1>
 
-	<sect1 id ="box_indexing">
+	<sect1 xml:id="box_indexing">
 		<title>Indexación</title>
 		<para>Se pueden crear índices GiST y SP-GiST para columnas de tablas de los tipos <varname>tbox</varname> y <varname>stbox</varname>. El índice GiST implementa un árbol R, mientras que el índice SP-GiST implementa un árbol cuádruple n-dimensiónal. Un ejemplo de creación de un índice GiST en una columna <varname>Box</varname> de tipo <varname>stbox</varname> en una tabla <varname>Trips</varname> es el siguiente:
 			<programlisting language="sql" xml:space="preserve">

--- a/doc/es/set_span_types.xml
+++ b/doc/es/set_span_types.xml
@@ -912,7 +912,7 @@ SELECT tprecision(tstzspanset '{[2001-12-01 08:00, 2001-12-01 09:00],
 		</itemizedlist>
 	</sect1>
 
-	<sect1 id ="spatialset_spatial_srid">
+	<sect1 xml:id="spatialset_spatial_srid">
 		<title>Sistema de referencia espacial</title>
 
 		<itemizedlist>
@@ -1389,7 +1389,7 @@ SELECT tCount(ps) FROM periods;
 		</itemizedlist>
 	</sect1>
 
-	<sect1 id ="setspan_indexing">
+	<sect1 xml:id="setspan_indexing">
 		<title>Indexación</title>
 
 		<para>Se pueden crear índices GiST y SP-GiST en columnas de tablas de los tipos de conjunto y de rango. El índice GiST implementa un árbol R, mientras que el índice SP-GiST implementa un árbol cuádruple. Un ejemplo de creación de un índice GiST en una columna <varname>During</varname> de tipo <varname>tstzspan</varname> en una tabla <varname>Reservation</varname> es como sigue:


### PR DESCRIPTION
Seven section anchors in the Spanish manual used the DocBook 4 `id` attribute (written `id =` with a stray space) instead of the `xml:id` used throughout the rest of the manual. Because cross-references resolve by `xml:id`, the `<xref linkend="setspan_indexing"/>` in the set/span distance section pointed at an unresolvable target, and the five box-type section anchors were unaddressable.

This converts all seven to `xml:id` (`doc/es/box_types.xml`: box_transformations, box_srid, box_splitting, box_aggregations, box_indexing; `doc/es/set_span_types.xml`: spatialset_spatial_srid, setspan_indexing), matching the English chapters. The Spanish manual now builds with no broken cross-references.