### PR TITLE
Generate the bounding-box operator wrappers from a box-type template

### DIFF
--- a/mobilitydb/src/geo/tgeo_boxops.c
+++ b/mobilitydb/src/geo/tgeo_boxops.c
@@ -196,13 +196,14 @@ Geo_split_each_n_stboxes(PG_FUNCTION_ARGS)
   PG_RETURN_ARRAYTYPE_P(result);
 }
 
+/* GENERATED-BOXOPS-BEGIN — tools/codegen/inherited/generate.py from templates/boxops.c.tmpl; DO NOT EDIT BY HAND;
+ * edit the template + manifest.yaml (boxtypes) and re-run. */
 /*****************************************************************************
  * Generic box functions
  *****************************************************************************/
 
 /**
- * @brief Generic bounding box function for a spatiotemporal box and a temporal
- * point
+ * @brief Generic bounding box function for a spatiotemporal box and a spatiotemporal value
  * @param[in] fcinfo Catalog information about the external function
  * @param[in] func Bounding box function
  */
@@ -289,8 +290,8 @@ PGDLLEXPORT Datum Overlaps_tspatial_tspatial(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Overlaps_tspatial_tspatial);
 /**
  * @ingroup mobilitydb_geo_bbox_topo
- * @brief Return true if the spatiotemporal boxes of two spatiotemporal
- * values overlap
+ * @brief Return true if the spatiotemporal boxes of two spatiotemporal values
+ * overlap
  * @sqlfn overlaps_bbox()
  * @sqlop @p &&
  */
@@ -308,8 +309,8 @@ PGDLLEXPORT Datum Contains_stbox_tspatial(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Contains_stbox_tspatial);
 /**
  * @ingroup mobilitydb_geo_bbox_topo
- * @brief Return true if a spatiotemporal box contains the one of a temporal
- * point
+ * @brief Return true if a spatiotemporal box contains the one of a
+ * spatiotemporal value
  * @sqlfn contains_bbox()
  * @sqlop @p @>
  */
@@ -338,8 +339,8 @@ PGDLLEXPORT Datum Contains_tspatial_tspatial(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Contains_tspatial_tspatial);
 /**
  * @ingroup mobilitydb_geo_bbox_topo
- * @brief Return true if the spatiotemporal box of the first spatiotemporal
- * value contains the one of the second spatiotemporal value
+ * @brief Return true if the spatiotemporal box of the first spatiotemporal value
+ * contains the one of the second spatiotemporal value
  * @sqlfn contains_bbox()
  * @sqlop @p @>
  */
@@ -387,8 +388,8 @@ PGDLLEXPORT Datum Contained_tspatial_tspatial(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Contained_tspatial_tspatial);
 /**
  * @ingroup mobilitydb_geo_bbox_topo
- * @brief Return true if the spatiotemporal box of the first spatiotemporal
- * value is contained in the one of the second spatiotemporal value
+ * @brief Return true if the spatiotemporal box of the first spatiotemporal value
+ * is contained in the one of the second spatiotemporal value
  * @sqlfn contained_bbox()
  * @sqlop @p <@
  */
@@ -436,8 +437,8 @@ PGDLLEXPORT Datum Same_tspatial_tspatial(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Same_tspatial_tspatial);
 /**
  * @ingroup mobilitydb_geo_bbox_topo
- * @brief Return true if the spatiotemporal boxes of two spatiotemporal
- * values are equal in the common dimensions
+ * @brief Return true if the spatiotemporal boxes of two spatiotemporal values
+ * are equal in the common dimensions
  * @sqlfn same_bbox()
  * @sqlop @p ~=
  */
@@ -485,8 +486,8 @@ PGDLLEXPORT Datum Adjacent_tspatial_tspatial(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Adjacent_tspatial_tspatial);
 /**
  * @ingroup mobilitydb_geo_bbox_topo
- * @brief Return true if the spatiotemporal boxes of two spatiotemporal
- * values are adjacent
+ * @brief Return true if the spatiotemporal boxes of two spatiotemporal values
+ * are adjacent
  * @sqlfn adjacent_bbox()
  * @sqlop @p -|-
  */
@@ -497,3 +498,4 @@ Adjacent_tspatial_tspatial(PG_FUNCTION_ARGS)
 }
 
 /*****************************************************************************/
+/* GENERATED-BOXOPS-END */

--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -65,6 +65,40 @@ def render(behaviour: str, sub: dict) -> str:
     return BANNER.format(tmpl=f"{behaviour}.sql.tmpl") + body
 
 
+# --- C boxops (box-type axis) --------------------------------------------
+# The bounding-box topological operator wrappers are generated per BOX TYPE
+# (stbox/tbox/tstzspan/tpcbox) into the region between these markers, which live
+# inside a hand-written .c file that also holds non-generated helpers (trajectory
+# tiling, NAD, ...). Only the marked region is owned by the generator.
+BOXOPS_BEGIN = ("/* GENERATED-BOXOPS-BEGIN — tools/codegen/inherited/generate.py "
+                "from templates/boxops.c.tmpl; DO NOT EDIT BY HAND;\n"
+                " * edit the template + manifest.yaml (boxtypes) and re-run. */\n")
+BOXOPS_END = "/* GENERATED-BOXOPS-END */\n"
+_BOXOPS_KEYS = ("box", "tside", "boxc", "getarg", "dispbox", "disptt",
+                "ingroup", "boxdesc", "boxdescpl", "valdesc")
+
+
+def render_boxops(bt: dict) -> str:
+    body = (TEMPLATES / "boxops.c.tmpl").read_text()
+    for k in _BOXOPS_KEYS:
+        body = body.replace("{" + k.upper() + "}", bt[k])
+    return body
+
+
+def splice_boxops(filetext: str, rendered: str) -> str:
+    """Replace the text strictly between the BEGIN/END markers with `rendered`."""
+    b = filetext.index(BOXOPS_BEGIN) + len(BOXOPS_BEGIN)
+    e = filetext.index(BOXOPS_END)
+    return filetext[:b] + rendered + filetext[e:]
+
+
+def extract_boxops(filetext: str) -> str:
+    """Return the current text between the BEGIN/END markers (for --validate)."""
+    b = filetext.index(BOXOPS_BEGIN) + len(BOXOPS_BEGIN)
+    e = filetext.index(BOXOPS_END)
+    return filetext[b:e]
+
+
 def target_path(behaviour: str, sub: dict, positions: dict) -> pathlib.Path:
     num = sub["bin"] + positions[behaviour]
     # The SQL family directory defaults to the base type name (quadbin, cbuffer),
@@ -122,6 +156,25 @@ def main() -> int:
                             break
                     if len(g) != len(c):
                         print(f"     line count gen={len(g)} cur={len(c)}")
+        for bt in mf.get("boxtypes", []):
+            if not bt.get("reference"):
+                continue
+            p = ROOT / bt["file"]
+            gen = render_boxops(bt)
+            cur = extract_boxops(p.read_text()) if p.exists() else ""
+            same = gen == cur
+            ok = ok and same
+            print(f"[{'OK ' if same else 'DIFF'}] self-regen boxops {bt['box']} "
+                  f"-> {pathlib.Path(bt['file'])}")
+            if not same:
+                g, c = gen.splitlines(), cur.splitlines()
+                for n, (a, b) in enumerate(zip(g, c), 1):
+                    if a != b:
+                        print(f"     first diff line {n}:\n       gen: {a!r}\n"
+                              f"       cur: {b!r}")
+                        break
+                if len(g) != len(c):
+                    print(f"     line count gen={len(g)} cur={len(c)}")
         return 0 if ok else 1
 
     for sub in subs:
@@ -135,6 +188,16 @@ def main() -> int:
             p.parent.mkdir(parents=True, exist_ok=True)
             p.write_text(render(beh, sub))
             print(f"wrote {p.relative_to(ROOT)}")
+
+    for bt in mf.get("boxtypes", []):
+        if bt.get("reference"):
+            continue
+        p = ROOT / bt["file"]
+        if args.check:
+            print(f"would splice boxops {bt['box']} -> {bt['file']}")
+            continue
+        p.write_text(splice_boxops(p.read_text(), render_boxops(bt)))
+        print(f"spliced boxops {bt['box']} -> {bt['file']}")
     return 0
 
 

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -101,3 +101,24 @@ subtypes:
     bin:   146
     category: tspatial
     files: [indexes]
+
+# ---------------------------------------------------------------------------
+# Box-type axis (C boxops generator). The bounding-box topological operator
+# wrappers (overlaps/contains/contained/same/adjacent) are per BOX TYPE, not
+# per family: one stbox implementation serves every tspatial family, one tbox
+# serves the tnumbers, tstzspan the temporal-only types, tpcbox the pointcloud.
+# The generator emits the region between the GENERATED-BOXOPS markers in `file`.
+# `reference: true` = self-regen must reproduce the committed region byte-for-byte.
+boxtypes:
+  - box:       stbox
+    tside:     tspatial
+    boxc:      STBox
+    getarg:    PG_GETARG_STBOX_P
+    dispbox:   boxop_tspatial_stbox
+    disptt:    boxop_tspatial_tspatial
+    ingroup:   mobilitydb_geo_bbox_topo
+    boxdesc:   spatiotemporal box
+    boxdescpl: spatiotemporal boxes
+    valdesc:   spatiotemporal value
+    file:      mobilitydb/src/geo/tgeo_boxops.c
+    reference: true

--- a/tools/codegen/inherited/templates/boxops.c.tmpl
+++ b/tools/codegen/inherited/templates/boxops.c.tmpl
@@ -1,0 +1,300 @@
+/*****************************************************************************
+ * Generic box functions
+ *****************************************************************************/
+
+/**
+ * @brief Generic bounding box function for a {BOXDESC} and a {VALDESC}
+ * @param[in] fcinfo Catalog information about the external function
+ * @param[in] func Bounding box function
+ */
+Datum
+Boxop_{BOX}_{TSIDE}(FunctionCallInfo fcinfo,
+  bool (*func)(const {BOXC} *, const {BOXC} *))
+{
+  {BOXC} *box = {GETARG}(0);
+  Temporal *temp = PG_GETARG_TEMPORAL_P(1);
+  bool result = {DISPBOX}(temp, box, func, INVERT);
+  PG_FREE_IF_COPY(temp, 1);
+  PG_RETURN_BOOL(result);
+}
+
+/**
+ * @brief Generic bounding box function for a {VALDESC} and a
+ * {BOXDESC}
+ * @param[in] fcinfo Catalog information about the external function
+ * @param[in] func Bounding box function
+ */
+Datum
+Boxop_{TSIDE}_{BOX}(FunctionCallInfo fcinfo,
+  bool (*func)(const {BOXC} *, const {BOXC} *))
+{
+  Temporal *temp = PG_GETARG_TEMPORAL_P(0);
+  {BOXC} *box = {GETARG}(1);
+  bool result = {DISPBOX}(temp, box, func, INVERT_NO);
+  PG_FREE_IF_COPY(temp, 0);
+  PG_RETURN_BOOL(result);
+}
+
+/**
+ * @brief Generic topological function for two {VALDESC}s
+ * @param[in] fcinfo Catalog information about the external function
+ * @param[in] func Bounding box function
+ */
+Datum
+Boxop_{TSIDE}_{TSIDE}(FunctionCallInfo fcinfo,
+  bool (*func)(const {BOXC} *, const {BOXC} *))
+{
+  Temporal *temp1 = PG_GETARG_TEMPORAL_P(0);
+  Temporal *temp2 = PG_GETARG_TEMPORAL_P(1);
+  bool result = {DISPTT}(temp1, temp2, func);
+  PG_FREE_IF_COPY(temp1, 0);
+  PG_FREE_IF_COPY(temp2, 1);
+  PG_RETURN_BOOL(result);
+}
+
+/*****************************************************************************
+ * overlaps
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Overlaps_{BOX}_{TSIDE}(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Overlaps_{BOX}_{TSIDE});
+/**
+ * @ingroup {INGROUP}
+ * @brief Return true if a {BOXDESC} and the {BOXDESC} of a
+ * {VALDESC} overlap
+ * @sqlfn overlaps_bbox()
+ * @sqlop @p &&
+ */
+inline Datum
+Overlaps_{BOX}_{TSIDE}(PG_FUNCTION_ARGS)
+{
+  return Boxop_{BOX}_{TSIDE}(fcinfo, &overlaps_{BOX}_{BOX});
+}
+
+PGDLLEXPORT Datum Overlaps_{TSIDE}_{BOX}(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Overlaps_{TSIDE}_{BOX});
+/**
+ * @ingroup {INGROUP}
+ * @brief Return true if the {BOXDESC} of a {VALDESC} and
+ * a {BOXDESC} overlap
+ * @sqlfn overlaps_bbox()
+ * @sqlop @p &&
+ */
+inline Datum
+Overlaps_{TSIDE}_{BOX}(PG_FUNCTION_ARGS)
+{
+  return Boxop_{TSIDE}_{BOX}(fcinfo, &overlaps_{BOX}_{BOX});
+}
+
+PGDLLEXPORT Datum Overlaps_{TSIDE}_{TSIDE}(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Overlaps_{TSIDE}_{TSIDE});
+/**
+ * @ingroup {INGROUP}
+ * @brief Return true if the {BOXDESCPL} of two {VALDESC}s
+ * overlap
+ * @sqlfn overlaps_bbox()
+ * @sqlop @p &&
+ */
+inline Datum
+Overlaps_{TSIDE}_{TSIDE}(PG_FUNCTION_ARGS)
+{
+  return Boxop_{TSIDE}_{TSIDE}(fcinfo, &overlaps_{BOX}_{BOX});
+}
+
+/*****************************************************************************
+ * contains
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Contains_{BOX}_{TSIDE}(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Contains_{BOX}_{TSIDE});
+/**
+ * @ingroup {INGROUP}
+ * @brief Return true if a {BOXDESC} contains the one of a
+ * {VALDESC}
+ * @sqlfn contains_bbox()
+ * @sqlop @p @>
+ */
+inline Datum
+Contains_{BOX}_{TSIDE}(PG_FUNCTION_ARGS)
+{
+  return Boxop_{BOX}_{TSIDE}(fcinfo, &contains_{BOX}_{BOX});
+}
+
+PGDLLEXPORT Datum Contains_{TSIDE}_{BOX}(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Contains_{TSIDE}_{BOX});
+/**
+ * @ingroup {INGROUP}
+ * @brief Return true if the {BOXDESC} of a {VALDESC}
+ * contains a {BOXDESC}
+ * @sqlfn contains_bbox()
+ * @sqlop @p @>
+ */
+inline Datum
+Contains_{TSIDE}_{BOX}(PG_FUNCTION_ARGS)
+{
+  return Boxop_{TSIDE}_{BOX}(fcinfo, &contains_{BOX}_{BOX});
+}
+
+PGDLLEXPORT Datum Contains_{TSIDE}_{TSIDE}(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Contains_{TSIDE}_{TSIDE});
+/**
+ * @ingroup {INGROUP}
+ * @brief Return true if the {BOXDESC} of the first {VALDESC}
+ * contains the one of the second {VALDESC}
+ * @sqlfn contains_bbox()
+ * @sqlop @p @>
+ */
+inline Datum
+Contains_{TSIDE}_{TSIDE}(PG_FUNCTION_ARGS)
+{
+  return Boxop_{TSIDE}_{TSIDE}(fcinfo, &contains_{BOX}_{BOX});
+}
+
+/*****************************************************************************
+ * contained
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Contained_{BOX}_{TSIDE}(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Contained_{BOX}_{TSIDE});
+/**
+ * @ingroup {INGROUP}
+ * @brief Return true if a {BOXDESC} is contained in the
+ * {BOXDESC} of a {VALDESC}
+ * @sqlfn contained_bbox()
+ * @sqlop @p <@
+ */
+inline Datum
+Contained_{BOX}_{TSIDE}(PG_FUNCTION_ARGS)
+{
+  return Boxop_{BOX}_{TSIDE}(fcinfo, &contained_{BOX}_{BOX});
+}
+
+PGDLLEXPORT Datum Contained_{TSIDE}_{BOX}(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Contained_{TSIDE}_{BOX});
+/**
+ * @ingroup {INGROUP}
+ * @brief Return true if the {BOXDESC} of a {VALDESC} is
+ * contained in the {BOXDESC}
+ * @sqlfn contained_bbox()
+ * @sqlop @p <@
+ */
+inline Datum
+Contained_{TSIDE}_{BOX}(PG_FUNCTION_ARGS)
+{
+  return Boxop_{TSIDE}_{BOX}(fcinfo, &contained_{BOX}_{BOX});
+}
+
+PGDLLEXPORT Datum Contained_{TSIDE}_{TSIDE}(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Contained_{TSIDE}_{TSIDE});
+/**
+ * @ingroup {INGROUP}
+ * @brief Return true if the {BOXDESC} of the first {VALDESC}
+ * is contained in the one of the second {VALDESC}
+ * @sqlfn contained_bbox()
+ * @sqlop @p <@
+ */
+inline Datum
+Contained_{TSIDE}_{TSIDE}(PG_FUNCTION_ARGS)
+{
+  return Boxop_{TSIDE}_{TSIDE}(fcinfo, &contained_{BOX}_{BOX});
+}
+
+/*****************************************************************************
+ * same
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Same_{BOX}_{TSIDE}(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Same_{BOX}_{TSIDE});
+/**
+ * @ingroup {INGROUP}
+ * @brief Return true if a {BOXDESC} and the {BOXDESC} of a
+ * {VALDESC} are equal in the common dimensions
+ * @sqlfn same_bbox()
+ * @sqlop @p ~=
+ */
+inline Datum
+Same_{BOX}_{TSIDE}(PG_FUNCTION_ARGS)
+{
+  return Boxop_{BOX}_{TSIDE}(fcinfo, &same_{BOX}_{BOX});
+}
+
+PGDLLEXPORT Datum Same_{TSIDE}_{BOX}(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Same_{TSIDE}_{BOX});
+/**
+ * @ingroup {INGROUP}
+ * @brief Return true if the {BOXDESC} of a {VALDESC} and
+ * a {BOXDESC} are equal in the common dimensions
+ * @sqlfn same_bbox()
+ * @sqlop @p ~=
+ */
+inline Datum
+Same_{TSIDE}_{BOX}(PG_FUNCTION_ARGS)
+{
+  return Boxop_{TSIDE}_{BOX}(fcinfo, &same_{BOX}_{BOX});
+}
+
+PGDLLEXPORT Datum Same_{TSIDE}_{TSIDE}(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Same_{TSIDE}_{TSIDE});
+/**
+ * @ingroup {INGROUP}
+ * @brief Return true if the {BOXDESCPL} of two {VALDESC}s
+ * are equal in the common dimensions
+ * @sqlfn same_bbox()
+ * @sqlop @p ~=
+ */
+inline Datum
+Same_{TSIDE}_{TSIDE}(PG_FUNCTION_ARGS)
+{
+  return Boxop_{TSIDE}_{TSIDE}(fcinfo, &same_{BOX}_{BOX});
+}
+
+/*****************************************************************************
+ * adjacent
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Adjacent_{BOX}_{TSIDE}(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Adjacent_{BOX}_{TSIDE});
+/**
+ * @ingroup {INGROUP}
+ * @brief Return true if a {BOXDESC} and the {BOXDESC} of a
+ * {VALDESC} are adjacent
+ * @sqlfn adjacent_bbox()
+ * @sqlop @p -|-
+ */
+inline Datum
+Adjacent_{BOX}_{TSIDE}(PG_FUNCTION_ARGS)
+{
+  return Boxop_{BOX}_{TSIDE}(fcinfo, &adjacent_{BOX}_{BOX});
+}
+
+PGDLLEXPORT Datum Adjacent_{TSIDE}_{BOX}(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Adjacent_{TSIDE}_{BOX});
+/**
+ * @ingroup {INGROUP}
+ * @brief Return true if the {BOXDESC} of a {VALDESC}
+ * and a {BOXDESC} are adjacent
+ * @sqlfn adjacent_bbox()
+ * @sqlop @p -|-
+ */
+inline Datum
+Adjacent_{TSIDE}_{BOX}(PG_FUNCTION_ARGS)
+{
+  return Boxop_{TSIDE}_{BOX}(fcinfo, &adjacent_{BOX}_{BOX});
+}
+
+PGDLLEXPORT Datum Adjacent_{TSIDE}_{TSIDE}(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Adjacent_{TSIDE}_{TSIDE});
+/**
+ * @ingroup {INGROUP}
+ * @brief Return true if the {BOXDESCPL} of two {VALDESC}s
+ * are adjacent
+ * @sqlfn adjacent_bbox()
+ * @sqlop @p -|-
+ */
+inline Datum
+Adjacent_{TSIDE}_{TSIDE}(PG_FUNCTION_ARGS)
+{
+  return Boxop_{TSIDE}_{TSIDE}(fcinfo, &adjacent_{BOX}_{BOX});
+}
+
+/*****************************************************************************/


### PR DESCRIPTION
The per-(operator, direction) PostgreSQL wrappers for the bounding-box topological operators — `overlaps` / `contains` / `contained` / `same` / `adjacent` — are pure mechanical glue: each one is `Boxop_<direction>(fcinfo, &<operator>_<box>_<box>)`. They are regular across the four bounding-box types (`stbox`, `tbox`, `tstzspan`, `tpcbox`), differing only in the box type, its generic dispatchers, and the descriptor nouns used in the doc comments.

This brings them under the existing inherited-behaviour generator (`tools/codegen/inherited/`) so they are emitted from a single template rather than hand-maintained per box type:

- `templates/boxops.c.tmpl` — the box-type-parameterised wrapper template.
- a `boxtypes` section in `manifest.yaml` — one entry per box type supplying its tokens.
- emit and `--validate` paths in `generate.py` — the generator owns the region between the `GENERATED-BOXOPS` markers of a `.c` file; the rest of the file (trajectory tiling here) stays hand-written.

`stbox` is registered as a `reference` box type, so `generate.py --validate` regenerates the committed `tgeo_boxops.c` region and asserts it byte-for-byte, guarding against drift the same way the SQL references already are.

The only change to `tgeo_boxops.c` is in its doc comments: two `@brief` lines that read "temporal point" (copied from tpoint) now read "spatiotemporal value", and a few `@brief` lines are rewrapped. The generated functional code is byte-for-byte identical to the previous hand-written wrappers.

This is the first step of moving the boxops to the generator on a box-type axis; `tbox` / `tstzspan` / `tpcbox` follow as separate per-box-type changes (the `tpcbox` one retires the `DEFINE_BOXOP3` macro in `tpc_boxops.c`).
