### PR TITLE
Detect geodetic segment crossings in ever intersects and dwithin over a geo

### DIFF
--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -1582,16 +1582,17 @@ ea_dwithin_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist,
       ! ensure_not_negative_datum(Float8GetDatum(dist), T_FLOAT8))
     return -1;
 
-  /* For geodetic coordinates the planar `spatialrel_tgeo_geo`
-   * trajectory and the planar `geom_buffer` + `covers` machinery below
-   * are not applicable. Use the lifted temporal-base helper
-   * `eafunc_temporal_base` with the geodetic-aware `geo_dwithin_fn_geo`
-   * selector (which returns `datum_geog_dwithin` for geodetic input);
-   * this mirrors `ea_dwithin_tgeo_tgeo` for the temporal-base case and
-   * stays inside extension-safe lifting machinery (no `*_meos.c`
-   * dependency). Same architectural pattern as `tdistance_tgeo_geo`
-   * for the geo argument. */
-  if (MEOS_FLAGS_GET_GEODETIC(temp->flags))
+  /* For geodetic coordinates the planar `geom_buffer` + `covers` machinery
+   * (the ALWAYS branch below) is not applicable. The EVER case is exactly
+   * "the trajectory ever comes within `dist` of the geo", i.e. the minimum
+   * geodesic distance between the trajectory and the geo is <= dist, which the
+   * trajectory-based `spatialrel_tgeo_geo` EVER path below computes: its
+   * `geo_dwithin_fn_geo` selector returns `datum_geog_dwithin` for geodetic
+   * input, and `datum_geog_dwithin` measures the true geodesic distance to the
+   * trajectory linestring, so a segment that enters the geo with both endpoints
+   * outside is detected. The ALWAYS case uses the lifted temporal-base helper
+   * `eafunc_temporal_base`, which for geodetic samples instants. */
+  if (MEOS_FLAGS_GET_GEODETIC(temp->flags) && ! ever)
   {
     LiftedFunctionInfo lfinfo;
     memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));

--- a/mobilitydb/test/geo/expected/070_tpoint_spatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/070_tpoint_spatialrels_tbl.test.out
@@ -97,13 +97,13 @@ SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2 WHERE aDisjoint(t1
 SELECT COUNT(*) FROM tbl_geog t1, tbl_tgeogpoint t2 WHERE t1.k % 3 = 0 AND aDisjoint(g, temp);
  count 
 -------
-  2584
+  2000
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_geog t2 WHERE t2.k % 3 = 0 AND aDisjoint(temp, g);
  count 
 -------
-  2584
+  2000
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_tgeogpoint t2 WHERE aDisjoint(t1.temp, t2.temp);
@@ -115,13 +115,13 @@ SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_tgeogpoint t2 WHERE aDisjoint(t1.tem
 SELECT COUNT(*) FROM tbl_geog3D t1, tbl_tgeogpoint3D t2 WHERE t1.k % 3 = 0 AND t2.k % 3 = 0 AND aDisjoint(g, temp);
  count 
 -------
-   930
+   751
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_geog3D t2 WHERE t1.k % 3 = 0 AND t2.k % 3 = 0 AND aDisjoint(temp, g);
  count 
 -------
-   930
+   751
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2 WHERE aDisjoint(t1.temp, t2.temp);
@@ -175,13 +175,13 @@ SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_tgeogpoint t2 WHERE eIntersects(t1.t
 SELECT COUNT(*) FROM tbl_geog3D t1, tbl_tgeogpoint3D t2 WHERE t1.k % 3 = 0 AND t2.k % 3 = 0 AND eIntersects(g, temp);
  count 
 -------
-    93
+   272
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_geog3D t2 WHERE t1.k % 3 = 0 AND t2.k % 3 = 0 AND eIntersects(temp, g);
  count 
 -------
-    93
+   272
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2 WHERE eIntersects(t1.temp, t2.temp);
@@ -319,13 +319,13 @@ SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2 WHERE eDwithin(t1.
 SELECT COUNT(*) FROM tbl_geog_point, tbl_tgeogpoint WHERE eDwithin(g, temp, 10);
  count 
 -------
-     1
+     2
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeogpoint, tbl_geog_point WHERE eDwithin(temp, g, 10);
  count 
 -------
-     1
+     2
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_tgeogpoint t2 WHERE eDwithin(t1.temp, t2.temp, 10);


### PR DESCRIPTION
## Problem

For geodetic coordinates, `eintersects_tgeo_geo` / `edwithin_tgeo_geo` return FALSE for a trajectory that crosses (or passes within `dist` of) a geography when both endpoints lie outside it. A geodesic segment bows between its endpoints, so a path whose two endpoints are outside a polygon can still enter it in the interior.

Minimal reproduction (geodetic):

```
polygon = geom_to_geog(POLYGON((0 0, 2 0, 2 2, 0 2, 0 0)))
traj    = tgeogpoint '[POINT(-1 1)@t0, POINT(3 1)@t1]'   -- crosses the square, both ends outside

eintersects_geo_tgeo(polygon, traj)   →  0   (should be 1 — the geodesic enters the square)
```

## Cause

For geodetic input, `ea_dwithin_tgeo_geo` routed the *ever* case through `eafunc_temporal_base` with `tpfn_base = NULL`, i.e. it sampled only the instants and never evaluated the segment interior. Both endpoints being outside → all sampled instants outside → FALSE.

## Fix

Route the geodetic *ever* case through the existing trajectory-based `spatialrel_tgeo_geo` path. Its `geo_dwithin_fn_geo` selector already returns `datum_geog_dwithin` for geodetic input, and `datum_geog_dwithin` measures the true geodesic distance to the trajectory linestring — so a segment that enters the geo with both endpoints outside is detected. The *always* case keeps the instant-sampling helper (the continuous turning point for geodetic ALWAYS is a separate matter). This also corrects `adisjoint_tgeo_geo`, which is defined via the *ever* dwithin. No GEOS involvement.

One conditional (`&& ! ever`) gates the geodetic instant-sampling block to the ALWAYS case; the bounding-box prefilter and the native fast path below are already guarded for geodetic input, so geodetic *ever* falls straight through to the trajectory path.

## Validation

Built libmeos from this branch (all families) and ran the reproduction plus a regression probe against the freshly installed lib:

- crossing, endpoints outside → **1** (was 0); both endpoints inside → 1; single instant inside → 1
- planar `tgeompoint` intersects crossing → 1 (unchanged)
- geodetic far-outside intersects → 0; `edisjoint` crossing → 1; `edisjoint` far-outside → 1
- geodetic `edwithin` with `dist > 0`: for a trajectory whose mid-segment closest approach is ≈333 km, `edwithin(300 km)=0` and `edwithin(400 km)=1` — the continuous closest approach that instant sampling missed is now found.

Surfaced by the MobilityDuck `tgeogpoint` regression test (`test/sql/tgeogpoint.test:72`), which stays red until this lands.
