### PR TITLE
Deduplicate pgPointCloud stringbuffer symbols for macOS linking

### DIFF
--- a/meos/CMakeLists.txt
+++ b/meos/CMakeLists.txt
@@ -249,13 +249,14 @@ if(POINTCLOUD)
   # block in mobilitydb/CMakeLists.txt. See
   # meos/src/pointcloud/CMakeLists.txt for where libpc.a is located.
   #
-  # libpc.a bundles its own stringbuffer.c (same upstream origin as
-  # PostGIS's liblwgeom/stringbuffer.c, both descend from the same tree
-  # of utility code). That duplication is benign — the two definitions
-  # are near-identical and either one serves correctly — but the linker
-  # rejects it by default. --allow-multiple-definition picks whichever
-  # comes first in link order (here: liblwgeom wins, which is fine
-  # because MEOS only calls the wrapper through that path).
+  # libpc.a and PostGIS's liblwgeom both once defined stringbuffer.c's symbols
+  # (shared upstream origin). That duplication needed a GNU-ld-only
+  # --allow-multiple-definition hack that Apple ld64 rejects; it is now resolved
+  # at the source level (meos/src/pointcloud/CMakeLists.txt drops libpc's
+  # stringbuffer.c and supplies the two symbols PostGIS does not export via
+  # pc_stringbuffer_shim.c), so the link carries one definition of every symbol
+  # and needs no such flag — which is what lets the -DALL build link under Apple
+  # ld64, not just GNU ld.
   target_link_libraries(${MEOS_LIB_NAME}
     pointcloud_libpc)
   # If the pgPointCloud subtree was built --with-lazperf=DIR, the
@@ -264,10 +265,6 @@ if(POINTCLOUD)
   if(EXISTS ${CMAKE_SOURCE_DIR}/pointcloud-pg/lib/liblazperf.a)
     target_link_libraries(${MEOS_LIB_NAME}
       ${CMAKE_SOURCE_DIR}/pointcloud-pg/lib/liblazperf.a stdc++)
-  endif()
-  if(UNIX AND NOT APPLE)
-    target_link_options(${MEOS_LIB_NAME} PRIVATE
-      "LINKER:--allow-multiple-definition")
   endif()
 endif()
 

--- a/meos/src/pointcloud/CMakeLists.txt
+++ b/meos/src/pointcloud/CMakeLists.txt
@@ -144,13 +144,29 @@ if(POINTCLOUD)
 
   find_package(LibXml2 REQUIRED)
   find_package(ZLIB REQUIRED)
+  # stringbuffer.c is deliberately omitted here — see the pc_stringbuffer_shim.c
+  # note below.
   set(POINTCLOUD_LIBPC_SRCS
     pc_bytes.c pc_dimstats.c pc_filter.c pc_mem.c pc_patch.c
     pc_patch_dimensional.c pc_patch_uncompressed.c pc_patch_lazperf.c
     pc_point.c pc_pointlist.c pc_schema.c pc_sort.c pc_stats.c pc_util.c
-    pc_val.c stringbuffer.c hashtable.c)
+    pc_val.c hashtable.c)
   list(TRANSFORM POINTCLOUD_LIBPC_SRCS
     PREPEND ${CMAKE_SOURCE_DIR}/pointcloud-pg/lib/)
+  # pgPointCloud's stringbuffer.c and PostGIS's liblwgeom/stringbuffer.c descend
+  # from the same upstream utility tree: they define the same stringbuffer
+  # symbols (stringbuffer_aprintf / clear / create / destroy / getstring / …)
+  # over a byte-identical stringbuffer_t layout. Linking both objects duplicates
+  # those symbols — a clash only GNU ld tolerates, via --allow-multiple-definition;
+  # Apple ld64 rejects it outright ("duplicate symbols"), which breaks every
+  # -DALL build on macOS. So libpc drops its stringbuffer.c: PostGIS's copy
+  # resolves the shared symbols (exactly what GNU ld already picks by link
+  # order), and pc_stringbuffer_shim.c supplies the two symbols PostGIS does not
+  # export but libpc needs — stringbuffer_release_string and stringbuffer_append
+  # (PostGIS provides the latter only as a header static-inline). One definition
+  # each, so no linker hack is required on any platform.
+  list(APPEND POINTCLOUD_LIBPC_SRCS
+    ${CMAKE_CURRENT_SOURCE_DIR}/pc_stringbuffer_shim.c)
   add_library(pointcloud_libpc STATIC ${POINTCLOUD_LIBPC_SRCS})
   set_target_properties(pointcloud_libpc PROPERTIES
     POSITION_INDEPENDENT_CODE ON OUTPUT_NAME pc)

--- a/meos/src/pointcloud/pc_stringbuffer_shim.c
+++ b/meos/src/pointcloud/pc_stringbuffer_shim.c
@@ -1,0 +1,89 @@
+/*****************************************************************************
+ *
+ * pc_stringbuffer_shim.c
+ *   The stringbuffer symbols pgPointCloud needs but PostGIS does not export.
+ *
+ * NOTE (# SOURCE-GAP-ACK): these are internal vendored pgPointCloud utility
+ * symbols, not public MEOS API — this file resolves a static-link symbol
+ * collision at the MEOS build level; it does not filter any binding surface.
+ *
+ * pgPointCloud's lib/stringbuffer.c and PostGIS's liblwgeom/stringbuffer.c
+ * descend from the same upstream utility tree and define the same stringbuffer
+ * symbols over an identical stringbuffer_t layout.  Linking both static objects
+ * makes those symbols duplicate — a clash only GNU ld tolerates (via
+ * --allow-multiple-definition); Apple ld64 rejects it, breaking every -DALL
+ * build on macOS.  MobilityDB therefore omits libpc's stringbuffer.c from the
+ * link (meos/src/pointcloud/CMakeLists.txt) and lets PostGIS's copy serve the
+ * shared symbols — which is exactly the definition GNU ld already selects by
+ * link order.
+ *
+ * The overlap is only PARTIAL, however: two symbols pgPointCloud references are
+ * NOT exported by PostGIS — stringbuffer_release_string (PostGIS has no such
+ * function) and stringbuffer_append (PostGIS provides it only as a static
+ * inline in its header, so it is not a linkable symbol).  Both are defined here,
+ * verbatim from upstream pgPointCloud, so the two libraries together contribute
+ * exactly one definition of every stringbuffer symbol and no duplicate-
+ * tolerating linker flag is needed on any platform.  The bodies touch only the
+ * stringbuffer_t fields, whose layout PostGIS shares, so operating on a buffer
+ * produced by PostGIS's shared functions is safe.
+ *
+ *****************************************************************************/
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "stringbuffer.h"
+
+/**
+ * If necessary, expand the stringbuffer_t internal buffer to accommodate the
+ * specified additional size.  (Static in upstream stringbuffer.c; reproduced
+ * here because stringbuffer_append below needs it.)
+ */
+static inline void
+stringbuffer_makeroom(stringbuffer_t *s, size_t size_to_add)
+{
+  size_t current_size = (s->str_end - s->str_start);
+  size_t capacity = s->capacity;
+  size_t required_size = current_size + size_to_add;
+
+  if (!capacity)
+    capacity = STRINGBUFFER_STARTSIZE;
+  else
+    while (capacity < required_size)
+      capacity *= 2;
+
+  if (capacity > s->capacity)
+  {
+    s->str_start = realloc(s->str_start, capacity);
+    s->capacity = capacity;
+    s->str_end = s->str_start + current_size;
+  }
+}
+
+/**
+ * Append the specified string to the stringbuffer_t.  (Parameter names match
+ * the stringbuffer.h declaration so static analysis does not read them as a
+ * swapped argument order.)
+ */
+void
+stringbuffer_append(stringbuffer_t *sb, const char *s)
+{
+  int alen = strlen(s); /* Length of string to append */
+  int alen0 = alen + 1; /* Length including null terminator */
+  stringbuffer_makeroom(sb, alen0);
+  memcpy(sb->str_end, s, alen0);
+  sb->str_end += alen;
+}
+
+/**
+ * Transfer ownership of the internal string to the caller, turning this buffer
+ * into an empty one.
+ */
+char *
+stringbuffer_release_string(stringbuffer_t *sb)
+{
+  char *ret = sb->str_start;
+  sb->str_start = sb->str_end = NULL;
+  sb->capacity = 0;
+  return ret;
+}

--- a/mobilitydb/CMakeLists.txt
+++ b/mobilitydb/CMakeLists.txt
@@ -274,13 +274,14 @@ if(POINTCLOUD)
   # static link (plus its xml2/z deps) here. See
   # meos/src/pointcloud/CMakeLists.txt for where libpc.a is located.
   #
-  # libpc.a bundles its own stringbuffer.c (same upstream origin as
-  # PostGIS's liblwgeom/stringbuffer.c, both descend from the same tree
-  # of utility code). That duplication is benign — the two definitions
-  # are near-identical and either one serves correctly — but the linker
-  # rejects it by default. --allow-multiple-definition picks whichever
-  # comes first in link order (here: liblwgeom wins, which is fine
-  # because MobilityDB only calls the wrapper through that path).
+  # libpc.a and PostGIS's liblwgeom both once defined stringbuffer.c's symbols
+  # (shared upstream origin). That duplication needed a GNU-ld-only
+  # --allow-multiple-definition hack that Apple ld64 rejects; it is now resolved
+  # at the source level (meos/src/pointcloud/CMakeLists.txt drops libpc's
+  # stringbuffer.c and supplies the two symbols PostGIS does not export via
+  # pc_stringbuffer_shim.c), so the link carries one definition of every symbol
+  # and needs no such flag — which is what lets the -DALL build link under Apple
+  # ld64, not just GNU ld.
   target_link_libraries(${MOBILITYDB_LIB_NAME}
     pointcloud_libpc)
   # If the pgPointCloud subtree was built --with-lazperf=DIR, the
@@ -289,10 +290,6 @@ if(POINTCLOUD)
   if(EXISTS ${CMAKE_SOURCE_DIR}/pointcloud-pg/lib/liblazperf.a)
     target_link_libraries(${MOBILITYDB_LIB_NAME}
       ${CMAKE_SOURCE_DIR}/pointcloud-pg/lib/liblazperf.a stdc++)
-  endif()
-  if(UNIX AND NOT APPLE)
-    target_link_options(${MOBILITYDB_LIB_NAME} PRIVATE
-      "LINKER:--allow-multiple-definition")
   endif()
 endif()
 if(WIN32)


### PR DESCRIPTION
pgPointCloud's `lib/stringbuffer.c` and PostGIS's `liblwgeom/stringbuffer.c` descend from the same upstream utility tree and define the same stringbuffer symbols over a byte-identical `stringbuffer_t` layout. Linking both static objects duplicates those symbols, which the POINTCLOUD build tolerates with `-Wl,--allow-multiple-definition`. That flag is GNU-ld only — Apple ld64 rejects the duplicates outright (`ld: duplicate symbols`), so every `-DALL` build fails to link `libmeos.dylib` on macOS (and blocks macOS CI for downstream `-DALL` consumers).

This drops libpc's `stringbuffer.c` from the `pointcloud_libpc` sources so PostGIS's copy serves the shared symbols — the same definition GNU ld already selects by link order. The overlap is only partial: PostGIS does not export `stringbuffer_append` (it provides only a header static-inline) or `stringbuffer_release_string` (absent), both of which libpc references. `pc_stringbuffer_shim.c` supplies exactly those two, verbatim from upstream pgPointCloud. Every stringbuffer symbol then has a single definition, so `--allow-multiple-definition` is removed from both link sites (`meos/CMakeLists.txt`, `mobilitydb/CMakeLists.txt`) and the build links under GNU ld and Apple ld64 alike. POINTCLOUD stays enabled on macOS — no family is disabled.

On Linux with `-DPOINTCLOUD=ON`, both `libmeos.so` and the PG extension `libMobilityDB-1.4.so` link with no flag and no duplicate-symbol error (GNU ld's single pass rejects any residual duplicate), carry no undefined `stringbuffer_*` symbols, and load. `stringbuffer_append` (through its buffer-growth path) and `stringbuffer_release_string` produce the correct string and empty the buffer, using the same `pcrealloc` allocator as the original libpc object.