### PR TITLE
Add an optional strict argument to valueAtTimestamp

### DIFF
--- a/doc/es/temporal_circular_buffers.xml
+++ b/doc/es/temporal_circular_buffers.xml
@@ -537,7 +537,7 @@ SELECT radius(tcbuffer 'SRID=5676;{Cbuffer(Point(3 3), 0.3)@2001-01-01,
 			<listitem xml:id="tcbuffer_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Devuelve el valor en una marca de tiempo</para>
-				<para><varname>valueAtTimestamp(tcbuffer,timestamptz) → cbuffer</varname></para>
+				<para><varname>valueAtTimestamp(tcbuffer,timestamptz,strict bool=TRUE) → cbuffer</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(valueAtTimestamp(tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
   Cbuffer(Point(3 3), 0.5)@2001-01-03)', '2001-01-02'));

--- a/doc/es/temporal_h3_index.xml
+++ b/doc/es/temporal_h3_index.xml
@@ -159,7 +159,7 @@ SELECT getValues(th3index '831c02fffffffff@2001-01-01');
 			<listitem xml:id="th3_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Devolver el identificador de celda H3 en una marca de tiempo dada, utilizando interpolación de pasos</para>
-				<para><varname>valueAtTimestamp(th3index,timestamptz) → h3index</varname></para>
+				<para><varname>valueAtTimestamp(th3index,timestamptz,strict bool=TRUE) → h3index</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueAtTimestamp(th3index
   '[831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-05]',

--- a/doc/es/temporal_jsonb.xml
+++ b/doc/es/temporal_jsonb.xml
@@ -703,7 +703,7 @@ SELECT getValues(tjsonb
 			<listitem xml:id="tjsonb_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Devolver el valor en una marca de tiempo</para>
-				<para><varname>valueAtTimestamp(tjsonb,timestamptz) → jsonb</varname></para>
+				<para><varname>valueAtTimestamp(tjsonb,timestamptz,strict bool=TRUE) → jsonb</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueAtTimestamp(tjsonb
   '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,

--- a/doc/es/temporal_network_points.xml
+++ b/doc/es/temporal_network_points.xml
@@ -450,7 +450,7 @@ SELECT routes(tnpoint '{NPoint(3, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02}');
 			<listitem xml:id="tnpoint_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Devuelve el valor en una marca de tiempo</para>
-				<para><varname>valueAtTimestamp(tnpoint,timestamptz) → npoint</varname></para>
+				<para><varname>valueAtTimestamp(tnpoint,timestamptz,strict bool=TRUE) → npoint</varname></para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT valueAtTimestamp(tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-03)',
   '2001-01-02');

--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -895,7 +895,7 @@ SELECT rotation(tpose 'SRID=5676;{[Pose(Point(1 1), 0.3)@2001-01-01,
 			<listitem xml:id="tpose_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Devuelve el valor en una marca de tiempo</para>
-				<para><varname>valueAtTimestamp(tpose,timestamptz) → pose</varname></para>
+				<para><varname>valueAtTimestamp(tpose,timestamptz,strict bool=TRUE) → pose</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(valueAtTimestamp(tpose '[Pose(Point(1 1), 0.3)@2001-01-01, 
   Pose(Point(3 3), 0.5)@2001-01-03)', '2001-01-02'));

--- a/doc/es/temporal_quadbin_index.xml
+++ b/doc/es/temporal_quadbin_index.xml
@@ -143,7 +143,7 @@ SELECT getValues(tquadbin
 			<listitem xml:id="tquadbin_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Devuelve el identificador de celda QUADBIN en un instante dado, usando interpolación de pasos</para>
-				<para><varname>valueAtTimestamp(tquadbin,timestamptz) → quadbin</varname></para>
+				<para><varname>valueAtTimestamp(tquadbin,timestamptz,strict bool=TRUE) → quadbin</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueAtTimestamp(tquadbin
   '[480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-05]',

--- a/doc/es/temporal_rigid_geometries.xml
+++ b/doc/es/temporal_rigid_geometries.xml
@@ -176,7 +176,7 @@ SELECT asText(tgeompoint(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(
 				<para>Devuelve la geometría materializada al inicio, al final o en una marca de tiempo elegida</para>
 				<para><varname>startValue(trgeometry) → geometry</varname></para>
 				<para><varname>endValue(trgeometry) → geometry</varname></para>
-				<para><varname>valueAtTimestamp(trgeometry, timestamptz) → geometry</varname></para>
+				<para><varname>valueAtTimestamp(trgeometry, timestamptz,strict bool=TRUE) → geometry</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(startValue(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]'));
 -- POLYGON((0 0,1 0,1 1,0 1,0 0))

--- a/doc/es/temporal_types_p1.xml
+++ b/doc/es/temporal_types_p1.xml
@@ -955,7 +955,7 @@ SELECT valueN(tfloat '{[1@2001-01-01, 2@2001-01-03), [3@2001-01-03, 5@2001-01-05
 			<listitem xml:id="ttype_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Devuelve el valor en una marca de tiempo</para>
-				<para><varname>valueAtTimestamp(ttype,timestamptz) → base</varname></para>
+				<para><varname>valueAtTimestamp(ttype,timestamptz,strict bool=TRUE) → base</varname></para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT valueAtTimestamp(tfloat '[1@2001-01-01, 4@2001-01-04)', '2001-01-02');
 -- 2

--- a/doc/temporal_circular_buffers.xml
+++ b/doc/temporal_circular_buffers.xml
@@ -537,7 +537,7 @@ SELECT radius(tcbuffer 'SRID=5676;{Cbuffer(Point(3 3), 0.3)@2001-01-01,
 			<listitem xml:id="tcbuffer_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Return the value at a timestamp</para>
-				<para><varname>valueAtTimestamp(tcbuffer,timestamptz) → cbuffer</varname></para>
+				<para><varname>valueAtTimestamp(tcbuffer,timestamptz,strict bool=TRUE) → cbuffer</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(valueAtTimestamp(tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01, 
   Cbuffer(Point(3 3), 0.5)@2001-01-03)', '2001-01-02'));

--- a/doc/temporal_h3_index.xml
+++ b/doc/temporal_h3_index.xml
@@ -165,7 +165,7 @@ SELECT getValues(th3index
 			<listitem xml:id="th3_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Return the H3 cell identifier at a given timestamp, using step interpolation</para>
-				<para><varname>valueAtTimestamp(th3index,timestamptz) → h3index</varname></para>
+				<para><varname>valueAtTimestamp(th3index,timestamptz,strict bool=TRUE) → h3index</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueAtTimestamp(th3index
   '[831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-05]',

--- a/doc/temporal_jsonb.xml
+++ b/doc/temporal_jsonb.xml
@@ -703,7 +703,7 @@ SELECT getValues(tjsonb
 			<listitem xml:id="tjsonb_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Return the value at a timestamp</para>
-				<para><varname>valueAtTimestamp(tjsonb,timestamptz) → jsonb</varname></para>
+				<para><varname>valueAtTimestamp(tjsonb,timestamptz,strict bool=TRUE) → jsonb</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueAtTimestamp(tjsonb
   '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,

--- a/doc/temporal_network_points.xml
+++ b/doc/temporal_network_points.xml
@@ -468,7 +468,7 @@ SELECT routes(tnpoint '{NPoint(3, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02}');
 			<listitem xml:id="tnpoint_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Return the value at a timestamp</para>
-				<para><varname>valueAtTimestamp(tnpoint,timestamptz) → npoint</varname></para>
+				<para><varname>valueAtTimestamp(tnpoint,timestamptz,strict bool=TRUE) → npoint</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueAtTimestamp(tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-03)',
   '2001-01-02');

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -902,7 +902,7 @@ SELECT rotation(tpose 'SRID=5676;{[Pose(Point(1 1), 0.3)@2001-01-01,
 			<listitem xml:id="tpose_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Return the value at a timestamp</para>
-				<para><varname>valueAtTimestamp(tpose,timestamptz) → pose</varname></para>
+				<para><varname>valueAtTimestamp(tpose,timestamptz,strict bool=TRUE) → pose</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(valueAtTimestamp(tpose '[Pose(Point(1 1), 0.3)@2001-01-01, 
   Pose(Point(3 3), 0.5)@2001-01-03)', '2001-01-02'));

--- a/doc/temporal_quadbin_index.xml
+++ b/doc/temporal_quadbin_index.xml
@@ -143,7 +143,7 @@ SELECT getValues(tquadbin
 			<listitem xml:id="tquadbin_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Return the QUADBIN cell identifier at a given timestamp, using step interpolation</para>
-				<para><varname>valueAtTimestamp(tquadbin,timestamptz) → quadbin</varname></para>
+				<para><varname>valueAtTimestamp(tquadbin,timestamptz,strict bool=TRUE) → quadbin</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueAtTimestamp(tquadbin
   '[480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-05]',

--- a/doc/temporal_rigid_geometries.xml
+++ b/doc/temporal_rigid_geometries.xml
@@ -176,7 +176,7 @@ SELECT asText(tgeompoint(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(
 				<para>Return the materialised geometry at the start, end, or a chosen timestamp</para>
 				<para><varname>startValue(trgeometry) → geometry</varname></para>
 				<para><varname>endValue(trgeometry) → geometry</varname></para>
-				<para><varname>valueAtTimestamp(trgeometry, timestamptz) → geometry</varname></para>
+				<para><varname>valueAtTimestamp(trgeometry, timestamptz,strict bool=TRUE) → geometry</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(startValue(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]'));
 -- POLYGON((0 0,1 0,1 1,0 1,0 0))

--- a/doc/temporal_types_p1.xml
+++ b/doc/temporal_types_p1.xml
@@ -947,7 +947,7 @@ SELECT valueN(tfloat '{[1@2001-01-01, 2@2001-01-03), [3@2001-01-03, 5@2001-01-05
 			<listitem xml:id="ttype_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Return the value at a timestamp</para>
-				<para><varname>valueAtTimestamp(ttype,timestamptz) → base</varname></para>
+				<para><varname>valueAtTimestamp(ttype,timestamptz,strict bool=TRUE) → base</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueAtTimestamp(tfloat '[1@2001-01-01, 4@2001-01-04)', '2001-01-02');
 -- 2

--- a/mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
+++ b/mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
@@ -315,7 +315,7 @@ CREATE FUNCTION valueN(tcbuffer, int)
   AS 'MODULE_PATHNAME', 'Temporal_value_n'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION valueAtTimestamp(tcbuffer, timestamptz)
+CREATE FUNCTION valueAtTimestamp(tcbuffer, timestamptz, strict bool DEFAULT TRUE)
   RETURNS cbuffer
   AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/geo/052_tgeo.in.sql
+++ b/mobilitydb/sql/geo/052_tgeo.in.sql
@@ -680,11 +680,11 @@ CREATE FUNCTION minusTime(tgeography, timestamptz)
   AS 'MODULE_PATHNAME', 'Temporal_minus_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION valueAtTimestamp(tgeometry, timestamptz)
+CREATE FUNCTION valueAtTimestamp(tgeometry, timestamptz, strict bool DEFAULT TRUE)
   RETURNS geometry
   AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION valueAtTimestamp(tgeography, timestamptz)
+CREATE FUNCTION valueAtTimestamp(tgeography, timestamptz, strict bool DEFAULT TRUE)
   RETURNS geography
   AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/geo/052_tpoint.in.sql
+++ b/mobilitydb/sql/geo/052_tpoint.in.sql
@@ -681,11 +681,11 @@ CREATE FUNCTION minusTime(tgeogpoint, timestamptz)
   AS 'MODULE_PATHNAME', 'Temporal_minus_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION valueAtTimestamp(tgeompoint, timestamptz)
+CREATE FUNCTION valueAtTimestamp(tgeompoint, timestamptz, strict bool DEFAULT TRUE)
   RETURNS geometry(Point)
   AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION valueAtTimestamp(tgeogpoint, timestamptz)
+CREATE FUNCTION valueAtTimestamp(tgeogpoint, timestamptz, strict bool DEFAULT TRUE)
   RETURNS geography(Point)
   AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/h3/255_th3index_spatialfuncs.in.sql
+++ b/mobilitydb/sql/h3/255_th3index_spatialfuncs.in.sql
@@ -135,7 +135,7 @@ CREATE FUNCTION getValues(th3index)
   AS 'MODULE_PATHNAME', 'Temporal_valueset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION valueAtTimestamp(th3index, timestamptz)
+CREATE FUNCTION valueAtTimestamp(th3index, timestamptz, strict bool DEFAULT TRUE)
   RETURNS h3index
   AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/json/452_tjsonb.in.sql
+++ b/mobilitydb/sql/json/452_tjsonb.in.sql
@@ -257,7 +257,7 @@ CREATE FUNCTION valueN(tjsonb, integer)
   AS 'MODULE_PATHNAME', 'Temporal_value_n'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION valueAtTimestamp(tjsonb, timestamptz)
+CREATE FUNCTION valueAtTimestamp(tjsonb, timestamptz, strict bool DEFAULT TRUE)
   RETURNS jsonb
   AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/npoint/302_tnpoint.in.sql
+++ b/mobilitydb/sql/npoint/302_tnpoint.in.sql
@@ -480,7 +480,7 @@ CREATE FUNCTION minusTime(tnpoint, timestamptz)
   AS 'MODULE_PATHNAME', 'Temporal_minus_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION valueAtTimestamp(tnpoint, timestamptz)
+CREATE FUNCTION valueAtTimestamp(tnpoint, timestamptz, strict bool DEFAULT TRUE)
   RETURNS npoint
   AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
+++ b/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
@@ -332,7 +332,7 @@ CREATE CAST (tpcpoint AS tgeompoint) WITH FUNCTION tgeompoint(tpcpoint);
  * Value-at-timestamp / restriction
  ******************************************************************************/
 
-CREATE FUNCTION valueAtTimestamp(tpcpoint, timestamptz)
+CREATE FUNCTION valueAtTimestamp(tpcpoint, timestamptz, strict bool DEFAULT TRUE)
   RETURNS pcpoint
   AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
+++ b/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
@@ -280,7 +280,7 @@ CREATE FUNCTION numPoints(tpcpatch)
  * Value-at-timestamp / restriction
  ******************************************************************************/
 
-CREATE FUNCTION valueAtTimestamp(tpcpatch, timestamptz)
+CREATE FUNCTION valueAtTimestamp(tpcpatch, timestamptz, strict bool DEFAULT TRUE)
   RETURNS pcpatch
   AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/pose/102_tpose.in.sql
+++ b/mobilitydb/sql/pose/102_tpose.in.sql
@@ -345,7 +345,7 @@ CREATE FUNCTION valueN(tpose, int)
   AS 'MODULE_PATHNAME', 'Temporal_value_n'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION valueAtTimestamp(tpose, timestamptz)
+CREATE FUNCTION valueAtTimestamp(tpose, timestamptz, strict bool DEFAULT TRUE)
   RETURNS pose
   AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/quadbin/355_tquadbin_spatialfuncs.in.sql
+++ b/mobilitydb/sql/quadbin/355_tquadbin_spatialfuncs.in.sql
@@ -70,7 +70,7 @@ CREATE FUNCTION getValues(tquadbin)
   AS 'MODULE_PATHNAME', 'Temporal_valueset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION valueAtTimestamp(tquadbin, timestamptz)
+CREATE FUNCTION valueAtTimestamp(tquadbin, timestamptz, strict bool DEFAULT TRUE)
   RETURNS quadbin
   AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/rgeo/150_trgeo.in.sql
+++ b/mobilitydb/sql/rgeo/150_trgeo.in.sql
@@ -316,7 +316,7 @@ CREATE FUNCTION rotation(trgeometry)
   AS 'MODULE_PATHNAME', 'Trgeometry_rotation'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION valueAtTimestamp(trgeometry, timestamptz)
+CREATE FUNCTION valueAtTimestamp(trgeometry, timestamptz, strict bool DEFAULT TRUE)
   RETURNS geometry
   AS 'MODULE_PATHNAME', 'Trgeometry_value_at_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/temporal/022_temporal.in.sql
+++ b/mobilitydb/sql/temporal/022_temporal.in.sql
@@ -1892,23 +1892,23 @@ CREATE FUNCTION minusTime(ttext, timestamptz)
   AS 'MODULE_PATHNAME', 'Temporal_minus_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION valueAtTimestamp(tbool, timestamptz)
+CREATE FUNCTION valueAtTimestamp(tbool, timestamptz, strict bool DEFAULT TRUE)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION valueAtTimestamp(tint, timestamptz)
+CREATE FUNCTION valueAtTimestamp(tint, timestamptz, strict bool DEFAULT TRUE)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION valueAtTimestamp(tbigint, timestamptz)
+CREATE FUNCTION valueAtTimestamp(tbigint, timestamptz, strict bool DEFAULT TRUE)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION valueAtTimestamp(tfloat, timestamptz)
+CREATE FUNCTION valueAtTimestamp(tfloat, timestamptz, strict bool DEFAULT TRUE)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION valueAtTimestamp(ttext, timestamptz)
+CREATE FUNCTION valueAtTimestamp(ttext, timestamptz, strict bool DEFAULT TRUE)
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/src/rgeo/trgeo.c
+++ b/mobilitydb/src/rgeo/trgeo.c
@@ -568,8 +568,9 @@ Trgeometry_value_at_timestamptz(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   TimestampTz t = PG_GETARG_TIMESTAMPTZ(1);
+  bool strict = PG_GETARG_BOOL(2);
   Datum result;
-  bool found = trgeo_value_at_timestamptz(temp, t, true, &result);
+  bool found = trgeo_value_at_timestamptz(temp, t, strict, &result);
   PG_FREE_IF_COPY(temp, 0);
   if (! found)
     PG_RETURN_NULL();

--- a/mobilitydb/src/temporal/temporal.c
+++ b/mobilitydb/src/temporal/temporal.c
@@ -1605,8 +1605,9 @@ Temporal_value_at_timestamptz(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   TimestampTz t = PG_GETARG_TIMESTAMPTZ(1);
+  bool strict = PG_GETARG_BOOL(2);
   Datum result;
-  bool found = temporal_value_at_timestamptz(temp, t, true, &result);
+  bool found = temporal_value_at_timestamptz(temp, t, strict, &result);
   PG_FREE_IF_COPY(temp, 0);
   if (! found)
     PG_RETURN_NULL();

--- a/mobilitydb/test/temporal/expected/022_temporal.test.out
+++ b/mobilitydb/test/temporal/expected/022_temporal.test.out
@@ -10426,6 +10426,24 @@ SELECT valueAtTimestamp(ttext '{[AAA@2000-01-01, BBB@2000-01-02, AAA@2000-01-03]
  AAA
 (1 row)
 
+SELECT valueAtTimestamp(tfloat '(1.5@2000-01-01, 2.5@2000-01-03]', timestamptz '2000-01-01');
+ valueattimestamp 
+------------------
+                 
+(1 row)
+
+SELECT valueAtTimestamp(tfloat '(1.5@2000-01-01, 2.5@2000-01-03]', timestamptz '2000-01-01', true);
+ valueattimestamp 
+------------------
+                 
+(1 row)
+
+SELECT valueAtTimestamp(tfloat '(1.5@2000-01-01, 2.5@2000-01-03]', timestamptz '2000-01-01', false);
+ valueattimestamp 
+------------------
+              1.5
+(1 row)
+
 SELECT minusTime(tbool 't@2000-01-01', timestamptz '2000-01-01');
  minustime 
 -----------

--- a/mobilitydb/test/temporal/queries/022_temporal.test.sql
+++ b/mobilitydb/test/temporal/queries/022_temporal.test.sql
@@ -2345,6 +2345,11 @@ SELECT valueAtTimestamp(ttext '{AAA@2000-01-01, BBB@2000-01-02, AAA@2000-01-03}'
 SELECT valueAtTimestamp(ttext '[AAA@2000-01-01, BBB@2000-01-02, AAA@2000-01-03]', timestamptz '2000-01-01');
 SELECT valueAtTimestamp(ttext '{[AAA@2000-01-01, BBB@2000-01-02, AAA@2000-01-03],[CCC@2000-01-04, CCC@2000-01-05]}', timestamptz '2000-01-01');
 
+-- Optional strict argument: a non-strict lookup returns the value at an exclusive bound
+SELECT valueAtTimestamp(tfloat '(1.5@2000-01-01, 2.5@2000-01-03]', timestamptz '2000-01-01');
+SELECT valueAtTimestamp(tfloat '(1.5@2000-01-01, 2.5@2000-01-03]', timestamptz '2000-01-01', true);
+SELECT valueAtTimestamp(tfloat '(1.5@2000-01-01, 2.5@2000-01-03]', timestamptz '2000-01-01', false);
+
 SELECT minusTime(tbool 't@2000-01-01', timestamptz '2000-01-01');
 SELECT minusTime(tbool '{t@2000-01-01}', timestamptz '2000-01-01');
 SELECT minusTime(tbool '{t@2000-01-01, f@2000-01-02, t@2000-01-03}', timestamptz '2000-01-01');


### PR DESCRIPTION
The `valueAtTimestamp` functions are thin wrappers over the MEOS
`<type>_value_at_timestamptz(temp, t, bool strict, result)` primitives. The SQL
surface exposes only the first two arguments and the wrappers bind `strict` to
the literal `true`, so a non-strict lookup — one that returns the value even when
the timestamp falls on an exclusive bound of the temporal value — is not
reachable from SQL.

This change exposes `strict` as an optional third argument defaulting to `TRUE`,
leaving existing two-argument calls unchanged. It follows the pattern of the
sibling `beforeTimestamp`/`afterTimestamp` restrictions (same
`*_timestamptz(temp, t, bool strict, ...)` shape) and of `segmentMinDuration`.

The `Temporal_value_at_timestamptz` and `Trgeometry_value_at_timestamptz`
wrappers read the third argument via `PG_GETARG_BOOL(2)`. The change spans every
temporal family (temporal, tgeo/tpoint, tcbuffer, tnpoint, trgeo, tjsonb, tpose,
th3index, tquadbin, tpcpoint, tpcpatch), the English and Spanish documentation,
and a regression test that exercises the non-strict path at an exclusive bound.
