### PR TITLE
Add the atElevation summary entry to the English reference chapter

### DIFF
--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1187,6 +1187,9 @@
 				<listitem>
 					<para><link linkend="tgeo_atStbox"><varname>atStbox</varname>, <varname>minusStbox</varname></link>: Restrict to (the complement of) an <varname>stbox</varname></para>
 				</listitem>
+				<listitem>
+					<para><link linkend="tgeo_atElevation"><varname>atElevation</varname>, <varname>minusElevation</varname></link>: Restrict to (the complement of) an elevation range</para>
+				</listitem>
 			</itemizedlist>
 		</sect2>
 


### PR DESCRIPTION
## Summary

The `atElevation` / `minusElevation` functions are documented in the temporal spatial chapter (`temporal_spatial_p2.xml`, id `tgeo_atElevation`) and listed in the Spanish reference, but the English reference "Restrictions" summary omitted them. This adds the missing entry, right after `atStbox`, mirroring the chapter order.

Display-text summary entry only; it links to the existing `tgeo_atElevation` id. The manual builds cleanly (well-formed, no broken cross-references).