### PR TITLE
Add MEOS-C etouches_geo_tpoint / atouches_geo_tpoint

### DIFF
--- a/meos/include/meos_geo.h
+++ b/meos/include/meos_geo.h
@@ -836,6 +836,7 @@ extern int atouches_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp);
 extern int atouches_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs);
 extern int atouches_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2);
 extern int atouches_tpoint_geo(const Temporal *temp, const GSERIALIZED *gs);
+extern int atouches_geo_tpoint(const GSERIALIZED *gs, const Temporal *temp);
 extern int econtains_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp);
 extern int econtains_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs);
 extern int econtains_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2);
@@ -855,6 +856,7 @@ extern int etouches_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp);
 extern int etouches_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs);
 extern int etouches_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2);
 extern int etouches_tpoint_geo(const Temporal *temp, const GSERIALIZED *gs);
+extern int etouches_geo_tpoint(const GSERIALIZED *gs, const Temporal *temp);
 
 /* Spatiotemporal relationships */
 

--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -1389,6 +1389,34 @@ atouches_tpoint_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   return ea_touches_tpoint_geo(temp, gs, ALWAYS);
 }
+
+/**
+ * @ingroup meos_geo_rel_ever
+ * @brief Return 1 if a geometry and a temporal point ever touch, 0 if not,
+ * and -1 on error or if the geometry is empty
+ * @param[in] gs Geometry
+ * @param[in] temp Temporal point
+ * @csqlfn #Etouches_geo_tpoint()
+ */
+int
+etouches_geo_tpoint(const GSERIALIZED *gs, const Temporal *temp)
+{
+  return etouches_tpoint_geo(temp, gs);
+}
+
+/**
+ * @ingroup meos_geo_rel_ever
+ * @brief Return 1 if a geometry and a temporal point always touch, 0 if not,
+ * and -1 on error or if the geometry is empty
+ * @param[in] gs Geometry
+ * @param[in] temp Temporal point
+ * @csqlfn #Atouches_geo_tpoint()
+ */
+int
+atouches_geo_tpoint(const GSERIALIZED *gs, const Temporal *temp)
+{
+  return atouches_tpoint_geo(temp, gs);
+}
 #endif /* MEOS */
 
 /*****************************************************************************/


### PR DESCRIPTION
The `eTouches(geometry, tgeompoint)` and `aTouches(geometry, tgeompoint)` SQL overloads are backed by the PostgreSQL wrappers `Etouches_geo_tpoint` / `Atouches_geo_tpoint`, but no MEOS-C function carries the matching `@csqlfn` tag. The derived catalog therefore holds no `sqlSignature` for the geometry-first temporal point direction, and non-PostgreSQL bindings (JMEOS, GoMEOS, MEOS.NET, PyMEOS) drop the overload.

This adds `etouches_geo_tpoint` / `atouches_geo_tpoint` as thin argument-swap wrappers over `etouches_tpoint_geo` / `atouches_tpoint_geo`, mirroring the existing `etouches_geo_tgeo` / `atouches_geo_tgeo` pair, tags them `@csqlfn`, and exports them in `meos_geo.h`. The catalog then carries the `[geometry, tgeompoint]` signature so every binding derives the overload.

The change is additive at the MEOS-C layer. The PostgreSQL SQL surface is identical, since the existing PG wrappers already register the overload.