### PR TITLE
Declare the previous-instant pointers as const in the nearest-approach kernel

### DIFF
--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -470,7 +470,7 @@ nad_tpointseq_tpointseq_sync(const TSequence *seq1, const TSequence *seq2,
   MeosType temptype = seq1->temptype;
   TInstant *inst1 = (TInstant *) TSEQUENCE_INST_N(seq1, 0);
   TInstant *inst2 = (TInstant *) TSEQUENCE_INST_N(seq2, 0);
-  TInstant *prev1 = NULL, *prev2 = NULL; /* make compiler quiet */
+  const TInstant *prev1 = NULL, *prev2 = NULL; /* make compiler quiet */
   TimestampTz lower = DatumGetTimestampTz(inter->lower);
   TimestampTz upper = DatumGetTimestampTz(inter->upper);
   int i = 0, j = 0, ninsts = 0, nfree = 0;


### PR DESCRIPTION
## Summary

The `prev1` and `prev2` pointers in `nad_tpointseq_tpointseq_sync` (`meos/src/geo/tgeo_distance.c`) only read their pointee — the previous synchronized instants — so they should be declared as pointers to const. This silences the cppcheck `constVariablePointer` finding reported by code scanning on the current master and mirrors how the surrounding kernel already uses `const TInstant *`.

Behavior-neutral; the full build passes with all families and the pg_regress suite matches the baseline.