### PR TITLE
Correct Doxygen out-parameter and @csqlfn annotations

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -1120,7 +1120,7 @@ extern Span *tstzspanset_bins(const SpanSet *ss, const Interval *duration, Times
  * Input and output functions for box types
  *****************************************************************************/
 
-extern char *tbox_as_hexwkb(const TBox *box, uint8_t variant, size_t *size);
+extern char *tbox_as_hexwkb(const TBox *box, uint8_t variant, size_t *size_out);
 extern uint8_t *tbox_as_wkb(const TBox *box, uint8_t variant, size_t *size_out);
 extern TBox *tbox_from_hexwkb(const char *hexwkb);
 extern TBox *tbox_from_wkb(const uint8_t *wkb, size_t size);
@@ -1933,7 +1933,7 @@ extern Temporal *temporal_ext_kalman_filter(const Temporal *temp, double gate,
 /* Tile functions for temporal types */
 
 extern Span *temporal_time_bins(const Temporal *temp, const Interval *duration, TimestampTz origin, int *count);
-extern Temporal **temporal_time_split(const Temporal *temp, const Interval *duration, TimestampTz torigin, TimestampTz **time_bins, int *count);
+extern Temporal **temporal_time_split(const Temporal *temp, const Interval *duration, TimestampTz torigin, TimestampTz **bins, int *count);
 extern TBox *tfloat_time_boxes(const Temporal *temp, const Interval *duration, TimestampTz torigin, int *count);
 extern Span *tfloat_value_bins(const Temporal *temp, double vsize, double vorigin, int *count);
 extern TBox *tfloat_value_boxes(const Temporal *temp, double vsize, double vorigin, int *count);

--- a/meos/include/meos_cbuffer.h
+++ b/meos/include/meos_cbuffer.h
@@ -101,7 +101,7 @@ typedef struct Cbuffer Cbuffer;
 /* Input and output functions */
 
 extern char *cbuffer_as_ewkt(const Cbuffer *cb, int maxdd);
-extern char *cbuffer_as_hexwkb(const Cbuffer *cb, uint8_t variant, size_t *size);
+extern char *cbuffer_as_hexwkb(const Cbuffer *cb, uint8_t variant, size_t *size_out);
 extern char *cbuffer_as_text(const Cbuffer *cb, int maxdd);
 extern uint8_t *cbuffer_as_wkb(const Cbuffer *cb, uint8_t variant, size_t *size_out);
 extern Cbuffer *cbuffer_from_hexwkb(const char *hexwkb);

--- a/meos/include/meos_geo.h
+++ b/meos/include/meos_geo.h
@@ -500,7 +500,7 @@ extern Set *spatialset_transform_pipeline(const Set *s, const char *pipelinestr,
 
 /* Input/output functions */
 
-extern char *stbox_as_hexwkb(const STBox *box, uint8_t variant, size_t *size);
+extern char *stbox_as_hexwkb(const STBox *box, uint8_t variant, size_t *size_out);
 extern uint8_t *stbox_as_wkb(const STBox *box, uint8_t variant, size_t *size_out);
 extern STBox *stbox_from_hexwkb(const char *hexwkb);
 extern STBox *stbox_from_wkb(const uint8_t *wkb, size_t size);

--- a/meos/include/meos_internal.h
+++ b/meos/include/meos_internal.h
@@ -1144,7 +1144,7 @@ extern Datum tinstant_value_p(const TInstant *inst);
 extern Datum tinstant_value(const TInstant *inst);
 extern bool tinstant_value_at_timestamptz(const TInstant *inst, TimestampTz t, Datum *result);
 extern Datum *tinstant_values_p(const TInstant *inst, int *count);
-extern void tnumber_set_span(const Temporal *temp, Span *span);
+extern void tnumber_set_span(const Temporal *temp, Span *s);
 extern SpanSet *tnumberinst_valuespans(const TInstant *inst);
 extern double tnumberseq_avg_val(const TSequence *seq);
 extern SpanSet *tnumberseq_valuespans(const TSequence *seq);

--- a/meos/include/meos_internal_geo.h
+++ b/meos/include/meos_internal_geo.h
@@ -120,22 +120,22 @@ extern GSERIALIZED *point_round(const GSERIALIZED *gs, int maxdd);
 
 /* Constructor functions for box types */
 
-extern void stbox_set(bool hasx, bool hasz, bool geodetic, int32 srid, double xmin, double xmax, double ymin, double ymax, double zmin, double zmax, const Span *s, STBox *box);
+extern void stbox_set(bool hasx, bool hasz, bool geodetic, int32 srid, double xmin, double xmax, double ymin, double ymax, double zmin, double zmax, const Span *s, STBox *result);
 
 /*****************************************************************************/
 
 /* Conversion functions for box types */
 
 extern void gbox_set_stbox(const GBOX *box, int32_t srid, STBox *result);
-extern bool geo_set_stbox(const GSERIALIZED *gs, STBox *box);
-extern void geoarr_set_stbox(const Datum *values, int count, STBox *box);
-extern bool spatial_set_stbox(Datum d, MeosType basetype, STBox *box);
-extern void spatialset_set_stbox(const Set *set, STBox *box);
-extern void stbox_set_box3d(const STBox *box, BOX3D *box3d);
-extern void stbox_set_gbox(const STBox *box, GBOX *gbox);
-extern void tstzset_set_stbox(const Set *s, STBox *box);
-extern void tstzspan_set_stbox(const Span *s, STBox *box);
-extern void tstzspanset_set_stbox(const SpanSet *s, STBox *box);
+extern bool geo_set_stbox(const GSERIALIZED *gs, STBox *result);
+extern void geoarr_set_stbox(const Datum *values, int count, STBox *result);
+extern bool spatial_set_stbox(Datum d, MeosType basetype, STBox *result);
+extern void spatialset_set_stbox(const Set *set, STBox *result);
+extern void stbox_set_box3d(const STBox *box, BOX3D *result);
+extern void stbox_set_gbox(const STBox *box, GBOX *result);
+extern void tstzset_set_stbox(const Set *s, STBox *result);
+extern void tstzspan_set_stbox(const Span *s, STBox *result);
+extern void tstzspanset_set_stbox(const SpanSet *s, STBox *result);
 
 /*****************************************************************************/
 
@@ -205,7 +205,7 @@ extern TSequenceSet *tgeometryseqset_in(const char *str);
 
 /* Bounding box functions */
 
-extern void tspatial_set_stbox(const Temporal *temp, STBox *box);
+extern void tspatial_set_stbox(const Temporal *temp, STBox *result);
 extern void tgeoinst_set_stbox(const TInstant *inst, STBox *box);
 extern void tspatialseq_set_stbox(const TSequence *seq, STBox *box);
 extern void tspatialseqset_set_stbox(const TSequenceSet *ss, STBox *box);

--- a/meos/include/meos_pose.h
+++ b/meos/include/meos_pose.h
@@ -100,7 +100,7 @@ typedef struct Pose Pose;
 /* Input and output functions */
 
 extern char *pose_as_ewkt(const Pose *pose, int maxdd);
-extern char *pose_as_hexwkb(const Pose *pose, uint8_t variant, size_t *size);
+extern char *pose_as_hexwkb(const Pose *pose, uint8_t variant, size_t *size_out);
 extern char *pose_as_text(const Pose *pose, int maxdd);
 extern uint8_t *pose_as_wkb(const Pose *pose, uint8_t variant, size_t *size_out);
 extern Pose *pose_from_wkb(const uint8_t *wkb, size_t size);

--- a/meos/include/temporal/temporal_aggfuncs.h
+++ b/meos/include/temporal/temporal_aggfuncs.h
@@ -60,7 +60,7 @@ extern Datum datum_sum_double4(Datum l, Datum r);
 /* Specific skiplist functions for temporal aggregations */
 
 extern int temporal_skiplist_common(SkipList *list, void **values, int count,
-  int *lower, int *upper, int update[SKIPLIST_MAXLEVEL]);
+  int *lower, int *upper, int *update);
 extern void **temporal_skiplist_merge(void **spliced, int spliced_count,
   void **values, int count, datum_func2 func, bool crossings, int *newcount,
   void ***tofree, int *nfree);

--- a/meos/include/temporal/temporal_boxops.h
+++ b/meos/include/temporal/temporal_boxops.h
@@ -58,7 +58,7 @@
 extern size_t temporal_bbox_size(MeosType tempype);
 extern void tinstant_set_bbox(const TInstant *inst, void *bbox);
 extern void tinstarr_set_bbox(TInstant **instants, int count,
-  bool lower_inc, bool upper_inc, interpType interp, void *bbox);
+  bool lower_inc, bool upper_inc, interpType interp, void *box);
 extern void tsequence_compute_bbox(TSequence *seq);
 extern void tseqarr_compute_bbox(TSequence **sequences, int count, void *bbox);
 extern void tsequenceset_compute_bbox(TSequenceSet *ss);

--- a/meos/include/temporal/tsequence.h
+++ b/meos/include/temporal/tsequence.h
@@ -141,7 +141,7 @@ extern TSequenceSet *tstepseq_to_linear(const TSequence *seq);
 /* Accessor functions */
 
 extern int tsequence_segments_iter(const TSequence *seq, TSequence **result);
-extern int tsequence_timestamps_iter(const TSequence *seq, TimestampTz *result);
+extern int tsequence_timestamps_iter(const TSequence *seq, TimestampTz *times);
 
 /* Local Aggregate Functions */
 

--- a/meos/src/cbuffer/tcbuffer.c
+++ b/meos/src/cbuffer/tcbuffer.c
@@ -146,7 +146,7 @@ tcbuffersegm_distance_at_time(double dx0, double dy0, double vx, double vy,
  * @param[in] start1,end1 Circular buffers defining the first segment
  * @param[in] start2,end2 Circular buffers the second segment
  * @param[in] dist Distance
- * @param[out] lower,upper Timestamps defining the segments
+ * @param[in] lower,upper Timestamps defining the segments
  * @param[out] t1,t2 Timestamps defining the resulting period, may be equal
  * @pre The segments are not constant.
  */
@@ -406,7 +406,7 @@ tcbuffersegm_tdwithin_turnpt(Datum start1, Datum end1, Datum start2,
  * @param[in] start1,end1 Circular buffers defining the first segment
  * @param[in] start2,end2 Circular buffers the second segment
  * @param[in] dist Distance, unused parameter
- * @param[out] lower,upper Timestamps defining the segments
+ * @param[in] lower,upper Timestamps defining the segments
  * @param[out] t1,t2 Timestamps defining the resulting period, may be equal
  * @pre The segments are not constant.
  */

--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -222,7 +222,7 @@ tcbuffer_cbuffer_distance_turnpt(Datum start, Datum end, Datum value,
  * @details These are the turning points when computing the temporal distance.
  * @param[in] start1,end1 Circular buffers defining the first segment
  * @param[in] start2,end2 Circular buffers the second segment
- * @param[out] lower,upper Timestamps defining the segments
+ * @param[in] lower,upper Timestamps defining the segments
  * @param[out] t1,t2 Timestamps defining the resulting period, may be equal
  * @pre The segments are not constant.
  */

--- a/meos/src/geo/tgeo_tile.c
+++ b/meos/src/geo/tgeo_tile.c
@@ -807,8 +807,8 @@ stbox_time_tiles(const STBox *bounds, const Interval *duration,
  * @param[in] duration Size of the time dimension as an interval
  * @param[in] sorigin Origin for the space dimension, may be `NULL`
  * @param[in] torigin Origin for the time dimension, may be `NULL`
- * @param[out] hasx True when spliting by space
- * @param[out] hast True when spliting by time
+ * @param[in] hasx True when spliting by space
+ * @param[in] hast True when spliting by time
  */
 STBox *
 stbox_space_time_tile(const GSERIALIZED *point, TimestampTz t,

--- a/meos/src/geo/tpoint_spatialfuncs.c
+++ b/meos/src/geo/tpoint_spatialfuncs.c
@@ -3157,7 +3157,7 @@ bearing_point_point(const GSERIALIZED *gs1, const GSERIALIZED *gs2,
  * @brief Return the temporal bearing between a temporal point and a point
  * @param[in] temp Temporal point
  * @param[in] gs Geometry
- * @param[out] invert True when the result should be inverted
+ * @param[in] invert True when the result should be inverted
  * @return On empty geometry or on error return NULL
  * @csqlfn #Bearing_tpoint_point()
  */

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -1615,7 +1615,7 @@ temporal_compact(const Temporal *temp)
  * @brief Return a temporal sequence (set) that keepsg only the last n instants
  * or sequences
  * @param[in] temp Temporal value
- * @param[out] count Number of instants or sequences kept
+ * @param[in] count Number of instants or sequences kept
  */
 void
 temporal_restart(Temporal *temp, int count)

--- a/meos/src/temporal/temporal_aggfuncs.c
+++ b/meos/src/temporal/temporal_aggfuncs.c
@@ -279,7 +279,7 @@ temporal_skiplist_elempos(const SkipList *list, Span *s, int cur)
  */
 int
 temporal_skiplist_common(SkipList *list, void **values, int count,
-  int *lower, int *upper, int update[SKIPLIST_MAXLEVEL])
+  int *lower, int *upper, int *update)
 {
   /* Temporal aggregation cannot mix instants and sequences */
   Temporal *temp1 = (Temporal *) skiplist_headval(list);

--- a/meos/src/temporal/tsequenceset.c
+++ b/meos/src/temporal/tsequenceset.c
@@ -1401,7 +1401,7 @@ tsequenceset_compact(const TSequenceSet *ss)
  * @brief Return a temporal sequence set restared by keeping only the last n
  * sequences
  * @param[in] ss Temporal sequence set
- * @param[out] count Number of sequences kept
+ * @param[in] count Number of sequences kept
  */
 void
 tsequenceset_restart(TSequenceSet *ss, int count)
@@ -1442,7 +1442,7 @@ tsequenceset_restart(TSequenceSet *ss, int count)
  * @ingroup meos_internal_temporal_transf
  * @brief Return a temporal instant transformed into a temporal sequence set
  * @param[in] inst Temporal instant
- * @param[out] interp Interpolation
+ * @param[in] interp Interpolation
  * @csqlfn #Temporal_to_tsequenceset()
  */
 TSequenceSet *
@@ -1505,7 +1505,7 @@ tsequence_to_tsequenceset_free(TSequence *seq)
  * @ingroup meos_internal_temporal_transf
  * @brief Return a temporal sequence transformed into a temporal sequence set
  * @param[in] seq Temporal sequence
- * @param[out] interp Interpolation
+ * @param[in] interp Interpolation
  * @csqlfn #Temporal_to_tsequenceset()
  */
 TSequenceSet *

--- a/meos/src/temporal/ttext_funcs_meos.c
+++ b/meos/src/temporal/ttext_funcs_meos.c
@@ -122,7 +122,7 @@ ttext_upper(const Temporal *temp)
  * @ingroup meos_temporal_text
  * @brief Return a temporal text transformed to initcap
  * @param[in] temp Temporal value
- * @csqlfn #Ttext_lower()
+ * @csqlfn #Ttext_initcap()
  */
 Temporal *
 ttext_initcap(const Temporal *temp)

--- a/meos/src/temporal/type_parser.c
+++ b/meos/src/temporal/type_parser.c
@@ -764,8 +764,7 @@ error:
  * @param[in] interp Interpolation
  * @param[in] end Set to true when reading a single sequence to ensure there is
  * no more input after the sequence
- * @param[out] result New sequence, may be NULL
- * @return On error return false
+ * @return New sequence, may be NULL, on error return @p NULL
  */
 TSequence *
 tcontseq_parse(const char **str, MeosType temptype, interpType interp,


### PR DESCRIPTION
Two independent Doxygen-tag corrections in the MEOS C sources, each as its own commit.

**Correct Doxygen out-parameter annotations.** Reconcile the `@param[out]`
annotations with the actual C signatures:
- retag by-value inputs wrongly marked `@param[out]` as `@param[in]` (bearing
  invert flag, space/time tile `hasx`/`hast`, the restart counts, the
  to-tsequenceset interpolation, and the segment-bound `lower`/`upper`
  timestamps of the circular-buffer turning-point helpers);
- align header prototype parameter names with their implementations and Doxygen
  (`*_as_hexwkb` `size_out`, the `*_set_stbox` / `stbox_set` `result`,
  `tnumber_set_span`, `temporal_time_split`, `tinstarr_set_bbox`,
  `tsequence_timestamps_iter`);
- normalize the skiplist `update` out-parameter to the pointer form `int *update`
  used elsewhere for out-array parameters;
- document `tcontseq_parse`'s returned sequence with `@return` rather than a
  spurious `@param[out] result`.

**Fix copy-pasted @csqlfn tag on `ttext_initcap`.** Its block carried
`@csqlfn #Ttext_lower()` (copied from the `ttext_lower` wrapper), chaining
`ttext_initcap` to the `lower` SQL function; retarget it to `#Ttext_initcap()`
to match `initcap(ttext)`.

Comment/annotation and parameter-name changes only — no behavioural or ABI
change. Builds with `-DALL=ON`.