### PR TITLE
Compute the boundary of compound curves and multisurfaces

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -816,6 +816,59 @@ geom_perimeter(const GSERIALIZED *gs)
 }
 
 /**
+ * @brief Return the boundary of a compound curve, that is, its two end points,
+ * or an empty multipoint if the curve is closed
+ * @details The embedded PostGIS @p lwgeom_boundary does not handle
+ * @p COMPOUNDTYPE (it errors on it), while it does handle circular strings; the
+ * boundary is computed here from the first point of the first component and the
+ * last point of the last component, mirroring the linestring/circularstring case
+ */
+static LWGEOM *
+lwcompound_boundary(const LWGEOM *geom)
+{
+  int32_t srid = lwgeom_get_srid(geom);
+  uint8_t hasz = lwgeom_has_z(geom);
+  uint8_t hasm = lwgeom_has_m(geom);
+  if (lwgeom_is_closed(geom) || lwgeom_is_empty(geom))
+    return (LWGEOM *) lwmpoint_construct_empty(srid, hasz, hasm);
+  /* A compound curve is a chain of (circular) lines sharing their end points */
+  const LWCOLLECTION *col = (const LWCOLLECTION *) geom;
+  const LWLINE *first = (const LWLINE *) col->geoms[0];
+  const LWLINE *last = (const LWLINE *) col->geoms[col->ngeoms - 1];
+  LWMPOINT *result = lwmpoint_construct_empty(srid, hasz, hasm);
+  POINT4D pt;
+  getPoint4d_p(first->points, 0, &pt);
+  lwmpoint_add_lwpoint(result, lwpoint_make(srid, hasz, hasm, &pt));
+  getPoint4d_p(last->points, last->points->npoints - 1, &pt);
+  lwmpoint_add_lwpoint(result, lwpoint_make(srid, hasz, hasm, &pt));
+  return (LWGEOM *) result;
+}
+
+/**
+ * @brief Return the boundary of a multisurface, that is, the union of the
+ * boundaries of its member surfaces
+ * @details The embedded PostGIS @p lwgeom_boundary does not handle
+ * @p MULTISURFACETYPE (it errors on it), while it does handle its member curve
+ * polygons; the boundaries of the members are collected and homogenized,
+ * mirroring the multipolygon case
+ */
+static LWGEOM *
+lwmsurface_boundary(const LWGEOM *geom)
+{
+  int32_t srid = lwgeom_get_srid(geom);
+  uint8_t hasz = lwgeom_has_z(geom);
+  uint8_t hasm = lwgeom_has_m(geom);
+  const LWCOLLECTION *col = (const LWCOLLECTION *) geom;
+  LWCOLLECTION *result =
+    lwcollection_construct_empty(COLLECTIONTYPE, srid, hasz, hasm);
+  for (uint32_t i = 0; i < col->ngeoms; i++)
+    result = lwcollection_add_lwgeom(result, lwgeom_boundary(col->geoms[i]));
+  LWGEOM *lwout = lwgeom_homogenize((LWGEOM *) result);
+  lwgeom_free((LWGEOM *) result);
+  return lwout;
+}
+
+/**
  * @ingroup meos_geo_base_spatial
  * @brief Return the boundary of a geometry
  * @param[in] gs Geometry
@@ -827,7 +880,15 @@ geom_boundary(const GSERIALIZED *gs)
   assert(gs);
   /* Empty.Boundary() == Empty, but of other dimension, so can't shortcut */
   LWGEOM *geom = lwgeom_from_gserialized(gs);
-  LWGEOM *lwresult = lwgeom_boundary(geom);
+  /* The embedded PostGIS lwgeom_boundary does not support compound curves or
+   * multisurfaces; compute their boundary natively */
+  LWGEOM *lwresult;
+  if (geom->type == COMPOUNDTYPE)
+    lwresult = lwcompound_boundary(geom);
+  else if (geom->type == MULTISURFACETYPE)
+    lwresult = lwmsurface_boundary(geom);
+  else
+    lwresult = lwgeom_boundary(geom);
   if (! lwresult)
   {
     lwgeom_free(geom);

--- a/mobilitydb/test/geo/expected/070_tpoint_spatialrels.test.out
+++ b/mobilitydb/test/geo/expected/070_tpoint_spatialrels.test.out
@@ -1040,6 +1040,24 @@ SELECT eTouches(tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]', geo
  t
 (1 row)
 
+SELECT eTouches(tgeompoint '[Point(0 0)@2000-01-01, Point(3 3)@2000-01-04]', geometry 'CompoundCurve(CircularString(1 1,2 2,3 1),(3 1,4 0))');
+ etouches 
+----------
+ t
+(1 row)
+
+SELECT eTouches(tgeompoint '[Point(0 0)@2000-01-01, Point(3 3)@2000-01-04]', geometry 'CompoundCurve(CircularString(1 1,2 2,3 1),(3 1,1 1))');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(tgeompoint '[Point(0 0)@2000-01-01, Point(3 3)@2000-01-04]', geometry 'MultiSurface(((1 1,3 1,3 3,1 3,1 1)),CurvePolygon(CircularString(5 5,6 6,7 5,6 4,5 5)))');
+ etouches 
+----------
+ t
+(1 row)
+
 /* Errors */
 SELECT eTouches(geometry 'SRID=5676;Point(1 1)', tgeompoint 'Point(1 1)@2000-01-01');
 ERROR:  Operation on mixed SRID

--- a/mobilitydb/test/geo/expected/072_tpoint_tempspatialrels.test.out
+++ b/mobilitydb/test/geo/expected/072_tpoint_tempspatialrels.test.out
@@ -749,6 +749,24 @@ SELECT tTouches(geometry 'Linestring(1 1,2 2)', tgeompoint '[Point(1 1)@2000-01-
  {[t@Sat Jan 01 00:00:00 2000 PST], (f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST]}
 (1 row)
 
+SELECT tTouches(geometry 'CompoundCurve(CircularString(1 1,2 2,3 1),(3 1,4 0))', tgeompoint '[Point(0 0)@2000-01-01, Point(4 4)@2000-01-04]');
+                                                               ttouches                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 18:00:00 2000 PST], (f@Sat Jan 01 18:00:00 2000 PST, f@Tue Jan 04 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tTouches(tgeompoint '[Point(0 0)@2000-01-01, Point(4 4)@2000-01-04]', geometry 'CompoundCurve(CircularString(1 1,2 2,3 1),(3 1,4 0))');
+                                                               ttouches                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 18:00:00 2000 PST], (f@Sat Jan 01 18:00:00 2000 PST, f@Tue Jan 04 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tTouches(geometry 'MultiSurface(((1 1,3 1,3 3,1 3,1 1)),CurvePolygon(CircularString(5 5,6 6,7 5,6 4,5 5)))', tgeompoint '[Point(0 0)@2000-01-01, Point(4 4)@2000-01-04]');
+                                                                                                ttouches                                                                                                
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 18:00:00 2000 PST], (f@Sat Jan 01 18:00:00 2000 PST, t@Mon Jan 03 06:00:00 2000 PST], (f@Mon Jan 03 06:00:00 2000 PST, f@Tue Jan 04 00:00:00 2000 PST]}
+(1 row)
+
 /* Errors */
 SELECT tTouches(geometry 'SRID=5676;Point(1 1)', tgeompoint 'Point(1 1)@2000-01-01');
 ERROR:  Operation on mixed SRID

--- a/mobilitydb/test/geo/queries/070_tpoint_spatialrels.test.sql
+++ b/mobilitydb/test/geo/queries/070_tpoint_spatialrels.test.sql
@@ -293,6 +293,11 @@ SELECT eTouches(tgeompoint '[Point(0 0)@2000-01-01, Point(3 3)@2000-01-04]', geo
 SELECT eTouches(tgeompoint '[Point(0 0)@2000-01-01, Point(3 3)@2000-01-04]', geometry 'CurvePolygon((1 1,2 2,3 1,2 0,1 1))');
 -- Notice that the boundary of a closed linear or circular string is empty !
 SELECT eTouches(tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]', geometry 'CircularString(1 1,2 2,3 1,2 0,1 1)');
+-- The boundary of a compound curve is its two end points, or empty if closed
+SELECT eTouches(tgeompoint '[Point(0 0)@2000-01-01, Point(3 3)@2000-01-04]', geometry 'CompoundCurve(CircularString(1 1,2 2,3 1),(3 1,4 0))');
+SELECT eTouches(tgeompoint '[Point(0 0)@2000-01-01, Point(3 3)@2000-01-04]', geometry 'CompoundCurve(CircularString(1 1,2 2,3 1),(3 1,1 1))');
+-- The boundary of a multisurface is the union of the boundaries of its surfaces
+SELECT eTouches(tgeompoint '[Point(0 0)@2000-01-01, Point(3 3)@2000-01-04]', geometry 'MultiSurface(((1 1,3 1,3 3,1 3,1 1)),CurvePolygon(CircularString(5 5,6 6,7 5,6 4,5 5)))');
 
 /* Errors */
 SELECT eTouches(geometry 'SRID=5676;Point(1 1)', tgeompoint 'Point(1 1)@2000-01-01');

--- a/mobilitydb/test/geo/queries/072_tpoint_tempspatialrels.test.sql
+++ b/mobilitydb/test/geo/queries/072_tpoint_tempspatialrels.test.sql
@@ -241,6 +241,12 @@ SELECT tTouches(tgeompoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Poin
 
 SELECT tTouches(geometry 'Linestring(1 1,2 2)', tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]');
 
+-- Coverage of curved types whose boundary the embedded PostGIS lwgeom_boundary
+-- does not compute: compound curves (boundary = end points) and multisurfaces
+SELECT tTouches(geometry 'CompoundCurve(CircularString(1 1,2 2,3 1),(3 1,4 0))', tgeompoint '[Point(0 0)@2000-01-01, Point(4 4)@2000-01-04]');
+SELECT tTouches(tgeompoint '[Point(0 0)@2000-01-01, Point(4 4)@2000-01-04]', geometry 'CompoundCurve(CircularString(1 1,2 2,3 1),(3 1,4 0))');
+SELECT tTouches(geometry 'MultiSurface(((1 1,3 1,3 3,1 3,1 1)),CurvePolygon(CircularString(5 5,6 6,7 5,6 4,5 5)))', tgeompoint '[Point(0 0)@2000-01-01, Point(4 4)@2000-01-04]');
+
 /* Errors */
 SELECT tTouches(geometry 'SRID=5676;Point(1 1)', tgeompoint 'Point(1 1)@2000-01-01');
 SELECT tTouches(tgeompoint 'Point(1 1)@2000-01-01', geometry 'SRID=5676;Point(1 1)');


### PR DESCRIPTION
The embedded PostGIS `lwgeom_boundary` does not support the `COMPOUNDTYPE` and
`MULTISURFACETYPE` geometry types and raises

```
ERROR:  lwgeom_boundary: unsupported geometry type: CompoundCurve
```

on them. As a result the `eTouches`, `aTouches`, and `tTouches` functions —
which take the boundary of their geometry argument — fail on compound curves
and multisurfaces, even though circular strings, multicurves and curve polygons
are handled.

This computes the boundary of these two types natively in `geom_boundary`:

- a compound curve: its two end points (the first point of the first component
  and the last point of the last component), or an empty multipoint when the
  curve is closed — mirroring the linestring / circular string case;
- a multisurface: the homogenized union of the boundaries of its member
  surfaces — mirroring the multipolygon case.

Coverage is added to the `eTouches` and `tTouches` tests for an open compound
curve, a closed compound curve, and a multisurface.