### PR TITLE
Use the native geometry clip for tIntersects and tDisjoint on temporal points

### DIFF
--- a/meos/include/meos_internal_geo.h
+++ b/meos/include/meos_internal_geo.h
@@ -224,6 +224,11 @@ extern Temporal *tgeoseq_restrict_stbox(const TSequence *seq, const STBox *box, 
 extern TSequenceSet *tgeoseqset_restrict_geom(const TSequenceSet *ss, const GSERIALIZED *gs, bool atfunc);
 extern TSequenceSet *tgeoseqset_restrict_stbox(const TSequenceSet *ss, const STBox *box, bool border_inc, bool atfunc);
 
+/* Native temporal-point geometry-clip engine */
+
+extern Temporal *tpoint_linear_inter_geom(const Temporal *temp, const GSERIALIZED *gs, bool clip);
+extern Temporal *tpoint_linear_restrict_geom(const Temporal *temp, const GSERIALIZED *gs, bool atfunc);
+
 /*****************************************************************************/
 
 /* Traditional comparison functions */

--- a/meos/src/geo/CMakeLists.txt
+++ b/meos/src/geo/CMakeLists.txt
@@ -14,6 +14,7 @@ set(GEO_SOURCES
   tgeo_tile.c
   geo_poly_clip.c
   tpoint_datagen.c
+  tpoint_geom_clip.c
   tpoint_spatialfuncs.c
   tspatial.c
   tspatial_parser.c

--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -40,6 +40,7 @@
 /* PostgreSQL */
 #include "postgres.h"
 #include <utils/float.h>
+#include <utils/timestamp.h>
 /* PostGIS */
 #include "liblwgeom.h"
 #include "liblwgeom_internal.h"
@@ -66,7 +67,7 @@
 static MEOS_TLS MeosArray *events = NULL;
 static MEOS_TLS MeosArray *intervals = NULL;
 static MEOS_TLS MeosArray *periods = NULL;
-static MEOS_TLS int *rtree_results = NULL;
+static MEOS_TLS MeosArray *rtree_results = NULL;
 
 /**
  * @brief Enumeration defining the edge types 
@@ -609,11 +610,11 @@ tpointinst_clip_edges(const TInstant *inst, Edge **edges, int nedges,
     stbox_set(true, false, false, srid, a->x, a->x, a->y, a->y, 0, 0, NULL,
       &query);
     /* Query the R-tree */
-    int cand_nedges = rtree_search(rtree, RTREE_OVERLAPS, &query, &rtree_results);
+    int cand_nedges = rtree_search(rtree, RTREE_OVERLAPS, &query, rtree_results);
 
     /* Convert the result of an R-tree look up into an edge pointer array */
     for (int j = 0; j < cand_nedges; j++)
-      cand_edges[j] = edges[rtree_results[j]];
+      cand_edges[j] = edges[*(int *) meos_array_get(rtree_results, j)];
     sel_edges = cand_edges;
     sel_nedges = cand_nedges;
   }
@@ -686,11 +687,11 @@ tpointseq_clip_edges(const TSequence *seq, Edge **edges, int nedges,
         FP_MAX(a->x, b->x), FP_MIN(a->y, b->y), FP_MAX(a->y, b->y),
         0, 0, NULL, &query);
       /* Query the R-tree */
-      int cand_nedges = rtree_search(rtree, RTREE_OVERLAPS, &query, &rtree_results);
+      int cand_nedges = rtree_search(rtree, RTREE_OVERLAPS, &query, rtree_results);
 
       /* Convert the result of an R-tree look up into an edge pointer array */
       for (int j = 0; j < cand_nedges; j++)
-        cand_edges[j] = edges[rtree_results[j]];
+        cand_edges[j] = edges[*(int *) meos_array_get(rtree_results, j)];
       sel_edges = cand_edges;
       sel_nedges = cand_nedges;
     }
@@ -1047,8 +1048,8 @@ tpoint_linear_inter_geom(const Temporal *temp, const GSERIALIZED *gs,
       rtree_free(rtree); 
       return NULL;
     }
-    /* Array of integer pointers for storing the results of an R-tree search */
-    rtree_results = palloc(sizeof(int) * edges->count);
+    /* Array for collecting the ids resulting from an R-tree search */
+    rtree_results = meos_array_create(sizeof(int));
     if (! rtree_results)
     {
       meos_error(ERROR, MEOS_ERR_INTERNAL_ERROR,
@@ -1126,12 +1127,12 @@ tpoint_linear_inter_geom(const Temporal *temp, const GSERIALIZED *gs,
 cleanup_return:
   if (edges->count > RTREE_MIN_NUMBER_ELEMS)
   {
-    rtree_free(rtree); pfree(cand_edges); pfree(rtree_results);
+    rtree_free(rtree); pfree(cand_edges); meos_array_destroy(rtree_results);
   }
-  meos_array_destroy(events, false);
-  meos_array_destroy(intervals, false);
-  meos_array_destroy(periods, false);
-  meos_array_destroy(edges, false); pfree(edge_ptrs);
+  meos_array_destroy(events);
+  meos_array_destroy(intervals);
+  meos_array_destroy(periods);
+  meos_array_destroy(edges); pfree(edge_ptrs);
   return result;  
 }
 

--- a/meos/src/geo/tspatial_tempspatialrels.c
+++ b/meos/src/geo/tspatial_tempspatialrels.c
@@ -530,6 +530,27 @@ tinterrel_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool tinter)
     return result;
   }
 
+  /* Native fast path for a temporal geometry point with linear interpolation
+   * over a non-curved geometry, avoiding the GEOS ST_Intersection call.
+   * Instantaneous values and curved geometries (which the native clip does not
+   * support) fall through to the general path below. */
+  if (temp->temptype == T_TGEOMPOINT && temp->subtype != TINSTANT &&
+      MEOS_FLAGS_GET_INTERP(temp->flags) == LINEAR)
+  {
+    LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
+    bool curved = (lwgeom_has_arc(lwgeom) == LW_TRUE);
+    lwgeom_free(lwgeom);
+    if (! curved)
+    {
+      Temporal *res = tpoint_linear_inter_geom(temp, gs, false);
+      if (tinter)
+        return res;
+      Temporal *result = tnot_tbool(res);
+      pfree(res);
+      return result;
+    }
+  }
+
   /* 3D only if both arguments are 3D */
   datum_func2 func = MEOS_FLAGS_GET_Z(temp->flags) && FLAGS_GET_Z(gs->gflags) ?
       &datum_geom_intersects3d : &datum_geom_intersects2d;

--- a/meos/src/temporal/CMakeLists.txt
+++ b/meos/src/temporal/CMakeLists.txt
@@ -27,6 +27,7 @@ set(TEMPORAL_SOURCES
   temporal_compops.c
   temporal_modif.c
   temporal_restrict.c
+  temporal_rtree.c
   temporal_tile.c
   temporal_waggfuncs.c
   tinstant.c
@@ -60,7 +61,6 @@ if(MEOS)
     temporal_meos.c
     temporal_posops_meos.c
     temporal_restrict_meos.c
-    temporal_rtree.c
     temporal_tile_meos.c
     tinstant_meos.c
     tnumber_distance_meos.c


### PR DESCRIPTION
The temporal spatial relationships `tIntersects` and `tDisjoint` between a temporal geometry point and a geometry delegate the intersection to GEOS via `ST_Intersection`. This computes the common case — a temporal geometry point with linear interpolation over a non-curved geometry — with the native temporal-point geometry clip instead, avoiding the GEOS call.

- The `tpoint_geom_clip.c` module is added to the build and adapted to the current `MeosArray` and R-tree APIs. `temporal_rtree.c` is moved to the shared source list so that `rtree_search`, on which the clip relies, is available to both `libmeos` and the PostgreSQL extension.
- `tIntersects` and `tDisjoint` of a temporal geometry point with linear interpolation over a non-curved geometry are computed by `tpoint_linear_inter_geom`. Curved geometries and instantaneous values fall through to the existing GEOS path unchanged.

The local regression suite passes with no output differences against master.
