### PR TITLE
Compute the tcbuffer shortest line natively for circular arc input

### DIFF
--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -687,7 +687,7 @@ tcbuffer_arc_set_bbox(TcbSeg *e)
  */
 static void
 tcbuffer_segs_add_arc(double ax, double ay, double bx, double by, double cx,
-  double cy, TcbSeg **arr, int *cap, int *cnt)
+  double cy, bool is_poly, TcbSeg **arr, int *cap, int *cnt)
 {
   if (*cnt + 2 > *cap)
   {
@@ -711,7 +711,7 @@ tcbuffer_segs_add_arc(double ax, double ay, double bx, double by, double cx,
       s->x1 = p1x; s->y1 = p1y; s->x2 = p2x; s->y2 = p2y;
       s->xmin = fmin(p1x, p2x); s->xmax = fmax(p1x, p2x);
       s->ymin = fmin(p1y, p2y); s->ymax = fmax(p1y, p2y);
-      s->is_poly = false; s->is_arc = false;
+      s->is_poly = is_poly; s->is_arc = false;
     }
     return;
   }
@@ -724,7 +724,7 @@ tcbuffer_segs_add_arc(double ax, double ay, double bx, double by, double cx,
   s->at0 = atan2(ay - s->acy, ax - s->acx);
   s->at1 = atan2(cy - s->acy, cx - s->acx);
   s->accw = ((bx - ax) * (cy - ay) - (by - ay) * (cx - ax)) > 0.0;
-  s->is_poly = false; s->is_arc = true;
+  s->is_poly = is_poly; s->is_arc = true;
   tcbuffer_arc_set_bbox(s);
 }
 
@@ -733,8 +733,8 @@ tcbuffer_segs_add_arc(double ax, double ay, double bx, double by, double cx,
  * groups) to the segment array
  */
 static void
-tcbuffer_segs_add_circstring(const LWCIRCSTRING *circ, TcbSeg **arr, int *cap,
-  int *cnt)
+tcbuffer_segs_add_circstring(const LWCIRCSTRING *circ, bool is_poly,
+  TcbSeg **arr, int *cap, int *cnt)
 {
   const POINTARRAY *pa = circ->points;
   int np = (int) pa->npoints;
@@ -743,7 +743,44 @@ tcbuffer_segs_add_circstring(const LWCIRCSTRING *circ, TcbSeg **arr, int *cap,
     const POINT2D *a = getPoint2d_cp(pa, i);
     const POINT2D *b = getPoint2d_cp(pa, i + 1);
     const POINT2D *c = getPoint2d_cp(pa, i + 2);
-    tcbuffer_segs_add_arc(a->x, a->y, b->x, b->y, c->x, c->y, arr, cap, cnt);
+    tcbuffer_segs_add_arc(a->x, a->y, b->x, b->y, c->x, c->y, is_poly, arr, cap,
+      cnt);
+  }
+}
+
+/**
+ * @brief Append the boundary segments of a curve polygon ring (a line string,
+ * a circular string, or a compound curve chaining both) with polygon (region)
+ * semantics. Returns false when an arc ring is present but the caller does not
+ * consume arc edges (@p allow_arc is false), so the exact path is used.
+ */
+static bool
+tcbuffer_segs_add_curvepoly_ring(const LWGEOM *ring, bool allow_arc,
+  TcbSeg **arr, int *cap, int *cnt)
+{
+  switch (ring->type)
+  {
+    case LINETYPE:
+      tcbuffer_segs_add_ptarray(lwgeom_as_lwline(ring)->points, true, arr, cap,
+        cnt);
+      return true;
+    case CIRCSTRINGTYPE:
+      if (! allow_arc)
+        return false;
+      tcbuffer_segs_add_circstring(lwgeom_as_lwcircstring(ring), true, arr, cap,
+        cnt);
+      return true;
+    case COMPOUNDTYPE:
+    {
+      const LWCOLLECTION *c = lwgeom_as_lwcollection(ring);
+      for (uint32_t i = 0; i < c->ngeoms; i++)
+        if (! tcbuffer_segs_add_curvepoly_ring(c->geoms[i], allow_arc, arr, cap,
+              cnt))
+          return false;
+      return true;
+    }
+    default:
+      return false;
   }
 }
 
@@ -767,7 +804,8 @@ tcbuffer_geo_segs(const LWGEOM *lw, bool allow_arc, TcbSeg **arr, int *cap,
        * nearest-approach distance). Otherwise fall back to the exact path. */
       if (! allow_arc)
         return false;
-      tcbuffer_segs_add_circstring(lwgeom_as_lwcircstring(lw), arr, cap, cnt);
+      tcbuffer_segs_add_circstring(lwgeom_as_lwcircstring(lw), false, arr, cap,
+        cnt);
       return true;
     case LINETYPE:
       tcbuffer_segs_add_ptarray(lwgeom_as_lwline(lw)->points, false, arr, cap,
@@ -787,16 +825,33 @@ tcbuffer_geo_segs(const LWGEOM *lw, bool allow_arc, TcbSeg **arr, int *cap,
         *has_poly = true;
       return true;
     }
+    case CURVEPOLYTYPE:
+    {
+      /* A curve polygon is bounded by rings that are line strings, circular
+       * strings, or compound curves. Decompose each ring with polygon (region)
+       * semantics so the arc-aware even-odd test in #tcbuffer_pt_in_polys
+       * treats it as a boundary. */
+      const LWCURVEPOLY *cp = lwgeom_as_lwcurvepoly(lw);
+      for (uint32_t i = 0; i < cp->nrings; i++)
+        if (! tcbuffer_segs_add_curvepoly_ring(cp->rings[i], allow_arc, arr,
+              cap, cnt))
+          return false;
+      if (cp->nrings > 0)
+        *has_poly = true;
+      return true;
+    }
     case MULTIPOINTTYPE:
     case MULTILINETYPE:
     case MULTIPOLYGONTYPE:
-    /* A compound curve chains line strings and circular strings, and a multi
-     * curve groups line/circular/compound components; both share the
-     * collection memory layout, so their components are decomposed
-     * recursively. Circular-arc components resolve through the CIRCSTRINGTYPE
-     * case above, which gates on @p allow_arc. */
+    /* A compound curve chains line strings and circular strings, a multi curve
+     * groups line/circular/compound components, and a multi surface groups
+     * curve polygons; all share the collection memory layout, so their
+     * components are decomposed recursively. Circular-arc components resolve
+     * through the CIRCSTRINGTYPE / CURVEPOLYTYPE cases, which gate on
+     * @p allow_arc. */
     case COMPOUNDTYPE:
     case MULTICURVETYPE:
+    case MULTISURFACETYPE:
     case COLLECTIONTYPE:
     {
       const LWCOLLECTION *c = lwgeom_as_lwcollection(lw);
@@ -815,23 +870,71 @@ tcbuffer_geo_segs(const LWGEOM *lw, bool allow_arc, TcbSeg **arr, int *cap,
  * @brief Ray-casting test: true if (x,y) is inside any polygon ring among
  * the segments (even-odd rule over the polygon-ring segments only)
  */
+/**
+ * @brief Apply the rightward-ray crossings of one polygon-boundary segment to
+ * the even-odd accumulator @p inside. A straight edge contributes at most one
+ * crossing; a circular arc contributes the crossings of the horizontal line
+ * y with its supporting circle that fall within the arc's angular span. Point,
+ * line, and standalone (1D) arc edges (not @p is_poly) contribute nothing.
+ */
+static void
+tcbuffer_poly_seg_raycross(const TcbSeg *s, double x, double y, bool *inside)
+{
+  if (! s->is_poly)
+    return;
+  if (s->is_arc)
+  {
+    /* The horizontal line at height y meets the supporting circle at
+     * acx +/- sqrt(arad^2 - (y - acy)^2). Flip the parity for each crossing
+     * strictly to the right of x that lies within the arc's angular span; a
+     * ray that only grazes the circle tangentially does not cross. */
+    const double dyc = y - s->acy;
+    const double h2 = s->arad * s->arad - dyc * dyc;
+    if (h2 <= 1e-12)
+      return;
+    const double h = sqrt(h2);
+    const double xhit[2] = {s->acx - h, s->acx + h};
+    /* Forward traversal direction of the arc in the angle parameter */
+    const double sdir = s->accw ? 1.0 : -1.0;
+    for (int k = 0; k < 2; k++)
+    {
+      const double xi = xhit[k];
+      if (xi <= x)
+        continue;
+      if (! tcbuffer_arc_contains_angle(s, atan2(dyc, xi - s->acx)))
+        continue;
+      /* Half-open ownership, mirroring the straight-edge rule: a crossing at an
+       * arc endpoint (a ring junction on the ray) is owned by this edge only if
+       * the arc interior rises above the ray there; an interior crossing is
+       * always transversal and always counted. */
+      const bool at_ep0 = fabs(xi - s->x1) < 1e-12 && fabs(y - s->y1) < 1e-12;
+      const bool at_ep1 = fabs(xi - s->x2) < 1e-12 && fabs(y - s->y2) < 1e-12;
+      if (at_ep0 || at_ep1)
+      {
+        const double theta_e = at_ep0 ? s->at0 : s->at1;
+        const double dtheta_in = at_ep0 ? sdir : -sdir;
+        if (dtheta_in * cos(theta_e) <= 0)
+          continue;
+      }
+      *inside = ! *inside;
+    }
+    return;
+  }
+  double y1 = s->y1, y2 = s->y2;
+  if ((y1 > y) != (y2 > y))
+  {
+    double xint = s->x1 + (y - y1) / (y2 - y1) * (s->x2 - s->x1);
+    if (x < xint)
+      *inside = ! *inside;
+  }
+}
+
 static bool
 tcbuffer_pt_in_polys(double x, double y, const TcbSeg *segs, int n)
 {
   bool inside = false;
   for (int i = 0; i < n; i++)
-  {
-    if (! segs[i].is_poly)
-      continue;
-    double y1 = segs[i].y1, y2 = segs[i].y2;
-    if ((y1 > y) != (y2 > y))
-    {
-      double xint = segs[i].x1 +
-        (y - y1) / (y2 - y1) * (segs[i].x2 - segs[i].x1);
-      if (x < xint)
-        inside = ! inside;
-    }
-  }
+    tcbuffer_poly_seg_raycross(&segs[i], x, y, &inside);
   return inside;
 }
 
@@ -1447,16 +1550,7 @@ tcbuffer_pt_in_polys_g(double x, double y, const TcbGeom *g)
     int e = bk->start + bk->n;
     for (int i = bk->start; i < e; i++)
     {
-      const TcbSeg *s = &g->segs[i];
-      if (! s->is_poly)
-        continue;
-      double y1 = s->y1, y2 = s->y2;
-      if ((y1 > y) != (y2 > y))
-      {
-        double xint = s->x1 + (y - y1) / (y2 - y1) * (s->x2 - s->x1);
-        if (x < xint)
-          inside = ! inside;
-      }
+      tcbuffer_poly_seg_raycross(&g->segs[i], x, y, &inside);
     }
   }
   return inside;

--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -1242,6 +1242,93 @@ tcbuffer_seg_edge_dt(double cx1, double cy1, double cx2, double cy2, double r1,
 }
 
 /**
+ * @brief Like #tcbuffer_seg_arc_mindist but also returns the argument t that
+ * attains the minimum (mirrors #tcbuffer_seg_edge_dt for arc edges)
+ */
+static double
+tcbuffer_seg_arc_dt(double cx1, double cy1, double cx2, double cy2, double r1,
+  double r2, const TcbSeg *e, double *out_t)
+{
+  const double dcx = cx2 - cx1, dcy = cy2 - cy1;
+  const double dr = r2 - r1;
+  const double px = e->acx, py = e->acy, R = e->arad;
+  const double A = dcx * dcx + dcy * dcy;
+  const double B = 2.0 * ((cx1 - px) * dcx + (cy1 - py) * dcy);
+  const double C = (cx1 - px) * (cx1 - px) + (cy1 - py) * (cy1 - py);
+
+  double cand[8];
+  int nc = 0;
+  cand[nc++] = 0.0;
+  cand[nc++] = 1.0;
+  /* Circle crossings Q(t) = R^2 */
+  {
+    double c0 = C - R * R;
+    if (fabs(A) > 1e-18)
+    {
+      double disc = B * B - 4.0 * A * c0;
+      if (disc >= 0.0)
+      {
+        double sd = sqrt(disc);
+        cand[nc++] = (-B + sd) / (2.0 * A);
+        cand[nc++] = (-B - sd) / (2.0 * A);
+      }
+    }
+    else if (fabs(B) > 1e-18)
+      cand[nc++] = -c0 / B;
+  }
+  /* Vertex of Q (closest approach to the centre) */
+  if (fabs(A) > 1e-18)
+    cand[nc++] = -B / (2.0 * A);
+  /* Stationary points of | sqrt(Q) - R | - r(t): (Q')^2 = 4 dr^2 Q */
+  {
+    double a2 = A * (A - dr * dr);
+    double a1 = B * (A - dr * dr);
+    double a0 = 0.25 * B * B - C * dr * dr;
+    if (fabs(a2) > 1e-18)
+    {
+      double disc = a1 * a1 - 4.0 * a2 * a0;
+      if (disc >= 0.0)
+      {
+        double sd = sqrt(disc);
+        cand[nc++] = (-a1 + sd) / (2.0 * a2);
+        cand[nc++] = (-a1 - sd) / (2.0 * a2);
+      }
+    }
+    else if (fabs(a1) > 1e-18)
+      cand[nc++] = -a0 / a1;
+  }
+
+  double best = DBL_MAX, bt = 0.0;
+  /* On-span candidates: exact distance to the arc's circle, angle-gated */
+  for (int i = 0; i < nc; i++)
+  {
+    double t = cand[i];
+    if (t < 0.0) t = 0.0;
+    if (t > 1.0) t = 1.0;
+    double q = A * t * t + B * t + C;
+    if (q < 0.0) q = 0.0;
+    double cpx = cx1 + dcx * t, cpy = cy1 + dcy * t;
+    if (! tcbuffer_arc_contains_angle(e, atan2(cpy - py, cpx - px)))
+      continue;
+    double f = fabs(sqrt(q) - R) - (r1 + dr * t);
+    if (f < best) { best = f; bt = t; }
+  }
+  /* Off-span regions are nearest to an arc endpoint */
+  for (int ep = 0; ep < 2; ep++)
+  {
+    double ex = ep == 0 ? e->x1 : e->x2;
+    double ey = ep == 0 ? e->y1 : e->y2;
+    double Be = 2.0 * ((cx1 - ex) * dcx + (cy1 - ey) * dcy);
+    double Ce = (cx1 - ex) * (cx1 - ex) + (cy1 - ey) * (cy1 - ey);
+    double rt;
+    double m = tcbuffer_minfun_w(A, Be, Ce, r1, dr, 0.0, 1.0, &rt);
+    if (m < best) { best = m; bt = rt; }
+  }
+  *out_t = bt;
+  return best;
+}
+
+/**
  * @brief Witness of the nearest approach: the point @p (px,py) on the
  * swept-capsule boundary and @p (qx,qy) on the geometry
  */
@@ -1267,6 +1354,29 @@ tcbuffer_closest_on_edge(double px, double py, const TcbSeg *e, double *qx,
   if (s > 1.0) s = 1.0;
   *qx = e->x1 + s * ux;
   *qy = e->y1 + s * uy;
+}
+
+/**
+ * @brief Closest point on arc edge @p e to (px,py): the projection onto the
+ * supporting circle when its angle lies in the arc span, otherwise the nearer
+ * arc endpoint
+ */
+static void
+tcbuffer_closest_on_arc(double px, double py, const TcbSeg *e, double *qx,
+  double *qy)
+{
+  double vx = px - e->acx, vy = py - e->acy;
+  double vl = hypot(vx, vy);
+  if (vl > 1e-12 && tcbuffer_arc_contains_angle(e, atan2(vy, vx)))
+  {
+    *qx = e->acx + vx * (e->arad / vl);
+    *qy = e->acy + vy * (e->arad / vl);
+    return;
+  }
+  double d1 = (px - e->x1) * (px - e->x1) + (py - e->y1) * (py - e->y1);
+  double d2 = (px - e->x2) * (px - e->x2) + (py - e->y2) * (py - e->y2);
+  if (d1 <= d2) { *qx = e->x1; *qy = e->y1; }
+  else { *qx = e->x2; *qy = e->y2; }
 }
 
 /**
@@ -1309,14 +1419,19 @@ tcbuffer_sl_unit(double cx1, double cy1, double r1, double cx2, double cy2,
         continue;
     }
     double t;
-    double m = tcbuffer_seg_edge_dt(cx1, cy1, cx2, cy2, r1, r2, e, &t);
+    double m = e->is_arc ?
+      tcbuffer_seg_arc_dt(cx1, cy1, cx2, cy2, r1, r2, e, &t) :
+      tcbuffer_seg_edge_dt(cx1, cy1, cx2, cy2, r1, r2, e, &t);
     if (! w->set || m < w->d)
     {
       double ccx = cx1 + (cx2 - cx1) * t;
       double ccy = cy1 + (cy2 - cy1) * t;
       double rr = r1 + (r2 - r1) * t;
       double qx, qy;
-      tcbuffer_closest_on_edge(ccx, ccy, e, &qx, &qy);
+      if (e->is_arc)
+        tcbuffer_closest_on_arc(ccx, ccy, e, &qx, &qy);
+      else
+        tcbuffer_closest_on_edge(ccx, ccy, e, &qx, &qy);
       double vx = qx - ccx, vy = qy - ccy;
       double vl = sqrt(vx * vx + vy * vy);
       double pxp, pyp;
@@ -1372,9 +1487,9 @@ tcbuffer_sl_seq(const TSequence *seq, const TcbSeg *segs, int n, bool has_poly,
 
 /**
  * @brief GEOS-free shortest line between a temporal circular buffer and a
- * geometry. Returns NULL when the analytic path does not apply (curved or
- * unsupported geometry, or a polygon-contained centre), so the caller can
- * fall back to the exact traversed-area shortest line.
+ * geometry, arc-exact for circular-arc input. Returns NULL when the analytic
+ * path does not apply (an unsupported geometry type), so the caller can fall
+ * back to the exact traversed-area shortest line.
  */
 static GSERIALIZED *
 tcbuffer_geo_shortestline_analytic(const Temporal *temp,
@@ -1384,7 +1499,7 @@ tcbuffer_geo_shortestline_analytic(const Temporal *temp,
   TcbSeg *segs = NULL;
   int cap = 0, n = 0;
   bool has_poly = false;
-  bool ok = tcbuffer_geo_segs(lw, false, &segs, &cap, &n, &has_poly);
+  bool ok = tcbuffer_geo_segs(lw, true, &segs, &cap, &n, &has_poly);
   lwgeom_free(lw);
   if (! ok || n == 0)
   {

--- a/mobilitydb/test/cbuffer/expected/210_tcbuffer_distance.test.out
+++ b/mobilitydb/test/cbuffer/expected/210_tcbuffer_distance.test.out
@@ -447,6 +447,18 @@ SELECT round(tcbuffer 'Cbuffer(Point(8 6), 1)@2000-01-01' |=| geometry 'MultiCur
  0.414214
 (1 row)
 
+SELECT round(tcbuffer 'Cbuffer(Point(0 0), 1)@2000-01-01' |=| geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', 6);
+ round 
+-------
+     0
+(1 row)
+
+SELECT round(tcbuffer 'Cbuffer(Point(4 4), 0.3)@2000-01-01' |=| geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', 6);
+  round   
+----------
+ 0.356854
+(1 row)
+
 SELECT round(geometry 'Polygon((5 5,5 8,8 8,8 5,5 5))' |=| tcbuffer 'Cbuffer(Point(0 0), 1)@2000-01-01', 6);
   round   
 ----------

--- a/mobilitydb/test/cbuffer/expected/210_tcbuffer_distance.test.out
+++ b/mobilitydb/test/cbuffer/expected/210_tcbuffer_distance.test.out
@@ -579,6 +579,24 @@ SELECT round(ST_Length(shortestLine(tcbuffer 'Interp=Step;[Cbuffer(Point(0 0), 1
  3.324555
 (1 row)
 
+SELECT round(ST_Length(shortestLine(tcbuffer 'Cbuffer(Point(3 8), 1)@2000-01-01', geometry 'CircularString(5 0, 0 5, -5 0)'))::numeric, 6);
+  round   
+----------
+ 2.544004
+(1 row)
+
+SELECT round(ST_Length(shortestLine(tcbuffer 'Cbuffer(Point(0 0), 1)@2000-01-01', geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))'))::numeric, 6);
+  round   
+----------
+ 0.000000
+(1 row)
+
+SELECT round(ST_Length(shortestLine(tcbuffer 'Cbuffer(Point(4 4), 0.3)@2000-01-01', geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))'))::numeric, 6);
+  round   
+----------
+ 0.356854
+(1 row)
+
 SELECT round(ST_Length(shortestLine(tcbuffer '{[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(4 0), 1)@2000-01-02], [Cbuffer(Point(20 20), 2)@2000-01-03, Cbuffer(Point(25 20), 1)@2000-01-04]}', geometry 'Polygon((-5 -5,-5 15,15 15,15 -5,-5 -5),(0 0,4 0,4 4,0 4,0 0))'))::numeric, 6);
   round   
 ----------

--- a/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels_tbl.test.out
@@ -91,7 +91,7 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eDisjoint(g, temp);
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aDisjoint(g, temp);
  count 
 -------
- 10182
+ 10181
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eDisjoint(temp, g);
@@ -103,7 +103,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eDisjoint(temp, g);
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aDisjoint(temp, g);
  count 
 -------
- 10182
+ 10181
 (1 row)
 
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eDisjoint(cb, temp);
@@ -145,7 +145,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE aDisjoint(t1.temp, t
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eIntersects(g, temp);
  count 
 -------
-  5218
+  5219
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aIntersects(g, temp);
@@ -157,7 +157,7 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aIntersects(g, temp);
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eIntersects(temp, g);
  count 
 -------
-  5218
+  5219
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aIntersects(temp, g);

--- a/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels.test.out
@@ -438,6 +438,12 @@ SELECT tIntersects(geometry 'CompoundCurve(CircularString(5 0, 4 3, 0 5),(0 5, -
  {[f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 06:00:00 2000 PST, t@Sun Jan 02 18:00:00 2000 PST], (f@Sun Jan 02 18:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
 (1 row)
 
+SELECT tIntersects(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
+                                                             tintersects                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 09:00:00 2000 PST], (f@Sun Jan 02 09:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer 'Cbuffer(Point(2 2),0.5)@2000-01-02');
  tintersects 
 -------------

--- a/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels_tbl.test.out
@@ -122,13 +122,13 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) ?= tr
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tIntersects(g, temp) ?= true <> eIntersects(g, temp);
  count 
 -------
-     1
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) ?= true <> eIntersects(temp, g);
  count 
 -------
-     1
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2

--- a/mobilitydb/test/cbuffer/queries/210_tcbuffer_distance.test.sql
+++ b/mobilitydb/test/cbuffer/queries/210_tcbuffer_distance.test.sql
@@ -227,6 +227,11 @@ SELECT round(ST_Length(shortestLine(geometry 'Polygon((5 5,5 8,8 8,8 5,5 5))', t
 SELECT round(ST_Length(shortestLine(tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(10 0), 2)@2000-01-02, Cbuffer(Point(10 10), 1)@2000-01-03]', geometry 'Polygon((20 20,20 24,24 24,24 20,20 20))'))::numeric, 6);
 SELECT round(ST_Length(shortestLine(tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(10 0), 2)@2000-01-02, Cbuffer(Point(10 10), 1)@2000-01-03]', geometry 'Multipolygon(((200 200,200 210,210 210,210 200,200 200)),((9 -1,9 1,12 1,12 -1,9 -1)))'))::numeric, 6);
 SELECT round(ST_Length(shortestLine(tcbuffer 'Interp=Step;[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(5 5), 3)@2000-01-02]', geometry 'Polygon((11 -1,11 3,14 3,14 -1,11 -1))'))::numeric, 6);
+-- Curved input: the analytic shortest line is arc-exact, so its length equals
+-- the arc-exact nearest-approach distance (2.544004, 0, 0.356854 respectively)
+SELECT round(ST_Length(shortestLine(tcbuffer 'Cbuffer(Point(3 8), 1)@2000-01-01', geometry 'CircularString(5 0, 0 5, -5 0)'))::numeric, 6);
+SELECT round(ST_Length(shortestLine(tcbuffer 'Cbuffer(Point(0 0), 1)@2000-01-01', geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))'))::numeric, 6);
+SELECT round(ST_Length(shortestLine(tcbuffer 'Cbuffer(Point(4 4), 0.3)@2000-01-01', geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))'))::numeric, 6);
 SELECT round(ST_Length(shortestLine(tcbuffer '{[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(4 0), 1)@2000-01-02], [Cbuffer(Point(20 20), 2)@2000-01-03, Cbuffer(Point(25 20), 1)@2000-01-04]}', geometry 'Polygon((-5 -5,-5 15,15 15,15 -5,-5 -5),(0 0,4 0,4 4,0 4,0 0))'))::numeric, 6);
 SELECT round(ST_Length(shortestLine(tcbuffer '{Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(8 3), 2)@2000-01-02}', geometry 'Multipolygon(((200 200,200 210,210 210,210 200,200 200)),((9 -1,9 1,12 1,12 -1,9 -1)))'))::numeric, 6);
 

--- a/mobilitydb/test/cbuffer/queries/210_tcbuffer_distance.test.sql
+++ b/mobilitydb/test/cbuffer/queries/210_tcbuffer_distance.test.sql
@@ -189,6 +189,12 @@ SELECT round(tcbuffer '[Cbuffer(Point(0 8), 1)@2000-01-01, Cbuffer(Point(0 5), 1
 SELECT round(tcbuffer 'Cbuffer(Point(3 8), 1)@2000-01-01' |=| geometry 'CompoundCurve(CircularString(5 0, 0 5, -5 0),(-5 0, -5 -8))', 6);
 SELECT round(tcbuffer 'Cbuffer(Point(-8 -4), 1)@2000-01-01' |=| geometry 'CompoundCurve(CircularString(5 0, 0 5, -5 0),(-5 0, -5 -8))', 6);
 SELECT round(tcbuffer 'Cbuffer(Point(8 6), 1)@2000-01-01' |=| geometry 'MultiCurve((6 6, 10 10),CircularString(5 0, 0 5, -5 0))', 6);
+-- Curve polygon (arc ring, a disk of radius 5 at the origin): a centre inside
+-- the arc ring gives distance 0 (arc-aware interior ray cast), and an outside
+-- centre measures to the arc boundary exactly (non-vertex, unreachable by
+-- stroking)
+SELECT round(tcbuffer 'Cbuffer(Point(0 0), 1)@2000-01-01' |=| geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', 6);
+SELECT round(tcbuffer 'Cbuffer(Point(4 4), 0.3)@2000-01-01' |=| geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', 6);
 SELECT round(geometry 'Polygon((5 5,5 8,8 8,8 5,5 5))' |=| tcbuffer 'Cbuffer(Point(0 0), 1)@2000-01-01', 6);
 SELECT round(tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(10 0), 2)@2000-01-02, Cbuffer(Point(10 10), 1)@2000-01-03]' |=| geometry 'Polygon((20 20,20 24,24 24,24 20,20 20))', 6);
 SELECT round(tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(10 0), 2)@2000-01-02, Cbuffer(Point(10 10), 1)@2000-01-03]' |=| geometry 'Linestring(20 -5,20 20)', 6);

--- a/mobilitydb/test/cbuffer/queries/214_tcbuffer_tempspatialrels.test.sql
+++ b/mobilitydb/test/cbuffer/queries/214_tcbuffer_tempspatialrels.test.sql
@@ -146,6 +146,8 @@ SELECT tIntersects(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(
 -- result as the arc-only case, and the line component is walked too
 SELECT tIntersects(geometry 'CompoundCurve(CircularString(5 0, 4 3, 0 5),(0 5, -4 5))', tcbuffer '[Cbuffer(Point(8 6),2.5)@2000-01-01, Cbuffer(Point(4 3),2.5)@2000-01-03]');
 SELECT tIntersects(geometry 'CompoundCurve(CircularString(5 0, 4 3, 0 5),(0 5, -4 5))', tcbuffer '[Cbuffer(Point(-2 8),0.5)@2000-01-01, Cbuffer(Point(-2 4),0.5)@2000-01-03]');
+-- Curve polygon (arc ring): the disc starts inside the ring and exits it
+SELECT tIntersects(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
 
 -- Coverage
 SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer 'Cbuffer(Point(2 2),0.5)@2000-01-02');


### PR DESCRIPTION
The GEOS-free analytic shortest line between a temporal circular buffer and a
geometry decomposed only straight edges, so a circular string, compound curve,
or curve polygon operand fell back to the traversed-area shortest line, which
strokes the arc into chords and loses precision.

This decomposes the arc edges as well and computes the witness on an arc edge
exactly: the closest point is the projection onto the supporting circle when its
angle lies in the arc span, otherwise the nearer arc endpoint. The shortest line
for curved input is then arc-exact, and its length equals the arc-exact
nearest-approach distance.
