### PR TITLE
Generate pc_config.h before compiling its consumers under POINTCLOUD

### DIFF
--- a/mobilitydb/src/geo/CMakeLists.txt
+++ b/mobilitydb/src/geo/CMakeLists.txt
@@ -25,4 +25,9 @@ add_library(pg_geo OBJECT
 if(POINTCLOUD)
   target_include_directories(pg_geo PRIVATE
     ${CMAKE_SOURCE_DIR}/pointcloud-pg/lib)
+  # tgeo.c includes pc_api.h, which includes the generated pc_config.h. That
+  # header is produced when the pointcloud module builds the vendored subtree
+  # (autotools). Depend on the pointcloud target so pc_config.h exists before
+  # tgeo.c compiles, instead of racing it under a parallel build.
+  add_dependencies(pg_geo pointcloud)
 endif()

--- a/mobilitydb/src/pointcloud/CMakeLists.txt
+++ b/mobilitydb/src/pointcloud/CMakeLists.txt
@@ -49,4 +49,8 @@ if(POINTCLOUD_PG_SRCS)
     ${CMAKE_SOURCE_DIR}/meos/include
     ${CMAKE_SOURCE_DIR}/mobilitydb/include
     ${CMAKE_SOURCE_DIR}/pointcloud-pg/lib)
+  # These wrappers include pc_api.h, which includes the generated pc_config.h.
+  # Depend on the pointcloud target so that header exists before they compile,
+  # instead of racing its autotools generation under a parallel build.
+  add_dependencies(pg_pointcloud pointcloud)
 endif()


### PR DESCRIPTION
When `POINTCLOUD` is enabled, `tgeo.c` and the pointcloud PG wrappers include `pc_api.h`, which includes the generated `pc_config.h`. That header is produced when the pointcloud module builds the vendored pgpointcloud subtree via autotools, but the `pg_geo` and `pg_pointcloud` targets have no dependency on it. Under a parallel build they can therefore compile before `pc_config.h` exists and fail with `fatal error: pc_config.h: No such file or directory` while compiling `tgeo.c`.

Each target now depends on the `pointcloud` target, mirroring the existing `pointcloud` → `pointcloud_libpc` ordering, so `pc_config.h` is generated before its consumers compile.