### PR TITLE
Support multicurves and multisurfaces in the native temporal point clip

### DIFF
--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -1322,10 +1322,13 @@ geom_extract_edges_iter(const LWGEOM *geom, MeosArray *edges)
       extract_triangle((const LWTRIANGLE *) geom, edges);
       break;
 
-    /* A compound curve is a chain of line strings and circular strings; it
-     * shares the collection memory layout, so its components are extracted in
-     * the same way */
+    /* A compound curve (chain of line/circular strings), a multicurve
+     * (collection of line/circular/compound curves) and a multisurface
+     * (collection of polygons/curve polygons) all share the collection memory
+     * layout, so their components are extracted the same way as a collection */
     case COMPOUNDTYPE:
+    case MULTICURVETYPE:
+    case MULTISURFACETYPE:
     case COLLECTIONTYPE:
     {
       const LWCOLLECTION *col = (const LWCOLLECTION *) geom;
@@ -1386,8 +1389,13 @@ geom_clip_supported(const LWGEOM *geom)
     case CIRCSTRINGTYPE:
       return true;
     case COMPOUNDTYPE:
+    case MULTICURVETYPE:
+    case MULTISURFACETYPE:
     case COLLECTIONTYPE:
     {
+      /* A multicurve/multisurface is supported when every component is: its
+       * components are line/circular/compound curves and polygons/curve
+       * polygons, each validated by the recursive call */
       const LWCOLLECTION *col = (const LWCOLLECTION *) geom;
       for (uint32_t i = 0; i < col->ngeoms; i++)
         if (! geom_clip_supported(col->geoms[i]))

--- a/mobilitydb/test/geo/expected/072_tpoint_tempspatialrels.test.out
+++ b/mobilitydb/test/geo/expected/072_tpoint_tempspatialrels.test.out
@@ -235,6 +235,30 @@ SELECT tDisjoint(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0
  {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], (t@Mon Jan 03 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
+SELECT tDisjoint(tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]', geometry 'MultiCurve(CircularString(5 0, 4 3, 0 5), (0 5, -3 5))');
+                                                              tdisjoint                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], (t@Mon Jan 03 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tDisjoint(geometry 'MultiCurve(CircularString(5 0, 4 3, 0 5), (0 5, -3 5))', tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]');
+                                                              tdisjoint                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], (t@Mon Jan 03 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tDisjoint(tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]', geometry 'MultiSurface(CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0)))');
+                                                              tdisjoint                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], (t@Mon Jan 03 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tDisjoint(geometry 'MultiSurface(CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0)))', tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]');
+                                                              tdisjoint                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], (t@Mon Jan 03 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tDisjoint(tgeompoint 'Point(1 1)@2000-01-01', geometry 'Point empty');
  tdisjoint 
 -----------
@@ -481,6 +505,42 @@ SELECT tIntersects(tgeompoint '[Point(-6 0)@2000-01-01, Point(6 0)@2000-01-05]',
 (1 row)
 
 SELECT tIntersects(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]');
+                                                             tintersects                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], (f@Mon Jan 03 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tIntersects(tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]', geometry 'MultiCurve(CircularString(5 0, 4 3, 0 5), (0 5, -3 5))');
+                                                             tintersects                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], (f@Mon Jan 03 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tIntersects(tgeompoint '[Point(-2 0)@2000-01-01, Point(-2 8)@2000-01-05]', geometry 'MultiCurve(CircularString(5 0, 4 3, 0 5), (0 5, -3 5))');
+                                                             tintersects                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 12:00:00 2000 PST], (f@Mon Jan 03 12:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tIntersects(geometry 'MultiCurve(CircularString(5 0, 4 3, 0 5), (0 5, -3 5))', tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]');
+                                                             tintersects                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], (f@Mon Jan 03 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tIntersects(tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]', geometry 'MultiSurface(CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0)))');
+                                                             tintersects                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], (f@Mon Jan 03 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tIntersects(tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]', geometry 'MultiSurface(Polygon((2 5, 6 5, 6 9, 2 9, 2 5)), CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0)))');
+                                                                             tintersects                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], (f@Mon Jan 03 00:00:00 2000 PST, t@Mon Jan 03 12:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tIntersects(geometry 'MultiSurface(CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0)))', tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]');
                                                              tintersects                                                              
 --------------------------------------------------------------------------------------------------------------------------------------
  {[t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], (f@Mon Jan 03 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}

--- a/mobilitydb/test/geo/queries/072_tpoint_tempspatialrels.test.sql
+++ b/mobilitydb/test/geo/queries/072_tpoint_tempspatialrels.test.sql
@@ -96,6 +96,14 @@ SELECT tDisjoint(geometry 'CompoundCurve(CircularString(5 0, 4 3, 0 5), (0 5, -3
 SELECT tDisjoint(tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]', geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))');
 SELECT tDisjoint(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]');
 
+-- Multicurve (heterogeneous collection of a circular string and a line string)
+SELECT tDisjoint(tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]', geometry 'MultiCurve(CircularString(5 0, 4 3, 0 5), (0 5, -3 5))');
+SELECT tDisjoint(geometry 'MultiCurve(CircularString(5 0, 4 3, 0 5), (0 5, -3 5))', tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]');
+
+-- Multisurface (collection of a curve polygon)
+SELECT tDisjoint(tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]', geometry 'MultiSurface(CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0)))');
+SELECT tDisjoint(geometry 'MultiSurface(CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0)))', tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]');
+
 SELECT tDisjoint(tgeompoint 'Point(1 1)@2000-01-01', geometry 'Point empty');
 SELECT tDisjoint(tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03}', geometry 'Point empty');
 SELECT tDisjoint(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03]', geometry 'Point empty');
@@ -163,6 +171,18 @@ SELECT tIntersects(tgeompoint '[Point(0 -2)@2000-01-01, Point(0 8)@2000-01-05]',
 -- Curve polygon with a circular hole: two inside segments across the annulus
 SELECT tIntersects(tgeompoint '[Point(-6 0)@2000-01-01, Point(6 0)@2000-01-05]', geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0), CircularString(2 0, 0 2, -2 0, 0 -2, 2 0))');
 SELECT tIntersects(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]');
+
+-- Multicurve (circular string + line string): crossing the arc component
+SELECT tIntersects(tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]', geometry 'MultiCurve(CircularString(5 0, 4 3, 0 5), (0 5, -3 5))');
+-- crossing the line component only
+SELECT tIntersects(tgeompoint '[Point(-2 0)@2000-01-01, Point(-2 8)@2000-01-05]', geometry 'MultiCurve(CircularString(5 0, 4 3, 0 5), (0 5, -3 5))');
+SELECT tIntersects(geometry 'MultiCurve(CircularString(5 0, 4 3, 0 5), (0 5, -3 5))', tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]');
+
+-- Multisurface with a curve polygon (disk): starting inside and exiting through the arc
+SELECT tIntersects(tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]', geometry 'MultiSurface(CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0)))');
+-- Multisurface combining a straight polygon and a curve polygon (disjoint regions the trajectory crosses in turn)
+SELECT tIntersects(tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]', geometry 'MultiSurface(Polygon((2 5, 6 5, 6 9, 2 9, 2 5)), CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0)))');
+SELECT tIntersects(geometry 'MultiSurface(CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0)))', tgeompoint '[Point(0 0)@2000-01-01, Point(6 8)@2000-01-05]');
 
 SELECT tIntersects(tgeompoint 'Point(1 1)@2000-01-01', geometry 'Point empty');
 SELECT tIntersects(tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03}', geometry 'Point empty');


### PR DESCRIPTION
`tIntersects` and `tDisjoint` of a temporal geometry point over a multicurve or a multisurface currently fall back to GEOS, which strokes the circular arcs instead of solving them exactly.

A multicurve is a collection of line strings, circular strings and compound curves; a multisurface is a collection of polygons and curve polygons. All of these component types are already handled by the native clip engine, and both collections share the collection memory layout, so their components are extracted the same way as a geometry collection, routing them through the native circular-arc path.

Adds literal cases exercising a multicurve (circular string and line string components) and a multisurface (a curve polygon, and a mix of a straight polygon and a curve polygon) to the temporal spatial relationship tests.