### PR TITLE
Name the union aggregates with the csqlaggfn tag

### DIFF
--- a/meos/src/temporal/set_aggfuncs_meos.c
+++ b/meos/src/temporal/set_aggfuncs_meos.c
@@ -201,6 +201,7 @@ set_append_value(Set *set, Datum value)
  * @code
  * state = value_union_transfn(state, value, basetype);
  * @endcode
+ * @csqlaggfn #setUnionTransition()
  */
 Set *
 value_union_transfn(Set *state, Datum value, MeosType basetype)
@@ -226,6 +227,7 @@ value_union_transfn(Set *state, Datum value, MeosType basetype)
  * state = set_union_transfn(state, set);
  * @endcode
  * @csqlfn #Set_union_transfn()
+ * @csqlaggfn #setUnionTransition()
  */
 Set *
 set_union_transfn(Set *state, Set *s)
@@ -256,6 +258,7 @@ set_union_transfn(Set *state, Set *s)
  * @param[in,out] state Current aggregate state
  * @note The input state must be free by the calling function
  * @csqlfn #Set_union_finalfn()
+ * @csqlaggfn #setUnionFinal()
  */
 Set *
 set_union_finalfn(Set *state)
@@ -284,6 +287,7 @@ set_union_finalfn(Set *state)
  * @brief Transition function for set union aggregate of integers
  * @param[in,out] state Current aggregate state
  * @param[in] i Value
+ * @csqlaggfn #setUnionTransition()
  */
 Set *
 int_union_transfn(Set *state, int32 i)
@@ -299,6 +303,7 @@ int_union_transfn(Set *state, int32 i)
  * @brief Transition function for set union aggregate of big integers
  * @param[in,out] state Current aggregate state
  * @param[in] i Value
+ * @csqlaggfn #setUnionTransition()
  */
 Set *
 bigint_union_transfn(Set *state, int64 i)
@@ -314,6 +319,7 @@ bigint_union_transfn(Set *state, int64 i)
  * @brief Transition function for set union aggregate of floats
  * @param[in,out] state Current aggregate state
  * @param[in] d Value
+ * @csqlaggfn #setUnionTransition()
  */
 Set *
 float_union_transfn(Set *state, double d)
@@ -329,6 +335,7 @@ float_union_transfn(Set *state, double d)
  * @brief Transition function for set union aggregate of dates
  * @param[in,out] state Current aggregate state
  * @param[in] d Value
+ * @csqlaggfn #setUnionTransition()
  */
 Set *
 date_union_transfn(Set *state, DateADT d)
@@ -344,6 +351,7 @@ date_union_transfn(Set *state, DateADT d)
  * @brief Transition function for set union aggregate of timestamptz
  * @param[in,out] state Current aggregate state
  * @param[in] t Value
+ * @csqlaggfn #setUnionTransition()
  */
 Set *
 timestamptz_union_transfn(Set *state, TimestampTz t)
@@ -359,6 +367,7 @@ timestamptz_union_transfn(Set *state, TimestampTz t)
  * @brief Transition function for set union aggregate of texts
  * @param[in,out] state Current aggregate state
  * @param[in] txt Value
+ * @csqlaggfn #setUnionTransition()
  */
 Set *
 text_union_transfn(Set *state, const text *txt)

--- a/meos/src/temporal/span_aggfuncs_meos.c
+++ b/meos/src/temporal/span_aggfuncs_meos.c
@@ -224,6 +224,7 @@ spanset_append_spanset(SpanSet *ss1, const SpanSet *ss2, bool expand)
  * @code
  * state = span_union_transfn(state, span);
  * @endcode
+ * @csqlaggfn #spanUnionTransition()
  */
 SpanSet *
 span_union_transfn(SpanSet *state, const Span *s)
@@ -255,6 +256,7 @@ span_union_transfn(SpanSet *state, const Span *s)
  * state = spanset_union_transfn(state, spanset);
  * @endcode
  * @csqlfn #Spanset_union_transfn()
+ * @csqlaggfn #spansetUnionTransition()
  */
 SpanSet *
 spanset_union_transfn(SpanSet *state, const SpanSet *ss)
@@ -279,8 +281,9 @@ spanset_union_transfn(SpanSet *state, const SpanSet *ss)
 
 /**
  * @ingroup meos_setspan_agg
- * @brief Transition function for set aggregate of values
+ * @brief Final function for span and span set union aggregate
  * @param[in] state Current aggregate state, may be `NULL`
+ * @csqlaggfn #spanUnionFinal(), #spansetUnionFinal()
  */
 SpanSet *
 spanset_union_finalfn(SpanSet *state)


### PR DESCRIPTION
The MEOS-C aggregate functions are identifiable only by their name suffix (`_transfn`/`_finalfn`/`_combinefn`) and their `meos_setspan_agg` group; nothing names the user-facing SQL aggregate they implement (`setUnion` / `spanUnion` / `spansetUnion`). A catalog derived from the source therefore cannot distinguish an aggregate member from the identically named *binary* set/span union function (`setUnion(intset,intset)`, `spanUnion(intspan,intspan)`), which are real overloaded functions in their own right.

This introduces a `@csqlaggfn` Doxygen tag that names the SQL aggregate a function implements, following the standard PostgreSQL aggregate model (`<aggregate>Transition` / `Combine` / `Final`) and keeping the three roles distinct rather than collapsing them under one aggregate name.

Tags added on the existing union transition and final functions:

| MEOS-C function | `@csqlaggfn` |
|---|---|
| `set_union_transfn` + the per-type `value/int/bigint/float/date/timestamptz/text_union_transfn` | `#setUnionTransition()` |
| `set_union_finalfn` | `#setUnionFinal()` |
| `span_union_transfn` | `#spanUnionTransition()` |
| `spanset_union_transfn` | `#spansetUnionTransition()` |
| `spanset_union_finalfn` (shared by both) | `#spanUnionFinal(), #spansetUnionFinal()` |

The combine step is intentionally left untagged: the union aggregates have no combine function of their own — `spanUnion`/`spansetUnion` borrow PostgreSQL's built-in `array_agg_combine`, and `setUnion` has none — so there is no source function to hang a `#…Combine()` tag on. Adding dedicated combine functions is a separate change gated on the aggregate memory-context handling.

The change stays within Doxygen comments and also corrects one copy-paste `@brief` on `spanset_union_finalfn` that describes it as a transition function. It touches no code, catalog, or SQL surface; the MEOS-API side that reads `@csqlaggfn` follows separately.