### PR TITLE
Compute the ever/always tcbuffer-geometry intersection predicates natively

### DIFF
--- a/meos/include/cbuffer/tcbuffer_tempspatialrels.h
+++ b/meos/include/cbuffer/tcbuffer_tempspatialrels.h
@@ -46,6 +46,8 @@ extern Temporal *tinterrel_tcbuffer_cbuffer(const Temporal *temp,
   const Cbuffer *cb, bool tinter);
 extern Temporal *tinterrel_tcbuffer_geo(const Temporal *temp,
   const GSERIALIZED *gs, bool tinter);
+extern int edisjoint_tcbuffer_geo_native(const Temporal *temp,
+  const GSERIALIZED *gs);
 // extern Temporal *tinterrel_tcbuffer_tcbuffer(const Temporal *temp1,
 //   const Temporal *temp2, bool tinter);
 

--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -56,6 +56,7 @@
 #include "cbuffer/tcbuffer.h"
 #include "cbuffer/tcbuffer_boxops.h"
 #include "cbuffer/tcbuffer_spatialfuncs.h"
+#include "cbuffer/tcbuffer_tempspatialrels.h"
 #include <meos_cbuffer.h>
 
 /*****************************************************************************
@@ -968,16 +969,18 @@ ea_disjoint_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs,
 {
   /* The always semantics reduce exactly to the native nearest-approach
    * distance: aDisjoint(temp, gs) ⟺ ¬eIntersects(temp, gs) ⟺
-   * min_t dist(disk(t), gs) > 0. The ever semantics (∃t disjoint) do not
-   * reduce to a single running minimum, so they stay on the traversed-area
-   * path. */
+   * min_t dist(disk(t), gs) > 0. The ever semantics are computed from the
+   * native coverage of the intersecting sub-periods: eDisjoint(temp, gs) ⟺
+   * ∃t disk(t) ∩ gs = ∅. Both avoid GEOS; curved or unsupported geometry falls
+   * back to the exact traversed-area path. */
+  VALIDATE_TCBUFFER(temp, -1); VALIDATE_NOT_NULL(gs, -1);
+  if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
+    return -1;
   if (! ever)
-  {
-    VALIDATE_TCBUFFER(temp, -1); VALIDATE_NOT_NULL(gs, -1);
-    if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
-      return -1;
     return nad_tcbuffer_geo(temp, gs) > 0.0 ? 1 : 0;
-  }
+  int native = edisjoint_tcbuffer_geo_native(temp, gs);
+  if (native >= 0)
+    return native;
   return ea_spatialrel_tcbuffer_geo(temp, gs, (Datum) NULL,
     (varfunc) &datum_geom_disjoint2d, 2, ever, INVERT_NO);
 }
@@ -1169,18 +1172,20 @@ int
 ea_intersects_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs,
   bool ever)
 {
-  /* The ever semantics reduce exactly to the native nearest-approach
-   * distance: eIntersects(temp, gs) ⟺ min_t dist(disk(t), gs) ≤ 0. This
-   * avoids linearizing the round buffer through GEOS. The always semantics
-   * (∀t intersects) do not reduce to a single running minimum, so they stay
-   * on the traversed-area path. */
+  /* The ever semantics reduce exactly to the native nearest-approach distance:
+   * eIntersects(temp, gs) ⟺ min_t dist(disk(t), gs) ≤ 0. The always semantics
+   * are the complement of ever disjoint: aIntersects(temp, gs) ⟺
+   * ¬eDisjoint(temp, gs), computed from the native coverage of the intersecting
+   * sub-periods. Both avoid linearizing the round buffer through GEOS; curved
+   * or unsupported geometry falls back to the exact traversed-area path. */
+  VALIDATE_TCBUFFER(temp, -1); VALIDATE_NOT_NULL(gs, -1);
+  if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
+    return -1;
   if (ever)
-  {
-    VALIDATE_TCBUFFER(temp, -1); VALIDATE_NOT_NULL(gs, -1);
-    if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
-      return -1;
     return nad_tcbuffer_geo(temp, gs) <= 0.0 ? 1 : 0;
-  }
+  int native = edisjoint_tcbuffer_geo_native(temp, gs);
+  if (native >= 0)
+    return native == 1 ? 0 : 1;
   return ea_spatialrel_tcbuffer_geo(temp, gs, (Datum) NULL,
     (varfunc) &datum_geom_intersects2d, 2, ever, INVERT_NO);
 }

--- a/meos/src/cbuffer/tcbuffer_tempspatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_tempspatialrels.c
@@ -661,11 +661,14 @@ tinterrel_tcbufferseq_from_spanset(const TSequence *seq, const SpanSet *ss,
 }
 
 /**
- * @brief Native version of #tinterrel_tcbufferseq_step_geom
+ * @brief Return the spanset of sub-periods during which a step-interpolated
+ * temporal circular buffer sequence intersects (is within distance 0 of) the
+ * geometry (NULL if it never intersects)
+ * @note Shared by the temporal-relationship tbool builder and the ever/always
+ * coverage projection
  */
-static Temporal *
-tinterrel_tcbufferseq_step_geo_native(const TSequence *seq, bool tinter,
-  const void *ctx)
+static SpanSet *
+tcbufferseq_step_within_spanset(const TSequence *seq, const void *ctx)
 {
   SpanSet *ss = NULL;
   bool lower_inc = seq->period.lower_inc;
@@ -705,6 +708,17 @@ tinterrel_tcbufferseq_step_geo_native(const TSequence *seq, bool tinter,
     }
     pfree(sp);
   }
+  return ss;
+}
+
+/**
+ * @brief Native version of #tinterrel_tcbufferseq_step_geom
+ */
+static Temporal *
+tinterrel_tcbufferseq_step_geo_native(const TSequence *seq, bool tinter,
+  const void *ctx)
+{
+  SpanSet *ss = tcbufferseq_step_within_spanset(seq, ctx);
   Temporal *result = tinterrel_tcbufferseq_from_spanset(seq, ss, tinter);
   if (ss)
     pfree(ss);
@@ -712,11 +726,14 @@ tinterrel_tcbufferseq_step_geo_native(const TSequence *seq, bool tinter,
 }
 
 /**
- * @brief Native version of #tinterrel_tcbufferseq_linear_geom
+ * @brief Return the spanset of sub-periods during which a linear temporal
+ * circular buffer sequence intersects (is within distance 0 of) the geometry,
+ * from the exact swept-capsule kernel (NULL if it never intersects)
+ * @note Shared by the temporal-relationship tbool builder and the
+ * ever/always coverage projection, so both use the identical crossing kernel
  */
-static Temporal *
-tinterrel_tcbufferseq_linear_geo_native(const TSequence *seq, bool tinter,
-  const void *ctx)
+static SpanSet *
+tcbufferseq_linear_within_spanset(const TSequence *seq, const void *ctx)
 {
   int maxo = tcbuffer_geo_ctx_nsegs(ctx) + 2;
   double *rlo = palloc(sizeof(double) * maxo);
@@ -756,6 +773,17 @@ tinterrel_tcbufferseq_linear_geo_native(const TSequence *seq, bool tinter,
     inst1 = inst2;
   }
   pfree(rlo); pfree(rhi);
+  return ss;
+}
+
+/**
+ * @brief Native version of #tinterrel_tcbufferseq_linear_geom
+ */
+static Temporal *
+tinterrel_tcbufferseq_linear_geo_native(const TSequence *seq, bool tinter,
+  const void *ctx)
+{
+  SpanSet *ss = tcbufferseq_linear_within_spanset(seq, ctx);
   Temporal *result = tinterrel_tcbufferseq_from_spanset(seq, ss, tinter);
   if (ss)
     pfree(ss);
@@ -813,6 +841,90 @@ tinterrel_tcbufferseqset_geo_native(const TSequenceSet *ss, bool tinter,
   }
   result = temporal_merge_array(res_seq, count);
   pfree_array((void *) res_seq, count);
+  return result;
+}
+
+/*****************************************************************************
+ * Ever/always intersects and disjoint (GEOS-free)
+ *
+ * aIntersects and eDisjoint are the two ever/always intersection predicates
+ * that do NOT reduce to the nearest-approach running minimum used by
+ * eIntersects/aDisjoint. Instead of materializing the temporal intersects
+ * Boolean and projecting it, they scan the same exact within-distance-0
+ * sub-period set as the temporal relationship and test whether it COVERS the
+ * whole definition time, with early exit on the first uncovered (disjoint)
+ * instant or sequence:
+ *   eDisjoint(temp, gs) ⟺ ∃t disk(t) ∩ gs = ∅ ⟺ the intersecting sub-periods
+ *     do not cover the definition time;
+ *   aIntersects(temp, gs) ⟺ ¬eDisjoint(temp, gs).
+ * Curved or unsupported geometry (no context) returns -1 so the caller keeps
+ * the exact traversed-area path.
+ *****************************************************************************/
+
+/**
+ * @brief Return true if a temporal circular buffer sequence is ever disjoint
+ * from the geometry, that is, the intersecting sub-periods do not cover the
+ * whole sequence period
+ */
+static bool
+tcbufferseq_ever_disjoint_native(const TSequence *seq, const void *ctx)
+{
+  interpType interp = MEOS_FLAGS_GET_INTERP(seq->flags);
+  /* Discrete and single-instant sequences are defined only at their instants;
+   * an instant is disjoint when its disc is not within the geometry. */
+  if (seq->count == 1 || interp == DISCRETE)
+  {
+    for (int i = 0; i < seq->count; i++)
+      if (! tcbuffer_disc_within_ctx(
+          DatumGetCbufferP(tinstant_value_p(TSEQUENCE_INST_N(seq, i))), 0.0,
+          ctx))
+        return true;
+    return false;
+  }
+  /* Step and linear: build the exact intersecting sub-periods (the same set the
+   * temporal relationship uses) and test full coverage of the sequence period.
+   */
+  SpanSet *ss = (interp == STEP) ?
+    tcbufferseq_step_within_spanset(seq, ctx) :
+    tcbufferseq_linear_within_spanset(seq, ctx);
+  bool covered = (ss != NULL) && contains_spanset_span(ss, &seq->period);
+  if (ss)
+    pfree(ss);
+  return ! covered;
+}
+
+/**
+ * @ingroup meos_internal_cbuffer_rel_ever
+ * @brief Return 1 if a temporal circular buffer is ever disjoint from a
+ * geometry, 0 if it always intersects, and -1 for curved or unsupported
+ * geometry (the caller then uses the traversed-area path)
+ * @param[in] temp Temporal circular buffer
+ * @param[in] gs Geometry
+ */
+int
+edisjoint_tcbuffer_geo_native(const Temporal *temp, const GSERIALIZED *gs)
+{
+  void *ctx = tcbuffer_geo_ctx_make(gs);
+  if (! ctx)
+    return -1;
+  int result = 0;
+  assert(temptype_subtype(temp->subtype));
+  if (temp->subtype == TINSTANT)
+    result = tcbuffer_disc_within_ctx(
+      DatumGetCbufferP(tinstant_value_p((TInstant *) temp)), 0.0, ctx) ? 0 : 1;
+  else if (temp->subtype == TSEQUENCE)
+    result = tcbufferseq_ever_disjoint_native((TSequence *) temp, ctx) ? 1 : 0;
+  else /* TSEQUENCESET */
+  {
+    const TSequenceSet *ss = (TSequenceSet *) temp;
+    for (int i = 0; i < ss->count; i++)
+      if (tcbufferseq_ever_disjoint_native(TSEQUENCESET_SEQ_N(ss, i), ctx))
+      {
+        result = 1;
+        break;
+      }
+  }
+  tcbuffer_geo_ctx_free(ctx);
   return result;
 }
 

--- a/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels_tbl.test.out
@@ -85,7 +85,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aCovers(temp, cb);
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eDisjoint(g, temp);
  count 
 -------
- 15277
+ 15321
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aDisjoint(g, temp);
@@ -97,7 +97,7 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aDisjoint(g, temp);
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eDisjoint(temp, g);
  count 
 -------
- 15277
+ 15321
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aDisjoint(temp, g);
@@ -151,7 +151,7 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eIntersects(g, temp);
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aIntersects(g, temp);
  count 
 -------
-   317
+    79
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eIntersects(temp, g);
@@ -163,7 +163,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eIntersects(temp, g);
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aIntersects(temp, g);
  count 
 -------
-   317
+    79
 (1 row)
 
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eIntersects(cb, temp);

--- a/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels_tbl.test.out
@@ -85,13 +85,13 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE tDisjoint(t1.temp, t
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tDisjoint(g, temp) ?= true <> eDisjoint(g, temp);
  count 
 -------
-   128
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tDisjoint(temp, g) ?= true <> eDisjoint(temp, g);
  count 
 -------
-   128
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2
@@ -116,7 +116,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) IS NO
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE tIntersects(temp, g) ?= true <> eDisjoint(temp, g);
  count 
 -------
- 10304
+ 10260
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tIntersects(g, temp) ?= true <> eIntersects(g, temp);


### PR DESCRIPTION
`aIntersects` and `eDisjoint` of a temporal circular buffer against a geometry were the last two ever/always intersection predicates still linearising the round buffer through GEOS on the traversed area.

This computes them natively from the exact within-distance-0 sub-periods that the temporal relationship already builds (the swept-capsule crossing kernel, now exposed as a shared spanset builder): `eDisjoint` holds when those sub-periods do not cover the definition time, and `aIntersects` is its complement. The scan exits at the first uncovered instant and never materialises the temporal Boolean. Curved or unsupported geometry keeps the exact traversed-area path.

Because the native predicate reuses the same crossing kernel as `tDisjoint`, `eDisjoint` is now exactly consistent with `ever(tDisjoint)`: in `214_tcbuffer_tempspatialrels_tbl` the consistency check `tDisjoint(temp, g) ?= true <> eDisjoint(temp, g)` drops from 128 to 0, and `aIntersects` + `eDisjoint` now equals `eIntersects` + `aDisjoint` (both complementary pairs count the defined pairs), which the GEOS traversed-area path did not satisfy. The expected outputs for `212_tcbuffer_spatialrels_tbl` and `214_tcbuffer_tempspatialrels_tbl` are updated accordingly.
