### PR TITLE
Add extended hash support for circular buffer and JSONB sets

### DIFF
--- a/meos/src/temporal/type_util.c
+++ b/meos/src/temporal/type_util.c
@@ -600,6 +600,14 @@ datum_hash_extended(Datum d, MeosType type, uint64 seed)
     // case T_GEOMETRY:
     // case T_GEOGRAPHY:
       // return gserialized_hash_extended(DatumGetGserializedP(d), seed);
+#if CBUFFER
+    case T_CBUFFER:
+      return cbuffer_hash_extended(DatumGetCbufferP(d), seed);
+#endif
+#if JSON
+    case T_JSONB:
+      return pg_jsonb_hash_extended(DatumGetJsonbP(d), seed);
+#endif /* JSON */
 #if NPOINT
     case T_NPOINT:
       return npoint_hash_extended(DatumGetNpointP(d), seed);

--- a/mobilitydb/test/cbuffer/expected/201_cbufferset_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/201_cbufferset_tbl.test.out
@@ -145,6 +145,12 @@ SELECT MAX(set_hash(s)) FROM tbl_cbufferset;
  2108338657
 (1 row)
 
+SELECT MAX(set_hash_extended(s, 1)) FROM tbl_cbufferset;
+         max         
+---------------------
+ 8841573282622179135
+(1 row)
+
 SELECT numValues(setUnion(cb)) FROM tbl_cbuffer;
  numvalues 
 -----------

--- a/mobilitydb/test/cbuffer/queries/201_cbufferset_tbl.test.sql
+++ b/mobilitydb/test/cbuffer/queries/201_cbufferset_tbl.test.sql
@@ -97,6 +97,8 @@ SELECT COUNT(*) FROM tbl_cbufferset t1, tbl_cbufferset t2 WHERE t1.s >= t2.s;
 
 SELECT MAX(set_hash(s)) FROM tbl_cbufferset;
 
+SELECT MAX(set_hash_extended(s, 1)) FROM tbl_cbufferset;
+
 -------------------------------------------------------------------------------
 -- Aggregation functions
 

--- a/mobilitydb/test/json/expected/450_jsonbset_tbl.test.out
+++ b/mobilitydb/test/json/expected/450_jsonbset_tbl.test.out
@@ -223,6 +223,12 @@ SELECT MAX(set_hash(s)) FROM tbl_jsonbset;
  2107504745
 (1 row)
 
+SELECT MAX(set_hash_extended(s, 1)) FROM tbl_jsonbset;
+         max         
+---------------------
+ 9209195217540800445
+(1 row)
+
 SELECT numValues(setUnion(jb)) FROM tbl_jsonb;
  numvalues 
 -----------

--- a/mobilitydb/test/json/queries/450_jsonbset_tbl.test.sql
+++ b/mobilitydb/test/json/queries/450_jsonbset_tbl.test.sql
@@ -113,6 +113,8 @@ SELECT COUNT(*) FROM tbl_jsonbset t1, tbl_jsonbset t2 WHERE t1.s >= t2.s;
 
 SELECT MAX(set_hash(s)) FROM tbl_jsonbset;
 
+SELECT MAX(set_hash_extended(s, 1)) FROM tbl_jsonbset;
+
 -------------------------------------------------------------------------------
 -- Aggregation functions
 


### PR DESCRIPTION
The `set_hash_extended` dispatch in `datum_hash_extended` lacks arms for `T_CBUFFER` and `T_JSONB`, leaving `set_hash_extended` on `cbufferset` and `jsonbset` values unsupported. This adds both arms, mirroring the corresponding arms in the non-extended `datum_hash`.

For JSONB, the arm calls `pg_jsonb_hash_extended` rather than the `jsonb_hash_extended` wrapper. The wrapper compiles only under `#if MEOS`; in the PostgreSQL extension build it is absent and its name collides with PostgreSQL's own `jsonb_hash_extended` backend function, so calling it with the internal `(Jsonb *, uint64)` signature crashes the backend. The unguarded `pg_jsonb_hash_extended` avoids the collision, exactly as the non-extended arm already uses `pg_jsonb_hash`.

Regression tests for `set_hash_extended` cover `tbl_cbufferset` and `tbl_jsonbset`.