### PR TITLE
Restore the trailing int *count on array-returning accessors

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -592,7 +592,7 @@ extern bool spanset_lower_inc(const SpanSet *ss);
 extern int spanset_num_spans(const SpanSet *ss);
 extern Span *spanset_span(const SpanSet *ss);
 extern Span *spanset_span_n(const SpanSet *ss, int i);
-extern Span **spanset_spanarr(const SpanSet *ss);
+extern Span **spanset_spanarr(const SpanSet *ss, int *count);
 extern Span *spanset_start_span(const SpanSet *ss);
 extern bool spanset_upper_inc(const SpanSet *ss);
 extern text *textset_end_value(const Set *s);
@@ -696,10 +696,10 @@ extern bool spanset_ne(const SpanSet *ss1, const SpanSet *ss2);
 
 /* Split functions */
 
-extern Span *set_spans(const Set *s);
+extern Span *set_spans(const Set *s, int *count);
 extern Span *set_split_each_n_spans(const Set *s, int elems_per_span, int *count);
 extern Span *set_split_n_spans(const Set *s, int span_count, int *count);
-extern Span *spanset_spans(const SpanSet *ss);
+extern Span *spanset_spans(const SpanSet *ss, int *count);
 extern Span *spanset_split_each_n_spans(const SpanSet *ss, int elems_per_span, int *count);
 extern Span *spanset_split_n_spans(const SpanSet *ss, int span_count, int *count);
 

--- a/meos/include/meos_internal.h
+++ b/meos/include/meos_internal.h
@@ -857,7 +857,7 @@ extern Datum *set_vals(const Set *s);
 extern Datum *set_values(const Set *s, int *count);
 extern Datum spanset_lower(const SpanSet *ss);
 extern int spanset_mem_size(const SpanSet *ss);
-extern const Span **spanset_sps(const SpanSet *ss);
+extern const Span **spanset_sps(const SpanSet *ss, int *count);
 extern Datum spanset_upper(const SpanSet *ss);
 
 /*****************************************************************************/

--- a/meos/include/meos_json.h
+++ b/meos/include/meos_json.h
@@ -239,7 +239,7 @@ extern Set *jsonb_to_set(const Jsonb *jb);
 extern Jsonb *jsonbset_end_value(const Set *s);
 extern Jsonb *jsonbset_start_value(const Set *s);
 extern bool jsonbset_value_n(const Set *s, int n, Jsonb **result);
-extern Jsonb **jsonbset_values(const Set *s);
+extern Jsonb **jsonbset_values(const Set *s, int *count);
 
 /* JSON operations */
 

--- a/meos/include/meos_pointcloud.h
+++ b/meos/include/meos_pointcloud.h
@@ -238,7 +238,7 @@ extern Set *pcpoint_to_set(const Pcpoint *pt);
 extern Pcpoint *pcpointset_start_value(const Set *s);
 extern Pcpoint *pcpointset_end_value(const Set *s);
 extern bool pcpointset_value_n(const Set *s, int n, Pcpoint **result);
-extern Pcpoint **pcpointset_values(const Set *s);
+extern Pcpoint **pcpointset_values(const Set *s, int *count);
 
 /* Set operations */
 
@@ -277,7 +277,7 @@ extern Set *pcpatch_to_set(const Pcpatch *pa);
 extern Pcpatch *pcpatchset_start_value(const Set *s);
 extern Pcpatch *pcpatchset_end_value(const Set *s);
 extern bool pcpatchset_value_n(const Set *s, int n, Pcpatch **result);
-extern Pcpatch **pcpatchset_values(const Set *s);
+extern Pcpatch **pcpatchset_values(const Set *s, int *count);
 
 /* Set operations */
 

--- a/meos/src/json/jsonbset.c
+++ b/meos/src/json/jsonbset.c
@@ -194,17 +194,19 @@ jsonbset_value_n(const Set *s, int n, Jsonb **result)
  * @ingroup meos_json_set_accessor
  * @brief Return an array of copies of the values of a JSONB set
  * @param[in] s Set
+ * @param[out] count Number of elements in the output array
  * @return On error return @p NULL
  * @csqlfn #Set_values()
  */
 Jsonb **
-jsonbset_values(const Set *s)
+jsonbset_values(const Set *s, int *count)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_JSONBSET(s, NULL);
+  VALIDATE_JSONBSET(s, NULL); VALIDATE_NOT_NULL(count, NULL);
   Jsonb **result = palloc(sizeof(Jsonb *) * s->count);
   for (int i = 0; i < s->count; i++)
     result[i] = DatumGetJsonbP(datum_copy(SET_VAL_N(s, i), s->basetype));
+  *count = s->count;
   return result;
 }
 

--- a/meos/src/pointcloud/pcset_meos.c
+++ b/meos/src/pointcloud/pcset_meos.c
@@ -234,17 +234,19 @@ pcpointset_value_n(const Set *s, int n, Pcpoint **result)
  * @ingroup meos_pointcloud_set_accessor
  * @brief Return an array of copies of the values of a pcpoint set
  * @param[in] s Set
+ * @param[out] count Number of elements in the output array
  * @return On error return @p NULL
  * @csqlfn #Set_values()
  */
 Pcpoint **
-pcpointset_values(const Set *s)
+pcpointset_values(const Set *s, int *count)
 {
-  VALIDATE_PCPOINTSET(s, NULL);
+  VALIDATE_PCPOINTSET(s, NULL); VALIDATE_NOT_NULL(count, NULL);
   Pcpoint **result = palloc(sizeof(Pcpoint *) * s->count);
   for (int i = 0; i < s->count; i++)
     result[i] = (Pcpoint *) DatumGetPointer(datum_copy(SET_VAL_N(s, i),
       s->basetype));
+  *count = s->count;
   return result;
 }
 
@@ -495,17 +497,19 @@ pcpatchset_value_n(const Set *s, int n, Pcpatch **result)
  * @ingroup meos_pointcloud_set_accessor
  * @brief Return an array of copies of the values of a pcpatch set
  * @param[in] s Set
+ * @param[out] count Number of elements in the output array
  * @return On error return @p NULL
  * @csqlfn #Set_values()
  */
 Pcpatch **
-pcpatchset_values(const Set *s)
+pcpatchset_values(const Set *s, int *count)
 {
-  VALIDATE_PCPATCHSET(s, NULL);
+  VALIDATE_PCPATCHSET(s, NULL); VALIDATE_NOT_NULL(count, NULL);
   Pcpatch **result = palloc(sizeof(Pcpatch *) * s->count);
   for (int i = 0; i < s->count; i++)
     result[i] = (Pcpatch *) DatumGetPointer(datum_copy(SET_VAL_N(s, i),
       s->basetype));
+  *count = s->count;
   return result;
 }
 

--- a/meos/src/temporal/span.c
+++ b/meos/src/temporal/span.c
@@ -1512,18 +1512,20 @@ tstzspan_shift_scale(const Span *s, const Interval *shift,
  * @ingroup meos_setspan_bbox_split
  * @brief Return an array of spans from the values of a set
  * @param[in] s Set
+ * @param[out] count Number of elements in the output array
  * @return On error return @p NULL
  * @csqlfn #Set_spans()
  */
 Span *
-set_spans(const Set *s)
+set_spans(const Set *s, int *count)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(s, NULL);
+  VALIDATE_NOT_NULL(s, NULL); VALIDATE_NOT_NULL(count, NULL);
   /* Output the composing spans */
   Span *result = palloc(sizeof(Span) * s->count);
   for (int i = 0; i < s->count; i++)
     set_set_subspan(s, i, i, &result[i]);
+  *count = s->count;
   return result;
 }
 

--- a/meos/src/temporal/spanset.c
+++ b/meos/src/temporal/spanset.c
@@ -1013,16 +1013,18 @@ spanset_span_n(const SpanSet *ss, int n)
  * @ingroup meos_internal_setspan_accessor
  * @brief Return an array of pointers to the spans of a span set
  * @param[in] ss Span set
+ * @param[out] count Number of elements in the output array
  * @return On error return @p NULL
  */
 const Span **
-spanset_sps(const SpanSet *ss)
+spanset_sps(const SpanSet *ss, int *count)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(ss, NULL);
+  VALIDATE_NOT_NULL(ss, NULL); VALIDATE_NOT_NULL(count, NULL);
   const Span **spans = palloc(sizeof(Span *) * ss->count);
   for (int i = 0; i < ss->count; i++)
     spans[i] = SPANSET_SP_N(ss, i);
+  *count = ss->count;
   return spans;
 }
 
@@ -1030,16 +1032,18 @@ spanset_sps(const SpanSet *ss)
  * @ingroup meos_setspan_accessor
  * @brief Return a C array with copies of the spans of a span set
  * @param[in] ss Span set
+ * @param[out] count Number of elements in the output array
  * @return On error return @p NULL
  */
 Span **
-spanset_spanarr(const SpanSet *ss)
+spanset_spanarr(const SpanSet *ss, int *count)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(ss, NULL);
+  VALIDATE_NOT_NULL(ss, NULL); VALIDATE_NOT_NULL(count, NULL);
   Span **spans = palloc(sizeof(Span *) * ss->count);
   for (int i = 0; i < ss->count; i++)
     spans[i] = span_copy(SPANSET_SP_N(ss, i));
+  *count = ss->count;
   return spans;
 }
 #endif /* MEOS */
@@ -1259,19 +1263,21 @@ tstzspanset_shift_scale(const SpanSet *ss, const Interval *shift,
  * @ingroup meos_setspan_bbox_split
  * @brief Return the array of spans of a spanset
  * @param[in] ss Span set
+ * @param[out] count Number of elements in the output array
  * @return On error return @p NULL
  * @csqlfn #Spanset_spans()
  */
 Span *
-spanset_spans(const SpanSet *ss)
+spanset_spans(const SpanSet *ss, int *count)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(ss, NULL);
+  VALIDATE_NOT_NULL(ss, NULL); VALIDATE_NOT_NULL(count, NULL);
 
   Span *result = palloc(sizeof(Span) * ss->count);
   /* Output the composing spans */
   for (int i = 0; i < ss->count; i++)
     memcpy(&result[i], SPANSET_SP_N(ss, i), sizeof(Span));
+  *count = ss->count;
   return result;
 }
 
@@ -1335,10 +1341,7 @@ spanset_split_n_spans(const SpanSet *ss, int span_count, int *count)
 
   /* Output the composing spans */
   if (ss->count <= span_count)
-  {
-    *count = ss->count;
-    return spanset_spans(ss);
-  }
+    return spanset_spans(ss, count);
 
   /* Merge consecutive sequences having the smallest gap */
   Span *result = palloc(sizeof(Span) * span_count);

--- a/meos/test/setspan_test.c
+++ b/meos/test/setspan_test.c
@@ -1120,7 +1120,7 @@ printf("tstzset_make({%s, %s}): %s\n", tstz1_out, tstz2_out, char_result);
   free(ispan_result); free(char_result);
 
   /* Span **spanset_spanarr(const SpanSet *ss); */
-  ispanarray_result = spanset_spanarr(ispanset1);
+  ispanarray_result = spanset_spanarr(ispanset1, &count);
   printf("spanset_spanarr(%s): {", ispanset1_out);
   for (int i = 0; i < ispanset1->count; i++)
   {
@@ -1636,7 +1636,7 @@ printf("tstzset_make({%s, %s}): %s\n", tstz1_out, tstz2_out, char_result);
   /* Split functions */
 
   /* Span *set_spans(const Set *s); */
-  ispanvector_result = set_spans(iset1);
+  ispanvector_result = set_spans(iset1, &count);
   printf("set_spans(%s): {", iset1_out);
   for (int i = 0; i < iset1->count; i++)
   {
@@ -1681,7 +1681,7 @@ printf("tstzset_make({%s, %s}): %s\n", tstz1_out, tstz2_out, char_result);
   free(ispanvector_result);
 
   /* Span *spanset_spans(const SpanSet *ss); */
-  ispanvector_result = spanset_spans(ispanset1);
+  ispanvector_result = spanset_spans(ispanset1, &count);
   printf("spanset_spans(%s, &count): {", ispanset1_out);
   for (int i = 0; i < ispanset1->count; i++)
   {

--- a/mobilitydb/src/temporal/span.c
+++ b/mobilitydb/src/temporal/span.c
@@ -294,8 +294,9 @@ Datum
 Set_spans(PG_FUNCTION_ARGS)
 {
   Set *s = PG_GETARG_SET_P(0);
-  Span *spans = set_spans(s);
-  ArrayType *result = spanarr_to_array(spans, s->count);
+  int count;
+  Span *spans = set_spans(s, &count);
+  ArrayType *result = spanarr_to_array(spans, count);
   pfree(spans);
   PG_FREE_IF_COPY(s, 0);
   PG_RETURN_ARRAYTYPE_P(result);

--- a/mobilitydb/src/temporal/spanset.c
+++ b/mobilitydb/src/temporal/spanset.c
@@ -1040,8 +1040,9 @@ Datum
 Spanset_spans(PG_FUNCTION_ARGS)
 {
   SpanSet *ss = PG_GETARG_SPANSET_P(0);
-  Span *spans = spanset_spans(ss);
-  ArrayType *result = spanarr_to_array(spans, ss->count);
+  int count;
+  Span *spans = spanset_spans(ss, &count);
+  ArrayType *result = spanarr_to_array(spans, count);
   pfree(spans);
   PG_FREE_IF_COPY(ss, 0);
   PG_RETURN_ARRAYTYPE_P(result);


### PR DESCRIPTION
The MEOS array-return convention is a trailing `int *count` out-parameter (`floatset_values`, `set_split_n_spans`, `temporal_spans`, …), so the array shape is derivable from the signature alone without any per-function rule. Six public accessors were missing it, leaving their length reachable only through a separate `*_num_*` accessor:

- `set_spans`, `spanset_spans`, `spanset_spanarr` — the uniformization added earlier did not survive the clean-family re-derivation;
- `jsonbset_values`, `pcpointset_values`, `pcpatchset_values` — newer families never brought onto the convention (their siblings `npointset_values` / `cbufferset_values` / `poseset_values` already carry `int *count`);
- plus the internal `spanset_sps`.

This adds `int *count` to all of them (writing the element count before returning, `VALIDATE_NOT_NULL(count)` mirroring `spanset_split_n_spans`) and updates every caller: `spanset_split_n_spans`, the `Set_spans` / `Spanset_spans` SQL wrappers, and the setspan smoke test.

Every array-returning accessor now follows the one convention, so a catalog / binding generator derives the array shape uniformly.
