### PR TITLE
Compute the tcbuffer temporal predicates natively for circular arc input

### DIFF
--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -1651,7 +1651,7 @@ tcbuffer_geo_ctx_make(const GSERIALIZED *gs)
   TcbSeg *segs = NULL;
   int cap = 0, n = 0;
   bool has_poly = false;
-  bool ok = tcbuffer_geo_segs(lw, false, &segs, &cap, &n, &has_poly);
+  bool ok = tcbuffer_geo_segs(lw, true, &segs, &cap, &n, &has_poly);
   lwgeom_free(lw);
   if (! ok || n == 0)
   {
@@ -1818,6 +1818,43 @@ tcbuffer_seg_edge_within_roots(double cx1, double cy1, double cx2, double cy2,
 }
 
 /**
+ * @brief Append the within-distance crossing times of one moving disc segment
+ * against one circular-arc edge, the temporal analogue of the on-span circle /
+ * off-span endpoint split of #tcbuffer_seg_arc_mindist
+ * @details On the arc's angular span the distance to the disc is
+ * | sqrt(Q(t)) - R | - r(t); setting it equal to @p dist gives
+ * sqrt(Q) = R + r(t) + dist (disc outside the circle) or
+ * sqrt(Q) = R - r(t) - dist (disc inside), each a region-crossing quadratic with
+ * the arc radius folded into R0. Off the span the nearest arc point is an
+ * endpoint, so the two endpoint region crossings are added as well. The result
+ * is a superset of the true crossings; each candidate sub-interval is then
+ * classified exactly by the arc-aware unit distance (#tcbuffer_unit_nad), so
+ * roots from the squared equation or the wrong angular regime are harmless.
+ */
+static void
+tcbuffer_seg_arc_within_roots(double cx1, double cy1, double cx2, double cy2,
+  double r1, double r2, const TcbSeg *e, double dist, double *cand, int *nc)
+{
+  const double dcx = cx2 - cx1, dcy = cy2 - cy1, dr = r2 - r1;
+  const double px = e->acx, py = e->acy, R = e->arad;
+  const double A = dcx * dcx + dcy * dcy;
+  const double B = 2.0 * ((cx1 - px) * dcx + (cy1 - py) * dcy);
+  const double C = (cx1 - px) * (cx1 - px) + (cy1 - py) * (cy1 - py);
+  /* On-span circle crossings: sqrt(Q) = R + r(t) + dist and R - r(t) - dist */
+  tcbuffer_region_within_roots(A, B, C, R + r1 + dist, dr, 0.0, 1.0, cand, nc);
+  tcbuffer_region_within_roots(A, B, C, R - r1 - dist, -dr, 0.0, 1.0, cand, nc);
+  /* Off-span regions are nearest to an arc endpoint: their region crossings */
+  for (int ep = 0; ep < 2; ep++)
+  {
+    double ex = ep == 0 ? e->x1 : e->x2;
+    double ey = ep == 0 ? e->y1 : e->y2;
+    double Be = 2.0 * ((cx1 - ex) * dcx + (cy1 - ey) * dcy);
+    double Ce = (cx1 - ex) * (cx1 - ex) + (cy1 - ey) * (cy1 - ey);
+    tcbuffer_region_within_roots(A, Be, Ce, r1 + dist, dr, 0.0, 1.0, cand, nc);
+  }
+}
+
+/**
  * @brief Comparator for sorting the candidate crossing times
  */
 static int
@@ -1842,14 +1879,21 @@ tcbufferseg_within_ctx(const Cbuffer *cb1, const Cbuffer *cb2, double dist,
   const POINT2D *p2 = GSERIALIZED_POINT2D_P(cbuffer_point_p(cb2));
   double cx1 = p1->x, cy1 = p1->y, r1 = cb1->radius;
   double cx2 = p2->x, cy2 = p2->y, r2 = cb2->radius;
-  int ncap = 2 + 4 * ctx->g.n;
+  int ncap = 2 + 8 * ctx->g.n;
   double *cand = palloc(sizeof(double) * ncap);
   int nc = 0;
   cand[nc++] = 0.0;
   cand[nc++] = 1.0;
   for (int k = 0; k < ctx->g.n; k++)
-    tcbuffer_seg_edge_within_roots(cx1, cy1, cx2, cy2, r1, r2, &ctx->g.segs[k],
-      dist, cand, &nc);
+  {
+    const TcbSeg *ed = &ctx->g.segs[k];
+    if (ed->is_arc)
+      tcbuffer_seg_arc_within_roots(cx1, cy1, cx2, cy2, r1, r2, ed, dist, cand,
+        &nc);
+    else
+      tcbuffer_seg_edge_within_roots(cx1, cy1, cx2, cy2, r1, r2, ed, dist, cand,
+        &nc);
+  }
   qsort(cand, nc, sizeof(double), tcbuffer_double_cmp);
   int m = 0;
   for (int i = 0; i < nc; i++)

--- a/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels.test.out
@@ -408,6 +408,24 @@ SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(
  {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 12:00:00 2000 PST], (f@Sat Jan 01 12:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
 (1 row)
 
+SELECT tIntersects(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Point(8 6),2.5)@2000-01-01, Cbuffer(Point(4 3),2.5)@2000-01-03]');
+                                            tintersects                                             
+----------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(4 3),2.5)@2000-01-01, Cbuffer(Point(8 6),2.5)@2000-01-03]', geometry 'CircularString(5 0, 4 3, 0 5)');
+                                                             tintersects                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST], (f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tIntersects(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Point(5 -3),0.5)@2000-01-01, Cbuffer(Point(5 -1),0.5)@2000-01-03]');
+                           tintersects                            
+------------------------------------------------------------------
+ [f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
 SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer 'Cbuffer(Point(2 2),0.5)@2000-01-02');
  tintersects 
 -------------
@@ -900,6 +918,24 @@ SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Linestr
             tdwithin            
 --------------------------------
  t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tDwithin(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Point(8 6),0.5)@2000-01-01, Cbuffer(Point(4 3),0.5)@2000-01-03]', 2);
+                                              tdwithin                                              
+----------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tDwithin(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Point(10 0),0.5)@2000-01-01, Cbuffer(Point(10 0),4.5)@2000-01-03]', 2.5);
+                                              tdwithin                                              
+----------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tDwithin(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Point(5 -3),0.5)@2000-01-01, Cbuffer(Point(5 -1),0.5)@2000-01-03]', 0.3);
+                             tdwithin                             
+------------------------------------------------------------------
+ [f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]
 (1 row)
 
 /* Errors */

--- a/mobilitydb/test/cbuffer/queries/214_tcbuffer_tempspatialrels.test.sql
+++ b/mobilitydb/test/cbuffer/queries/214_tcbuffer_tempspatialrels.test.sql
@@ -137,6 +137,12 @@ SELECT tIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]', geometry 'Linestring(1 1,2 2)');
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(4 1),0.5)@2000-01-02]', geometry 'Linestring(1 2,1 0,2 0,2 2)');
 
+-- Circular arc input (native arc-exact); arc centre (0,0) radius 5, upper-right quadrant
+SELECT tIntersects(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Point(8 6),2.5)@2000-01-01, Cbuffer(Point(4 3),2.5)@2000-01-03]');
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(4 3),2.5)@2000-01-01, Cbuffer(Point(8 6),2.5)@2000-01-03]', geometry 'CircularString(5 0, 4 3, 0 5)');
+-- Off-span: the disc meets the full circle but not the arc (angular gating)
+SELECT tIntersects(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Point(5 -3),0.5)@2000-01-01, Cbuffer(Point(5 -1),0.5)@2000-01-03]');
+
 -- Coverage
 SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer 'Cbuffer(Point(2 2),0.5)@2000-01-02');
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(2 1),0.5)@2000-01-01, Cbuffer(Point(1 2),0.5)@2000-01-02]');
@@ -264,6 +270,13 @@ SELECT tDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 
 
 SELECT tDwithin(geometry 'Linestring(1 1,2 2)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Linestring(1 1,2 2)', 2);
+
+-- Circular arc input (native arc-exact); arc centre (0,0) radius 5, upper-right quadrant
+SELECT tDwithin(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Point(8 6),0.5)@2000-01-01, Cbuffer(Point(4 3),0.5)@2000-01-03]', 2);
+-- Moving radius (dr != 0): the growing disc reaches within-distance of the arc
+SELECT tDwithin(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Point(10 0),0.5)@2000-01-01, Cbuffer(Point(10 0),4.5)@2000-01-03]', 2.5);
+-- Off-span: within the full circle but not the arc (angular gating)
+SELECT tDwithin(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Point(5 -3),0.5)@2000-01-01, Cbuffer(Point(5 -1),0.5)@2000-01-03]', 0.3);
 
 /* Errors */
 SELECT tDwithin(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);


### PR DESCRIPTION
## Summary

The temporal `tcbuffer`–geometry predicates `tIntersects` / `tDwithin` / `tDisjoint` are computed natively for **circular-arc** (`CIRCULARSTRING`) input, without a GEOS fallback.

The native within-interval kernel behind these predicates handled only straight-edge geometry; a curved geometry fell back to GEOS, which linearises the circular string into straight chords — an approximation. The kernel now evaluates the arc directly, matching the exact treatment the scalar `nearestApproachDistance` already gives curved input.

## Approach

- The geometry context decomposes a `CIRCULARSTRING` into exact arcs (centre, radius, angular span, orientation), degrading collinear triples to line segments.
- Each moving-disc segment contributes the arc within-distance crossing times: the on-span circle crossings (`sqrt(Q(t)) = R ± (r(t) + dist)`, folding the arc radius into the region-crossing quadratic) and the off-span arc-endpoint crossings. Each candidate sub-interval is classified by the existing arc-aware unit distance, so the crossing set only needs to be a superset.
- Straight-edge input, the ever predicates, and the `nad` path are unchanged.

## Correctness

New per-value cases in `214_tcbuffer_tempspatialrels` evaluate the predicates against the arc `CircularString(5 0, 4 3, 0 5)` (centre origin, radius 5) with exact-crossing trajectories:

- on-span `tIntersects` flips at an exact instant;
- **off-span** `tIntersects` is `false` even though the disc lies inside the full circle — the nearest arc point is an endpoint outside the angular span. A chord linearisation reports this as `true`, so it is the discriminating case.
- `tDwithin` on-span, moving-radius, and off-span cases all cross at exact instants.

All added crossings land on whole instants (drift-safe). The straight-input corpus (`210`, `212`, and the `_tbl` variants) is unchanged.