### PR TITLE
Fix the always semantics of the tcbuffer covers and touches predicates on two temporal circular buffers

### DIFF
--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -957,7 +957,7 @@ ecovers_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 int
 acovers_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
-  return ea_covers_tcbuffer_tcbuffer(temp1, temp2, EVER);
+  return ea_covers_tcbuffer_tcbuffer(temp1, temp2, ALWAYS);
 }
 
 /*****************************************************************************
@@ -1621,7 +1621,7 @@ etouches_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 int
 atouches_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
-  return ea_touches_tcbuffer_tcbuffer(temp1, temp2, EVER);
+  return ea_touches_tcbuffer_tcbuffer(temp1, temp2, ALWAYS);
 }
 
 /*****************************************************************************

--- a/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels_tbl.test.out
@@ -82,6 +82,18 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aCovers(temp, cb);
      9
 (1 row)
 
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE eCovers(t1.temp, t2.temp);
+ count 
+-------
+    92
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE aCovers(t1.temp, t2.temp);
+ count 
+-------
+    54
+(1 row)
+
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eDisjoint(g, temp);
  count 
 -------
@@ -245,6 +257,18 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eTouches(temp, cb);
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aTouches(temp, cb);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE eTouches(t1.temp, t2.temp);
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE aTouches(t1.temp, t2.temp);
  count 
 -------
      0

--- a/mobilitydb/test/cbuffer/queries/212_tcbuffer_spatialrels_tbl.test.sql
+++ b/mobilitydb/test/cbuffer/queries/212_tcbuffer_spatialrels_tbl.test.sql
@@ -57,6 +57,9 @@ SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aCovers(cb, temp);
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eCovers(temp, cb);
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aCovers(temp, cb);
 
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE eCovers(t1.temp, t2.temp);
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE aCovers(t1.temp, t2.temp);
+
 -------------------------------------------------------------------------------
 -- eDisjoint, aDisjoint
 -------------------------------------------------------------------------------
@@ -110,6 +113,9 @@ SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aTouches(cb, temp);
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eTouches(temp, cb);
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aTouches(temp, cb);
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE eTouches(t1.temp, t2.temp);
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE aTouches(t1.temp, t2.temp);
 
 -------------------------------------------------------------------------------
 -- eDwithin, aDwithin


### PR DESCRIPTION
## Summary

The always variants `acovers_tcbuffer_tcbuffer` and
`atouches_tcbuffer_tcbuffer` forward `EVER` to the shared ever/always
implementation, so they evaluate the ever semantics: a pair counts as
covering or touching when the relationship holds at some instant rather
than over the whole common time span. This forwards `ALWAYS` instead,
matching every other always variant in the file.

## Test coverage

The covers and touches table tests exercise the geometry and static
circular buffer operands but omit the two temporal circular buffer pair
for both the ever and the always semantics. This adds those four counts
to `212_tcbuffer_spatialrels_tbl`. The always covers count (54) sits
below the ever covers count (92), so a regression back to the ever
semantics fails the test.
