### PR TITLE
Make the always-dwithin tcbuffer predicate GEOS-free on straight geometry

### DIFF
--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -1628,11 +1628,21 @@ ea_dwithin_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs,
     return 0;
   /* The ever semantics reduce exactly to the native nearest-approach
    * distance: eDwithin(temp, gs, d) ⟺ min_t dist(disk(t), gs) ≤ d. This
-   * avoids linearizing the round buffer through GEOS. The always semantics
-   * (∀t within d) do not reduce to a single running minimum, so they stay on
-   * the traversed-area path. */
+   * avoids linearizing the round buffer through GEOS. */
   if (ever)
     return nad_tcbuffer_geo(temp, gs) <= dist ? 1 : 0;
+  /* The always semantics reduce to native coverage: being within d of the
+   * geometry is the same as intersecting it once the disk radius is grown by d
+   * (dist(disk, gs) ≤ d ⟺ dist(disk⊕d, gs) ≤ 0), so aDwithin(temp, gs, d) ⟺
+   * the buffer expanded by d always intersects the geometry ⟺ it is never
+   * disjoint from it. Reuse the GEOS-free ever-disjoint coverage kernel on the
+   * expanded buffer; curved or unsupported geometry returns -1 and keeps the
+   * traversed-area path below. */
+  Temporal *temp_exp = tcbuffer_expand(temp, dist);
+  int native = edisjoint_tcbuffer_geo_native(temp_exp, gs);
+  pfree(temp_exp);
+  if (native >= 0)
+    return native == 0 ? 1 : 0;
   return ea_spatialrel_tcbuffer_geo(temp, gs, Float8GetDatum(dist),
     (varfunc) &datum_geom_dwithin2d, 3, ever, invert);
 }
@@ -1714,25 +1724,13 @@ adwithin_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb,
   if (! ensure_valid_tcbuffer_cbuffer(temp, cb) ||
       ! ensure_not_negative_datum(Float8GetDatum(dist), T_FLOAT8))
     return -1;
-  /* Bbox prefilter: short-circuit the expensive geom_buffer call when
-   * temp's bbox is clearly outside the static cbuffer's d-expanded
-   * bbox. Mirrors the sibling tgeo prefilter pattern. tcbuffer is
-   * planar by construction (cbuffer_make rejects geodetic input
-   * points and tcbuffer_make requires tgeompoint, not tgeogpoint),
-   * so no geodetic branch is needed here. */
-  STBox box_temp, box_cb;
-  tspatial_set_stbox(temp, &box_temp);
-  cbuffer_set_stbox(cb, &box_cb);
-  STBox *box_cb_exp = stbox_expand_space(&box_cb, dist);
-  bool pass = overlaps_stbox_stbox(&box_temp, box_cb_exp);
-  pfree(box_cb_exp);
-  if (! pass)
-    return 0;
-  GSERIALIZED *trav = cbuffer_to_geom(cb);
-  GSERIALIZED *buffer = geom_buffer(trav, dist, "");
-  int result = ea_spatialrel_tcbuffer_geo(temp, buffer, (Datum) NULL,
-    (varfunc) &datum_geom_covers, 2, ALWAYS, INVERT_NO);
-  pfree(trav); pfree(buffer);
+  /* A static circular buffer is a degenerate constant temporal circular
+   * buffer. Promote it and route through the native (GEOS-free) temporal
+   * circular buffer dwithin engine, mirroring the ever variant; that engine
+   * carries its own radius-aware bounding-box and time-overlap prefilter. */
+  Temporal *ctemp = tcbuffer_from_base_temp(cb, temp);
+  int result = ea_dwithin_tcbuffer_tcbuffer(temp, ctemp, dist, ALWAYS);
+  pfree(ctemp);
   return result;
 }
 

--- a/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels_tbl.test.out
@@ -259,7 +259,7 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eDwithin(g, temp, 10);
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aDwithin(g, temp, 10);
  count 
 -------
-   614
+   311
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eDwithin(temp, g, 10);
@@ -271,7 +271,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eDwithin(temp, g, 10);
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aDwithin(temp, g, 10);
  count 
 -------
-   614
+   311
 (1 row)
 
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eDwithin(cb, temp, 10);
@@ -283,7 +283,7 @@ SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eDwithin(cb, temp, 10);
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aDwithin(cb, temp, 10);
  count 
 -------
-     0
+   134
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eDwithin(temp, cb, 10);
@@ -295,7 +295,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eDwithin(temp, cb, 10);
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aDwithin(temp, cb, 10);
  count 
 -------
-     0
+   134
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE eDwithin(t1.temp, t2.temp, 10);
@@ -325,13 +325,13 @@ SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seqset WHERE eDwithin(cb, ss, 10)
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seq WHERE aDwithin(cb, seq, 10);
  count 
 -------
-     0
+    57
 (1 row)
 
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seqset WHERE aDwithin(cb, ss, 10);
  count 
 -------
-     0
+     2
 (1 row)
 
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seq WHERE eDwithin(seq, cb, 10);
@@ -349,13 +349,13 @@ SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seqset WHERE eDwithin(ss, cb, 10)
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seq WHERE aDwithin(seq, cb, 10);
  count 
 -------
-     0
+    57
 (1 row)
 
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer_seqset WHERE aDwithin(ss, cb, 10);
  count 
 -------
-     0
+     2
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer_seq t1, tbl_tcbuffer t2 WHERE eDwithin(t1.seq, t2.temp, 10);


### PR DESCRIPTION
## Summary

Makes the always-semantics of `dwithin` between a temporal circular
buffer and a static operand GEOS-free on straight geometry — the last
`dwithin` paths that linearize the round buffer through GEOS
(`adwithin_tcbuffer_geo` via the traversed-area predicate,
`adwithin_tcbuffer_cbuffer` via a GEOS buffer of the static circular
buffer).

Both reuse the existing native engine through the identity that being
within a distance `d` of a geometry is the same as intersecting it once
the disk radius is grown by `d` (`dist(disk, gs) <= d` ⟺
`dist(disk⊕d, gs) <= 0`):

- geometry operand: grow the buffer with `tcbuffer_expand` and take the
  complement of the GEOS-free ever-disjoint coverage kernel
  (`aDwithin ⟺ ¬eDisjoint(expand(temp, d), gs)`).
- static circular buffer: promote it to a constant temporal circular
  buffer and route through the native two-buffer `dwithin` engine, as the
  ever variant already does.

Curved or unsupported geometry keeps the traversed-area path, the only
remaining GEOS fallback.

## Correctness

The native always-dwithin equals the always projection of the native
temporal `tDwithin` by construction, since both read the same
intersecting sub-period coverage — it composes two kernels already in the
tree: the radius expansion behind native `tDwithin`, and the ever-disjoint
coverage kernel.

The datagen counts in `212_tcbuffer_spatialrels_tbl` move to the native
values. The geometry cases drop (the stroked traversed-area path
over-counts always-within), and the static circular buffer cases rise from
zero (that path evaluates `covers` rather than within, so it reports no
pair as always-within); each new count stays within its unchanged
`eDwithin` count, as `always ⊆ ever` requires. The literal `212` and the
temporal `214` outputs are unchanged.
