### PR TITLE
Correct copy-pasted @sqlfn doxygen tags on span and cbuffer wrappers

### DIFF
--- a/mobilitydb/src/cbuffer/tcbuffer.c
+++ b/mobilitydb/src/cbuffer/tcbuffer.c
@@ -393,9 +393,9 @@ PGDLLEXPORT Datum Tcbuffer_at_stbox(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Tcbuffer_at_stbox);
 /**
  * @ingroup mobilitydb_geo_restrict
- * @brief Return a temporal circular buffer restricted to a circular buffer
+ * @brief Return a temporal circular buffer restricted to a spatiotemporal box
  * @note Only 2D is supported
- * @sqlfn atValue()
+ * @sqlfn atStbox()
  */
 inline Datum
 Tcbuffer_at_stbox(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/cbuffer/tcbuffer_spatialrels.c
+++ b/mobilitydb/src/cbuffer/tcbuffer_spatialrels.c
@@ -336,8 +336,8 @@ PG_FUNCTION_INFO_V1(Ecovers_tcbuffer_tcbuffer);
 /**
  * @ingroup mobilitydb_cbuffer_rel_ever
  * @brief Return true if a temporal circular buffer and a circular buffer 
- * ever touch
- * @sqlfn eTouches()
+ * ever cover
+ * @sqlfn eCovers()
  */
 inline Datum
 Ecovers_tcbuffer_tcbuffer(PG_FUNCTION_ARGS)
@@ -351,8 +351,8 @@ PG_FUNCTION_INFO_V1(Acovers_tcbuffer_tcbuffer);
 /**
  * @ingroup mobilitydb_cbuffer_rel_ever
  * @brief Return true if a temporal circular buffer and a circular buffer 
- * always touch
- * @sqlfn aTouches()
+ * always cover
+ * @sqlfn aCovers()
  */
 inline Datum
 Acovers_tcbuffer_tcbuffer(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/temporal/span.c
+++ b/mobilitydb/src/temporal/span.c
@@ -600,7 +600,7 @@ PG_FUNCTION_INFO_V1(Numspan_expand);
  * @ingroup mobilitydb_setspan_transf
  * @brief Return a number span with its bounds expanded or shrinded by a value
  * @note This function is also used for `datespan`
- * @sqlfn shift()
+ * @sqlfn expand()
  */
 Datum
 Numspan_expand(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/temporal/span_ops.c
+++ b/mobilitydb/src/temporal/span_ops.c
@@ -518,8 +518,8 @@ PG_FUNCTION_INFO_V1(Minus_value_span);
 /**
  * @ingroup mobilitydb_setspan_set
  * @brief Return the difference of a value and a span
- * @sqlfn spanIntersection()
- * @sqlop @p *
+ * @sqlfn spanMinus()
+ * @sqlop @p -
  */
 Datum
 Minus_value_span(PG_FUNCTION_ARGS)
@@ -537,8 +537,8 @@ PG_FUNCTION_INFO_V1(Minus_span_value);
 /**
  * @ingroup mobilitydb_setspan_set
  * @brief Return the difference of a span and a value
- * @sqlfn spanIntersection()
- * @sqlop @p *
+ * @sqlfn spanMinus()
+ * @sqlop @p -
  */
 Datum
 Minus_span_value(PG_FUNCTION_ARGS)
@@ -556,7 +556,7 @@ PG_FUNCTION_INFO_V1(Minus_span_span);
 /**
  * @ingroup mobilitydb_setspan_set
  * @brief Return the difference of two spans
- * @sqlfn time_minus()
+ * @sqlfn spanMinus()
  * @sqlop @p -
  */
 Datum


### PR DESCRIPTION
Seven PostgreSQL wrappers carry a doxygen `@sqlfn` (and in places `@brief`/`@sqlop`) copied from a neighbouring function and never corrected, so the wrapper advertises a SQL function it does not back. The catalog that maps each function to its SQL name reads these tags, so a wrong tag mis-associates the wrapper with an unrelated SQL function.

Each corrected name is the `CREATE FUNCTION <name>(...)` that maps `AS 'MODULE_PATHNAME','<Wrapper>'` in the matching `.in.sql`:

- `Ecovers_tcbuffer_tcbuffer` / `Acovers_tcbuffer_tcbuffer` — `eTouches`/`aTouches` to `eCovers`/`aCovers`
- `Tcbuffer_at_stbox` — `atValue` to `atStbox`
- `Numspan_expand` — `shift` to `expand`
- `Minus_value_span` / `Minus_span_value` / `Minus_span_span` — `spanIntersection`/`time_minus` to `spanMinus` (and the `@sqlop` from `*` to `-`)

The `@brief` lines copied along with the tag are corrected to match (covers vs touches, spatiotemporal box vs circular buffer).
