### PR TITLE
Declare each public family symbol once in its umbrella header

### DIFF
--- a/meos/include/cbuffer/cbuffer.h
+++ b/meos/include/cbuffer/cbuffer.h
@@ -117,13 +117,6 @@ extern int cbuffer_intersects(const Cbuffer *cb1, const Cbuffer *cb2);
 extern int cbuffer_dwithin(const Cbuffer *cb1, const Cbuffer *cb2, double dist);
 extern int cbuffer_touches(const Cbuffer *cb1, const Cbuffer *cb2);
 
-extern int contains_cbuffer_cbuffer(const Cbuffer *cb1, const Cbuffer *cb2);
-extern int covers_cbuffer_cbuffer(const Cbuffer *cb1, const Cbuffer *cb2);
-extern int disjoint_cbuffer_cbuffer(const Cbuffer *cb1, const Cbuffer *cb2);
-extern int intersects_cbuffer_cbuffer(const Cbuffer *cb1, const Cbuffer *cb2);
-extern int dwithin_cbuffer_cbuffer(const Cbuffer *cb1, const Cbuffer *cb2, double dist);
-extern int touches_cbuffer_cbuffer(const Cbuffer *cb1, const Cbuffer *cb2);
-
 extern Datum datum_cbuffer_contains(Datum cb1, Datum cb2);
 extern Datum datum_cbuffer_covers(Datum cb1, Datum cb2);
 extern Datum datum_cbuffer_disjoint(Datum cb1, Datum cb2);

--- a/meos/include/cbuffer/tcbuffer_spatialrels.h
+++ b/meos/include/cbuffer/tcbuffer_spatialrels.h
@@ -99,10 +99,6 @@ extern int ea_touches_tcbuffer_tcbuffer(const Temporal *temp1,
 
 extern int ea_dwithin_tcbuffer_tcbuffer(const Temporal *temp1,
   const Temporal *temp2, double dist, bool ever);
-extern int edwithin_tcbuffer_tcbuffer(const Temporal *temp1,
-  const Temporal *temp2, double dist);
-extern int adwithin_tcbuffer_tcbuffer(const Temporal *temp1, 
-  const Temporal *temp2, double dist);
 
 /*****************************************************************************/
 

--- a/meos/include/h3/h3index.h
+++ b/meos/include/h3/h3index.h
@@ -52,6 +52,8 @@
 /* PostgreSQL — for Datum / Int64GetDatum / DatumGetInt64 */
 #include <postgres.h>
 #include <h3api.h>
+/* MEOS — public h3index declarations (I/O, comparison, hashing) */
+#include <meos_h3.h>
 
 /*****************************************************************************
  * Datum packing
@@ -63,46 +65,5 @@
 
 #define DatumGetH3Index(X)   ((H3Index) DatumGetInt64(X))
 #define H3IndexGetDatum(X)   Int64GetDatum((int64) (X))
-
-/*****************************************************************************
- * Parsing / formatting
- *****************************************************************************/
-
-/**
- * Parse a string into an H3Index. Accepts:
- *   * a decimal integer literal (e.g. "590464338553208831"),
- *   * a hex string with no prefix (e.g. "8a2a1072b59ffff"), the
- *     canonical h3-pg form,
- *   * a hex string with the "0x" prefix (e.g. "0x8a2a1072b59ffff").
- *
- * Returns the parsed cell on success. Raises `meos_error(ERROR, …)`
- * on malformed input or on a value that does not encode a valid H3
- * cell (libh3's `isValidCell`).
- */
-extern H3Index h3index_in(const char *str);
-
-/**
- * Format an H3Index into its canonical hex string (lowercase, no
- * "0x" prefix, no leading zeros — matches h3-pg's output). The
- * caller owns the returned `palloc`'d C string.
- */
-extern char *h3index_out(H3Index cell);
-
-/*****************************************************************************
- * Comparison / ordering / hashing
- *
- * H3 cell identifiers are uint64; ordering and equality fall through
- * to plain int64 bit-compare — they carry no geographic meaning but
- * are required for btree indexing, ORDER BY, GROUP BY, DISTINCT, etc.
- *****************************************************************************/
-
-extern bool h3index_eq(H3Index a, H3Index b);
-extern bool h3index_ne(H3Index a, H3Index b);
-extern bool h3index_lt(H3Index a, H3Index b);
-extern bool h3index_le(H3Index a, H3Index b);
-extern bool h3index_gt(H3Index a, H3Index b);
-extern bool h3index_ge(H3Index a, H3Index b);
-extern int h3index_cmp(H3Index a, H3Index b);
-extern uint32 h3index_hash(H3Index cell);
 
 #endif /* __H3INDEX_H__ */

--- a/meos/include/h3/h3index_sets.h
+++ b/meos/include/h3/h3index_sets.h
@@ -57,6 +57,7 @@
 #include <h3api.h>
 /* MEOS */
 #include <meos.h>  /* Set typedef */
+#include <meos_h3.h>  /* public h3 cell-set declarations */
 #include "temporal/meos_catalog.h"
 
 /*****************************************************************************
@@ -66,12 +67,6 @@
  * owns the return. NULL is returned on libh3 failure after raising
  * a `meos_error`.
  *****************************************************************************/
-
-/**
- * Return all cells within `k` grid steps of `origin` (including
- * `origin` itself at k=0).
- */
-extern Set *h3_grid_disk(H3Index origin, int k);
 
 /**
  * Return all cells at exactly `k` grid steps from `origin`.
@@ -84,24 +79,6 @@ extern Set *h3_grid_ring(H3Index origin, int k);
  * Fails on non-comparable resolutions or paths crossing pentagons.
  */
 extern Set *h3_grid_path_cells(H3Index start, H3Index end);
-
-/**
- * Return all children of `origin` at resolution `childRes`.
- */
-extern Set *h3_cell_to_children(H3Index origin, int childRes);
-
-/**
- * Return the compacted representation of `cells` (finer cells
- * merged up into parents where the full hexagonal set of siblings
- * is present).
- */
-extern Set *h3_compact_cells(const Set *cells);
-
-/**
- * Return the uncompacted representation of `cells` at resolution
- * `res` (fails if any input is finer than `res`).
- */
-extern Set *h3_uncompact_cells(const Set *cells, int res);
 
 /**
  * Return all outgoing directed edges of `origin` (up to 6;

--- a/meos/include/h3/th3index_internal.h
+++ b/meos/include/h3/th3index_internal.h
@@ -61,6 +61,7 @@
 #include <h3api.h>
 #include <liblwgeom.h>
 #include <meos.h>
+#include <meos_h3.h>  /* public h3 geometry-conversion declarations */
 
 /*****************************************************************************
  * Shared metrics enum
@@ -83,8 +84,6 @@ typedef enum
  *****************************************************************************/
 
 /* Point / polygon conversions — bodies in th3index_latlng.c. */
-extern H3Index h3_gs_point_to_cell(const GSERIALIZED *point,
-  int32 resolution);
 extern GSERIALIZED *h3_cell_to_gs_point(H3Index cell);
 extern GSERIALIZED *h3_cell_to_gs_boundary(H3Index cell);
 

--- a/meos/include/meos_h3.h
+++ b/meos/include/meos_h3.h
@@ -70,14 +70,33 @@
  *****************************************************************************/
 
 /* Input and output */
+
+/**
+ * Parse a string into an H3Index. Accepts a decimal integer literal,
+ * a bare hex string (the canonical h3-pg form), or a hex string with
+ * a "0x" prefix. Returns the parsed cell on success; raises
+ * `meos_error(ERROR, ...)` on malformed input or on a value that does
+ * not encode a valid H3 cell (libh3's `isValidCell`).
+ */
 extern H3Index h3index_in(const char *str);
+
+/**
+ * Format an H3Index into its canonical hex string (lowercase, no
+ * "0x" prefix, no leading zeros, matching h3-pg's output). The caller
+ * owns the returned `palloc`'d C string.
+ */
 extern char *h3index_out(H3Index cell);
 extern H3Index h3index_from_wkb(const uint8_t *wkb, size_t size);
 extern H3Index h3index_from_hexwkb(const char *hexwkb);
 extern uint8_t *h3index_as_wkb(H3Index cell, uint8_t variant, size_t *size_out);
 extern char *h3index_as_hexwkb(H3Index cell, uint8_t variant, size_t *size_out);
 
-/* Comparisons */
+/*
+ * Comparison / ordering / hashing. H3 cell identifiers are uint64;
+ * ordering and equality fall through to plain int64 bit-compare. They
+ * carry no geographic meaning but are required for btree indexing,
+ * ORDER BY, GROUP BY, DISTINCT, etc.
+ */
 extern bool h3index_eq(H3Index a, H3Index b);
 extern bool h3index_ne(H3Index a, H3Index b);
 extern bool h3index_lt(H3Index a, H3Index b);
@@ -87,10 +106,22 @@ extern bool h3index_ge(H3Index a, H3Index b);
 extern int h3index_cmp(H3Index a, H3Index b);
 extern uint32 h3index_hash(H3Index cell);
 
-/* Cell operations */
+/* Cell operations. Each returns a heap-allocated `Set *` owned by the
+ * caller; NULL on libh3 failure after raising a `meos_error`. */
+
+/** Return all cells within `k` grid steps of `origin` (including
+ * `origin` itself at k=0). */
 extern Set *h3_grid_disk(H3Index origin, int k);
+
+/** Return all children of `origin` at resolution `childRes`. */
 extern Set *h3_cell_to_children(H3Index origin, int childRes);
+
+/** Return the compacted representation of `cells` (finer cells merged
+ * up into parents where the full hexagonal set of siblings is present). */
 extern Set *h3_compact_cells(const Set *cells);
+
+/** Return the uncompacted representation of `cells` at resolution `res`
+ * (fails if any input is finer than `res`). */
 extern Set *h3_uncompact_cells(const Set *cells, int res);
 
 /*****************************************************************************

--- a/meos/include/meos_rgeo.h
+++ b/meos/include/meos_rgeo.h
@@ -116,6 +116,8 @@ extern GSERIALIZED *trgeometry_convex_hull(const Temporal *temp);
 extern Temporal *trgeometry_body_point_trajectory(const Temporal *temp, const GSERIALIZED *gs);
 extern STBox *trgeometry_space_boxes(const Temporal *temp, double xsize, double ysize, double zsize, const GSERIALIZED *sorigin, bool bitmatrix, bool border_inc, int *count);
 extern STBox *trgeometry_space_time_boxes(const Temporal *temp, double xsize, double ysize, double zsize, const Interval *duration, const GSERIALIZED *sorigin, TimestampTz torigin, bool bitmatrix, bool border_inc, int *count);
+/* Functions decomposing a temporal rigid geometry into per-instant or
+ * per-segment spatiotemporal boxes */
 extern STBox *trgeometry_stboxes(const Temporal *temp, int *count);
 extern STBox *trgeometry_split_n_stboxes(const Temporal *temp, int box_count, int *count);
 extern STBox *trgeometry_split_each_n_stboxes(const Temporal *temp, int elem_count, int *count);

--- a/meos/include/rgeo/trgeo_boxops.h
+++ b/meos/include/rgeo/trgeo_boxops.h
@@ -38,6 +38,7 @@
 /* Postgres */
 #include <postgres.h>
 /* MEOS */
+#include <meos_rgeo.h>  /* public trgeometry declarations */
 #include "temporal/temporal.h"
 #include "geo/stbox.h"
 
@@ -54,15 +55,6 @@ extern void trgeoinstarr_rotating_stbox(const GSERIALIZED *geom,
   TInstant **instants, int count, STBox *box);
 extern void trgeoinstarr_compute_bbox(const GSERIALIZED *geom,
   TInstant **instants, int count, interpType interp, void *box);
-
-/* Functions decomposing a temporal rigid geometry into per-instant or
- * per-segment spatiotemporal boxes */
-
-extern STBox *trgeometry_stboxes(const Temporal *temp, int *count);
-extern STBox *trgeometry_split_n_stboxes(const Temporal *temp, int box_count,
-  int *count);
-extern STBox *trgeometry_split_each_n_stboxes(const Temporal *temp,
-  int elems_per_box, int *count);
 
 /*****************************************************************************/
 

--- a/meos/include/rgeo/trgeo_spatialfuncs.h
+++ b/meos/include/rgeo/trgeo_spatialfuncs.h
@@ -34,6 +34,7 @@
 #ifndef __TRGEO_SPATIALFUNCS_H__
 #define __TRGEO_SPATIALFUNCS_H__
 
+#include <meos_rgeo.h>  /* public trgeometry declarations */
 #include "temporal/temporal.h"
 #include "geo/stbox.h"
 
@@ -43,18 +44,6 @@ extern Temporal *trgeo_restrict_geom(const Temporal *temp,
   const GSERIALIZED *gs, bool atfunc);
 extern Temporal *trgeo_restrict_stbox(const Temporal *temp, const STBox *box,
   bool border_inc, bool atfunc);
-extern Temporal *trgeometry_centroid(const Temporal *temp);
-extern GSERIALIZED *trgeometry_convex_hull(const Temporal *temp);
-extern Temporal *trgeometry_body_point_trajectory(const Temporal *temp, const GSERIALIZED *gs);
-extern double trgeometry_hausdorff_distance(const Temporal *temp1, const Temporal *temp2);
-extern double trgeometry_frechet_distance(const Temporal *temp1, const Temporal *temp2);
-extern double trgeometry_dyntimewarp_distance(const Temporal *temp1, const Temporal *temp2);
-extern Match *trgeometry_frechet_path(const Temporal *temp1, const Temporal *temp2, int *count);
-extern Match *trgeometry_dyntimewarp_path(const Temporal *temp1, const Temporal *temp2, int *count);
-extern double trgeometry_length(const Temporal *temp);
-extern Temporal *trgeometry_cumulative_length(const Temporal *temp);
-extern Temporal *trgeometry_speed(const Temporal *temp);
-extern GSERIALIZED *trgeometry_twcentroid(const Temporal *temp);
 
 /*****************************************************************************/
 

--- a/meos/include/rgeo/trgeo_spatialrels.h
+++ b/meos/include/rgeo/trgeo_spatialrels.h
@@ -39,6 +39,7 @@
 #include <postgres.h>
 /* PostGIS */
 #include <liblwgeom.h>
+#include <meos_rgeo.h>  /* public trgeometry spatial-relationship declarations */
 /* MEOS */
 #include "temporal/temporal.h"
 #include "pose/pose.h"
@@ -86,8 +87,6 @@ extern int ea_touches_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp,
   bool ever);
 extern int ea_touches_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
   bool ever);
-extern int etouches_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs);
-extern int atouches_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs);
 extern int ea_touches_trgeo_trgeo(const Temporal *temp1,
   const Temporal *temp2, bool ever);
 


### PR DESCRIPTION
## Summary

A number of public MEOS symbols were declared twice: once in their public umbrella header (`meos_<family>.h`, the surface installed by `meos/CMakeLists.txt` and included by bindings) and again in a family-internal implementation header. This PR keeps the single public declaration in the umbrella and removes the redundant copies from the internal headers.

Affected families:

| Umbrella | Internal headers | Redundant declarations removed |
|---|---|---|
| `meos_h3.h` | `h3/h3index.h`, `h3/h3index_sets.h`, `h3/th3index_internal.h` | 15 |
| `meos_cbuffer.h` | `cbuffer/cbuffer.h`, `cbuffer/tcbuffer_spatialrels.h` | 8 |
| `meos_rgeo.h` | `rgeo/trgeo_boxops.h`, `rgeo/trgeo_spatialfuncs.h`, `rgeo/trgeo_spatialrels.h` | 17 |

Each internal header now includes its umbrella header so the declarations its `.c` files consume remain available, and the elaborated per-symbol documentation is kept on the umbrella declaration. Internal-only symbols and macros stay in the internal headers unchanged.

## Verification

- MEOS builds clean with `-DCBUFFER -DPOSE -DRGEO -DH3` (`libmeos.so` links).
- The umbrella include in each internal header is required, not cosmetic: without it the build fails with `implicit declaration of 'h3index_in'` (`type_in.c`) / `'h3index_out'` (`type_out.c`).
- The generated function catalog is unchanged except for header attribution: no function is added or removed, and the only difference is that the 15 h3 symbols are now attributed to `meos_h3.h` rather than an internal header.
