### PR TITLE
Generate the ever/always disjoint and intersects PG wrappers

### DIFF
--- a/mobilitydb/src/geo/tgeo_spatialrels.c
+++ b/mobilitydb/src/geo/tgeo_spatialrels.c
@@ -332,6 +332,8 @@ Acovers_tgeo_tgeo(PG_FUNCTION_ARGS)
 }
 /* GENERATED-SPATIALRELS-END geo_ea_contains_covers */
 
+/* GENERATED-SPATIALRELS-BEGIN geo_ea_disjoint_intersects — tools/codegen/inherited/generate.py from templates/spatialrels.c.tmpl;
+ * DO NOT EDIT BY HAND; edit the template + manifest.yaml (spatialrel_families) and re-run. */
 /*****************************************************************************
  * Ever disjoint (for both geometry and geography)
  *****************************************************************************/
@@ -396,7 +398,7 @@ PGDLLEXPORT Datum Edisjoint_tgeo_tgeo(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Edisjoint_tgeo_tgeo);
 /**
  * @ingroup mobilitydb_geo_rel_ever
- * @brief Return true if two temporal geometrys are ever disjoint
+ * @brief Return true if two temporal geometries are ever disjoint
  * @sqlfn eDisjoint()
  */
 inline Datum
@@ -409,7 +411,7 @@ PGDLLEXPORT Datum Adisjoint_tgeo_tgeo(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Adisjoint_tgeo_tgeo);
 /**
  * @ingroup mobilitydb_geo_rel_ever
- * @brief Return true if two temporal geometrys are ever disjoint
+ * @brief Return true if two temporal geometries are always disjoint
  * @sqlfn aDisjoint()
  */
 inline Datum
@@ -440,7 +442,7 @@ PGDLLEXPORT Datum Aintersects_geo_tgeo(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Aintersects_geo_tgeo);
 /**
  * @ingroup mobilitydb_geo_rel_ever
- * @brief Return true if a geometry/geography and a temporal geometry ever
+ * @brief Return true if a geometry/geography and a temporal geometry always
  * intersect
  * @sqlfn aIntersects()
  */
@@ -482,7 +484,7 @@ PGDLLEXPORT Datum Eintersects_tgeo_tgeo(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Eintersects_tgeo_tgeo);
 /**
  * @ingroup mobilitydb_geo_rel_ever
- * @brief Return true if two temporal geometrys ever intersect
+ * @brief Return true if two temporal geometries ever intersect
  * @sqlfn eIntersects()
  */
 inline Datum
@@ -495,7 +497,7 @@ PGDLLEXPORT Datum Aintersects_tgeo_tgeo(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Aintersects_tgeo_tgeo);
 /**
  * @ingroup mobilitydb_geo_rel_ever
- * @brief Return true if two temporal geometrys ever intersect
+ * @brief Return true if two temporal geometries always intersect
  * @sqlfn aIntersects()
  */
 inline Datum
@@ -503,6 +505,7 @@ Aintersects_tgeo_tgeo(PG_FUNCTION_ARGS)
 {
   return EA_spatialrel_tspatial_tspatial(fcinfo, &ea_intersects_tgeo_tgeo, ALWAYS);
 }
+/* GENERATED-SPATIALRELS-END geo_ea_disjoint_intersects */
 
 /*****************************************************************************
  * Ever/always touches

--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -171,14 +171,32 @@ def _spatialrels_markers(family: str):
     return begin, f"/* GENERATED-SPATIALRELS-END {family} */\n"
 
 
-# The three ever/always directions in file order: PG dispatcher + the (subject,
-# object) noun phrases of the @brief. Each direction emits an EVER then ALWAYS
-# wrapper.
+# The three ever/always directions in file order: (dir token, PG dispatcher).
+# Each direction emits an EVER then ALWAYS wrapper; the @brief noun phrase is
+# per-predicate (transitive "X contains Y" vs symmetric "X and Y are disjoint"),
+# so it comes from the manifest `briefs` map, not from a shared subject/object.
 _SR_DIRECTIONS = [
-    ("geo_tgeo",  "EA_spatialrel_geo_tspatial",      "a geometry",          "a temporal geometry"),
-    ("tgeo_geo",  "EA_spatialrel_tspatial_geo",      "a temporal geometry", "a geometry"),
-    ("tgeo_tgeo", "EA_spatialrel_tspatial_tspatial", "a temporal geometry", "another one"),
+    ("geo_tgeo",  "EA_spatialrel_geo_tspatial"),
+    ("tgeo_geo",  "EA_spatialrel_tspatial_geo"),
+    ("tgeo_tgeo", "EA_spatialrel_tspatial_tspatial"),
 ]
+
+
+def _wrap_brief(text: str, width: int = 80) -> str:
+    """Greedy word-wrap a @brief string to the 80-column house style. The first
+    line carries the ` * @brief ` prefix, continuation lines ` * `; returns the
+    text to substitute for {BRIEF} (continuation lines already prefixed)."""
+    first, cont = " * @brief ", " * "
+    lines, cur, prefix = [], "", first
+    for w in text.split(" "):
+        cand = w if not cur else cur + " " + w
+        if len(prefix) + len(cand) <= width:
+            cur = cand
+        else:
+            lines.append(cur)
+            cur, prefix = w, cont
+    lines.append(cur)
+    return lines[0] + "".join("\n" + cont + l for l in lines[1:])
 
 
 def render_spatialrels(fam: dict) -> str:
@@ -189,11 +207,13 @@ def render_spatialrels(fam: dict) -> str:
     out = []
     for pred in fam["predicates"]:
         out.append(banner_t.replace("{BANNER}", pred["banner"]))
-        for direc, disp, subj, obj in _SR_DIRECTIONS:
+        for direc, disp in _SR_DIRECTIONS:
             for ea, word, low in (("E", "ever", "e"), ("A", "always", "a")):
+                brief = _wrap_brief(
+                    "Return true if " + pred["briefs"][direc].replace("{word}", word))
                 sub = {
                     "FN": f"{ea}{pred['rel']}_{direc}",
-                    "BRIEF": f"Return true if {subj} {word} {pred['verb3']} {obj}",
+                    "BRIEF": brief,
                     "SQLFN": f"{low}{pred['Rel']}",
                     "DISP": disp,
                     "MEOS": f"ea_{pred['rel']}_{direc}",

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -196,5 +196,36 @@ spatialrel_families:
     file:      mobilitydb/src/geo/tgeo_spatialrels.c
     reference: true
     predicates:
-      - {rel: contains, Rel: Contains, verb3: contains, banner: "Ever/always contains"}
-      - {rel: covers,   Rel: Covers,   verb3: covers,   banner: "Ever covers"}
+      - rel: contains
+        Rel: Contains
+        banner: "Ever/always contains"
+        briefs:
+          geo_tgeo:  "a geometry {word} contains a temporal geometry"
+          tgeo_geo:  "a temporal geometry {word} contains a geometry"
+          tgeo_tgeo: "a temporal geometry {word} contains another one"
+      - rel: covers
+        Rel: Covers
+        banner: "Ever covers"
+        briefs:
+          geo_tgeo:  "a geometry {word} covers a temporal geometry"
+          tgeo_geo:  "a temporal geometry {word} covers a geometry"
+          tgeo_tgeo: "a temporal geometry {word} covers another one"
+
+  - family:    geo_ea_disjoint_intersects
+    file:      mobilitydb/src/geo/tgeo_spatialrels.c
+    reference: true
+    predicates:
+      - rel: disjoint
+        Rel: Disjoint
+        banner: "Ever disjoint (for both geometry and geography)"
+        briefs:
+          geo_tgeo:  "a geometry/geography and a temporal geometry are {word} disjoint"
+          tgeo_geo:  "a temporal geometry and a geometry/geography are {word} disjoint"
+          tgeo_tgeo: "two temporal geometries are {word} disjoint"
+      - rel: intersects
+        Rel: Intersects
+        banner: "Ever intersects (for both geometry and geography)"
+        briefs:
+          geo_tgeo:  "a geometry/geography and a temporal geometry {word} intersect"
+          tgeo_geo:  "a temporal geometry and a geometry/geography {word} intersect"
+          tgeo_tgeo: "two temporal geometries {word} intersect"


### PR DESCRIPTION
Follow-up to the spatial-relationship generator (contains/covers), extending it to the geo `disjoint` and `intersects` ever/always PG wrappers and completing the symmetric half of the geo uniform core.

The disjoint/intersects `@brief` phrasing differs from the transitive contains/covers form (`X and Y are disjoint` / `X and Y intersect` vs `X contains Y`) and wraps across two comment lines. To keep the surface fully data-driven, the per-direction `@brief` text comes from a `briefs` map in `manifest.yaml` (with a `{word}` ever/always placeholder) plus an 80-column word-wrap helper, replacing the hard-coded subject/object nouns. The contains/covers region regenerates byte-for-byte (both regions pass `generate.py --validate`).

Deriving each `@brief` from the quantifier also corrects three copy-paste documentation defects the hand-written wrappers carried — `Adisjoint_tgeo_tgeo`, `Aintersects_geo_tgeo` and `Aintersects_tgeo_tgeo` each documented `ever` while dispatching `ALWAYS` — and the `temporal geometrys` typo becomes `geometries`.

The change is limited to `@brief` doxygen comments; the `@sqlfn` tags, the dispatchers and the `EVER`/`ALWAYS` arguments are unchanged, so the generated catalog and the SQL surface are identical.