### PR TITLE
Add curved geometries to the tbl_geometry test table

### DIFF
--- a/mobilitydb/datagen/geo/random_tgeo.sql
+++ b/mobilitydb/datagen/geo/random_tgeo.sql
@@ -34,8 +34,8 @@
 -------------------------------------------------------------------------------
 
 /**
- * @brief Generate a random geometry which can be (currently) a point, a 
- * linestring or a polygon
+ * @brief Generate a random geometry which can be a point, a linestring, a
+ * multipoint, a circular string, a compound curve or a curve polygon
  * @param[in] lowx, highx Inclusive bounds of the range for the x coordinates
  * @param[in] lowy, highy Inclusive bounds of the range for the y coordinates
  * @param[in] srid Optional SRID
@@ -47,13 +47,19 @@ CREATE FUNCTION random_geometry(lowx float, highx float, lowy float,
 DECLARE
   i int;
 BEGIN
-  i = random_int(1, 3);
+  i = random_int(1, 6);
   IF i = 1 THEN
     RETURN random_geom_point(lowx, highx, lowy, highy, srid);
   ELSIF i = 2 THEN
     RETURN random_geom_linestring(lowx, highx, lowy, highy, 10, 2, 2, srid);
-  ELSE -- i = 0 
+  ELSIF i = 3 THEN
     RETURN random_geom_multipoint(lowx, highx, lowy, highy, 10, 2, 2, srid);
+  ELSIF i = 4 THEN
+    RETURN random_geom_circularstring(lowx, highx, lowy, highy, 10, 1, 5, srid);
+  ELSIF i = 5 THEN
+    RETURN random_geom_compoundcurve(lowx, highx, lowy, highy, 10, 1, 5, srid);
+  ELSE -- i = 6
+    RETURN random_geom_curvepolygon(lowx, highx, lowy, highy, 10, 2, 5, srid);
   END IF;
 END;
 $$ LANGUAGE PLPGSQL STRICT;

--- a/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels_tbl.test.out
@@ -1,19 +1,19 @@
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aContains(g, temp);
  count 
 -------
-     9
+    16
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eContains(temp, g);
  count 
 -------
-  3334
+  5153
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aContains(temp, g);
  count 
 -------
-    20
+    21
 (1 row)
 
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eContains(cb, temp);
@@ -43,19 +43,19 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aContains(temp, cb);
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aCovers(g, temp);
  count 
 -------
-     9
+    16
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eCovers(temp, g);
  count 
 -------
-  1487
+  1565
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aCovers(temp, g);
  count 
 -------
-    20
+    21
 (1 row)
 
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eCovers(cb, temp);
@@ -85,25 +85,25 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aCovers(temp, cb);
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eDisjoint(g, temp);
  count 
 -------
-  9362
+ 15277
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aDisjoint(g, temp);
  count 
 -------
-  6041
+ 10155
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eDisjoint(temp, g);
  count 
 -------
-  9362
+ 15277
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aDisjoint(temp, g);
  count 
 -------
-  6041
+ 10155
 (1 row)
 
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eDisjoint(cb, temp);
@@ -145,25 +145,25 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE aDisjoint(t1.temp, t
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eIntersects(g, temp);
  count 
 -------
-  3359
+  5245
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aIntersects(g, temp);
  count 
 -------
-   232
+   317
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eIntersects(temp, g);
  count 
 -------
-  3359
+  5245
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aIntersects(temp, g);
  count 
 -------
-   232
+   317
 (1 row)
 
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eIntersects(cb, temp);
@@ -253,25 +253,25 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aTouches(temp, cb);
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eDwithin(g, temp, 10);
  count 
 -------
-  4391
+  6887
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aDwithin(g, temp, 10);
  count 
 -------
-   464
+   614
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eDwithin(temp, g, 10);
  count 
 -------
-  4391
+  6887
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aDwithin(temp, g, 10);
  count 
 -------
-   464
+   614
 (1 row)
 
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eDwithin(cb, temp, 10);

--- a/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels_tbl.test.out
@@ -1,13 +1,13 @@
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tContains(g, temp) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tContains(temp, g) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE tContains(cb, temp) IS NOT NULL;
@@ -31,7 +31,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tContains(t1.temp, t
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tContains(g, temp) ?= true <> eContains(g, temp);
  count 
 -------
-  3275
+  3563
 (1 row)
 
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE tContains(cb, temp) ?= true <> eContains(cb, temp);
@@ -43,13 +43,13 @@ SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE tContains(cb, temp) ?= true
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tCovers(g, temp) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tCovers(temp, g) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tCovers(t1.temp, t2.temp) IS NOT NULL;
@@ -61,19 +61,19 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tCovers(t1.temp, t2.
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tCovers(g, temp) ?= true <> eCovers(g, temp);
  count 
 -------
-  3275
+  3563
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDisjoint(g, temp) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDisjoint(temp, g) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tDisjoint(t1.temp, t2.temp) IS NOT NULL;
@@ -85,13 +85,13 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tDisjoint(t1.temp, t
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDisjoint(g, temp) ?= true <> eDisjoint(g, temp);
  count 
 -------
-    88
+   139
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDisjoint(temp, g) ?= true <> eDisjoint(temp, g);
  count 
 -------
-    88
+   139
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
@@ -104,31 +104,31 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tIntersects(g, temp) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) ?= true <> eDisjoint(temp, g);
  count 
 -------
-  6096
+ 10321
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tIntersects(g, temp) ?= true <> eIntersects(g, temp);
  count 
 -------
-    17
+    57
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) ?= true <> eIntersects(temp, g);
  count 
 -------
-    17
+    57
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
@@ -141,13 +141,13 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tTouches(g, temp) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tTouches(temp, g) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tTouches(t1.temp, t2.temp) IS NOT NULL;
@@ -171,13 +171,13 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tTouches(temp, g) ?= true 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDwithin(g, temp, 10) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDwithin(temp, g, 10) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tDwithin(t1.temp, t2.temp, 10) IS NOT NULL;
@@ -190,14 +190,14 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer
   WHERE tDwithin(g, temp, 10) ?= true <> edwithin(g, temp, 10);
  count 
 -------
-     8
+    18
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry
   WHERE tDwithin(temp, g, 10) ?= true <> edwithin(temp, g, 10);
  count 
 -------
-     8
+    18
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2

--- a/mobilitydb/test/geo/expected/054_tgeo_compops_tbl.test.out
+++ b/mobilitydb/test/geo/expected/054_tgeo_compops_tbl.test.out
@@ -1,7 +1,7 @@
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE g #= temp IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeography, tbl_geography WHERE g #= temp IS NOT NULL;
@@ -49,7 +49,7 @@ SELECT COUNT(*) FROM tbl_tgeography3D t1, tbl_tgeography3D t2 WHERE t1.temp #= t
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE g #<> temp IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeography, tbl_geography WHERE g #<> temp IS NOT NULL;

--- a/mobilitydb/test/geo/expected/064_tgeo_distance_tbl.test.out
+++ b/mobilitydb/test/geo/expected/064_tgeo_distance_tbl.test.out
@@ -86,7 +86,7 @@ SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry t
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2
@@ -142,7 +142,7 @@ SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2
@@ -198,7 +198,7 @@ SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry t
 WHERE g |=| temp IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2
@@ -254,7 +254,7 @@ SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry t
 WHERE shortestLine(g, temp) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2

--- a/mobilitydb/test/geo/expected/070_tgeo_spatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/070_tgeo_spatialrels_tbl.test.out
@@ -1,19 +1,19 @@
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE eContains(g, temp);
  count 
 -------
-  1230
+  1606
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE aContains(g, temp);
  count 
 -------
-    35
+    44
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE eContains(temp, g);
  count 
 -------
-  1230
+  1606
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE aContains(temp, g);
@@ -37,13 +37,13 @@ SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE aContains(t1.temp,
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE eCovers(g, temp);
  count 
 -------
-   574
+   775
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE aCovers(g, temp);
  count 
 -------
-    35
+    44
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE eCovers(temp, g);
@@ -73,13 +73,13 @@ SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE aCovers(t1.temp, t
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE eDisjoint(g, temp);
  count 
 -------
-  9326
+ 15308
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE eDisjoint(temp, g);
  count 
 -------
-  9326
+ 15308
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE eDisjoint(t1.temp, t2.temp);
@@ -121,13 +121,13 @@ SELECT COUNT(*) FROM tbl_tgeography3D t1, tbl_tgeography3D t2 WHERE eDisjoint(t1
 SELECT COUNT(*) FROM tbl_geometry t1, tbl_tgeometry t2 WHERE t1.k % 3 = 0 AND aDisjoint(g, temp);
  count 
 -------
-  2719
+  4586
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_geometry t2 WHERE t1.k % 3 = 0 AND aDisjoint(temp, g);
  count 
 -------
-  2729
+  4591
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE aDisjoint(t1.temp, t2.temp);
@@ -193,13 +193,13 @@ SELECT COUNT(*) FROM tbl_tgeography3D t1, tbl_tgeography3D t2 WHERE aDisjoint(t1
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE eIntersects(g, temp);
  count 
 -------
-  1230
+  1606
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE eIntersects(temp, g);
  count 
 -------
-  1230
+  1606
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE eIntersects(t1.temp, t2.temp);
@@ -253,13 +253,13 @@ SELECT COUNT(*) FROM tbl_tgeography3D t1, tbl_tgeography3D t2 WHERE eIntersects(
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE aIntersects(g, temp);
  count 
 -------
-    74
+    92
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE aIntersects(temp, g);
  count 
 -------
-    74
+    92
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE aIntersects(t1.temp, t2.temp);
@@ -337,13 +337,13 @@ SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE aTouches(t1.temp, 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE eDwithin(g, temp, 10);
  count 
 -------
-  3397
+  4802
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE eDwithin(temp, g, 10);
  count 
 -------
-  3397
+  4802
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE eDwithin(t1.temp, t2.temp, 10);
@@ -355,13 +355,13 @@ SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE eDwithin(t1.temp, 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry_seq WHERE eDwithin(g, seq, 10);
  count 
 -------
-  3237
+  4292
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry_seqset WHERE eDwithin(g, ss, 10);
  count 
 -------
-  6187
+  9563
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry_seq t1, tbl_tgeometry t2 WHERE eDwithin(t1.seq, t2.temp, 10);
@@ -427,13 +427,13 @@ SELECT COUNT(*) FROM tbl_tgeography3D t1, tbl_tgeography3D t2 WHERE eDwithin(t1.
 SELECT COUNT(*) FROM tbl_geometry t1, tbl_tgeometry t2 WHERE t1.k % 3 = 0 AND t2.k % 3 = 0 AND aDwithin(g, temp, 10);
  count 
 -------
-     1
+     6
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_geometry t2 WHERE t1.k % 3 = 0 AND t2.k % 3 = 0 AND aDwithin(temp, g, 10);
  count 
 -------
-     1
+     6
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE aDwithin(t1.temp, t2.temp, 10);
@@ -445,7 +445,7 @@ SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE aDwithin(t1.temp, 
 SELECT COUNT(*) FROM tbl_geometry t1, tbl_tgeometry_seq t2 WHERE t1.k % 3 = 0 AND t2.k % 3 = 0 AND aDwithin(g, seq, 10);
  count 
 -------
-    23
+    27
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry t1, tbl_tgeometry_seqset t2 WHERE t1.k % 3 = 0 AND t1.k % 3 = 0 AND aDwithin(g, ss, 10);

--- a/mobilitydb/test/geo/expected/072_tgeo_tempspatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/072_tgeo_tempspatialrels_tbl.test.out
@@ -1,13 +1,13 @@
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE tContains(g, temp) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE tContains(temp, g) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE tContains(t1.temp, t2.temp) IS NOT NULL;
@@ -19,19 +19,19 @@ SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE tContains(t1.temp,
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE tContains(g, temp) ?= true <> eContains(g, temp);
  count 
 -------
-   656
+   831
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE tCovers(g, temp) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE tCovers(temp, g) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE tCovers(t1.temp, t2.temp) IS NOT NULL;
@@ -49,13 +49,13 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE tCovers(g, temp) ?= true 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE tDisjoint(g, temp) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE tDisjoint(temp, g) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE tDisjoint(t1.temp, t2.temp) IS NOT NULL;
@@ -93,19 +93,19 @@ SELECT COUNT(*) FROM tbl_tgeometry3D t1, tbl_tgeometry3D t2
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE tIntersects(g, temp) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE tIntersects(temp, g) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE tIntersects(temp, g) ?= true <> eDisjoint(temp, g);
  count 
 -------
-  8244
+ 13886
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE tIntersects(g, temp) ?= true <> eIntersects(g, temp);
@@ -137,13 +137,13 @@ SELECT COUNT(*) FROM tbl_tgeometry3D t1, tbl_tgeometry3D t2
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE tTouches(g, temp) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE tTouches(temp, g) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE tTouches(t1.temp, t2.temp) IS NOT NULL;
@@ -167,13 +167,13 @@ SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE tTouches(temp, g) ?= true
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE tDwithin(g, temp, 10) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE tDwithin(temp, g, 10) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE tDwithin(t1.temp, t2.temp, 10) IS NOT NULL;

--- a/mobilitydb/test/npoint/expected/306_tnpoint_spatialfuncs_tbl.test.out
+++ b/mobilitydb/test/npoint/expected/306_tnpoint_spatialfuncs_tbl.test.out
@@ -7,13 +7,13 @@ SELECT MAX(st_npoints(trajectory(temp))) FROM tbl_tnpoint;
 SELECT COUNT(*) FROM tbl_tnpoint t1, tbl_geometry t2 WHERE atGeometry(t1.temp, ST_SetSRID(t2.g, 5676)) IS NOT NULL;
  count 
 -------
-  2770
+  2967
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tnpoint t1, tbl_geometry t2 WHERE minusGeometry(t1.temp, ST_SetSRID(t2.g, 5676)) IS NOT NULL;
  count 
 -------
-  9705
+ 15698
 (1 row)
 
 SELECT round(MAX(length(temp)), 6) FROM tbl_tnpoint;
@@ -37,13 +37,13 @@ SELECT round(MAX(maxValue(speed(temp))), 6) FROM tbl_tnpoint WHERE interp(temp) 
 SELECT COUNT(*) FROM tbl_tnpoint t1, tbl_geometry t2 WHERE nearestApproachInstant(t1.temp, ST_SetSRID(t2.g, 5676)) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry t1, tbl_tnpoint t2 WHERE nearestApproachInstant(ST_SetSRID(t1.g, 5676), t2.temp) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tnpoint t1, tbl_npoint t2 WHERE nearestApproachInstant(t1.temp, t2.np) IS NOT NULL;
@@ -67,13 +67,13 @@ SELECT COUNT(*) FROM tbl_tnpoint t1, tbl_tnpoint t2 WHERE nearestApproachInstant
 SELECT COUNT(*) FROM tbl_tnpoint t1, tbl_geometry t2 WHERE nearestApproachDistance(t1.temp, ST_SetSRID(t2.g, 5676)) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry t1, tbl_tnpoint t2 WHERE nearestApproachDistance(ST_SetSRID(t1.g, 5676), t2.temp) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tnpoint t1, tbl_npoint t2 WHERE nearestApproachDistance(t1.temp, t2.np) IS NOT NULL;
@@ -97,13 +97,13 @@ SELECT COUNT(*) FROM tbl_tnpoint t1, tbl_tnpoint t2 WHERE nearestApproachDistanc
 SELECT COUNT(*) FROM tbl_tnpoint t1, tbl_geometry t2 WHERE shortestLine(t1.temp, ST_SetSRID(t2.g, 5676)) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry t1, tbl_tnpoint t2 WHERE shortestLine(ST_SetSRID(t1.g, 5676), t2.temp) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tnpoint t1, tbl_npoint t2 WHERE shortestLine(t1.temp, t2.np) IS NOT NULL;

--- a/mobilitydb/test/rgeo/expected/152_trgeo_compops_tbl.test.out
+++ b/mobilitydb/test/rgeo/expected/152_trgeo_compops_tbl.test.out
@@ -1,13 +1,13 @@
 SELECT COUNT(*) FROM tbl_geometry t1, tbl_trgeometry2d t2 WHERE ST_SetSRID(t1.g, 5676) #= t2.temp IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_trgeometry2d t1, tbl_geometry t2 WHERE t1.temp #= ST_SetSRID(t2.g, 5676) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_trgeometry2d t1, tbl_trgeometry2d t2 WHERE t1.temp #= t2.temp IS NOT NULL;
@@ -19,13 +19,13 @@ SELECT COUNT(*) FROM tbl_trgeometry2d t1, tbl_trgeometry2d t2 WHERE t1.temp #= t
 SELECT COUNT(*) FROM tbl_geometry t1, tbl_trgeometry2d t2 WHERE ST_SetSRID(t1.g, 5676) #<> t2.temp IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_trgeometry2d t1, tbl_geometry t2 WHERE t1.temp #<> ST_SetSRID(t2.g, 5676) IS NOT NULL;
  count 
 -------
-  9400
+ 15400
 (1 row)
 
 SELECT COUNT(*) FROM tbl_trgeometry2d t1, tbl_trgeometry2d t2 WHERE t1.temp #<> t2.temp IS NOT NULL;


### PR DESCRIPTION
Following the addition of the curved types to the `tbl_geom` test table, this
unions circular strings, compound curves and curve polygons into the
`tbl_geometry` superclass table so that every `_tbl` test reading it also
exercises these curved geometries.

- The `random_geometry` generator now also returns a circular string, a compound
  curve or a curve polygon (the curve polygon is bounded by a closed circular
  string built from points in angular order, so the ring is simple).
- The frozen `load_geo.sql.xz` snapshot is updated by appending the new rows
  (pure insertion; all existing rows preserved).

The only expected-output changes are the row counts of the `_tbl` tests that
read `tbl_geometry`, across the geometry, rgeometry, circular-buffer and network
point families.