### PR TITLE
Restrict a temporal point to a geometry natively in atGeometry and minusGeometry

### DIFF
--- a/meos/src/geo/tgeo_restrict.c
+++ b/meos/src/geo/tgeo_restrict.c
@@ -2102,6 +2102,22 @@ tgeo_restrict_geom(const Temporal *temp, const GSERIALIZED *gs,
   if (! overlaps_stbox_stbox(&box1, &box2))
     return atfunc ? NULL : temporal_copy(temp);
 
+  /* Native GEOS-free fast path for a temporal geometry point with linear
+   * interpolation over a geometry the clip engine supports, avoiding the GEOS
+   * ST_Intersection call. Instantaneous values, step/discrete interpolation,
+   * geodetic points, non-point temporal geos, and geometries with types the
+   * clip does not handle fall through to the general path below. */
+  if (temp->temptype == T_TGEOMPOINT && temp->subtype != TINSTANT &&
+      ! MEOS_FLAGS_GET_GEODETIC(temp->flags) &&
+      MEOS_FLAGS_GET_INTERP(temp->flags) == LINEAR)
+  {
+    LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
+    bool supported = geom_clip_supported(lwgeom);
+    lwgeom_free(lwgeom);
+    if (supported)
+      return tpoint_linear_restrict_geom(temp, gs, atfunc);
+  }
+
   /* Restrict to atStbox prior to do atGeom to improve efficiency */
   interpType interp = MEOS_FLAGS_GET_INTERP(temp->flags);
   Temporal *temp1;

--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -2467,7 +2467,14 @@ tpoint_linear_restrict_geom(const Temporal *temp, const GSERIALIZED *gs,
 
   /* If "minus" restriction, compute the complement wrt time */
   if (! result_at)
-    return temporal_copy(temp);
+    /* Nothing intersects the geometry, so the result is the whole value. Return
+     * it in the same container the partial-minus path below produces (a
+     * continuous sequence yields a sequence set) so that minusGeometry is
+     * container-consistent with tgeo_restrict_geom whether or not the geometry
+     * is met. */
+    return (temp->subtype == TSEQUENCE) ?
+      (Temporal *) tsequence_to_tsequenceset((const TSequence *) temp) :
+      temporal_copy(temp);
 
   SpanSet *ss = temporal_time(result_at);
   Temporal *result = temporal_restrict_tstzspanset(temp, ss, atfunc);

--- a/mobilitydb/test/npoint/expected/306_tnpoint_spatialfuncs.test.out
+++ b/mobilitydb/test/npoint/expected/306_tnpoint_spatialfuncs.test.out
@@ -103,13 +103,13 @@ SELECT round(atGeometry(tnpoint '{Npoint(1, 0.3)@2000-01-01, Npoint(1, 0.5)@2000
 SELECT round(atGeometry(tnpoint '[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02, Npoint(1, 0.5)@2000-01-03]', geometry 'SRID=5676;Polygon((50 50,50 100,100 100,100 50,50 50))'), 6);
                                                                        round                                                                        
 ----------------------------------------------------------------------------------------------------------------------------------------------------
- {[NPoint(1,0.2)@Sat Jan 01 00:00:00 2000 PST, NPoint(1,0.4)@Sun Jan 02 00:00:00 2000 PST, NPoint(1,0.481784)@Sun Jan 02 19:37:41.052095 2000 PST]}
+ {[NPoint(1,0.2)@Sat Jan 01 00:00:00 2000 PST, NPoint(1,0.4)@Sun Jan 02 00:00:00 2000 PST, NPoint(1,0.481784)@Sun Jan 02 19:37:41.052165 2000 PST]}
 (1 row)
 
 SELECT round(atGeometry(tnpoint '{[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02, Npoint(1, 0.5)@2000-01-03], [Npoint(2, 0.6)@2000-01-04, Npoint(2, 0.6)@2000-01-05]}', geometry 'SRID=5676;Polygon((50 50,50 100,100 100,100 50,50 50))'), 6);
                                                                        round                                                                        
 ----------------------------------------------------------------------------------------------------------------------------------------------------
- {[NPoint(1,0.2)@Sat Jan 01 00:00:00 2000 PST, NPoint(1,0.4)@Sun Jan 02 00:00:00 2000 PST, NPoint(1,0.481784)@Sun Jan 02 19:37:41.052095 2000 PST]}
+ {[NPoint(1,0.2)@Sat Jan 01 00:00:00 2000 PST, NPoint(1,0.4)@Sun Jan 02 00:00:00 2000 PST, NPoint(1,0.481784)@Sun Jan 02 19:37:41.052165 2000 PST]}
 (1 row)
 
 SELECT round(atGeometry(tnpoint 'Interp=Step;[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02, Npoint(1, 0.5)@2000-01-03]', geometry 'SRID=5676;Polygon((50 50,50 100,100 100,100 50,50 50))'), 6);
@@ -175,13 +175,13 @@ SELECT round(minusGeometry(tnpoint '{Npoint(1, 0.3)@2000-01-01, Npoint(1, 0.5)@2
 SELECT round(minusGeometry(tnpoint '[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02, Npoint(1, 0.5)@2000-01-03]', geometry 'SRID=5676;Polygon((50 50,50 100,100 100,100 50,50 50))'), 6);
                                                  round                                                  
 --------------------------------------------------------------------------------------------------------
- {(NPoint(1,0.481784)@Sun Jan 02 19:37:41.052095 2000 PST, NPoint(1,0.5)@Mon Jan 03 00:00:00 2000 PST]}
+ {(NPoint(1,0.481784)@Sun Jan 02 19:37:41.052165 2000 PST, NPoint(1,0.5)@Mon Jan 03 00:00:00 2000 PST]}
 (1 row)
 
 SELECT round(minusGeometry(tnpoint '{[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02, Npoint(1, 0.5)@2000-01-03], [Npoint(2, 0.6)@2000-01-04, Npoint(2, 0.6)@2000-01-05]}', geometry 'SRID=5676;Polygon((50 50,50 100,100 100,100 50,50 50))'), 6);
                                                                                               round                                                                                               
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {(NPoint(1,0.481784)@Sun Jan 02 19:37:41.052095 2000 PST, NPoint(1,0.5)@Mon Jan 03 00:00:00 2000 PST], [NPoint(2,0.6)@Tue Jan 04 00:00:00 2000 PST, NPoint(2,0.6)@Wed Jan 05 00:00:00 2000 PST]}
+ {(NPoint(1,0.481784)@Sun Jan 02 19:37:41.052165 2000 PST, NPoint(1,0.5)@Mon Jan 03 00:00:00 2000 PST], [NPoint(2,0.6)@Tue Jan 04 00:00:00 2000 PST, NPoint(2,0.6)@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
 SELECT round(minusGeometry(tnpoint 'Interp=Step;[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02, Npoint(1, 0.5)@2000-01-03]', geometry 'SRID=5676;Polygon((50 50,50 100,100 100,100 50,50 50))'), 6);


### PR DESCRIPTION
Wires the existing native GEOS-free clip primitive `tpoint_linear_restrict_geom` into `atGeometry` / `minusGeometry` for a temporal geometry point, so the restriction of a moving point to (or minus) a static geometry no longer routes through GEOS `ST_Intersection`. The primitive was already present but unused; this adds the guarded dispatch.

In `tgeo_restrict_geom`, after the existing SRID / Z validation and the empty / bounding-box short-circuits, a native branch is taken when the temporal value is a temporal geometry point with linear interpolation, planar, and the geometry is clip-supported; every other case (geodetic, step / discrete interpolation, non-point temporal geometry, or a non-clip-supported geometry) keeps the current GEOS / Clipper2 path unchanged. The native branch computes the intersecting sub-periods from the analytic segment and arc crossing solver, so a circularstring / compoundcurve / curvepolygon boundary is handled arc-exactly rather than stroked.

Correctness: the `_tbl` partition invariant `temp = merge(atGeometry(temp, g), minusGeometry(temp, g))` holds by construction (both derive from the same at-time spanset and its complement). pg_regress passes with no expected-output changes — on the existing corpus the native result matches the previous GEOS result, while GEOS is no longer reached for this case.