### PR TITLE
Own raster-file ingest through GDAL under the RASTER option

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -57,6 +57,7 @@ jobs:
             cppcheck \
             libgeos-dev \
             libproj-dev \
+            libgdal-dev \
             libjson-c-dev \
             libgsl-dev \
             libh3-dev \

--- a/.github/workflows/pgversion.yml
+++ b/.github/workflows/pgversion.yml
@@ -76,6 +76,7 @@ jobs:
           sudo apt-get install -y \
             libgeos++-dev \
             libproj-dev \
+            libgdal-dev \
             libjson-c-dev \
             libgsl-dev \
             postgresql-${{ matrix.psql }} \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,11 +442,9 @@ endif()
 # Configure PostGIS with optional dependencies
 #----------------------------------------------
 
-find_package(GDAL QUIET)
-if(GDAL_FOUND)
-  message(STATUS "GDAL version '${GDAL_VERSION}' found")
-else()
-  message(STATUS "GDAL not found")
+if(RASTER)
+  find_package(GDAL REQUIRED)
+  message(STATUS "GDAL version '${GDAL_VERSION}' found (required by RASTER)")
 endif()
 
 find_package(LibXml2)

--- a/meos/CMakeLists.txt
+++ b/meos/CMakeLists.txt
@@ -239,6 +239,12 @@ target_link_libraries(${MEOS_LIB_NAME} ${GSL_CBLAS_LIBRARY})
 if(H3)
   target_link_libraries(${MEOS_LIB_NAME} ${H3_LIBRARY})
 endif()
+if(RASTER)
+  # The raster OBJECT library decodes raster files through GDAL; its link
+  # requirements do not propagate through $<TARGET_OBJECTS:raster>, so GDAL is
+  # linked into the MEOS library here (mirroring the H3 and pointcloud blocks).
+  target_link_libraries(${MEOS_LIB_NAME} ${GDAL_LIBRARY})
+endif()
 
 # Link the application to pgtypes and postgis
 target_link_libraries(${MEOS_LIB_NAME} pgtypes)

--- a/meos/include/meos_raster.h
+++ b/meos/include/meos_raster.h
@@ -82,6 +82,7 @@ extern char *raquet_as_hexwkb(const Raquet *rq, uint8_t variant, size_t *size_ou
 extern Raquet *raquet_make(uint64 quadbin, uint16_t width, uint16_t height,
   MeosPixType pixtype, double nodata, bool has_nodata, const uint8_t *pixels);
 extern Raquet *raquet_copy(const Raquet *rq);
+extern Raquet *raquet_read(const char *path, uint64 quadbin);
 
 /* Accessor functions for Raquet tiles */
 

--- a/meos/src/raster/CMakeLists.txt
+++ b/meos/src/raster/CMakeLists.txt
@@ -1,3 +1,4 @@
-add_library(raster OBJECT raster_quadbin.c raquet.c)
+add_library(raster OBJECT raster_quadbin.c raquet.c raquet_gdal.c)
 target_include_directories(raster PRIVATE
-  "${CMAKE_SOURCE_DIR}/meos/include/raster")
+  "${CMAKE_SOURCE_DIR}/meos/include/raster"
+  ${GDAL_INCLUDE_DIR})

--- a/meos/src/raster/raquet_gdal.c
+++ b/meos/src/raster/raquet_gdal.c
@@ -1,0 +1,155 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief GDAL-backed ingest of a raster file into a Raquet raster chip.
+ *
+ * This is the one place in the RASTER family that depends on GDAL: MEOS owns
+ * the raster-format decode (as it owns geometry decode via PostGIS/GEOS),
+ * rather than delegating it to an external tool. GDAL opens any of its
+ * supported raster formats, and the first band is packed row-major into the
+ * ::T_RAQUET value identified by the supplied CARTO QUADBIN cell. The rest of
+ * the family (serialization in `raquet.c`, sampling in `raster_quadbin.c`)
+ * stays GDAL-free.
+ *
+ * The caller supplies the @p quadbin that identifies the Web-Mercator tile the
+ * raster represents, so the decode reads pixels, type and nodata from the band
+ * without interpreting the dataset geotransform or SRS.
+ */
+
+#include "raster/raquet.h"
+
+/* C */
+#include <stdint.h>
+/* GDAL */
+#include <gdal.h>
+#include <cpl_error.h>
+/* PostgreSQL */
+#include <postgres.h>
+/* MEOS */
+#include <meos.h>
+#include <meos_internal.h>
+#include "temporal/temporal.h"
+
+/**
+ * @brief Map a GDAL data type to the corresponding Raquet pixel type
+ * @return true on success; on failure sets a MEOS error and returns false
+ */
+static bool
+gdal_to_pixtype(GDALDataType dt, MeosPixType *pixtype)
+{
+  switch (dt)
+  {
+    case GDT_Byte:    *pixtype = MEOS_PT_UINT8;   return true;
+    case GDT_Int16:   *pixtype = MEOS_PT_INT16;   return true;
+    case GDT_Int32:   *pixtype = MEOS_PT_INT32;   return true;
+    case GDT_Float32: *pixtype = MEOS_PT_FLOAT32; return true;
+    case GDT_Float64: *pixtype = MEOS_PT_FLOAT64; return true;
+    default:
+      meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+        "Unsupported GDAL raster data type for raquet ingest: %s",
+        GDALGetDataTypeName(dt));
+      return false;
+  }
+}
+
+/**
+ * @ingroup meos_raster_base_constructor
+ * @brief Return a Raquet tile read from a raster file via GDAL
+ * @details GDAL decodes the file (any format it supports) and the first raster
+ * band is packed row-major into a Raquet chip identified by @p quadbin. The
+ * band data type must be one of Byte / Int16 / Int32 / Float32 / Float64; the
+ * band nodata value (if any) is carried into the tile.
+ * @param[in] path Path to a GDAL-readable raster file
+ * @param[in] quadbin CARTO QUADBIN cell identifying the Web-Mercator tile
+ */
+Raquet *
+raquet_read(const char *path, uint64 quadbin)
+{
+  VALIDATE_NOT_NULL(path, NULL);
+
+  GDALAllRegister();
+  GDALDatasetH ds = GDALOpen(path, GA_ReadOnly);
+  if (! ds)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Cannot open raster file for raquet ingest: %s", path);
+    return NULL;
+  }
+
+  Raquet *result = NULL;
+  uint8_t *buf = NULL;
+  int xsize = GDALGetRasterXSize(ds);
+  int ysize = GDALGetRasterYSize(ds);
+  if (GDALGetRasterCount(ds) < 1)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Raster file has no bands: %s", path);
+    goto cleanup;
+  }
+  if (xsize <= 0 || ysize <= 0 || xsize > UINT16_MAX || ysize > UINT16_MAX)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Raster dimensions %dx%d out of range for a raquet tile (1..%u)",
+      xsize, ysize, (unsigned) UINT16_MAX);
+    goto cleanup;
+  }
+
+  GDALRasterBandH band = GDALGetRasterBand(ds, 1);
+  GDALDataType dt = GDALGetRasterDataType(band);
+  MeosPixType pixtype;
+  if (! gdal_to_pixtype(dt, &pixtype))
+    goto cleanup;
+
+  int has_nodata = 0;
+  double nodata = GDALGetRasterNoDataValue(band, &has_nodata);
+
+  size_t pixsize = raquet_pixtype_size(pixtype);
+  size_t nbytes = (size_t) xsize * ysize * pixsize;
+  buf = palloc(nbytes);
+  if (GDALRasterIO(band, GF_Read, 0, 0, xsize, ysize, buf, xsize, ysize,
+      dt, 0, 0) != CE_None)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "GDAL failed to read raster band for raquet ingest: %s", path);
+    goto cleanup;
+  }
+
+  result = raquet_make(quadbin, (uint16) xsize, (uint16) ysize, pixtype,
+    nodata, (bool) has_nodata, buf);
+
+cleanup:
+  if (buf)
+    pfree(buf);
+  GDALClose(ds);
+  return result;
+}
+
+/*****************************************************************************/

--- a/mobilitydb/CMakeLists.txt
+++ b/mobilitydb/CMakeLists.txt
@@ -261,6 +261,11 @@ target_link_libraries(${MOBILITYDB_LIB_NAME} ${PROJ_LIBRARIES})
 if(H3)
   target_link_libraries(${MOBILITYDB_LIB_NAME} ${H3_LIBRARY})
 endif()
+if(RASTER)
+  # The raster objects decode raster files through GDAL; link it here since the
+  # requirement does not propagate through $<TARGET_OBJECTS:pg_raster>.
+  target_link_libraries(${MOBILITYDB_LIB_NAME} ${GDAL_LIBRARY})
+endif()
 target_link_libraries(${MOBILITYDB_LIB_NAME} ${GSL_LIBRARY})
 target_link_libraries(${MOBILITYDB_LIB_NAME} ${GSL_CBLAS_LIBRARY})
 if(POINTCLOUD)


### PR DESCRIPTION
## Summary

Makes GDAL a required dependency of the raster family: whenever `RASTER` is enabled, MEOS owns the raster-file decode through GDAL, mirroring how the geometry types depend on PostGIS/GEOS and `POINTCLOUD` depends on pgPointCloud. The dependency rule is uniform and explicit: `RASTER ⇒ GDAL, owned by MEOS`.

## Changes

- Adds **`raquet_read(path, quadbin)`** (`meos/src/raster/raquet_gdal.c`): reads the first band of any GDAL-supported raster file into a `raquet` chip identified by the given QUADBIN cell. Maps the GDAL band type to the raquet pixel type (Byte/Int16/Int32/Float32/Float64), carries the band nodata value, and packs the pixels row-major. This is the single GDAL-dependent point in the family; serialization (`raquet.c`) and sampling (`raster_quadbin.c`) are GDAL-free math.
- Requires and links GDAL under `if(RASTER)`: `find_package(GDAL REQUIRED)` plus a GDAL link into both the MEOS library and the PostgreSQL extension, alongside the existing H3/pointcloud family-dependency blocks.
- Installs `libgdal-dev` in the two workflows that build with `RASTER` enabled (`cppcheck`, `pgversion`) so `find_package(GDAL)` resolves.

## Testing

- MEOS `RASTER=ON` builds and links GDAL (`libgdal.so` in `DT_NEEDED`); `raquet_read` is exported.
- PostgreSQL extension builds clean with `RASTER=ON`.
- Functional check against a GDAL-produced 3×4 Float64 GeoTIFF: `raquet_read` returns the correct width/height/quadbin/nodata, and its pixels compare equal (`raquet_eq`) to an independently constructed raquet, confirming row-major pixel fidelity end to end.
- cppcheck clean on the new file.
