### PR TITLE
Build the temporal rigid geometry aggregate functions

### DIFF
--- a/mobilitydb/sql/rgeo/CMakeLists.txt
+++ b/mobilitydb/sql/rgeo/CMakeLists.txt
@@ -1,6 +1,5 @@
 # No Postgres version dependant files
 
-# 168_trgeo_aggfuncs has no build entry upstream and is not built; left unchanged here.
 SET(LOCAL_FILES
   150_trgeo
   154_trgeo_compops
@@ -11,6 +10,7 @@ SET(LOCAL_FILES
   162_trgeo_posops
   164_trgeo_distance
   166_trgeo_similarity
+  168_trgeo_aggfuncs
   170_trgeo_spatialrels
   172_trgeo_tempspatialrels
   173_trgeo_indexes


### PR DESCRIPTION
The trgeometry aggregate functions (`tcount`, `wcount`, `merge`, `appendInstant`, `appendSequence`, `extent`) are defined in `mobilitydb/sql/rgeo/168_trgeo_aggfuncs.in.sql` and documented in the reference chapter, but the file is not listed in the rgeo `CMakeLists` `LOCAL_FILES`, so the aggregates are absent from the built extension. Every other spatial family (pose, cbuffer, geo) builds its aggregate file.

This adds `168_trgeo_aggfuncs` to `LOCAL_FILES` so `CREATE EXTENSION` defines the aggregates. They dispatch to the generic temporal aggregate transition, combine and final functions (`Temporal_tcount_transfn`, `Temporal_merge_transfn`, `Tspatial_extent_transfn`, `tcount_combinefn`, `taggstate_serialize`, `stbox_extent_combinefn`, ...) that the other families already use; all are created in lower-numbered files (`040_temporal_aggfuncs`, `051_stbox`), so load order is satisfied.