### PR TITLE
Centralize the 2D and planar constraint for tcbuffer-geometry operations

### DIFF
--- a/meos/src/cbuffer/tcbuffer.c
+++ b/meos/src/cbuffer/tcbuffer.c
@@ -73,12 +73,18 @@ ensure_valid_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @brief Ensure the validity of a temporal circular buffer and a geometry
  * @param[in] temp Temporal value
  * @param[in] gs Geometry
+ * @note A circular buffer is 2D and planar by construction (#cbuffer_make
+ * rejects geodetic, Z and M input), so the geometry must likewise be 2D and
+ * planar. Centralizing these constraints here keeps every temporal
+ * circular-buffer/geometry operation consistent and makes switching the
+ * supported dimensionality a single-place change.
  */
 bool
 ensure_valid_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   VALIDATE_TCBUFFER(temp, false); VALIDATE_NOT_NULL(gs, false);
-  if (! ensure_same_srid(tspatial_srid(temp), gserialized_get_srid(gs)))
+  if (! ensure_same_srid(tspatial_srid(temp), gserialized_get_srid(gs)) ||
+      ! ensure_not_geodetic_geo(gs) || ! ensure_has_not_Z_geo(gs))
     return false;
   return true;
 }

--- a/meos/src/cbuffer/tcbuffer_tempspatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_tempspatialrels.c
@@ -80,9 +80,9 @@ tspatialrel_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs,
   bool invert, datum_func2 func)
 {
   VALIDATE_TCBUFFER(temp, NULL); VALIDATE_NOT_NULL(gs, NULL);
-  /* Ensure the validity of the arguments */
-  if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs) ||
-      ! ensure_not_geodetic_geo(gs) || ! ensure_has_not_Z_geo(gs))
+  /* Ensure the validity of the arguments (the 2D/planar constraint is
+   * centralized in ensure_valid_tcbuffer_geo) */
+  if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
     return NULL;
 
   Cbuffer *cb = geom_to_cbuffer(gs);

--- a/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels.test.out
@@ -428,11 +428,7 @@ SELECT eTouches(tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(1 1
   ((0 0 0, 0 1 0, 1 1 0, 1 0 0, 0 0 0)), ((0 0 0, 1 0 0, 1 0 1, 0 0 1, 0 0 0)),
   ((1 1 0, 1 1 1, 1 0 1, 1 0 0, 1 1 0)),
   ((0 1 0, 0 1 1, 1 1 1, 1 1 0, 0 1 0)), ((0 0 1, 1 0 1, 1 1 1, 0 1 1, 0 0 1)) )');
- etouches 
-----------
- f
-(1 row)
-
+ERROR:  The geometry cannot have Z dimension
 SELECT eDwithin(geometry 'Linestring(1 1,2 2)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
  edwithin 
 ----------


### PR DESCRIPTION
A circular buffer is 2D and planar by construction (`cbuffer_make` rejects geodetic, Z and M input), so every operation between a temporal circular buffer and a geometry requires the geometry to be 2D and planar as well.

This constraint was enforced inconsistently. The temporal spatial-relationship dispatcher (`tspatialrel_tcbuffer_geo`) hand-checked `ensure_not_geodetic_geo` / `ensure_has_not_Z_geo`, but the ever/always relationship functions and the distance functions did not, and `ensure_valid_tcbuffer_geo` itself only checked the SRID. As a result, for example, `tTouches` on a 3D geometry raised an error while `eTouches` on the same geometry silently returned a result through GEOS.

This states the constraint once, in `ensure_valid_tcbuffer_geo` — the single place where every temporal circular-buffer/geometry operation validates its arguments — and removes the now-redundant per-function check. The ever/always, temporal and distance predicates now behave consistently, and the supported dimensionality is a single-place change.

The one expected regression-test change is `eTouches` on a 3D `POLYHEDRALSURFACE`, which the test file already lists under `-- unsupported geometry type`: it now raises `The geometry cannot have Z dimension` instead of silently returning `f`.