### PR TITLE
Generate the temporal topological bounding-box operators

### DIFF
--- a/mobilitydb/src/geo/tgeo_boxops.c
+++ b/mobilitydb/src/geo/tgeo_boxops.c
@@ -196,7 +196,7 @@ Geo_split_each_n_stboxes(PG_FUNCTION_ARGS)
   PG_RETURN_ARRAYTYPE_P(result);
 }
 
-/* GENERATED-BOXOPS-BEGIN — tools/codegen/inherited/generate.py from templates/boxops.c.tmpl; DO NOT EDIT BY HAND;
+/* GENERATED-BOXOPS-BEGIN stbox — tools/codegen/inherited/generate.py from templates/boxops.c.tmpl; DO NOT EDIT BY HAND;
  * edit the template + manifest.yaml (boxtypes) and re-run. */
 /*****************************************************************************
  * Generic box functions
@@ -498,4 +498,4 @@ Adjacent_tspatial_tspatial(PG_FUNCTION_ARGS)
 }
 
 /*****************************************************************************/
-/* GENERATED-BOXOPS-END */
+/* GENERATED-BOXOPS-END stbox */

--- a/mobilitydb/src/pointcloud/tpc_boxops.c
+++ b/mobilitydb/src/pointcloud/tpc_boxops.c
@@ -58,7 +58,7 @@
 #include "pointcloud/tpcbox.h"          /* PG_GETARG_TPCBOX_P */
 #include "temporal/temporal.h"
 
-/* GENERATED-BOXOPS-BEGIN — tools/codegen/inherited/generate.py from templates/boxops.c.tmpl; DO NOT EDIT BY HAND;
+/* GENERATED-BOXOPS-BEGIN tpcbox — tools/codegen/inherited/generate.py from templates/boxops.c.tmpl; DO NOT EDIT BY HAND;
  * edit the template + manifest.yaml (boxtypes) and re-run. */
 /*****************************************************************************
  * Generic box functions
@@ -360,7 +360,7 @@ Adjacent_tpointcloud_tpointcloud(PG_FUNCTION_ARGS)
 }
 
 /*****************************************************************************/
-/* GENERATED-BOXOPS-END */
+/* GENERATED-BOXOPS-END tpcbox */
 
 #define DEFINE_BOXOP3(opname, primitive)                                       \
 PGDLLEXPORT Datum opname##_tpcbox_tpointcloud(PG_FUNCTION_ARGS);               \

--- a/mobilitydb/src/temporal/temporal_boxops.c
+++ b/mobilitydb/src/temporal/temporal_boxops.c
@@ -191,14 +191,14 @@ Tnumber_split_each_n_tboxes(PG_FUNCTION_ARGS)
   PG_RETURN_ARRAYTYPE_P(result);
 }
 
+/* GENERATED-BOXOPS-BEGIN tstzspan — tools/codegen/inherited/generate.py from templates/boxops.c.tmpl; DO NOT EDIT BY HAND;
+ * edit the template + manifest.yaml (boxtypes) and re-run. */
 /*****************************************************************************
- * Bounding box functions for temporal types: Generic functions
- * The inclusive/exclusive bounds are taken into account for the comparisons
+ * Generic box functions
  *****************************************************************************/
 
 /**
- * @brief Generic bounding box function for a timestamptz span and a temporal
- * value
+ * @brief Generic bounding box function for a timestamptz span and a temporal value
  * @param[in] fcinfo Catalog information about the external function
  * @param[in] func Bounding box function
  */
@@ -206,16 +206,16 @@ Datum
 Boxop_tstzspan_temporal(FunctionCallInfo fcinfo,
   bool (*func)(const Span *, const Span *))
 {
-  Span *s = PG_GETARG_SPAN_P(0);
+  Span *box = PG_GETARG_SPAN_P(0);
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
-  bool result = boxop_temporal_tstzspan(temp, s, func, INVERT);
+  bool result = boxop_temporal_tstzspan(temp, box, func, INVERT);
   PG_FREE_IF_COPY(temp, 1);
   PG_RETURN_BOOL(result);
 }
 
 /**
- * @brief Generic bounding box function for a temporal value and a timestamptz
- * span
+ * @brief Generic bounding box function for a temporal value and a
+ * timestamptz span
  * @param[in] fcinfo Catalog information about the external function
  * @param[in] func Bounding box function
  */
@@ -224,14 +224,14 @@ Boxop_temporal_tstzspan(FunctionCallInfo fcinfo,
   bool (*func)(const Span *, const Span *))
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
-  Span *s = PG_GETARG_SPAN_P(1);
-  bool result = boxop_temporal_tstzspan(temp, s, func, INVERT_NO);
+  Span *box = PG_GETARG_SPAN_P(1);
+  bool result = boxop_temporal_tstzspan(temp, box, func, INVERT_NO);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_BOOL(result);
 }
 
 /**
- * @brief Generic bounding box function for two temporal values
+ * @brief Generic topological function for two temporal values
  * @param[in] fcinfo Catalog information about the external function
  * @param[in] func Bounding box function
  */
@@ -248,108 +248,14 @@ Boxop_temporal_temporal(FunctionCallInfo fcinfo,
 }
 
 /*****************************************************************************
- * Bounding box functions for temporal types
+ * overlaps
  *****************************************************************************/
-
-PGDLLEXPORT Datum Contains_tstzspan_temporal(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Contains_tstzspan_temporal);
-/**
- * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if a timestamptz span contains the time span of a
- * temporal value
- * @sqlfn contains_bbox()
- * @sqlop @p @>
- */
-inline Datum
-Contains_tstzspan_temporal(PG_FUNCTION_ARGS)
-{
-  return Boxop_tstzspan_temporal(fcinfo, &contains_span_span);
-}
-
-PGDLLEXPORT Datum Contains_temporal_tstzspan(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Contains_temporal_tstzspan);
-/**
- * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if the time span of a temporal value contains a
- * timestamptz span
- * @sqlfn contains_bbox()
- * @sqlop @p @>
- */
-inline Datum
-Contains_temporal_tstzspan(PG_FUNCTION_ARGS)
-{
-  return Boxop_temporal_tstzspan(fcinfo, &contains_span_span);
-}
-
-PGDLLEXPORT Datum Contains_temporal_temporal(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Contains_temporal_temporal);
-/**
- * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if the time span of the first temporal value
- * contains the one of the second one
- * @sqlfn contains_bbox()
- * @sqlop @p @>
- */
-inline Datum
-Contains_temporal_temporal(PG_FUNCTION_ARGS)
-{
-  return Boxop_temporal_temporal(fcinfo, &contains_span_span);
-}
-
-/*****************************************************************************/
-
-PGDLLEXPORT Datum Contained_tstzspan_temporal(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Contained_tstzspan_temporal);
-/**
- * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if a timestamptz span is contained the time span of
- * a temporal value
- * @sqlfn contained_bbox()
- * @sqlop @p <@
- */
-inline Datum
-Contained_tstzspan_temporal(PG_FUNCTION_ARGS)
-{
-  return Boxop_tstzspan_temporal(fcinfo, &contained_span_span);
-}
-
-PGDLLEXPORT Datum Contained_temporal_tstzspan(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Contained_temporal_tstzspan);
-/**
- * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if the time span of a temporal value is contained
- * in a timestamptz span
- * @sqlfn contained_bbox()
- * @sqlop @p <@
- */
-inline Datum
-Contained_temporal_tstzspan(PG_FUNCTION_ARGS)
-{
-  return Boxop_temporal_tstzspan(fcinfo, &contained_span_span);
-}
-
-PGDLLEXPORT Datum Contained_temporal_temporal(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Contained_temporal_temporal);
-/**
- * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if the time span of the first temporal value is
- * contained in the one of the second temporal value
- * @sqlfn contained_bbox()
- * @sqlop @p <@
- */
-inline Datum
-Contained_temporal_temporal(PG_FUNCTION_ARGS)
-{
-  return Boxop_temporal_temporal(fcinfo, &contained_span_span);
-}
-
-/*****************************************************************************/
 
 PGDLLEXPORT Datum Overlaps_tstzspan_temporal(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Overlaps_tstzspan_temporal);
 /**
  * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if a timestamptz span and the time span of a
+ * @brief Return true if a timestamptz span and the timestamptz span of a
  * temporal value overlap
  * @sqlfn overlaps_bbox()
  * @sqlop @p &&
@@ -364,8 +270,8 @@ PGDLLEXPORT Datum Overlaps_temporal_tstzspan(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Overlaps_temporal_tstzspan);
 /**
  * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if the time span of a temporal value and a
- * timestamptz span overlap
+ * @brief Return true if the timestamptz span of a temporal value and
+ * a timestamptz span overlap
  * @sqlfn overlaps_bbox()
  * @sqlop @p &&
  */
@@ -379,7 +285,8 @@ PGDLLEXPORT Datum Overlaps_temporal_temporal(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Overlaps_temporal_temporal);
 /**
  * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if the time spans of two temporal values overlap
+ * @brief Return true if the timestamptz spans of two temporal values
+ * overlap
  * @sqlfn overlaps_bbox()
  * @sqlop @p &&
  */
@@ -389,14 +296,114 @@ Overlaps_temporal_temporal(PG_FUNCTION_ARGS)
   return Boxop_temporal_temporal(fcinfo, &overlaps_span_span);
 }
 
-/*****************************************************************************/
+/*****************************************************************************
+ * contains
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Contains_tstzspan_temporal(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Contains_tstzspan_temporal);
+/**
+ * @ingroup mobilitydb_temporal_bbox_topo
+ * @brief Return true if a timestamptz span contains the one of a
+ * temporal value
+ * @sqlfn contains_bbox()
+ * @sqlop @p @>
+ */
+inline Datum
+Contains_tstzspan_temporal(PG_FUNCTION_ARGS)
+{
+  return Boxop_tstzspan_temporal(fcinfo, &contains_span_span);
+}
+
+PGDLLEXPORT Datum Contains_temporal_tstzspan(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Contains_temporal_tstzspan);
+/**
+ * @ingroup mobilitydb_temporal_bbox_topo
+ * @brief Return true if the timestamptz span of a temporal value
+ * contains a timestamptz span
+ * @sqlfn contains_bbox()
+ * @sqlop @p @>
+ */
+inline Datum
+Contains_temporal_tstzspan(PG_FUNCTION_ARGS)
+{
+  return Boxop_temporal_tstzspan(fcinfo, &contains_span_span);
+}
+
+PGDLLEXPORT Datum Contains_temporal_temporal(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Contains_temporal_temporal);
+/**
+ * @ingroup mobilitydb_temporal_bbox_topo
+ * @brief Return true if the timestamptz span of the first temporal value
+ * contains the one of the second temporal value
+ * @sqlfn contains_bbox()
+ * @sqlop @p @>
+ */
+inline Datum
+Contains_temporal_temporal(PG_FUNCTION_ARGS)
+{
+  return Boxop_temporal_temporal(fcinfo, &contains_span_span);
+}
+
+/*****************************************************************************
+ * contained
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Contained_tstzspan_temporal(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Contained_tstzspan_temporal);
+/**
+ * @ingroup mobilitydb_temporal_bbox_topo
+ * @brief Return true if a timestamptz span is contained in the
+ * timestamptz span of a temporal value
+ * @sqlfn contained_bbox()
+ * @sqlop @p <@
+ */
+inline Datum
+Contained_tstzspan_temporal(PG_FUNCTION_ARGS)
+{
+  return Boxop_tstzspan_temporal(fcinfo, &contained_span_span);
+}
+
+PGDLLEXPORT Datum Contained_temporal_tstzspan(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Contained_temporal_tstzspan);
+/**
+ * @ingroup mobilitydb_temporal_bbox_topo
+ * @brief Return true if the timestamptz span of a temporal value is
+ * contained in the timestamptz span
+ * @sqlfn contained_bbox()
+ * @sqlop @p <@
+ */
+inline Datum
+Contained_temporal_tstzspan(PG_FUNCTION_ARGS)
+{
+  return Boxop_temporal_tstzspan(fcinfo, &contained_span_span);
+}
+
+PGDLLEXPORT Datum Contained_temporal_temporal(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Contained_temporal_temporal);
+/**
+ * @ingroup mobilitydb_temporal_bbox_topo
+ * @brief Return true if the timestamptz span of the first temporal value
+ * is contained in the one of the second temporal value
+ * @sqlfn contained_bbox()
+ * @sqlop @p <@
+ */
+inline Datum
+Contained_temporal_temporal(PG_FUNCTION_ARGS)
+{
+  return Boxop_temporal_temporal(fcinfo, &contained_span_span);
+}
+
+/*****************************************************************************
+ * same
+ *****************************************************************************/
 
 PGDLLEXPORT Datum Same_tstzspan_temporal(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Same_tstzspan_temporal);
 /**
  * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if a timestamptz span and the time span of a
- * temporal value are equal
+ * @brief Return true if a timestamptz span and the timestamptz span of a
+ * temporal value are equal in the common dimensions
  * @sqlfn same_bbox()
  * @sqlop @p ~=
  */
@@ -410,8 +417,8 @@ PGDLLEXPORT Datum Same_temporal_tstzspan(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Same_temporal_tstzspan);
 /**
  * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if the time span of a temporal value and a
- * timestamptz span are equal
+ * @brief Return true if the timestamptz span of a temporal value and
+ * a timestamptz span are equal in the common dimensions
  * @sqlfn same_bbox()
  * @sqlop @p ~=
  */
@@ -425,7 +432,8 @@ PGDLLEXPORT Datum Same_temporal_temporal(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Same_temporal_temporal);
 /**
  * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if the time spans of two temporal values are equal
+ * @brief Return true if the timestamptz spans of two temporal values
+ * are equal in the common dimensions
  * @sqlfn same_bbox()
  * @sqlop @p ~=
  */
@@ -435,13 +443,15 @@ Same_temporal_temporal(PG_FUNCTION_ARGS)
   return Boxop_temporal_temporal(fcinfo, &same_span_span);
 }
 
-/*****************************************************************************/
+/*****************************************************************************
+ * adjacent
+ *****************************************************************************/
 
 PGDLLEXPORT Datum Adjacent_tstzspan_temporal(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Adjacent_tstzspan_temporal);
 /**
  * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if a timestamptz span and the time span of a
+ * @brief Return true if a timestamptz span and the timestamptz span of a
  * temporal value are adjacent
  * @sqlfn adjacent_bbox()
  * @sqlop @p -|-
@@ -456,8 +466,8 @@ PGDLLEXPORT Datum Adjacent_temporal_tstzspan(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Adjacent_temporal_tstzspan);
 /**
  * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if the time span of a temporal value and a
- * timestamptz span are adjacent
+ * @brief Return true if the timestamptz span of a temporal value
+ * and a timestamptz span are adjacent
  * @sqlfn adjacent_bbox()
  * @sqlop @p -|-
  */
@@ -471,7 +481,8 @@ PGDLLEXPORT Datum Adjacent_temporal_temporal(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Adjacent_temporal_temporal);
 /**
  * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if the time spans of two temporal values are adjacent
+ * @brief Return true if the timestamptz spans of two temporal values
+ * are adjacent
  * @sqlfn adjacent_bbox()
  * @sqlop @p -|-
  */
@@ -481,12 +492,17 @@ Adjacent_temporal_temporal(PG_FUNCTION_ARGS)
   return Boxop_temporal_temporal(fcinfo, &adjacent_span_span);
 }
 
+/*****************************************************************************/
+/* GENERATED-BOXOPS-END tstzspan */
+
+/* GENERATED-BOXOPS-BEGIN tbox — tools/codegen/inherited/generate.py from templates/boxops.c.tmpl; DO NOT EDIT BY HAND;
+ * edit the template + manifest.yaml (boxtypes) and re-run. */
 /*****************************************************************************
- * Generic bounding box functions for temporal number types
+ * Generic box functions
  *****************************************************************************/
 
 /**
- * @brief Generic bounding box function for a span and a temporal number
+ * @brief Generic bounding box function for a number span and a temporal number
  * @param[in] fcinfo Catalog information about the external function
  * @param[in] func Bounding box function
  */
@@ -494,15 +510,16 @@ Datum
 Boxop_numspan_tnumber(FunctionCallInfo fcinfo,
   bool (*func)(const Span *, const Span *))
 {
-  Span *s = PG_GETARG_SPAN_P(0);
+  Span *box = PG_GETARG_SPAN_P(0);
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
-  bool result = boxop_tnumber_numspan(temp, s, func, INVERT);
+  bool result = boxop_tnumber_numspan(temp, box, func, INVERT);
   PG_FREE_IF_COPY(temp, 1);
   PG_RETURN_BOOL(result);
 }
 
 /**
- * @brief Generic bounding box function for a temporal number and a span
+ * @brief Generic bounding box function for a temporal number and a
+ * number span
  * @param[in] fcinfo Catalog information about the external function
  * @param[in] func Bounding box function
  */
@@ -511,15 +528,14 @@ Boxop_tnumber_numspan(FunctionCallInfo fcinfo,
   bool (*func)(const Span *, const Span *))
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
-  Span *s = PG_GETARG_SPAN_P(1);
-  bool result = boxop_tnumber_numspan(temp, s, func, INVERT_NO);
+  Span *box = PG_GETARG_SPAN_P(1);
+  bool result = boxop_tnumber_numspan(temp, box, func, INVERT_NO);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_BOOL(result);
 }
 
 /**
- * @brief Generic bounding box function for a temporal box and a temporal
- * number
+ * @brief Generic bounding box function for a temporal box and a temporal number
  * @param[in] fcinfo Catalog information about the external function
  * @param[in] func Bounding box function
  */
@@ -529,16 +545,14 @@ Boxop_tbox_tnumber(FunctionCallInfo fcinfo,
 {
   TBox *box = PG_GETARG_TBOX_P(0);
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
-  TBox box1;
-  tnumber_set_tbox(temp, &box1);
   bool result = boxop_tnumber_tbox(temp, box, func, INVERT);
   PG_FREE_IF_COPY(temp, 1);
   PG_RETURN_BOOL(result);
 }
 
 /**
- * @brief Generic bounding box function for a temporal number and a temporal
- * box
+ * @brief Generic bounding box function for a temporal number and a
+ * temporal box
  * @param[in] fcinfo Catalog information about the external function
  * @param[in] func Bounding box function
  */
@@ -554,7 +568,7 @@ Boxop_tnumber_tbox(FunctionCallInfo fcinfo,
 }
 
 /**
- * @brief Generic bounding box function for two temporal numbers
+ * @brief Generic topological function for two temporal numbers
  * @param[in] fcinfo Catalog information about the external function
  * @param[in] func Bounding box function
  */
@@ -571,168 +585,14 @@ Boxop_tnumber_tnumber(FunctionCallInfo fcinfo,
 }
 
 /*****************************************************************************
- * Bounding box functions for temporal numbers
+ * overlaps
  *****************************************************************************/
-
-PGDLLEXPORT Datum Contains_numspan_tnumber(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Contains_numspan_tnumber);
-/**
- * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if a number span contains the value span of a temporal
- * number
- * @sqlfn contains_bbox()
- * @sqlop @p @>
- */
-inline Datum
-Contains_numspan_tnumber(PG_FUNCTION_ARGS)
-{
-  return Boxop_numspan_tnumber(fcinfo, &contains_span_span);
-}
-
-PGDLLEXPORT Datum Contains_tnumber_numspan(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Contains_tnumber_numspan);
-/**
- * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if the value span of a temporal number contains
- * a number span
- * @sqlfn contains_bbox()
- * @sqlop @p @>
- */
-inline Datum
-Contains_tnumber_numspan(PG_FUNCTION_ARGS)
-{
-  return Boxop_tnumber_numspan(fcinfo, &contains_span_span);
-}
-
-PGDLLEXPORT Datum Contains_tbox_tnumber(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Contains_tbox_tnumber);
-/**
- * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if a temporal box contains the bounding box of a
- * temporal number
- * @sqlfn contains_bbox()
- * @sqlop @p @>
- */
-inline Datum
-Contains_tbox_tnumber(PG_FUNCTION_ARGS)
-{
-  return Boxop_tbox_tnumber(fcinfo, &contains_tbox_tbox);
-}
-
-PGDLLEXPORT Datum Contains_tnumber_tbox(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Contains_tnumber_tbox);
-/**
- * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if the bounding box of a temporal number contains a
- * temporal box
- * @sqlfn contains_bbox()
- * @sqlop @p @>
- */
-inline Datum
-Contains_tnumber_tbox(PG_FUNCTION_ARGS)
-{
-  return Boxop_tnumber_tbox(fcinfo, &contains_tbox_tbox);
-}
-
-PGDLLEXPORT Datum Contains_tnumber_tnumber(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Contains_tnumber_tnumber);
-/**
- * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if the bounding box of the first temporal number contains
- * the one of the second temporal number
- * @sqlfn contains_bbox()
- * @sqlop @p @>
- */
-inline Datum
-Contains_tnumber_tnumber(PG_FUNCTION_ARGS)
-{
-  return Boxop_tnumber_tnumber(fcinfo, &contains_tbox_tbox);
-}
-
-/*****************************************************************************/
-
-PGDLLEXPORT Datum Contained_numspan_tnumber(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Contained_numspan_tnumber);
-/**
- * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if a number span is contained in the value span
- * of a temporal number
- * @sqlfn contained_bbox()
- * @sqlop @p <@
- */
-inline Datum
-Contained_numspan_tnumber(PG_FUNCTION_ARGS)
-{
-  return Boxop_numspan_tnumber(fcinfo, &contained_span_span);
-}
-
-PGDLLEXPORT Datum Contained_tnumber_numspan(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Contained_tnumber_numspan);
-/**
- * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if the value span of a temporal number is
- * contained in a number span
- * @sqlfn contained_bbox()
- * @sqlop @p <@
- */
-inline Datum
-Contained_tnumber_numspan(PG_FUNCTION_ARGS)
-{
-  return Boxop_tnumber_numspan(fcinfo, &contained_span_span);
-}
-
-PGDLLEXPORT Datum Contained_tbox_tnumber(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Contained_tbox_tnumber);
-/**
- * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if a temporal box is contained in the bounding box of a
- * temporal number
- * @sqlfn contained_bbox()
- * @sqlop @p <@
- */
-inline Datum
-Contained_tbox_tnumber(PG_FUNCTION_ARGS)
-{
-  return Boxop_tbox_tnumber(fcinfo, &contained_tbox_tbox);
-}
-
-PGDLLEXPORT Datum Contained_tnumber_tbox(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Contained_tnumber_tbox);
-/**
- * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if the bounding box of a temporal number is contained in
- * a temporal box
- * @sqlfn contained_bbox()
- * @sqlop @p <@
- */
-inline Datum
-Contained_tnumber_tbox(PG_FUNCTION_ARGS)
-{
-  return Boxop_tnumber_tbox(fcinfo, &contained_tbox_tbox);
-}
-
-PGDLLEXPORT Datum Contained_tnumber_tnumber(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Contained_tnumber_tnumber);
-/**
- * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if the bounding box of the first temporal number is
- * contained in the one of the second temporal number
- * @sqlfn contained_bbox()
- * @sqlop @p <@
- */
-inline Datum
-Contained_tnumber_tnumber(PG_FUNCTION_ARGS)
-{
-  return Boxop_tnumber_tnumber(fcinfo, &contained_tbox_tbox);
-}
-
-/*****************************************************************************/
 
 PGDLLEXPORT Datum Overlaps_numspan_tnumber(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Overlaps_numspan_tnumber);
 /**
  * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if a number span and the value span of a
+ * @brief Return true if a number span and the number span of a
  * temporal number overlap
  * @sqlfn overlaps_bbox()
  * @sqlop @p &&
@@ -747,8 +607,8 @@ PGDLLEXPORT Datum Overlaps_tnumber_numspan(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Overlaps_tnumber_numspan);
 /**
  * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if the value span of a temporal number and the
- * number span overlap
+ * @brief Return true if the number span of a temporal number and
+ * a number span overlap
  * @sqlfn overlaps_bbox()
  * @sqlop @p &&
  */
@@ -762,8 +622,8 @@ PGDLLEXPORT Datum Overlaps_tbox_tnumber(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Overlaps_tbox_tnumber);
 /**
  * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if a temporal box and the bounding box of a temporal
- * number overlap
+ * @brief Return true if a temporal box and the temporal box of a
+ * temporal number overlap
  * @sqlfn overlaps_bbox()
  * @sqlop @p &&
  */
@@ -777,8 +637,8 @@ PGDLLEXPORT Datum Overlaps_tnumber_tbox(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Overlaps_tnumber_tbox);
 /**
  * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if the bounding box of a temporal number and a temporal
- * box overlap
+ * @brief Return true if the temporal box of a temporal number and
+ * a temporal box overlap
  * @sqlfn overlaps_bbox()
  * @sqlop @p &&
  */
@@ -792,7 +652,8 @@ PGDLLEXPORT Datum Overlaps_tnumber_tnumber(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Overlaps_tnumber_tnumber);
 /**
  * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if the bounding boxes of two temporal numbers overlap
+ * @brief Return true if the temporal boxes of two temporal numbers
+ * overlap
  * @sqlfn overlaps_bbox()
  * @sqlop @p &&
  */
@@ -802,14 +663,174 @@ Overlaps_tnumber_tnumber(PG_FUNCTION_ARGS)
   return Boxop_tnumber_tnumber(fcinfo, &overlaps_tbox_tbox);
 }
 
-/*****************************************************************************/
+/*****************************************************************************
+ * contains
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Contains_numspan_tnumber(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Contains_numspan_tnumber);
+/**
+ * @ingroup mobilitydb_temporal_bbox_topo
+ * @brief Return true if a number span contains the one of a
+ * temporal number
+ * @sqlfn contains_bbox()
+ * @sqlop @p @>
+ */
+inline Datum
+Contains_numspan_tnumber(PG_FUNCTION_ARGS)
+{
+  return Boxop_numspan_tnumber(fcinfo, &contains_span_span);
+}
+
+PGDLLEXPORT Datum Contains_tnumber_numspan(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Contains_tnumber_numspan);
+/**
+ * @ingroup mobilitydb_temporal_bbox_topo
+ * @brief Return true if the number span of a temporal number
+ * contains a number span
+ * @sqlfn contains_bbox()
+ * @sqlop @p @>
+ */
+inline Datum
+Contains_tnumber_numspan(PG_FUNCTION_ARGS)
+{
+  return Boxop_tnumber_numspan(fcinfo, &contains_span_span);
+}
+
+PGDLLEXPORT Datum Contains_tbox_tnumber(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Contains_tbox_tnumber);
+/**
+ * @ingroup mobilitydb_temporal_bbox_topo
+ * @brief Return true if a temporal box contains the one of a
+ * temporal number
+ * @sqlfn contains_bbox()
+ * @sqlop @p @>
+ */
+inline Datum
+Contains_tbox_tnumber(PG_FUNCTION_ARGS)
+{
+  return Boxop_tbox_tnumber(fcinfo, &contains_tbox_tbox);
+}
+
+PGDLLEXPORT Datum Contains_tnumber_tbox(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Contains_tnumber_tbox);
+/**
+ * @ingroup mobilitydb_temporal_bbox_topo
+ * @brief Return true if the temporal box of a temporal number
+ * contains a temporal box
+ * @sqlfn contains_bbox()
+ * @sqlop @p @>
+ */
+inline Datum
+Contains_tnumber_tbox(PG_FUNCTION_ARGS)
+{
+  return Boxop_tnumber_tbox(fcinfo, &contains_tbox_tbox);
+}
+
+PGDLLEXPORT Datum Contains_tnumber_tnumber(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Contains_tnumber_tnumber);
+/**
+ * @ingroup mobilitydb_temporal_bbox_topo
+ * @brief Return true if the temporal box of the first temporal number
+ * contains the one of the second temporal number
+ * @sqlfn contains_bbox()
+ * @sqlop @p @>
+ */
+inline Datum
+Contains_tnumber_tnumber(PG_FUNCTION_ARGS)
+{
+  return Boxop_tnumber_tnumber(fcinfo, &contains_tbox_tbox);
+}
+
+/*****************************************************************************
+ * contained
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Contained_numspan_tnumber(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Contained_numspan_tnumber);
+/**
+ * @ingroup mobilitydb_temporal_bbox_topo
+ * @brief Return true if a number span is contained in the
+ * number span of a temporal number
+ * @sqlfn contained_bbox()
+ * @sqlop @p <@
+ */
+inline Datum
+Contained_numspan_tnumber(PG_FUNCTION_ARGS)
+{
+  return Boxop_numspan_tnumber(fcinfo, &contained_span_span);
+}
+
+PGDLLEXPORT Datum Contained_tnumber_numspan(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Contained_tnumber_numspan);
+/**
+ * @ingroup mobilitydb_temporal_bbox_topo
+ * @brief Return true if the number span of a temporal number is
+ * contained in the number span
+ * @sqlfn contained_bbox()
+ * @sqlop @p <@
+ */
+inline Datum
+Contained_tnumber_numspan(PG_FUNCTION_ARGS)
+{
+  return Boxop_tnumber_numspan(fcinfo, &contained_span_span);
+}
+
+PGDLLEXPORT Datum Contained_tbox_tnumber(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Contained_tbox_tnumber);
+/**
+ * @ingroup mobilitydb_temporal_bbox_topo
+ * @brief Return true if a temporal box is contained in the
+ * temporal box of a temporal number
+ * @sqlfn contained_bbox()
+ * @sqlop @p <@
+ */
+inline Datum
+Contained_tbox_tnumber(PG_FUNCTION_ARGS)
+{
+  return Boxop_tbox_tnumber(fcinfo, &contained_tbox_tbox);
+}
+
+PGDLLEXPORT Datum Contained_tnumber_tbox(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Contained_tnumber_tbox);
+/**
+ * @ingroup mobilitydb_temporal_bbox_topo
+ * @brief Return true if the temporal box of a temporal number is
+ * contained in the temporal box
+ * @sqlfn contained_bbox()
+ * @sqlop @p <@
+ */
+inline Datum
+Contained_tnumber_tbox(PG_FUNCTION_ARGS)
+{
+  return Boxop_tnumber_tbox(fcinfo, &contained_tbox_tbox);
+}
+
+PGDLLEXPORT Datum Contained_tnumber_tnumber(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Contained_tnumber_tnumber);
+/**
+ * @ingroup mobilitydb_temporal_bbox_topo
+ * @brief Return true if the temporal box of the first temporal number
+ * is contained in the one of the second temporal number
+ * @sqlfn contained_bbox()
+ * @sqlop @p <@
+ */
+inline Datum
+Contained_tnumber_tnumber(PG_FUNCTION_ARGS)
+{
+  return Boxop_tnumber_tnumber(fcinfo, &contained_tbox_tbox);
+}
+
+/*****************************************************************************
+ * same
+ *****************************************************************************/
 
 PGDLLEXPORT Datum Same_numspan_tnumber(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Same_numspan_tnumber);
 /**
  * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if a number span and the value span of a
- * temporal number are equal
+ * @brief Return true if a number span and the number span of a
+ * temporal number are equal in the common dimensions
  * @sqlfn same_bbox()
  * @sqlop @p ~=
  */
@@ -823,8 +844,8 @@ PGDLLEXPORT Datum Same_tnumber_numspan(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Same_tnumber_numspan);
 /**
  * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if the value span of a temporal number and a
- * number span are equal
+ * @brief Return true if the number span of a temporal number and
+ * a number span are equal in the common dimensions
  * @sqlfn same_bbox()
  * @sqlop @p ~=
  */
@@ -838,8 +859,8 @@ PGDLLEXPORT Datum Same_tbox_tnumber(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Same_tbox_tnumber);
 /**
  * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if a temporal box and the bounding box of a temporal
- * number are equal in the common dimensions
+ * @brief Return true if a temporal box and the temporal box of a
+ * temporal number are equal in the common dimensions
  * @sqlfn same_bbox()
  * @sqlop @p ~=
  */
@@ -853,8 +874,8 @@ PGDLLEXPORT Datum Same_tnumber_tbox(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Same_tnumber_tbox);
 /**
  * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if the bounding box of a temporal number and a
- * temporal box are equal in the common dimensions
+ * @brief Return true if the temporal box of a temporal number and
+ * a temporal box are equal in the common dimensions
  * @sqlfn same_bbox()
  * @sqlop @p ~=
  */
@@ -868,7 +889,8 @@ PGDLLEXPORT Datum Same_tnumber_tnumber(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Same_tnumber_tnumber);
 /**
  * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if the bounding boxes of two temporal numbers are equal
+ * @brief Return true if the temporal boxes of two temporal numbers
+ * are equal in the common dimensions
  * @sqlfn same_bbox()
  * @sqlop @p ~=
  */
@@ -878,13 +900,15 @@ Same_tnumber_tnumber(PG_FUNCTION_ARGS)
   return Boxop_tnumber_tnumber(fcinfo, &same_tbox_tbox);
 }
 
-/*****************************************************************************/
+/*****************************************************************************
+ * adjacent
+ *****************************************************************************/
 
 PGDLLEXPORT Datum Adjacent_numspan_tnumber(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Adjacent_numspan_tnumber);
 /**
  * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if a number span and the value span of a
+ * @brief Return true if a number span and the number span of a
  * temporal number are adjacent
  * @sqlfn adjacent_bbox()
  * @sqlop @p -|-
@@ -899,8 +923,8 @@ PGDLLEXPORT Datum Adjacent_tnumber_numspan(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Adjacent_tnumber_numspan);
 /**
  * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if the value span of a temporal number and a
- * number span are adjacent
+ * @brief Return true if the number span of a temporal number
+ * and a number span are adjacent
  * @sqlfn adjacent_bbox()
  * @sqlop @p -|-
  */
@@ -914,8 +938,8 @@ PGDLLEXPORT Datum Adjacent_tbox_tnumber(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Adjacent_tbox_tnumber);
 /**
  * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if a temporal box and the bounding box of a temporal
- * number are adjacent
+ * @brief Return true if a temporal box and the temporal box of a
+ * temporal number are adjacent
  * @sqlfn adjacent_bbox()
  * @sqlop @p -|-
  */
@@ -929,8 +953,8 @@ PGDLLEXPORT Datum Adjacent_tnumber_tbox(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Adjacent_tnumber_tbox);
 /**
  * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if the bounding box of a temporal number and a temporal
- * box are adjacent
+ * @brief Return true if the temporal box of a temporal number
+ * and a temporal box are adjacent
  * @sqlfn adjacent_bbox()
  * @sqlop @p -|-
  */
@@ -944,7 +968,8 @@ PGDLLEXPORT Datum Adjacent_tnumber_tnumber(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Adjacent_tnumber_tnumber);
 /**
  * @ingroup mobilitydb_temporal_bbox_topo
- * @brief Return true if the bounding boxes of two temporal numbers are adjacent
+ * @brief Return true if the temporal boxes of two temporal numbers
+ * are adjacent
  * @sqlfn adjacent_bbox()
  * @sqlop @p -|-
  */
@@ -955,3 +980,4 @@ Adjacent_tnumber_tnumber(PG_FUNCTION_ARGS)
 }
 
 /*****************************************************************************/
+/* GENERATED-BOXOPS-END tbox */

--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -70,32 +70,88 @@ def render(behaviour: str, sub: dict) -> str:
 # (stbox/tbox/tstzspan/tpcbox) into the region between these markers, which live
 # inside a hand-written .c file that also holds non-generated helpers (trajectory
 # tiling, NAD, ...). Only the marked region is owned by the generator.
-BOXOPS_BEGIN = ("/* GENERATED-BOXOPS-BEGIN — tools/codegen/inherited/generate.py "
-                "from templates/boxops.c.tmpl; DO NOT EDIT BY HAND;\n"
-                " * edit the template + manifest.yaml (boxtypes) and re-run. */\n")
-BOXOPS_END = "/* GENERATED-BOXOPS-END */\n"
-_BOXOPS_KEYS = ("box", "tside", "boxc", "getarg", "dispbox", "disptt",
-                "ingroup", "boxdesc", "boxdescpl", "valdesc")
+def _boxops_markers(box: str):
+    """BEGIN/END markers keyed by box type, so one file can host several
+    generated regions (temporal_boxops.c holds both tstzspan and tbox)."""
+    begin = (f"/* GENERATED-BOXOPS-BEGIN {box} — tools/codegen/inherited/generate.py "
+             "from templates/boxops.c.tmpl; DO NOT EDIT BY HAND;\n"
+             " * edit the template + manifest.yaml (boxtypes) and re-run. */\n")
+    return begin, f"/* GENERATED-BOXOPS-END {box} */\n"
+# The template defines one implementation per OP (overlaps/contains/contained/
+# same/adjacent) as three "direction kinds", reused across every box type:
+#   0 = box-first    Boxop_{BOX}_{TSIDE}   dispatch {DISPBOX}  (INVERT)
+#   1 = tside-first  Boxop_{TSIDE}_{BOX}   dispatch {DISPBOX}  (INVERT_NO)
+#   2 = tside-tside  Boxop_{TSIDE}_{TSIDE} dispatch {DISPTT}
+# A box type is a LIST of directions. A plain box (stbox/tpcbox/tstzspan) has the
+# three template directions. A composite box (tbox) whose value dimension is a
+# span<T> prepends a `valspan` sub-block — its 2 box-directions (numspan_tnumber,
+# tnumber_numspan) dispatch on span primitives — before its own 3 box-directions.
+# This is the single generation mechanism for {tstzspan, stbox, tpcbox, tbox, …}.
+
+
+def _boxops_blocks():
+    """boxops.c.tmpl split on blank lines: [header], 3 dispatchers (kinds 0/1/2),
+    then per op [banner, wrap0, wrap1, wrap2], [trailer]. Roundtrips exactly."""
+    blocks = (TEMPLATES / "boxops.c.tmpl").read_text().split("\n\n")
+    header, trailer = blocks[0], blocks[-1]
+    dispatch = blocks[1:4]
+    ops = [(blocks[4 + i * 4], blocks[5 + i * 4:8 + i * 4]) for i in range(5)]
+    return header, dispatch, ops, trailer
+
+
+def _boxops_directions(bt: dict) -> list:
+    """Ordered directions for a box type: an optional value-span sub-block (kinds
+    0,1 on span primitives) followed by the box's own 3 directions (kinds 0,1,2)."""
+    dirs = []
+    vs = bt.get("valspan")
+    if vs:
+        dirs += [{**vs, "kind": k} for k in (0, 1)]
+    dirs += [{**bt, "kind": k} for k in (0, 1, 2)]
+    return dirs
+
+
+def _boxops_sub(fragment: str, d: dict, bt: dict) -> str:
+    """Substitute the per-direction tokens into one template block. {PRIM} is the
+    box name for a self-contained box (overlaps_stbox_stbox) but differs for a
+    span<T> instance (overlaps_span_span for tstzspan/numspan) — defaults to box."""
+    vals = {
+        "BOX": d["box"], "BOXC": d["boxc"], "GETARG": d["getarg"],
+        "PRIM": d.get("prim", d["box"]),
+        "DISPBOX": d.get("dispbox", ""), "DISPTT": d.get("disptt", bt.get("disptt", "")),
+        "BOXDESC": d.get("boxdesc", bt["boxdesc"]),
+        "BOXDESCPL": d.get("boxdescpl", bt["boxdescpl"]),
+        "TSIDE": bt["tside"], "VALDESC": bt["valdesc"], "INGROUP": bt["ingroup"],
+    }
+    for k, v in vals.items():
+        fragment = fragment.replace("{" + k + "}", v)
+    return fragment
 
 
 def render_boxops(bt: dict) -> str:
-    body = (TEMPLATES / "boxops.c.tmpl").read_text()
-    for k in _BOXOPS_KEYS:
-        body = body.replace("{" + k.upper() + "}", bt[k])
-    return body
+    header, dispatch, ops, trailer = _boxops_blocks()
+    dirs = _boxops_directions(bt)
+    out = [header]
+    out += [_boxops_sub(dispatch[d["kind"]], d, bt) for d in dirs]
+    for banner, wraps in ops:
+        out.append(banner)
+        out += [_boxops_sub(wraps[d["kind"]], d, bt) for d in dirs]
+    out.append(trailer)
+    return "\n\n".join(out)
 
 
-def splice_boxops(filetext: str, rendered: str) -> str:
-    """Replace the text strictly between the BEGIN/END markers with `rendered`."""
-    b = filetext.index(BOXOPS_BEGIN) + len(BOXOPS_BEGIN)
-    e = filetext.index(BOXOPS_END)
+def splice_boxops(filetext: str, box: str, rendered: str) -> str:
+    """Replace the text strictly between the box's BEGIN/END markers with `rendered`."""
+    begin, end = _boxops_markers(box)
+    b = filetext.index(begin) + len(begin)
+    e = filetext.index(end)
     return filetext[:b] + rendered + filetext[e:]
 
 
-def extract_boxops(filetext: str) -> str:
-    """Return the current text between the BEGIN/END markers (for --validate)."""
-    b = filetext.index(BOXOPS_BEGIN) + len(BOXOPS_BEGIN)
-    e = filetext.index(BOXOPS_END)
+def extract_boxops(filetext: str, box: str) -> str:
+    """Return the current text between the box's BEGIN/END markers (for --validate)."""
+    begin, end = _boxops_markers(box)
+    b = filetext.index(begin) + len(begin)
+    e = filetext.index(end)
     return filetext[b:e]
 
 
@@ -161,7 +217,7 @@ def main() -> int:
                 continue
             p = ROOT / bt["file"]
             gen = render_boxops(bt)
-            cur = extract_boxops(p.read_text()) if p.exists() else ""
+            cur = extract_boxops(p.read_text(), bt["box"]) if p.exists() else ""
             same = gen == cur
             ok = ok and same
             print(f"[{'OK ' if same else 'DIFF'}] self-regen boxops {bt['box']} "
@@ -196,7 +252,7 @@ def main() -> int:
         if args.check:
             print(f"would splice boxops {bt['box']} -> {bt['file']}")
             continue
-        p.write_text(splice_boxops(p.read_text(), render_boxops(bt)))
+        p.write_text(splice_boxops(p.read_text(), bt["box"], render_boxops(bt)))
         print(f"spliced boxops {bt['box']} -> {bt['file']}")
     return 0
 

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -135,3 +135,47 @@ boxtypes:
     valdesc:   temporal pointcloud value
     file:      mobilitydb/src/pointcloud/tpc_boxops.c
     reference: true
+
+  # tstzspan: the box IS a span<timestamptz>, so the primitives are the generic
+  # span operators (overlaps_span_span, ...) via prim: span. Serves every
+  # temporal-only type (the time-span bounding box).
+  - box:       tstzspan
+    tside:     temporal
+    prim:      span
+    boxc:      Span
+    getarg:    PG_GETARG_SPAN_P
+    dispbox:   boxop_temporal_tstzspan
+    disptt:    boxop_temporal_temporal
+    ingroup:   mobilitydb_temporal_bbox_topo
+    boxdesc:   timestamptz span
+    boxdescpl: timestamptz spans
+    valdesc:   temporal value
+    file:      mobilitydb/src/temporal/temporal_boxops.c
+    reference: true
+
+  # tbox: a COMPOSITE box (value span × time). Its own directions dispatch on the
+  # tbox primitives (overlaps_tbox_tbox, ...); the `valspan` sub-block adds the
+  # value-dimension directions (numspan_tnumber, tnumber_numspan) which dispatch on
+  # the generic span primitives (overlaps_span_span, ...) via prim: span — the
+  # span<T> value dimension of the tnumber. Shares temporal_boxops.c with tstzspan.
+  - box:       tbox
+    tside:     tnumber
+    prim:      tbox
+    boxc:      TBox
+    getarg:    PG_GETARG_TBOX_P
+    dispbox:   boxop_tnumber_tbox
+    disptt:    boxop_tnumber_tnumber
+    ingroup:   mobilitydb_temporal_bbox_topo
+    boxdesc:   temporal box
+    boxdescpl: temporal boxes
+    valdesc:   temporal number
+    file:      mobilitydb/src/temporal/temporal_boxops.c
+    reference: true
+    valspan:
+      box:       numspan
+      prim:      span
+      boxc:      Span
+      getarg:    PG_GETARG_SPAN_P
+      dispbox:   boxop_tnumber_numspan
+      boxdesc:   number span
+      boxdescpl: number spans

--- a/tools/codegen/inherited/templates/boxops.c.tmpl
+++ b/tools/codegen/inherited/templates/boxops.c.tmpl
@@ -68,7 +68,7 @@ PG_FUNCTION_INFO_V1(Overlaps_{BOX}_{TSIDE});
 inline Datum
 Overlaps_{BOX}_{TSIDE}(PG_FUNCTION_ARGS)
 {
-  return Boxop_{BOX}_{TSIDE}(fcinfo, &overlaps_{BOX}_{BOX});
+  return Boxop_{BOX}_{TSIDE}(fcinfo, &overlaps_{PRIM}_{PRIM});
 }
 
 PGDLLEXPORT Datum Overlaps_{TSIDE}_{BOX}(PG_FUNCTION_ARGS);
@@ -83,7 +83,7 @@ PG_FUNCTION_INFO_V1(Overlaps_{TSIDE}_{BOX});
 inline Datum
 Overlaps_{TSIDE}_{BOX}(PG_FUNCTION_ARGS)
 {
-  return Boxop_{TSIDE}_{BOX}(fcinfo, &overlaps_{BOX}_{BOX});
+  return Boxop_{TSIDE}_{BOX}(fcinfo, &overlaps_{PRIM}_{PRIM});
 }
 
 PGDLLEXPORT Datum Overlaps_{TSIDE}_{TSIDE}(PG_FUNCTION_ARGS);
@@ -98,7 +98,7 @@ PG_FUNCTION_INFO_V1(Overlaps_{TSIDE}_{TSIDE});
 inline Datum
 Overlaps_{TSIDE}_{TSIDE}(PG_FUNCTION_ARGS)
 {
-  return Boxop_{TSIDE}_{TSIDE}(fcinfo, &overlaps_{BOX}_{BOX});
+  return Boxop_{TSIDE}_{TSIDE}(fcinfo, &overlaps_{PRIM}_{PRIM});
 }
 
 /*****************************************************************************
@@ -117,7 +117,7 @@ PG_FUNCTION_INFO_V1(Contains_{BOX}_{TSIDE});
 inline Datum
 Contains_{BOX}_{TSIDE}(PG_FUNCTION_ARGS)
 {
-  return Boxop_{BOX}_{TSIDE}(fcinfo, &contains_{BOX}_{BOX});
+  return Boxop_{BOX}_{TSIDE}(fcinfo, &contains_{PRIM}_{PRIM});
 }
 
 PGDLLEXPORT Datum Contains_{TSIDE}_{BOX}(PG_FUNCTION_ARGS);
@@ -132,7 +132,7 @@ PG_FUNCTION_INFO_V1(Contains_{TSIDE}_{BOX});
 inline Datum
 Contains_{TSIDE}_{BOX}(PG_FUNCTION_ARGS)
 {
-  return Boxop_{TSIDE}_{BOX}(fcinfo, &contains_{BOX}_{BOX});
+  return Boxop_{TSIDE}_{BOX}(fcinfo, &contains_{PRIM}_{PRIM});
 }
 
 PGDLLEXPORT Datum Contains_{TSIDE}_{TSIDE}(PG_FUNCTION_ARGS);
@@ -147,7 +147,7 @@ PG_FUNCTION_INFO_V1(Contains_{TSIDE}_{TSIDE});
 inline Datum
 Contains_{TSIDE}_{TSIDE}(PG_FUNCTION_ARGS)
 {
-  return Boxop_{TSIDE}_{TSIDE}(fcinfo, &contains_{BOX}_{BOX});
+  return Boxop_{TSIDE}_{TSIDE}(fcinfo, &contains_{PRIM}_{PRIM});
 }
 
 /*****************************************************************************
@@ -166,7 +166,7 @@ PG_FUNCTION_INFO_V1(Contained_{BOX}_{TSIDE});
 inline Datum
 Contained_{BOX}_{TSIDE}(PG_FUNCTION_ARGS)
 {
-  return Boxop_{BOX}_{TSIDE}(fcinfo, &contained_{BOX}_{BOX});
+  return Boxop_{BOX}_{TSIDE}(fcinfo, &contained_{PRIM}_{PRIM});
 }
 
 PGDLLEXPORT Datum Contained_{TSIDE}_{BOX}(PG_FUNCTION_ARGS);
@@ -181,7 +181,7 @@ PG_FUNCTION_INFO_V1(Contained_{TSIDE}_{BOX});
 inline Datum
 Contained_{TSIDE}_{BOX}(PG_FUNCTION_ARGS)
 {
-  return Boxop_{TSIDE}_{BOX}(fcinfo, &contained_{BOX}_{BOX});
+  return Boxop_{TSIDE}_{BOX}(fcinfo, &contained_{PRIM}_{PRIM});
 }
 
 PGDLLEXPORT Datum Contained_{TSIDE}_{TSIDE}(PG_FUNCTION_ARGS);
@@ -196,7 +196,7 @@ PG_FUNCTION_INFO_V1(Contained_{TSIDE}_{TSIDE});
 inline Datum
 Contained_{TSIDE}_{TSIDE}(PG_FUNCTION_ARGS)
 {
-  return Boxop_{TSIDE}_{TSIDE}(fcinfo, &contained_{BOX}_{BOX});
+  return Boxop_{TSIDE}_{TSIDE}(fcinfo, &contained_{PRIM}_{PRIM});
 }
 
 /*****************************************************************************
@@ -215,7 +215,7 @@ PG_FUNCTION_INFO_V1(Same_{BOX}_{TSIDE});
 inline Datum
 Same_{BOX}_{TSIDE}(PG_FUNCTION_ARGS)
 {
-  return Boxop_{BOX}_{TSIDE}(fcinfo, &same_{BOX}_{BOX});
+  return Boxop_{BOX}_{TSIDE}(fcinfo, &same_{PRIM}_{PRIM});
 }
 
 PGDLLEXPORT Datum Same_{TSIDE}_{BOX}(PG_FUNCTION_ARGS);
@@ -230,7 +230,7 @@ PG_FUNCTION_INFO_V1(Same_{TSIDE}_{BOX});
 inline Datum
 Same_{TSIDE}_{BOX}(PG_FUNCTION_ARGS)
 {
-  return Boxop_{TSIDE}_{BOX}(fcinfo, &same_{BOX}_{BOX});
+  return Boxop_{TSIDE}_{BOX}(fcinfo, &same_{PRIM}_{PRIM});
 }
 
 PGDLLEXPORT Datum Same_{TSIDE}_{TSIDE}(PG_FUNCTION_ARGS);
@@ -245,7 +245,7 @@ PG_FUNCTION_INFO_V1(Same_{TSIDE}_{TSIDE});
 inline Datum
 Same_{TSIDE}_{TSIDE}(PG_FUNCTION_ARGS)
 {
-  return Boxop_{TSIDE}_{TSIDE}(fcinfo, &same_{BOX}_{BOX});
+  return Boxop_{TSIDE}_{TSIDE}(fcinfo, &same_{PRIM}_{PRIM});
 }
 
 /*****************************************************************************
@@ -264,7 +264,7 @@ PG_FUNCTION_INFO_V1(Adjacent_{BOX}_{TSIDE});
 inline Datum
 Adjacent_{BOX}_{TSIDE}(PG_FUNCTION_ARGS)
 {
-  return Boxop_{BOX}_{TSIDE}(fcinfo, &adjacent_{BOX}_{BOX});
+  return Boxop_{BOX}_{TSIDE}(fcinfo, &adjacent_{PRIM}_{PRIM});
 }
 
 PGDLLEXPORT Datum Adjacent_{TSIDE}_{BOX}(PG_FUNCTION_ARGS);
@@ -279,7 +279,7 @@ PG_FUNCTION_INFO_V1(Adjacent_{TSIDE}_{BOX});
 inline Datum
 Adjacent_{TSIDE}_{BOX}(PG_FUNCTION_ARGS)
 {
-  return Boxop_{TSIDE}_{BOX}(fcinfo, &adjacent_{BOX}_{BOX});
+  return Boxop_{TSIDE}_{BOX}(fcinfo, &adjacent_{PRIM}_{PRIM});
 }
 
 PGDLLEXPORT Datum Adjacent_{TSIDE}_{TSIDE}(PG_FUNCTION_ARGS);
@@ -294,7 +294,7 @@ PG_FUNCTION_INFO_V1(Adjacent_{TSIDE}_{TSIDE});
 inline Datum
 Adjacent_{TSIDE}_{TSIDE}(PG_FUNCTION_ARGS)
 {
-  return Boxop_{TSIDE}_{TSIDE}(fcinfo, &adjacent_{BOX}_{BOX});
+  return Boxop_{TSIDE}_{TSIDE}(fcinfo, &adjacent_{PRIM}_{PRIM});
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
The bounding-box topological operator wrappers (`overlaps`/`contains`/`contained`/`same`/`adjacent`) for `tstzspan` (temporal-only types) and `tbox` (temporal numbers) in `mobilitydb/src/temporal/temporal_boxops.c` were hand-written, while the same operators for `stbox` and `tpcbox` are already emitted by the inherited generator (`tools/codegen/inherited/`). This brings `tstzspan` and `tbox` under that generator on the same box-type axis.

The generator changes:

- A `{PRIM}` token: a box backed by a span (its bounding box *is* a span, e.g. `tstzspan`, or its value dimension is one, e.g. the `numspan` of a `tbox`) dispatches on the generic span primitives (`overlaps_span_span`, …), while a self-contained box keeps its own (`overlaps_stbox_stbox`). The token defaults to the box name, so `stbox` and `tpcbox` regenerate byte for byte.
- The emitter is driven by an explicit list of directions per box type. A plain box has three directions; a composite box (`tbox`) additionally emits its value-span directions (`numspan_tnumber`, `tnumber_numspan`, on span primitives) alongside its box directions (`tbox_tnumber`, `tnumber_tbox`, `tnumber_tnumber`).
- The `GENERATED-BOXOPS` markers are keyed by box type so one file can hold several generated regions; `temporal_boxops.c` holds both `tstzspan` and `tbox`.

The generated regions give the operators a uniform layout (overlaps first) and drop an unused local box that the hand-written `tbox` dispatchers computed but never read.

`generate.py --validate` confirms all four box types (`stbox`, `tpcbox`, `tstzspan`, `tbox`) reproduce their committed regions byte for byte. The temporal topological regression tests pass unchanged.
