### PR TITLE
Add curve polygons to the tbl_geom test table

### DIFF
--- a/mobilitydb/datagen/geo/create_test_tables_tpoint.sql
+++ b/mobilitydb/datagen/geo/create_test_tables_tpoint.sql
@@ -228,6 +228,12 @@ SELECT 1 AS k, geometry 'compoundcurve empty' AS g UNION
 SELECT k, random_geom_compoundcurve(0, 100, 0, 100, 10, 1, 5)
 FROM generate_series(2, size) k;
 
+DROP TABLE IF EXISTS tbl_geom_curvepolygon;
+CREATE TABLE tbl_geom_curvepolygon AS
+SELECT 1 AS k, geometry 'curvepolygon empty' AS g UNION
+SELECT k, random_geom_curvepolygon(0, 100, 0, 100, 10, 2, 5)
+FROM generate_series(2, size) k;
+
 DROP TABLE IF EXISTS tbl_geom;
 CREATE TABLE tbl_geom (
   k serial PRIMARY KEY,
@@ -240,7 +246,8 @@ INSERT INTO tbl_geom(g)
 (SELECT g FROM tbl_geom_multilinestring ORDER BY k LIMIT (size * 0.2)) UNION ALL
 (SELECT g FROM tbl_geom_multipolygon ORDER BY k LIMIT (size * 0.2)) UNION ALL
 (SELECT g FROM tbl_geom_circularstring ORDER BY k LIMIT (size * 0.2)) UNION ALL
-(SELECT g FROM tbl_geom_compoundcurve ORDER BY k LIMIT (size * 0.2));
+(SELECT g FROM tbl_geom_compoundcurve ORDER BY k LIMIT (size * 0.2)) UNION ALL
+(SELECT g FROM tbl_geom_curvepolygon ORDER BY k LIMIT (size * 0.2));
 
 DROP TABLE IF EXISTS tbl_geom3D;
 CREATE TABLE tbl_geom3D (

--- a/mobilitydb/datagen/geo/random_tpoint.sql
+++ b/mobilitydb/datagen/geo/random_tpoint.sql
@@ -811,6 +811,70 @@ FROM generate_series(1, 15) AS k;
 -------------------------------------------------------------------------------
 
 /**
+ * @brief Generate a random 2D geometric curve polygon without holes bounded by
+ * a closed circular string
+ * @param[in] lowx, highx Inclusive bounds of the range for the x coordinates
+ * @param[in] lowy, highy Inclusive bounds of the range for the y coordinates
+ * @param[in] maxdelta Maximum difference between two consecutive coordinate values
+ * @param[in] minarcs, maxarcs Inclusive bounds of the number of arcs
+ * @param[in] srid SRID of the coordinates
+ */
+DROP FUNCTION IF EXISTS random_geom_curvepolygon;
+CREATE FUNCTION random_geom_curvepolygon(lowx float, highx float, lowy float,
+  highy float, maxdelta float, minarcs int, maxarcs int, srid int DEFAULT 0)
+  RETURNS geometry AS $$
+DECLARE
+  narcs int;
+  npoints int;
+  cx float;
+  cy float;
+  r float;
+  xs float[];
+  ys float[];
+  wkt text;
+BEGIN
+  IF minarcs < 2 THEN
+    RAISE EXCEPTION 'A curve polygon requires at least 2 arcs';
+  END IF;
+  IF minarcs > maxarcs THEN
+    RAISE EXCEPTION 'minarcs must be less than or equal to maxarcs: %, %',
+      minarcs, maxarcs;
+  END IF;
+  narcs = random_int(minarcs, maxarcs);
+  /* A curve polygon bounded by a closed circular string of n arcs is defined by
+   * 2 * n points plus the closing point equal to the first one. The points are
+   * placed on a circle in increasing angular order so that the ring is simple
+   * (a random walk would frequently self-intersect, yielding invalid polygons) */
+  npoints = 2 * narcs;
+  r = random_float(maxdelta, 2 * maxdelta);
+  cx = random_float(lowx + r, highx - r);
+  cy = random_float(lowy + r, highy - r);
+  SELECT array_agg(cx + r * cos(2 * pi() * i / npoints) ORDER BY i),
+         array_agg(cy + r * sin(2 * pi() * i / npoints) ORDER BY i)
+  INTO xs, ys
+  FROM generate_series(0, npoints - 1) AS i;
+  SELECT string_agg(xs[i] || ' ' || ys[i], ',' ORDER BY i)
+  INTO wkt
+  FROM generate_series(1, npoints) AS i;
+  RETURN ST_GeomFromText('CURVEPOLYGON(CIRCULARSTRING(' || wkt || ',' ||
+    xs[1] || ' ' || ys[1] || '))', srid);
+END;
+$$ LANGUAGE PLPGSQL STRICT;
+
+/*
+SELECT k, st_asEWKT(random_geom_curvepolygon(-100, 100, -100, 100, 10, 2, 5)) AS g
+FROM generate_series(1, 15) AS k;
+
+SELECT k, st_asEWKT(random_geom_curvepolygon(-100, 100, -100, 100, 10, 2, 5, 3812)) AS g
+FROM generate_series(1, 15) AS k;
+
+SELECT distinct geometrytype(random_geom_curvepolygon(-100, 100, -100, 100, 10, 2, 5)) AS g
+FROM generate_series(1, 15) AS k;
+*/
+
+-------------------------------------------------------------------------------
+
+/**
  * @brief Generate a random 3D geometric linestring
  * @param[in] lowx, highx Inclusive bounds of the range for the x coordinates
  * @param[in] lowy, highy Inclusive bounds of the range for the y coordinates

--- a/mobilitydb/test/geo/expected/064_tpoint_distance_tbl.test.out
+++ b/mobilitydb/test/geo/expected/064_tpoint_distance_tbl.test.out
@@ -86,7 +86,7 @@ SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
  count 
 -------
- 13200
+ 15100
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2
@@ -142,7 +142,7 @@ SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
  count 
 -------
- 13200
+ 15100
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2
@@ -198,7 +198,7 @@ SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE g |=| temp IS NOT NULL;
  count 
 -------
- 13200
+ 15100
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2
@@ -254,7 +254,7 @@ SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE shortestLine(g, temp) IS NOT NULL;
  count 
 -------
- 13200
+ 15100
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2

--- a/mobilitydb/test/geo/expected/070_tpoint_spatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/070_tpoint_spatialrels_tbl.test.out
@@ -1,25 +1,25 @@
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE eContains(g, temp);
  count 
 -------
-  4686
+  5540
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE aContains(g, temp);
  count 
 -------
-   146
+   182
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE eDisjoint(g, temp);
  count 
 -------
- 13054
+ 14918
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom WHERE eDisjoint(temp, g);
  count 
 -------
- 13054
+ 14918
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE eDisjoint(t1.temp, t2.temp);
@@ -61,13 +61,13 @@ SELECT COUNT(*) > 0 FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2 WHERE eDisjoin
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE aDisjoint(g, temp);
  count 
 -------
-  8514
+  9560
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom WHERE aDisjoint(temp, g);
  count 
 -------
-  8514
+  9560
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE aDisjoint(t1.temp, t2.temp);
@@ -133,13 +133,13 @@ SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2 WHERE aDisjoint(t1
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE eIntersects(g, temp);
  count 
 -------
-  4686
+  5540
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom WHERE eIntersects(temp, g);
  count 
 -------
-  4686
+  5540
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE eIntersects(t1.temp, t2.temp);
@@ -193,13 +193,13 @@ SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2 WHERE eIntersects(
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE aIntersects(g, temp);
  count 
 -------
-   146
+   182
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom WHERE aIntersects(temp, g);
  count 
 -------
-   146
+   182
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE aIntersects(t1.temp, t2.temp);
@@ -241,13 +241,13 @@ SELECT COUNT(*) > 0 FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2 WHERE aInterse
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE eTouches(g, temp);
  count 
 -------
-  1602
+  2294
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom WHERE eTouches(temp, g);
  count 
 -------
-  1602
+  2294
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE aTouches(g, temp);

--- a/mobilitydb/test/geo/expected/072_tpoint_tempspatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/072_tpoint_tempspatialrels_tbl.test.out
@@ -2,21 +2,21 @@ SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint
   WHERE tContains(g, temp) IS NOT NULL;
  count 
 -------
- 13200
+ 15100
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint_step_seq
   WHERE tContains(g, seq) IS NOT NULL;
  count 
 -------
- 13200
+ 15100
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint_step_seqset
   WHERE tContains(g, ss) IS NOT NULL;
  count 
 -------
- 13200
+ 15100
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint
@@ -184,7 +184,7 @@ SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint
   WHERE tTouches(g, temp) IS NOT NULL;
  count 
 -------
- 13200
+ 15100
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom_point
@@ -198,14 +198,14 @@ SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint_step_seq
   WHERE tTouches(g, seq) IS NOT NULL;
  count 
 -------
- 13200
+ 15100
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint_step_seqset
   WHERE tTouches(g, ss) IS NOT NULL;
  count 
 -------
- 13200
+ 15100
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint


### PR DESCRIPTION
Following the addition of circular strings and compound curves, this unions
curve polygons into the `tbl_geom` superclass table so that every `_tbl` test
reading it also exercises curve polygons.

- A `random_geom_curvepolygon` generator producing a curve polygon bounded by a
  closed circular string. The points are placed on a circle in increasing
  angular order so the ring is simple: a random walk would frequently
  self-intersect, and an invalid curve polygon makes the intersection-based
  functions raise a GEOS `TopologyException`.
- A narrow `tbl_geom_curvepolygon` table, with a 20% slice unioned into
  `tbl_geom`.
- The frozen `load_point.sql.xz` snapshot is updated by appending the new rows
  (pure insertion; all existing rows preserved).

The only expected-output changes are the row counts of the `_tbl` tests that
read `tbl_geom` (`064`/`070`/`072`), which grow accordingly.