### PR TITLE
Add circular strings to the temporal-point spatial relationship tests

### DIFF
--- a/mobilitydb/datagen/geo/create_test_tables_tpoint.sql
+++ b/mobilitydb/datagen/geo/create_test_tables_tpoint.sql
@@ -216,6 +216,17 @@ SELECT 1 AS k, geography 'multipolygon Z empty' AS g UNION
 SELECT k, random_geog_multipolygon3D(-10, 32, 35, 72, 0, 1000, 10, 5, 10, 5, 10)
 FROM generate_series(2, size) k;
 
+DROP TABLE IF EXISTS tbl_geom_circularstring;
+CREATE TABLE tbl_geom_circularstring AS
+SELECT 1 AS k, geometry 'circularstring empty' AS g UNION
+SELECT k, random_geom_circularstring(0, 100, 0, 100, 10, 1, 5)
+FROM generate_series(2, size) k;
+
+/* Circular strings are kept in their own table and intentionally NOT added to
+ * tbl_geom below: only the temporal spatial relationships tIntersects and
+ * tDisjoint compute circular arcs natively, so a circular string is exercised
+ * only by those tests, not by the spatial functions/relationships/distance
+ * tests that also read tbl_geom. */
 DROP TABLE IF EXISTS tbl_geom;
 CREATE TABLE tbl_geom (
   k serial PRIMARY KEY,

--- a/mobilitydb/datagen/geo/random_tpoint.sql
+++ b/mobilitydb/datagen/geo/random_tpoint.sql
@@ -725,6 +725,52 @@ FROM generate_series(1, 15) AS k;
 -------------------------------------------------------------------------------
 
 /**
+ * @brief Generate a random geometric circular string
+ * @param[in] lowx, highx Inclusive bounds of the range for the x coordinates
+ * @param[in] lowy, highy Inclusive bounds of the range for the y coordinates
+ * @param[in] maxdelta Maximum difference between two consecutive coordinate values
+ * @param[in] minarcs, maxarcs Inclusive bounds of the number of circular arcs
+ * @param[in] srid SRID of the coordinates
+ */
+DROP FUNCTION IF EXISTS random_geom_circularstring;
+CREATE FUNCTION random_geom_circularstring(lowx float, highx float, lowy float,
+  highy float, maxdelta float, minarcs int, maxarcs int, srid int DEFAULT 0)
+  RETURNS geometry AS $$
+DECLARE
+  narcs int;
+  points geometry[];
+  wkt text;
+BEGIN
+  IF minarcs > maxarcs THEN
+    RAISE EXCEPTION 'minarcs must be less than or equal to maxarcs: %, %',
+      minarcs, maxarcs;
+  END IF;
+  narcs = random_int(minarcs, maxarcs);
+  /* A circular string with n arcs is defined by 2 * n + 1 points */
+  points = random_geom_point_array(lowx, highx, lowy, highy, maxdelta,
+    2 * narcs + 1, 2 * narcs + 1, srid);
+  SELECT 'CIRCULARSTRING(' ||
+    string_agg(st_x(p) || ' ' || st_y(p), ',' ORDER BY ord) || ')'
+  INTO wkt
+  FROM unnest(points) WITH ORDINALITY AS t(p, ord);
+  RETURN ST_GeomFromText(wkt, srid);
+END;
+$$ LANGUAGE PLPGSQL STRICT;
+
+/*
+SELECT k, st_asEWKT(random_geom_circularstring(-100, 100, -100, 100, 10, 1, 5)) AS g
+FROM generate_series(1, 15) AS k;
+
+SELECT k, st_asEWKT(random_geom_circularstring(-100, 100, -100, 100, 10, 1, 5, 3812)) AS g
+FROM generate_series(1, 15) AS k;
+
+SELECT distinct geometrytype(random_geom_circularstring(-100, 100, -100, 100, 10, 1, 5)) AS g
+FROM generate_series(1, 15) AS k;
+*/
+
+-------------------------------------------------------------------------------
+
+/**
  * @brief Generate a random 3D geometric linestring
  * @param[in] lowx, highx Inclusive bounds of the range for the x coordinates
  * @param[in] lowy, highy Inclusive bounds of the range for the y coordinates

--- a/mobilitydb/test/geo/expected/072_tpoint_tempspatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/072_tpoint_tempspatialrels_tbl.test.out
@@ -68,6 +68,20 @@ SELECT COUNT(*) FROM tbl_geom_point, tbl_tgeompoint_step_seqset
   9900
 (1 row)
 
+SELECT COUNT(*) FROM tbl_geom_circularstring, tbl_tgeompoint
+  WHERE tDisjoint(g, temp) IS NOT NULL;
+ count 
+-------
+  9900
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom_circularstring
+  WHERE tDisjoint(temp, g) IS NOT NULL;
+ count 
+-------
+  9900
+(1 row)
+
 SELECT COUNT(*) FROM tbl_geom_point, tbl_tgeompoint
   WHERE tDisjoint(g, temp) ?= true <> eDisjoint(g, temp);
  count 
@@ -133,6 +147,20 @@ SELECT COUNT(*) FROM tbl_geom_point, tbl_tgeompoint_step_seq
 
 SELECT COUNT(*) FROM tbl_geom_point, tbl_tgeompoint_step_seqset
   WHERE tIntersects(g, ss) IS NOT NULL;
+ count 
+-------
+  9900
+(1 row)
+
+SELECT COUNT(*) FROM tbl_geom_circularstring, tbl_tgeompoint
+  WHERE tIntersects(g, temp) IS NOT NULL;
+ count 
+-------
+  9900
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom_circularstring
+  WHERE tIntersects(temp, g) IS NOT NULL;
  count 
 -------
   9900

--- a/mobilitydb/test/geo/queries/072_tpoint_tempspatialrels_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/072_tpoint_tempspatialrels_tbl.test.sql
@@ -67,6 +67,12 @@ SELECT COUNT(*) FROM tbl_geom_point, tbl_tgeompoint_step_seq
 SELECT COUNT(*) FROM tbl_geom_point, tbl_tgeompoint_step_seqset
   WHERE tDisjoint(g, ss) IS NOT NULL;
 
+-- Circular strings
+SELECT COUNT(*) FROM tbl_geom_circularstring, tbl_tgeompoint
+  WHERE tDisjoint(g, temp) IS NOT NULL;
+SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom_circularstring
+  WHERE tDisjoint(temp, g) IS NOT NULL;
+
 -------------------------------------------------------------------------------
 -- Robustness test
 
@@ -101,6 +107,12 @@ SELECT COUNT(*) FROM tbl_geom_point, tbl_tgeompoint_step_seq
   WHERE tIntersects(g, seq) IS NOT NULL;
 SELECT COUNT(*) FROM tbl_geom_point, tbl_tgeompoint_step_seqset
   WHERE tIntersects(g, ss) IS NOT NULL;
+
+-- Circular strings
+SELECT COUNT(*) FROM tbl_geom_circularstring, tbl_tgeompoint
+  WHERE tIntersects(g, temp) IS NOT NULL;
+SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom_circularstring
+  WHERE tIntersects(temp, g) IS NOT NULL;
 
 -------------------------------------------------------------------------------
 -- Robustness test


### PR DESCRIPTION
The table-driven temporal spatial relationship tests cover point, line and polygon geometries, but not circular strings, so the native circular-arc path used by `tIntersects` and `tDisjoint` is exercised only by the individual literal cases.

This adds a `random_geom_circularstring` generator (a random walk of `2n+1` points assembled into a circular string) and a `tbl_geom_circularstring` test table, and runs `tIntersects` and `tDisjoint` over it in both argument orders.

The table is kept separate from `tbl_geom` on purpose: only `tIntersects` and `tDisjoint` compute circular arcs natively, so circular strings are exercised by those tests only, not by the spatial functions, spatial relationships and distance tests that also read `tbl_geom`.

The circular strings are added to the frozen `load_point.sql.xz` fixture; the pre-existing tables are unchanged.
