### PR TITLE
Compute the temporal tcbuffer-geometry relationships natively

### DIFF
--- a/meos/include/cbuffer/tcbuffer.h
+++ b/meos/include/cbuffer/tcbuffer.h
@@ -72,6 +72,16 @@ extern int tcbuffersegm_distance_turnpt(Datum start1, Datum end1, Datum start2,
   Datum end2, Datum dist UNUSED, TimestampTz lower, TimestampTz upper,
   TimestampTz *t1, TimestampTz *t2);
 
+/* Native (GEOS-free) temporal within relationship helpers */
+
+extern void *tcbuffer_geo_ctx_make(const GSERIALIZED *gs);
+extern void tcbuffer_geo_ctx_free(void *ctx);
+extern int tcbuffer_geo_ctx_nsegs(const void *ctx);
+extern bool tcbuffer_disc_within_ctx(const Cbuffer *cb, double dist,
+  const void *ctx);
+extern int tcbufferseg_within_ctx(const Cbuffer *cb1, const Cbuffer *cb2,
+  double dist, const void *ctx, double *outlo, double *outhi, int maxout);
+
 /*****************************************************************************/
 
 #endif /* __TCBUFFER_H__ */

--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -1382,6 +1382,280 @@ nad_tcbuffer_geo_analytic(const Temporal *temp, const GSERIALIZED *gs)
 }
 
 /*****************************************************************************
+ * Temporal within relationship (GEOS-free)
+ *
+ * The sub-periods during which a temporal circular buffer stays within a
+ * distance of a non-curved geometry, from the same swept-capsule distance
+ * kernel as the nearest-approach value. The candidate crossing instants are
+ * the roots of dist(centre(t), edge) = radius(t) + dist per boundary edge;
+ * each candidate sub-interval is classified with the exact interior-aware unit
+ * distance, so the ever-projection of the result agrees with the
+ * nearest-approach value.
+ *****************************************************************************/
+
+/**
+ * @brief Reusable geometry context that owns the boundary segments and the
+ * bucket hierarchy, so many discs and segments can be tested against one
+ * geometry without reparsing it
+ */
+typedef struct
+{
+  TcbSeg *segs;
+  TcbBucket *bks;
+  TcbGeom g;
+} TcbGeoCtx;
+
+/**
+ * @brief Build the reusable geometry context for the native within kernel, or
+ * return NULL for curved or unsupported geometry (the caller then uses the
+ * exact traversed-area path)
+ */
+void *
+tcbuffer_geo_ctx_make(const GSERIALIZED *gs)
+{
+  LWGEOM *lw = lwgeom_from_gserialized(gs);
+  TcbSeg *segs = NULL;
+  int cap = 0, n = 0;
+  bool has_poly = false;
+  bool ok = tcbuffer_geo_segs(lw, &segs, &cap, &n, &has_poly);
+  lwgeom_free(lw);
+  if (! ok || n == 0)
+  {
+    if (segs) pfree(segs);
+    return NULL;
+  }
+  double gxmin = DBL_MAX, gymin = DBL_MAX, gxmax = -DBL_MAX, gymax = -DBL_MAX;
+  for (int k = 0; k < n; k++)
+  {
+    if (segs[k].xmin < gxmin) gxmin = segs[k].xmin;
+    if (segs[k].ymin < gymin) gymin = segs[k].ymin;
+    if (segs[k].xmax > gxmax) gxmax = segs[k].xmax;
+    if (segs[k].ymax > gymax) gymax = segs[k].ymax;
+  }
+  int nbk = 0;
+  TcbBucket *bks = tcbuffer_build_buckets(segs, n, gxmin, gymin, gxmax, gymax,
+    &nbk);
+  TcbGeoCtx *ctx = palloc(sizeof(TcbGeoCtx));
+  ctx->segs = segs;
+  ctx->bks = bks;
+  ctx->g = (TcbGeom) { segs, n, has_poly, gxmin, gymin, gxmax, gymax, bks,
+    nbk };
+  return ctx;
+}
+
+/**
+ * @brief Free a geometry context built by #tcbuffer_geo_ctx_make
+ */
+void
+tcbuffer_geo_ctx_free(void *ctx)
+{
+  if (! ctx)
+    return;
+  TcbGeoCtx *c = (TcbGeoCtx *) ctx;
+  pfree(c->bks);
+  pfree(c->segs);
+  pfree(c);
+}
+
+/**
+ * @brief Return the number of boundary segments in a geometry context, used to
+ * size the per-segment within-interval output
+ */
+int
+tcbuffer_geo_ctx_nsegs(const void *ctxv)
+{
+  return ((const TcbGeoCtx *) ctxv)->g.n;
+}
+
+/**
+ * @brief Return true if a static circular buffer is within @p dist of the
+ * geometry, i.e. dist(centre, geometry) - radius <= dist
+ */
+bool
+tcbuffer_disc_within_ctx(const Cbuffer *cb, double dist, const void *ctxv)
+{
+  const TcbGeoCtx *ctx = (const TcbGeoCtx *) ctxv;
+  const POINT2D *p = GSERIALIZED_POINT2D_P(cbuffer_point_p(cb));
+  double best = DBL_MAX;
+  tcbuffer_unit_nad(p->x, p->y, cb->radius, p->x, p->y, cb->radius, &ctx->g,
+    &best);
+  return best <= dist;
+}
+
+/**
+ * @brief Append to @p cand the normalized times in (lo,hi) at which the moving
+ * disc distance to a region equals @p dist, i.e. the roots of
+ * (A - DR^2) t^2 + (B - 2 R0 DR) t + (C - R0^2) = 0 with R0 = r1 + dist
+ */
+static void
+tcbuffer_region_within_roots(double A, double B, double C, double R0,
+  double DR, double lo, double hi, double *cand, int *nc)
+{
+  double a = A - DR * DR;
+  double b = B - 2.0 * R0 * DR;
+  double c = C - R0 * R0;
+  if (fabs(a) < 1e-18)
+  {
+    if (fabs(b) > 1e-18)
+    {
+      double t = -c / b;
+      if (t > lo && t < hi)
+        cand[(*nc)++] = t;
+    }
+    return;
+  }
+  double disc = b * b - 4.0 * a * c;
+  if (disc < 0.0)
+    return;
+  double sd = sqrt(disc);
+  double t1 = (-b - sd) / (2.0 * a);
+  double t2 = (-b + sd) / (2.0 * a);
+  if (t1 > lo && t1 < hi)
+    cand[(*nc)++] = t1;
+  if (t2 > lo && t2 < hi)
+    cand[(*nc)++] = t2;
+}
+
+/**
+ * @brief Append the within-distance crossing times of one moving disc segment
+ * against one geometry edge, mirroring the perpendicular/endpoint region split
+ * of #tcbuffer_seg_edge_mindist
+ */
+static void
+tcbuffer_seg_edge_within_roots(double cx1, double cy1, double cx2, double cy2,
+  double r1, double r2, const TcbSeg *e, double dist, double *cand, int *nc)
+{
+  const double dcx = cx2 - cx1, dcy = cy2 - cy1, dr = r2 - r1, R0 = r1 + dist;
+  const double ax = e->x1, ay = e->y1, bx = e->x2, by = e->y2;
+  const double ux = bx - ax, uy = by - ay, l2 = ux * ux + uy * uy;
+  if (l2 <= 1e-24)
+  {
+    double A = dcx * dcx + dcy * dcy;
+    double B = 2.0 * ((cx1 - ax) * dcx + (cy1 - ay) * dcy);
+    double C = (cx1 - ax) * (cx1 - ax) + (cy1 - ay) * (cy1 - ay);
+    tcbuffer_region_within_roots(A, B, C, R0, dr, 0.0, 1.0, cand, nc);
+    return;
+  }
+  const double s0 = (cx1 - ax) * ux + (cy1 - ay) * uy;
+  const double s1 = dcx * ux + dcy * uy;
+  double bp[4];
+  int nb = 0;
+  bp[nb++] = 0.0;
+  bp[nb++] = 1.0;
+  if (fabs(s1) > 1e-18)
+  {
+    double ta = -s0 / s1, tb = (l2 - s0) / s1;
+    if (ta > 0.0 && ta < 1.0) bp[nb++] = ta;
+    if (tb > 0.0 && tb < 1.0) bp[nb++] = tb;
+  }
+  for (int i = 0; i < nb; i++)
+    for (int j = i + 1; j < nb; j++)
+      if (bp[j] < bp[i]) { double tmp = bp[i]; bp[i] = bp[j]; bp[j] = tmp; }
+  for (int k = 0; k + 1 < nb; k++)
+  {
+    double lo = bp[k], hi = bp[k + 1];
+    if (hi - lo < 1e-15)
+      continue;
+    double mt = 0.5 * (lo + hi);
+    double s = (s0 + s1 * mt) / l2;
+    double A, B, C;
+    if (s <= 0.0)
+    {
+      A = dcx * dcx + dcy * dcy;
+      B = 2.0 * ((cx1 - ax) * dcx + (cy1 - ay) * dcy);
+      C = (cx1 - ax) * (cx1 - ax) + (cy1 - ay) * (cy1 - ay);
+    }
+    else if (s >= 1.0)
+    {
+      A = dcx * dcx + dcy * dcy;
+      B = 2.0 * ((cx1 - bx) * dcx + (cy1 - by) * dcy);
+      C = (cx1 - bx) * (cx1 - bx) + (cy1 - by) * (cy1 - by);
+    }
+    else
+    {
+      double k0 = (cx1 - ax) * uy - (cy1 - ay) * ux;
+      double k1 = dcx * uy - dcy * ux;
+      A = k1 * k1 / l2;
+      B = 2.0 * k0 * k1 / l2;
+      C = k0 * k0 / l2;
+    }
+    tcbuffer_region_within_roots(A, B, C, R0, dr, lo, hi, cand, nc);
+  }
+}
+
+/**
+ * @brief Comparator for sorting the candidate crossing times
+ */
+static int
+tcbuffer_double_cmp(const void *a, const void *b)
+{
+  double d = *(const double *) a - *(const double *) b;
+  return (d < 0.0) ? -1 : (d > 0.0 ? 1 : 0);
+}
+
+/**
+ * @brief Return the within-distance sub-intervals of one linear moving disc
+ * segment as normalized [0,1] time ranges in @p outlo / @p outhi, returning
+ * their count. The crossing candidates come from the per-edge roots and each
+ * sub-interval is classified with the exact interior-aware unit distance.
+ */
+int
+tcbufferseg_within_ctx(const Cbuffer *cb1, const Cbuffer *cb2, double dist,
+  const void *ctxv, double *outlo, double *outhi, int maxout)
+{
+  const TcbGeoCtx *ctx = (const TcbGeoCtx *) ctxv;
+  const POINT2D *p1 = GSERIALIZED_POINT2D_P(cbuffer_point_p(cb1));
+  const POINT2D *p2 = GSERIALIZED_POINT2D_P(cbuffer_point_p(cb2));
+  double cx1 = p1->x, cy1 = p1->y, r1 = cb1->radius;
+  double cx2 = p2->x, cy2 = p2->y, r2 = cb2->radius;
+  int ncap = 2 + 4 * ctx->g.n;
+  double *cand = palloc(sizeof(double) * ncap);
+  int nc = 0;
+  cand[nc++] = 0.0;
+  cand[nc++] = 1.0;
+  for (int k = 0; k < ctx->g.n; k++)
+    tcbuffer_seg_edge_within_roots(cx1, cy1, cx2, cy2, r1, r2, &ctx->g.segs[k],
+      dist, cand, &nc);
+  qsort(cand, nc, sizeof(double), tcbuffer_double_cmp);
+  int m = 0;
+  for (int i = 0; i < nc; i++)
+    if (i == 0 || cand[i] - cand[m - 1] > 1e-15)
+      cand[m++] = cand[i];
+  int nout = 0;
+  int k = 0;
+  while (k < m - 1 && nout < maxout)
+  {
+    double tm = 0.5 * (cand[k] + cand[k + 1]);
+    double cx = cx1 + (cx2 - cx1) * tm, cy = cy1 + (cy2 - cy1) * tm;
+    double r = r1 + (r2 - r1) * tm;
+    double best = DBL_MAX;
+    tcbuffer_unit_nad(cx, cy, r, cx, cy, r, &ctx->g, &best);
+    if (best <= dist)
+    {
+      int ks = k;
+      k++;
+      while (k < m - 1)
+      {
+        double tm2 = 0.5 * (cand[k] + cand[k + 1]);
+        double cx_2 = cx1 + (cx2 - cx1) * tm2, cy_2 = cy1 + (cy2 - cy1) * tm2;
+        double r_2 = r1 + (r2 - r1) * tm2;
+        double best2 = DBL_MAX;
+        tcbuffer_unit_nad(cx_2, cy_2, r_2, cx_2, cy_2, r_2, &ctx->g, &best2);
+        if (best2 <= dist) k++;
+        else break;
+      }
+      outlo[nout] = cand[ks];
+      outhi[nout] = cand[k];
+      nout++;
+    }
+    else
+      k++;
+  }
+  pfree(cand);
+  return nout;
+}
+
+/*****************************************************************************
  * Nearest approach distance (NAD)
  *****************************************************************************/
 

--- a/meos/src/cbuffer/tcbuffer_tempspatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_tempspatialrels.c
@@ -271,11 +271,9 @@ tinterrel_tcbufferseq_step_geom(const TSequence *seq, const GSERIALIZED *gs,
     bool upper_inc = (i == seq->count - 1) ? false : seq->period.upper_inc;
     GSERIALIZED *circle = tcbufferinst_traversed_area(inst);
     /* Loop for each point in the intersection */
-    bool found = false;
     for (int j = 0; j < npoints; j++)
     {
-      found = geom_intersects2d(circle, points[j]);
-      if (found)
+      if (geom_intersects2d(circle, points[j]))
       {
         if (timestamptz_cmp_internal(inst->t, mint) < 0)
           mint = inst->t;
@@ -314,11 +312,8 @@ tinterrel_tcbufferseq_step_geom(const TSequence *seq, const GSERIALIZED *gs,
         }
         pfree(s);
       }
-      else
-      {}
     }
     pfree(circle);
-    inst = next;
   }
   pfree_array((void *) points, npoints);
   /* If there is no intersection */
@@ -558,6 +553,269 @@ tinterrel_tcbufferseqset_geom(const TSequenceSet *ss, const GSERIALIZED *gs,
   return result;
 }
 
+/*****************************************************************************
+ * Native (GEOS-free) temporal intersects/disjoint with a geometry
+ *
+ * These mirror the traversed-area functions above but discover the intersecting
+ * sub-periods from the exact swept-capsule distance kernel instead of
+ * linearizing the circular buffer through GEOS. They are used for every
+ * non-curved geometry; the traversed-area functions remain the fallback for
+ * curved input.
+ *****************************************************************************/
+
+/**
+ * @brief Native version of #tinterrel_tcbufferinst_geom
+ */
+static Temporal *
+tinterrel_tcbufferinst_geo_native(const TInstant *inst, bool tinter,
+  const void *ctx)
+{
+  bool within = tcbuffer_disc_within_ctx(
+    DatumGetCbufferP(tinstant_value_p(inst)), 0.0, ctx);
+  Datum d = (within == tinter) ? BoolGetDatum(true) : BoolGetDatum(false);
+  return (Temporal *) tinstant_make(d, T_TBOOL, inst->t);
+}
+
+/**
+ * @brief Native version of #tinterrel_tcbufferseq_disc_geom
+ */
+static Temporal *
+tinterrel_tcbufferseq_disc_geo_native(const TSequence *seq, bool tinter,
+  const void *ctx)
+{
+  Set *s = NULL;
+  for (int i = 0; i < seq->count; i++)
+  {
+    const TInstant *inst = TSEQUENCE_INST_N(seq, i);
+    if (tcbuffer_disc_within_ctx(DatumGetCbufferP(tinstant_value_p(inst)), 0.0,
+        ctx))
+    {
+      if (! s)
+        s = value_set(TimestampTzGetDatum(inst->t), T_TIMESTAMPTZ);
+      else
+      {
+        Set *s1 = union_set_value(s, TimestampTzGetDatum(inst->t));
+        pfree(s);
+        s = s1;
+      }
+    }
+  }
+  Datum bool_true = tinter ? BoolGetDatum(true) : BoolGetDatum(false);
+  Datum bool_false = tinter ? BoolGetDatum(false) : BoolGetDatum(true);
+  if (! s)
+    return (Temporal *) tsequence_from_base_temp(bool_false, T_TBOOL, seq);
+  TSequence *res_true = tsequence_from_base_tstzset(bool_true, T_TBOOL, s);
+  int count;
+  TimestampTz *times = tsequence_timestamps(seq, &count);
+  Datum *datumarr = palloc(sizeof(Datum) * count);
+  for (int i = 0; i < count; i++)
+    datumarr[i] = TimestampTzGetDatum(times[i]);
+  pfree(times);
+  Set *s_time = set_make_free(datumarr, count, T_TIMESTAMPTZ, ORDER);
+  Set *s_minus = minus_set_set(s_time, s);
+  Temporal *result;
+  if (s_minus)
+  {
+    TSequence *res_false = tsequence_from_base_tstzset(bool_false, T_TBOOL,
+      s_minus);
+    result = tsequence_merge(res_true, res_false);
+    pfree(res_true); pfree(s_minus); pfree(res_false);
+  }
+  else
+    result = (Temporal *) res_true;
+  pfree(s); pfree(s_time);
+  return result;
+}
+
+/**
+ * @brief Build the intersects/disjoint temporal Boolean of a sequence from the
+ * spanset @p ss of intersecting sub-periods (shared by the step and linear
+ * native paths)
+ */
+static Temporal *
+tinterrel_tcbufferseq_from_spanset(const TSequence *seq, const SpanSet *ss,
+  bool tinter)
+{
+  Datum bool_true = tinter ? BoolGetDatum(true) : BoolGetDatum(false);
+  Datum bool_false = tinter ? BoolGetDatum(false) : BoolGetDatum(true);
+  /* No intersecting sub-period: the relationship is false over the whole
+   * sequence (resp. true for disjoint), matching the traversed-area path */
+  if (! ss)
+    return (Temporal *) tsequence_from_base_temp(bool_false, T_TBOOL, seq);
+  TSequenceSet *res_true = tsequenceset_from_base_tstzspanset(bool_true,
+    T_TBOOL, ss, STEP);
+  SpanSet *ss_time = tsequence_time(seq);
+  SpanSet *ss_minus = minus_spanset_spanset(ss_time, ss);
+  TSequenceSet *result;
+  if (ss_minus)
+  {
+    TSequenceSet *res_false = tsequenceset_from_base_tstzspanset(bool_false,
+      T_TBOOL, ss_minus, STEP);
+    result = tsequenceset_merge(res_true, res_false);
+    pfree(res_true); pfree(ss_minus); pfree(res_false);
+  }
+  else
+    result = res_true;
+  pfree(ss_time);
+  return (Temporal *) result;
+}
+
+/**
+ * @brief Native version of #tinterrel_tcbufferseq_step_geom
+ */
+static Temporal *
+tinterrel_tcbufferseq_step_geo_native(const TSequence *seq, bool tinter,
+  const void *ctx)
+{
+  SpanSet *ss = NULL;
+  bool lower_inc = seq->period.lower_inc;
+  for (int i = 0; i < seq->count; i++)
+  {
+    const TInstant *inst = TSEQUENCE_INST_N(seq, i);
+    const TInstant *next = (i < seq->count - 1) ?
+      TSEQUENCE_INST_N(seq, i + 1) : inst;
+    bool upper_inc = (i == seq->count - 1) ? false : seq->period.upper_inc;
+    if (! tcbuffer_disc_within_ctx(DatumGetCbufferP(tinstant_value_p(inst)),
+        0.0, ctx))
+      continue;
+    /* The step value is constant over [inst, next), so the span is exactly
+     * [inst->t, next->t); mint/maxt equal the segment endpoints, hence the
+     * endpoint inclusivity is the sequence's own lower_inc/upper_inc. For the
+     * last instant (next == inst) the span degenerates to a point. */
+    TimestampTz mint = inst->t, maxt = next->t;
+    if (mint == maxt && (! lower_inc || ! upper_inc))
+      continue;
+    bool lower_inc1, upper_inc1;
+    if (mint == maxt)
+      lower_inc1 = upper_inc1 = true;
+    else
+    {
+      lower_inc1 = lower_inc;
+      upper_inc1 = upper_inc;
+    }
+    Span *sp = span_make(TimestampTzGetDatum(mint), TimestampTzGetDatum(maxt),
+      lower_inc1, upper_inc1, T_TIMESTAMPTZ);
+    if (! ss)
+      ss = span_to_spanset(sp);
+    else
+    {
+      SpanSet *ss1 = union_spanset_span(ss, sp);
+      pfree(ss);
+      ss = ss1;
+    }
+    pfree(sp);
+  }
+  Temporal *result = tinterrel_tcbufferseq_from_spanset(seq, ss, tinter);
+  if (ss)
+    pfree(ss);
+  return result;
+}
+
+/**
+ * @brief Native version of #tinterrel_tcbufferseq_linear_geom
+ */
+static Temporal *
+tinterrel_tcbufferseq_linear_geo_native(const TSequence *seq, bool tinter,
+  const void *ctx)
+{
+  int maxo = tcbuffer_geo_ctx_nsegs(ctx) + 2;
+  double *rlo = palloc(sizeof(double) * maxo);
+  double *rhi = palloc(sizeof(double) * maxo);
+  SpanSet *ss = NULL;
+  bool lower_inc = seq->period.lower_inc;
+  const TInstant *inst1 = TSEQUENCE_INST_N(seq, 0);
+  for (int i = 1; i < seq->count; i++)
+  {
+    const TInstant *inst2 = TSEQUENCE_INST_N(seq, i);
+    bool upper_inc = seq->period.upper_inc;
+    double dur = (double) (inst2->t - inst1->t);
+    int nr = tcbufferseg_within_ctx(DatumGetCbufferP(tinstant_value_p(inst1)),
+      DatumGetCbufferP(tinstant_value_p(inst2)), 0.0, ctx, rlo, rhi, maxo);
+    for (int j = 0; j < nr; j++)
+    {
+      TimestampTz mint = inst1->t + (TimestampTz) llround(rlo[j] * dur);
+      TimestampTz maxt = inst1->t + (TimestampTz) llround(rhi[j] * dur);
+      if (mint < inst1->t) mint = inst1->t;
+      if (maxt > inst2->t) maxt = inst2->t;
+      bool lower_inc1 = (mint == inst1->t) ? lower_inc : true;
+      bool upper_inc1 = (maxt == inst2->t) ? upper_inc : true;
+      if (mint == maxt && ! (lower_inc1 && upper_inc1))
+        continue;
+      Span *sp = span_make(TimestampTzGetDatum(mint),
+        TimestampTzGetDatum(maxt), lower_inc1, upper_inc1, T_TIMESTAMPTZ);
+      if (! ss)
+        ss = span_to_spanset(sp);
+      else
+      {
+        SpanSet *ss1 = union_spanset_span(ss, sp);
+        pfree(ss);
+        ss = ss1;
+      }
+      pfree(sp);
+    }
+    inst1 = inst2;
+  }
+  pfree(rlo); pfree(rhi);
+  Temporal *result = tinterrel_tcbufferseq_from_spanset(seq, ss, tinter);
+  if (ss)
+    pfree(ss);
+  return result;
+}
+
+/**
+ * @brief Native dispatch over a temporal circular buffer sequence
+ */
+static Temporal *
+tinterrel_tcbufferseq_geo_native(const TSequence *seq, bool tinter,
+  const void *ctx)
+{
+  if (seq->count == 1)
+    return tinterrel_tcbufferinst_geo_native(TSEQUENCE_INST_N(seq, 0), tinter,
+      ctx);
+  if (MEOS_FLAGS_GET_INTERP(seq->flags) == DISCRETE)
+    return tinterrel_tcbufferseq_disc_geo_native(seq, tinter, ctx);
+  if (MEOS_FLAGS_GET_INTERP(seq->flags) == STEP)
+    return tinterrel_tcbufferseq_step_geo_native(seq, tinter, ctx);
+  return tinterrel_tcbufferseq_linear_geo_native(seq, tinter, ctx);
+}
+
+/**
+ * @brief Native dispatch over a temporal circular buffer sequence set
+ */
+static Temporal *
+tinterrel_tcbufferseqset_geo_native(const TSequenceSet *ss, bool tinter,
+  const void *ctx)
+{
+  if (ss->count == 1)
+    return tinterrel_tcbufferseq_geo_native(TSEQUENCESET_SEQ_N(ss, 0), tinter,
+      ctx);
+  Temporal **res_seq = palloc(sizeof(Temporal *) * ss->count);
+  int count = 0;
+  for (int i = 0; i < ss->count; i++)
+  {
+    Temporal *res = tinterrel_tcbufferseq_geo_native(TSEQUENCESET_SEQ_N(ss, i),
+      tinter, ctx);
+    if (res)
+      res_seq[count++] = res;
+  }
+  Datum datum_false = tinter ? BoolGetDatum(false) : BoolGetDatum(true);
+  if (! count)
+  {
+    pfree(res_seq);
+    return (Temporal *) tsequenceset_from_base_temp(datum_false, T_TBOOL, ss);
+  }
+  Temporal *result;
+  if (count == 1)
+  {
+    result = res_seq[0];
+    pfree(res_seq);
+    return result;
+  }
+  result = temporal_merge_array(res_seq, count);
+  pfree_array((void *) res_seq, count);
+  return result;
+}
+
 /**
  * @brief Return a temporal Boolean that states whether a temporal circular
  * buffer and a geometry intersect or are disjoint
@@ -586,8 +844,30 @@ tinterrel_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs,
       /* Computing disjoint */
       temporal_from_base_temp(BoolGetDatum(true), T_TBOOL, temp);
 
+  /* Native GEOS-free path for non-curved geometry; the traversed-area path
+   * remains the fallback for curved input */
+  void *ctx = tcbuffer_geo_ctx_make(gs);
   Temporal *result = NULL;
   assert(temptype_subtype(temp->subtype));
+  if (ctx)
+  {
+    switch (temp->subtype)
+    {
+      case TINSTANT:
+        result = tinterrel_tcbufferinst_geo_native((TInstant *) temp, tinter,
+          ctx);
+        break;
+      case TSEQUENCE:
+        result = tinterrel_tcbufferseq_geo_native((TSequence *) temp, tinter,
+          ctx);
+        break;
+      default: /* TSEQUENCESET */
+        result = tinterrel_tcbufferseqset_geo_native((TSequenceSet *) temp,
+          tinter, ctx);
+    }
+    tcbuffer_geo_ctx_free(ctx);
+    return result;
+  }
   switch (temp->subtype)
   {
     case TINSTANT:

--- a/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels.test.out
@@ -126,13 +126,13 @@ SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-
 SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
                                                                                          tdisjoint                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[f@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987053 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tDisjoint(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
                                                                                                                           tdisjoint                                                                                                                          
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[f@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [t@Tue Jan 04 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987053 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [t@Tue Jan 04 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tDisjoint(geometry 'Point empty', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
@@ -174,13 +174,13 @@ SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 
 SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)');
                                                                                          tdisjoint                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[f@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987053 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)');
                                                                                                                           tdisjoint                                                                                                                          
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[f@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987052 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [t@Tue Jan 04 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 08:29:07.012947 2000 PST], (t@Sat Jan 01 08:29:07.012947 2000 PST, f@Sun Jan 02 15:30:52.987053 2000 PST, f@Mon Jan 03 00:00:00 2000 PST], [t@Tue Jan 04 00:00:00 2000 PST, t@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tDisjoint(tcbuffer '[Cbuffer(Point(0 1),0.5)@2000-01-01, Cbuffer(Point(2 1),0.5)@2000-01-04]', geometry 'Linestring(1 0,1 1,2 1,2 0)');
@@ -297,13 +297,13 @@ SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '{Cbuffer(Point(1 1),0.5)@200
 SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
                                                                                         tintersects                                                                                        
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987053 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tIntersects(geometry 'Point(1 1)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
                                                                                                                          tintersects                                                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987053 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tIntersects(geometry 'Point empty', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
@@ -345,13 +345,13 @@ SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point(1 1)');
                                                                                         tintersects                                                                                        
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987053 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point(1 1)');
                                                                                                                          tintersects                                                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987052 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:29:07.012947 2000 PST], (f@Sat Jan 01 08:29:07.012947 2000 PST, t@Sun Jan 02 15:30:52.987053 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(0 1),0.5)@2000-01-01, Cbuffer(Point(2 1),0.5)@2000-01-04]', geometry 'Linestring(1 0,1 1,2 1,2 0)');
@@ -403,9 +403,9 @@ SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(
 (1 row)
 
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(4 1),0.5)@2000-01-02]', geometry 'Linestring(1 2,1 0,2 0,2 2)');
-                            tintersects                             
---------------------------------------------------------------------
- {[t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST]}
+                                                             tintersects                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 12:00:00 2000 PST], (f@Sat Jan 01 12:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer 'Cbuffer(Point(2 2),0.5)@2000-01-02');

--- a/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels_tbl.test.out
@@ -85,13 +85,13 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tDisjoint(t1.temp, t
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDisjoint(g, temp) ?= true <> eDisjoint(g, temp);
  count 
 -------
-   139
+   128
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDisjoint(temp, g) ?= true <> eDisjoint(temp, g);
  count 
 -------
-   139
+   128
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
@@ -116,19 +116,19 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) IS NO
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) ?= true <> eDisjoint(temp, g);
  count 
 -------
- 10321
+ 10304
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tIntersects(g, temp) ?= true <> eIntersects(g, temp);
  count 
 -------
-    57
+    40
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) ?= true <> eIntersects(temp, g);
  count 
 -------
-    57
+    40
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
@@ -190,14 +190,14 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer
   WHERE tDwithin(g, temp, 10) ?= true <> edwithin(g, temp, 10);
  count 
 -------
-    18
+    10
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry
   WHERE tDwithin(temp, g, 10) ?= true <> edwithin(temp, g, 10);
  count 
 -------
-    18
+    10
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2


### PR DESCRIPTION
Computes the temporal spatial relationships between a temporal circular buffer and a geometry (`tIntersects` / `tDisjoint` / `tDwithin(tcbuffer, geo)`) natively in the distance domain. Per moving-disc segment, the within/intersection sub-intervals come from the closed-form `dist(center(t), edge) − r(t)` roots and are unioned into a spanset, mirroring the native ever/always predicates (#1279) and the native nad (#1280). No swept footprint is built, so the result is arc-exact for the disc's curved footprint (the GEOS traversed-area path strokes that footprint and is only approximate).

Native-first with a GEOS fallback: a non-curved-input geometry decomposes into segments and is evaluated natively; a curved-input geometry (circularstring / compoundcurve / curvepolygon) falls back to the GEOS traversed-area path (native curved-input handling is a separate future slice).

Correctness (frozen `tbl_tcbuffer` × `tbl_geometry`):
- Straight-operand same-engine invariants are exact: `tIntersects ⟺ eIntersects` and `tDwithin ⟺ edwithin` have 0 mismatches; `tDisjoint ⟺ ¬tIntersects` has 0 mismatches.
- Native `nearestApproachDistance` equals `ST_Distance(traversedArea)` to 0.000000 over 10000 straight-operand rows.
- The residual `tDisjoint`-vs-`eDisjoint` differences are the native-exact temporal value against the still-GEOS-stroked ever predicate (native is correct); curved-operand differences are the GEOS fallback.

Expected-output changes: the `_tbl` consistency counts hold the true native values, and one `tIntersects` case is arc-exact where the GEOS path over-approximates a whole interval as intersecting while the disc is disjoint after the crossing instant.