### PR TITLE
Order the optional-family gates alphabetically in the generic temporal I/O

### DIFF
--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -285,6 +285,16 @@ basetype_in(const char *str, MeosType type, bool end UNUSED, Datum *result)
       return true;
     }
 #endif
+#if RASTER
+    case T_RAQUET:
+    {
+      Raquet *rq = raquet_in(str);
+      if (! rq)
+        return false;
+      *result = PointerGetDatum(rq);
+      return true;
+    }
+#endif
     default: /* Error! */
       meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
         "Unknown input function for type: %s", meostype_name(type));

--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -175,26 +175,6 @@ basetype_in(const char *str, MeosType type, bool end UNUSED, Datum *result)
       *result = Int64GetDatum(i);
       return true;
     }
-#if H3
-    case T_H3INDEX:
-    {
-      H3Index cell = h3index_in(str);
-      if (cell == (H3Index) 0)
-        return false;
-      *result = Int64GetDatum((int64) cell);
-      return true;
-    }
-#endif
-#if QUADBIN
-    case T_QUADBIN:
-    {
-      Quadbin cell = quadbin_parse(str);
-      if (cell == (Quadbin) 0)
-        return false;
-      *result = Int64GetDatum((int64) cell);
-      return true;
-    }
-#endif
     case T_FLOAT8:
     {
       double d = float8_in(str);
@@ -234,6 +214,16 @@ basetype_in(const char *str, MeosType type, bool end UNUSED, Datum *result)
       if (! cb)
         return false;
       *result = PointerGetDatum(cb);
+      return true;
+    }
+#endif
+#if H3
+    case T_H3INDEX:
+    {
+      H3Index cell = h3index_in(str);
+      if (cell == (H3Index) 0)
+        return false;
+      *result = Int64GetDatum((int64) cell);
       return true;
     }
 #endif
@@ -282,6 +272,16 @@ basetype_in(const char *str, MeosType type, bool end UNUSED, Datum *result)
       if (! pose)
         return false;
       *result = PointerGetDatum(pose);
+      return true;
+    }
+#endif
+#if QUADBIN
+    case T_QUADBIN:
+    {
+      Quadbin cell = quadbin_parse(str);
+      if (cell == (Quadbin) 0)
+        return false;
+      *result = Int64GetDatum((int64) cell);
       return true;
     }
 #endif
@@ -443,7 +443,9 @@ parse_mfjson_values(json_object *mfjson, MeosType temptype, int *count)
         values[i] = Int32GetDatum(json_object_get_int(jvalue));
         break;
       case T_TBIGINT:
+#if H3
       case T_TH3INDEX:
+#endif
         if (json_object_get_type(jvalue) != json_type_int)
         {
           meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
@@ -593,41 +595,158 @@ parse_mfjson_geos(json_object *mfjson, int32_t srid, bool geodetic, int *count)
   return values;
 }
 
-#if RGEO
+#if CBUFFER
 /**
- * @brief Return a reference geometry of a temporal rigid geometry from its
- * MF-JSON representation
+ * @brief Return a circular buffer from its MF-JSON representation
+ * @details A circular buffer value is a JSON object with a `point` member
+ * (a planar 2D `[x, y]` coordinate array, as for a temporal point) and a
+ * numeric `radius` member, e.g. `{"point":[1,2],"radius":3}`. The member
+ * names mirror the @p point and @p radius accessors. Circular buffers are
+ * always planar 2D, so there is no Z/geodetic handling as for poses.
  */
-static GSERIALIZED *
-parse_mfjson_ref_geo(json_object *mfjson, int32_t srid, bool geodetic)
+static Cbuffer *
+parse_mfjson_cbuffer(json_object *mfjson, int32_t srid)
 {
-  json_object *mfjsonTmp = mfjson;
-  json_object *geo_json = NULL;
-  geo_json = findMemberByName(mfjsonTmp, "geometry");
-  if (geo_json == NULL)
+  assert(mfjson);
+  json_object *point = findMemberByName(mfjson, "point");
+  if (point == NULL)
   {
     meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
-      "Unable to find 'geometry' in MFJSON string");
+      "Unable to find 'point' in MFJSON string");
     return NULL;
   }
-  int hasz = LW_FALSE;
-  LWGEOM *geo = parse_geojson(geo_json, &hasz);
-  if (! geo)
-    return NULL;
-  if (! hasz)
+  json_object *radius = findMemberByName(mfjson, "radius");
+  if (radius == NULL)
   {
-    LWGEOM *tmp = lwgeom_force_2d(geo);
-    lwgeom_free(geo);
-    geo = tmp;
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "Unable to find 'radius' in MFJSON string");
+    return NULL;
   }
-  lwgeom_add_bbox(geo);
-  lwgeom_set_srid(geo, srid);
-  lwgeom_set_geodetic(geo, geodetic);
-  GSERIALIZED *result = geo_serialize(geo);
-  lwgeom_free(geo);
+  Datum ptdatum = parse_mfjson_coord(point, srid, false);
+  if (! ptdatum)
+    return NULL;
+  GSERIALIZED *gs = DatumGetGserializedP(ptdatum);
+  Cbuffer *result = cbuffer_make(gs, json_object_get_double(radius));
+  pfree(gs);
   return result;
 }
-#endif /* RGEO */
+
+/**
+ * @brief Return an array of circular buffers from its MF-JSON values
+ */
+static Datum *
+parse_mfjson_cbuffers(json_object *mfjson, int32_t srid, int *count)
+{
+  json_object *mfjsonTmp = mfjson;
+  json_object *values_json = findMemberByName(mfjsonTmp, "values");
+  if (values_json == NULL)
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "Unable to find 'values' in MFJSON string");
+    return NULL;
+  }
+  if (json_object_get_type(values_json) != json_type_array)
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "Invalid 'values' array in MFJSON string");
+    return NULL;
+  }
+  int nvalues = (int) json_object_array_length(values_json);
+  if (nvalues < 1)
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "Invalid value of 'values' array in MFJSON string");
+    return NULL;
+  }
+  Datum *values = palloc(sizeof(Datum) * nvalues);
+  for (int i = 0; i < nvalues; ++i)
+  {
+    json_object *cb = json_object_array_get_idx(values_json, i);
+    values[i] = PointerGetDatum(parse_mfjson_cbuffer(cb, srid));
+  }
+  *count = nvalues;
+  return values;
+}
+#endif /* CBUFFER */
+
+/*****************************************************************************/
+
+#if NPOINT
+/**
+ * @brief Return a network point from its MF-JSON value
+ *
+ * The expected payload shape (matching the asMFJSON output side) is
+ * @code {"route":<route>,"position":<position>} @endcode.  The position
+ * must be in [0, 1] and the route id must be present in the loaded ways
+ * cache; both are validated by @c npoint_make.  The @p srid argument is
+ * ignored: a network point inherits its SRID from its route, so the
+ * caller-supplied SRID has no effect on the resulting Npoint.
+ */
+static Npoint *
+parse_mfjson_npoint(json_object *mfjson, int32_t srid __attribute__((unused)))
+{
+  assert(mfjson);
+  /* Get the route id */
+  json_object *rid_json = findMemberByName(mfjson, "route");
+  if (rid_json == NULL)
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "Unable to find 'route' in MFJSON string");
+    return NULL;
+  }
+  int64 rid = (int64) json_object_get_int64(rid_json);
+
+  /* Get the position */
+  json_object *pos_json = findMemberByName(mfjson, "position");
+  if (pos_json == NULL)
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "Unable to find 'position' in MFJSON string");
+    return NULL;
+  }
+  double pos = json_object_get_double(pos_json);
+
+  /* npoint_make validates route registration and pos in [0, 1] */
+  return npoint_make(rid, pos);
+}
+
+/**
+ * @brief Return an array of network points from its MF-JSON values
+ */
+static Datum *
+parse_mfjson_npoints(json_object *mfjson, int32_t srid, int *count)
+{
+  json_object *values_json = findMemberByName(mfjson, "values");
+  if (values_json == NULL)
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "Unable to find 'values' in MFJSON string");
+    return NULL;
+  }
+  if (json_object_get_type(values_json) != json_type_array)
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "Invalid 'values' array in MFJSON string");
+    return NULL;
+  }
+  int nnpoints = (int) json_object_array_length(values_json);
+  if (nnpoints < 1)
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "Invalid value of 'values' array in MFJSON string");
+    return NULL;
+  }
+
+  Datum *values = palloc(sizeof(Datum) * nnpoints);
+  for (int i = 0; i < nnpoints; ++i)
+  {
+    json_object *np = json_object_array_get_idx(values_json, i);
+    values[i] = PointerGetDatum(parse_mfjson_npoint(np, srid));
+  }
+  *count = nnpoints;
+  return values;
+}
+#endif /* NPOINT */
 
 /*****************************************************************************/
 
@@ -784,158 +903,43 @@ parse_mfjson_poses(json_object *mfjson, int32_t srid, int *count)
 }
 #endif /* POSE */
 
-#if NPOINT
-/**
- * @brief Return a network point from its MF-JSON value
- *
- * The expected payload shape (matching the asMFJSON output side) is
- * @code {"route":<route>,"position":<position>} @endcode.  The position
- * must be in [0, 1] and the route id must be present in the loaded ways
- * cache; both are validated by @c npoint_make.  The @p srid argument is
- * ignored: a network point inherits its SRID from its route, so the
- * caller-supplied SRID has no effect on the resulting Npoint.
- */
-static Npoint *
-parse_mfjson_npoint(json_object *mfjson, int32_t srid __attribute__((unused)))
-{
-  assert(mfjson);
-  /* Get the route id */
-  json_object *rid_json = findMemberByName(mfjson, "route");
-  if (rid_json == NULL)
-  {
-    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
-      "Unable to find 'route' in MFJSON string");
-    return NULL;
-  }
-  int64 rid = (int64) json_object_get_int64(rid_json);
-
-  /* Get the position */
-  json_object *pos_json = findMemberByName(mfjson, "position");
-  if (pos_json == NULL)
-  {
-    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
-      "Unable to find 'position' in MFJSON string");
-    return NULL;
-  }
-  double pos = json_object_get_double(pos_json);
-
-  /* npoint_make validates route registration and pos in [0, 1] */
-  return npoint_make(rid, pos);
-}
-
-/**
- * @brief Return an array of network points from its MF-JSON values
- */
-static Datum *
-parse_mfjson_npoints(json_object *mfjson, int32_t srid, int *count)
-{
-  json_object *values_json = findMemberByName(mfjson, "values");
-  if (values_json == NULL)
-  {
-    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
-      "Unable to find 'values' in MFJSON string");
-    return NULL;
-  }
-  if (json_object_get_type(values_json) != json_type_array)
-  {
-    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
-      "Invalid 'values' array in MFJSON string");
-    return NULL;
-  }
-  int nnpoints = (int) json_object_array_length(values_json);
-  if (nnpoints < 1)
-  {
-    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
-      "Invalid value of 'values' array in MFJSON string");
-    return NULL;
-  }
-
-  Datum *values = palloc(sizeof(Datum) * nnpoints);
-  for (int i = 0; i < nnpoints; ++i)
-  {
-    json_object *np = json_object_array_get_idx(values_json, i);
-    values[i] = PointerGetDatum(parse_mfjson_npoint(np, srid));
-  }
-  *count = nnpoints;
-  return values;
-}
-#endif /* NPOINT */
-
 /*****************************************************************************/
 
-#if CBUFFER
+#if RGEO
 /**
- * @brief Return a circular buffer from its MF-JSON representation
- * @details A circular buffer value is a JSON object with a `point` member
- * (a planar 2D `[x, y]` coordinate array, as for a temporal point) and a
- * numeric `radius` member, e.g. `{"point":[1,2],"radius":3}`. The member
- * names mirror the @p point and @p radius accessors. Circular buffers are
- * always planar 2D, so there is no Z/geodetic handling as for poses.
+ * @brief Return a reference geometry of a temporal rigid geometry from its
+ * MF-JSON representation
  */
-static Cbuffer *
-parse_mfjson_cbuffer(json_object *mfjson, int32_t srid)
-{
-  assert(mfjson);
-  json_object *point = findMemberByName(mfjson, "point");
-  if (point == NULL)
-  {
-    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
-      "Unable to find 'point' in MFJSON string");
-    return NULL;
-  }
-  json_object *radius = findMemberByName(mfjson, "radius");
-  if (radius == NULL)
-  {
-    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
-      "Unable to find 'radius' in MFJSON string");
-    return NULL;
-  }
-  Datum ptdatum = parse_mfjson_coord(point, srid, false);
-  if (! ptdatum)
-    return NULL;
-  GSERIALIZED *gs = DatumGetGserializedP(ptdatum);
-  Cbuffer *result = cbuffer_make(gs, json_object_get_double(radius));
-  pfree(gs);
-  return result;
-}
-
-/**
- * @brief Return an array of circular buffers from its MF-JSON values
- */
-static Datum *
-parse_mfjson_cbuffers(json_object *mfjson, int32_t srid, int *count)
+static GSERIALIZED *
+parse_mfjson_ref_geo(json_object *mfjson, int32_t srid, bool geodetic)
 {
   json_object *mfjsonTmp = mfjson;
-  json_object *values_json = findMemberByName(mfjsonTmp, "values");
-  if (values_json == NULL)
+  json_object *geo_json = NULL;
+  geo_json = findMemberByName(mfjsonTmp, "geometry");
+  if (geo_json == NULL)
   {
     meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
-      "Unable to find 'values' in MFJSON string");
+      "Unable to find 'geometry' in MFJSON string");
     return NULL;
   }
-  if (json_object_get_type(values_json) != json_type_array)
-  {
-    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
-      "Invalid 'values' array in MFJSON string");
+  int hasz = LW_FALSE;
+  LWGEOM *geo = parse_geojson(geo_json, &hasz);
+  if (! geo)
     return NULL;
-  }
-  int nvalues = (int) json_object_array_length(values_json);
-  if (nvalues < 1)
+  if (! hasz)
   {
-    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
-      "Invalid value of 'values' array in MFJSON string");
-    return NULL;
+    LWGEOM *tmp = lwgeom_force_2d(geo);
+    lwgeom_free(geo);
+    geo = tmp;
   }
-  Datum *values = palloc(sizeof(Datum) * nvalues);
-  for (int i = 0; i < nvalues; ++i)
-  {
-    json_object *cb = json_object_array_get_idx(values_json, i);
-    values[i] = PointerGetDatum(parse_mfjson_cbuffer(cb, srid));
-  }
-  *count = nvalues;
-  return values;
+  lwgeom_add_bbox(geo);
+  lwgeom_set_srid(geo, srid);
+  lwgeom_set_geodetic(geo, geodetic);
+  GSERIALIZED *result = geo_serialize(geo);
+  lwgeom_free(geo);
+  return result;
 }
-#endif /* CBUFFER */
+#endif /* RGEO */
 
 /*****************************************************************************/
 
@@ -1015,18 +1019,10 @@ tinstant_from_mfjson(json_object *mfjson, bool spatial, int32_t srid,
       values = parse_mfjson_points(mfjson, srid, geodetic, &nvalues);
     else if (tgeo_type(temptype))
       values = parse_mfjson_geos(mfjson, srid, geodetic, &nvalues);
-#if POSE || RGEO
-    else if (temptype == T_TPOSE || temptype == T_TRGEOMETRY)
-      values = parse_mfjson_poses(mfjson, srid, &nvalues);
-#endif /* POSE */
 #if CBUFFER
     else if (temptype == T_TCBUFFER)
       values = parse_mfjson_cbuffers(mfjson, srid, &nvalues);
 #endif /* CBUFFER */
-#if NPOINT
-    else if (temptype == T_TNPOINT)
-      values = parse_mfjson_npoints(mfjson, srid, &nvalues);
-#endif /* NPOINT */
 #if H3
     /* h3index is a scalar (int8) cell id carried with a geodetic bbox: the
      * crs/SRID is parsed as for a spatial type, but the 'values' array holds
@@ -1035,6 +1031,14 @@ tinstant_from_mfjson(json_object *mfjson, bool spatial, int32_t srid,
     else if (temptype == T_TH3INDEX)
       values = parse_mfjson_values(mfjson, temptype, &nvalues);
 #endif /* H3 */
+#if NPOINT
+    else if (temptype == T_TNPOINT)
+      values = parse_mfjson_npoints(mfjson, srid, &nvalues);
+#endif /* NPOINT */
+#if POSE || RGEO
+    else if (temptype == T_TPOSE || temptype == T_TRGEOMETRY)
+      values = parse_mfjson_poses(mfjson, srid, &nvalues);
+#endif /* POSE */
     else
     {
       meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
@@ -1078,18 +1082,10 @@ tinstarr_from_mfjson(json_object *mfjson, bool isgeo, int32_t srid,
       values = parse_mfjson_points(mfjson, srid, geodetic, &nvalues);
     else if (tgeo_type(temptype))
       values = parse_mfjson_geos(mfjson, srid, geodetic, &nvalues);
-#if POSE || RGEO
-    else if (temptype == T_TPOSE || temptype == T_TRGEOMETRY)
-      values = parse_mfjson_poses(mfjson, srid, &nvalues);
-#endif /* RGEO */
 #if CBUFFER
     else if (temptype == T_TCBUFFER)
       values = parse_mfjson_cbuffers(mfjson, srid, &nvalues);
 #endif /* CBUFFER */
-#if NPOINT
-    else if (temptype == T_TNPOINT)
-      values = parse_mfjson_npoints(mfjson, srid, &nvalues);
-#endif /* NPOINT */
 #if H3
     /* h3index is a scalar (int8) cell id carried with a geodetic bbox: the
      * crs/SRID is parsed as for a spatial type, but the 'values' array holds
@@ -1098,6 +1094,14 @@ tinstarr_from_mfjson(json_object *mfjson, bool isgeo, int32_t srid,
     else if (temptype == T_TH3INDEX)
       values = parse_mfjson_values(mfjson, temptype, &nvalues);
 #endif /* H3 */
+#if NPOINT
+    else if (temptype == T_TNPOINT)
+      values = parse_mfjson_npoints(mfjson, srid, &nvalues);
+#endif /* NPOINT */
+#if POSE || RGEO
+    else if (temptype == T_TPOSE || temptype == T_TRGEOMETRY)
+      values = parse_mfjson_poses(mfjson, srid, &nvalues);
+#endif /* RGEO */
    else
     {
       meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
@@ -1234,25 +1238,29 @@ ensure_temptype_mfjson(const char *typestr)
       strcmp(typestr, "MovingFloat") != 0 &&
       strcmp(typestr, "MovingText") != 0 &&
       strcmp(typestr, "MovingPoint") != 0 &&
-      strcmp(typestr, "MovingGeometry") != 0  &&
-      strcmp(typestr, "MovingPose") != 0 &&
-      strcmp(typestr, "MovingRigidGeometry") != 0
+      strcmp(typestr, "MovingGeometry") != 0
 #if CBUFFER
       && strcmp(typestr, "MovingCircularBuffer") != 0
 #endif /* CBUFFER */
-#if NPOINT
-      && strcmp(typestr, "MovingNetworkPoint") != 0
-#endif /* NPOINT */
 #if H3
       && strcmp(typestr, "MovingH3Index") != 0
 #endif /* H3 */
 #if JSON
       && strcmp(typestr, "MovingJSON") != 0
 #endif /* JSON */
+#if NPOINT
+      && strcmp(typestr, "MovingNetworkPoint") != 0
+#endif /* NPOINT */
 #if POINTCLOUD
       && strcmp(typestr, "MovingPCPoint") != 0
       && strcmp(typestr, "MovingPCPatch") != 0
 #endif /* POINTCLOUD */
+#if POSE
+      && strcmp(typestr, "MovingPose") != 0
+#endif /* POSE */
+#if RGEO
+      && strcmp(typestr, "MovingRigidGeometry") != 0
+#endif /* RGEO */
       )
   {
     meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
@@ -1318,18 +1326,10 @@ temporal_from_mfjson(const char *mfjson, MeosType temptype)
     jtemptype = T_TINT;
   else if (strcmp(typestr, "MovingBigInteger") == 0)
     jtemptype = T_TBIGINT;
-#if H3
-  else if (strcmp(typestr, "MovingH3Index") == 0)
-    jtemptype = T_TH3INDEX;
-#endif
   else if (strcmp(typestr, "MovingFloat") == 0)
     jtemptype = T_TFLOAT;
   else if (strcmp(typestr, "MovingText") == 0)
     jtemptype = T_TTEXT;
-#if JSON
-  else if (strcmp(typestr, "MovingJSON") == 0)
-    jtemptype = T_TJSONB;
-#endif /* JSON */
   else if (strcmp(typestr, "MovingPoint") == 0)
   {
     if (temptype == T_TGEOGPOINT)
@@ -1344,27 +1344,36 @@ temporal_from_mfjson(const char *mfjson, MeosType temptype)
     else /* Default to T_TGEOMETRY */
       jtemptype = T_TGEOMETRY;
   }
-  else if (strcmp(typestr, "MovingPose") == 0)
-    jtemptype = T_TPOSE;
-  else if (strcmp(typestr, "MovingRigidGeometry") == 0)
-    jtemptype = T_TRGEOMETRY;
-#if NPOINT
-  else if (strcmp(typestr, "MovingNetworkPoint") == 0)
-    jtemptype = T_TNPOINT;
-#endif /* NPOINT */
-
 #if CBUFFER
   else if (strcmp(typestr, "MovingCircularBuffer") == 0)
     jtemptype = T_TCBUFFER;
 #endif /* CBUFFER */
-
+#if H3
+  else if (strcmp(typestr, "MovingH3Index") == 0)
+    jtemptype = T_TH3INDEX;
+#endif /* H3 */
+#if JSON
+  else if (strcmp(typestr, "MovingJSON") == 0)
+    jtemptype = T_TJSONB;
+#endif /* JSON */
+#if NPOINT
+  else if (strcmp(typestr, "MovingNetworkPoint") == 0)
+    jtemptype = T_TNPOINT;
+#endif /* NPOINT */
 #if POINTCLOUD
   else if (strcmp(typestr, "MovingPCPoint") == 0)
     jtemptype = T_TPCPOINT;
   else if (strcmp(typestr, "MovingPCPatch") == 0)
     jtemptype = T_TPCPATCH;
 #endif /* POINTCLOUD */
-
+#if POSE
+  else if (strcmp(typestr, "MovingPose") == 0)
+    jtemptype = T_TPOSE;
+#endif /* POSE */
+#if RGEO
+  else if (strcmp(typestr, "MovingRigidGeometry") == 0)
+    jtemptype = T_TRGEOMETRY;
+#endif /* RGEO */
   if (temptype != T_UNKNOWN && jtemptype != temptype)
   {
     meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
@@ -1755,45 +1764,33 @@ cbuffer_from_wkb_state(meos_wkb_parse_state *s, bool component)
 }
 #endif /* CBUFFER */
 
-#if RASTER
+#if H3
 /**
- * @brief Read a Raquet raster tile and advance the parse state forward
- * @details The endian flag has already been consumed in
- * #type_from_wkb_state. What remains are the tile header fields followed by
- * the row-major packed pixel bytes, whose length is derived from the width,
- * height and pixel type.
+ * @brief Read an h3index and advance the parse state forward
+ * @details The endian flag was consumed by #type_from_wkb. Consume the SRID
+ * flag and the optional SRID — which, if present, must be WGS84 (EPSG:4326),
+ * an h3 cell being inherently geographic — then read the cell id (int8).
  */
-Datum
-raquet_from_wkb_state(meos_wkb_parse_state *s)
+static Datum
+h3index_from_wkb_state(meos_wkb_parse_state *s)
 {
-  uint64 quadbin = (uint64) int64_from_wkb_state(s);
-  uint8_t pixtype = byte_from_wkb_state(s);
-  uint16_t width = (uint16_t) int32_from_wkb_state(s);
-  uint16_t height = (uint16_t) int32_from_wkb_state(s);
-  bool has_nodata = (bool) byte_from_wkb_state(s);
-  double nodata = double_from_wkb_state(s);
-  size_t pixsize;
-  switch (pixtype)
+  /* Read the flags; consume the SRID only when it is present */
+  uint8_t wkb_flags = byte_from_wkb_state(s);
+  if (wkb_flags & MEOS_WKB_SRIDFLAG)
   {
-    case MEOS_PT_UINT8:   pixsize = 1; break;
-    case MEOS_PT_INT16:   pixsize = 2; break;
-    case MEOS_PT_INT32:   pixsize = 4; break;
-    case MEOS_PT_FLOAT32: pixsize = 4; break;
-    case MEOS_PT_FLOAT64: pixsize = 8; break;
-    default:
+    int32_t srid = int32_from_wkb_state(s);
+    if (srid != SRID_DEFAULT)
+    {
       meos_error(ERROR, MEOS_ERR_WKB_INPUT,
-        "Unknown raquet pixel type in WKB: %u", pixtype);
+        "Only SRID %d (WGS84) is accepted for an h3index, received %d",
+        SRID_DEFAULT, srid);
       return (Datum) 0;
+    }
   }
-  size_t npixels = (size_t) width * height * pixsize;
-  /* Check that there is enough data to read the pixel payload */
-  wkb_parse_state_check(s, npixels);
-  Raquet *result = raquet_make(quadbin, width, height, (MeosPixType) pixtype,
-    nodata, has_nodata, s->pos);
-  s->pos += npixels;
-  return PointerGetDatum(result);
+  /* Read the cell id, wire-format identical to int8 */
+  return Int64GetDatum(int64_from_wkb_state(s));
 }
-#endif /* RASTER */
+#endif /* H3 */
 
 #if JSON
 /**
@@ -1822,6 +1819,7 @@ jsonb_from_wkb_state(meos_wkb_parse_state *s)
   return jb;
 }
 #endif /* JSON */
+
 #if NPOINT
 /**
  * @brief Return the state flags initialized with a byte flag read from the
@@ -1868,34 +1866,6 @@ npoint_from_wkb_state(meos_wkb_parse_state *s)
   return result;
 }
 #endif /* NPOINT */
-
-#if H3
-/**
- * @brief Read an h3index and advance the parse state forward
- * @details The endian flag was consumed by #type_from_wkb. Consume the SRID
- * flag and the optional SRID — which, if present, must be WGS84 (EPSG:4326),
- * an h3 cell being inherently geographic — then read the cell id (int8).
- */
-static Datum
-h3index_from_wkb_state(meos_wkb_parse_state *s)
-{
-  /* Read the flags; consume the SRID only when it is present */
-  uint8_t wkb_flags = byte_from_wkb_state(s);
-  if (wkb_flags & MEOS_WKB_SRIDFLAG)
-  {
-    int32_t srid = int32_from_wkb_state(s);
-    if (srid != SRID_DEFAULT)
-    {
-      meos_error(ERROR, MEOS_ERR_WKB_INPUT,
-        "Only SRID %d (WGS84) is accepted for an h3index, received %d",
-        SRID_DEFAULT, srid);
-      return (Datum) 0;
-    }
-  }
-  /* Read the cell id, wire-format identical to int8 */
-  return Int64GetDatum(int64_from_wkb_state(s));
-}
-#endif /* H3 */
 
 #if POSE || RGEO
 /**
@@ -1956,6 +1926,46 @@ pose_from_wkb_state(meos_wkb_parse_state *s)
 }
 #endif /* POSE */
 
+#if RASTER
+/**
+ * @brief Read a Raquet raster tile and advance the parse state forward
+ * @details The endian flag has already been consumed in
+ * #type_from_wkb_state. What remains are the tile header fields followed by
+ * the row-major packed pixel bytes, whose length is derived from the width,
+ * height and pixel type.
+ */
+Datum
+raquet_from_wkb_state(meos_wkb_parse_state *s)
+{
+  uint64 quadbin = (uint64) int64_from_wkb_state(s);
+  uint8_t pixtype = byte_from_wkb_state(s);
+  uint16_t width = (uint16_t) int32_from_wkb_state(s);
+  uint16_t height = (uint16_t) int32_from_wkb_state(s);
+  bool has_nodata = (bool) byte_from_wkb_state(s);
+  double nodata = double_from_wkb_state(s);
+  size_t pixsize;
+  switch (pixtype)
+  {
+    case MEOS_PT_UINT8:   pixsize = 1; break;
+    case MEOS_PT_INT16:   pixsize = 2; break;
+    case MEOS_PT_INT32:   pixsize = 4; break;
+    case MEOS_PT_FLOAT32: pixsize = 4; break;
+    case MEOS_PT_FLOAT64: pixsize = 8; break;
+    default:
+      meos_error(ERROR, MEOS_ERR_WKB_INPUT,
+        "Unknown raquet pixel type in WKB: %u", pixtype);
+      return (Datum) 0;
+  }
+  size_t npixels = (size_t) width * height * pixsize;
+  /* Check that there is enough data to read the pixel payload */
+  wkb_parse_state_check(s, npixels);
+  Raquet *result = raquet_make(quadbin, width, height, (MeosPixType) pixtype,
+    nodata, has_nodata, s->pos);
+  s->pos += npixels;
+  return PointerGetDatum(result);
+}
+#endif /* RASTER */
+
 /*****************************************************************************/
 
 /**
@@ -1987,6 +1997,11 @@ base_from_wkb_state(meos_wkb_parse_state *s)
     case T_CBUFFER:
       return PointerGetDatum(cbuffer_from_wkb_state(s, true));
 #endif /* NPOINT */
+#if H3
+    case T_H3INDEX:
+      /* h3index is a uint64 cell id, wire-format identical to int8. */
+      return Int64GetDatum(int64_from_wkb_state(s));
+#endif /* H3 */
 #if JSON
     case T_JSONB:
       return PointerGetDatum(jsonb_from_wkb_state(s));
@@ -1999,11 +2014,6 @@ base_from_wkb_state(meos_wkb_parse_state *s)
     case T_POSE:
       return PointerGetDatum(pose_from_wkb_state(s));
 #endif /* POSE */
-#if H3
-    case T_H3INDEX:
-      /* h3index is a uint64 cell id, wire-format identical to int8. */
-      return Int64GetDatum(int64_from_wkb_state(s));
-#endif /* H3 */
 #if QUADBIN
     case T_QUADBIN:
       /* quadbin is a uint64 cell id, wire-format identical to int8. */
@@ -2621,10 +2631,10 @@ type_from_wkb(const uint8_t *wkb, size_t size, MeosType type)
   if (type == T_CBUFFER)
     return PointerGetDatum(cbuffer_from_wkb_state(&s, false));
 #endif /* CBUFFER */
-#if RASTER
-  if (type == T_RAQUET)
-    return raquet_from_wkb_state(&s);
-#endif /* RASTER */
+#if H3
+  if (type == T_H3INDEX)
+    return h3index_from_wkb_state(&s);
+#endif /* H3 */
 #if JSON
   if (type == T_JSONB)
     return PointerGetDatum(jsonb_from_wkb_state(&s));
@@ -2633,14 +2643,14 @@ type_from_wkb(const uint8_t *wkb, size_t size, MeosType type)
   if (type == T_NPOINT)
     return PointerGetDatum(npoint_from_wkb_state(&s));
 #endif /* NPOINT */
-#if H3
-  if (type == T_H3INDEX)
-    return h3index_from_wkb_state(&s);
-#endif /* H3 */
 #if POSE || RGEO
   if (type == T_POSE)
     return PointerGetDatum(pose_from_wkb_state(&s));
 #endif /* POSE */
+#if RASTER
+  if (type == T_RAQUET)
+    return raquet_from_wkb_state(&s);
+#endif /* RASTER */
   if (temporal_type(type))
     return PointerGetDatum(temporal_from_wkb_state(&s));
   /* Error! */

--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -456,6 +456,9 @@ parse_mfjson_values(json_object *mfjson, MeosType temptype, int *count)
 #if H3
       case T_TH3INDEX:
 #endif
+#if QUADBIN
+      case T_TQUADBIN:
+#endif
         if (json_object_get_type(jvalue) != json_type_int)
         {
           meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
@@ -1049,6 +1052,12 @@ tinstant_from_mfjson(json_object *mfjson, bool spatial, int32_t srid,
     else if (temptype == T_TPOSE || temptype == T_TRGEOMETRY)
       values = parse_mfjson_poses(mfjson, srid, &nvalues);
 #endif /* POSE */
+#if QUADBIN
+    /* quadbin, like h3index, is a scalar cell id carried with a bbox: the
+     * 'values' array holds plain cell ids parsed as base values */
+    else if (temptype == T_TQUADBIN)
+      values = parse_mfjson_values(mfjson, temptype, &nvalues);
+#endif /* QUADBIN */
     else
     {
       meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
@@ -1112,6 +1121,12 @@ tinstarr_from_mfjson(json_object *mfjson, bool isgeo, int32_t srid,
     else if (temptype == T_TPOSE || temptype == T_TRGEOMETRY)
       values = parse_mfjson_poses(mfjson, srid, &nvalues);
 #endif /* RGEO */
+#if QUADBIN
+    /* quadbin, like h3index, is a scalar cell id carried with a bbox: the
+     * 'values' array holds plain cell ids parsed as base values */
+    else if (temptype == T_TQUADBIN)
+      values = parse_mfjson_values(mfjson, temptype, &nvalues);
+#endif /* QUADBIN */
    else
     {
       meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
@@ -1268,6 +1283,9 @@ ensure_temptype_mfjson(const char *typestr)
 #if POSE
       && strcmp(typestr, "MovingPose") != 0
 #endif /* POSE */
+#if QUADBIN
+      && strcmp(typestr, "MovingQuadbin") != 0
+#endif /* QUADBIN */
 #if RGEO
       && strcmp(typestr, "MovingRigidGeometry") != 0
 #endif /* RGEO */
@@ -1380,6 +1398,10 @@ temporal_from_mfjson(const char *mfjson, MeosType temptype)
   else if (strcmp(typestr, "MovingPose") == 0)
     jtemptype = T_TPOSE;
 #endif /* POSE */
+#if QUADBIN
+  else if (strcmp(typestr, "MovingQuadbin") == 0)
+    jtemptype = T_TQUADBIN;
+#endif /* QUADBIN */
 #if RGEO
   else if (strcmp(typestr, "MovingRigidGeometry") == 0)
     jtemptype = T_TRGEOMETRY;

--- a/meos/src/temporal/type_out.c
+++ b/meos/src/temporal/type_out.c
@@ -60,14 +60,12 @@
 #if CBUFFER
   #include "cbuffer/cbuffer.h"
 #endif
-#if RASTER
-  #include "raster/raquet.h"
+#if H3
+  #include <h3api.h>
+  #include "h3/h3index.h"
 #endif
 #if JSON
   #include <utils/jsonb.h>
-#endif
-#if QUADBIN
-  #include <meos_quadbin.h>
 #endif
 #if NPOINT
   #include "npoint/tnpoint.h"
@@ -80,12 +78,14 @@
 #if POSE
   #include "pose/pose.h"
 #endif
+#if QUADBIN
+  #include <meos_quadbin.h>
+#endif
+#if RASTER
+  #include "raster/raquet.h"
+#endif
 #if RGEO
   #include "rgeo/trgeo_all.h"
-#endif
-#if H3
-  #include <h3api.h>
-  #include "h3/h3index.h"
 #endif
 
 #include <utils/jsonb.h>
@@ -136,14 +136,6 @@ basetype_out(Datum value, MeosType type, int maxdd)
       return int32_out(DatumGetInt32(value));
     case T_INT8:
       return int64_out(DatumGetInt64(value));
-#if H3
-    case T_H3INDEX:
-      return h3index_out((H3Index) DatumGetInt64(value));
-#endif
-#if QUADBIN
-    case T_QUADBIN:
-      return quadbin_index_to_string((Quadbin) DatumGetInt64(value));
-#endif
     case T_FLOAT8:
       return float8_out(DatumGetFloat8(value), maxdd);
     case T_TEXT:
@@ -174,9 +166,9 @@ basetype_out(Datum value, MeosType type, int maxdd)
     case T_CBUFFER:
       return cbuffer_out(DatumGetCbufferP(value), maxdd);
 #endif
-#if RASTER
-    case T_RAQUET:
-      return raquet_out(DatumGetRaquetP(value));
+#if H3
+    case T_H3INDEX:
+      return h3index_out((H3Index) DatumGetInt64(value));
 #endif
 #if JSON
     case T_JSONB:
@@ -195,6 +187,14 @@ basetype_out(Datum value, MeosType type, int maxdd)
 #if POSE || RGEO
     case T_POSE:
       return pose_out(DatumGetPoseP(value), maxdd);
+#endif
+#if QUADBIN
+    case T_QUADBIN:
+      return quadbin_index_to_string((Quadbin) DatumGetInt64(value));
+#endif
+#if RASTER
+    case T_RAQUET:
+      return raquet_out(DatumGetRaquetP(value));
 #endif
     default: /* Error! */
       meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
@@ -260,6 +260,34 @@ text_as_mfjson_sb(stringbuffer_t *sb, const text *txt)
   return;
 }
 
+#if CBUFFER
+/**
+ * @brief Write into the buffer a circular buffer in the MF-JSON
+ * representation
+ * @details Circular buffers are always planar 2D: a `point` member (an
+ * `[x, y]` coordinate array, as for a temporal point) and a numeric
+ * `radius` member, e.g. `{"point":[1,2],"radius":3}`. The member names
+ * mirror the @p point and @p radius accessors. There is no Z/geodetic
+ * handling as for poses.
+ */
+static void
+cbuffer_as_mfjson_sb(stringbuffer_t *sb, const Cbuffer *cb, int precision)
+{
+  assert(precision <= OUT_MAX_DOUBLE_PRECISION);
+  GSERIALIZED *gs = cbuffer_point(cb);
+  const POINT2D *pt = GSERIALIZED_POINT2D_P(gs);
+  stringbuffer_append_len(sb, "{\"point\":[", 10);
+  stringbuffer_append_double(sb, pt->x, precision);
+  stringbuffer_append_char(sb, ',');
+  stringbuffer_append_double(sb, pt->y, precision);
+  stringbuffer_append_len(sb, "],\"radius\":", 11);
+  stringbuffer_append_double(sb, cbuffer_radius(cb), precision);
+  stringbuffer_append_char(sb, '}');
+  pfree(gs);
+  return;
+}
+#endif /* CBUFFER */
+
 #if JSON
 /**
  * @brief Write into the buffer a JSONB value in the MF-JSON representation
@@ -318,7 +346,7 @@ coordinates_as_mfjson_sb(stringbuffer_t *sb, const TInstant *inst, int precision
  * with INT64_FORMAT to avoid loss of precision in the JSON payload.
  */
 static void
-npoint_as_json_sb(stringbuffer_t *sb, const Npoint *np, int precision)
+npoint_as_mfjson_sb(stringbuffer_t *sb, const Npoint *np, int precision)
 {
   assert(precision <= OUT_MAX_DOUBLE_PRECISION);
   stringbuffer_aprintf(sb, "{\"route\":" INT64_FORMAT ",\"position\":", np->rid);
@@ -430,34 +458,6 @@ stringbuffer_append_char(sb, '}');
 }
 #endif /* POSE */
 
-#if CBUFFER
-/**
- * @brief Write into the buffer a circular buffer in the MF-JSON
- * representation
- * @details Circular buffers are always planar 2D: a `point` member (an
- * `[x, y]` coordinate array, as for a temporal point) and a numeric
- * `radius` member, e.g. `{"point":[1,2],"radius":3}`. The member names
- * mirror the @p point and @p radius accessors. There is no Z/geodetic
- * handling as for poses.
- */
-static void
-cbuffer_as_json_sb(stringbuffer_t *sb, const Cbuffer *cb, int precision)
-{
-  assert(precision <= OUT_MAX_DOUBLE_PRECISION);
-  GSERIALIZED *gs = cbuffer_point(cb);
-  const POINT2D *pt = GSERIALIZED_POINT2D_P(gs);
-  stringbuffer_append_len(sb, "{\"point\":[", 10);
-  stringbuffer_append_double(sb, pt->x, precision);
-  stringbuffer_append_char(sb, ',');
-  stringbuffer_append_double(sb, pt->y, precision);
-  stringbuffer_append_len(sb, "],\"radius\":", 11);
-  stringbuffer_append_double(sb, cbuffer_radius(cb), precision);
-  stringbuffer_append_char(sb, '}');
-  pfree(gs);
-  return;
-}
-#endif /* CBUFFER */
-
 /**
  * @brief Write into the buffer a base value in the MF-JSON representation
  */
@@ -475,7 +475,9 @@ temporal_base_as_mfjson_sb(stringbuffer_t *sb, Datum value, MeosType temptype,
       int32_as_mfjson_sb(sb, DatumGetInt32(value));
       break;
     case T_TBIGINT:
+#if H3
     case T_TH3INDEX:
+#endif
       int64_as_mfjson_sb(sb, DatumGetInt64(value));
       break;
     case T_TFLOAT:
@@ -653,20 +655,28 @@ bbox_as_mfjson_sb(stringbuffer_t *sb, MeosType temptype, const bboxunion *box,
       tstzspan_as_mfjson_sb(sb, (Span *) box);
       break;
     case T_TBIGINT:
-    case T_TH3INDEX:
     case T_TINT:
     case T_TFLOAT:
+#if H3
+    case T_TH3INDEX:
+#endif
       tbox_as_mfjson_sb(sb, (TBox *) box, precision);
       break;
     case T_TGEOMPOINT:
     case T_TGEOGPOINT:
     case T_TGEOMETRY:
     case T_TGEOGRAPHY:
-    case T_TPOSE:
-    case T_TRGEOMETRY:
+#if CBUFFER
     case T_TCBUFFER:
+#endif
 #if NPOINT
     case T_TNPOINT:
+#endif
+#if POSE
+    case T_TPOSE:
+#endif
+#if RGEO
+    case T_TRGEOMETRY:
 #endif
       stbox_as_mfjson_sb(sb, (STBox *) box, precision);
       break;
@@ -703,9 +713,6 @@ temptype_as_mfjson_sb(stringbuffer_t *sb, MeosType temptype)
     case T_TBIGINT:
       stringbuffer_append_len(sb, "{\"type\":\"MovingBigInteger\",", 27);
       break;
-    case T_TH3INDEX:
-      stringbuffer_append_len(sb, "{\"type\":\"MovingH3Index\",", 24);
-      break;
     case T_TFLOAT:
       stringbuffer_append_len(sb, "{\"type\":\"MovingFloat\",", 22);
       break;
@@ -720,25 +727,19 @@ temptype_as_mfjson_sb(stringbuffer_t *sb, MeosType temptype)
     case T_TGEOGRAPHY:
       stringbuffer_append_len(sb, "{\"type\":\"MovingGeometry\",", 25);
       break;
-#if JSON
-    case T_TJSONB:
-      stringbuffer_append_len(sb, "{\"type\":\"MovingJsonb\",", 22);
-      break;
-#endif
-#if POSE
-    case T_TPOSE:
-      stringbuffer_append_len(sb, "{\"type\":\"MovingPose\",", 21);
-      break;
-#endif
-#if RGEO
-    case T_TRGEOMETRY:
-      stringbuffer_append_len(sb, "{\"type\":\"MovingRigidGeometry\",", 30);
-      break;
-#endif
-
 #if CBUFFER
     case T_TCBUFFER:
       stringbuffer_append_len(sb, "{\"type\":\"MovingCircularBuffer\",", 31);
+      break;
+#endif
+#if H3
+    case T_TH3INDEX:
+      stringbuffer_append_len(sb, "{\"type\":\"MovingH3Index\",", 24);
+      break;
+#endif
+#if JSON
+    case T_TJSONB:
+      stringbuffer_append_len(sb, "{\"type\":\"MovingJsonb\",", 22);
       break;
 #endif
 #if NPOINT
@@ -752,6 +753,16 @@ temptype_as_mfjson_sb(stringbuffer_t *sb, MeosType temptype)
       break;
     case T_TPCPATCH:
       stringbuffer_append_len(sb, "{\"type\":\"MovingPCPatch\",", 24);
+      break;
+#endif
+#if POSE
+    case T_TPOSE:
+      stringbuffer_append_len(sb, "{\"type\":\"MovingPose\",", 21);
+      break;
+#endif
+#if RGEO
+    case T_TRGEOMETRY:
+      stringbuffer_append_len(sb, "{\"type\":\"MovingRigidGeometry\",", 30);
       break;
 #endif
     default: /* Error! */
@@ -799,6 +810,32 @@ tinstant_as_mfjson_sb(stringbuffer_t *sb, const TInstant *inst,
     stringbuffer_aprintf(sb, "\"values\":[%s", str);
     pfree(str);
   }
+#if CBUFFER
+  else if (inst->temptype == T_TCBUFFER)
+  {
+    stringbuffer_append_len(sb, "\"values\":[", 10);
+    cbuffer_as_mfjson_sb(sb, DatumGetCbufferP(tinstant_value_p(inst)), precision);
+  }
+#endif /* CBUFFER */
+#if NPOINT
+  else if (inst->temptype == T_TNPOINT)
+  {
+    stringbuffer_append_len(sb, "\"values\":[", 10);
+    npoint_as_mfjson_sb(sb, DatumGetNpointP(tinstant_value_p(inst)), precision);
+  }
+#endif /* NPOINT */
+#if POINTCLOUD
+  else if (inst->temptype == T_TPCPOINT)
+  {
+    stringbuffer_append_len(sb, "\"coordinates\":[", 15);
+    tpcpoint_coordinates_as_mfjson_sb(sb, inst, precision);
+  }
+  else if (inst->temptype == T_TPCPATCH)
+  {
+    stringbuffer_append_len(sb, "\"values\":[", 10);
+    tpcpatch_as_mfjson_sb(sb, inst, precision);
+  }
+#endif /* POINTCLOUD */
 #if POSE
   else if (inst->temptype == T_TPOSE)
   {
@@ -819,33 +856,6 @@ tinstant_as_mfjson_sb(stringbuffer_t *sb, const TInstant *inst,
     pose_as_json_sb(sb, DatumGetPoseP(tinstant_value_p(inst)), precision);
   }
 #endif /* RGEO */
-
-#if CBUFFER
-  else if (inst->temptype == T_TCBUFFER)
-  {
-    stringbuffer_append_len(sb, "\"values\":[", 10);
-    cbuffer_as_json_sb(sb, DatumGetCbufferP(tinstant_value_p(inst)), precision);
-  }
-#endif /* CBUFFER */
-#if NPOINT
-  else if (inst->temptype == T_TNPOINT)
-  {
-    stringbuffer_append_len(sb, "\"values\":[", 10);
-    npoint_as_json_sb(sb, DatumGetNpointP(tinstant_value_p(inst)), precision);
-  }
-#endif /* NPOINT */
-#if POINTCLOUD
-  else if (inst->temptype == T_TPCPOINT)
-  {
-    stringbuffer_append_len(sb, "\"coordinates\":[", 15);
-    tpcpoint_coordinates_as_mfjson_sb(sb, inst, precision);
-  }
-  else if (inst->temptype == T_TPCPATCH)
-  {
-    stringbuffer_append_len(sb, "\"values\":[", 10);
-    tpcpatch_as_mfjson_sb(sb, inst, precision);
-  }
-#endif /* POINTCLOUD */
   else
   {
     stringbuffer_append_len(sb, "\"values\":[", 10);
@@ -884,6 +894,10 @@ tsequence_as_mfjson_sb(stringbuffer_t *sb, const TSequence *seq,
   }
   if (tpoint_type(seq->temptype))
     stringbuffer_append_len(sb, "\"coordinates\":[", 15);
+#if POINTCLOUD
+  else if (seq->temptype == T_TPCPOINT)
+    stringbuffer_append_len(sb, "\"coordinates\":[", 15);
+#endif /* POINTCLOUD */
 #if RGEO
   else if (seq->temptype == T_TRGEOMETRY)
   {
@@ -893,10 +907,6 @@ tsequence_as_mfjson_sb(stringbuffer_t *sb, const TSequence *seq,
     stringbuffer_aprintf(sb, "%s,\"values\":[", str);
   }
 #endif /* RGEO */
-#if POINTCLOUD
-  else if (seq->temptype == T_TPCPOINT)
-    stringbuffer_append_len(sb, "\"coordinates\":[", 15);
-#endif
   else
     stringbuffer_append_len(sb, "\"values\":[", 10);
   const TInstant *inst;
@@ -915,6 +925,24 @@ tsequence_as_mfjson_sb(stringbuffer_t *sb, const TSequence *seq,
       stringbuffer_aprintf(sb, "%s", str);
       pfree(str);
     }
+#if CBUFFER
+    else if (inst->temptype == T_TCBUFFER)
+    {
+      cbuffer_as_mfjson_sb(sb, DatumGetCbufferP(tinstant_value_p(inst)), precision);
+    }
+#endif /* CBUFFER */
+#if NPOINT
+    else if (inst->temptype == T_TNPOINT)
+    {
+      npoint_as_mfjson_sb(sb, DatumGetNpointP(tinstant_value_p(inst)), precision);
+    }
+#endif /* NPOINT */
+#if POINTCLOUD
+    else if (inst->temptype == T_TPCPOINT)
+      tpcpoint_coordinates_as_mfjson_sb(sb, inst, precision);
+    else if (inst->temptype == T_TPCPATCH)
+      tpcpatch_as_mfjson_sb(sb, inst, precision);
+#endif /* POINTCLOUD */
 #if POSE
     else if (inst->temptype == T_TPOSE)
     {
@@ -930,24 +958,6 @@ tsequence_as_mfjson_sb(stringbuffer_t *sb, const TSequence *seq,
     }
 #endif /* RGEO */
 
-#if CBUFFER
-    else if (inst->temptype == T_TCBUFFER)
-    {
-      cbuffer_as_json_sb(sb, DatumGetCbufferP(tinstant_value_p(inst)), precision);
-    }
-#endif /* CBUFFER */
-#if NPOINT
-    else if (inst->temptype == T_TNPOINT)
-    {
-      npoint_as_json_sb(sb, DatumGetNpointP(tinstant_value_p(inst)), precision);
-    }
-#endif /* NPOINT */
-#if POINTCLOUD
-    else if (inst->temptype == T_TPCPOINT)
-      tpcpoint_coordinates_as_mfjson_sb(sb, inst, precision);
-    else if (inst->temptype == T_TPCPATCH)
-      tpcpatch_as_mfjson_sb(sb, inst, precision);
-#endif /* POINTCLOUD */
     else
     {
       success = temporal_base_as_mfjson_sb(sb, tinstant_value_p(inst),
@@ -1052,13 +1062,13 @@ tsequenceset_as_mfjson_sb(stringbuffer_t *sb, const TSequenceSet *ss,
 #if CBUFFER
       else if (inst->temptype == T_TCBUFFER)
       {
-        cbuffer_as_json_sb(sb, DatumGetCbufferP(tinstant_value_p(inst)), precision);
+        cbuffer_as_mfjson_sb(sb, DatumGetCbufferP(tinstant_value_p(inst)), precision);
       }
 #endif /* CBUFFER */
 #if NPOINT
       else if (inst->temptype == T_TNPOINT)
       {
-        npoint_as_json_sb(sb, DatumGetNpointP(tinstant_value_p(inst)), precision);
+        npoint_as_mfjson_sb(sb, DatumGetNpointP(tinstant_value_p(inst)), precision);
       }
 #endif /* NPOINT */
 #if POINTCLOUD
@@ -1391,6 +1401,11 @@ base_to_wkb_size(Datum value, MeosType basetype, uint8_t variant)
     case T_CBUFFER:
       return cbuffer_to_wkb_size(DatumGetCbufferP(value), variant, true);
 #endif /* CBUFFER */
+#if H3
+    case T_H3INDEX:
+      /* h3index is a uint64 cell id, wire-format identical to int8. */
+      return MEOS_WKB_INT8_SIZE;
+#endif /* H3 */
 #if JSON
     case T_JSONB:
       return jsonb_to_wkb_size(DatumGetJsonbP(value), true);
@@ -1403,16 +1418,6 @@ base_to_wkb_size(Datum value, MeosType basetype, uint8_t variant)
     case T_POSE:
       return pose_to_wkb_size(DatumGetPoseP(value), variant, true);
 #endif /* POSE || RGEO */
-#if H3
-    case T_H3INDEX:
-      /* h3index is a uint64 cell id, wire-format identical to int8. */
-      return MEOS_WKB_INT8_SIZE;
-#endif /* H3 */
-#if QUADBIN
-    case T_QUADBIN:
-      /* quadbin is a uint64 cell id, wire-format identical to int8. */
-      return MEOS_WKB_INT8_SIZE;
-#endif /* QUADBIN */
 #if POINTCLOUD
     case T_PCPOINT:
       return pcpoint_to_wkb_size((const Pcpoint *) DatumGetPointer(value),
@@ -1421,6 +1426,11 @@ base_to_wkb_size(Datum value, MeosType basetype, uint8_t variant)
       return pcpatch_to_wkb_size((const Pcpatch *) DatumGetPointer(value),
         variant);
 #endif /* POINTCLOUD */
+#if QUADBIN
+    case T_QUADBIN:
+      /* quadbin is a uint64 cell id, wire-format identical to int8. */
+      return MEOS_WKB_INT8_SIZE;
+#endif /* QUADBIN */
     default: /* Error! */
       meos_error(ERROR, MEOS_ERR_MFJSON_OUTPUT,
         "Unknown temporal base type in WKB output: %s",
@@ -1678,10 +1688,10 @@ datum_to_wkb_size(Datum value, MeosType type, uint8_t variant)
   if (type == T_CBUFFER)
     return cbuffer_to_wkb_size(DatumGetCbufferP(value), variant, false);
 #endif /* CBUFFER */
-#if RASTER
-  if (type == T_RAQUET)
-    return raquet_to_wkb_size(DatumGetRaquetP(value), false);
-#endif /* RASTER */
+#if H3
+  if (type == T_H3INDEX)
+    return h3index_to_wkb_size(variant);
+#endif /* H3 */
 #if JSON
   if (type == T_JSONB)
     return jsonb_to_wkb_size(DatumGetJsonbP(value), variant);
@@ -1690,14 +1700,14 @@ datum_to_wkb_size(Datum value, MeosType type, uint8_t variant)
   if (type == T_NPOINT)
     return npoint_to_wkb_size(DatumGetNpointP(value), variant, false);
 #endif /* NPOINT */
-#if H3
-  if (type == T_H3INDEX)
-    return h3index_to_wkb_size(variant);
-#endif /* H3 */
 #if POSE || RGEO
   if (type == T_POSE)
     return pose_to_wkb_size(DatumGetPoseP(value), variant, false);
 #endif /* POSE || RGEO */
+#if RASTER
+  if (type == T_RAQUET)
+    return raquet_to_wkb_size(DatumGetRaquetP(value), false);
+#endif /* RASTER */
   if (temporal_type(type))
     return temporal_to_wkb_size((Temporal *) DatumGetPointer(value), variant);
   /* Error! */
@@ -1977,33 +1987,33 @@ cbuffer_to_wkb_buf(const Cbuffer *cb, uint8_t *buf, uint8_t variant,
 }
 #endif /* CBUFFER */
 
-#if RASTER
+#if H3
 /**
- * @brief Write into the buffer a Raquet raster tile in the Well-Known Binary
- * (WKB) representation
+ * @brief Write into the buffer an h3index in the Well-Known Binary (WKB)
+ * representation
+ * @details endian flag, SRID flag, optional SRID (WGS84, extended variant
+ * only), then the cell id (int8). The SRID flag bit is set only when the SRID
+ * is actually written — matching the npoint/pose readers (and unlike the
+ * unconditional cbuffer flag).
  */
 static uint8_t *
-raquet_to_wkb_buf(const Raquet *rq, uint8_t *buf, uint8_t variant,
-  bool component)
+h3index_to_wkb_buf(Datum value, uint8_t *buf, uint8_t variant)
 {
-  if (! component)
-    /* Write the endian flag (byte) */
-    buf = endian_to_wkb_buf(buf, variant);
-  /* Write the tile header */
-  buf = int64_to_wkb_buf((int64) rq->quadbin, buf, variant);
-  uint8_t pixtype = rq->pixtype;
-  buf = bytes_to_wkb_buf(&pixtype, MEOS_WKB_BYTE_SIZE, buf, variant);
-  buf = int32_to_wkb_buf((int) rq->width, buf, variant);
-  buf = int32_to_wkb_buf((int) rq->height, buf, variant);
-  uint8_t has_nodata = rq->has_nodata ? 1 : 0;
-  buf = bytes_to_wkb_buf(&has_nodata, MEOS_WKB_BYTE_SIZE, buf, variant);
-  buf = double_to_wkb_buf(rq->nodata, buf, variant);
-  /* Write the row-major packed pixel bytes */
-  buf = bytes_to_wkb_buf((uint8_t *) rq->pixels, raquet_pixels_size(rq), buf,
-    variant);
+  /* Write the endian flag (byte) */
+  buf = endian_to_wkb_buf(buf, variant);
+  /* Write the SRID flag, set only when the SRID will follow */
+  int32_t srid = SRID_DEFAULT;
+  uint8_t wkb_flags = spatial_wkb_needs_srid(srid, variant) ?
+    (uint8_t) MEOS_WKB_SRIDFLAG : 0;
+  buf = uint8_to_wkb_buf(wkb_flags, buf, variant);
+  /* Write the SRID (extended/EWKB variant only) */
+  if (spatial_wkb_needs_srid(srid, variant))
+    buf = int32_to_wkb_buf(srid, buf, variant);
+  /* Write the cell id, wire-format identical to int8 */
+  buf = int64_to_wkb_buf((int64) DatumGetInt64(value), buf, variant);
   return buf;
 }
-#endif /* RASTER */
+#endif /* H3 */
 
 #if JSON
 /**
@@ -2026,6 +2036,7 @@ jsonb_to_wkb_buf(const Jsonb *jb, uint8_t *buf, uint8_t variant)
   return buf;
 }
 #endif /* JSON */
+
 #if NPOINT
 /**
  * @brief Write into the buffer the flag of a network point in the Well-Known
@@ -2128,34 +2139,6 @@ pose_to_wkb_buf(const Pose *pose, uint8_t *buf, uint8_t variant,
 }
 #endif /* POSE */
 
-#if H3
-/**
- * @brief Write into the buffer an h3index in the Well-Known Binary (WKB)
- * representation
- * @details endian flag, SRID flag, optional SRID (WGS84, extended variant
- * only), then the cell id (int8). The SRID flag bit is set only when the SRID
- * is actually written — matching the npoint/pose readers (and unlike the
- * unconditional cbuffer flag).
- */
-static uint8_t *
-h3index_to_wkb_buf(Datum value, uint8_t *buf, uint8_t variant)
-{
-  /* Write the endian flag (byte) */
-  buf = endian_to_wkb_buf(buf, variant);
-  /* Write the SRID flag, set only when the SRID will follow */
-  int32_t srid = SRID_DEFAULT;
-  uint8_t wkb_flags = spatial_wkb_needs_srid(srid, variant) ?
-    (uint8_t) MEOS_WKB_SRIDFLAG : 0;
-  buf = uint8_to_wkb_buf(wkb_flags, buf, variant);
-  /* Write the SRID (extended/EWKB variant only) */
-  if (spatial_wkb_needs_srid(srid, variant))
-    buf = int32_to_wkb_buf(srid, buf, variant);
-  /* Write the cell id, wire-format identical to int8 */
-  buf = int64_to_wkb_buf((int64) DatumGetInt64(value), buf, variant);
-  return buf;
-}
-#endif /* H3 */
-
 #if POINTCLOUD
 /**
  * @brief Emit @p body_len bytes from @p src into @p buf, hex-encoding when
@@ -2205,6 +2188,34 @@ pcpatch_to_wkb_buf(const Pcpatch *pa, uint8_t *buf, uint8_t variant)
 }
 #endif /* POINTCLOUD */
 
+#if RASTER
+/**
+ * @brief Write into the buffer a Raquet raster tile in the Well-Known Binary
+ * (WKB) representation
+ */
+static uint8_t *
+raquet_to_wkb_buf(const Raquet *rq, uint8_t *buf, uint8_t variant,
+  bool component)
+{
+  if (! component)
+    /* Write the endian flag (byte) */
+    buf = endian_to_wkb_buf(buf, variant);
+  /* Write the tile header */
+  buf = int64_to_wkb_buf((int64) rq->quadbin, buf, variant);
+  uint8_t pixtype = rq->pixtype;
+  buf = bytes_to_wkb_buf(&pixtype, MEOS_WKB_BYTE_SIZE, buf, variant);
+  buf = int32_to_wkb_buf((int) rq->width, buf, variant);
+  buf = int32_to_wkb_buf((int) rq->height, buf, variant);
+  uint8_t has_nodata = rq->has_nodata ? 1 : 0;
+  buf = bytes_to_wkb_buf(&has_nodata, MEOS_WKB_BYTE_SIZE, buf, variant);
+  buf = double_to_wkb_buf(rq->nodata, buf, variant);
+  /* Write the row-major packed pixel bytes */
+  buf = bytes_to_wkb_buf((uint8_t *) rq->pixels, raquet_pixels_size(rq), buf,
+    variant);
+  return buf;
+}
+#endif /* RASTER */
+
 /**
  * @brief Write into the buffer a temporal instant in the Well-Known Binary
  * (WKB) representation
@@ -2248,6 +2259,12 @@ base_to_wkb_buf(Datum value, MeosType basetype, uint8_t *buf,
       buf = cbuffer_to_wkb_buf(DatumGetCbufferP(value), buf, variant, true);
       break;
 #endif /* CBUFFER */
+#if H3
+    case T_H3INDEX:
+      /* h3index is a uint64 cell id; wire it as int8. */
+      buf = int64_to_wkb_buf((int64) DatumGetInt64(value), buf, variant);
+      break;
+#endif /* H3 */
 #if JSON
     case T_JSONB:
       buf = jsonb_to_wkb_buf(DatumGetJsonbP(value), buf, variant);
@@ -2263,12 +2280,6 @@ base_to_wkb_buf(Datum value, MeosType basetype, uint8_t *buf,
       buf = pose_to_wkb_buf(DatumGetPoseP(value), buf, variant, true);
       break;
 #endif /* POSE || RGEO */
-#if H3
-    case T_H3INDEX:
-      /* h3index is a uint64 cell id; wire it as int8. */
-      buf = int64_to_wkb_buf((int64) DatumGetInt64(value), buf, variant);
-      break;
-#endif /* H3 */
 #if QUADBIN
     case T_QUADBIN:
       /* quadbin is a uint64 cell id; wire it as int8. */
@@ -2906,10 +2917,10 @@ datum_to_wkb_buf(Datum value, MeosType type, uint8_t *buf, uint8_t variant)
   else if (type == T_CBUFFER)
     buf = cbuffer_to_wkb_buf(DatumGetCbufferP(value), buf, variant, false);
 #endif /* CBUFFER */
-#if RASTER
-  else if (type == T_RAQUET)
-    buf = raquet_to_wkb_buf(DatumGetRaquetP(value), buf, variant, false);
-#endif /* RASTER */
+#if H3
+  else if (type == T_H3INDEX)
+    buf = h3index_to_wkb_buf(value, buf, variant);
+#endif /* H3 */
 #if JSON
   else if (type == T_JSONB)
     buf = jsonb_to_wkb_buf(DatumGetJsonbP(value), buf, variant);
@@ -2919,14 +2930,14 @@ datum_to_wkb_buf(Datum value, MeosType type, uint8_t *buf, uint8_t variant)
     buf = npoint_to_wkb_buf(DatumGetNpointP(value), buf, variant,
       false);
 #endif /* NPOINT */
-#if H3
-  else if (type == T_H3INDEX)
-    buf = h3index_to_wkb_buf(value, buf, variant);
-#endif /* H3 */
 #if POSE || RGEO
   else if (type == T_POSE)
     buf = pose_to_wkb_buf(DatumGetPoseP(value), buf, variant, false);
 #endif /* POSE || RGEO */
+#if RASTER
+  else if (type == T_RAQUET)
+    buf = raquet_to_wkb_buf(DatumGetRaquetP(value), buf, variant, false);
+#endif /* RASTER */
   else if (temporal_type(type))
     buf = temporal_to_wkb_buf((Temporal *) DatumGetPointer(value), buf,
       variant);

--- a/meos/src/temporal/type_out.c
+++ b/meos/src/temporal/type_out.c
@@ -478,6 +478,9 @@ temporal_base_as_mfjson_sb(stringbuffer_t *sb, Datum value, MeosType temptype,
 #if H3
     case T_TH3INDEX:
 #endif
+#if QUADBIN
+    case T_TQUADBIN:
+#endif
       int64_as_mfjson_sb(sb, DatumGetInt64(value));
       break;
     case T_TFLOAT:
@@ -660,6 +663,9 @@ bbox_as_mfjson_sb(stringbuffer_t *sb, MeosType temptype, const bboxunion *box,
 #if H3
     case T_TH3INDEX:
 #endif
+#if QUADBIN
+    case T_TQUADBIN:
+#endif
       tbox_as_mfjson_sb(sb, (TBox *) box, precision);
       break;
     case T_TGEOMPOINT:
@@ -758,6 +764,11 @@ temptype_as_mfjson_sb(stringbuffer_t *sb, MeosType temptype)
 #if POSE
     case T_TPOSE:
       stringbuffer_append_len(sb, "{\"type\":\"MovingPose\",", 21);
+      break;
+#endif
+#if QUADBIN
+    case T_TQUADBIN:
+      stringbuffer_append_len(sb, "{\"type\":\"MovingQuadbin\",", 24);
       break;
 #endif
 #if RGEO


### PR DESCRIPTION
As the number of optional families keeps growing, it becomes hard to tell at a glance whether a given family is handled in a particular dispatch function. This orders the optional-family `#if` gates alphabetically (CBUFFER, H3, JSON, NPOINT, POINTCLOUD, POSE, QUADBIN, RASTER, RGEO) in the generic temporal input/output code, and fills the family cases that were missing.

**Order families alphabetically**
Reorders the `#if <FAMILY>` blocks and their case labels alphabetically in `meos/src/temporal/type_in.c` and `meos/src/temporal/type_out.c` (base-type input/output, MF-JSON input/output, and the temporal-type dispatch). The ordering is behavior-preserving; a per-configuration check (all families on, and the coverage subset with H3/JSON/POINTCLOUD/RASTER off) confirms the resolved case sets and emitted output are unchanged.

**Add the raster base type input to basetype_in**
Adds the missing `#if RASTER case T_RAQUET` arm to `basetype_in`, mirroring the existing `raquet_out` arm in `basetype_out`.

**Add the temporal quadbin MF-JSON serialization**
Adds the `T_TQUADBIN` cases to the generic MF-JSON input and output dispatch, mirroring the existing temporal h3index support: a temporal quadbin carries a 64-bit cell id, so its value is serialized/parsed as an int64, its bounding box as a tbox, and its MF-JSON type tag is `MovingQuadbin`.
