### PR TITLE
Short-circuit the ever-disjoint tcbuffer test at the first disjoint vertex

### DIFF
--- a/meos/src/cbuffer/tcbuffer_tempspatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_tempspatialrels.c
@@ -881,9 +881,19 @@ tcbufferseq_ever_disjoint_native(const TSequence *seq, const void *ctx)
         return true;
     return false;
   }
-  /* Step and linear: build the exact intersecting sub-periods (the same set the
-   * temporal relationship uses) and test full coverage of the sequence period.
-   */
+  /* Step and linear: a vertex whose disc is already disjoint decides the
+   * ever-disjoint result immediately, without building the intersecting
+   * sub-periods. This is the common case for a buffer that spends most of its
+   * life away from the geometry, and reuses the same instant test as the
+   * discrete branch. */
+  for (int i = 0; i < seq->count; i++)
+    if (! tcbuffer_disc_within_ctx(
+        DatumGetCbufferP(tinstant_value_p(TSEQUENCE_INST_N(seq, i))), 0.0,
+        ctx))
+      return true;
+  /* Every vertex intersects; a disjoint gap can still open inside a segment for
+   * a non-convex geometry, so build the exact intersecting sub-periods (the same
+   * set the temporal relationship uses) and test full coverage of the period. */
   SpanSet *ss = (interp == STEP) ?
     tcbufferseq_step_within_spanset(seq, ctx) :
     tcbufferseq_linear_within_spanset(seq, ctx);


### PR DESCRIPTION
`tcbufferseq_ever_disjoint_native` computed the ever-disjoint predicate for
a step or linear temporal circular buffer by building the full set of
intersecting sub-periods and testing whether they cover the sequence period —
even when a vertex of the buffer is already disjoint from the geometry.

Ever-disjoint holds as soon as any instant is disjoint, so the vertices are now
scanned first and the function returns on the first disjoint one, reusing the
same per-instant test as the discrete branch. When every vertex intersects, the
exact full-coverage path still runs, so a disjoint gap opening inside a segment
for a non-convex geometry is still detected. The result is unchanged; the common
case of a buffer that spends most of its life away from the geometry now decides
in a single vertex test instead of solving the crossing roots for every segment
against every edge.

This is the hot path for `eDisjoint(tcbuffer, geometry)` and, by the
`aIntersects = ¬eDisjoint` reduction, for `aIntersects` as well.
