### PR TITLE
Build the vendored pgPointCloud libpc.a during the CMake build

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -80,17 +80,6 @@ jobs:
           echo "H3_INCLUDE_DIR=$(dirname "$H3_INC")" >> $GITHUB_ENV
           echo "H3_LIBRARY=$H3_LIB" >> $GITHUB_ENV
 
-      - name: Build pgPointCloud from source (for libpc.a)
-        # The POINTCLOUD build links the vendored pgPointCloud static library
-        # (pointcloud-pg/lib/libpc.a, produced as a side-effect of its own
-        # autotools build); build it here so cmake can find it.
-        run: |
-          cd pointcloud-pg
-          ./autogen.sh
-          ./configure --with-pgconfig=/usr/lib/postgresql/17/bin/pg_config
-          make -j "$(nproc)"
-          ls -la lib/libpc.a
-
       - name: Configure (generate compile_commands.json)
         run: |
           mkdir build

--- a/.github/workflows/meos-arrow.yml
+++ b/.github/workflows/meos-arrow.yml
@@ -189,19 +189,6 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install pyarrow duckdb
 
-      # MEOS's POINTCLOUD=ON build links pgPointCloud's static libpc.a,
-      # produced as a side-effect of the upstream autotools build. The
-      # source is vendored at pointcloud-pg/; run its autotools build to
-      # harvest libpc.a.
-      - name: Build pgPointCloud from source (for libpc.a)
-        run: |
-          cd pointcloud-pg
-          ./autogen.sh
-          ./configure \
-            --with-pgconfig=/usr/lib/postgresql/17/bin/pg_config
-          make -j $(nproc)
-          ls -la lib/libpc.a
-
       # Build MEOS over the FULL temporal base type surface the per-type
       # Arrow conformance covers: scalars + geo points are always on;
       # -DCBUFFER -DPOSE -DRGEO -DNPOINT add the decomposed extended
@@ -218,7 +205,8 @@ jobs:
             -DCBUFFER=on -DPOSE=on -DRGEO=on -DNPOINT=on \
             -DH3=on -DH3_INCLUDE_DIR="$H3_INCLUDE_DIR" \
             -DH3_LIBRARY="$H3_LIBRARY" \
-            -DPOINTCLOUD=on -DQUADBIN=on -DARROW=on ..
+            -DPOINTCLOUD=on -DQUADBIN=on -DARROW=on \
+            -DPOSTGRESQL_PG_CONFIG=/usr/lib/postgresql/17/bin/pg_config ..
           make -j $(nproc)
           sudo make install
 

--- a/.github/workflows/pgversion.yml
+++ b/.github/workflows/pgversion.yml
@@ -116,24 +116,14 @@ jobs:
           echo "H3_INCLUDE_DIR=$(dirname "$H3_INC")" >> $GITHUB_ENV
           echo "H3_LIBRARY=$H3_LIB" >> $GITHUB_ENV
 
-      - name: Build pgPointCloud from source (for libpc.a)
+      - name: Install pgPointCloud build dependencies
         if: matrix.coverage == '1'
+        # meos/src/pointcloud/CMakeLists.txt builds the vendored pgPointCloud
+        # static libpc.a as a by-product of the CMake build; it needs the
+        # autotools plus libxml2/zlib development files.
         run: |
-          # MobilityDB's POINTCLOUD=ON build links against pgPointCloud's
-          # static lib (pointcloud-pg/lib/libpc.a, produced as a side-
-          # effect of the pgPointCloud build) but does not redistribute
-          # the .so. So build the vendored pgPointCloud here just to
-          # harvest the libpc.a that meos/src/pointcloud/CMakeLists.txt
-          # links against.
           sudo apt-get -y install autoconf automake libtool \
             libxml2-dev zlib1g-dev
-          cd pointcloud-pg
-          ./autogen.sh
-          ./configure \
-            --with-pgconfig=/usr/lib/postgresql/${{ matrix.psql }}/bin/pg_config
-          make -j$(nproc)
-          # Sanity: libpc.a must land where MobilityDB's CMake will look.
-          ls -la lib/libpc.a
 
       - name: Configure for gcc
         run: |

--- a/meos/src/pointcloud/CMakeLists.txt
+++ b/meos/src/pointcloud/CMakeLists.txt
@@ -107,20 +107,39 @@ if(POINTCLOUD)
   # pgpointcloud does not ship a standalone shared library —
   # `pointcloud-1.2.so` is the PostgreSQL extension, not a linkable
   # libpointcloud.so. Instead we link against the static `libpc.a`
-  # built as a by-product of the upstream autotools build. The user
-  # must have run `./configure && make` inside `pointcloud-pg/` at
-  # least once for this file to exist.
+  # built as a by-product of the upstream autotools build.
   set(POINTCLOUD_LIBPC
     ${CMAKE_SOURCE_DIR}/pointcloud-pg/lib/libpc.a)
   set(POINTCLOUD_LIBLAZPERF
     ${CMAKE_SOURCE_DIR}/pointcloud-pg/lib/liblazperf.a)
+
+  # Build libpc.a from the vendored subtree as a by-product of the CMake build
+  # instead of requiring a manual `./autogen.sh && ./configure && make` first,
+  # so POINTCLOUD=ON works on a clean checkout and CI needs no dedicated step —
+  # the same way H3 (libh3) and GDAL resolve automatically. The autotools build
+  # needs autoconf/automake/libtool and libxml2/zlib development files.
   if(NOT EXISTS ${POINTCLOUD_LIBPC})
-    message(FATAL_ERROR
-      "POINTCLOUD=ON but ${POINTCLOUD_LIBPC} not found. "
-      "Run `cd pointcloud-pg && ./autogen.sh && ./configure "
-      "--with-pgconfig=\$(pg_config-path) [--with-lazperf=DIR] && "
-      "make` first — libpc.a is built as a side-effect and is "
-      "needed at MobilityDB link time.")
+    set(_pc_pgconfig ${POSTGRESQL_PG_CONFIG})
+    if(NOT _pc_pgconfig)
+      find_program(_pc_pgconfig NAMES pg_config)
+    endif()
+    if(NOT _pc_pgconfig)
+      # Not resolvable at configure time (e.g. a configure-only analysis build
+      # with no PG on PATH); fall back to the PATH lookup done when the build
+      # actually runs the command. Pass -DPOSTGRESQL_PG_CONFIG for an explicit
+      # path when pg_config is not on PATH at build time.
+      set(_pc_pgconfig pg_config)
+    endif()
+    add_custom_command(
+      OUTPUT ${POINTCLOUD_LIBPC}
+      COMMAND ./autogen.sh
+      COMMAND ./configure --with-pgconfig=${_pc_pgconfig}
+      COMMAND make
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/pointcloud-pg
+      COMMENT "Building vendored pgPointCloud static libpc.a (${_pc_pgconfig})"
+      VERBATIM)
+    add_custom_target(pointcloud_libpc DEPENDS ${POINTCLOUD_LIBPC})
+    add_dependencies(pointcloud pointcloud_libpc)
   endif()
 
   # When the pgPointCloud subtree was configured --with-lazperf=DIR,


### PR DESCRIPTION
## Summary

`POINTCLOUD=ON` links pgPointCloud's static `libpc.a`. pgPointCloud ships no linkable library (only its PostgreSQL extension `.so`), so MobilityDB builds `libpc.a` from the vendored `pointcloud-pg/` subtree. This builds it as a by-product of the CMake build, so `POINTCLOUD=ON` (and `-DALL=ON`) works on a clean checkout — the same way `H3` (libh3) and `GDAL` resolve automatically.

## Changes

- **`meos/src/pointcloud/CMakeLists.txt`**: a custom command builds `libpc.a` when it is absent by running `./autogen.sh && ./configure --with-pgconfig=<pg_config> && make` in `pointcloud-pg/`, and the `pointcloud` object library depends on it. The build reuses the `pg_config` CMake resolves (`POSTGRESQL_PG_CONFIG`), falling back to a `PATH` lookup; pass `-DPOSTGRESQL_PG_CONFIG` for an explicit path.
- **Workflows** (`cppcheck.yml`, `pgversion.yml`, `meos-arrow.yml`): the CMake build produces `libpc.a`, so the workflows carry no separate pgPointCloud build step. `pgversion` installs the autotools plus libxml2/zlib build dependencies; `meos-arrow` passes an explicit `-DPOSTGRESQL_PG_CONFIG` because its build step has no PostgreSQL on `PATH`.

## Testing

- Clean checkout with no `pointcloud-pg/lib/libpc.a`: `cmake -DPOINTCLOUD=ON` and build auto-run the pgPointCloud autotools build (`Building vendored pgPointCloud static libpc.a`) and link the extension (`Built target MobilityDB-1.4`).
- Strict build over all optional families (`-Werror`, both MEOS and extension targets) is green.