### PR TITLE
Document that tcbuffer convexHull returns a linearized hull

### DIFF
--- a/doc/es/temporal_circular_buffers.xml
+++ b/doc/es/temporal_circular_buffers.xml
@@ -705,6 +705,7 @@ SELECT asText(centroid(tcbuffer '[Cbuffer(Point(1 1), 0.5)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>convexHull</varname></primary></indexterm>
 				<para>Devuelve la envolvente convexa del área atravesada por el búfer circular temporal</para>
 				<para><varname>convexHull(tcbuffer) → geometry</varname></para>
+				<para>La envolvente convexa se calcula sobre el área atravesada linealizada: los arcos circulares que delimitan la región barrida se convierten primero en segmentos rectos y la envolvente se calcula luego con GEOS. Por lo tanto, el resultado es un <varname>POLYGON</varname> lineal que aproxima el contorno circular, no un <varname>CURVEDPOLYGON</varname> curvo. Utilice <varname>traversedArea</varname> para obtener la región barrida curva exacta.</para>
 			</listitem>
 		</itemizedlist>
 	</sect1>

--- a/doc/temporal_circular_buffers.xml
+++ b/doc/temporal_circular_buffers.xml
@@ -706,6 +706,7 @@ SELECT asText(centroid(tcbuffer '[Cbuffer(Point(1 1), 0.5)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>convexHull</varname></primary></indexterm>
 				<para>Return the convex hull of the area traversed by the temporal circular buffer</para>
 				<para><varname>convexHull(tcbuffer) → geometry</varname></para>
+				<para>The convex hull is computed on the linearized traversed area: the circular arcs bounding the swept region are first stroked into straight segments and the hull is then computed with GEOS. The result is therefore a linear <varname>POLYGON</varname> that approximates the circular boundary, not a curved <varname>CURVEDPOLYGON</varname>. Use <varname>traversedArea</varname> to obtain the exact curved swept region.</para>
 			</listitem>
 		</itemizedlist>
 	</sect1>


### PR DESCRIPTION
`convexHull(tcbuffer)` computes the convex hull on the *linearized* traversed area: the circular arcs bounding the swept region are stroked into straight segments and the hull is then produced with GEOS (`geom_convex_hull`). The result is a linear `POLYGON` that approximates the circular boundary, not a curved `CURVEDPOLYGON`.

This is not obvious from the current entry, since `traversedArea(tcbuffer)` returns the exact curved region (`CURVEPOLYGON(CIRCULARSTRING(...))`). A user reasonably expects the hull of a circular buffer to preserve those arcs.

This change adds an explicit note to the `convexHull` entry in the temporal circular buffer chapter (English and Spanish manuals) stating that the hull is a linear approximation and pointing to `traversedArea` for the exact curved swept region. Documentation only; no functional change. English and Spanish manuals build clean (HTML + PDF).
