### PR TITLE
Support compound curves in the native temporal point clip

### DIFF
--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -1182,6 +1182,10 @@ geom_extract_edges_iter(const LWGEOM *geom, MeosArray *edges)
       extract_triangle((const LWTRIANGLE *) geom, edges);
       break;
 
+    /* A compound curve is a chain of line strings and circular strings; it
+     * shares the collection memory layout, so its components are extracted in
+     * the same way */
+    case COMPOUNDTYPE:
     case COLLECTIONTYPE:
     {
       const LWCOLLECTION *col = (const LWCOLLECTION *) geom;
@@ -1218,8 +1222,8 @@ geom_extract_edges(const LWGEOM *geom)
  * @brief Return true if a geometry is composed solely of the types the clip
  * engine can extract into edges
  * @details Mirrors the type dispatch of #geom_extract_edges_iter. Geometries
- * containing any other type (compound and curved polygons, TIN, polyhedral
- * surfaces, ...) are not supported and must be handled by the caller
+ * containing any other type (curved polygons, TIN, polyhedral surfaces, ...)
+ * are not supported and must be handled by the caller
  */
 bool
 geom_clip_supported(const LWGEOM *geom)
@@ -1237,6 +1241,7 @@ geom_clip_supported(const LWGEOM *geom)
     case TRIANGLETYPE:
     case CIRCSTRINGTYPE:
       return true;
+    case COMPOUNDTYPE:
     case COLLECTIONTYPE:
     {
       const LWCOLLECTION *col = (const LWCOLLECTION *) geom;

--- a/mobilitydb/test/geo/expected/072_tpoint_tempspatialrels.test.out
+++ b/mobilitydb/test/geo/expected/072_tpoint_tempspatialrels.test.out
@@ -211,6 +211,18 @@ SELECT tDisjoint(geometry 'CircularString(5 0, 4 3, 0 5)', tgeompoint '[Point(0 
  {[t@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], (t@Mon Jan 03 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
+SELECT tDisjoint(tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]', geometry 'CompoundCurve(CircularString(5 0, 4 3, 0 5), (0 5, -3 5))');
+                                                              tdisjoint                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], (t@Mon Jan 03 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tDisjoint(geometry 'CompoundCurve(CircularString(5 0, 4 3, 0 5), (0 5, -3 5))', tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]');
+                                                              tdisjoint                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], (t@Mon Jan 03 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDisjoint(tgeompoint 'Point(1 1)@2000-01-01', geometry 'Point empty');
  tdisjoint 
 -----------
@@ -409,6 +421,24 @@ SELECT tIntersects(tgeompoint '[Point(0 0)@2000-01-01, Point(0 4)@2000-01-05]', 
 (1 row)
 
 SELECT tIntersects(geometry 'CircularString(5 0, 4 3, 0 5)', tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]');
+                                                             tintersects                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], (f@Mon Jan 03 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tIntersects(tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]', geometry 'CompoundCurve(CircularString(5 0, 4 3, 0 5), (0 5, -3 5))');
+                                                             tintersects                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], (f@Mon Jan 03 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tIntersects(tgeompoint '[Point(-2 0)@2000-01-01, Point(-2 8)@2000-01-05]', geometry 'CompoundCurve(CircularString(5 0, 4 3, 0 5), (0 5, -3 5))');
+                                                             tintersects                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 12:00:00 2000 PST], (f@Mon Jan 03 12:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tIntersects(geometry 'CompoundCurve(CircularString(5 0, 4 3, 0 5), (0 5, -3 5))', tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]');
                                                              tintersects                                                              
 --------------------------------------------------------------------------------------------------------------------------------------
  {[f@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], (f@Mon Jan 03 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}

--- a/mobilitydb/test/geo/queries/072_tpoint_tempspatialrels.test.sql
+++ b/mobilitydb/test/geo/queries/072_tpoint_tempspatialrels.test.sql
@@ -88,6 +88,10 @@ SELECT tDisjoint(tgeompoint '[Point(1 1)@2000-01-01, Point(0 0)@2000-01-04)', ge
 SELECT tDisjoint(tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]', geometry 'CircularString(5 0, 4 3, 0 5)');
 SELECT tDisjoint(geometry 'CircularString(5 0, 4 3, 0 5)', tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]');
 
+-- Compound curve (circular arc followed by a line segment)
+SELECT tDisjoint(tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]', geometry 'CompoundCurve(CircularString(5 0, 4 3, 0 5), (0 5, -3 5))');
+SELECT tDisjoint(geometry 'CompoundCurve(CircularString(5 0, 4 3, 0 5), (0 5, -3 5))', tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]');
+
 SELECT tDisjoint(tgeompoint 'Point(1 1)@2000-01-01', geometry 'Point empty');
 SELECT tDisjoint(tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03}', geometry 'Point empty');
 SELECT tDisjoint(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03]', geometry 'Point empty');
@@ -139,6 +143,12 @@ SELECT tIntersects(tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]', 
 SELECT tIntersects(tgeompoint '[Point(-6 -8)@2000-01-01, Point(6 8)@2000-01-05]', geometry 'CircularString(5 0, 4 3, 0 5)');
 SELECT tIntersects(tgeompoint '[Point(0 0)@2000-01-01, Point(0 4)@2000-01-05]', geometry 'CircularString(5 0, 4 3, 0 5)');
 SELECT tIntersects(geometry 'CircularString(5 0, 4 3, 0 5)', tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]');
+
+-- Compound curve (circular arc followed by a line segment): crossing the arc part
+SELECT tIntersects(tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]', geometry 'CompoundCurve(CircularString(5 0, 4 3, 0 5), (0 5, -3 5))');
+-- crossing the line part only
+SELECT tIntersects(tgeompoint '[Point(-2 0)@2000-01-01, Point(-2 8)@2000-01-05]', geometry 'CompoundCurve(CircularString(5 0, 4 3, 0 5), (0 5, -3 5))');
+SELECT tIntersects(geometry 'CompoundCurve(CircularString(5 0, 4 3, 0 5), (0 5, -3 5))', tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]');
 
 SELECT tIntersects(tgeompoint 'Point(1 1)@2000-01-01', geometry 'Point empty');
 SELECT tIntersects(tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03}', geometry 'Point empty');


### PR DESCRIPTION
`tIntersects` and `tDisjoint` of a temporal geometry point over a compound curve currently fall back to GEOS, which strokes the circular arcs instead of solving them exactly.

A compound curve is a chain of line strings and circular strings, both already handled by the native clip engine. Since it shares the collection memory layout, its components are extracted the same way as a geometry collection, routing compound curves through the native circular-arc path added in #1316.

Adds literal cases exercising both the circular arc and the line segment components of a compound curve to the temporal spatial relationship tests.
