### PR TITLE
Expose the temporal rigid geometry sequence constructors publicly

### DIFF
--- a/meos/examples/trgeo_distance.c
+++ b/meos/examples/trgeo_distance.c
@@ -65,8 +65,8 @@
  * (max 64 ships, max 5000 instants per ship). The defaults are 8 ships and
  * 500 instants per ship; both can be overridden on the command line.
  *
- * The program is intentionally short (single C file, only public MEOS API
- * + one extern for `trgeoseq_make`) so that the canonical pipeline
+ * The program is intentionally short (single C file, only public MEOS API)
+ * so that the canonical pipeline
  *
  *      AIS CSV → trgeometry trips → trgeo/trgeo distance → closest approach
  *
@@ -89,12 +89,6 @@
 #include <meos.h>
 #include <meos_geo.h>
 #include <meos_rgeo.h>
-
-/* The trgeometry-specific sequence constructor lives in
- * `meos/include/rgeo/trgeo_seq.h`, which pulls in `postgres.h`. We declare
- * the symbol directly so the tutorial stays in pure MEOS-public-API land. */
-extern TSequence *trgeoseq_make(const GSERIALIZED *geom, TInstant **instants,
-  int count, bool lower_inc, bool upper_inc, interpType interp, bool normalize);
 
 #define CSV_PATH "/home/esteban/src/MobilityDB/meos/examples/data/aisdk-2026-02-26.csv"
 #define MAX_LINE 1024
@@ -326,7 +320,7 @@ main(int argc, char **argv)
     GSERIALIZED *refgeom = geom_in(ref_with_srid, -1);
     /* The trgeometry-specific constructor wires the per-sequence
      * reference-geometry pointer (the generic tsequence_make does not). */
-    trips[i].trgeo = (Temporal *) trgeoseq_make(refgeom, trips[i].insts,
+    trips[i].trgeo = (Temporal *) trgeometryseq_make(refgeom, trips[i].insts,
       trips[i].n_inst, true, true, LINEAR, true);
     free(refgeom);
     fprintf(stderr,

--- a/meos/include/meos_rgeo.h
+++ b/meos/include/meos_rgeo.h
@@ -81,6 +81,9 @@ extern char *trgeometry_out(const Temporal *temp);
  *****************************************************************************/
 
 extern TInstant *trgeometryinst_make(const GSERIALIZED *geom, const Pose *pose, TimestampTz t);
+extern TSequence *trgeometryseq_make(const GSERIALIZED *geom, TInstant **instants, int count, bool lower_inc, bool upper_inc, interpType interp, bool normalize);
+extern TSequenceSet *trgeometryseqset_make(const GSERIALIZED *geom, TSequence **sequences, int count, bool normalize);
+extern TSequenceSet *trgeometryseqset_make_gaps(const GSERIALIZED *geom, TInstant **instants, int count, interpType interp, const Interval *maxt, double maxdist);
 extern Temporal *geo_tpose_to_trgeometry(const GSERIALIZED *gs, const Temporal *temp);
 
 /*****************************************************************************

--- a/meos/include/rgeo/trgeo_seq.h
+++ b/meos/include/rgeo/trgeo_seq.h
@@ -60,8 +60,6 @@ extern TSequence *trgeoseq_make1(const GSERIALIZED *geom, TInstant **instants,
   int count, bool lower_inc, bool upper_inc, interpType interp, bool normalize);
 extern TSequence *trgeoseq_make_exp(const GSERIALIZED *geom, TInstant **instants,
   int count, int maxcount, bool lower_inc, bool upper_inc, interpType interp, bool normalize);
-extern TSequence *trgeoseq_make(const GSERIALIZED *geom, TInstant **instants,
-  int count, bool lower_inc, bool upper_inc, interpType interp, bool normalize);
 extern TSequence *trgeoseq_make_free_exp(const GSERIALIZED *geom, TInstant **instants,
   int count, int maxcount, bool lower_inc, bool upper_inc, interpType interp, bool normalize);
 extern TSequence *trgeoseq_make_free(const GSERIALIZED *geom, TInstant **instants,

--- a/meos/include/rgeo/trgeo_seqset.h
+++ b/meos/include/rgeo/trgeo_seqset.h
@@ -53,13 +53,8 @@ extern TSequenceSet *trgeoseqset_make1_exp(const GSERIALIZED *geom,
   TSequence **sequences, int count, int maxcount, bool normalize);
 extern TSequenceSet *trgeoseqset_make_exp(const GSERIALIZED *geom,
   TSequence **sequences, int count, int maxcount, bool normalize);
-extern TSequenceSet *trgeoseqset_make(const GSERIALIZED *geom,
-  TSequence **sequences, int count, bool normalize);
 extern TSequenceSet *trgeoseqset_make_free(const GSERIALIZED *geom,
   TSequence **sequences, int count, bool normalize);
-extern TSequenceSet *trgeoseqset_make_gaps(const GSERIALIZED *geom,
-  TInstant **instants, int count, interpType interp, const Interval *maxt,
-  double maxdist);
 
 /* Transformation functions */
 

--- a/meos/src/rgeo/trgeo_parser.c
+++ b/meos/src/rgeo/trgeo_parser.c
@@ -120,7 +120,7 @@ trgeoseq_disc_parse(const char **str, MeosType temptype, int *temp_srid,
   TInstant **instants = palloc(sizeof(TInstant *) * array->count);
   for (int i = 0; i < (int) array->count; i++)
     instants[i] = (TInstant *) meos_array_get(array, i);
-  result = trgeoseq_make(geom, instants, array->count, true, true,
+  result = trgeometryseq_make(geom, instants, array->count, true, true,
     DISCRETE, NORMALIZE_NO);
   pfree(instants);
 
@@ -190,7 +190,7 @@ trgeoseq_cont_parse(const char **str, MeosType temptype, interpType interp,
     instants[i] = (TInstant *) meos_array_get(array, i);
   p_cbracket(str);
   p_cparen(str);
-  result = trgeoseq_make(geom, instants, array->count, lower_inc,
+  result = trgeometryseq_make(geom, instants, array->count, lower_inc,
     upper_inc, interp, NORMALIZE);
   pfree(instants);
 
@@ -240,7 +240,7 @@ trgeoseqset_parse(const char **str, MeosType temptype, interpType interp,
   for (int i = 0; i < (int) array->count; i++)
     sequences[i] = (TSequence *) meos_array_get(array, i);
   p_cbrace(str);
-  result = trgeoseqset_make(geom, sequences, array->count, NORMALIZE);
+  result = trgeometryseqset_make(geom, sequences, array->count, NORMALIZE);
   pfree(sequences);
 
 error:

--- a/meos/src/rgeo/trgeo_seq.c
+++ b/meos/src/rgeo/trgeo_seq.c
@@ -40,6 +40,7 @@
 #include <utils/timestamp.h>
 /* MEOS */
 #include <meos_internal.h>
+#include <meos_rgeo.h>
 #include "temporal/temporal.h"
 #include "temporal/tsequence.h"
 #include "temporal/type_util.h"
@@ -279,7 +280,7 @@ trgeoseq_make_exp(const GSERIALIZED *geom, TInstant **instants,
  * @param[in] normalize True if the resulting value should be normalized
  */
 inline TSequence *
-trgeoseq_make(const GSERIALIZED *geom, TInstant **instants, int count,
+trgeometryseq_make(const GSERIALIZED *geom, TInstant **instants, int count,
   bool lower_inc, bool upper_inc, interpType interp, bool normalize)
 {
   return trgeoseq_make_exp(geom, instants, count, count, lower_inc, upper_inc,
@@ -355,7 +356,7 @@ TSequence *
 trgeoinst_to_tsequence(const TInstant *inst, interpType interp)
 {
   assert(inst);
-  return trgeoseq_make(trgeoinst_geom_p(inst), (TInstant **) &inst, 1, true,
+  return trgeometryseq_make(trgeoinst_geom_p(inst), (TInstant **) &inst, 1, true,
     true, interp, NORMALIZE_NO);
 }
 

--- a/meos/src/rgeo/trgeo_seqset.c
+++ b/meos/src/rgeo/trgeo_seqset.c
@@ -242,7 +242,7 @@ trgeoseqset_make_exp(const GSERIALIZED *geom, TSequence **sequences,
  * @sqlfn tbool_seqset(), tint_seqset(), tfloat_seqset(), ttext_seqset(), etc.
  */
 inline TSequenceSet *
-trgeoseqset_make(const GSERIALIZED *geom, TSequence **sequences, int count,
+trgeometryseqset_make(const GSERIALIZED *geom, TSequence **sequences, int count,
   bool normalize)
 {
   return trgeoseqset_make_exp(geom, sequences, count, count, normalize);
@@ -273,7 +273,7 @@ trgeoseqset_make_free(const GSERIALIZED *geom, TSequence **sequences,
     pfree(sequences);
     return NULL;
   }
-  TSequenceSet *result = trgeoseqset_make(geom, sequences, count, normalize);
+  TSequenceSet *result = trgeometryseqset_make(geom, sequences, count, normalize);
   pfree_array((void **) sequences, count);
   return result;
 }
@@ -310,7 +310,7 @@ trgeoseqset_make_valid_gaps(const GSERIALIZED *geom, TInstant **instants,
  * tgeompoint_seqset_gaps(), tgeogpoint_seqset_gaps()
  */
 TSequenceSet *
-trgeoseqset_make_gaps(const GSERIALIZED *geom, TInstant **instants,
+trgeometryseqset_make_gaps(const GSERIALIZED *geom, TInstant **instants,
   int count, interpType interp, const Interval *maxt, double maxdist)
 {
   /* Ensure the validity of the arguments */
@@ -324,8 +324,8 @@ trgeoseqset_make_gaps(const GSERIALIZED *geom, TInstant **instants,
   /* If no gaps are given construt call the standard sequence constructor */
   if (maxt == NULL && maxdist <= 0.0)
   {
-    seq = trgeoseq_make(geom, instants, count, true, true, interp, NORMALIZE);
-    result = trgeoseqset_make(geom, &seq, 1, NORMALIZE_NO);
+    seq = trgeometryseq_make(geom, instants, count, true, true, interp, NORMALIZE);
+    result = trgeometryseqset_make(geom, &seq, 1, NORMALIZE_NO);
     pfree(seq);
     return result;
   }
@@ -339,7 +339,7 @@ trgeoseqset_make_gaps(const GSERIALIZED *geom, TInstant **instants,
     /* There are no gaps */
     pfree(splits);
     seq = trgeoseq_make1(geom, instants, count, true, true, interp, NORMALIZE);
-    result = trgeoseqset_make(geom, &seq, 1, NORMALIZE_NO);
+    result = trgeometryseqset_make(geom, &seq, 1, NORMALIZE_NO);
     pfree(seq);
   }
   else
@@ -366,7 +366,7 @@ trgeoseqset_make_gaps(const GSERIALIZED *geom, TInstant **instants,
     if (k > 0)
       sequences[newcount++] = trgeoseq_make1(geom, newinsts, k, true, true,
         interp, NORMALIZE);
-    result = trgeoseqset_make(geom, sequences, newcount, NORMALIZE);
+    result = trgeometryseqset_make(geom, sequences, newcount, NORMALIZE);
     pfree(newinsts); pfree(sequences);
   }
   return result;
@@ -425,7 +425,7 @@ trgeoseq_to_tsequenceset(const TSequence *seq)
     interpType interp = MEOS_FLAGS_GET_CONTINUOUS(seq->flags) ? LINEAR : STEP;
     return trgeodiscseq_to_tsequenceset(seq, interp);
   }
-  return trgeoseqset_make(trgeoseq_geom_p(seq), (TSequence **) &seq, 1,
+  return trgeometryseqset_make(trgeoseq_geom_p(seq), (TSequence **) &seq, 1,
     NORMALIZE_NO);
 }
 

--- a/mobilitydb/src/rgeo/trgeo.c
+++ b/mobilitydb/src/rgeo/trgeo.c
@@ -300,7 +300,7 @@ Trgeometry_seq_constructor(PG_FUNCTION_ARGS)
   ensure_not_empty_array(array);
   int count;
   TInstant **instants = (TInstant **) temparr_extract(array, &count);
-  Temporal *result = (Temporal *) trgeoseq_make(trgeoinst_geom_p(instants[0]),
+  Temporal *result = (Temporal *) trgeometryseq_make(trgeoinst_geom_p(instants[0]),
     instants, count, lower_inc, upper_inc, interp,
     NORMALIZE);
   pfree(instants);
@@ -323,7 +323,7 @@ Trgeometry_seqset_constructor(PG_FUNCTION_ARGS)
   ensure_not_empty_array(array);
   int count;
   TSequence **sequences = (TSequence **) temparr_extract(array, &count);
-  Temporal *result = (Temporal *) trgeoseqset_make(
+  Temporal *result = (Temporal *) trgeometryseqset_make(
     trgeoseq_geom_p(sequences[0]), sequences, count, NORMALIZE);
   pfree(sequences);
   PG_FREE_IF_COPY(array, 0);
@@ -368,7 +368,7 @@ Trgeometry_seqset_constructor_gaps(PG_FUNCTION_ARGS)
   /* Extract the array of instants */
   int count;
   TInstant **instants = (TInstant **) temparr_extract(array, &count);
-  TSequenceSet *result = trgeoseqset_make_gaps(trgeoinst_geom_p(instants[0]),
+  TSequenceSet *result = trgeometryseqset_make_gaps(trgeoinst_geom_p(instants[0]),
     instants, count, interp, maxt, maxdist);
   pfree(instants);
   PG_FREE_IF_COPY(array, 0);


### PR DESCRIPTION
Exposes the rigid geometry sequence, sequence-set, and gaps constructors as public API under the canonical `trgeometry*` prefix.

## Change

- `trgeoseq_make` → `trgeometryseq_make`
- `trgeoseqset_make` → `trgeometryseqset_make`
- `trgeoseqset_make_gaps` → `trgeometryseqset_make_gaps`

The three declarations move to the public umbrella header `meos_rgeo.h`, alongside `trgeometryinst_make`. This gives the temporal rigid geometry type the same public constructor surface as the sibling temporal types — `th3indexinst_make`/`th3indexseq_make`/`th3indexseqset_make` in `meos_h3.h`, `tquadbininst_make`/`tquadbinseq_make`/`tquadbinseqset_make` in `meos_quadbin.h` — following the `<type>inst_make` / `<type>seq_make` / `<type>seqset_make` / `<type>seqset_make_gaps` convention.

The `trgeo*`-prefixed internal helpers (`trgeoseq_make_exp`, `trgeoseq_make1`, `trgeoseqset_make_free`, `trgeoseqset_make_valid_gaps`, …) keep their abbreviated names, consistent with the user-facing-vs-internal naming split.

The example `meos/examples/trgeo_distance.c` uses the public constructor directly instead of a local `extern` declaration.