### PR TITLE
Add circular strings to the tbl_geom test table

### DIFF
--- a/mobilitydb/datagen/geo/create_test_tables_tpoint.sql
+++ b/mobilitydb/datagen/geo/create_test_tables_tpoint.sql
@@ -216,6 +216,12 @@ SELECT 1 AS k, geography 'multipolygon Z empty' AS g UNION
 SELECT k, random_geog_multipolygon3D(-10, 32, 35, 72, 0, 1000, 10, 5, 10, 5, 10)
 FROM generate_series(2, size) k;
 
+DROP TABLE IF EXISTS tbl_geom_circularstring;
+CREATE TABLE tbl_geom_circularstring AS
+SELECT 1 AS k, geometry 'circularstring empty' AS g UNION
+SELECT k, random_geom_circularstring(0, 100, 0, 100, 10, 1, 5)
+FROM generate_series(2, size) k;
+
 DROP TABLE IF EXISTS tbl_geom;
 CREATE TABLE tbl_geom (
   k serial PRIMARY KEY,
@@ -226,7 +232,8 @@ INSERT INTO tbl_geom(g)
 (SELECT g FROM tbl_geom_polygon ORDER BY k LIMIT (size * 0.2)) UNION ALL
 (SELECT g FROM tbl_geom_multipoint ORDER BY k LIMIT (size * 0.2)) UNION ALL
 (SELECT g FROM tbl_geom_multilinestring ORDER BY k LIMIT (size * 0.2)) UNION ALL
-(SELECT g FROM tbl_geom_multipolygon ORDER BY k LIMIT (size * 0.2));
+(SELECT g FROM tbl_geom_multipolygon ORDER BY k LIMIT (size * 0.2)) UNION ALL
+(SELECT g FROM tbl_geom_circularstring ORDER BY k LIMIT (size * 0.2));
 
 DROP TABLE IF EXISTS tbl_geom3D;
 CREATE TABLE tbl_geom3D (

--- a/mobilitydb/datagen/geo/random_tpoint.sql
+++ b/mobilitydb/datagen/geo/random_tpoint.sql
@@ -725,6 +725,52 @@ FROM generate_series(1, 15) AS k;
 -------------------------------------------------------------------------------
 
 /**
+ * @brief Generate a random geometric circular string
+ * @param[in] lowx, highx Inclusive bounds of the range for the x coordinates
+ * @param[in] lowy, highy Inclusive bounds of the range for the y coordinates
+ * @param[in] maxdelta Maximum difference between two consecutive coordinate values
+ * @param[in] minarcs, maxarcs Inclusive bounds of the number of circular arcs
+ * @param[in] srid SRID of the coordinates
+ */
+DROP FUNCTION IF EXISTS random_geom_circularstring;
+CREATE FUNCTION random_geom_circularstring(lowx float, highx float, lowy float,
+  highy float, maxdelta float, minarcs int, maxarcs int, srid int DEFAULT 0)
+  RETURNS geometry AS $$
+DECLARE
+  narcs int;
+  points geometry[];
+  wkt text;
+BEGIN
+  IF minarcs > maxarcs THEN
+    RAISE EXCEPTION 'minarcs must be less than or equal to maxarcs: %, %',
+      minarcs, maxarcs;
+  END IF;
+  narcs = random_int(minarcs, maxarcs);
+  /* A circular string with n arcs is defined by 2 * n + 1 points */
+  points = random_geom_point_array(lowx, highx, lowy, highy, maxdelta,
+    2 * narcs + 1, 2 * narcs + 1, srid);
+  SELECT 'CIRCULARSTRING(' ||
+    string_agg(st_x(p) || ' ' || st_y(p), ',' ORDER BY ord) || ')'
+  INTO wkt
+  FROM unnest(points) WITH ORDINALITY AS t(p, ord);
+  RETURN ST_GeomFromText(wkt, srid);
+END;
+$$ LANGUAGE PLPGSQL STRICT;
+
+/*
+SELECT k, st_asEWKT(random_geom_circularstring(-100, 100, -100, 100, 10, 1, 5)) AS g
+FROM generate_series(1, 15) AS k;
+
+SELECT k, st_asEWKT(random_geom_circularstring(-100, 100, -100, 100, 10, 1, 5, 3812)) AS g
+FROM generate_series(1, 15) AS k;
+
+SELECT distinct geometrytype(random_geom_circularstring(-100, 100, -100, 100, 10, 1, 5)) AS g
+FROM generate_series(1, 15) AS k;
+*/
+
+-------------------------------------------------------------------------------
+
+/**
  * @brief Generate a random 3D geometric linestring
  * @param[in] lowx, highx Inclusive bounds of the range for the x coordinates
  * @param[in] lowy, highy Inclusive bounds of the range for the y coordinates

--- a/mobilitydb/test/geo/expected/064_tpoint_distance_tbl.test.out
+++ b/mobilitydb/test/geo/expected/064_tpoint_distance_tbl.test.out
@@ -86,7 +86,7 @@ SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
  count 
 -------
-  9400
+ 11300
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2
@@ -142,7 +142,7 @@ SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
  count 
 -------
-  9400
+ 11300
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2
@@ -198,7 +198,7 @@ SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE g |=| temp IS NOT NULL;
  count 
 -------
-  9400
+ 11300
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2
@@ -254,7 +254,7 @@ SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE shortestLine(g, temp) IS NOT NULL;
  count 
 -------
-  9400
+ 11300
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2

--- a/mobilitydb/test/geo/expected/070_tpoint_spatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/070_tpoint_spatialrels_tbl.test.out
@@ -1,7 +1,7 @@
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE eContains(g, temp);
  count 
 -------
-  3280
+  3806
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE aContains(g, temp);
@@ -13,13 +13,13 @@ SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE aContains(g, temp);
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE eDisjoint(g, temp);
  count 
 -------
-  9254
+ 11154
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom WHERE eDisjoint(temp, g);
  count 
 -------
-  9254
+ 11154
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE eDisjoint(t1.temp, t2.temp);
@@ -61,13 +61,13 @@ SELECT COUNT(*) > 0 FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2 WHERE eDisjoin
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE aDisjoint(g, temp);
  count 
 -------
-  6120
+  7494
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom WHERE aDisjoint(temp, g);
  count 
 -------
-  6120
+  7494
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE aDisjoint(t1.temp, t2.temp);
@@ -133,13 +133,13 @@ SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2 WHERE aDisjoint(t1
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE eIntersects(g, temp);
  count 
 -------
-  3280
+  3806
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom WHERE eIntersects(temp, g);
  count 
 -------
-  3280
+  3806
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE eIntersects(t1.temp, t2.temp);

--- a/mobilitydb/test/geo/expected/072_tpoint_tempspatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/072_tpoint_tempspatialrels_tbl.test.out
@@ -2,21 +2,21 @@ SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint
   WHERE tContains(g, temp) IS NOT NULL;
  count 
 -------
-  9400
+ 11300
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint_step_seq
   WHERE tContains(g, seq) IS NOT NULL;
  count 
 -------
-  9400
+ 11300
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint_step_seqset
   WHERE tContains(g, ss) IS NOT NULL;
  count 
 -------
-  9400
+ 11300
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint
@@ -184,7 +184,7 @@ SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint
   WHERE tTouches(g, temp) IS NOT NULL;
  count 
 -------
-  9400
+ 11300
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom_point
@@ -198,14 +198,14 @@ SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint_step_seq
   WHERE tTouches(g, seq) IS NOT NULL;
  count 
 -------
-  9400
+ 11300
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint_step_seqset
   WHERE tTouches(g, ss) IS NOT NULL;
  count 
 -------
-  9400
+ 11300
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint


### PR DESCRIPTION
The superclass geometry test table `tbl_geom` is a union of the narrow per-type tables (point, line string, polygon, multipoint, multiline string, multipolygon), so every `_tbl` test that reads it exercises those types. Circular strings were absent, so no table-level test exercised a curved geometry.

Add a `random_geom_circularstring` generator and a `tbl_geom_circularstring` narrow table, and union a slice of it into `tbl_geom`, so the spatial functions, relationships, distance and temporal relationship `_tbl` tests now also run over circular strings. Regenerate the affected expected outputs (the added rows only change the counts).