### PR TITLE
Give time-axis span/set positional operators their own SQL wrappers

### DIFF
--- a/meos/src/temporal/set_ops_meos.c
+++ b/meos/src/temporal/set_ops_meos.c
@@ -303,7 +303,7 @@ left_text_set(const text *txt, const Set *s)
  * @brief Return true if a date is before a set
  * @param[in] d Value
  * @param[in] s Set
- * @csqlfn #Left_value_set()
+ * @csqlfn #Before_value_set()
  */
 bool
 before_date_set(DateADT d, const Set *s)
@@ -318,7 +318,7 @@ before_date_set(DateADT d, const Set *s)
  * @brief Return true if a timestamptz is before a set
  * @param[in] t Value
  * @param[in] s Set
- * @csqlfn #Left_value_set()
+ * @csqlfn #Before_value_set()
  */
 bool
 before_timestamptz_set(TimestampTz t, const Set *s)
@@ -396,7 +396,7 @@ left_set_text(const Set *s, text *txt)
  * @brief Return true if a set is before a date
  * @param[in] s Set
  * @param[in] d Value
- * @csqlfn #Left_set_value()
+ * @csqlfn #Before_set_value()
  */
 bool
 before_set_date(const Set *s, DateADT d)
@@ -411,7 +411,7 @@ before_set_date(const Set *s, DateADT d)
  * @brief Return true if a set is before a timestamptz
  * @param[in] s Set
  * @param[in] t Value
- * @csqlfn #Left_set_value()
+ * @csqlfn #Before_set_value()
  */
 bool
 before_set_timestamptz(const Set *s, TimestampTz t)
@@ -491,7 +491,7 @@ right_text_set(const text *txt, const Set *s)
  * @brief Return true if a date is after a set
  * @param[in] d Value
  * @param[in] s Set
- * @csqlfn #Right_value_set()
+ * @csqlfn #After_value_set()
  */
 bool
 after_date_set(DateADT d, const Set *s)
@@ -505,7 +505,7 @@ after_date_set(DateADT d, const Set *s)
  * @brief Return true if a timestamptz is after a set
  * @param[in] t Value
  * @param[in] s Set
- * @csqlfn #Right_value_set()
+ * @csqlfn #After_value_set()
  */
 bool
 after_timestamptz_set(TimestampTz t, const Set *s)
@@ -583,7 +583,7 @@ right_set_text(const Set *s, text *txt)
  * @brief Return true if a set is after a date
  * @param[in] s Set
  * @param[in] d Value
- * @csqlfn #Right_set_value()
+ * @csqlfn #After_set_value()
  */
 bool
 after_set_date(const Set *s, DateADT d)
@@ -598,7 +598,7 @@ after_set_date(const Set *s, DateADT d)
  * @brief Return true if a set is after a timestamptz
  * @param[in] s Set
  * @param[in] t Value
- * @csqlfn #Right_set_value()
+ * @csqlfn #After_set_value()
  */
 bool
 after_set_timestamptz(const Set *s, TimestampTz t)
@@ -678,7 +678,7 @@ overleft_text_set(const text *txt, const Set *s)
  * @brief Return true if a date is not after a set
  * @param[in] d Value
  * @param[in] s Set
- * @csqlfn #Overleft_value_set()
+ * @csqlfn #Overbefore_value_set()
  */
 bool
 overbefore_date_set(DateADT d, const Set *s)
@@ -691,7 +691,7 @@ overbefore_date_set(DateADT d, const Set *s)
 /**
  * @ingroup meos_setspan_pos
  * @brief Return true if a timestamptz is not after a set
- * @csqlfn #Overleft_value_set()
+ * @csqlfn #Overbefore_value_set()
  * @param[in] t Value
  * @param[in] s Set
  */
@@ -771,7 +771,7 @@ overleft_set_text(const Set *s, text *txt)
  * @brief Return true if a set is not after a date
  * @param[in] s Set
  * @param[in] d Value
- * @csqlfn #Overleft_set_value()
+ * @csqlfn #Overbefore_set_value()
  */
 bool
 overbefore_set_date(const Set *s, DateADT d)
@@ -786,7 +786,7 @@ overbefore_set_date(const Set *s, DateADT d)
  * @brief Return true if a set is not after a timestamptz
  * @param[in] s Set
  * @param[in] t Value
- * @csqlfn #Overleft_set_value()
+ * @csqlfn #Overbefore_set_value()
  */
 bool
 overbefore_set_timestamptz(const Set *s, TimestampTz t)
@@ -866,7 +866,7 @@ overright_text_set(const text *txt, const Set *s)
  * @brief Return true if a date is not before a set
  * @param[in] d Value
  * @param[in] s Set
- * @csqlfn #Overright_value_set()
+ * @csqlfn #Overafter_value_set()
  */
 bool
 overafter_date_set(DateADT d, const Set *s)
@@ -881,7 +881,7 @@ overafter_date_set(DateADT d, const Set *s)
  * @brief Return true if a timestamptz is not before a set
  * @param[in] t Value
  * @param[in] s Set
- * @csqlfn #Overright_value_set()
+ * @csqlfn #Overafter_value_set()
  */
 bool
 overafter_timestamptz_set(TimestampTz t, const Set *s)
@@ -959,7 +959,7 @@ overright_set_text(const Set *s, text *txt)
  * @brief Return true if a set is not before a date
  * @param[in] s Set
  * @param[in] d Value
- * @csqlfn #Overright_set_value()
+ * @csqlfn #Overafter_set_value()
  */
 bool
 overafter_set_date(const Set *s, DateADT d)
@@ -974,7 +974,7 @@ overafter_set_date(const Set *s, DateADT d)
  * @brief Return true if a set is not before a timestamptz
  * @param[in] s Set
  * @param[in] t Value
- * @csqlfn #Overright_set_value()
+ * @csqlfn #Overafter_set_value()
  */
 bool
 overafter_set_timestamptz(const Set *s, TimestampTz t)

--- a/meos/src/temporal/span_ops_meos.c
+++ b/meos/src/temporal/span_ops_meos.c
@@ -323,7 +323,7 @@ left_float_span(double d, const Span *s)
  * @brief Return true if a date is before a span
  * @param[in] d Value
  * @param[in] s Span
- * @csqlfn #Left_value_span()
+ * @csqlfn #Before_value_span()
  */
 bool
 before_date_span(DateADT d, const Span *s)
@@ -338,7 +338,7 @@ before_date_span(DateADT d, const Span *s)
  * @brief Return true if a timestamptz is before a span
  * @param[in] t Value
  * @param[in] s Span
- * @csqlfn #Left_value_span()
+ * @csqlfn #Before_value_span()
  */
 bool
 before_timestamptz_span(TimestampTz t, const Span *s)
@@ -400,7 +400,7 @@ left_span_float(const Span *s, double d)
  * @brief Return true if a span is before a date
  * @param[in] s Span
  * @param[in] d Value
- * @csqlfn #Left_span_value()
+ * @csqlfn #Before_span_value()
  */
 bool
 before_span_date(const Span *s, DateADT d)
@@ -414,7 +414,7 @@ before_span_date(const Span *s, DateADT d)
  * @brief Return true if a span is before a timestamptz
  * @param[in] s Span
  * @param[in] t Value
- * @csqlfn #Left_span_value()
+ * @csqlfn #Before_span_value()
  */
 bool
 before_span_timestamptz(const Span *s, TimestampTz t)
@@ -478,7 +478,7 @@ right_float_span(double d, const Span *s)
  * @brief Return true if a date is after a span
  * @param[in] d Value
  * @param[in] s Span
- * @csqlfn #Right_value_span()
+ * @csqlfn #After_value_span()
  */
 bool
 after_date_span(DateADT d, const Span *s)
@@ -493,7 +493,7 @@ after_date_span(DateADT d, const Span *s)
  * @brief Return true if a timestamptz is after a span
  * @param[in] t Value
  * @param[in] s Span
- * @csqlfn #Right_value_span()
+ * @csqlfn #After_value_span()
  */
 bool
 after_timestamptz_span(TimestampTz t, const Span *s)
@@ -555,7 +555,7 @@ right_span_float(const Span *s, double d)
  * @brief Return true if a span is after a date
  * @param[in] s Span
  * @param[in] d Value
- * @csqlfn #Right_span_value()
+ * @csqlfn #After_span_value()
  */
 bool
 after_span_date(const Span *s, DateADT d)
@@ -570,7 +570,7 @@ after_span_date(const Span *s, DateADT d)
  * @brief Return true if a span is after a timestamptz
  * @param[in] s Span
  * @param[in] t Value
- * @csqlfn #Right_span_value()
+ * @csqlfn #After_span_value()
  */
 bool
 after_span_timestamptz(const Span *s, TimestampTz t)
@@ -634,7 +634,7 @@ overleft_float_span(double d, const Span *s)
  * @brief Return true if a date is not after a span
  * @param[in] d Value
  * @param[in] s Span
- * @csqlfn #Overleft_value_span()
+ * @csqlfn #Overbefore_value_span()
  */
 bool
 overbefore_date_span(DateADT d, const Span *s)
@@ -649,7 +649,7 @@ overbefore_date_span(DateADT d, const Span *s)
  * @brief Return true if a timestamptz is not after a span
  * @param[in] t Value
  * @param[in] s Span
- * @csqlfn #Overleft_value_span()
+ * @csqlfn #Overbefore_value_span()
  */
 bool
 overbefore_timestamptz_span(TimestampTz t, const Span *s)
@@ -711,7 +711,7 @@ overleft_span_float(const Span *s, double d)
  * @brief Return true if a span is not after a date
  * @param[in] s Span
  * @param[in] d Value
- * @csqlfn #Overleft_span_value()
+ * @csqlfn #Overbefore_span_value()
  */
 bool
 overbefore_span_date(const Span *s, DateADT d)
@@ -726,7 +726,7 @@ overbefore_span_date(const Span *s, DateADT d)
  * @brief Return true if a span is not after a timestamptz
  * @param[in] s Span
  * @param[in] t Value
- * @csqlfn #Overleft_span_value()
+ * @csqlfn #Overbefore_span_value()
  */
 bool
 overbefore_span_timestamptz(const Span *s, TimestampTz t)
@@ -790,7 +790,7 @@ overright_float_span(double d, const Span *s)
  * @brief Return true if a date is not before a span
  * @param[in] d Value
  * @param[in] s Span
- * @csqlfn #Overright_value_span()
+ * @csqlfn #Overafter_value_span()
  */
 bool
 overafter_date_span(DateADT d, const Span *s)
@@ -805,7 +805,7 @@ overafter_date_span(DateADT d, const Span *s)
  * @brief Return true if a timestamptz is not before a span
  * @param[in] t Value
  * @param[in] s Span
- * @csqlfn #Overright_value_span()
+ * @csqlfn #Overafter_value_span()
  */
 bool
 overafter_timestamptz_span(TimestampTz t, const Span *s)
@@ -867,7 +867,7 @@ overright_span_float(const Span *s, double d)
  * @brief Return true if a span is not before a date
  * @param[in] s Span
  * @param[in] d Value
- * @csqlfn #Overright_span_value()
+ * @csqlfn #Overafter_span_value()
  */
 bool
 overafter_span_date(const Span *s, DateADT d)
@@ -882,7 +882,7 @@ overafter_span_date(const Span *s, DateADT d)
  * @brief Return true if a span is not before a timestamptz
  * @param[in] s Span
  * @param[in] t Value
- * @csqlfn #Overright_span_value()
+ * @csqlfn #Overafter_span_value()
  */
 bool
 overafter_span_timestamptz(const Span *s, TimestampTz t)

--- a/meos/src/temporal/spanset_ops_meos.c
+++ b/meos/src/temporal/spanset_ops_meos.c
@@ -321,7 +321,7 @@ left_float_spanset(double d, const SpanSet *ss)
  * @brief Return true if a date is before a span set
  * @param[in] d Value
  * @param[in] ss Span set
- * @csqlfn #Left_value_spanset()
+ * @csqlfn #Before_value_spanset()
  */
 bool
 before_date_spanset(DateADT d, const SpanSet *ss)
@@ -336,7 +336,7 @@ before_date_spanset(DateADT d, const SpanSet *ss)
  * @brief Return true if a timestamptz is before a span set
  * @param[in] t Value
  * @param[in] ss Span set
- * @csqlfn #Left_value_spanset()
+ * @csqlfn #Before_value_spanset()
  */
 bool
 before_timestamptz_spanset(TimestampTz t, const SpanSet *ss)
@@ -398,7 +398,7 @@ left_spanset_float(const SpanSet *ss, double d)
  * @brief Return true if a span set is before a date
  * @param[in] ss Span set
  * @param[in] d Value
- * @csqlfn #Left_spanset_value()
+ * @csqlfn #Before_spanset_value()
  */
 bool
 before_spanset_date(const SpanSet *ss, DateADT d)
@@ -413,7 +413,7 @@ before_spanset_date(const SpanSet *ss, DateADT d)
  * @brief Return true if a span set is before a timestamptz
  * @param[in] ss Span set
  * @param[in] t Value
- * @csqlfn #Left_spanset_value()
+ * @csqlfn #Before_spanset_value()
  */
 bool
 before_spanset_timestamptz(const SpanSet *ss, TimestampTz t)
@@ -471,7 +471,7 @@ right_float_spanset(double d, const SpanSet *ss)
  * @brief Return true if a date is after a span set
  * @param[in] d Value
  * @param[in] ss Span set
- * @csqlfn #Right_value_spanset()
+ * @csqlfn #After_value_spanset()
  */
 bool
 after_date_spanset(DateADT d, const SpanSet *ss)
@@ -484,7 +484,7 @@ after_date_spanset(DateADT d, const SpanSet *ss)
  * @brief Return true if a timestamptz is after a span set
  * @param[in] t Value
  * @param[in] ss Span set
- * @csqlfn #Right_value_spanset()
+ * @csqlfn #After_value_spanset()
  */
 bool
 after_timestamptz_spanset(TimestampTz t, const SpanSet *ss)
@@ -538,7 +538,7 @@ right_spanset_float(const SpanSet *ss, double d)
  * @brief Return true if a span set is after a date
  * @param[in] ss Span set
  * @param[in] d Value
- * @csqlfn #Right_spanset_value()
+ * @csqlfn #After_spanset_value()
  */
 bool
 after_spanset_date(const SpanSet *ss, DateADT d)
@@ -551,7 +551,7 @@ after_spanset_date(const SpanSet *ss, DateADT d)
  * @brief Return true if a span set is after a timestamptz
  * @param[in] ss Span set
  * @param[in] t Value
- * @csqlfn #Right_spanset_value()
+ * @csqlfn #After_spanset_value()
  */
 bool
 after_spanset_timestamptz(const SpanSet *ss, TimestampTz t)
@@ -614,7 +614,7 @@ overleft_spanset_float(const SpanSet *ss, double d)
  * @brief Return true if a span set is not after a date
  * @param[in] ss Span set
  * @param[in] d Value
- * @csqlfn #Overleft_spanset_value()
+ * @csqlfn #Overbefore_spanset_value()
  */
 bool
 overbefore_spanset_date(const SpanSet *ss, DateADT d)
@@ -629,7 +629,7 @@ overbefore_spanset_date(const SpanSet *ss, DateADT d)
  * @brief Return true if a span set is not after a timestamptz
  * @param[in] ss Span set
  * @param[in] t Value
- * @csqlfn #Overleft_spanset_value()
+ * @csqlfn #Overbefore_spanset_value()
  */
 bool
 overbefore_spanset_timestamptz(const SpanSet *ss, TimestampTz t)
@@ -692,7 +692,7 @@ overleft_float_spanset(double d, const SpanSet *ss)
  * @brief Return true if a date is not after a span set.
  * @param[in] d Value
  * @param[in] ss Span set
- * @csqlfn #Overleft_value_spanset()
+ * @csqlfn #Overbefore_value_spanset()
  */
 bool
 overbefore_date_spanset(DateADT d, const SpanSet *ss)
@@ -707,7 +707,7 @@ overbefore_date_spanset(DateADT d, const SpanSet *ss)
  * @brief Return true if a timestamptz is not after a span set
  * @param[in] t Value
  * @param[in] ss Span set
- * @csqlfn #Overleft_value_spanset()
+ * @csqlfn #Overbefore_value_spanset()
  */
 bool
 overbefore_timestamptz_spanset(TimestampTz t, const SpanSet *ss)
@@ -771,7 +771,7 @@ overright_float_spanset(double d, const SpanSet *ss)
  * @brief Return true if a date is not before a span set
  * @param[in] d Value
  * @param[in] ss Span set
- * @csqlfn #Overright_value_spanset()
+ * @csqlfn #Overafter_value_spanset()
  */
 bool
 overafter_date_spanset(DateADT d, const SpanSet *ss)
@@ -786,7 +786,7 @@ overafter_date_spanset(DateADT d, const SpanSet *ss)
  * @brief Return true if a timestamptz is not before a span set
  * @param[in] t Value
  * @param[in] ss Span set
- * @csqlfn #Overright_value_spanset()
+ * @csqlfn #Overafter_value_spanset()
  */
 bool
 overafter_timestamptz_spanset(TimestampTz t, const SpanSet *ss)
@@ -848,7 +848,7 @@ overright_spanset_float(const SpanSet *ss, double d)
  * @brief Return true if a span set is before a date
  * @param[in] ss Span set
  * @param[in] d Value
- * @csqlfn #Overright_spanset_value()
+ * @csqlfn #Overafter_spanset_value()
  */
 bool
 overafter_spanset_date(const SpanSet *ss, DateADT d)
@@ -863,7 +863,7 @@ overafter_spanset_date(const SpanSet *ss, DateADT d)
  * @brief Return true if a span set is before a timestamptz
  * @param[in] ss Span set
  * @param[in] t Value
- * @csqlfn #Overright_spanset_value()
+ * @csqlfn #Overafter_spanset_value()
  */
 bool
 overafter_spanset_timestamptz(const SpanSet *ss, TimestampTz t)

--- a/mobilitydb/sql/temporal/002_set_ops.in.sql
+++ b/mobilitydb/sql/temporal/002_set_ops.in.sql
@@ -388,27 +388,27 @@ CREATE FUNCTION left(textset, textset)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(date, dateset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Left_value_set'
+  AS 'MODULE_PATHNAME', 'Before_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(dateset, date)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Left_set_value'
+  AS 'MODULE_PATHNAME', 'Before_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(dateset, dateset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Left_set_set'
+  AS 'MODULE_PATHNAME', 'Before_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(timestamptz, tstzset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Left_value_set'
+  AS 'MODULE_PATHNAME', 'Before_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(tstzset, timestamptz)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Left_set_value'
+  AS 'MODULE_PATHNAME', 'Before_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(tstzset, tstzset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Left_set_set'
+  AS 'MODULE_PATHNAME', 'Before_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR << (
@@ -566,27 +566,27 @@ CREATE FUNCTION right(textset, textset)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(date, dateset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Right_value_set'
+  AS 'MODULE_PATHNAME', 'After_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(dateset, date)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Right_set_value'
+  AS 'MODULE_PATHNAME', 'After_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(dateset, dateset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Right_set_set'
+  AS 'MODULE_PATHNAME', 'After_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(timestamptz, tstzset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Right_value_set'
+  AS 'MODULE_PATHNAME', 'After_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(tstzset, timestamptz)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Right_set_value'
+  AS 'MODULE_PATHNAME', 'After_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(tstzset, tstzset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Right_set_set'
+  AS 'MODULE_PATHNAME', 'After_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR >> (
@@ -744,27 +744,27 @@ CREATE FUNCTION overleft(textset, textset)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(date, dateset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overleft_value_set'
+  AS 'MODULE_PATHNAME', 'Overbefore_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(dateset, date)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overleft_set_value'
+  AS 'MODULE_PATHNAME', 'Overbefore_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(dateset, dateset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overleft_set_set'
+  AS 'MODULE_PATHNAME', 'Overbefore_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(timestamptz, tstzset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overleft_value_set'
+  AS 'MODULE_PATHNAME', 'Overbefore_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(tstzset, timestamptz)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overleft_set_value'
+  AS 'MODULE_PATHNAME', 'Overbefore_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(tstzset, tstzset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overleft_set_set'
+  AS 'MODULE_PATHNAME', 'Overbefore_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR &< (
@@ -907,27 +907,27 @@ CREATE FUNCTION overright(textset, textset)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(date, dateset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overright_value_set'
+  AS 'MODULE_PATHNAME', 'Overafter_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(dateset, date)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overright_set_value'
+  AS 'MODULE_PATHNAME', 'Overafter_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(dateset, dateset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overright_set_set'
+  AS 'MODULE_PATHNAME', 'Overafter_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(timestamptz, tstzset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overright_value_set'
+  AS 'MODULE_PATHNAME', 'Overafter_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(tstzset, timestamptz)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overright_set_value'
+  AS 'MODULE_PATHNAME', 'Overafter_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(tstzset, tstzset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overright_set_set'
+  AS 'MODULE_PATHNAME', 'Overafter_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR &> (

--- a/mobilitydb/sql/temporal/005_span_ops.in.sql
+++ b/mobilitydb/sql/temporal/005_span_ops.in.sql
@@ -584,15 +584,15 @@ CREATE OPERATOR << (
 
 CREATE FUNCTION before(date, datespan)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Left_value_span'
+  AS 'MODULE_PATHNAME', 'Before_value_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(datespan, date)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Left_span_value'
+  AS 'MODULE_PATHNAME', 'Before_span_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(datespan, datespan)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Left_span_span'
+  AS 'MODULE_PATHNAME', 'Before_span_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <<# (
@@ -616,15 +616,15 @@ CREATE OPERATOR <<# (
 
 CREATE FUNCTION before(timestamptz, tstzspan)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Left_value_span'
+  AS 'MODULE_PATHNAME', 'Before_value_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(tstzspan, timestamptz)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Left_span_value'
+  AS 'MODULE_PATHNAME', 'Before_span_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(tstzspan, tstzspan)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Left_span_span'
+  AS 'MODULE_PATHNAME', 'Before_span_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <<# (
@@ -746,15 +746,15 @@ CREATE OPERATOR >> (
 
 CREATE FUNCTION after(date, datespan)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Right_value_span'
+  AS 'MODULE_PATHNAME', 'After_value_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(datespan, date)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Right_span_value'
+  AS 'MODULE_PATHNAME', 'After_span_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(datespan, datespan)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Right_span_span'
+  AS 'MODULE_PATHNAME', 'After_span_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR #>> (
@@ -778,15 +778,15 @@ CREATE OPERATOR #>> (
 
 CREATE FUNCTION after(timestamptz, tstzspan)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Right_value_span'
+  AS 'MODULE_PATHNAME', 'After_value_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(tstzspan, timestamptz)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Right_span_value'
+  AS 'MODULE_PATHNAME', 'After_span_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(tstzspan, tstzspan)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Right_span_span'
+  AS 'MODULE_PATHNAME', 'After_span_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR #>> (
@@ -899,15 +899,15 @@ CREATE OPERATOR &< (
 
 CREATE FUNCTION overbefore(date, datespan)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overleft_value_span'
+  AS 'MODULE_PATHNAME', 'Overbefore_value_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(datespan, date)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overleft_span_value'
+  AS 'MODULE_PATHNAME', 'Overbefore_span_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(datespan, datespan)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overleft_span_span'
+  AS 'MODULE_PATHNAME', 'Overbefore_span_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR &<# (
@@ -928,15 +928,15 @@ CREATE OPERATOR &<# (
 
 CREATE FUNCTION overbefore(timestamptz, tstzspan)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overleft_value_span'
+  AS 'MODULE_PATHNAME', 'Overbefore_value_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(tstzspan, timestamptz)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overleft_span_value'
+  AS 'MODULE_PATHNAME', 'Overbefore_span_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(tstzspan, tstzspan)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overleft_span_span'
+  AS 'MODULE_PATHNAME', 'Overbefore_span_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR &<# (
@@ -1046,15 +1046,15 @@ CREATE OPERATOR &> (
 
 CREATE FUNCTION overafter(date, datespan)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overright_value_span'
+  AS 'MODULE_PATHNAME', 'Overafter_value_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(datespan, date)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overright_span_value'
+  AS 'MODULE_PATHNAME', 'Overafter_span_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(datespan, datespan)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overright_span_span'
+  AS 'MODULE_PATHNAME', 'Overafter_span_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR #&> (
@@ -1075,15 +1075,15 @@ CREATE OPERATOR #&> (
 
 CREATE FUNCTION overafter(timestamptz, tstzspan)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overright_value_span'
+  AS 'MODULE_PATHNAME', 'Overafter_value_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(tstzspan, timestamptz)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overright_span_value'
+  AS 'MODULE_PATHNAME', 'Overafter_span_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(tstzspan, tstzspan)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overright_span_span'
+  AS 'MODULE_PATHNAME', 'Overafter_span_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR #&> (

--- a/mobilitydb/sql/temporal/009_spanset_ops.in.sql
+++ b/mobilitydb/sql/temporal/009_spanset_ops.in.sql
@@ -801,23 +801,23 @@ CREATE OPERATOR << (
 
 CREATE FUNCTION before(date, datespanset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Left_value_spanset'
+  AS 'MODULE_PATHNAME', 'Before_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(datespan, datespanset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Left_span_spanset'
+  AS 'MODULE_PATHNAME', 'Before_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(datespanset, date)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Left_spanset_value'
+  AS 'MODULE_PATHNAME', 'Before_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(datespanset, datespan)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Left_spanset_span'
+  AS 'MODULE_PATHNAME', 'Before_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(datespanset, datespanset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Left_spanset_spanset'
+  AS 'MODULE_PATHNAME', 'Before_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <<# (
@@ -853,23 +853,23 @@ CREATE OPERATOR <<# (
 
 CREATE FUNCTION before(timestamptz, tstzspanset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Left_value_spanset'
+  AS 'MODULE_PATHNAME', 'Before_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(tstzspan, tstzspanset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Left_span_spanset'
+  AS 'MODULE_PATHNAME', 'Before_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(tstzspanset, timestamptz)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Left_spanset_value'
+  AS 'MODULE_PATHNAME', 'Before_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(tstzspanset, tstzspan)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Left_spanset_span'
+  AS 'MODULE_PATHNAME', 'Before_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(tstzspanset, tstzspanset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Left_spanset_spanset'
+  AS 'MODULE_PATHNAME', 'Before_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <<# (
@@ -1063,23 +1063,23 @@ CREATE OPERATOR >> (
 
 CREATE FUNCTION after(date, datespanset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Right_value_spanset'
+  AS 'MODULE_PATHNAME', 'After_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(datespan, datespanset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Right_span_spanset'
+  AS 'MODULE_PATHNAME', 'After_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(datespanset, date)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Right_spanset_value'
+  AS 'MODULE_PATHNAME', 'After_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(datespanset, datespan)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Right_spanset_span'
+  AS 'MODULE_PATHNAME', 'After_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(datespanset, datespanset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Right_spanset_spanset'
+  AS 'MODULE_PATHNAME', 'After_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR #>> (
@@ -1115,23 +1115,23 @@ CREATE OPERATOR #>> (
 
 CREATE FUNCTION after(timestamptz, tstzspanset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Right_value_spanset'
+  AS 'MODULE_PATHNAME', 'After_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(tstzspan, tstzspanset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Right_span_spanset'
+  AS 'MODULE_PATHNAME', 'After_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(tstzspanset, timestamptz)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Right_spanset_value'
+  AS 'MODULE_PATHNAME', 'After_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(tstzspanset, tstzspan)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Right_spanset_span'
+  AS 'MODULE_PATHNAME', 'After_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(tstzspanset, tstzspanset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Right_spanset_spanset'
+  AS 'MODULE_PATHNAME', 'After_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR #>> (
@@ -1310,23 +1310,23 @@ CREATE OPERATOR &< (
 
 CREATE FUNCTION overbefore(date, datespanset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overleft_value_spanset'
+  AS 'MODULE_PATHNAME', 'Overbefore_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(datespan, datespanset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overleft_span_spanset'
+  AS 'MODULE_PATHNAME', 'Overbefore_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(datespanset, date)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overleft_spanset_value'
+  AS 'MODULE_PATHNAME', 'Overbefore_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(datespanset, datespan)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overleft_spanset_span'
+  AS 'MODULE_PATHNAME', 'Overbefore_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(datespanset, datespanset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overleft_spanset_spanset'
+  AS 'MODULE_PATHNAME', 'Overbefore_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR &<# (
@@ -1357,23 +1357,23 @@ CREATE OPERATOR &<# (
 
 CREATE FUNCTION overbefore(timestamptz, tstzspanset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overleft_value_spanset'
+  AS 'MODULE_PATHNAME', 'Overbefore_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(tstzspan, tstzspanset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overleft_span_spanset'
+  AS 'MODULE_PATHNAME', 'Overbefore_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(tstzspanset, timestamptz)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overleft_spanset_value'
+  AS 'MODULE_PATHNAME', 'Overbefore_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(tstzspanset, tstzspan)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overleft_spanset_span'
+  AS 'MODULE_PATHNAME', 'Overbefore_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(tstzspanset, tstzspanset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overleft_spanset_spanset'
+  AS 'MODULE_PATHNAME', 'Overbefore_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR &<# (
@@ -1547,23 +1547,23 @@ CREATE OPERATOR &> (
 
 CREATE FUNCTION overafter(date, datespanset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overright_value_spanset'
+  AS 'MODULE_PATHNAME', 'Overafter_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(datespan, datespanset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overright_span_spanset'
+  AS 'MODULE_PATHNAME', 'Overafter_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(datespanset, date)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overright_spanset_value'
+  AS 'MODULE_PATHNAME', 'Overafter_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(datespanset, datespan)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overright_spanset_span'
+  AS 'MODULE_PATHNAME', 'Overafter_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(datespanset, datespanset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overright_spanset_spanset'
+  AS 'MODULE_PATHNAME', 'Overafter_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR #&> (
@@ -1594,23 +1594,23 @@ CREATE OPERATOR #&> (
 
 CREATE FUNCTION overafter(timestamptz, tstzspanset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overright_value_spanset'
+  AS 'MODULE_PATHNAME', 'Overafter_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(tstzspan, tstzspanset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overright_span_spanset'
+  AS 'MODULE_PATHNAME', 'Overafter_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(tstzspanset, timestamptz)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overright_spanset_value'
+  AS 'MODULE_PATHNAME', 'Overafter_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(tstzspanset, tstzspan)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overright_spanset_span'
+  AS 'MODULE_PATHNAME', 'Overafter_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(tstzspanset, tstzspanset)
   RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overright_spanset_spanset'
+  AS 'MODULE_PATHNAME', 'Overafter_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR #&> (

--- a/mobilitydb/src/temporal/set_ops.c
+++ b/mobilitydb/src/temporal/set_ops.c
@@ -619,3 +619,206 @@ Distance_set_set(PG_FUNCTION_ARGS)
 }
 
 /******************************************************************************/
+
+/*****************************************************************************
+ * Time-axis names for the relative position operators
+ *
+ * A 1-D span/set is ordered on a single axis, so its "before/after" (time)
+ * relation is the same bound comparison as its "left/right" (value) relation
+ * and reuses the value wrapper's code.  Each time-axis SQL name nonetheless
+ * needs its OWN wrapper carrying the matching @sqlfn/@sqlop, so the catalog
+ * (which maps one wrapper -> one SQL name) resolves before/after rather than
+ * folding them onto left/right.
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Before_set_set(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Before_set_set);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if the first set is before the second one
+ * @sqlfn before()
+ * @sqlop @p <<#
+ * @note Time-axis name for the same 1-D bound comparison as #Left_set_set; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Before_set_set(PG_FUNCTION_ARGS)
+{
+  return Left_set_set(fcinfo);
+}
+
+PGDLLEXPORT Datum After_set_set(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(After_set_set);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if the first set is after the second one
+ * @sqlfn after()
+ * @sqlop @p #>>
+ * @note Time-axis name for the same 1-D bound comparison as #Right_set_set; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+After_set_set(PG_FUNCTION_ARGS)
+{
+  return Right_set_set(fcinfo);
+}
+
+PGDLLEXPORT Datum Overbefore_set_set(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Overbefore_set_set);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if the first set is not after the second one
+ * @sqlfn overbefore()
+ * @sqlop @p &<#
+ * @note Time-axis name for the same 1-D bound comparison as #Overleft_set_set; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Overbefore_set_set(PG_FUNCTION_ARGS)
+{
+  return Overleft_set_set(fcinfo);
+}
+
+PGDLLEXPORT Datum Overafter_set_set(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Overafter_set_set);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if the first set is not before the second one
+ * @sqlfn overafter()
+ * @sqlop @p #&>
+ * @note Time-axis name for the same 1-D bound comparison as #Overright_set_set; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Overafter_set_set(PG_FUNCTION_ARGS)
+{
+  return Overright_set_set(fcinfo);
+}
+
+PGDLLEXPORT Datum Before_set_value(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Before_set_value);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a set is before a value
+ * @sqlfn before()
+ * @sqlop @p <<#
+ * @note Time-axis name for the same 1-D bound comparison as #Left_set_value; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Before_set_value(PG_FUNCTION_ARGS)
+{
+  return Left_set_value(fcinfo);
+}
+
+PGDLLEXPORT Datum After_set_value(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(After_set_value);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a set is after a value
+ * @sqlfn after()
+ * @sqlop @p #>>
+ * @note Time-axis name for the same 1-D bound comparison as #Right_set_value; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+After_set_value(PG_FUNCTION_ARGS)
+{
+  return Right_set_value(fcinfo);
+}
+
+PGDLLEXPORT Datum Overbefore_set_value(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Overbefore_set_value);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a set is not after a value
+ * @sqlfn overbefore()
+ * @sqlop @p &<#
+ * @note Time-axis name for the same 1-D bound comparison as #Overleft_set_value; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Overbefore_set_value(PG_FUNCTION_ARGS)
+{
+  return Overleft_set_value(fcinfo);
+}
+
+PGDLLEXPORT Datum Overafter_set_value(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Overafter_set_value);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a set is not before a value
+ * @sqlfn overafter()
+ * @sqlop @p #&>
+ * @note Time-axis name for the same 1-D bound comparison as #Overright_set_value; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Overafter_set_value(PG_FUNCTION_ARGS)
+{
+  return Overright_set_value(fcinfo);
+}
+
+PGDLLEXPORT Datum Before_value_set(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Before_value_set);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a value is before a set
+ * @sqlfn before()
+ * @sqlop @p <<#
+ * @note Time-axis name for the same 1-D bound comparison as #Left_value_set; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Before_value_set(PG_FUNCTION_ARGS)
+{
+  return Left_value_set(fcinfo);
+}
+
+PGDLLEXPORT Datum After_value_set(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(After_value_set);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a value is after a set
+ * @sqlfn after()
+ * @sqlop @p #>>
+ * @note Time-axis name for the same 1-D bound comparison as #Right_value_set; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+After_value_set(PG_FUNCTION_ARGS)
+{
+  return Right_value_set(fcinfo);
+}
+
+PGDLLEXPORT Datum Overbefore_value_set(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Overbefore_value_set);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a value is not after a set
+ * @sqlfn overbefore()
+ * @sqlop @p &<#
+ * @note Time-axis name for the same 1-D bound comparison as #Overleft_value_set; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Overbefore_value_set(PG_FUNCTION_ARGS)
+{
+  return Overleft_value_set(fcinfo);
+}
+
+PGDLLEXPORT Datum Overafter_value_set(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Overafter_value_set);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a value is not before a set
+ * @sqlfn overafter()
+ * @sqlop @p #&>
+ * @note Time-axis name for the same 1-D bound comparison as #Overright_value_set; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Overafter_value_set(PG_FUNCTION_ARGS)
+{
+  return Overright_value_set(fcinfo);
+}

--- a/mobilitydb/src/temporal/span_ops.c
+++ b/mobilitydb/src/temporal/span_ops.c
@@ -641,3 +641,206 @@ Distance_span_span(PG_FUNCTION_ARGS)
 }
 
 /******************************************************************************/
+
+/*****************************************************************************
+ * Time-axis names for the relative position operators
+ *
+ * A 1-D span/set is ordered on a single axis, so its "before/after" (time)
+ * relation is the same bound comparison as its "left/right" (value) relation
+ * and reuses the value wrapper's code.  Each time-axis SQL name nonetheless
+ * needs its OWN wrapper carrying the matching @sqlfn/@sqlop, so the catalog
+ * (which maps one wrapper -> one SQL name) resolves before/after rather than
+ * folding them onto left/right.
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Before_span_span(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Before_span_span);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if the first span is before the second one
+ * @sqlfn before()
+ * @sqlop @p <<#
+ * @note Time-axis name for the same 1-D bound comparison as #Left_span_span; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Before_span_span(PG_FUNCTION_ARGS)
+{
+  return Left_span_span(fcinfo);
+}
+
+PGDLLEXPORT Datum After_span_span(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(After_span_span);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if the first span is after the second one
+ * @sqlfn after()
+ * @sqlop @p #>>
+ * @note Time-axis name for the same 1-D bound comparison as #Right_span_span; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+After_span_span(PG_FUNCTION_ARGS)
+{
+  return Right_span_span(fcinfo);
+}
+
+PGDLLEXPORT Datum Overbefore_span_span(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Overbefore_span_span);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if the first span is not after the second one
+ * @sqlfn overbefore()
+ * @sqlop @p &<#
+ * @note Time-axis name for the same 1-D bound comparison as #Overleft_span_span; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Overbefore_span_span(PG_FUNCTION_ARGS)
+{
+  return Overleft_span_span(fcinfo);
+}
+
+PGDLLEXPORT Datum Overafter_span_span(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Overafter_span_span);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if the first span is not before the second one
+ * @sqlfn overafter()
+ * @sqlop @p #&>
+ * @note Time-axis name for the same 1-D bound comparison as #Overright_span_span; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Overafter_span_span(PG_FUNCTION_ARGS)
+{
+  return Overright_span_span(fcinfo);
+}
+
+PGDLLEXPORT Datum Before_span_value(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Before_span_value);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a span is before a value
+ * @sqlfn before()
+ * @sqlop @p <<#
+ * @note Time-axis name for the same 1-D bound comparison as #Left_span_value; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Before_span_value(PG_FUNCTION_ARGS)
+{
+  return Left_span_value(fcinfo);
+}
+
+PGDLLEXPORT Datum After_span_value(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(After_span_value);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a span is after a value
+ * @sqlfn after()
+ * @sqlop @p #>>
+ * @note Time-axis name for the same 1-D bound comparison as #Right_span_value; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+After_span_value(PG_FUNCTION_ARGS)
+{
+  return Right_span_value(fcinfo);
+}
+
+PGDLLEXPORT Datum Overbefore_span_value(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Overbefore_span_value);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a span is not after a value
+ * @sqlfn overbefore()
+ * @sqlop @p &<#
+ * @note Time-axis name for the same 1-D bound comparison as #Overleft_span_value; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Overbefore_span_value(PG_FUNCTION_ARGS)
+{
+  return Overleft_span_value(fcinfo);
+}
+
+PGDLLEXPORT Datum Overafter_span_value(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Overafter_span_value);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a span is not before a value
+ * @sqlfn overafter()
+ * @sqlop @p #&>
+ * @note Time-axis name for the same 1-D bound comparison as #Overright_span_value; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Overafter_span_value(PG_FUNCTION_ARGS)
+{
+  return Overright_span_value(fcinfo);
+}
+
+PGDLLEXPORT Datum Before_value_span(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Before_value_span);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a value is before a span
+ * @sqlfn before()
+ * @sqlop @p <<#
+ * @note Time-axis name for the same 1-D bound comparison as #Left_value_span; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Before_value_span(PG_FUNCTION_ARGS)
+{
+  return Left_value_span(fcinfo);
+}
+
+PGDLLEXPORT Datum After_value_span(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(After_value_span);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a value is after a span
+ * @sqlfn after()
+ * @sqlop @p #>>
+ * @note Time-axis name for the same 1-D bound comparison as #Right_value_span; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+After_value_span(PG_FUNCTION_ARGS)
+{
+  return Right_value_span(fcinfo);
+}
+
+PGDLLEXPORT Datum Overbefore_value_span(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Overbefore_value_span);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a value is not after a span
+ * @sqlfn overbefore()
+ * @sqlop @p &<#
+ * @note Time-axis name for the same 1-D bound comparison as #Overleft_value_span; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Overbefore_value_span(PG_FUNCTION_ARGS)
+{
+  return Overleft_value_span(fcinfo);
+}
+
+PGDLLEXPORT Datum Overafter_value_span(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Overafter_value_span);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a value is not before a span
+ * @sqlfn overafter()
+ * @sqlop @p #&>
+ * @note Time-axis name for the same 1-D bound comparison as #Overright_value_span; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Overafter_value_span(PG_FUNCTION_ARGS)
+{
+  return Overright_value_span(fcinfo);
+}

--- a/mobilitydb/src/temporal/spanset_ops.c
+++ b/mobilitydb/src/temporal/spanset_ops.c
@@ -1087,3 +1087,334 @@ Distance_spanset_spanset(PG_FUNCTION_ARGS)
 }
 
 /******************************************************************************/
+
+/*****************************************************************************
+ * Time-axis names for the relative position operators
+ *
+ * A 1-D span/set is ordered on a single axis, so its "before/after" (time)
+ * relation is the same bound comparison as its "left/right" (value) relation
+ * and reuses the value wrapper's code.  Each time-axis SQL name nonetheless
+ * needs its OWN wrapper carrying the matching @sqlfn/@sqlop, so the catalog
+ * (which maps one wrapper -> one SQL name) resolves before/after rather than
+ * folding them onto left/right.
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Before_span_spanset(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Before_span_spanset);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a span is before a span set
+ * @sqlfn before()
+ * @sqlop @p <<#
+ * @note Time-axis name for the same 1-D bound comparison as #Left_span_spanset; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Before_span_spanset(PG_FUNCTION_ARGS)
+{
+  return Left_span_spanset(fcinfo);
+}
+
+PGDLLEXPORT Datum After_span_spanset(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(After_span_spanset);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a span is after a span set
+ * @sqlfn after()
+ * @sqlop @p #>>
+ * @note Time-axis name for the same 1-D bound comparison as #Right_span_spanset; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+After_span_spanset(PG_FUNCTION_ARGS)
+{
+  return Right_span_spanset(fcinfo);
+}
+
+PGDLLEXPORT Datum Overbefore_span_spanset(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Overbefore_span_spanset);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a span is not after a span set
+ * @sqlfn overbefore()
+ * @sqlop @p &<#
+ * @note Time-axis name for the same 1-D bound comparison as #Overleft_span_spanset; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Overbefore_span_spanset(PG_FUNCTION_ARGS)
+{
+  return Overleft_span_spanset(fcinfo);
+}
+
+PGDLLEXPORT Datum Overafter_span_spanset(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Overafter_span_spanset);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a span is not before a span set
+ * @sqlfn overafter()
+ * @sqlop @p #&>
+ * @note Time-axis name for the same 1-D bound comparison as #Overright_span_spanset; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Overafter_span_spanset(PG_FUNCTION_ARGS)
+{
+  return Overright_span_spanset(fcinfo);
+}
+
+PGDLLEXPORT Datum Before_spanset_span(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Before_spanset_span);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a span set is before a span
+ * @sqlfn before()
+ * @sqlop @p <<#
+ * @note Time-axis name for the same 1-D bound comparison as #Left_spanset_span; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Before_spanset_span(PG_FUNCTION_ARGS)
+{
+  return Left_spanset_span(fcinfo);
+}
+
+PGDLLEXPORT Datum After_spanset_span(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(After_spanset_span);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a span set is after a span
+ * @sqlfn after()
+ * @sqlop @p #>>
+ * @note Time-axis name for the same 1-D bound comparison as #Right_spanset_span; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+After_spanset_span(PG_FUNCTION_ARGS)
+{
+  return Right_spanset_span(fcinfo);
+}
+
+PGDLLEXPORT Datum Overbefore_spanset_span(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Overbefore_spanset_span);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a span set is not after a span
+ * @sqlfn overbefore()
+ * @sqlop @p &<#
+ * @note Time-axis name for the same 1-D bound comparison as #Overleft_spanset_span; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Overbefore_spanset_span(PG_FUNCTION_ARGS)
+{
+  return Overleft_spanset_span(fcinfo);
+}
+
+PGDLLEXPORT Datum Overafter_spanset_span(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Overafter_spanset_span);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a span set is not before a span
+ * @sqlfn overafter()
+ * @sqlop @p #&>
+ * @note Time-axis name for the same 1-D bound comparison as #Overright_spanset_span; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Overafter_spanset_span(PG_FUNCTION_ARGS)
+{
+  return Overright_spanset_span(fcinfo);
+}
+
+PGDLLEXPORT Datum Before_spanset_value(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Before_spanset_value);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a span set is before a value
+ * @sqlfn before()
+ * @sqlop @p <<#
+ * @note Time-axis name for the same 1-D bound comparison as #Left_spanset_value; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Before_spanset_value(PG_FUNCTION_ARGS)
+{
+  return Left_spanset_value(fcinfo);
+}
+
+PGDLLEXPORT Datum After_spanset_value(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(After_spanset_value);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a span set is after a value
+ * @sqlfn after()
+ * @sqlop @p #>>
+ * @note Time-axis name for the same 1-D bound comparison as #Right_spanset_value; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+After_spanset_value(PG_FUNCTION_ARGS)
+{
+  return Right_spanset_value(fcinfo);
+}
+
+PGDLLEXPORT Datum Overbefore_spanset_value(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Overbefore_spanset_value);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a span set is not after a value
+ * @sqlfn overbefore()
+ * @sqlop @p &<#
+ * @note Time-axis name for the same 1-D bound comparison as #Overleft_spanset_value; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Overbefore_spanset_value(PG_FUNCTION_ARGS)
+{
+  return Overleft_spanset_value(fcinfo);
+}
+
+PGDLLEXPORT Datum Overafter_spanset_value(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Overafter_spanset_value);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a span set is not before a value
+ * @sqlfn overafter()
+ * @sqlop @p #&>
+ * @note Time-axis name for the same 1-D bound comparison as #Overright_spanset_value; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Overafter_spanset_value(PG_FUNCTION_ARGS)
+{
+  return Overright_spanset_value(fcinfo);
+}
+
+PGDLLEXPORT Datum Before_value_spanset(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Before_value_spanset);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a value is before a span set
+ * @sqlfn before()
+ * @sqlop @p <<#
+ * @note Time-axis name for the same 1-D bound comparison as #Left_value_spanset; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Before_value_spanset(PG_FUNCTION_ARGS)
+{
+  return Left_value_spanset(fcinfo);
+}
+
+PGDLLEXPORT Datum After_value_spanset(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(After_value_spanset);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a value is after a span set
+ * @sqlfn after()
+ * @sqlop @p #>>
+ * @note Time-axis name for the same 1-D bound comparison as #Right_value_spanset; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+After_value_spanset(PG_FUNCTION_ARGS)
+{
+  return Right_value_spanset(fcinfo);
+}
+
+PGDLLEXPORT Datum Overbefore_value_spanset(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Overbefore_value_spanset);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a value is not after a span set
+ * @sqlfn overbefore()
+ * @sqlop @p &<#
+ * @note Time-axis name for the same 1-D bound comparison as #Overleft_value_spanset; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Overbefore_value_spanset(PG_FUNCTION_ARGS)
+{
+  return Overleft_value_spanset(fcinfo);
+}
+
+PGDLLEXPORT Datum Overafter_value_spanset(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Overafter_value_spanset);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if a value is not before a span set
+ * @sqlfn overafter()
+ * @sqlop @p #&>
+ * @note Time-axis name for the same 1-D bound comparison as #Overright_value_spanset; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Overafter_value_spanset(PG_FUNCTION_ARGS)
+{
+  return Overright_value_spanset(fcinfo);
+}
+
+PGDLLEXPORT Datum Before_spanset_spanset(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Before_spanset_spanset);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if the first span set is before the second one
+ * @sqlfn before()
+ * @sqlop @p <<#
+ * @note Time-axis name for the same 1-D bound comparison as #Left_spanset_spanset; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Before_spanset_spanset(PG_FUNCTION_ARGS)
+{
+  return Left_spanset_spanset(fcinfo);
+}
+
+PGDLLEXPORT Datum After_spanset_spanset(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(After_spanset_spanset);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if the first span set is after the second one
+ * @sqlfn after()
+ * @sqlop @p #>>
+ * @note Time-axis name for the same 1-D bound comparison as #Right_spanset_spanset; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+After_spanset_spanset(PG_FUNCTION_ARGS)
+{
+  return Right_spanset_spanset(fcinfo);
+}
+
+PGDLLEXPORT Datum Overbefore_spanset_spanset(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Overbefore_spanset_spanset);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if the first span set is not after the second one
+ * @sqlfn overbefore()
+ * @sqlop @p &<#
+ * @note Time-axis name for the same 1-D bound comparison as #Overleft_spanset_spanset; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Overbefore_spanset_spanset(PG_FUNCTION_ARGS)
+{
+  return Overleft_spanset_spanset(fcinfo);
+}
+
+PGDLLEXPORT Datum Overafter_spanset_spanset(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Overafter_spanset_spanset);
+/**
+ * @ingroup mobilitydb_setspan_pos
+ * @brief Return true if the first span set is not before the second one
+ * @sqlfn overafter()
+ * @sqlop @p #&>
+ * @note Time-axis name for the same 1-D bound comparison as #Overright_spanset_spanset; a distinct
+ * wrapper so the SQL name/operator resolve correctly in the generated catalog.
+ */
+Datum
+Overafter_spanset_spanset(PG_FUNCTION_ARGS)
+{
+  return Overright_spanset_spanset(fcinfo);
+}


### PR DESCRIPTION
The relative-position operators on 1-D spans and sets expose two SQL names per bound comparison: the value axis (`left`/`right`/`overleft`/`overright`, `<<`/`>>`/`&<`/`&>`) and the time axis (`before`/`after`/`overbefore`/`overafter`, `<<#`/`#>>`/`&<#`/`#&>`). Both reuse the same underlying comparison, and the time-axis SQL functions were bound to the value wrapper — e.g.

```
CREATE FUNCTION before(tstzspan, timestamptz) ... AS 'MODULE_PATHNAME', 'Left_span_value'
```

whose doxygen carries a single `@sqlfn left()` / `@sqlop @p <<`. One wrapper backing two SQL names means the generated MEOS-API catalog resolves every time-axis function to the *value* name/operator, so a downstream binding emits `left(tstzspan, ...)` instead of `before(tstzspan, ...)`.

This adds a dedicated thin forwarder wrapper per time-axis name (`Before_`/`After_`/`Overbefore_`/`Overafter_*`), each forwarding to its value sibling and carrying the matching `@sqlfn`/`@sqlop`; rebinds the 88 time-axis `CREATE FUNCTION`s in `002_set_ops`/`005_span_ops`/`009_spanset_ops` to them; and repoints the `@csqlfn` of the 48 time-axis MEOS-C functions to the new wrappers.

Behaviour is unchanged — the forwarders call the same code; only the SQL name/operator resolution is corrected. libmeos and the extension compile clean and the regression suite passes with no diffs.
