### PR TITLE
Short-circuit the ever/always tcbuffer disjoint predicate on two temporal circular buffers by bounding box

### DIFF
--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -1142,6 +1142,42 @@ int
 ea_disjoint_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
   bool ever)
 {
+  VALIDATE_TCBUFFER(temp1, -1); VALIDATE_TCBUFFER(temp2, -1);
+  /* Ensure the validity of the arguments */
+  if (! ensure_valid_tcbuffer_tcbuffer(temp1, temp2))
+    return -1;
+
+  /* Time-overlap test: mirror the generic function's contract of returning -1
+   * when the two temporal circular buffers do not share time. */
+  Span s1, s2;
+  temporal_set_tstzspan(temp1, &s1);
+  temporal_set_tstzspan(temp2, &s2);
+  if (! overlaps_span_span(&s1, &s2))
+    return -1;
+  /* Bounding box test -- INVERTED relative to the positive predicates. The
+   * buffers share time, so a non-overlap of the space/time boxes can only be
+   * spatial, and two radius-aware boxes that are spatially apart bound disks
+   * that are disjoint at every common instant, so the pair is both ever and
+   * always disjoint. Constant-time accept that avoids the per-instant lifted
+   * disjoint below for far-away pairs in a spatial join. This is why the
+   * generic dispatcher's bbox test (which returns 0 on non-overlap for the
+   * positive predicates) is bypassed for disjoint.
+   *
+   * WARNING -- the accept returns 1 (true), the OPPOSITE of the intersects /
+   * covers / touches / dwithin rejects that return 0 on a box non-overlap.
+   * The direction is exact only because disjoint is the boolean complement of
+   * intersection over a FIXED (zero) threshold. DO NOT copy this reject/accept
+   * to a function that returns an exact DISTANCE VALUE with no fixed threshold
+   * (nearestApproachDistance / minDistance / |=|): a bbox prune there wrongly
+   * drops the pair whose nearest approach lies just outside the box (the
+   * documented minDistance bbox-prune dead end). Verify equivalence as the
+   * 212/214 pg_regress counts being unchanged, NEVER against `nad`. */
+  STBox box1, box2;
+  tspatial_set_stbox(temp1, &box1);
+  tspatial_set_stbox(temp2, &box2);
+  if (! overlaps_stbox_stbox(&box1, &box2))
+    return 1;
+
   return ea_spatialrel_tcbuffer_tcbuffer(temp1, temp2,
     &datum_cbuffer_disjoint, ever, false);
 }


### PR DESCRIPTION
## Summary

Adds a constant-time bounding-box short-circuit to the ever/always
`disjoint` predicate between two temporal circular buffers
(`ea_disjoint_tcbuffer_tcbuffer`), the one two-temporal tcbuffer
relationship kernel that still evaluated the lifted per-instant relation
for every pair.

The guard mirrors the `dwithin` kernel but with the direction inverted
for disjoint:

1. When the two time spans do not overlap, return `-1` — the lifted
   contract for temporal predicates with no shared time.
2. When the radius-aware space/time boxes do not overlap, return `1`. The
   buffers share time, so a box non-overlap can only be spatial, and two
   buffers whose boxes are spatially apart bound disks that are disjoint
   at every common instant — hence the pair is both ever and always
   disjoint.

This is why the generic dispatcher's bounding-box test, which returns `0`
on a non-overlap for the positive predicates (intersects / covers /
touches), is bypassed for disjoint: a box non-overlap makes disjoint
*true*, not false.

## Correctness

The inverted direction is exact only because disjoint is the boolean
complement of intersection over a fixed (zero) threshold. A code comment
on the kernel keeps this apart from the positive-predicate rejects and
from the exact-distance functions (`nearestApproachDistance` /
`minDistance` / `|=|`), which cannot use a fixed-box prune at all.

Verified by the `212_tcbuffer_spatialrels` / `214_tcbuffer_tempspatialrels`
regression counts being unchanged — the short-circuit only prunes work
that the exact predicate would have rejected anyway.
