### PR TITLE
Give temporal-sequence constructors a default interpolation argument

### DIFF
--- a/mobilitydb/sql/geo/052_tgeo.in.sql
+++ b/mobilitydb/sql/geo/052_tgeo.in.sql
@@ -229,50 +229,30 @@ CREATE FUNCTION tgeometryInst(tgeometry)
   AS 'MODULE_PATHNAME', 'Temporal_to_tinstant'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- The function is not strict
-CREATE FUNCTION tgeometrySeq(tgeometry, text)
+CREATE FUNCTION tgeometrySeq(tgeometry, text DEFAULT NULL)
   RETURNS tgeometry
   AS 'MODULE_PATHNAME', 'Temporal_to_tsequence'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 -- The function is not strict
-CREATE FUNCTION tgeometrySeq(tgeometry)
-  RETURNS tgeometry
-  AS 'SELECT @extschema@.tgeometrySeq($1, NULL)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
--- The function is not strict
-CREATE FUNCTION tgeometrySeqSet(tgeometry, text)
+CREATE FUNCTION tgeometrySeqSet(tgeometry, text DEFAULT NULL)
   RETURNS tgeometry
   AS 'MODULE_PATHNAME', 'Temporal_to_tsequenceset'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
--- The function is not strict
-CREATE FUNCTION tgeometrySeqSet(tgeometry)
-  RETURNS tgeometry
-  AS 'SELECT @extschema@.tgeometrySeqSet($1, NULL)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 
 CREATE FUNCTION tgeographyInst(tgeography)
   RETURNS tgeography
   AS 'MODULE_PATHNAME', 'Temporal_to_tinstant'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- The function is not strict
-CREATE FUNCTION tgeographySeq(tgeography, text)
+CREATE FUNCTION tgeographySeq(tgeography, text DEFAULT NULL)
   RETURNS tgeography
   AS 'MODULE_PATHNAME', 'Temporal_to_tsequence'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 -- The function is not strict
-CREATE FUNCTION tgeographySeq(tgeography)
-  RETURNS tgeography
-  AS 'SELECT @extschema@.tgeographySeq($1, NULL)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
--- The function is not strict
-CREATE FUNCTION tgeographySeqSet(tgeography, text)
+CREATE FUNCTION tgeographySeqSet(tgeography, text DEFAULT NULL)
   RETURNS tgeography
   AS 'MODULE_PATHNAME', 'Temporal_to_tsequenceset'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
--- The function is not strict
-CREATE FUNCTION tgeographySeqSet(tgeography)
-  RETURNS tgeography
-  AS 'SELECT @extschema@.tgeographySeqSet($1, NULL)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 
 CREATE FUNCTION setInterp(tgeometry, text)
   RETURNS tgeometry

--- a/mobilitydb/sql/geo/052_tpoint.in.sql
+++ b/mobilitydb/sql/geo/052_tpoint.in.sql
@@ -221,50 +221,30 @@ CREATE FUNCTION tgeompointInst(tgeompoint)
   AS 'MODULE_PATHNAME', 'Temporal_to_tinstant'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- The function is not strict
-CREATE FUNCTION tgeompointSeq(tgeompoint, text)
+CREATE FUNCTION tgeompointSeq(tgeompoint, text DEFAULT NULL)
   RETURNS tgeompoint
   AS 'MODULE_PATHNAME', 'Temporal_to_tsequence'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 -- The function is not strict
-CREATE FUNCTION tgeompointSeq(tgeompoint)
-  RETURNS tgeompoint
-  AS 'SELECT @extschema@.tgeompointSeq($1, NULL)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
--- The function is not strict
-CREATE FUNCTION tgeompointSeqSet(tgeompoint, text)
+CREATE FUNCTION tgeompointSeqSet(tgeompoint, text DEFAULT NULL)
   RETURNS tgeompoint
   AS 'MODULE_PATHNAME', 'Temporal_to_tsequenceset'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
--- The function is not strict
-CREATE FUNCTION tgeompointSeqSet(tgeompoint)
-  RETURNS tgeompoint
-  AS 'SELECT @extschema@.tgeompointSeqSet($1, NULL)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 
 CREATE FUNCTION tgeogpointInst(tgeogpoint)
   RETURNS tgeogpoint
   AS 'MODULE_PATHNAME', 'Temporal_to_tinstant'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- The function is not strict
-CREATE FUNCTION tgeogpointSeq(tgeogpoint, text)
+CREATE FUNCTION tgeogpointSeq(tgeogpoint, text DEFAULT NULL)
   RETURNS tgeogpoint
   AS 'MODULE_PATHNAME', 'Temporal_to_tsequence'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 -- The function is not strict
-CREATE FUNCTION tgeogpointSeq(tgeogpoint)
-  RETURNS tgeogpoint
-  AS 'SELECT @extschema@.tgeogpointSeq($1, NULL)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
--- The function is not strict
-CREATE FUNCTION tgeogpointSeqSet(tgeogpoint, text)
+CREATE FUNCTION tgeogpointSeqSet(tgeogpoint, text DEFAULT NULL)
   RETURNS tgeogpoint
   AS 'MODULE_PATHNAME', 'Temporal_to_tsequenceset'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
--- The function is not strict
-CREATE FUNCTION tgeogpointSeqSet(tgeogpoint)
-  RETURNS tgeogpoint
-  AS 'SELECT @extschema@.tgeogpointSeqSet($1, NULL)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 
 CREATE FUNCTION setInterp(tgeompoint, text)
   RETURNS tgeompoint

--- a/mobilitydb/sql/h3/253_th3index.in.sql
+++ b/mobilitydb/sql/h3/253_th3index.in.sql
@@ -229,25 +229,15 @@ CREATE FUNCTION th3indexInst(th3index)
   AS 'MODULE_PATHNAME', 'Temporal_to_tinstant'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- The function is not strict
-CREATE FUNCTION th3indexSeq(th3index, text)
+CREATE FUNCTION th3indexSeq(th3index, text DEFAULT NULL)
   RETURNS th3index
   AS 'MODULE_PATHNAME', 'Temporal_to_tsequence'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 -- The function is not strict
-CREATE FUNCTION th3indexSeq(th3index)
-  RETURNS th3index
-  AS 'SELECT @extschema@.th3indexSeq($1, NULL)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
--- The function is not strict
-CREATE FUNCTION th3indexSeqSet(th3index, text)
+CREATE FUNCTION th3indexSeqSet(th3index, text DEFAULT NULL)
   RETURNS th3index
   AS 'MODULE_PATHNAME', 'Temporal_to_tsequenceset'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
--- The function is not strict
-CREATE FUNCTION th3indexSeqSet(th3index)
-  RETURNS th3index
-  AS 'SELECT @extschema@.th3indexSeqSet($1, NULL)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 
 CREATE FUNCTION setInterp(th3index, text)
   RETURNS th3index

--- a/mobilitydb/sql/npoint/302_tnpoint.in.sql
+++ b/mobilitydb/sql/npoint/302_tnpoint.in.sql
@@ -190,25 +190,15 @@ CREATE FUNCTION tnpointInst(tnpoint)
   AS 'MODULE_PATHNAME', 'Temporal_to_tinstant'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- The function is not strict
-CREATE FUNCTION tnpointSeq(tnpoint, text)
+CREATE FUNCTION tnpointSeq(tnpoint, text DEFAULT NULL)
   RETURNS tnpoint
   AS 'MODULE_PATHNAME', 'Temporal_to_tsequence'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 -- The function is not strict
-CREATE FUNCTION tnpointSeq(tnpoint)
-  RETURNS tnpoint
-  AS 'SELECT @extschema@.tnpointSeq($1, NULL)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
--- The function is not strict
-CREATE FUNCTION tnpointSeqSet(tnpoint, text)
+CREATE FUNCTION tnpointSeqSet(tnpoint, text DEFAULT NULL)
   RETURNS tnpoint
   AS 'MODULE_PATHNAME', 'Temporal_to_tsequenceset'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
--- The function is not strict
-CREATE FUNCTION tnpointSeqSet(tnpoint)
-  RETURNS tnpoint
-  AS 'SELECT @extschema@.tnpointSeqSet($1, NULL)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 
 CREATE FUNCTION setInterp(tnpoint, text)
   RETURNS tnpoint

--- a/mobilitydb/sql/quadbin/353_tquadbin.in.sql
+++ b/mobilitydb/sql/quadbin/353_tquadbin.in.sql
@@ -189,25 +189,15 @@ CREATE FUNCTION tquadbinInst(tquadbin)
   AS 'MODULE_PATHNAME', 'Temporal_to_tinstant'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- The function is not strict
-CREATE FUNCTION tquadbinSeq(tquadbin, text)
+CREATE FUNCTION tquadbinSeq(tquadbin, text DEFAULT NULL)
   RETURNS tquadbin
   AS 'MODULE_PATHNAME', 'Temporal_to_tsequence'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 -- The function is not strict
-CREATE FUNCTION tquadbinSeq(tquadbin)
-  RETURNS tquadbin
-  AS 'SELECT @extschema@.tquadbinSeq($1, NULL)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
--- The function is not strict
-CREATE FUNCTION tquadbinSeqSet(tquadbin, text)
+CREATE FUNCTION tquadbinSeqSet(tquadbin, text DEFAULT NULL)
   RETURNS tquadbin
   AS 'MODULE_PATHNAME', 'Temporal_to_tsequenceset'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
--- The function is not strict
-CREATE FUNCTION tquadbinSeqSet(tquadbin)
-  RETURNS tquadbin
-  AS 'SELECT @extschema@.tquadbinSeqSet($1, NULL)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 
 CREATE FUNCTION setInterp(tquadbin, text)
   RETURNS tquadbin

--- a/mobilitydb/test/geo/expected/052_tgeo.test.out
+++ b/mobilitydb/test/geo/expected/052_tgeo.test.out
@@ -1285,7 +1285,6 @@ SELECT asEWKT(setInterp(tgeometry '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-0
 ERROR:  Cannot transform input value to a temporal discrete sequence
 SELECT asEWKT(tgeometrySeq(tgeometry '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03],[Point(3 3)@2000-01-04, Point(3 3)@2000-01-05]}'));
 ERROR:  Cannot transform input value to a temporal sequence
-CONTEXT:  SQL function "tgeometryseq" statement 1
 SELECT asEWKT(tgeographyInst(tgeography 'Point(1.5 1.5)@2000-01-01'));
                         asewkt                         
 -------------------------------------------------------
@@ -1353,7 +1352,6 @@ SELECT asEWKT(setInterp(tgeography '{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@
 ERROR:  Cannot transform input value to a temporal discrete sequence
 SELECT asEWKT(tgeographySeq(tgeography '{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03],[Point(3.5 3.5)@2000-01-04, Point(3.5 3.5)@2000-01-05]}'));
 ERROR:  Cannot transform input value to a temporal sequence
-CONTEXT:  SQL function "tgeographyseq" statement 1
 SELECT asText(appendInstant(tgeometry 'Point(1 1)@2000-01-01', tgeometry 'Point(1 1)@2000-01-02'));
                                        astext                                       
 ------------------------------------------------------------------------------------

--- a/mobilitydb/test/geo/expected/052_tpoint.test.out
+++ b/mobilitydb/test/geo/expected/052_tpoint.test.out
@@ -1272,7 +1272,6 @@ SELECT asEWKT(setInterp(tgeompoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-
 ERROR:  Cannot transform input value to a temporal discrete sequence
 SELECT asEWKT(tgeompointSeq(tgeompoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03],[Point(3 3)@2000-01-04, Point(3 3)@2000-01-05]}'));
 ERROR:  Cannot transform input value to a temporal sequence
-CONTEXT:  SQL function "tgeompointseq" statement 1
 SELECT asEWKT(tgeogpointInst(tgeogpoint 'Point(1.5 1.5)@2000-01-01'));
                         asewkt                         
 -------------------------------------------------------
@@ -1340,7 +1339,6 @@ SELECT asEWKT(setInterp(tgeogpoint '{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@
 ERROR:  Cannot transform input value to a temporal discrete sequence
 SELECT asEWKT(tgeogpointSeq(tgeogpoint '{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03],[Point(3.5 3.5)@2000-01-04, Point(3.5 3.5)@2000-01-05]}'));
 ERROR:  Cannot transform input value to a temporal sequence
-CONTEXT:  SQL function "tgeogpointseq" statement 1
 SELECT asText(setInterp(tgeompoint 'Interp=Step;[Point(1 1)@2000-01-01]', 'linear'));
                    astext                    
 ---------------------------------------------


### PR DESCRIPTION
Makes the `tsequence`/`tsequenceset` temporal constructors uniform across all families by declaring the interpolation argument `DEFAULT NULL` directly on the C function, instead of adding a separate single-argument `LANGUAGE SQL` wrapper that forwards to the C function with a NULL second argument.

This covers the `tgeompoint`, `tgeogpoint`, `tgeometry`, `tgeography`, `tnpoint`, `tquadbin` and `th3index` families, which were the last ones still providing the one-argument form via a SQL shim. Every other family (`tint`, `tfloat`, `ttext`, `tbool`, `tcbuffer`, `tpose`, `trgeo`, `tjsonb`) already declares the interpolation argument `DEFAULT NULL` directly, so this brings the seven remaining families in line.

The one-argument call resolves to the same C function with a NULL default, so behaviour is unchanged. The only observable difference is that when a constructor raises an error, the message no longer carries an extra `CONTEXT: SQL function "..." statement 1` line, since the error is now raised directly by the C function rather than through a SQL-function frame; the `052_tgeo` and `052_tpoint` expected outputs are updated accordingly.