### PR TITLE
Generate the ever/always dwithin PG wrappers

### DIFF
--- a/mobilitydb/src/geo/tgeo_spatialrels.c
+++ b/mobilitydb/src/geo/tgeo_spatialrels.c
@@ -683,6 +683,8 @@ Atouches_tgeo_tgeo(PG_FUNCTION_ARGS)
   return EA_spatialrel_tspatial_tspatial(fcinfo, &ea_touches_tgeo_tgeo, ALWAYS);
 }
 
+/* GENERATED-SPATIALRELS-BEGIN geo_ea_dwithin — tools/codegen/inherited/generate.py from templates/spatialrels.c.tmpl;
+ * DO NOT EDIT BY HAND; edit the template + manifest.yaml (spatialrel_families) and re-run. */
 /*****************************************************************************
  * Ever/always dwithin (for both geometry and geography)
  * The function only accepts points and not arbitrary geometries/geographies
@@ -734,7 +736,7 @@ PGDLLEXPORT Datum Adwithin_tgeo_geo(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Adwithin_tgeo_geo);
 /**
  * @ingroup mobilitydb_geo_rel_ever
- * @brief Return true if a temporal geometry and a geometry/geography are ever
+ * @brief Return true if a temporal geometry and a geometry/geography are always
  * within a distance
  * @sqlfn aDwithin()
  */
@@ -743,6 +745,7 @@ Adwithin_tgeo_geo(PG_FUNCTION_ARGS)
 {
   return EA_dwithin_tspatial_geo(fcinfo, &ea_dwithin_tgeo_geo, ALWAYS);
 }
+/* GENERATED-SPATIALRELS-END geo_ea_dwithin */
 
 /**
  * @brief Return true if two temporal geometries are even/always within a distance

--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -171,15 +171,20 @@ def _spatialrels_markers(family: str):
     return begin, f"/* GENERATED-SPATIALRELS-END {family} */\n"
 
 
-# The three ever/always directions in file order: (dir token, PG dispatcher).
-# Each direction emits an EVER then ALWAYS wrapper; the @brief noun phrase is
-# per-predicate (transitive "X contains Y" vs symmetric "X and Y are disjoint"),
-# so it comes from the manifest `briefs` map, not from a shared subject/object.
-_SR_DIRECTIONS = [
-    ("geo_tgeo",  "EA_spatialrel_geo_tspatial"),
-    ("tgeo_geo",  "EA_spatialrel_tspatial_geo"),
-    ("tgeo_tgeo", "EA_spatialrel_tspatial_tspatial"),
-]
+# The three ever/always directions in file order and the generic PG dispatcher
+# each maps to. Each direction emits an EVER then ALWAYS wrapper; the @brief noun
+# phrase is per-predicate (transitive "X contains Y" vs symmetric "X and Y are
+# disjoint"), so it comes from the manifest `briefs` map, not a shared subj/obj.
+# A predicate may restrict itself to a subset of directions (`directions:`), swap
+# the dispatcher (`disp:`, e.g. dwithin's EA_dwithin_* which carries a distance),
+# and pin one MEOS kernel across both arg orders (`meos_fixed:`, dwithin's
+# ea_dwithin_tgeo_geo) — every other predicate uses the defaults below.
+_SR_ORDER = ["geo_tgeo", "tgeo_geo", "tgeo_tgeo"]
+_SR_DISP = {
+    "geo_tgeo":  "EA_spatialrel_geo_tspatial",
+    "tgeo_geo":  "EA_spatialrel_tspatial_geo",
+    "tgeo_tgeo": "EA_spatialrel_tspatial_tspatial",
+}
 
 
 def _wrap_brief(text: str, width: int = 80) -> str:
@@ -207,7 +212,11 @@ def render_spatialrels(fam: dict) -> str:
     out = []
     for pred in fam["predicates"]:
         out.append(banner_t.replace("{BANNER}", pred["banner"]))
-        for direc, disp in _SR_DIRECTIONS:
+        disp_over = pred.get("disp", {})
+        meos_fixed = pred.get("meos_fixed")
+        for direc in pred.get("directions", _SR_ORDER):
+            disp = disp_over.get(direc, _SR_DISP[direc])
+            meos = meos_fixed or f"ea_{pred['rel']}_{direc}"
             for ea, word, low in (("E", "ever", "e"), ("A", "always", "a")):
                 brief = _wrap_brief(
                     "Return true if " + pred["briefs"][direc].replace("{word}", word))
@@ -216,7 +225,7 @@ def render_spatialrels(fam: dict) -> str:
                     "BRIEF": brief,
                     "SQLFN": f"{low}{pred['Rel']}",
                     "DISP": disp,
-                    "MEOS": f"ea_{pred['rel']}_{direc}",
+                    "MEOS": meos,
                     "EA": "EVER" if ea == "E" else "ALWAYS",
                 }
                 frag = block_t

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -229,3 +229,24 @@ spatialrel_families:
           geo_tgeo:  "a geometry/geography and a temporal geometry {word} intersect"
           tgeo_geo:  "a temporal geometry and a geometry/geography {word} intersect"
           tgeo_tgeo: "two temporal geometries {word} intersect"
+
+  # dwithin's geo/tgeo core: only the two mixed directions are mechanical (the
+  # tgeo_tgeo direction has a bespoke distance-carrying dispatcher + a different
+  # @ingroup, so it stays hand-written). Both directions share the single MEOS
+  # kernel ea_dwithin_tgeo_geo (the dispatcher fixes the argument order), and the
+  # dispatcher is the distance-aware EA_dwithin_* rather than EA_spatialrel_*.
+  - family:    geo_ea_dwithin
+    file:      mobilitydb/src/geo/tgeo_spatialrels.c
+    reference: true
+    predicates:
+      - rel: dwithin
+        Rel: Dwithin
+        banner: "Ever/always dwithin (for both geometry and geography)\n * The function only accepts points and not arbitrary geometries/geographies"
+        directions: [geo_tgeo, tgeo_geo]
+        meos_fixed: ea_dwithin_tgeo_geo
+        disp:
+          geo_tgeo: EA_dwithin_geo_tspatial
+          tgeo_geo: EA_dwithin_tspatial_geo
+        briefs:
+          geo_tgeo:  "a geometry/geography and a temporal geometry are {word} within a distance"
+          tgeo_geo:  "a temporal geometry and a geometry/geography are {word} within a distance"


### PR DESCRIPTION
Extends the spatial-relationship generator to the geo `dwithin` geo/tgeo core, the last mechanical block of the geo ever/always PG surface. The two mixed directions (`Edwithin`/`Adwithin` `geo_tgeo` and `tgeo_geo`) are pure dispatch wrappers, so they are generated into a `geo_ea_dwithin` region; the `tgeo_tgeo` direction keeps its bespoke distance-carrying dispatcher and different `@ingroup` and stays hand-written, as do the touches dispatchers and the array set-set join surface.

`dwithin` needs three per-predicate knobs the earlier predicates do not: it restricts itself to a subset of directions, dispatches through the distance-aware `EA_dwithin_*` rather than `EA_spatialrel_*`, and pins the single kernel `ea_dwithin_tgeo_geo` across both argument orders. These are optional manifest fields (`directions`/`disp`/`meos_fixed`); the contains, covers, disjoint and intersects regions use the defaults and regenerate byte-for-byte.

Generating the briefs also corrects the last copy-paste defect in this file: `Adwithin_tgeo_geo` documented `ever` while dispatching `ALWAYS`. The change is limited to that `@brief` comment plus the region markers; the dispatcher and the `EVER`/`ALWAYS` argument are unchanged, so the generated catalog and the SQL surface are identical.