### PR TITLE
Name the span union PG wrappers spanUnion in the sqlfn tag

### DIFF
--- a/mobilitydb/src/temporal/span_ops.c
+++ b/mobilitydb/src/temporal/span_ops.c
@@ -405,7 +405,7 @@ PG_FUNCTION_INFO_V1(Union_value_span);
 /**
  * @ingroup mobilitydb_setspan_set
  * @brief Return the union of a value and a span
- * @sqlfn time_union()
+ * @sqlfn spanUnion()
  * @sqlop @p +
  */
 Datum
@@ -421,7 +421,7 @@ PG_FUNCTION_INFO_V1(Union_span_value);
 /**
  * @ingroup mobilitydb_setspan_set
  * @brief Return the union of a span and a value
- * @sqlfn time_union()
+ * @sqlfn spanUnion()
  * @sqlop @p +
  */
 Datum
@@ -437,7 +437,7 @@ PG_FUNCTION_INFO_V1(Union_span_span);
 /**
  * @ingroup mobilitydb_setspan_set
  * @brief Return the union of two spans
- * @sqlfn time_union()
+ * @sqlfn spanUnion()
  * @sqlop @p +
  */
 Datum


### PR DESCRIPTION
The binary span-union PG wrappers `Union_value_span`, `Union_span_value` and `Union_span_span` (`mobilitydb/src/temporal/span_ops.c`) are documented with `@sqlfn time_union()`, but that name is non-canonical: no `CREATE FUNCTION time_union` exists anywhere, and the SQL these wrappers back is `CREATE FUNCTION spanUnion(...)` (`mobilitydb/sql/temporal/005_span_ops.in.sql:1109-1119`). `spanUnion` is the documented canonical name (`doc/*.xml`, catalog).

This is the union counterpart of the `time_minus` → `spanMinus` correction already merged for the span-minus wrappers (#1323).

The three `@sqlfn` tags are repointed to `spanUnion()`. The change is limited to Doxygen comments; the dispatch and the SQL surface are unchanged.