### PR TITLE
Short-circuit native tcbuffer contains and covers by bounding box

### DIFF
--- a/meos/src/cbuffer/tcbuffer_tempspatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_tempspatialrels.c
@@ -1906,6 +1906,17 @@ tcontains_geo_tcbuffer_native(const Temporal *temp, const GSERIALIZED *gs,
   VALIDATE_TCBUFFER(temp, NULL); VALIDATE_NOT_NULL(gs, NULL);
   if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
     return NULL;
+
+  /* Bounding box test: a moving disk whose radius-aware bounding box is
+   * disjoint from the geometry is never inside it, so it never contains/covers.
+   * This constant-time reject avoids the per-segment clearance kernel on the
+   * common non-overlapping case (e.g. a spatial join over disjoint extents) */
+  STBox box1, box2;
+  tspatial_set_stbox(temp, &box1);
+  geo_set_stbox(gs, &box2);
+  if (! overlaps_stbox_stbox(&box1, &box2))
+    return temporal_from_base_temp(BoolGetDatum(false), T_TBOOL, temp);
+
   void *ctx = tcbuffer_geo_ctx_make(gs);
   if (! ctx)
     return NULL;
@@ -2161,6 +2172,20 @@ int
 eacontains_tcbuffer_geo_native(const Temporal *temp, const GSERIALIZED *gs,
   bool ever, bool strict)
 {
+  if (gserialized_is_empty(gs))
+    return -1;
+
+  /* Bounding box test: a moving disk whose radius-aware bounding box is
+   * disjoint from the geometry is never inside it, so it never contains/covers
+   * at any instant. This constant-time reject avoids the per-segment clearance
+   * scan on the common non-overlapping case (e.g. a spatial join over disjoint
+   * extents), giving 0 for both the ever and always semantics */
+  STBox box1, box2;
+  tspatial_set_stbox(temp, &box1);
+  geo_set_stbox(gs, &box2);
+  if (! overlaps_stbox_stbox(&box1, &box2))
+    return 0;
+
   void *ctx = tcbuffer_geo_ctx_make(gs);
   if (! ctx)
     return -1;


### PR DESCRIPTION
The native geometry-contains-tcbuffer path (`tContains`/`tCovers` and their ever/always forms) evaluates a per-segment signed-clearance kernel to locate the exact instants at which a moving disk enters or leaves a geometry. It runs that kernel unconditionally, including for candidate pairs whose extents are far apart.

When the disk trajectory's radius-aware bounding box is disjoint from the geometry, the disk is never inside it, so contains and covers are false over the whole definition time — no kernel evaluation is needed. This adds the constant-time `overlaps_stbox_stbox` reject already used by the touches, intersects, disjoint and dwithin paths:

- `tcontains_geo_tcbuffer_native` returns an all-false temporal on a disjoint bounding box (feeds both `tContains` and `tCovers`);
- `eacontains_tcbuffer_geo_native` returns `0` on a disjoint bounding box for both the ever and always semantics (feeds `eContains`/`aContains`/`eCovers`/`aCovers`).

The reject is exact: it fires only when no instant of the disk can lie inside the geometry, which is precisely the case the kernel would resolve to false. Regression outputs are unchanged.

On a spatial join over disjoint extents, where the large majority of candidate pairs never overlap, this removes the dominant cost. On a moving-disk vs polygon benchmark (VesselTrip × NaturalAreas), the geometry-contains-tcbuffer operators drop from tens of seconds to the same range as the sibling touches operators.
