### PR TITLE
Use canonical camelCase for spatial predicate SQL function names

### DIFF
--- a/mobilitydb/sql/cbuffer/212_tcbuffer_spatialrels.in.sql
+++ b/mobilitydb/sql/cbuffer/212_tcbuffer_spatialrels.in.sql
@@ -207,12 +207,12 @@ CREATE FUNCTION aDisjoint(tcbuffer, tcbuffer)
  * eIntersects, aIntersects
  *****************************************************************************/
 
-CREATE FUNCTION eintersects(cbuffer, tcbuffer)
+CREATE FUNCTION eIntersects(cbuffer, tcbuffer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Eintersects_cbuffer_tcbuffer'
   SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION eintersects(tcbuffer, cbuffer)
+CREATE FUNCTION eIntersects(tcbuffer, cbuffer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Eintersects_tcbuffer_cbuffer'
   SUPPORT tspatial_supportfn

--- a/mobilitydb/sql/geo/070_tgeo_spatialrels.in.sql
+++ b/mobilitydb/sql/geo/070_tgeo_spatialrels.in.sql
@@ -117,7 +117,7 @@ CREATE FUNCTION _edisjoint(geometry, tgeometry)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Edisjoint_geo_tgeo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION edisjoint(geometry, tgeometry)
+CREATE FUNCTION eDisjoint(geometry, tgeometry)
   RETURNS boolean
   AS 'SELECT NOT(stbox($1) OPERATOR(@extschema@.&&) $2) OR @extschema@._edisjoint($1,$2)'
   LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
@@ -126,7 +126,7 @@ CREATE FUNCTION _edisjoint(tgeometry, geometry)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Edisjoint_tgeo_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION edisjoint(tgeometry, geometry)
+CREATE FUNCTION eDisjoint(tgeometry, geometry)
   RETURNS boolean
   AS 'SELECT NOT($1 OPERATOR(@extschema@.&&) stbox($2)) OR @extschema@._edisjoint($1,$2)'
   LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
@@ -135,7 +135,7 @@ CREATE FUNCTION _edisjoint(tgeometry, tgeometry)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Edisjoint_tgeo_tgeo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION edisjoint(tgeometry, tgeometry)
+CREATE FUNCTION eDisjoint(tgeometry, tgeometry)
   RETURNS boolean
   AS 'SELECT NOT($1 OPERATOR(@extschema@.&&) $2) OR @extschema@._edisjoint($1,$2)'
   LANGUAGE SQL IMMUTABLE PARALLEL SAFE;

--- a/mobilitydb/sql/geo/070_tpoint_spatialrels.in.sql
+++ b/mobilitydb/sql/geo/070_tpoint_spatialrels.in.sql
@@ -61,7 +61,7 @@ CREATE FUNCTION _edisjoint(geometry, tgeompoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Edisjoint_geo_tgeo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION edisjoint(geometry, tgeompoint)
+CREATE FUNCTION eDisjoint(geometry, tgeompoint)
   RETURNS boolean
   AS 'SELECT NOT(stbox($1) OPERATOR(@extschema@.&&) $2) OR @extschema@._edisjoint($1,$2)'
   LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
@@ -70,7 +70,7 @@ CREATE FUNCTION _edisjoint(tgeompoint, geometry)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Edisjoint_tgeo_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION edisjoint(tgeompoint, geometry)
+CREATE FUNCTION eDisjoint(tgeompoint, geometry)
   RETURNS boolean
   AS 'SELECT NOT($1 OPERATOR(@extschema@.&&) stbox($2)) OR @extschema@._edisjoint($1,$2)'
   LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
@@ -79,7 +79,7 @@ CREATE FUNCTION _edisjoint(tgeompoint, tgeompoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Edisjoint_tgeo_tgeo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION edisjoint(tgeompoint, tgeompoint)
+CREATE FUNCTION eDisjoint(tgeompoint, tgeompoint)
   RETURNS boolean
   AS 'SELECT NOT($1 OPERATOR(@extschema@.&&) $2) OR @extschema@._edisjoint($1,$2)'
   LANGUAGE SQL IMMUTABLE PARALLEL SAFE;


### PR DESCRIPTION
The cbuffer `eIntersects` overloads and the geometry/geography `eDisjoint` wrappers carry a lowercase leading letter, unlike their camelCase siblings in the same files (the geography `eDisjoint` wrappers are already camelCase) and the documented canonical names.

PostgreSQL folds unquoted identifiers, so the lowercase spelling resolves locally, but catalog-driven bindings read names case-sensitively and case-insensitive engines collapse the two spellings into one function. This recases the `CREATE FUNCTION` names to `eIntersects` and `eDisjoint`. The internal `_edisjoint` helpers and all C symbols stay unchanged, and the tests already call the camelCase names, so there are no expected-output changes.