### PR TITLE
Document the averageHausdorffDistance and lcssDistance functions

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1332,7 +1332,7 @@
 				</listitem>
 
 				<listitem>
-					<para><link linkend="ttype_similarityPath"><varname>frechetDistancePath</varname>, <varname>dynTimeWarpDistance</varname></link>: Devuelve las parejas de correspondencia entre dos valores temporales con respecto a la distancia de Fréchet discreta o a la distancia de distorsión de tiempo dinámica (Dynamic Time Warp)</para>
+					<para><link linkend="ttype_similarityPath"><varname>frechetDistancePath</varname>, <varname>dynTimeWarpPath</varname></link>: Devuelve las parejas de correspondencia entre dos valores temporales con respecto a la distancia de Fréchet discreta o a la distancia de distorsión de tiempo dinámica (Dynamic Time Warp)</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1328,7 +1328,7 @@
 
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="ttype_similarityDistance"><varname>hausdorffDistance</varname>, <varname>frechetDistance</varname>, <varname>dynTimeWarpDistance</varname></link>: Devuelve la distancia de Hausdorff discreta, la distancia de Fréchet discreta o la distancia de distorsión de tiempo dinámica (Dynamic Time Warp) entre dos valores temporales</para>
+					<para><link linkend="ttype_similarityDistance"><varname>hausdorffDistance</varname>, <varname>frechetDistance</varname>, <varname>dynTimeWarpDistance</varname>, <varname>averageHausdorffDistance</varname>, <varname>lcssDistance</varname></link>: Devuelve la distancia de Hausdorff discreta, la distancia de Fréchet discreta, la distancia de distorsión de tiempo dinámica (Dynamic Time Warp), la distancia de Hausdorff promedio o la distancia de subsecuencia común más larga (Longest Common SubSequence o LCSS) entre dos valores temporales</para>
 				</listitem>
 
 				<listitem>

--- a/doc/es/temporal_types_analytics.xml
+++ b/doc/es/temporal_types_analytics.xml
@@ -188,10 +188,15 @@ SELECT asText(tprecision(tgeompoint '[Point(1 1)@2001-01-01, Point(5 5)@2001-01-
 				<indexterm significance="normal"><primary><varname>hausdorffDistance</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>frechetDistance</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>dynTimeWarpDistance</varname></primary></indexterm>
-				<para>Devuelve la <ulink url="https://en.wikipedia.org/wiki/Hausdorff_distance">distancia de Hausdorff</ulink> discreta, la <ulink url="https://en.wikipedia.org/wiki/Fr%C3%A9chet_distance">distancia de Fréchet</ulink> discreta, o la distancia de distorsión de tiempo dinámica (<ulink url="https://en.wikipedia.org/wiki/Dynamic_time_warping">Dynamic Time Warp</ulink> o DTW) entre dos valores temporales &Z_support; &geography_support;</para>
+				<indexterm significance="normal"><primary><varname>averageHausdorffDistance</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>lcssDistance</varname></primary></indexterm>
+				<para>Devuelve la <ulink url="https://en.wikipedia.org/wiki/Hausdorff_distance">distancia de Hausdorff</ulink> discreta, la <ulink url="https://en.wikipedia.org/wiki/Fr%C3%A9chet_distance">distancia de Fréchet</ulink> discreta, la distancia de distorsión de tiempo dinámica (<ulink url="https://en.wikipedia.org/wiki/Dynamic_time_warping">Dynamic Time Warp</ulink> o DTW), la distancia de Hausdorff promedio, o la distancia de <ulink url="https://en.wikipedia.org/wiki/Longest_common_subsequence">subsecuencia común más larga</ulink> (Longest Common SubSequence o LCSS) entre dos valores temporales &Z_support; &geography_support;</para>
 				<para><varname>hausdorffDistance({tnumber, tgeo}, {tnumber, tgeo}) → float</varname></para>
 				<para><varname>frechetDistance({tnumber, tgeo}, {tnumber, tgeo}) → float</varname></para>
 				<para><varname>dynTimeWarpDistance({tnumber, tgeo}, {tnumber, tgeo}) → float</varname></para>
+				<para><varname>averageHausdorffDistance({tnumber, tgeo}, {tnumber, tgeo}) → float</varname></para>
+				<para><varname>lcssDistance({tnumber, tgeo}, {tnumber, tgeo}, float) → float</varname></para>
+				<para>La función <varname>lcssDistance</varname> requiere un parámetro adicional que especifica el umbral de distancia por debajo del cual dos valores se consideran coincidentes.</para>
 				<para>Estas funciones tienen una complejidad de espacio lineal ya que solo dos filas de la matriz de distancia son asignadas en la memoria. Sin embargo, su complejidad de tiempo es cuadrática en el número de instantes de los valores temporales. Por lo tanto, las funciones requerien un tiempo considerable para valores temporales con gran número de instantes.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT hausdorffDistance(tfloat '[1@2001-01-01, 3@2001-01-03, 1@2001-01-06]',
@@ -222,6 +227,26 @@ SELECT round(dynTimeWarpDistance(tgeompoint '[Point(1 1)@2001-01-01,
   tgeompoint '[Point(1.1 1.1)@2001-01-01, Point(2.5 2.5)@2001-01-02,
   Point(4 4)@2001-01-03, Point(3 3)@2001-01-04, Point(1.5 2)@2001-01-05]')::numeric, 6);
 -- 3.380776
+</programlisting>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT round(averageHausdorffDistance(tfloat '[1@2001-01-01, 3@2001-01-03, 1@2001-01-06]',
+ tfloat '[1@2001-01-01, 1.5@2001-01-02, 2.5@2001-01-03, 1.5@2001-01-04, 1.5@2001-01-05]')::numeric, 6);
+-- 0.283333
+SELECT round(averageHausdorffDistance(tgeompoint '[Point(1 1)@2001-01-01, Point(3 3)@2001-01-03,
+  Point(1 1)@2001-01-05]', tgeompoint '[Point(1.1 1.1)@2001-01-01,
+  Point(2.5 2.5)@2001-01-02, Point(4 4)@2001-01-03, Point(3 3)@2001-01-04,
+  Point(1.5 2)@2001-01-05]')::numeric, 6);
+-- 0.385218
+</programlisting>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT lcssDistance(tfloat '[1@2001-01-01, 3@2001-01-03, 1@2001-01-06]',
+ tfloat '[1@2001-01-01, 1.5@2001-01-02, 2.5@2001-01-03, 1.5@2001-01-04, 1.5@2001-01-05]', 1.0);
+-- 3
+SELECT round(lcssDistance(tgeompoint '[Point(1 1)@2001-01-01, Point(3 3)@2001-01-03,
+  Point(1 1)@2001-01-05]', tgeompoint '[Point(1.1 1.1)@2001-01-01,
+  Point(2.5 2.5)@2001-01-02, Point(4 4)@2001-01-03, Point(3 3)@2001-01-04,
+  Point(1.5 2)@2001-01-05]', 1.0)::numeric, 6);
+-- 2.000000
 </programlisting>
 			</listitem>
 

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1308,7 +1308,7 @@
 
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="ttype_similarityDistance"><varname>hausdorffDistance</varname>, <varname>frechetDistance</varname>, <varname>dynTimeWarpDistance</varname></link>: Return the discrete Hausdorff distance, the discrete Fréchet distance, or the Dynamic Time Warp distance between two temporal values</para>
+					<para><link linkend="ttype_similarityDistance"><varname>hausdorffDistance</varname>, <varname>frechetDistance</varname>, <varname>dynTimeWarpDistance</varname>, <varname>averageHausdorffDistance</varname>, <varname>lcssDistance</varname></link>: Return the discrete Hausdorff distance, the discrete Fréchet distance, the Dynamic Time Warp distance, the average Hausdorff distance, or the Longest Common SubSequence (LCSS) distance between two temporal values</para>
 				</listitem>
 
 				<listitem>

--- a/doc/temporal_types_analytics.xml
+++ b/doc/temporal_types_analytics.xml
@@ -189,11 +189,16 @@ SELECT asText(tprecision(tgeompoint '[Point(1 1)@2001-01-01, Point(5 5)@2001-01-
 				<indexterm significance="normal"><primary><varname>hausdorffDistance</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>frechetDistance</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>dynTimeWarpDistance</varname></primary></indexterm>
-				<para>Return the discrete <ulink url="https://en.wikipedia.org/wiki/Hausdorff_distance">Hausdorff distance</ulink>, the discrete <ulink url="https://en.wikipedia.org/wiki/Fr%C3%A9chet_distance">Fréchet distance</ulink>, or the <ulink url="https://en.wikipedia.org/wiki/Dynamic_time_warping">Dynamic Time Warp</ulink> (DTW) distance between two temporal values &Z_support; &geography_support;
+				<indexterm significance="normal"><primary><varname>averageHausdorffDistance</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>lcssDistance</varname></primary></indexterm>
+				<para>Return the discrete <ulink url="https://en.wikipedia.org/wiki/Hausdorff_distance">Hausdorff distance</ulink>, the discrete <ulink url="https://en.wikipedia.org/wiki/Fr%C3%A9chet_distance">Fréchet distance</ulink>, the <ulink url="https://en.wikipedia.org/wiki/Dynamic_time_warping">Dynamic Time Warp</ulink> (DTW) distance, the average Hausdorff distance, or the <ulink url="https://en.wikipedia.org/wiki/Longest_common_subsequence">Longest Common SubSequence</ulink> (LCSS) distance between two temporal values &Z_support; &geography_support;
 </para>
 				<para><varname>hausdorffDistance({tnumber, tgeo}, {tnumber, tgeo}) → float</varname></para>
 				<para><varname>frechetDistance({tnumber, tgeo}, {tnumber, tgeo}) → float</varname></para>
 				<para><varname>dynTimeWarpDistance({tnumber, tgeo}, {tnumber, tgeo}) → float</varname></para>
+				<para><varname>averageHausdorffDistance({tnumber, tgeo}, {tnumber, tgeo}) → float</varname></para>
+				<para><varname>lcssDistance({tnumber, tgeo}, {tnumber, tgeo}, float) → float</varname></para>
+				<para>The <varname>lcssDistance</varname> function requires an additional parameter that specifies the distance threshold under which two values are considered to match.</para>
 				<para>These functions have a linear space complexity since only two rows of the distance matrix are allocated in memory. Nevertheless, their time complexity is quadratic in the number of instants of the temporal values. Therefore, the functions require considerable time for temporal values with large number of instants.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT hausdorffDistance(tfloat '[1@2001-01-01, 3@2001-01-03, 1@2001-01-06]',
@@ -224,6 +229,26 @@ SELECT round(dynTimeWarpDistance(tgeompoint '[Point(1 1)@2001-01-01,
   tgeompoint '[Point(1.1 1.1)@2001-01-01, Point(2.5 2.5)@2001-01-02,
   Point(4 4)@2001-01-03, Point(3 3)@2001-01-04, Point(1.5 2)@2001-01-05]')::numeric, 6);
 -- 3.380776
+</programlisting>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT round(averageHausdorffDistance(tfloat '[1@2001-01-01, 3@2001-01-03, 1@2001-01-06]',
+ tfloat '[1@2001-01-01, 1.5@2001-01-02, 2.5@2001-01-03, 1.5@2001-01-04, 1.5@2001-01-05]')::numeric, 6);
+-- 0.283333
+SELECT round(averageHausdorffDistance(tgeompoint '[Point(1 1)@2001-01-01, Point(3 3)@2001-01-03,
+  Point(1 1)@2001-01-05]', tgeompoint '[Point(1.1 1.1)@2001-01-01,
+  Point(2.5 2.5)@2001-01-02, Point(4 4)@2001-01-03, Point(3 3)@2001-01-04,
+  Point(1.5 2)@2001-01-05]')::numeric, 6);
+-- 0.385218
+</programlisting>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT lcssDistance(tfloat '[1@2001-01-01, 3@2001-01-03, 1@2001-01-06]',
+ tfloat '[1@2001-01-01, 1.5@2001-01-02, 2.5@2001-01-03, 1.5@2001-01-04, 1.5@2001-01-05]', 1.0);
+-- 3
+SELECT round(lcssDistance(tgeompoint '[Point(1 1)@2001-01-01, Point(3 3)@2001-01-03,
+  Point(1 1)@2001-01-05]', tgeompoint '[Point(1.1 1.1)@2001-01-01,
+  Point(2.5 2.5)@2001-01-02, Point(4 4)@2001-01-03, Point(3 3)@2001-01-04,
+  Point(1.5 2)@2001-01-05]', 1.0)::numeric, 6);
+-- 2.000000
 </programlisting>
 			</listitem>
 


### PR DESCRIPTION
The `averageHausdorffDistance` and `lcssDistance` similarity functions were added to the code, SQL and tests but were not documented in the manual. This adds them to the Similarity section, in both the English and Spanish manuals:

- Chapter (`doc/temporal_types_analytics.xml` + `doc/es/temporal_types_analytics.xml`): indexterms, signatures, and worked examples in the `ttype_similarityDistance` list. The examples reuse the same input values as the existing `hausdorffDistance`/`frechetDistance`/`dynTimeWarpDistance` examples so the results can be compared directly. The `lcssDistance` signature documents its additional distance-threshold parameter.
- Reference summary (`doc/reference.xml` + `doc/es/reference.xml`): both functions added to the similarity-distance entry.

The example outputs were produced by running the functions against a build of the current `master`.

A second commit corrects a pre-existing mismatch in the Spanish reference, where the similarity-path entry linked `dynTimeWarpDistance` instead of `dynTimeWarpPath` (the English manual is correct).

Both manuals build cleanly (`xmllint`, HTML via `xsltproc`, and PDF via `dblatex`) with no broken cross-references.