### PR TITLE
Add compound curves to the tbl_geom test table

### DIFF
--- a/mobilitydb/datagen/geo/create_test_tables_tpoint.sql
+++ b/mobilitydb/datagen/geo/create_test_tables_tpoint.sql
@@ -222,6 +222,12 @@ SELECT 1 AS k, geometry 'circularstring empty' AS g UNION
 SELECT k, random_geom_circularstring(0, 100, 0, 100, 10, 1, 5)
 FROM generate_series(2, size) k;
 
+DROP TABLE IF EXISTS tbl_geom_compoundcurve;
+CREATE TABLE tbl_geom_compoundcurve AS
+SELECT 1 AS k, geometry 'compoundcurve empty' AS g UNION
+SELECT k, random_geom_compoundcurve(0, 100, 0, 100, 10, 1, 5)
+FROM generate_series(2, size) k;
+
 DROP TABLE IF EXISTS tbl_geom;
 CREATE TABLE tbl_geom (
   k serial PRIMARY KEY,
@@ -233,7 +239,8 @@ INSERT INTO tbl_geom(g)
 (SELECT g FROM tbl_geom_multipoint ORDER BY k LIMIT (size * 0.2)) UNION ALL
 (SELECT g FROM tbl_geom_multilinestring ORDER BY k LIMIT (size * 0.2)) UNION ALL
 (SELECT g FROM tbl_geom_multipolygon ORDER BY k LIMIT (size * 0.2)) UNION ALL
-(SELECT g FROM tbl_geom_circularstring ORDER BY k LIMIT (size * 0.2));
+(SELECT g FROM tbl_geom_circularstring ORDER BY k LIMIT (size * 0.2)) UNION ALL
+(SELECT g FROM tbl_geom_compoundcurve ORDER BY k LIMIT (size * 0.2));
 
 DROP TABLE IF EXISTS tbl_geom3D;
 CREATE TABLE tbl_geom3D (

--- a/mobilitydb/datagen/geo/random_tpoint.sql
+++ b/mobilitydb/datagen/geo/random_tpoint.sql
@@ -768,6 +768,46 @@ SELECT distinct geometrytype(random_geom_circularstring(-100, 100, -100, 100, 10
 FROM generate_series(1, 15) AS k;
 */
 
+DROP FUNCTION IF EXISTS random_geom_compoundcurve;
+CREATE FUNCTION random_geom_compoundcurve(lowx float, highx float, lowy float,
+  highy float, maxdelta float, minarcs int, maxarcs int, srid int DEFAULT 0)
+  RETURNS geometry AS $$
+DECLARE
+  narcs int;
+  npoints int;
+  points geometry[];
+  wkt text;
+BEGIN
+  IF minarcs > maxarcs THEN
+    RAISE EXCEPTION 'minarcs must be less than or equal to maxarcs: %, %',
+      minarcs, maxarcs;
+  END IF;
+  narcs = random_int(minarcs, maxarcs);
+  /* A compound curve joins a circular string of n arcs (2 * n + 1 points) to a
+   * trailing line segment sharing the last arc point (1 additional point) */
+  npoints = 2 * narcs + 1;
+  points = random_geom_point_array(lowx, highx, lowy, highy, maxdelta,
+    npoints + 1, npoints + 1, srid);
+  SELECT string_agg(st_x(p) || ' ' || st_y(p), ',' ORDER BY ord)
+  INTO wkt
+  FROM unnest(points[1:npoints]) WITH ORDINALITY AS t(p, ord);
+  RETURN ST_GeomFromText('COMPOUNDCURVE(CIRCULARSTRING(' || wkt || '),(' ||
+    st_x(points[npoints]) || ' ' || st_y(points[npoints]) || ',' ||
+    st_x(points[npoints + 1]) || ' ' || st_y(points[npoints + 1]) || '))', srid);
+END;
+$$ LANGUAGE PLPGSQL STRICT;
+
+/*
+SELECT k, st_asEWKT(random_geom_compoundcurve(-100, 100, -100, 100, 10, 1, 5)) AS g
+FROM generate_series(1, 15) AS k;
+
+SELECT k, st_asEWKT(random_geom_compoundcurve(-100, 100, -100, 100, 10, 1, 5, 3812)) AS g
+FROM generate_series(1, 15) AS k;
+
+SELECT distinct geometrytype(random_geom_compoundcurve(-100, 100, -100, 100, 10, 1, 5)) AS g
+FROM generate_series(1, 15) AS k;
+*/
+
 -------------------------------------------------------------------------------
 
 /**

--- a/mobilitydb/test/geo/expected/064_tpoint_distance_tbl.test.out
+++ b/mobilitydb/test/geo/expected/064_tpoint_distance_tbl.test.out
@@ -86,7 +86,7 @@ SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
  count 
 -------
- 11300
+ 13200
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2
@@ -142,7 +142,7 @@ SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
  count 
 -------
- 11300
+ 13200
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2
@@ -198,7 +198,7 @@ SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE g |=| temp IS NOT NULL;
  count 
 -------
- 11300
+ 13200
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2
@@ -254,7 +254,7 @@ SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE shortestLine(g, temp) IS NOT NULL;
  count 
 -------
- 11300
+ 13200
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2

--- a/mobilitydb/test/geo/expected/070_tpoint_spatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/070_tpoint_spatialrels_tbl.test.out
@@ -1,7 +1,7 @@
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE eContains(g, temp);
  count 
 -------
-  3806
+  4686
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE aContains(g, temp);
@@ -13,13 +13,13 @@ SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE aContains(g, temp);
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE eDisjoint(g, temp);
  count 
 -------
- 11154
+ 13054
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom WHERE eDisjoint(temp, g);
  count 
 -------
- 11154
+ 13054
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE eDisjoint(t1.temp, t2.temp);
@@ -61,13 +61,13 @@ SELECT COUNT(*) > 0 FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2 WHERE eDisjoin
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE aDisjoint(g, temp);
  count 
 -------
-  7494
+  8514
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom WHERE aDisjoint(temp, g);
  count 
 -------
-  7494
+  8514
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE aDisjoint(t1.temp, t2.temp);
@@ -133,13 +133,13 @@ SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2 WHERE aDisjoint(t1
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE eIntersects(g, temp);
  count 
 -------
-  3806
+  4686
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom WHERE eIntersects(temp, g);
  count 
 -------
-  3806
+  4686
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE eIntersects(t1.temp, t2.temp);

--- a/mobilitydb/test/geo/expected/072_tpoint_tempspatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/072_tpoint_tempspatialrels_tbl.test.out
@@ -2,21 +2,21 @@ SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint
   WHERE tContains(g, temp) IS NOT NULL;
  count 
 -------
- 11300
+ 13200
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint_step_seq
   WHERE tContains(g, seq) IS NOT NULL;
  count 
 -------
- 11300
+ 13200
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint_step_seqset
   WHERE tContains(g, ss) IS NOT NULL;
  count 
 -------
- 11300
+ 13200
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint
@@ -184,7 +184,7 @@ SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint
   WHERE tTouches(g, temp) IS NOT NULL;
  count 
 -------
- 11300
+ 13200
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom_point
@@ -198,14 +198,14 @@ SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint_step_seq
   WHERE tTouches(g, seq) IS NOT NULL;
  count 
 -------
- 11300
+ 13200
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint_step_seqset
   WHERE tTouches(g, ss) IS NOT NULL;
  count 
 -------
- 11300
+ 13200
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint


### PR DESCRIPTION
Following the addition of circular strings, this makes compound curves a
first-class geometry type at the test level by unioning them into the `tbl_geom`
superclass table, so that every `_tbl` test reading `tbl_geom` also exercises
compound curves.

- A `random_geom_compoundcurve` generator (a circular string arc followed by a
  line segment sharing its endpoint), mirroring `random_geom_circularstring`.
- A narrow `tbl_geom_compoundcurve` table, with a 20% slice unioned into
  `tbl_geom` (120 → 140 rows).
- The frozen `load_point.sql.xz` snapshot is updated by appending the new rows
  (pure insertion; all existing rows preserved).

The only expected-output changes are the row counts of the `_tbl` tests that
read `tbl_geom` (`064`/`070`/`072`), which grow accordingly. The boundary of
compound curves is now computed natively, so the `Touches` predicates over the
new rows return results rather than erroring.