### PR TITLE
Include tjsonb in the temporal alphanumeric type predicate

### DIFF
--- a/meos/src/temporal/meos_catalog.c
+++ b/meos/src/temporal/meos_catalog.c
@@ -1185,11 +1185,7 @@ inline bool
 talphanum_type(MeosType type)
 {
   return (type == T_TBOOL || type == T_TFLOAT || type == T_TINT ||
-    type == T_TTEXT || type == T_TBIGINT
-// #if JSON
-    // || type == T_TJSONB
-// #endif
-    );
+    type == T_TTEXT || type == T_TJSONB || type == T_TBIGINT);
 }
 
 /**


### PR DESCRIPTION
`talphanum_type` identifies the temporal alphanumeric types — the union of `talpha_type` and `tnumber_type`. `talpha_type` accepts `tjsonb` (a temporal JSONB value is a temporal alphanumeric type), and the assert-only sibling `alphanum_temptype` lists exactly `tbool, tfloat, tint, ttext, tjsonb, tbigint`. But `talphanum_type` left its `tjsonb` term commented out, so it returned `false` for `T_TJSONB`, disagreeing with both siblings.

This adds the term at its enum-value position, making `talphanum_type` agree with `talpha_type` and `alphanum_temptype`.

Behaviour: its only caller — `assert(talphanum_type(restype))` in `tjsonb_to_talphanum` — passes the extracted scalar result type (boolean, numeric, or string), never `T_TJSONB`, so no existing call path changes; the fix only corrects the predicate's answer for `T_TJSONB` itself (these catalog predicates are part of the public API).