### PR TITLE
Generate the getValue temporal accessor for tcbuffer

### DIFF
--- a/mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
+++ b/mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
@@ -276,11 +276,15 @@ CREATE FUNCTION memSize(tcbuffer)
   AS 'MODULE_PATHNAME', 'Temporal_mem_size'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+-- GENERATED-ACCESSORS-GETVALUE-BEGIN cbuffer — tools/codegen/inherited/generate.py from templates/accessors_getvalue.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.yaml (accessor_families) and re-run.
+
 -- value is a reserved word in SQL
 CREATE FUNCTION getValue(tcbuffer)
   RETURNS cbuffer
   AS 'MODULE_PATHNAME', 'Tinstant_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+-- GENERATED-ACCESSORS-GETVALUE-END cbuffer
 
 -- timestamp is a reserved word in SQL
 CREATE FUNCTION getTimestamp(tcbuffer)

--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -263,9 +263,9 @@ def extract_spatialrels(filetext: str, family: str) -> str:
 # (numInstants..segments) is {TEMP}-only — every wrapper is a pure CREATE FUNCTION
 # over a generic Temporal_* symbol whose signature is independent of the base value
 # type; the `value` run (startValue/endValue/valueN/valueAtTimestamp) carries the
-# {BASE}-typed value signature; the `collection` accessor (getValues) returns the
-# {BASESET} value-collection type. getValue interleaves above the collection
-# accessor and stays hand-written until its own block lands.
+# {BASE}-typed value signature (as does the `getvalue` accessor, which sits
+# isolated above the collection accessor); the `collection` accessor (getValues)
+# returns the {BASESET} value-collection type.
 def accessor_blocks(fam: dict) -> list:
     """The accessor regions this family hosts. Defaults to the single T-agnostic
     `core` run (numInstants..segments). A family may declare extra blocks via

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -273,13 +273,14 @@ accessor_families:
     # The accessor surface splits into region-in-file blocks. `core` = the
     # T-agnostic run numInstants..segments ({TEMP}-only). `value` = the scalar
     # value run startValue/endValue/valueN/valueAtTimestamp, whose signatures
-    # return the {BASE} value type. `collection` = getValues, returning the
-    # {BASESET} value-collection type. getValue is a value accessor too but sits
-    # isolated above the getValues collection accessor, so it stays hand-written
-    # until its own block lands.
+    # return the {BASE} value type. `getvalue` = the getValue accessor (also
+    # {BASE}), which sits isolated above the getValues collection accessor.
+    # `collection` = getValues, returning the {BASESET} value-collection type.
     blocks:
       - kind:     core
         template: accessors.sql.tmpl
+      - kind:     getvalue
+        template: accessors_getvalue.sql.tmpl
       - kind:     value
         template: accessors_value.sql.tmpl
       - kind:     collection

--- a/tools/codegen/inherited/templates/accessors_getvalue.sql.tmpl
+++ b/tools/codegen/inherited/templates/accessors_getvalue.sql.tmpl
@@ -1,0 +1,5 @@
+-- value is a reserved word in SQL
+CREATE FUNCTION getValue({TEMP})
+  RETURNS {BASE}
+  AS 'MODULE_PATHNAME', 'Tinstant_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;


### PR DESCRIPTION
Completes the scalar-value accessor class for the inherited-behaviour generator: `getValue` joins `startValue`/`endValue`/`valueN`/`valueAtTimestamp`. Because `getValue` sits isolated above the `getValues` collection accessor, it forms its own region rather than part of the `value` run.

## What changes

- A `getvalue` accessor block emits `getValue` from `templates/accessors_getvalue.sql.tmpl` with the `{BASE}` token (cbuffer, symbol `Tinstant_value`).
- Its reserved-word comment is family-agnostic, so it lives in the template.
- The cbuffer reference self-regenerates every accessor block (`core`/`getvalue`/`value`/`collection`) byte-for-byte via `generate.py --validate`; the only change to `202_tcbuffer.in.sql` is the two comment markers.