### PR TITLE
Remove arrowRoundtrip self-check functions from the manual

### DIFF
--- a/doc/box_types.xml
+++ b/doc/box_types.xml
@@ -127,17 +127,6 @@ SELECT stboxFromHexWKB(
 </programlisting>
 				</listitem>
 
-				<listitem xml:id="box_arrowRoundtrip">
-					<indexterm significance="normal"><primary><varname>arrowRoundtrip</varname></primary></indexterm>
-					<para>Convert a temporal or spatiotemporal box to the Arrow C Data Interface and back, returning the reconstructed value</para>
-					<para><varname>arrowRoundtrip(box) → box</varname></para>
-					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT arrowRoundtrip(tbox 'TBOXFLOAT XT([1.5,9.75],[2000-01-01,2000-12-31))');
--- TBOXFLOAT XT([1.5, 9.75],[2000-01-01,2000-12-31))
-SELECT arrowRoundtrip(stbox 'SRID=4326;STBOX XT(((1,1),(5,5)),[2000-01-01,2000-01-05])');
--- SRID=4326;STBOX XT(((1,1),(5,5)),[2000-01-01,2000-01-05])
-</programlisting>
-				</listitem>
 			</itemizedlist>
 	</sect1>
 

--- a/doc/es/box_types.xml
+++ b/doc/es/box_types.xml
@@ -125,17 +125,6 @@ SELECT stboxFromHexWKB(
 </programlisting>
 				</listitem>
 
-				<listitem xml:id="box_arrowRoundtrip">
-					<indexterm significance="normal"><primary><varname>arrowRoundtrip</varname></primary></indexterm>
-					<para>Convierte una caja temporal o espaciotemporal a la interfaz Arrow C Data Interface y de vuelta, devolviendo el valor reconstruido</para>
-					<para><varname>arrowRoundtrip(box) → box</varname></para>
-					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT arrowRoundtrip(tbox 'TBOXFLOAT XT([1.5,9.75],[2000-01-01,2000-12-31))');
--- TBOXFLOAT XT([1.5, 9.75],[2000-01-01,2000-12-31))
-SELECT arrowRoundtrip(stbox 'SRID=4326;STBOX XT(((1,1),(5,5)),[2000-01-01,2000-01-05])');
--- SRID=4326;STBOX XT(((1,1),(5,5)),[2000-01-01,2000-01-05])
-</programlisting>
-				</listitem>
 			</itemizedlist>
 	</sect1>
 

--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3490,9 +3490,6 @@
 					<listitem>
 						<para><link linkend="tpcpoint_tgeompoint"><varname>tpcpoint::tgeompoint</varname></link>: Convertir un tpcpoint en un punto de geometría temporal</para>
 					</listitem>
-					<listitem>
-						<para><link linkend="tpcpoint_arrowRoundtrip"><varname>arrowRoundtrip</varname></link>: Convertir un tpcpoint a la interfaz Arrow C Data y de vuelta</para>
-					</listitem>
 				</itemizedlist>
 			</sect3>
 
@@ -3584,14 +3581,6 @@
 				</itemizedlist>
 			</sect3>
 
-			<sect3>
-				<title>Conversiones de tipo</title>
-				<itemizedlist>
-					<listitem>
-						<para><link linkend="tpcpatch_arrowRoundtrip"><varname>arrowRoundtrip</varname></link>: Convertir un tpcpatch a la interfaz Arrow C Data y de vuelta</para>
-					</listitem>
-				</itemizedlist>
-			</sect3>
 
 			<sect3>
 				<title>Restricciones</title>

--- a/doc/es/set_span_types.xml
+++ b/doc/es/set_span_types.xml
@@ -261,17 +261,6 @@ SELECT floatspansetFromHexWKB(
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="setspan_arrowRoundtrip">
-				<indexterm significance="normal"><primary><varname>arrowRoundtrip</varname></primary></indexterm>
-				<para>Convierte un conjunto, span o conjunto de spans a la interfaz Arrow C Data Interface y de vuelta, devolviendo el valor reconstruido</para>
-				<para><varname>arrowRoundtrip({set,span,spanset}) → {set,span,spanset}</varname></para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT arrowRoundtrip(intset '{1, 2, 3}');
--- {1, 2, 3}
-SELECT arrowRoundtrip(floatspanset '{[1.5, 2.5), (3, 4]}');
--- {[1.5, 2.5), (3, 4]}
-</programlisting>
-			</listitem>
 		</itemizedlist>
 	</sect1>
 

--- a/doc/es/temporal_circular_buffers.xml
+++ b/doc/es/temporal_circular_buffers.xml
@@ -335,16 +335,6 @@ SELECT asHexEWKB(tcbuffer 'SRID=3812;Cbuffer(Point(1 2),1)@2001-01-01');
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="tcbuffer_arrowRoundtrip">
-				<indexterm significance="normal"><primary><varname>arrowRoundtrip</varname></primary></indexterm>
-				<para>Convierte un búfer circular temporal a la interfaz Arrow C Data y de vuelta, devolviendo el valor reconstruido</para>
-				<para><varname>arrowRoundtrip(tcbuffer) → tcbuffer</varname></para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT arrowRoundtrip(tcbuffer 'Cbuffer(Point(1 2),1)@2001-01-01');
--- Cbuffer(POINT(1 2),1)@2001-01-01
-</programlisting>
-			</listitem>
-
 			<listitem xml:id="tcbufferFromText">
 				<indexterm significance="normal"><primary><varname>tcbufferFromText</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tcbufferFromEWKT</varname></primary></indexterm>

--- a/doc/es/temporal_h3_index.xml
+++ b/doc/es/temporal_h3_index.xml
@@ -36,11 +36,6 @@ SELECT th3index(SequenceSet) '{[831c02fffffffff@2001-01-01, 831c00fffffffff@2001
 -- ERROR: el tipo temporal (Instant) no coincide con el tipo de columna (Sequence)
 SELECT th3index(Sequence) '831c02fffffffff@2001-01-01';
 </programlisting>
-		<para>La función <varname>arrowRoundtrip</varname> convierte un índice H3 temporal a la interfaz Arrow C Data Interface y lo reconstruye, devolviendo un valor igual a la entrada.</para>
-		<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT arrowRoundtrip(th3index '831c02fffffffff@2001-01-01');
--- 831c02fffffffff@2001-01-01
-</programlisting>
 		<para>Las funciones <varname>asText</varname>, <varname>asBinary</varname> y <varname>asHexWKB</varname> serializan un valor <varname>th3index</varname>, y <varname>th3indexFromBinary</varname> y <varname>th3indexFromHexWKB</varname> lo reconstruyen. La forma hexadecimal WKB permite que una columna de índice H3 temporal se transfiera de ida y vuelta mediante un <varname>COPY</varname> basado en texto.</para>
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asHexWKB(th3index '831c02fffffffff@2001-01-01');

--- a/doc/es/temporal_jsonb.xml
+++ b/doc/es/temporal_jsonb.xml
@@ -560,15 +560,6 @@ SELECT tjsonbFromMFJSON('{"type": "MovingJSON", "interpolation": "Step",
    {"Position": "Point(2 2)"}@2001-01-01 13:00:00+01] */
 </programlisting>
 			</listitem>
-			<listitem xml:id="tjsonb_arrowRoundtrip">
-				<indexterm significance="normal"><primary><varname>arrowRoundtrip</varname></primary></indexterm>
-				<para>Convierte un valor JSONB temporal a la interfaz Arrow C Data Interface y de vuelta, devolviendo el valor reconstruido</para>
-				<para><varname>arrowRoundtrip(tjsonb) → tjsonb</varname></para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT arrowRoundtrip(tjsonb '1@2001-01-01');
-/* "1"@2001-01-01 */
-</programlisting>
-			</listitem>
 		</itemizedlist>
 	</sect1>
 

--- a/doc/es/temporal_network_points.xml
+++ b/doc/es/temporal_network_points.xml
@@ -399,15 +399,6 @@ SELECT tgeompoint '[POINT(23.057077727326 28.7666335767956)@2001-01-01,
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="tnpoint_arrowRoundtrip">
-				<indexterm significance="normal"><primary><varname>arrowRoundtrip</varname></primary></indexterm>
-				<para>Convierte un punto de red temporal a la interfaz Arrow C Data Interface y de vuelta, devolviendo el valor reconstruido</para>
-				<para><varname>arrowRoundtrip(tnpoint) → tnpoint</varname></para>
-				<programlisting language="sql" xml:space="preserve">
-SELECT arrowRoundtrip(tnpoint 'Npoint(1, 0.5)@2001-01-01');
--- NPoint(1,0.5)@2001-01-01
-</programlisting>
-			</listitem>
 		</itemizedlist>
 	</sect1>
 

--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -670,17 +670,6 @@ SELECT ST_AsText(startValue(tpcpoint(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),
 </programlisting>
 				</listitem>
 
-				<listitem xml:id="tpcpoint_arrowRoundtrip">
-					<indexterm significance="normal"><primary><varname>arrowRoundtrip</varname></primary></indexterm>
-					<para>Convertir un punto de nube de puntos temporal a la interfaz Arrow C Data Interface y de vuelta, devolviendo el valor reconstruido</para>
-					<para><varname>arrowRoundtrip(tpcpoint) → tpcpoint</varname></para>
-					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT arrowRoundtrip(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]),
-  '2024-01-01'::timestamptz)) = tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]),
-  '2024-01-01'::timestamptz);
--- t
-</programlisting>
-				</listitem>
 			</itemizedlist>
 		</sect2>
 
@@ -899,23 +888,6 @@ SELECT t, point FROM points(tpcpatch(
 			<para>Véase <xref linkend="tpcpatch_perpoint_roadmap" /> para conocer los límites de estos accesores y qué está y qué no está disponible a nivel de granularidad por punto.</para>
 		</sect2>
 
-		<sect2 xml:id="tpcpatch_conversions">
-			<title>Conversiones</title>
-			<itemizedlist>
-				<listitem xml:id="tpcpatch_arrowRoundtrip">
-					<indexterm significance="normal"><primary><varname>arrowRoundtrip</varname></primary></indexterm>
-					<para>Convertir un parche de nube de puntos temporal a la interfaz Arrow C Data Interface y de vuelta, devolviendo el valor reconstruido</para>
-					<para><varname>arrowRoundtrip(tpcpatch) → tpcpatch</varname></para>
-					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT arrowRoundtrip(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0,
-  1.0]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0])]), '2024-01-01'::timestamptz)) =
-  tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]),
-  PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0])]), '2024-01-01'::timestamptz);
--- t
-</programlisting>
-				</listitem>
-			</itemizedlist>
-		</sect2>
 
 		<sect2 xml:id="tpcpatch_restrictions">
 			<title>Restricciones</title>

--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -690,16 +690,6 @@ SELECT asHexEWKB(tpose 'SRID=3812;Pose(Point(1 2),1)@2001-01-01');
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="tpose_arrowRoundtrip">
-				<indexterm significance="normal"><primary><varname>arrowRoundtrip</varname></primary></indexterm>
-				<para>Convierte una pose temporal a la interfaz Arrow C Data y de vuelta, devolviendo el valor reconstruido</para>
-				<para><varname>arrowRoundtrip(tpose) → tpose</varname></para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT arrowRoundtrip(tpose 'Pose(Point(1 2),1)@2001-01-01');
--- Pose(POINT(1 2),1)@2001-01-01
-</programlisting>
-			</listitem>
-
 			<listitem xml:id="tposeFromText">
 				<indexterm significance="normal"><primary><varname>tposeFromText</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tposeFromEWKT</varname></primary></indexterm>

--- a/doc/es/temporal_quadbin_index.xml
+++ b/doc/es/temporal_quadbin_index.xml
@@ -36,11 +36,6 @@ SELECT tquadbin(SequenceSet) '{[480fffffffffffff@2001-01-01, 48427fffffffffff@20
 -- ERROR: el tipo temporal (Instant) no coincide con el tipo de columna (Sequence)
 SELECT tquadbin(Sequence) '480fffffffffffff@2001-01-01';
 </programlisting>
-		<para>La función <varname>arrowRoundtrip</varname> convierte un índice QUADBIN temporal a la interfaz Arrow C Data Interface y lo reconstruye, devolviendo un valor igual a la entrada.</para>
-		<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT arrowRoundtrip(tquadbin '480fffffffffffff@2001-01-01');
--- 480fffffffffffff@2001-01-01
-</programlisting>
 	</sect1>
 
 	<sect1 xml:id="tquadbin_conversions">

--- a/doc/es/temporal_types_p1.xml
+++ b/doc/es/temporal_types_p1.xml
@@ -628,26 +628,6 @@ SELECT asHexWKB(ttext 'AAA@2001-01-01');
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="ttype_arrowRoundtrip">
-				<indexterm significance="normal"><primary><varname>arrowRoundtrip</varname></primary></indexterm>
-				<para>Convierte un valor temporal a la interfaz Arrow C Data Interface y de vuelta, devolviendo el valor reconstruido</para>
-				<para><varname>arrowRoundtrip(tbool) → tbool</varname></para>
-				<para><varname>arrowRoundtrip(tint) → tint</varname></para>
-				<para><varname>arrowRoundtrip(tbigint) → tbigint</varname></para>
-				<para><varname>arrowRoundtrip(tfloat) → tfloat</varname></para>
-				<para><varname>arrowRoundtrip(ttext) → ttext</varname></para>
-				<para><varname>arrowRoundtrip(tgeompoint) → tgeompoint</varname></para>
-				<para><varname>arrowRoundtrip(tgeogpoint) → tgeogpoint</varname></para>
-				<para><varname>arrowRoundtrip(tgeometry) → tgeometry</varname></para>
-				<para><varname>arrowRoundtrip(tgeography) → tgeography</varname></para>
-				<programlisting language="sql" xml:space="preserve">
-SELECT arrowRoundtrip(tint '1@2001-01-01');
--- 1@2001-01-01
-SELECT arrowRoundtrip(tfloat '{[1@2001-01-01, 2@2001-01-02], [3@2001-01-03, 4@2001-01-04]}');
--- {[1@2001-01-01, 2@2001-01-02], [3@2001-01-03, 4@2001-01-04]}
-</programlisting>
-			</listitem>
-
 			<listitem xml:id="ttypeFromMFJSON">
 				<indexterm significance="normal"><primary><varname>ttypeFromMFJSON</varname></primary></indexterm>
 				<para>Entrar a partir de la representación Moving Features JSON (MF-JSON)</para>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3468,9 +3468,6 @@
 					<listitem>
 						<para><link linkend="tpcpoint_tgeompoint"><varname>tpcpoint::tgeompoint</varname></link>: Cast a tpcpoint to a temporal geometry point</para>
 					</listitem>
-					<listitem>
-						<para><link linkend="tpcpoint_arrowRoundtrip"><varname>arrowRoundtrip</varname></link>: Convert a tpcpoint to the Arrow C Data Interface and back</para>
-					</listitem>
 				</itemizedlist>
 			</sect3>
 
@@ -3562,14 +3559,6 @@
 				</itemizedlist>
 			</sect3>
 
-			<sect3>
-				<title>Conversions</title>
-				<itemizedlist>
-					<listitem>
-						<para><link linkend="tpcpatch_arrowRoundtrip"><varname>arrowRoundtrip</varname></link>: Convert a tpcpatch to the Arrow C Data Interface and back</para>
-					</listitem>
-				</itemizedlist>
-			</sect3>
 
 			<sect3>
 				<title>Restrictions</title>

--- a/doc/set_span_types.xml
+++ b/doc/set_span_types.xml
@@ -262,17 +262,6 @@ SELECT floatspansetFromHexWKB(
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="setspan_arrowRoundtrip">
-				<indexterm significance="normal"><primary><varname>arrowRoundtrip</varname></primary></indexterm>
-				<para>Convert a set, span or span set to the Arrow C Data Interface and back, returning the reconstructed value</para>
-				<para><varname>arrowRoundtrip({set,span,spanset}) → {set,span,spanset}</varname></para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT arrowRoundtrip(intset '{1, 2, 3}');
--- {1, 2, 3}
-SELECT arrowRoundtrip(floatspanset '{[1.5, 2.5), (3, 4]}');
--- {[1.5, 2.5), (3, 4]}
-</programlisting>
-			</listitem>
 		</itemizedlist>
 	</sect1>
 

--- a/doc/temporal_circular_buffers.xml
+++ b/doc/temporal_circular_buffers.xml
@@ -335,16 +335,6 @@ SELECT asHexEWKB(tcbuffer 'SRID=3812;Cbuffer(Point(1 2),1)@2001-01-01');
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="tcbuffer_arrowRoundtrip">
-				<indexterm significance="normal"><primary><varname>arrowRoundtrip</varname></primary></indexterm>
-				<para>Convert a temporal circular buffer to the Arrow C Data Interface and back, returning the reconstructed value</para>
-				<para><varname>arrowRoundtrip(tcbuffer) → tcbuffer</varname></para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT arrowRoundtrip(tcbuffer 'Cbuffer(Point(1 2),1)@2001-01-01');
--- Cbuffer(POINT(1 2),1)@2001-01-01
-</programlisting>
-			</listitem>
-
 			<listitem xml:id="tcbufferFromText">
 				<indexterm significance="normal"><primary><varname>tcbufferFromText</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tcbufferFromEWKT</varname></primary></indexterm>

--- a/doc/temporal_h3_index.xml
+++ b/doc/temporal_h3_index.xml
@@ -36,11 +36,6 @@ SELECT th3index(SequenceSet) '{[831c02fffffffff@2001-01-01, 831c00fffffffff@2001
 -- ERROR: temporal type (Instant) does not match column type (Sequence)
 SELECT th3index(Sequence) '831c02fffffffff@2001-01-01';
 </programlisting>
-		<para>The function <varname>arrowRoundtrip</varname> converts a temporal H3 index to the Arrow C Data Interface and reconstructs it, returning a value equal to the input.</para>
-		<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT arrowRoundtrip(th3index '831c02fffffffff@2001-01-01');
--- 831c02fffffffff@2001-01-01
-</programlisting>
 		<para>The functions <varname>asText</varname>, <varname>asBinary</varname>, and <varname>asHexWKB</varname> serialize a <varname>th3index</varname> value, and <varname>th3indexFromBinary</varname> and <varname>th3indexFromHexWKB</varname> reconstruct it. The hexadecimal WKB form lets a temporal H3 index column round-trip through a text-based <varname>COPY</varname>.</para>
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asHexWKB(th3index '831c02fffffffff@2001-01-01');

--- a/doc/temporal_jsonb.xml
+++ b/doc/temporal_jsonb.xml
@@ -560,15 +560,6 @@ SELECT tjsonbFromMFJSON('{"type": "MovingJSON", "interpolation": "Step",
    {"Position": "Point(2 2)"}@2001-01-01 13:00:00+01] */
 </programlisting>
 			</listitem>
-			<listitem xml:id="tjsonb_arrowRoundtrip">
-				<indexterm significance="normal"><primary><varname>arrowRoundtrip</varname></primary></indexterm>
-				<para>Convert a temporal JSONB value to the Arrow C Data Interface and back, returning the reconstructed value</para>
-				<para><varname>arrowRoundtrip(tjsonb) → tjsonb</varname></para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT arrowRoundtrip(tjsonb '1@2001-01-01');
-/* "1"@2001-01-01 */
-</programlisting>
-			</listitem>
 		</itemizedlist>
 	</sect1>
 

--- a/doc/temporal_network_points.xml
+++ b/doc/temporal_network_points.xml
@@ -417,15 +417,6 @@ SELECT tgeompoint '[POINT(23.057077727326 28.7666335767956)@2001-01-01,
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="tnpoint_arrowRoundtrip">
-				<indexterm significance="normal"><primary><varname>arrowRoundtrip</varname></primary></indexterm>
-				<para>Convert a temporal network point to the Arrow C Data Interface and back, returning the reconstructed value</para>
-				<para><varname>arrowRoundtrip(tnpoint) → tnpoint</varname></para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT arrowRoundtrip(tnpoint 'Npoint(1, 0.5)@2001-01-01');
--- NPoint(1,0.5)@2001-01-01
-</programlisting>
-			</listitem>
 		</itemizedlist>
 	</sect1>
 

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -675,17 +675,6 @@ SELECT ST_AsText(startValue(tpcpoint(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),
 </programlisting>
 				</listitem>
 
-				<listitem xml:id="tpcpoint_arrowRoundtrip">
-					<indexterm significance="normal"><primary><varname>arrowRoundtrip</varname></primary></indexterm>
-					<para>Convert a temporal point cloud point to the Arrow C Data Interface and back, returning the reconstructed value</para>
-					<para><varname>arrowRoundtrip(tpcpoint) → tpcpoint</varname></para>
-					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT arrowRoundtrip(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]),
-  '2024-01-01'::timestamptz)) = tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]),
-  '2024-01-01'::timestamptz);
--- t
-</programlisting>
-				</listitem>
 			</itemizedlist>
 		</sect2>
 
@@ -905,23 +894,6 @@ SELECT t, point FROM points(tpcpatch(
 			<para>See <xref linkend="tpcpatch_perpoint_roadmap" /> for the limits of these accessors and what is and is not available at per-point granularity.</para>
 		</sect2>
 
-		<sect2 xml:id="tpcpatch_conversions">
-			<title>Conversions</title>
-			<itemizedlist>
-				<listitem xml:id="tpcpatch_arrowRoundtrip">
-					<indexterm significance="normal"><primary><varname>arrowRoundtrip</varname></primary></indexterm>
-					<para>Convert a temporal point cloud patch to the Arrow C Data Interface and back, returning the reconstructed value</para>
-					<para><varname>arrowRoundtrip(tpcpatch) → tpcpatch</varname></para>
-					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT arrowRoundtrip(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0,
-  1.0]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0])]), '2024-01-01'::timestamptz)) =
-  tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]),
-  PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0])]), '2024-01-01'::timestamptz);
--- t
-</programlisting>
-				</listitem>
-			</itemizedlist>
-		</sect2>
 
 		<sect2 xml:id="tpcpatch_restrictions">
 			<title>Restrictions</title>

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -697,16 +697,6 @@ SELECT asHexEWKB(tpose 'SRID=3812;Pose(Point(1 2),1)@2001-01-01');
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="tpose_arrowRoundtrip">
-				<indexterm significance="normal"><primary><varname>arrowRoundtrip</varname></primary></indexterm>
-				<para>Convert a temporal pose to the Arrow C Data Interface and back, returning the reconstructed value</para>
-				<para><varname>arrowRoundtrip(tpose) → tpose</varname></para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT arrowRoundtrip(tpose 'Pose(Point(1 2),1)@2001-01-01');
--- Pose(POINT(1 2),1)@2001-01-01
-</programlisting>
-			</listitem>
-
 			<listitem xml:id="tposeFromText">
 				<indexterm significance="normal"><primary><varname>tposeFromText</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tposeFromEWKT</varname></primary></indexterm>

--- a/doc/temporal_quadbin_index.xml
+++ b/doc/temporal_quadbin_index.xml
@@ -36,11 +36,6 @@ SELECT tquadbin(SequenceSet) '{[480fffffffffffff@2001-01-01, 48427fffffffffff@20
 -- ERROR: temporal type (Instant) does not match column type (Sequence)
 SELECT tquadbin(Sequence) '480fffffffffffff@2001-01-01';
 </programlisting>
-		<para>The function <varname>arrowRoundtrip</varname> converts a temporal QUADBIN index to the Arrow C Data Interface and reconstructs it, returning a value equal to the input.</para>
-		<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT arrowRoundtrip(tquadbin '480fffffffffffff@2001-01-01');
--- 480fffffffffffff@2001-01-01
-</programlisting>
 	</sect1>
 
 	<sect1 xml:id="tquadbin_conversions">

--- a/doc/temporal_types_p1.xml
+++ b/doc/temporal_types_p1.xml
@@ -619,26 +619,6 @@ SELECT asHexWKB(ttext 'AAA@2001-01-01');
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="ttype_arrowRoundtrip">
-				<indexterm significance="normal"><primary><varname>arrowRoundtrip</varname></primary></indexterm>
-				<para>Convert a temporal value to the Arrow C Data Interface and back, returning the reconstructed value</para>
-				<para><varname>arrowRoundtrip(tbool) → tbool</varname></para>
-				<para><varname>arrowRoundtrip(tint) → tint</varname></para>
-				<para><varname>arrowRoundtrip(tbigint) → tbigint</varname></para>
-				<para><varname>arrowRoundtrip(tfloat) → tfloat</varname></para>
-				<para><varname>arrowRoundtrip(ttext) → ttext</varname></para>
-				<para><varname>arrowRoundtrip(tgeompoint) → tgeompoint</varname></para>
-				<para><varname>arrowRoundtrip(tgeogpoint) → tgeogpoint</varname></para>
-				<para><varname>arrowRoundtrip(tgeometry) → tgeometry</varname></para>
-				<para><varname>arrowRoundtrip(tgeography) → tgeography</varname></para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT arrowRoundtrip(tint '1@2001-01-01');
--- 1@2001-01-01
-SELECT arrowRoundtrip(tfloat '{[1@2001-01-01, 2@2001-01-02], [3@2001-01-03, 4@2001-01-04]}');
--- {[1@2001-01-01, 2@2001-01-02], [3@2001-01-03, 4@2001-01-04]}
-</programlisting>
-			</listitem>
-
 			<listitem xml:id="ttypeFromMFJSON">
 				<indexterm significance="normal"><primary><varname>ttypeFromMFJSON</varname></primary></indexterm>
 				<para>Input from the Moving Features JSON (MF-JSON) representation</para>


### PR DESCRIPTION
The `arrowRoundtrip` functions convert a value to the Arrow C Data Interface and immediately back, returning the input — round-trip self-checks (as described in the `mobilitydb/sql/arrow/*.in.sql` sources), not part of the documented input/output surface.

Every serialization format in the manual is documented as an orthogonal pair: an output function (`asText`/`asBinary`/`asHexWKB`/`asMFJSON`) and an input dual (`<type>FromBinary`/`<type>FromHexWKB`/…). `arrowRoundtrip` is neither — it is a fused identity, and documenting it per type is inconsistent with the rest of the manual.

This change removes the `arrowRoundtrip` entries from every type chapter and from the reference chapter, in both the English and Spanish manuals, and drops the `Conversions` subsections that are left empty as a result. The self-check SQL functions and their regression tests are unchanged.

## Arrow and Parquet interchange is already covered by WKB and covering columns

Columnar interchange for temporal values follows the GeoParquet 1.1 pattern: the value is stored opaque as MEOS-WKB in a `BYTE_ARRAY` column, alongside primitive covering columns — the bounding box and time extent — for row-group and manifest-level pruning. Open table formats have a closed type system, so a temporal value is always physically `binary`; the lever is the covering columns, not a native Arrow type.

Both sides are existing surface. The value column is `asBinary`/`asHexWKB` output with the `<type>FromBinary`/`<type>FromHexWKB` inverse. The covering columns are `Xmin`/`Xmax`/`Ymin`/`Ymax`/`Tmin`/`Tmax` of `stbox`/`tbox`, plus `SRID`. No Arrow-specific serialization is involved: the writer stores the WKB blob and the bbox primitives directly, exactly as GeoParquet 1.1 stores geometry as WKB with a `covering.bbox` sidecar.

The [MobilityLakehouse quickstart notebook](https://github.com/MobilityDB/MobilityLakehouse/blob/main/examples/mobility-lakehouse-quickstart.ipynb) builds this end to end — AIS trajectories, a TemporalParquet shard with covering columns, a space- and time-pruned query, and an Apache Iceberg table — and the convention is specified in [discussion #870, RFC: TemporalParquet](https://github.com/MobilityDB/MobilityDB/discussions/870).

## Open question: does the columnar Arrow C Data Interface tier earn its keep?

The Arrow C Data Interface tier is independent of the interchange model above and is off by default (`option(ARROW … OFF)`): `meos_*_to_arrow`/`_from_arrow`, `meos/src/arrow/temporal_arrow.c` (~3,000 lines), the vendored core `nanoarrow` (~4,100 lines), and the arrow CI jobs.

- Its only SQL surface is `arrowRoundtrip`.
- It provides no `asArrow`/`fromArrow` pair, and cannot provide one without an Arrow IPC serializer: the vendored `nanoarrow` is core-only (no IPC), and `meos_temporal_to_arrow` yields the in-process `ArrowSchema`/`ArrowArray` structs rather than a serializable buffer.
- What it uniquely provides is a zero-copy, in-process columnar handoff — decoding a value once into typed leaf arrays for vectorized analytics in an Arrow-native engine. That is a compute path, not a storage format, and its natural consumer is a binding (for example PyMEOS building a `pyarrow.Table`), not MobilityDB SQL.

The interchange model above needs none of this tier. Whether to keep it as an off-by-default experimental compute path, demote it, or remove it is an open question, separate from this documentation change.