### PR TITLE
Add spatial index support to eDwithin and eIntersects for temporal rigid geometries

### DIFF
--- a/mobilitydb/sql/rgeo/150_trgeo.in.sql
+++ b/mobilitydb/sql/rgeo/150_trgeo.in.sql
@@ -230,6 +230,11 @@ CREATE FUNCTION stbox(trgeometry)
 
 CREATE CAST (trgeometry AS stbox) WITH FUNCTION stbox(trgeometry);
 
+CREATE FUNCTION expandSpace(trgeometry, float)
+  RETURNS stbox
+  AS 'SELECT @extschema@.expandSpace($1::stbox, $2)'
+  LANGUAGE SQL IMMUTABLE PARALLEL SAFE STRICT;
+
 CREATE FUNCTION geometry(trgeometry)
   RETURNS geometry
   AS 'MODULE_PATHNAME', 'Trgeometry_to_geom'

--- a/mobilitydb/sql/rgeo/154_trgeo_spatialrels.in.sql
+++ b/mobilitydb/sql/rgeo/154_trgeo_spatialrels.in.sql
@@ -138,14 +138,17 @@ CREATE FUNCTION aDisjoint(trgeometry, trgeometry)
 CREATE FUNCTION eIntersects(geometry, trgeometry)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Eintersects_geo_trgeometry'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION eIntersects(trgeometry, geometry)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Eintersects_trgeometry_geo'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION eIntersects(trgeometry, trgeometry)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Eintersects_trgeometry_trgeometry'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************/
@@ -202,14 +205,17 @@ CREATE FUNCTION aTouches(trgeometry, trgeometry)
 CREATE FUNCTION eDwithin(geometry, trgeometry, dist float)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Edwithin_geo_trgeometry'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION eDwithin(trgeometry, geometry, dist float)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Edwithin_trgeometry_geo'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION eDwithin(trgeometry, trgeometry, dist float)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Edwithin_trgeometry_trgeometry'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************/

--- a/mobilitydb/src/temporal/temporal_supportfn.c
+++ b/mobilitydb/src/temporal/temporal_supportfn.c
@@ -241,6 +241,9 @@ makeExpandExpr(Node *arg, Node *radiusarg, Oid argoid, Oid retoid,
 #if POSE
       || argtype == T_TPOSE
 #endif /* POSE */
+#if RGEO
+      || argtype == T_TRGEOMETRY
+#endif /* RGEO */
       )
     funcname = "expandspace";
   else
@@ -288,6 +291,9 @@ makeBboxExpr(Node *arg, Oid argoid, Oid retoid, Oid callingfunc)
 #if POSE
       || argtype == T_TPOSE
 #endif /* POSE */
+#if RGEO
+      || argtype == T_TRGEOMETRY
+#endif /* RGEO */
       )
     funcname = "stbox";
   else
@@ -501,6 +507,9 @@ Temporal_supportfn(FunctionCallInfo fcinfo, TemporalFamily tempfamily)
 #if POSE
           || righttype == T_TPOSE
 #endif /* POSE */
+#if RGEO
+          || righttype == T_TRGEOMETRY
+#endif /* RGEO */
           )
         exproid = meostype_oid(T_STBOX);
       else


### PR DESCRIPTION
The ever spatial relationships `eIntersects` and `eDwithin` on temporal rigid geometries were already defined as C functions but did not attach the planner support function `tspatial_supportfn`. As a result these predicates could not use the spatial index and fell back to a sequential scan (or a nested loop over all pairs), unlike the same predicates on temporal geometries and temporal circular buffers.

This attaches the `SUPPORT tspatial_supportfn` clause to the six `eIntersects`/`eDwithin` functions, adds the missing `expandSpace(trgeometry, float)` function used by the rewrite, and adds `T_TRGEOMETRY` to the three type checks in the support function so the bounding-box index expression is built for temporal rigid geometries.

With a GiST or SP-GiST index on the temporal rigid geometry column, the planner now rewrites the predicates to a bounding-box index condition, keeping the exact predicate as a recheck filter:

```
eDwithin(trgeometry, geometry)    ->  Index Cond: (temp && expandspace(geom, dist))
eDwithin(trgeometry, trgeometry)  ->  Index Cond: (temp && expandspace(t1.temp, dist))
eIntersects(trgeometry, geometry) ->  Index Cond: (temp && stbox(geom))
```

The local regression suite passes with no output differences against master.
