### PR TITLE
Number the generated rgeo index file for the tgeo-aligned layout

### DIFF
--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -257,7 +257,11 @@ def extract_spatialrels(filetext: str, family: str) -> str:
 
 
 def target_path(behaviour: str, sub: dict, positions: dict) -> pathlib.Path:
-    num = sub["bin"] + positions[behaviour]
+    # The within-50-bin offset defaults to the shared `positions` map (the tight
+    # cbuffer-anchored layout); a family on the tgeo-aligned layout overrides a
+    # behaviour's offset via a per-subtype `positions` map (rgeo: indexes at +23).
+    pos = {**positions, **sub.get("positions", {})}
+    num = sub["bin"] + pos[behaviour]
     # The SQL family directory defaults to the base type name (quadbin, cbuffer),
     # but a family whose directory differs from its base type (h3: dir `h3`, base
     # `h3index`) overrides it with an explicit `fam`.

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -98,8 +98,12 @@ subtypes:
     fam:   rgeo
     stem:  trgeo
     brief: "temporal rigid geometries"
-    bin:   146
+    bin:   150
     category: tspatial
+    # rgeo follows the tgeo-aligned layout, where the combined index file sits at
+    # the gist offset (+23 -> 173) rather than the tight scheme's +16.
+    positions:
+      indexes: 23
     files: [indexes]
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The rgeo family uses the tgeo-aligned file layout, in which the combined index file is `173_trgeo_indexes.in.sql` (band base 150, gist offset +23). The `trgeometry` manifest entry has the inherited-behaviour generator emit `162_trgeo_indexes.in.sql` (base 146 + the tight-scheme `+16`), a stray file that does not match the committed layout.

- Set the `trgeometry` band base to `150` and override the index offset to `+23` via a per-subtype `positions` map.
- `target_path` merges a per-subtype `positions` override onto the shared map.

The generator emits `173_trgeo_indexes.in.sql`, byte-for-byte identical to the committed file. Generator configuration only — no `.in.sql` or C change.