### PR TITLE
Add same_span_span for the bounding-box same operator on spans

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -766,6 +766,7 @@ extern bool overlaps_span_span(const Span *s1, const Span *s2);
 extern bool overlaps_span_spanset(const Span *s, const SpanSet *ss);
 extern bool overlaps_spanset_span(const SpanSet *ss, const Span *s);
 extern bool overlaps_spanset_spanset(const SpanSet *ss1, const SpanSet *ss2);
+extern bool same_span_span(const Span *s1, const Span *s2);
 
 /*****************************************************************************/
 

--- a/meos/src/temporal/span_ops.c
+++ b/meos/src/temporal/span_ops.c
@@ -292,6 +292,26 @@ adjacent_span_span(const Span *s1, const Span *s2)
 }
 
 /*****************************************************************************
+ * Same
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_setspan_topo
+ * @brief Return true if two spans are equal in the common dimensions
+ * @param[in] s1,s2 Spans
+ */
+bool
+same_span_span(const Span *s1, const Span *s2)
+{
+  /* A span is a single dimension, so `same` (`~=`) reduces to span equality.
+   * This is the base case of the bounding-box `same` family (#same_tbox_tbox(),
+   * #same_stbox_stbox()), letting the temporal/span bounding-box wrappers
+   * dispatch on `~=` uniformly instead of borrowing the equality (`=`)
+   * function #span_eq(). */
+  return span_eq(s1, s2);
+}
+
+/*****************************************************************************
  * Left of
  *****************************************************************************/
 

--- a/mobilitydb/src/temporal/temporal_boxops.c
+++ b/mobilitydb/src/temporal/temporal_boxops.c
@@ -403,7 +403,7 @@ PG_FUNCTION_INFO_V1(Same_tstzspan_temporal);
 inline Datum
 Same_tstzspan_temporal(PG_FUNCTION_ARGS)
 {
-  return Boxop_tstzspan_temporal(fcinfo, &span_eq);
+  return Boxop_tstzspan_temporal(fcinfo, &same_span_span);
 }
 
 PGDLLEXPORT Datum Same_temporal_tstzspan(PG_FUNCTION_ARGS);
@@ -418,7 +418,7 @@ PG_FUNCTION_INFO_V1(Same_temporal_tstzspan);
 inline Datum
 Same_temporal_tstzspan(PG_FUNCTION_ARGS)
 {
-  return Boxop_temporal_tstzspan(fcinfo, &span_eq);
+  return Boxop_temporal_tstzspan(fcinfo, &same_span_span);
 }
 
 PGDLLEXPORT Datum Same_temporal_temporal(PG_FUNCTION_ARGS);
@@ -432,7 +432,7 @@ PG_FUNCTION_INFO_V1(Same_temporal_temporal);
 inline Datum
 Same_temporal_temporal(PG_FUNCTION_ARGS)
 {
-  return Boxop_temporal_temporal(fcinfo, &span_eq);
+  return Boxop_temporal_temporal(fcinfo, &same_span_span);
 }
 
 /*****************************************************************************/
@@ -816,7 +816,7 @@ PG_FUNCTION_INFO_V1(Same_numspan_tnumber);
 inline Datum
 Same_numspan_tnumber(PG_FUNCTION_ARGS)
 {
-  return Boxop_numspan_tnumber(fcinfo, &span_eq);
+  return Boxop_numspan_tnumber(fcinfo, &same_span_span);
 }
 
 PGDLLEXPORT Datum Same_tnumber_numspan(PG_FUNCTION_ARGS);
@@ -831,7 +831,7 @@ PG_FUNCTION_INFO_V1(Same_tnumber_numspan);
 inline Datum
 Same_tnumber_numspan(PG_FUNCTION_ARGS)
 {
-  return Boxop_tnumber_numspan(fcinfo, &span_eq);
+  return Boxop_tnumber_numspan(fcinfo, &same_span_span);
 }
 
 PGDLLEXPORT Datum Same_tbox_tnumber(PG_FUNCTION_ARGS);


### PR DESCRIPTION
The `~=` ("same") bounding-box operator is backed by a dedicated `same_*` predicate for every box type — `same_tbox_tbox`, `same_stbox_stbox`, `same_tpcbox_tpcbox` — but no such predicate existed for spans. As a result the five `Same_*` wrappers over a span and a temporal value (`Same_tstzspan_temporal` and both directions of tstzspan/temporal, plus the `numspan` directions of the temporal-number boxops) dispatched on `&span_eq`. That is the equality (`=`) function standing in for the same (`~=`) operator — two distinct operators sharing one primitive, which the per-box `same_<box>_<box>` naming otherwise avoids.

This adds `same_span_span` as that missing predicate. A span has a single dimension, so "same in the common dimensions" reduces to span equality — it is the 1-D base case of `same_tbox_tbox`, whose body already compares each common dimension with `span_eq`. The five wrappers now dispatch on `&same_span_span`, so `~=` is backed by a same-family function while `=` stays `span_eq`.

Behaviour is unchanged: for a one-dimensional span the two are computed identically.
