### PR TITLE
Correct the @sqlfn tags on the upperInc, perimeter and tDwithin wrappers

### DIFF
--- a/mobilitydb/src/cbuffer/tcbuffer_tempspatialrels.c
+++ b/mobilitydb/src/cbuffer/tcbuffer_tempspatialrels.c
@@ -526,7 +526,7 @@ PG_FUNCTION_INFO_V1(Tdwithin_geo_tcbuffer);
  * @ingroup mobilitydb_cbuffer_rel_temp
  * @brief Return a temporal boolean that states whether a geometry and a
  * temporal circular buffer are within a distance
- * @sqlfn tTouches()
+ * @sqlfn tDwithin()
  */
 Datum
 Tdwithin_geo_tcbuffer(PG_FUNCTION_ARGS)
@@ -540,7 +540,7 @@ PG_FUNCTION_INFO_V1(Tdwithin_tcbuffer_geo);
  * @ingroup mobilitydb_cbuffer_rel_temp
  * @brief Return a temporal boolean that states whether a temporal circular
  * buffer and a geometry are within a distance
- * @sqlfn tTouches()
+ * @sqlfn tDwithin()
  */
 Datum
 Tdwithin_tcbuffer_geo(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/geo/stbox.c
+++ b/mobilitydb/src/geo/stbox.c
@@ -926,8 +926,8 @@ PGDLLEXPORT Datum Stbox_perimeter(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Stbox_perimeter);
 /**
  * @ingroup mobilitydb_geo_box_accessor
- * @brief Return the area of a spatiotemporal box
- * @sqlfn area()
+ * @brief Return the perimeter of a spatiotemporal box
+ * @sqlfn perimeter()
  */
 Datum
 Stbox_perimeter(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/temporal/span.c
+++ b/mobilitydb/src/temporal/span.c
@@ -535,7 +535,7 @@ PG_FUNCTION_INFO_V1(Span_upper_inc);
 /**
  * @ingroup mobilitydb_setspan_accessor
  * @brief Return true if the upper bound of a span is inclusive
- * @sqlfn lower_inc()
+ * @sqlfn upperInc()
  */
 Datum
 Span_upper_inc(PG_FUNCTION_ARGS)


### PR DESCRIPTION
Four PG wrappers carried a `@sqlfn` doxygen tag that had been copied from a
neighbouring function and not corrected, so each was annotated with the wrong
SQL name:

| Wrapper | file | was `@sqlfn` | corrected to |
|---|---|---|---|
| `Span_upper_inc` | `mobilitydb/src/temporal/span.c` | `lower_inc()` | `upperInc()` |
| `Stbox_perimeter` | `mobilitydb/src/geo/stbox.c` | `area()` | `perimeter()` |
| `Tdwithin_geo_tcbuffer` | `mobilitydb/src/cbuffer/tcbuffer_tempspatialrels.c` | `tTouches()` | `tDwithin()` |
| `Tdwithin_tcbuffer_geo` | `mobilitydb/src/cbuffer/tcbuffer_tempspatialrels.c` | `tTouches()` | `tDwithin()` |

Each corrected name matches the `CREATE FUNCTION` that binds the wrapper in the
corresponding `.in.sql`:

- `upperInc(...)` → `Span_upper_inc` (`003_span.in.sql`)
- `perimeter(stbox, ...)` → `Stbox_perimeter` (`051_stbox.in.sql`)
- `tDwithin(geometry, tcbuffer, ...)` → `Tdwithin_geo_tcbuffer` and
  `tDwithin(tcbuffer, geometry, ...)` → `Tdwithin_tcbuffer_geo`
  (`214_tcbuffer_tempspatialrels.in.sql`)

The `Stbox_perimeter` brief, which also read "area", is corrected to
"perimeter". The other `Tdwithin` overloads (`tcbuffer`/`cbuffer`) already use
`@sqlfn tDwithin()`.

The change is limited to the doxygen comments; the SQL function names are
unchanged, so there is no behavioural or test difference.
</content>
