### PR TITLE
Add the raquet raster-tile type and typed raster_tile_value operator

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3731,6 +3731,14 @@
 				<listitem>
 					<para><link linkend="raster_tile_value_quadbin"><varname>raster_tile_value_quadbin</varname></link>: Muestrear un chip ráster de Raquet a lo largo de una trayectoria usando una celda QUADBIN para la georreferenciación</para>
 				</listitem>
+
+				<listitem>
+					<para><link linkend="raquet"><varname>raquet</varname></link>: Construir una tesela ráster Raquet a partir de sus bytes de píxeles, dimensiones, celda QUADBIN y tipo de píxel</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="raster_tile_value"><varname>raster_tile_value</varname></link>: Muestrear una tesela ráster raquet a lo largo de una trayectoria</para>
+				</listitem>
 			</itemizedlist>
 		</sect2>
 

--- a/doc/es/temporal_raster.xml
+++ b/doc/es/temporal_raster.xml
@@ -133,6 +133,35 @@ JOIN sst_raquet r
   ON r.quadbin = ANY(trajectory_quadbins(t.trip4326, 6));
 </programlisting>
 			</listitem>
+
+			<listitem xml:id="raquet">
+				<indexterm significance="normal"><primary><varname>raquet</varname></primary></indexterm>
+				<para>Construir una tesela ráster Raquet a partir de sus bytes de píxeles, dimensiones, celda QUADBIN y tipo de píxel</para>
+				<para><varname>raquet(bytea,integer,integer,bigint,text,float8) → raquet</varname></para>
+				<para>Empaqueta un arreglo de píxeles <varname>pixels</varname> de banda única en orden de fila mayor de <varname>width</varname> × <varname>height</varname> píxeles de tipo <varname>pixtype</varname> (uno de <varname>UINT8</varname>, <varname>INT16</varname>, <varname>INT32</varname>, <varname>FLOAT32</varname> o <varname>FLOAT64</varname>), georreferenciado por la celda <varname>quadbin</varname>, en un único valor <varname>raquet</varname> autodescriptivo. El argumento <varname>nodata</varname> es opcional; cuando se omite (<varname>NULL</varname>) la tesela no lleva valor centinela de nodata. Se genera un error cuando el arreglo <varname>pixels</varname> es menor que <varname>width</varname> × <varname>height</varname> × el tamaño del píxel. Un <varname>raquet</varname> es un valor de longitud variable, libre de GDAL, con una representación portátil en texto Hex-WKB y binaria, distinto de y coexistente con el tipo <varname>raster</varname> de PostGIS usado por <link linkend="raster_value"><varname>raster_value</varname></link>.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Empaquetar las columnas sueltas de una tabla Raquet en valores raquet
+SELECT raquet(band_data, width, height, quadbin, 'FLOAT32', nodata) AS tile
+FROM elevation_raquet;
+
+-- Una tesela UINT8 de 2 x 2 sin nodata
+SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8');
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="raster_tile_value">
+				<indexterm significance="normal"><primary><varname>raster_tile_value</varname></primary></indexterm>
+				<para>Muestrear una tesela ráster <varname>raquet</varname> a lo largo de una trayectoria</para>
+				<para><varname>raster_tile_value(raquet,tgeompoint) → tfloat</varname></para>
+				<para>Evalúa la tesela en cada instante de <varname>traj</varname> (SRID 4326), devolviendo los valores de píxel muestreados como un <varname>tfloat</varname>. Es el equivalente tipado de <link linkend="raster_tile_value_quadbin"><varname>raster_tile_value_quadbin</varname></link>: las dimensiones, la celda QUADBIN, el tipo de píxel y el tratamiento de nodata se toman del valor <varname>raquet</varname> en lugar de argumentos separados. Devuelve <varname>NULL</varname> cuando ningún instante cae dentro de la tesela o sobrevive al filtrado de nodata.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Muestrear teselas raquet preempaquetadas a lo largo de trayectorias de barcos
+SELECT t.tripid, raster_tile_value(r.tile, t.trip4326)
+FROM trips t
+JOIN elevation_tiles r
+  ON r.quadbin = ANY(trajectory_quadbins(t.trip4326, 8));
+</programlisting>
+			</listitem>
 		</itemizedlist>
 	</sect1>
 

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3709,6 +3709,14 @@
 				<listitem>
 					<para><link linkend="raster_tile_value_quadbin"><varname>raster_tile_value_quadbin</varname></link>: Sample a Raquet raster chip along a trajectory using a QUADBIN cell for georeferencing</para>
 				</listitem>
+
+				<listitem>
+					<para><link linkend="raquet"><varname>raquet</varname></link>: Construct a Raquet raster tile from its pixel bytes, dimensions, QUADBIN cell and pixel type</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="raster_tile_value"><varname>raster_tile_value</varname></link>: Sample a Raquet raster tile along a trajectory</para>
+				</listitem>
 			</itemizedlist>
 		</sect2>
 

--- a/doc/temporal_raster.xml
+++ b/doc/temporal_raster.xml
@@ -135,6 +135,35 @@ JOIN sst_raquet r
   ON r.quadbin = ANY(trajectory_quadbins(t.trip4326, 6));
 </programlisting>
 			</listitem>
+
+			<listitem xml:id="raquet">
+				<indexterm significance="normal"><primary><varname>raquet</varname></primary></indexterm>
+				<para>Construct a Raquet raster tile from its pixel bytes, dimensions, QUADBIN cell and pixel type</para>
+				<para><varname>raquet(bytea,integer,integer,bigint,text,float8) → raquet</varname></para>
+				<para>Packages a row-major single-band <varname>pixels</varname> array of <varname>width</varname> × <varname>height</varname> pixels of type <varname>pixtype</varname> (one of <varname>UINT8</varname>, <varname>INT16</varname>, <varname>INT32</varname>, <varname>FLOAT32</varname>, or <varname>FLOAT64</varname>), georeferenced by the <varname>quadbin</varname> cell, into a single self-describing <varname>raquet</varname> value. The <varname>nodata</varname> argument is optional; when omitted (<varname>NULL</varname>) the tile carries no nodata sentinel. An error is raised when the <varname>pixels</varname> array is smaller than <varname>width</varname> × <varname>height</varname> × the pixel size. A <varname>raquet</varname> is a GDAL-free, variable-length value with a portable Hex-WKB text and binary representation, distinct from and coexisting with the PostGIS <varname>raster</varname> type used by <link linkend="raster_value"><varname>raster_value</varname></link>.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Package the loose tile columns of a Raquet table into raquet values
+SELECT raquet(band_data, width, height, quadbin, 'FLOAT32', nodata) AS tile
+FROM elevation_raquet;
+
+-- A 2 x 2 UINT8 tile with no nodata
+SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8');
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="raster_tile_value">
+				<indexterm significance="normal"><primary><varname>raster_tile_value</varname></primary></indexterm>
+				<para>Sample a <varname>raquet</varname> raster tile along a trajectory</para>
+				<para><varname>raster_tile_value(raquet,tgeompoint) → tfloat</varname></para>
+				<para>Evaluates the tile at each instant of <varname>traj</varname> (SRID 4326), returning the sampled pixel values as a <varname>tfloat</varname>. This is the typed equivalent of <link linkend="raster_tile_value_quadbin"><varname>raster_tile_value_quadbin</varname></link>: the dimensions, QUADBIN cell, pixel type and nodata handling are taken from the <varname>raquet</varname> value instead of from separate arguments. Returns <varname>NULL</varname> when no instant falls inside the tile or survives nodata filtering.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Sample pre-packaged raquet tiles along ship trajectories
+SELECT t.tripid, raster_tile_value(r.tile, t.trip4326)
+FROM trips t
+JOIN elevation_tiles r
+  ON r.quadbin = ANY(trajectory_quadbins(t.trip4326, 8));
+</programlisting>
+			</listitem>
 		</itemizedlist>
 	</sect1>
 

--- a/meos/include/meos_raster.h
+++ b/meos/include/meos_raster.h
@@ -64,9 +64,44 @@ typedef enum
   MEOS_PT_FLOAT64 = 4,   /**< 64-bit IEEE double      */
 } MeosPixType;
 
+/* Opaque structure to represent a Raquet raster tile */
+
+typedef struct Raquet Raquet;
+
+/* Input and output functions for Raquet tiles */
+
+extern Raquet *raquet_in(const char *str);
+extern char *raquet_out(const Raquet *rq);
+extern Raquet *raquet_from_wkb(const uint8_t *wkb, size_t size);
+extern Raquet *raquet_from_hexwkb(const char *hexwkb);
+extern uint8_t *raquet_as_wkb(const Raquet *rq, uint8_t variant, size_t *size_out);
+extern char *raquet_as_hexwkb(const Raquet *rq, uint8_t variant, size_t *size_out);
+
+/* Constructor functions for Raquet tiles */
+
+extern Raquet *raquet_make(uint64 quadbin, uint16_t width, uint16_t height,
+  MeosPixType pixtype, double nodata, bool has_nodata, const uint8_t *pixels);
+extern Raquet *raquet_copy(const Raquet *rq);
+
+/* Accessor functions for Raquet tiles */
+
+extern uint64 raquet_quadbin(const Raquet *rq);
+extern int raquet_width(const Raquet *rq);
+extern int raquet_height(const Raquet *rq);
+extern double raquet_nodata(const Raquet *rq);
+
+/* Comparison functions for Raquet tiles */
+
+extern int raquet_cmp(const Raquet *rq1, const Raquet *rq2);
+extern bool raquet_eq(const Raquet *rq1, const Raquet *rq2);
+
+/* Sampling functions */
+
 extern Temporal *raster_tile_value_quadbin(const uint8_t *pixels,
   uint16_t width, uint16_t height, uint64 quadbin, MeosPixType pixtype,
   double nodata, bool has_nodata, const Temporal *traj);
+
+extern Temporal *raster_tile_value(const Raquet *rq, const Temporal *traj);
 
 extern uint64 *trajectory_quadbins(const Temporal *traj, uint32_t zoom,
   int *count);

--- a/meos/include/raster/raquet.h
+++ b/meos/include/raster/raquet.h
@@ -1,0 +1,117 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Internal definition of the Raquet raster-tile value type.
+ *
+ * A Raquet value is a single CARTO Raquet raster chip: a self-describing
+ * Web-Mercator tile identified by a QUADBIN cell, carrying a row-major packed
+ * pixel array. It is a GDAL-free MEOS value type; the trajectory-sampling
+ * kernel operates on it directly. See @ref meos_raster.h for the public API.
+ */
+
+#ifndef __RAQUET_H__
+#define __RAQUET_H__
+
+/* PostgreSQL */
+#include <postgres.h>
+/* MEOS */
+#include <meos.h>
+#include <meos_raster.h>
+
+/*****************************************************************************
+ * Type definitions
+ *****************************************************************************/
+
+/**
+ * @brief Structure to represent a Raquet raster tile.
+ * @details Variable-length (varlena) value. The field order is chosen so that
+ * the 8-byte members are naturally aligned and no internal padding is needed,
+ * hence the pixel payload starts at a fixed offset. The pixels are stored
+ * row-major, tightly packed, `width * height * raquet_pixtype_size(pixtype)`
+ * bytes; the tile geotransform is fully determined by @p quadbin.
+ */
+struct Raquet
+{
+  int32 vl_len_;        /**< Varlena header (do not touch directly!) */
+  uint16 width;         /**< Tile width in pixels */
+  uint16 height;        /**< Tile height in pixels */
+  uint64 quadbin;       /**< CARTO QUADBIN cell identifying the Web-Mercator tile */
+  double nodata;        /**< Nodata sentinel value */
+  uint8 pixtype;        /**< Pixel data type (::MeosPixType) */
+  bool has_nodata;      /**< Whether nodata filtering is active */
+  uint8 pixels[FLEXIBLE_ARRAY_MEMBER]; /**< Row-major packed pixel bytes */
+};
+
+/*****************************************************************************
+ * fmgr macros
+ *****************************************************************************/
+
+#if MEOS
+  #define DatumGetRaquetP(X)     ((Raquet *) DatumGetPointer(X))
+#else
+  #define DatumGetRaquetP(X)     ((Raquet *) PG_DETOAST_DATUM(X))
+#endif /* MEOS */
+#define RaquetPGetDatum(X)       PointerGetDatum(X)
+#define PG_GETARG_RAQUET_P(X)    ((Raquet *) PG_GETARG_VARLENA_P(X))
+#define PG_RETURN_RAQUET_P(X)    PG_RETURN_POINTER(X)
+
+/*****************************************************************************
+ * Internal accessors
+ *****************************************************************************/
+
+/**
+ * @brief Return the size in bytes of a single pixel of the given type
+ */
+static inline size_t
+raquet_pixtype_size(MeosPixType pixtype)
+{
+  switch (pixtype)
+  {
+    case MEOS_PT_UINT8:   return 1;
+    case MEOS_PT_INT16:   return 2;
+    case MEOS_PT_INT32:   return 4;
+    case MEOS_PT_FLOAT32: return 4;
+    case MEOS_PT_FLOAT64: return 8;
+    default:              return 0;
+  }
+}
+
+/**
+ * @brief Return the number of pixel bytes of a Raquet tile
+ */
+static inline size_t
+raquet_pixels_size(const Raquet *rq)
+{
+  return (size_t) rq->width * rq->height *
+    raquet_pixtype_size((MeosPixType) rq->pixtype);
+}
+
+#endif /* __RAQUET_H__ */

--- a/meos/include/temporal/meos_catalog.h
+++ b/meos/include/temporal/meos_catalog.h
@@ -134,6 +134,7 @@ typedef enum
   T_PCPATCHSET     = 78,  /**< pgpointcloud patch set type */
   T_TPCPATCH       = 79,  /**< temporal pgpointcloud patch type */
   T_TPCBOX         = 80,  /**< temporal pgpointcloud bounding box type */
+  T_RAQUET         = 81,  /**< Raquet raster tile type (GDAL-free QUADBIN chip) */
   NUM_MEOS_TYPES          /* Dummy value that determines the size of the
                            * lookup array MeosType -> Oid */
 } MeosType;

--- a/meos/src/raster/CMakeLists.txt
+++ b/meos/src/raster/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_library(raster OBJECT raster_quadbin.c)
+add_library(raster OBJECT raster_quadbin.c raquet.c)
 target_include_directories(raster PRIVATE
   "${CMAKE_SOURCE_DIR}/meos/include/raster")

--- a/meos/src/raster/raquet.c
+++ b/meos/src/raster/raquet.c
@@ -1,0 +1,346 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief General functions for the Raquet raster-tile value type.
+ *
+ * A Raquet value is a GDAL-free, self-describing Web-Mercator raster chip
+ * identified by a CARTO QUADBIN cell and carrying a row-major packed pixel
+ * array. Serialization goes through the central MEOS WKB machinery keyed by
+ * the ::T_RAQUET catalog type; the trajectory-sampling kernel in
+ * `raster_quadbin.c` operates on the unpacked fields.
+ */
+
+#include "raster/raquet.h"
+
+/* C */
+#include <assert.h>
+#include <string.h>
+/* PostgreSQL */
+#include <postgres.h>
+#include <pgtypes.h>
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  #include "varatt.h"
+#endif
+/* PostGIS */
+#include <liblwgeom.h>
+/* MEOS */
+#include <meos.h>
+#include <meos_internal.h>
+#include "temporal/temporal.h"
+#include "temporal/type_inout.h"
+
+/*****************************************************************************
+ * Validity functions
+ *****************************************************************************/
+
+/**
+ * @brief Ensure that a pixel type code is one of the supported values
+ */
+static bool
+ensure_valid_pixtype(uint8 pixtype)
+{
+  if (pixtype > (uint8) MEOS_PT_FLOAT64)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Unknown raquet pixel type code: %u", pixtype);
+    return false;
+  }
+  return true;
+}
+
+/*****************************************************************************
+ * Input/output functions
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_raster_base_inout
+ * @brief Return a Raquet tile from its ASCII hex-encoded Well-Known Binary
+ * (HexWKB) representation
+ * @param[in] str HexWKB string
+ * @csqlfn #Raquet_in()
+ */
+Raquet *
+raquet_in(const char *str)
+{
+  VALIDATE_NOT_NULL(str, NULL);
+  return DatumGetRaquetP(type_from_hexwkb(str, strlen(str), T_RAQUET));
+}
+
+/**
+ * @ingroup meos_raster_base_inout
+ * @brief Return the ASCII hex-encoded Well-Known Binary (HexWKB)
+ * representation of a Raquet tile
+ * @param[in] rq Raquet tile
+ * @csqlfn #Raquet_out()
+ */
+char *
+raquet_out(const Raquet *rq)
+{
+  VALIDATE_NOT_NULL(rq, NULL);
+  size_t size;
+  return (char *) datum_as_wkb(RaquetPGetDatum(rq), T_RAQUET,
+    (uint8_t) (WKB_NDR | WKB_HEX), &size);
+}
+
+/**
+ * @ingroup meos_raster_base_inout
+ * @brief Return a Raquet tile from its Well-Known Binary (WKB) representation
+ * @param[in] wkb WKB string
+ * @param[in] size Size of the string
+ * @csqlfn #Raquet_recv(), #Raquet_from_wkb()
+ */
+Raquet *
+raquet_from_wkb(const uint8_t *wkb, size_t size)
+{
+  VALIDATE_NOT_NULL(wkb, NULL);
+  return DatumGetRaquetP(type_from_wkb(wkb, size, T_RAQUET));
+}
+
+/**
+ * @ingroup meos_raster_base_inout
+ * @brief Return a Raquet tile from its ASCII hex-encoded Well-Known Binary
+ * (HexWKB) representation
+ * @param[in] hexwkb HexWKB string
+ * @csqlfn #Raquet_from_hexwkb()
+ */
+Raquet *
+raquet_from_hexwkb(const char *hexwkb)
+{
+  VALIDATE_NOT_NULL(hexwkb, NULL);
+  return DatumGetRaquetP(type_from_hexwkb(hexwkb, strlen(hexwkb), T_RAQUET));
+}
+
+/**
+ * @ingroup meos_raster_base_inout
+ * @brief Return the Well-Known Binary (WKB) representation of a Raquet tile
+ * @param[in] rq Raquet tile
+ * @param[in] variant Output variant
+ * @param[out] size_out Size of the output
+ * @csqlfn #Raquet_send(), #Raquet_as_wkb()
+ */
+uint8_t *
+raquet_as_wkb(const Raquet *rq, uint8_t variant, size_t *size_out)
+{
+  VALIDATE_NOT_NULL(rq, NULL); VALIDATE_NOT_NULL(size_out, NULL);
+  return datum_as_wkb(RaquetPGetDatum(rq), T_RAQUET, variant, size_out);
+}
+
+/**
+ * @ingroup meos_raster_base_inout
+ * @brief Return the ASCII hex-encoded Well-Known Binary (HexWKB)
+ * representation of a Raquet tile
+ * @param[in] rq Raquet tile
+ * @param[in] variant Output variant
+ * @param[out] size_out Size of the output
+ * @csqlfn #Raquet_as_hexwkb()
+ */
+char *
+raquet_as_hexwkb(const Raquet *rq, uint8_t variant, size_t *size_out)
+{
+  VALIDATE_NOT_NULL(rq, NULL); VALIDATE_NOT_NULL(size_out, NULL);
+  return (char *) datum_as_wkb(RaquetPGetDatum(rq), T_RAQUET,
+    variant | (uint8_t) WKB_HEX, size_out);
+}
+
+/*****************************************************************************
+ * Constructor functions
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_raster_base_constructor
+ * @brief Construct a Raquet tile from a QUADBIN cell, its dimensions, a pixel
+ * type and a row-major packed pixel array
+ * @param[in] quadbin CARTO QUADBIN cell identifying the Web-Mercator tile
+ * @param[in] width Tile width in pixels
+ * @param[in] height Tile height in pixels
+ * @param[in] pixtype Pixel data type
+ * @param[in] nodata Nodata sentinel value
+ * @param[in] has_nodata Whether nodata filtering is active
+ * @param[in] pixels Row-major packed pixel bytes (`width * height *
+ * raquet_pixtype_size(pixtype)` bytes)
+ * @csqlfn #Raquet_constructor()
+ */
+Raquet *
+raquet_make(uint64 quadbin, uint16 width, uint16 height, MeosPixType pixtype,
+  double nodata, bool has_nodata, const uint8_t *pixels)
+{
+  VALIDATE_NOT_NULL(pixels, NULL);
+  if (! ensure_valid_pixtype((uint8) pixtype))
+    return NULL;
+  if (width == 0 || height == 0)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "The width and height of a raquet tile must be positive");
+    return NULL;
+  }
+
+  size_t npixels = (size_t) width * height * raquet_pixtype_size(pixtype);
+  size_t size = offsetof(struct Raquet, pixels) + npixels;
+  Raquet *result = palloc0(size);
+  SET_VARSIZE(result, size);
+  result->width = width;
+  result->height = height;
+  result->quadbin = quadbin;
+  result->nodata = nodata;
+  result->pixtype = (uint8) pixtype;
+  result->has_nodata = has_nodata;
+  memcpy(result->pixels, pixels, npixels);
+  return result;
+}
+
+/**
+ * @ingroup meos_raster_base_constructor
+ * @brief Return a copy of a Raquet tile
+ * @param[in] rq Raquet tile
+ */
+Raquet *
+raquet_copy(const Raquet *rq)
+{
+  VALIDATE_NOT_NULL(rq, NULL);
+  Raquet *result = palloc(VARSIZE(rq));
+  memcpy(result, rq, VARSIZE(rq));
+  return result;
+}
+
+/*****************************************************************************
+ * Accessor functions
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_raster_base_accessor
+ * @brief Return the QUADBIN cell of a Raquet tile
+ * @csqlfn #Raquet_quadbin()
+ */
+uint64
+raquet_quadbin(const Raquet *rq)
+{
+  VALIDATE_NOT_NULL(rq, 0);
+  return rq->quadbin;
+}
+
+/**
+ * @ingroup meos_raster_base_accessor
+ * @brief Return the width in pixels of a Raquet tile
+ * @csqlfn #Raquet_width()
+ */
+int
+raquet_width(const Raquet *rq)
+{
+  VALIDATE_NOT_NULL(rq, -1);
+  return (int) rq->width;
+}
+
+/**
+ * @ingroup meos_raster_base_accessor
+ * @brief Return the height in pixels of a Raquet tile
+ * @csqlfn #Raquet_height()
+ */
+int
+raquet_height(const Raquet *rq)
+{
+  VALIDATE_NOT_NULL(rq, -1);
+  return (int) rq->height;
+}
+
+/**
+ * @ingroup meos_raster_base_accessor
+ * @brief Return the nodata sentinel value of a Raquet tile
+ * @csqlfn #Raquet_nodata()
+ */
+double
+raquet_nodata(const Raquet *rq)
+{
+  VALIDATE_NOT_NULL(rq, 0.0);
+  return rq->nodata;
+}
+
+/*****************************************************************************
+ * Comparison functions
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_raster_base_comp
+ * @brief Return -1, 0, or 1 depending on whether the first Raquet tile is
+ * less than, equal to, or greater than the second one
+ * @param[in] rq1,rq2 Raquet tiles
+ * @csqlfn #Raquet_cmp()
+ */
+int
+raquet_cmp(const Raquet *rq1, const Raquet *rq2)
+{
+  assert(rq1); assert(rq2);
+  if (rq1->quadbin != rq2->quadbin)
+    return (rq1->quadbin < rq2->quadbin) ? -1 : 1;
+  if (rq1->pixtype != rq2->pixtype)
+    return (rq1->pixtype < rq2->pixtype) ? -1 : 1;
+  if (rq1->width != rq2->width)
+    return (rq1->width < rq2->width) ? -1 : 1;
+  if (rq1->height != rq2->height)
+    return (rq1->height < rq2->height) ? -1 : 1;
+  size_t size1 = raquet_pixels_size(rq1);
+  int c = memcmp(rq1->pixels, rq2->pixels, size1);
+  return (c < 0) ? -1 : ((c > 0) ? 1 : 0);
+}
+
+/**
+ * @ingroup meos_raster_base_comp
+ * @brief Return true if two Raquet tiles are equal
+ * @param[in] rq1,rq2 Raquet tiles
+ * @csqlfn #Raquet_eq()
+ */
+bool
+raquet_eq(const Raquet *rq1, const Raquet *rq2)
+{
+  assert(rq1); assert(rq2);
+  return raquet_cmp(rq1, rq2) == 0;
+}
+
+/*****************************************************************************
+ * Sampling functions
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_raster
+ * @brief Return the values of a Raquet tile sampled at the instants of a
+ * trajectory
+ * @param[in] rq Raquet tile
+ * @param[in] traj Trajectory (temporal geometry point)
+ * @csqlfn #Raster_tile_value()
+ */
+Temporal *
+raster_tile_value(const Raquet *rq, const Temporal *traj)
+{
+  VALIDATE_NOT_NULL(rq, NULL); VALIDATE_NOT_NULL(traj, NULL);
+  return raster_tile_value_quadbin(rq->pixels, rq->width, rq->height,
+    rq->quadbin, (MeosPixType) rq->pixtype, rq->nodata, rq->has_nodata, traj);
+}
+
+/*****************************************************************************/

--- a/meos/src/temporal/meos_catalog.c
+++ b/meos/src/temporal/meos_catalog.c
@@ -166,6 +166,7 @@ static const char *MEOS_TYPE_NAMES[] =
   [T_PCPATCHSET] = "pcpatchset",
   [T_TPCPATCH] = "tpcpatch",
   [T_TPCBOX] = "tpcbox",
+  [T_RAQUET] = "raquet",
 };
 
 /**

--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -81,6 +81,9 @@
   #include <meos_rgeo.h>
   #include "rgeo/trgeo.h"
 #endif
+#if RASTER
+  #include <meos_raster.h>
+#endif
 
 #include <utils/jsonb.h>
 #include <utils/numeric.h>
@@ -1752,6 +1755,46 @@ cbuffer_from_wkb_state(meos_wkb_parse_state *s, bool component)
 }
 #endif /* CBUFFER */
 
+#if RASTER
+/**
+ * @brief Read a Raquet raster tile and advance the parse state forward
+ * @details The endian flag has already been consumed in
+ * #type_from_wkb_state. What remains are the tile header fields followed by
+ * the row-major packed pixel bytes, whose length is derived from the width,
+ * height and pixel type.
+ */
+Datum
+raquet_from_wkb_state(meos_wkb_parse_state *s)
+{
+  uint64 quadbin = (uint64) int64_from_wkb_state(s);
+  uint8_t pixtype = byte_from_wkb_state(s);
+  uint16_t width = (uint16_t) int32_from_wkb_state(s);
+  uint16_t height = (uint16_t) int32_from_wkb_state(s);
+  bool has_nodata = (bool) byte_from_wkb_state(s);
+  double nodata = double_from_wkb_state(s);
+  size_t pixsize;
+  switch (pixtype)
+  {
+    case MEOS_PT_UINT8:   pixsize = 1; break;
+    case MEOS_PT_INT16:   pixsize = 2; break;
+    case MEOS_PT_INT32:   pixsize = 4; break;
+    case MEOS_PT_FLOAT32: pixsize = 4; break;
+    case MEOS_PT_FLOAT64: pixsize = 8; break;
+    default:
+      meos_error(ERROR, MEOS_ERR_WKB_INPUT,
+        "Unknown raquet pixel type in WKB: %u", pixtype);
+      return (Datum) 0;
+  }
+  size_t npixels = (size_t) width * height * pixsize;
+  /* Check that there is enough data to read the pixel payload */
+  wkb_parse_state_check(s, npixels);
+  Raquet *result = raquet_make(quadbin, width, height, (MeosPixType) pixtype,
+    nodata, has_nodata, s->pos);
+  s->pos += npixels;
+  return PointerGetDatum(result);
+}
+#endif /* RASTER */
+
 #if JSON
 /**
  * @brief Read a JSONB value and advance the parse state forward
@@ -2578,6 +2621,10 @@ type_from_wkb(const uint8_t *wkb, size_t size, MeosType type)
   if (type == T_CBUFFER)
     return PointerGetDatum(cbuffer_from_wkb_state(&s, false));
 #endif /* CBUFFER */
+#if RASTER
+  if (type == T_RAQUET)
+    return raquet_from_wkb_state(&s);
+#endif /* RASTER */
 #if JSON
   if (type == T_JSONB)
     return PointerGetDatum(jsonb_from_wkb_state(&s));

--- a/meos/src/temporal/type_out.c
+++ b/meos/src/temporal/type_out.c
@@ -60,6 +60,9 @@
 #if CBUFFER
   #include "cbuffer/cbuffer.h"
 #endif
+#if RASTER
+  #include "raster/raquet.h"
+#endif
 #if JSON
   #include <utils/jsonb.h>
 #endif
@@ -170,6 +173,10 @@ basetype_out(Datum value, MeosType type, int maxdd)
 #if CBUFFER
     case T_CBUFFER:
       return cbuffer_out(DatumGetCbufferP(value), maxdd);
+#endif
+#if RASTER
+    case T_RAQUET:
+      return raquet_out(DatumGetRaquetP(value));
 #endif
 #if JSON
     case T_JSONB:
@@ -1219,6 +1226,27 @@ cbuffer_to_wkb_size(const Cbuffer *cb, uint8_t variant, bool component)
 }
 #endif /* CBUFFER */
 
+#if RASTER
+/**
+ * @brief Return the size in bytes of a Raquet raster tile in the Well-Known
+ * Binary (WKB) representation
+ */
+static size_t
+raquet_to_wkb_size(const Raquet *rq, bool component)
+{
+  size_t size = 0;
+  if (! component)
+    /* Endian flag */
+    size += MEOS_WKB_BYTE_SIZE;
+  /* quadbin + pixtype + width + height + has_nodata flag + nodata */
+  size += MEOS_WKB_INT8_SIZE + MEOS_WKB_BYTE_SIZE + MEOS_WKB_INT4_SIZE * 2 +
+    MEOS_WKB_BYTE_SIZE + MEOS_WKB_DOUBLE_SIZE;
+  /* Row-major packed pixel bytes */
+  size += raquet_pixels_size(rq);
+  return size;
+}
+#endif /* RASTER */
+
 #if JSON
 /**
  * @brief Return the size in bytes of a JSONB value in the Well-Known
@@ -1650,6 +1678,10 @@ datum_to_wkb_size(Datum value, MeosType type, uint8_t variant)
   if (type == T_CBUFFER)
     return cbuffer_to_wkb_size(DatumGetCbufferP(value), variant, false);
 #endif /* CBUFFER */
+#if RASTER
+  if (type == T_RAQUET)
+    return raquet_to_wkb_size(DatumGetRaquetP(value), false);
+#endif /* RASTER */
 #if JSON
   if (type == T_JSONB)
     return jsonb_to_wkb_size(DatumGetJsonbP(value), variant);
@@ -1944,6 +1976,34 @@ cbuffer_to_wkb_buf(const Cbuffer *cb, uint8_t *buf, uint8_t variant,
   return buf;
 }
 #endif /* CBUFFER */
+
+#if RASTER
+/**
+ * @brief Write into the buffer a Raquet raster tile in the Well-Known Binary
+ * (WKB) representation
+ */
+static uint8_t *
+raquet_to_wkb_buf(const Raquet *rq, uint8_t *buf, uint8_t variant,
+  bool component)
+{
+  if (! component)
+    /* Write the endian flag (byte) */
+    buf = endian_to_wkb_buf(buf, variant);
+  /* Write the tile header */
+  buf = int64_to_wkb_buf((int64) rq->quadbin, buf, variant);
+  uint8_t pixtype = rq->pixtype;
+  buf = bytes_to_wkb_buf(&pixtype, MEOS_WKB_BYTE_SIZE, buf, variant);
+  buf = int32_to_wkb_buf((int) rq->width, buf, variant);
+  buf = int32_to_wkb_buf((int) rq->height, buf, variant);
+  uint8_t has_nodata = rq->has_nodata ? 1 : 0;
+  buf = bytes_to_wkb_buf(&has_nodata, MEOS_WKB_BYTE_SIZE, buf, variant);
+  buf = double_to_wkb_buf(rq->nodata, buf, variant);
+  /* Write the row-major packed pixel bytes */
+  buf = bytes_to_wkb_buf((uint8_t *) rq->pixels, raquet_pixels_size(rq), buf,
+    variant);
+  return buf;
+}
+#endif /* RASTER */
 
 #if JSON
 /**
@@ -2846,6 +2906,10 @@ datum_to_wkb_buf(Datum value, MeosType type, uint8_t *buf, uint8_t variant)
   else if (type == T_CBUFFER)
     buf = cbuffer_to_wkb_buf(DatumGetCbufferP(value), buf, variant, false);
 #endif /* CBUFFER */
+#if RASTER
+  else if (type == T_RAQUET)
+    buf = raquet_to_wkb_buf(DatumGetRaquetP(value), buf, variant, false);
+#endif /* RASTER */
 #if JSON
   else if (type == T_JSONB)
     buf = jsonb_to_wkb_buf(DatumGetJsonbP(value), buf, variant);

--- a/mobilitydb/pg_include/pg_raster/temporal_raster.h
+++ b/mobilitydb/pg_include/pg_raster/temporal_raster.h
@@ -44,4 +44,11 @@ extern PGDLLEXPORT Datum Raster_value(PG_FUNCTION_ARGS);
 extern PGDLLEXPORT Datum Raster_tile_value_quadbin(PG_FUNCTION_ARGS);
 extern PGDLLEXPORT Datum Trajectory_quadbins(PG_FUNCTION_ARGS);
 
+extern PGDLLEXPORT Datum Raquet_in(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum Raquet_out(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum Raquet_recv(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum Raquet_send(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum Raquet_constructor(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum Raster_tile_value(PG_FUNCTION_ARGS);
+
 #endif /* TEMPORAL_RASTER_H */

--- a/mobilitydb/sql/raster/500_raster.in.sql
+++ b/mobilitydb/sql/raster/500_raster.in.sql
@@ -54,6 +54,58 @@
  */
 
 /******************************************************************************
+ * raquet type: a GDAL-free, self-describing Web-Mercator raster tile
+ * identified by a QUADBIN cell and carrying a row-major packed pixel array
+ ******************************************************************************/
+
+CREATE TYPE raquet;
+
+CREATE FUNCTION raquet_in(cstring)
+  RETURNS raquet
+  AS 'MODULE_PATHNAME', 'Raquet_in'
+  LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION raquet_out(raquet)
+  RETURNS cstring
+  AS 'MODULE_PATHNAME', 'Raquet_out'
+  LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION raquet_recv(internal)
+  RETURNS raquet
+  AS 'MODULE_PATHNAME', 'Raquet_recv'
+  LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION raquet_send(raquet)
+  RETURNS bytea
+  AS 'MODULE_PATHNAME', 'Raquet_send'
+  LANGUAGE C IMMUTABLE STRICT;
+
+CREATE TYPE raquet (
+  internallength = variable,
+  input = raquet_in,
+  output = raquet_out,
+  receive = raquet_recv,
+  send = raquet_send,
+  storage = extended,
+  alignment = double
+);
+
+/******************************************************************************
+ * raquet constructor
+ ******************************************************************************/
+
+CREATE FUNCTION raquet(
+    pixels  bytea,
+    width   integer,
+    height  integer,
+    quadbin bigint,
+    pixtype text,
+    nodata  float8 DEFAULT NULL
+) RETURNS raquet
+  AS 'MODULE_PATHNAME', 'Raquet_constructor'
+  LANGUAGE C IMMUTABLE;
+
+/******************************************************************************
  * raster_value
  *****************************************************************************/
 
@@ -103,6 +155,24 @@ CREATE OR REPLACE FUNCTION raster_tile_value_quadbin(
     traj       tgeompoint
 ) RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Raster_tile_value_quadbin'
+  LANGUAGE C STRICT;
+
+/******************************************************************************
+ * raster_tile_value
+ *****************************************************************************/
+
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Sample a raquet raster tile at the instants of a trajectory
+ * @param[in] rast Raquet tile
+ * @param[in] traj Trajectory
+ * @csqlfn #Raster_tile_value()
+ */
+CREATE FUNCTION raster_tile_value(
+    rast raquet,
+    traj tgeompoint
+) RETURNS tfloat
+  AS 'MODULE_PATHNAME', 'Raster_tile_value'
   LANGUAGE C STRICT;
 
 /******************************************************************************

--- a/mobilitydb/src/raster/temporal_raster.c
+++ b/mobilitydb/src/raster/temporal_raster.c
@@ -66,8 +66,10 @@ extern text *cstring_to_text(const char *s);
 #include <meos.h>
 #include <meos_internal.h>    /* temporal_insts_p, tsequence_make_free */
 #include <meos_raster.h>      /* MeosPixType, raster_tile_value_quadbin */
+#include "raster/raquet.h"    /* Raquet, PG_GETARG_RAQUET_P, raquet_pixtype_size */
 #include "temporal/tinstant.h"
 #include "temporal/tsequence.h"
+#include "temporal/type_util.h" /* bstring2bytea */
 /* MEOS raster kernel */
 #include "raster/raster_quadbin.h"
 /* MobilityDB */
@@ -270,6 +272,144 @@ Raster_tile_value_quadbin(PG_FUNCTION_ARGS)
 
   PG_FREE_IF_COPY(traj, 7);
 
+  if (result == NULL)
+    PG_RETURN_NULL();
+  PG_RETURN_POINTER(result);
+}
+
+/*****************************************************************************
+ * Raquet type: input/output, constructor, and typed sampling
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Raquet_in(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_in);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return a Raquet tile from its HexWKB representation
+ * @sqlfn raquet_in()
+ */
+Datum
+Raquet_in(PG_FUNCTION_ARGS)
+{
+  const char *str = PG_GETARG_CSTRING(0);
+  PG_RETURN_RAQUET_P(raquet_in(str));
+}
+
+PGDLLEXPORT Datum Raquet_out(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_out);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the HexWKB representation of a Raquet tile
+ * @sqlfn raquet_out()
+ */
+Datum
+Raquet_out(PG_FUNCTION_ARGS)
+{
+  Raquet *rq = PG_GETARG_RAQUET_P(0);
+  char *result = raquet_out(rq);
+  PG_FREE_IF_COPY(rq, 0);
+  PG_RETURN_CSTRING(result);
+}
+
+PGDLLEXPORT Datum Raquet_recv(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_recv);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return a Raquet tile from its Well-Known Binary (WKB) representation
+ * @sqlfn raquet_recv()
+ */
+Datum
+Raquet_recv(PG_FUNCTION_ARGS)
+{
+  StringInfo buf = (StringInfo) PG_GETARG_POINTER(0);
+  Raquet *result = raquet_from_wkb((uint8_t *) buf->data, buf->len);
+  /* Set cursor to the end of buffer (so the backend is happy) */
+  buf->cursor = buf->len;
+  PG_RETURN_RAQUET_P(result);
+}
+
+PGDLLEXPORT Datum Raquet_send(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_send);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the Well-Known Binary (WKB) representation of a Raquet tile
+ * @sqlfn raquet_send()
+ */
+Datum
+Raquet_send(PG_FUNCTION_ARGS)
+{
+  Raquet *rq = PG_GETARG_RAQUET_P(0);
+  size_t wkb_size;
+  uint8_t *wkb = raquet_as_wkb(rq, (uint8_t) WKB_NDR, &wkb_size);
+  bytea *result = bstring2bytea(wkb, wkb_size);
+  pfree(wkb);
+  PG_FREE_IF_COPY(rq, 0);
+  PG_RETURN_BYTEA_P(result);
+}
+
+PGDLLEXPORT Datum Raquet_constructor(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_constructor);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Construct a Raquet tile from a QUADBIN cell, dimensions, a pixel type
+ * name and a row-major packed pixel array
+ * @param[in] pixels   Row-major pixel bytes (bytea)
+ * @param[in] width    Tile width in pixels
+ * @param[in] height   Tile height in pixels
+ * @param[in] quadbin  CARTO QUADBIN cell (bigint)
+ * @param[in] pixtype  Pixel type name: UINT8 | INT16 | INT32 | FLOAT32 | FLOAT64
+ * @param[in] nodata   Nodata sentinel value (NULL disables nodata filtering)
+ * @sqlfn raquet()
+ */
+Datum
+Raquet_constructor(PG_FUNCTION_ARGS)
+{
+  /* Non-strict: the nodata argument (5) may be NULL to disable nodata */
+  if (PG_ARGISNULL(0) || PG_ARGISNULL(1) || PG_ARGISNULL(2) ||
+      PG_ARGISNULL(3) || PG_ARGISNULL(4))
+    PG_RETURN_NULL();
+  bytea      *pxbytea   = PG_GETARG_BYTEA_PP(0);
+  int32       width     = PG_GETARG_INT32(1);
+  int32       height    = PG_GETARG_INT32(2);
+  int64       quadbin   = PG_GETARG_INT64(3);
+  text       *pixtype_t = PG_GETARG_TEXT_PP(4);
+  bool        has_nd    = ! PG_ARGISNULL(5);
+  float8      nodata    = has_nd ? PG_GETARG_FLOAT8(5) : 0.0;
+  MeosPixType pixtype   = text_to_pixtype(pixtype_t);
+
+  if (width <= 0 || height <= 0)
+    ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+      errmsg("The width and height of a raquet tile must be positive")));
+  size_t need = (size_t) width * height * raquet_pixtype_size(pixtype);
+  if ((size_t) VARSIZE_ANY_EXHDR(pxbytea) < need)
+    ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+      errmsg("The pixel array has %zu bytes but %zu are required for a "
+        "%d x %d tile", (size_t) VARSIZE_ANY_EXHDR(pxbytea), need, width,
+        height)));
+
+  const uint8_t *pixels = (const uint8_t *) VARDATA_ANY(pxbytea);
+  Raquet *result = raquet_make((uint64) quadbin, (uint16_t) width,
+    (uint16_t) height, pixtype, nodata, has_nd, pixels);
+  PG_RETURN_RAQUET_P(result);
+}
+
+PGDLLEXPORT Datum Raster_tile_value(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_tile_value);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Sample a Raquet tile along a tgeompoint trajectory
+ * @param[in] rq    Raquet tile
+ * @param[in] traj  Trajectory (tgeompoint)
+ * @sqlfn raster_tile_value()
+ */
+Datum
+Raster_tile_value(PG_FUNCTION_ARGS)
+{
+  Raquet   *rq   = PG_GETARG_RAQUET_P(0);
+  Temporal *traj = PG_GETARG_TEMPORAL_P(1);
+  Temporal *result = raster_tile_value(rq, traj);
+  PG_FREE_IF_COPY(rq, 0);
+  PG_FREE_IF_COPY(traj, 1);
   if (result == NULL)
     PG_RETURN_NULL();
   PG_RETURN_POINTER(result);

--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -219,3 +219,42 @@ SELECT raster_tile_value_quadbin(
  {1@2024-01-01 00:00:00+00, 2@2024-01-02 00:00:00+00, 3@2024-01-03 00:00:00+00}
 (1 row)
 
+WITH t AS (
+  SELECT tgeompointFromText('SRID=4326;{Point(45.0 75.0)@2024-01-01 00:00:00+00, Point(135.0 75.0)@2024-01-02 00:00:00+00, Point(45.0 10.0)@2024-01-03 00:00:00+00, Point(-45.0 75.0)@2024-01-04 00:00:00+00}') AS traj
+)
+SELECT raster_tile_value(
+         raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8'), traj)::text
+     = raster_tile_value_quadbin(
+         '\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8', 0.0, false, traj)::text
+       AS typed_equals_untyped
+FROM t;
+ typed_equals_untyped 
+----------------------
+ t
+(1 row)
+
+SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8')::text::raquet::text
+     = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8')::text
+       AS hexwkb_roundtrip_ok;
+ hexwkb_roundtrip_ok 
+---------------------
+ t
+(1 row)
+
+SELECT raquet('\x0102'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8');
+ERROR:  The pixel array has 2 bytes but 4 are required for a 2 x 2 tile
+CREATE TEMP TABLE raquet_toast (rq raquet);
+CREATE TABLE
+INSERT INTO raquet_toast
+  VALUES (raquet(decode(repeat('01', 4096), 'hex'), 64, 64,
+    5193776270265024512::bigint, 'UINT8'));
+INSERT 0 1
+SELECT (SELECT rq FROM raquet_toast)::text
+     = raquet(decode(repeat('01', 4096), 'hex'), 64, 64,
+         5193776270265024512::bigint, 'UINT8')::text
+       AS toasted_roundtrip_ok;
+ toasted_roundtrip_ok 
+----------------------
+ t
+(1 row)
+

--- a/mobilitydb/test/raster/queries/500_raster.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster.test.sql
@@ -256,3 +256,41 @@ SELECT raster_tile_value_quadbin(
   0.0, false,
   tgeompointFromText('SRID=4326;{Point(45.0 75.0)@2024-01-01 00:00:00+00, Point(135.0 75.0)@2024-01-02 00:00:00+00, Point(45.0 10.0)@2024-01-03 00:00:00+00, Point(-45.0 75.0)@2024-01-04 00:00:00+00}')
 )::text AS result;
+
+-------------------------------------------------------------------------------
+-- raquet type: construction, WKB round-trip, and typed sampling
+-------------------------------------------------------------------------------
+
+-- The typed raster_tile_value(raquet, tgeompoint) yields the same result as the
+-- untyped raster_tile_value_quadbin(bytea, ...) path on the same 2×2 chip.
+WITH t AS (
+  SELECT tgeompointFromText('SRID=4326;{Point(45.0 75.0)@2024-01-01 00:00:00+00, Point(135.0 75.0)@2024-01-02 00:00:00+00, Point(45.0 10.0)@2024-01-03 00:00:00+00, Point(-45.0 75.0)@2024-01-04 00:00:00+00}') AS traj
+)
+SELECT raster_tile_value(
+         raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8'), traj)::text
+     = raster_tile_value_quadbin(
+         '\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8', 0.0, false, traj)::text
+       AS typed_equals_untyped
+FROM t;
+
+-- The HexWKB text representation round-trips through the raquet type's input
+-- and output functions (raquet::text uses raquet_out, text::raquet uses
+-- raquet_in).
+SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8')::text::raquet::text
+     = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8')::text
+       AS hexwkb_roundtrip_ok;
+
+-- The constructor rejects a pixel array too small for the given dimensions.
+SELECT raquet('\x0102'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8');
+
+-- A raquet large enough to be TOASTed (64 x 64 UINT8 = 4096 pixel bytes) must
+-- survive a store-and-read-back cycle: reading the stored value detoasts it, so
+-- its HexWKB output equals that of the same tile constructed inline.
+CREATE TEMP TABLE raquet_toast (rq raquet);
+INSERT INTO raquet_toast
+  VALUES (raquet(decode(repeat('01', 4096), 'hex'), 64, 64,
+    5193776270265024512::bigint, 'UINT8'));
+SELECT (SELECT rq FROM raquet_toast)::text
+     = raquet(decode(repeat('01', 4096), 'hex'), 64, 64,
+         5193776270265024512::bigint, 'UINT8')::text
+       AS toasted_roundtrip_ok;


### PR DESCRIPTION
## Summary

Adds a first-class, GDAL-free value type `raquet` for a single CARTO Raquet raster chip, and a typed `raster_tile_value(raquet, tgeompoint)` sampling operator.

Until now the `RASTER=ON` family exposed Raquet/QUADBIN sampling only as `raster_tile_value_quadbin(bytea, integer, integer, bigint, text, float8, boolean, tgeompoint)` — a function taking eight loose columns. This packages those columns into a single self-describing value that can be stored, passed around, and sampled directly.

The change is purely additive: the PostGIS-`raster` path (`raster_value`, `atRasterValue`, …) and the `postgis_raster` requirement are untouched. The new type is deliberately named `raquet` to coexist with the PostGIS `raster` type, which `RASTER=ON` requires.

## The `raquet` type

A `raquet` is a self-describing Web-Mercator raster tile identified by a QUADBIN cell and carrying a row-major, tightly packed single-band pixel array. The tile georeferencing (bounding box, pixel-to-coordinate mapping) is fully determined by the QUADBIN value, so no external spatial metadata is stored. It is GDAL-free: constructing and sampling a tile is pure QUADBIN/Web-Mercator arithmetic.

The type is a variable-length value registered in the catalog as `T_RAQUET` and serialized through the central WKB machinery (endian, QUADBIN, pixel type, width, height, nodata flag, nodata, then the packed pixel bytes), with HexWKB text input/output — the same mechanism used by the other base value types. `raster_tile_value(raquet, tgeompoint)` is the typed equivalent of `raster_tile_value_quadbin`; it delegates to the existing sampling kernel, which is unchanged.

## SQL surface

- `CREATE TYPE raquet` with `raquet_in`/`raquet_out`/`raquet_recv`/`raquet_send`.
- Constructor `raquet(pixels bytea, width integer, height integer, quadbin bigint, pixtype text, nodata float8 DEFAULT NULL) → raquet`, which validates the pixel-array length against the tile dimensions and treats a `NULL` nodata as "no nodata".
- `raster_tile_value(raquet, tgeompoint) → tfloat`.

```sql
-- Package the loose tile columns of a Raquet table into raquet values, then sample
SELECT t.tripid, raster_tile_value(raquet(r.band_data, r.width, r.height,
                                          r.quadbin, 'FLOAT32', r.nodata), t.trip4326)
FROM trips t
JOIN elevation_raquet r
  ON r.quadbin = ANY(trajectory_quadbins(t.trip4326, 8));
```

## Tests

Added to the raster suite: constructor validation (pixel array too small errors), the HexWKB round-trip, equality of the typed and untyped sampling paths on the same chip, and a store-and-read-back cycle of a tile large enough to be TOASTed.

## Commits

1. Add the raquet raster-tile type to MEOS — catalog registration, the value type and its WKB serialization, and the typed sampling function.
2. Add the raquet SQL type and typed raster_tile_value operator — extension wrappers, `CREATE TYPE`, constructor, operator, and tests.
3. Document the raquet type and raster_tile_value operator — English and Spanish chapter and reference entries.
