### PR TITLE
Hide vendored liblwgeom/ryu symbols to prevent librttopo interposition

### DIFF
--- a/meos/include/meos_geo.h
+++ b/meos/include/meos_geo.h
@@ -325,7 +325,6 @@ typedef enum
 
 /* Input and output functions */
 
-extern BOX3D *box3d_from_gbox(const GBOX *box);
 extern BOX3D *box3d_make(double xmin, double xmax, double ymin, double ymax,
   double zmin, double zmax, int32_t srid);
 extern BOX3D *box3d_in(const char *str);

--- a/postgis/liblwgeom/CMakeLists.txt
+++ b/postgis/liblwgeom/CMakeLists.txt
@@ -81,5 +81,13 @@ add_library(liblwgeom OBJECT
   varint.c
   )
 
-# set_property(TARGET liblwgeom PROPERTY C_VISIBILITY_PRESET hidden)
-# set_property(TARGET liblwgeom PROPERTY POSITION_INDEPENDENT_CODE ON)
+# Hide the vendored liblwgeom symbols (ptarray_construct_empty, rtalloc, ...)
+# from the shared library's dynamic table. Several of these names are also
+# exported by librttopo.so, which PostgreSQL co-loads with PostGIS. Without
+# hiding, ELF global symbol interposition can bind our internal liblwgeom calls
+# to librttopo's copy (whose allocator context is uninitialized on this path),
+# crashing the backend. Hiding makes both the extension and the standalone MEOS
+# library (and every binding built from it) resolve their own handler-equipped
+# liblwgeom. Established by #447, must not be disabled.
+set_property(TARGET liblwgeom PROPERTY C_VISIBILITY_PRESET hidden)
+set_property(TARGET liblwgeom PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/postgis/ryu/CMakeLists.txt
+++ b/postgis/ryu/CMakeLists.txt
@@ -2,5 +2,7 @@ add_library(ryu OBJECT
   d2s.c
   )
 
-# set_property(TARGET ryu PROPERTY C_VISIBILITY_PRESET hidden)
-# set_property(TARGET ryu PROPERTY POSITION_INDEPENDENT_CODE ON)
+# Hide the vendored ryu float-formatting symbols from the shared library's
+# dynamic table (see postgis/liblwgeom/CMakeLists.txt). Established by #447.
+set_property(TARGET ryu PROPERTY C_VISIBILITY_PRESET hidden)
+set_property(TARGET ryu PROPERTY POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
Loading the extension in the same session as PostGIS (the cascading `create extension` that also installs postgis) and then parsing a geometry crashes the backend:

```
select tcbuffer 'Cbuffer(Point(1 1),2)@2001-01-01';
server closed the connection unexpectedly
```

with a SIGSEGV in `rtalloc` (librttopo), reached through our own `geom_in -> lwgeom_parse_wkt -> ptarray_construct_empty`. In a fresh session (PostGIS not yet loaded) the same query succeeds.

## Root cause

MobilityDB statically bundles PostGIS's liblwgeom. Several of its symbols — `ptarray_construct_empty`, `ptarray_construct`, `lwalloc`, ... — are also exported by `librttopo.so`, which PostgreSQL co-loads with PostGIS/postgis_raster. With default ELF visibility these land in the shared object's dynamic table, so when librttopo loads first, global symbol interposition binds our internal liblwgeom calls to librttopo's copy, whose allocator context is uninitialized on this path -> crash on the first geometry input.

## Fix

Re-enables the `C_VISIBILITY_PRESET hidden` property on the `liblwgeom` and `ryu` object libraries (present since #447, dormant since #751) so the extension and the standalone MEOS library each resolve their own liblwgeom, immune to interposition in both directions. Both `libMobilityDB` and `libmeos` link the same object libraries, so this single change covers the extension and every binding built on `libmeos`.

Drops the `box3d_from_gbox` declaration from `meos_geo.h` — a deprecated liblwgeom internal (`/* TODO to be removed */`) with no callers — so the public MEOS surface contains no liblwgeom symbol and hiding preserves the invariant that every public MEOS function exports a linkable symbol.

## Verification

Isolated reproduction (no PostgreSQL) that loads `librttopo` first with `RTLD_GLOBAL` then drives `geom_in("Point(1 1)")` through `libmeos`:

- master `libmeos.so` (`ptarray_construct_empty` exported): SIGSEGV
- fixed `libmeos.so` (symbol hidden): returns cleanly

`nm -D` on both `libMobilityDB-1.4.so` and `libmeos.so` shows every librttopo-colliding symbol hidden, 0 residual collisions with librttopo, while the public MEOS API and the PostgreSQL entry points remain exported.
