### PR TITLE
Serialize gh-pages documentation deploys

### DIFF
--- a/.github/workflows/generate_dev_docs.yml
+++ b/.github/workflows/generate_dev_docs.yml
@@ -42,6 +42,13 @@ jobs:
     name: Deploy documentation
     runs-on: ubuntu-latest
     needs: build
+    # Serialize gh-pages deploys across both doc workflows: each merge to
+    # master triggers a doc build, and two concurrent runs pushing to the
+    # shared gh-pages branch make the loser fail non-fast-forward. A common
+    # concurrency group makes the deploy jobs run one at a time.
+    concurrency:
+      group: gh-pages-deploy
+      cancel-in-progress: false
 
     steps:
       # checkout the gh-pages branch

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -69,6 +69,13 @@ jobs:
     name: Deploy documentation
     runs-on: ubuntu-latest
     needs: build
+    # Serialize gh-pages deploys across both doc workflows: each merge to
+    # master triggers a doc build, and two concurrent runs pushing to the
+    # shared gh-pages branch make the loser fail non-fast-forward. A common
+    # concurrency group makes the deploy jobs run one at a time.
+    concurrency:
+      group: gh-pages-deploy
+      cancel-in-progress: false
 
     steps:
       # checkout the gh-pages branch


### PR DESCRIPTION
Both documentation workflows — *Generate MobilityDB documentation* (`generate_docs.yml`) and *Generate MEOS dev documentation* (`generate_dev_docs.yml`) — deploy by pushing their built output to the shared `gh-pages` branch.

When two commits land on master close together, each triggers its doc workflow. Both build and then push to `gh-pages`; the first push wins and the later run is rejected non-fast-forward:

```
 ! refs/heads/gh-pages:refs/heads/gh-pages  [rejected] (non-fast-forward)
 Updates were rejected because the tip of your current branch is behind its remote counterpart
```

The docs build and commit fine (`committed: true`); only the push loses the race (`pushed: false`). It is benign — the winning run already deployed and the next doc run republishes the full tree — but it surfaces as a red run on master.

This gives both deploy jobs a common `concurrency` group (`gh-pages-deploy`, `cancel-in-progress: false`) so they run one at a time. The build jobs still run in parallel; only the pushes to `gh-pages` serialize, which removes the race while always deploying the latest built tree.