### PR TITLE
Parameterize the scalar base-to-stbox cast in the inherited topops generator

### DIFF
--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -58,8 +58,13 @@ def render(behaviour: str, sub: dict) -> str:
     # the pg-h3 name temporalized by a bare `t` prefix (h3CellToBoundary ->
     # th3CellToBoundary, NOT th3indexCellToBoundary) - overrides it via `boundary_fn`.
     boundary = sub.get("boundary_fn", sub["temp"] + "CellToBoundary")
+    # Capitalized base = the C-symbol stem for the scalar base::stbox cast
+    # (Cbuffer_to_stbox, Pose_to_stbox, Npoint_to_stbox — all base.capitalize()).
+    # Families whose C symbol does not follow that rule override it via `cbase`.
+    cbase = sub.get("cbase", sub["base"].capitalize())
     body = (tmpl.replace("{TEMP}", sub["temp"])
                 .replace("{BASE}", sub["base"])
+                .replace("{CBASE}", cbase)
                 .replace("{BRIEF}", sub["brief"])
                 .replace("{BOUNDARY}", boundary))
     return BANNER.format(tmpl=f"{behaviour}.sql.tmpl") + body

--- a/tools/codegen/inherited/templates/topops.sql.tmpl
+++ b/tools/codegen/inherited/templates/topops.sql.tmpl
@@ -39,17 +39,17 @@
 -- @IF scalar_stbox_cast
 CREATE FUNCTION stbox({BASE})
   RETURNS stbox
-  AS 'MODULE_PATHNAME', 'Cbuffer_to_stbox'
+  AS 'MODULE_PATHNAME', '{CBASE}_to_stbox'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION stbox({BASE}, timestamptz)
   RETURNS stbox
-  AS 'MODULE_PATHNAME', 'Cbuffer_timestamptz_to_stbox'
+  AS 'MODULE_PATHNAME', '{CBASE}_timestamptz_to_stbox'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION stbox({BASE}, tstzspan)
   RETURNS stbox
-  AS 'MODULE_PATHNAME', 'Cbuffer_tstzspan_to_stbox'
+  AS 'MODULE_PATHNAME', '{CBASE}_tstzspan_to_stbox'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- @ENDIF
 


### PR DESCRIPTION
The `topops.sql.tmpl` template of the inherited-behaviour generator hardcodes the cbuffer C symbols for the scalar `base::stbox` cast — `Cbuffer_to_stbox`, `Cbuffer_timestamptz_to_stbox`, `Cbuffer_tstzspan_to_stbox` — so the `@IF scalar_stbox_cast` block emits correct wiring only for `tcbuffer`.

A `{CBASE}` token (`base.capitalize()`, overridable per subtype via a `cbase` manifest key) renders the C-symbol stem, and the three scalar-cast function bodies use it. `tcbuffer` renders `Cbuffer_*` unchanged (`--validate` self-regen is byte-identical); a scalar-cast subtype such as `pose` renders `Pose_to_stbox` / `Pose_timestamptz_to_stbox` / `Pose_tstzspan_to_stbox`, matching the live C symbols in `mobilitydb/src/pose/pose.c`.

The generic temporal cast (`Tspatial_to_stbox`) and the cell-index families (which strip the block via `scalar_stbox_cast: false`) are unaffected.