### PR TITLE
Export the WKB endian-string decode as a MEOS function

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -1262,6 +1262,7 @@ extern char *tbool_out(const Temporal *temp);
 extern char *temporal_as_hexwkb(const Temporal *temp, uint8_t variant, size_t *size_out);
 extern char *temporal_as_mfjson(const Temporal *temp, bool with_bbox, int flags, int precision, const char *srs);
 extern uint8_t *temporal_as_wkb(const Temporal *temp, uint8_t variant, size_t *size_out);
+extern uint8_t wkb_variant_from_endian(const char *endian);
 extern Temporal *temporal_from_hexwkb(const char *hexwkb);
 extern Temporal *temporal_from_wkb(const uint8_t *wkb, size_t size);
 extern Temporal *tfloat_from_mfjson(const char *str);

--- a/meos/src/temporal/type_out.c
+++ b/meos/src/temporal/type_out.c
@@ -3059,6 +3059,31 @@ datum_as_hexwkb(Datum value, MeosType type, uint8_t variant, size_t *size)
     variant | (uint8_t) WKB_EXTENDED | (uint8_t) WKB_HEX, size);
 }
 
+/**
+ * @ingroup meos_temporal_inout
+ * @brief Return the WKB output variant flag corresponding to an endian
+ * encoding string
+ * @details The result can be combined (with a bitwise OR) with the other WKB
+ * variant flags and passed to the @p *_as_wkb / @p *_as_hexwkb functions, so a
+ * caller can select the byte order from a textual value.
+ * @param[in] endian Endian encoding: an empty string (machine endianness),
+ * `"ndr"` (little-endian) or `"xdr"` (big-endian)
+ * @return On error return 0
+ */
+uint8_t
+wkb_variant_from_endian(const char *endian)
+{
+  if (! endian || strlen(endian) == 0)
+    return 0;
+  if (pg_strncasecmp(endian, "ndr", 3) == 0)
+    return (uint8_t) WKB_NDR;
+  if (pg_strncasecmp(endian, "xdr", 3) == 0)
+    return (uint8_t) WKB_XDR;
+  meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+    "Invalid value for endian flag");
+  return 0;
+}
+
 /*****************************************************************************
  * WKB and HexWKB output functions for set, span, and span set types
  *****************************************************************************/

--- a/mobilitydb/src/temporal/type_out.c
+++ b/mobilitydb/src/temporal/type_out.c
@@ -205,18 +205,8 @@ Temporal_as_mfjson(PG_FUNCTION_ARGS)
 static uint8_t
 get_endian_variant(const text *txt)
 {
-  uint8_t variant = 0;
   char *endian = text_to_cstring(txt);
-  /* When the endian is not given the default value is an empty text */
-  if (strlen(endian) == 0)
-    ;
-  else if (pg_strncasecmp(endian, "ndr", 3) != 0 &&
-      pg_strncasecmp(endian, "xdr", 3) != 0)
-    elog(ERROR, "Invalid value for endian flag");
-  else if (pg_strncasecmp(endian, "ndr", 3) == 0)
-    variant = variant | (uint8_t) WKB_NDR;
-  else /* txt = XDR */
-    variant = variant | (uint8_t) WKB_XDR;
+  uint8_t variant = wkb_variant_from_endian(endian);
   pfree(endian);
   return variant;
 }


### PR DESCRIPTION
The `asHexWKB(<type>, endian text)` / `asBinary(<type>, endian text)` SQL surface decodes the endian encoding string (``, `ndr`, `xdr`) into a WKB variant flag, but that decode lives only in the PostgreSQL wrapper (`get_endian_variant` in `mobilitydb/src/temporal/type_out.c`). The exported MEOS output functions (`temporal_as_hexwkb`, `set_as_hexwkb`, `span_as_hexwkb`, `tbox_as_hexwkb`, …) take a raw `uint8_t` variant, so a typed binding (e.g. per-type DuckDB overloads) cannot reproduce the text surface without re-implementing the endian decode.

This adds `uint8_t wkb_variant_from_endian(const char *endian)` to MEOS (declared in `meos.h`): it returns the WKB NDR/XDR variant flag for an endian string, with an empty string meaning machine endianness, and raises the `Invalid value for endian flag` error on an invalid value. The PostgreSQL `get_endian_variant` delegates to it. The returned variant composes with the existing `*_as_wkb` / `*_as_hexwkb` functions, so a binding projects the output side by combining the two — no new per-type functions, and the WKB variant constants are already public.

The MF-JSON output side needs no equivalent: `temporal_as_mfjson` already exposes `with_bbox` / `precision` / `srs` as parameters, so the `option`-int convenience decode is thin binding-side logic over an already-exported function.