### PR TITLE
Generate the value-collection temporal accessor for tcbuffer

### DIFF
--- a/mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
+++ b/mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
@@ -288,11 +288,15 @@ CREATE FUNCTION getTimestamp(tcbuffer)
   AS 'MODULE_PATHNAME', 'Tinstant_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+-- GENERATED-ACCESSORS-COLLECTION-BEGIN cbuffer — tools/codegen/inherited/generate.py from templates/accessors_collection.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.yaml (accessor_families) and re-run.
+
 -- values is a reserved word in SQL
 CREATE FUNCTION getValues(tcbuffer)
   RETURNS cbufferset
   AS 'MODULE_PATHNAME', 'Temporal_valueset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+-- GENERATED-ACCESSORS-COLLECTION-END cbuffer
 
 -- time is a reserved word in SQL
 CREATE FUNCTION getTime(tcbuffer)

--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -263,8 +263,9 @@ def extract_spatialrels(filetext: str, family: str) -> str:
 # (numInstants..segments) is {TEMP}-only — every wrapper is a pure CREATE FUNCTION
 # over a generic Temporal_* symbol whose signature is independent of the base value
 # type; the `value` run (startValue/endValue/valueN/valueAtTimestamp) carries the
-# {BASE}-typed value signature. getValue and the getValues collection accessor
-# interleave above the value run and stay hand-written until their own blocks land.
+# {BASE}-typed value signature; the `collection` accessor (getValues) returns the
+# {BASESET} value-collection type. getValue interleaves above the collection
+# accessor and stays hand-written until its own block lands.
 def accessor_blocks(fam: dict) -> list:
     """The accessor regions this family hosts. Defaults to the single T-agnostic
     `core` run (numInstants..segments). A family may declare extra blocks via
@@ -286,12 +287,15 @@ def _accessors_markers(family: str, kind: str, template: str):
 
 
 def render_accessors(fam: dict, block: dict) -> str:
-    """Render one accessor region: the block's template with {TEMP} (and {BASE}
-    for value-shaped accessors) substituted, wrapped in the blank lines that
-    separate it from the surrounding markers (leading blank after BEGIN, trailing
-    "\\n" before END). Roundtrips exactly against the committed reference region."""
+    """Render one accessor region: the block's template with {TEMP} (plus {BASE}
+    for the scalar-value run and {BASESET} for the value-collection accessor)
+    substituted, wrapped in the blank lines that separate it from the surrounding
+    markers (leading blank after BEGIN, trailing "\\n" before END). Roundtrips
+    exactly against the committed reference region."""
     body = (TEMPLATES / block["template"]).read_text().strip("\n")
-    body = body.replace("{TEMP}", fam["temp"]).replace("{BASE}", fam.get("base", ""))
+    body = (body.replace("{TEMP}", fam["temp"])
+                .replace("{BASESET}", fam.get("baseset", ""))
+                .replace("{BASE}", fam.get("base", "")))
     return "\n" + body + "\n"
 
 

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -267,16 +267,20 @@ accessor_families:
   - family:    cbuffer
     temp:      tcbuffer
     base:      cbuffer
+    baseset:   cbufferset
     file:      mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
     reference: true
     # The accessor surface splits into region-in-file blocks. `core` = the
     # T-agnostic run numInstants..segments ({TEMP}-only). `value` = the scalar
     # value run startValue/endValue/valueN/valueAtTimestamp, whose signatures
-    # return the {BASE} value type. getValue is a value accessor too but sits
+    # return the {BASE} value type. `collection` = getValues, returning the
+    # {BASESET} value-collection type. getValue is a value accessor too but sits
     # isolated above the getValues collection accessor, so it stays hand-written
-    # until the value-collection block lands.
+    # until its own block lands.
     blocks:
       - kind:     core
         template: accessors.sql.tmpl
       - kind:     value
         template: accessors_value.sql.tmpl
+      - kind:     collection
+        template: accessors_collection.sql.tmpl

--- a/tools/codegen/inherited/templates/accessors_collection.sql.tmpl
+++ b/tools/codegen/inherited/templates/accessors_collection.sql.tmpl
@@ -1,0 +1,5 @@
+-- values is a reserved word in SQL
+CREATE FUNCTION getValues({TEMP})
+  RETURNS {BASESET}
+  AS 'MODULE_PATHNAME', 'Temporal_valueset'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;


### PR DESCRIPTION
Completes the accessor token classes for the inherited-behaviour generator (`tools/codegen/inherited/`). After the T-agnostic (`core`) and scalar-value (`value`) runs, this adds the third class: the **value-collection** accessor `getValues`, which returns the base value-collection type.

## What changes

- New `collection` accessor block emits `getValues` from `templates/accessors_collection.sql.tmpl` with a `{BASESET}` token (cbuffer → `cbufferset`).
- The reserved-word comment that precedes `getValues` is family-agnostic, so it lives in the template.
- `cbuffer` (the reference family) self-regenerates all three blocks (`core`/`value`/`collection`) byte-for-byte (`generate.py --validate`); the only change to `202_tcbuffer.in.sql` is the two comment markers.

## Scope

`getValue` remains hand-written — it sits isolated above the `getValues` collection boundary and gets its own block later. For number/geo families the value-collection accessor differs (TNumber's `getValues` returns a value spanset; geo carries a separate `valueSet`), so those are wired when their families join `accessor_families`.