### PR TITLE
Short-circuit the tcbuffer touches predicates by bounding box

### DIFF
--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -1380,6 +1380,15 @@ ea_touches_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
   VALIDATE_TCBUFFER(temp, -1); VALIDATE_NOT_NULL(gs, -1);
   if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
     return -1;
+  /* Bounding box test: a moving disk whose radius-aware bounding box is
+   * disjoint from the geometry never reaches it, so it cannot touch. This is a
+   * constant-time reject that avoids the analytic nearest-approach distance
+   * below for the common case of far-away pairs in a spatial join. */
+  STBox box1, box2;
+  tspatial_set_stbox(temp, &box1);
+  geo_set_stbox(gs, &box2);
+  if (! overlaps_stbox_stbox(&box1, &box2))
+    return 0;
   /* Touch requires the temporal value and the geometry to be at distance
    * zero; a strictly positive exact nearest-approach distance means they
    * are disjoint, so they cannot touch under either quantifier. This is

--- a/meos/src/cbuffer/tcbuffer_tempspatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_tempspatialrels.c
@@ -1742,6 +1742,14 @@ ttouches_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
   if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
     return NULL;
 
+  /* Bounding box test: a moving disk whose radius-aware bounding box is
+   * disjoint from the geometry never reaches it, so it never touches */
+  STBox box1, box2;
+  tspatial_set_stbox(temp, &box1);
+  geo_set_stbox(gs, &box2);
+  if (! overlaps_stbox_stbox(&box1, &box2))
+    return temporal_from_base_temp(BoolGetDatum(false), T_TBOOL, temp);
+
   /* Native GEOS-free path for non-curved geometry: the moving-disk boundary
    * contact instants. Curved or unsupported geometry keeps the traversed-area
    * path. */


### PR DESCRIPTION
The temporal (`tTouches`), ever (`eTouches`), and always (`aTouches`) touches predicates of a temporal circular buffer against a geometry did their full work for every pair, even when the moving disk is nowhere near the geometry:

- `tTouches` solved the per-segment boundary-contact roots against every geometry edge.
- `eTouches`/`aTouches` computed the exact analytic nearest-approach distance.

In a spatial join most pairs are far apart, so this dominates the cost. The intersects and disjoint predicates already guard their kernels with a constant-time bounding-box reject (`tinterrel_tcbuffer_geo`); the touches predicates simply lacked the equivalent.

A moving disk whose radius-aware bounding box is disjoint from the geometry can never reach it, so it never touches. This adds the same reject:

- `ttouches_tcbuffer_geo` returns the all-false temporal directly.
- `ea_touches_tcbuffer_geo` returns 0 before the nearest-approach distance — exactly what that distance would then decide.

The results are unchanged (the `212_tcbuffer_spatialrels` / `214_tcbuffer_tempspatialrels` expected outputs are untouched); only far-away pairs are decided earlier.

Measured on the AIS `VesselTrip` × `NaturalAreas` POC (buffers vs multipolygons, ~19 of 1000 join pairs actually overlap by bounding box):

| predicate | before | after |
|---|---|---|
| `tTouches` | ~16.5 s | ~0.22 s |
| `eTouches` | ~1.09 s | ~0.21 s |
| `aTouches` | ~1.10 s | ~0.20 s |