### PR TITLE
Restrict a tcbuffer by its disk footprint in atGeometry/minusGeometry

### DIFF
--- a/meos/src/cbuffer/tcbuffer.c
+++ b/meos/src/cbuffer/tcbuffer.c
@@ -46,8 +46,10 @@
 #include "temporal/tnumber_mathfuncs.h"
 #include "temporal/type_util.h"
 #include "geo/tgeo_spatialfuncs.h"
+#include "geo/tgeo_tempspatialrels.h"
 #include "geo/tspatial_parser.h"
 #include "cbuffer/cbuffer.h"
+#include "cbuffer/tcbuffer_tempspatialrels.h"
 
 /*****************************************************************************
  * Validity functions
@@ -1338,16 +1340,20 @@ tcbuffer_restrict_geom(const Temporal *temp, const GSERIALIZED *gs, bool
   if (! overlaps_stbox_stbox(&box1, &box2))
     return atfunc ? NULL : temporal_copy(temp);
 
-  Temporal *tpoint = tcbuffer_to_tgeompoint(temp);
-  Temporal *tfloat = tcbuffer_to_tfloat(temp);
-  Temporal *tpoint_rest = tgeo_restrict_geom(tpoint, gs, atfunc);
-  Temporal *result = NULL;
-  if (tpoint_rest)
-  {
-    result = tcbuffer_make(tpoint_rest, tfloat);
-    pfree(tpoint_rest);
-  }
-  pfree(tpoint); pfree(tfloat); 
+  /* Restrict by the circular disk footprint, not the centre trajectory: the
+   * buffer meets the geometry exactly when the moving disk intersects it. That
+   * is the true time of the (arc-exact, GEOS-free) temporal intersects
+   * relationship, so the geometry restriction reduces to restricting the
+   * buffer to that time (`at`) or its complement (`minus`) */
+  Temporal *tinter = tinterrel_tcbuffer_geo(temp, gs, TINTERSECTS);
+  if (! tinter)
+    return atfunc ? NULL : temporal_copy(temp);
+  SpanSet *ss = tbool_when_true(tinter);
+  pfree(tinter);
+  if (! ss)
+    return atfunc ? NULL : temporal_copy(temp);
+  Temporal *result = temporal_restrict_tstzspanset(temp, ss, atfunc);
+  pfree(ss);
   return result;
 }
 

--- a/mobilitydb/test/cbuffer/expected/205_tcbuffer_spatialfuncs.test.out
+++ b/mobilitydb/test/cbuffer/expected/205_tcbuffer_spatialfuncs.test.out
@@ -16,6 +16,68 @@ SELECT ST_AsText(traversedArea(tcbuffer '[Cbuffer(Point(1 1),0.3)@2000-01-01, Cb
  CURVEPOLYGON(CIRCULARSTRING(0.7 1,1.3 1,0.7 1))
 (1 row)
 
+SELECT atGeometry(NULL::tcbuffer, geometry 'Point(1 1)');
+ atgeometry 
+------------
+ 
+(1 row)
+
+SELECT minusGeometry(NULL::tcbuffer, geometry 'Point(1 1)');
+ minusgeometry 
+---------------
+ 
+(1 row)
+
+SELECT atGeometry(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::geometry);
+ atgeometry 
+------------
+ 
+(1 row)
+
+SELECT asText(atGeometry(tcbuffer 'Cbuffer(Point(1 1),1)@2000-01-01', geometry 'Point(1.5 1)'));
+                       astext                       
+----------------------------------------------------
+ Cbuffer(POINT(1 1),1)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT atGeometry(tcbuffer 'Cbuffer(Point(1 1),1)@2000-01-01', geometry 'Point(5 5)');
+ atgeometry 
+------------
+ 
+(1 row)
+
+SELECT getTime(atGeometry(
+  tcbuffer '[Cbuffer(Point(0 0),1)@2000-01-01, Cbuffer(Point(4 0),1)@2000-01-05]',
+  geometry 'Polygon((1.5 0.5,2.5 0.5,2.5 1.5,1.5 1.5,1.5 0.5))'));
+                                   gettime                                    
+------------------------------------------------------------------------------
+ {[Sat Jan 01 15:12:55.405113 2000 PST, Tue Jan 04 08:47:04.594887 2000 PST]}
+(1 row)
+
+SELECT getTime(minusGeometry(
+  tcbuffer '[Cbuffer(Point(0 0),1)@2000-01-01, Cbuffer(Point(4 0),1)@2000-01-05]',
+  geometry 'Polygon((1.5 0.5,2.5 0.5,2.5 1.5,1.5 1.5,1.5 0.5))'));
+                                                                  gettime                                                                   
+--------------------------------------------------------------------------------------------------------------------------------------------
+ {[Sat Jan 01 00:00:00 2000 PST, Sat Jan 01 15:12:55.405113 2000 PST), (Tue Jan 04 08:47:04.594887 2000 PST, Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT atGeometry(
+  tcbuffer '[Cbuffer(Point(0 0),1)@2000-01-01, Cbuffer(Point(4 0),1)@2000-01-05]',
+  geometry 'Point(2 50)');
+ atgeometry 
+------------
+ 
+(1 row)
+
+SELECT getTime(minusGeometry(
+  tcbuffer '[Cbuffer(Point(0 0),1)@2000-01-01, Cbuffer(Point(4 0),1)@2000-01-05]',
+  geometry 'Point(2 50)'));
+                            gettime                             
+----------------------------------------------------------------
+ {[Sat Jan 01 00:00:00 2000 PST, Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
 SELECT centroid(NULL::tcbuffer);
  centroid 
 ----------

--- a/mobilitydb/test/cbuffer/queries/205_tcbuffer_spatialfuncs.test.sql
+++ b/mobilitydb/test/cbuffer/queries/205_tcbuffer_spatialfuncs.test.sql
@@ -36,6 +36,38 @@ SELECT ST_AsText(traversedArea(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01'));
 SELECT ST_AsText(traversedArea(tcbuffer '[Cbuffer(Point(1 1),0.3)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]'));
 
 -------------------------------------------------------------------------------
+-- Restriction to a geometry (atGeometry / minusGeometry)
+-- The restriction is by the circular disk footprint, not the centre path: the
+-- buffer meets the geometry when the moving disk intersects it.
+-------------------------------------------------------------------------------
+
+SELECT atGeometry(NULL::tcbuffer, geometry 'Point(1 1)');
+SELECT minusGeometry(NULL::tcbuffer, geometry 'Point(1 1)');
+SELECT atGeometry(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', NULL::geometry);
+
+-- Instant: the disk covers the geometry -> unchanged; disjoint -> NULL
+SELECT asText(atGeometry(tcbuffer 'Cbuffer(Point(1 1),1)@2000-01-01', geometry 'Point(1.5 1)'));
+SELECT atGeometry(tcbuffer 'Cbuffer(Point(1 1),1)@2000-01-01', geometry 'Point(5 5)');
+
+-- Sequence: a box lies ABOVE the centre path (y in [0.5,1.5]); the centre (y=0)
+-- never enters it but the radius-1 disk does, so the disk-footprint restriction
+-- is non-empty where a centre-only restriction would be empty
+SELECT getTime(atGeometry(
+  tcbuffer '[Cbuffer(Point(0 0),1)@2000-01-01, Cbuffer(Point(4 0),1)@2000-01-05]',
+  geometry 'Polygon((1.5 0.5,2.5 0.5,2.5 1.5,1.5 1.5,1.5 0.5))'));
+SELECT getTime(minusGeometry(
+  tcbuffer '[Cbuffer(Point(0 0),1)@2000-01-01, Cbuffer(Point(4 0),1)@2000-01-05]',
+  geometry 'Polygon((1.5 0.5,2.5 0.5,2.5 1.5,1.5 1.5,1.5 0.5))'));
+
+-- Disjoint over the whole sequence -> at NULL, minus unchanged
+SELECT atGeometry(
+  tcbuffer '[Cbuffer(Point(0 0),1)@2000-01-01, Cbuffer(Point(4 0),1)@2000-01-05]',
+  geometry 'Point(2 50)');
+SELECT getTime(minusGeometry(
+  tcbuffer '[Cbuffer(Point(0 0),1)@2000-01-01, Cbuffer(Point(4 0),1)@2000-01-05]',
+  geometry 'Point(2 50)'));
+
+-------------------------------------------------------------------------------
 -- Centroid
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
atGeometry and minusGeometry on a temporal circular buffer restricted by the
centre trajectory: they converted the tcbuffer to its centre tgeompoint,
restricted that point against the geometry, and re-attached the radius. The
radius was therefore ignored — a moving disk overlapping the geometry while its
centre is outside it was wrongly dropped, and the converse.

The restriction is now by the circular disk footprint: the buffer meets the
geometry when the moving disk intersects it. The implementation reuses the
existing arc-exact within-time engine (`tinterrel_tcbuffer_geo(temp, gs,
TINTERSECTS)`), takes the time span where the disk intersects the geometry
(`tbool_when_true`), and restricts the temporal value to that span
(`temporal_restrict_tstzspanset`). This is consistent by construction with
`tIntersects`/`eIntersects`, and stays native (no GEOS).

Adds coverage in `205_tcbuffer_spatialfuncs` including the key case of a region
lying above the centre path that only the radius-1 disk reaches — non-empty
under the disk-footprint restriction where a centre-only restriction is
empty.