### PR TITLE
Unify the accessor generator on a per-base-type table and generate the base Temporal accessors

### DIFF
--- a/mobilitydb/sql/temporal/022_temporal.in.sql
+++ b/mobilitydb/sql/temporal/022_temporal.in.sql
@@ -513,6 +513,9 @@ CREATE CAST (tfloat AS tbox) WITH FUNCTION tbox(tfloat);
  * Accessor functions
  ******************************************************************************/
 
+-- GENERATED-ACCESSORS-BEGIN temporal — tools/codegen/inherited/generate.py from templates/accessors.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.yaml (accessor_families) and re-run.
+
 CREATE FUNCTION tempSubtype(tbool)
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_subtype'
@@ -596,7 +599,7 @@ CREATE FUNCTION memSize(ttext)
   AS 'MODULE_PATHNAME', 'Temporal_mem_size'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
--- values is a reserved word in SQL
+-- value is a reserved word in SQL
 CREATE FUNCTION getValue(tbool)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Tinstant_value'
@@ -616,6 +619,28 @@ CREATE FUNCTION getValue(tfloat)
 CREATE FUNCTION getValue(ttext)
   RETURNS text
   AS 'MODULE_PATHNAME', 'Tinstant_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- timestamp is a reserved word in SQL
+CREATE FUNCTION getTimestamp(tbool)
+  RETURNS timestamptz
+  AS 'MODULE_PATHNAME', 'Tinstant_timestamptz'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION getTimestamp(tint)
+  RETURNS timestamptz
+  AS 'MODULE_PATHNAME', 'Tinstant_timestamptz'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION getTimestamp(tbigint)
+  RETURNS timestamptz
+  AS 'MODULE_PATHNAME', 'Tinstant_timestamptz'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION getTimestamp(tfloat)
+  RETURNS timestamptz
+  AS 'MODULE_PATHNAME', 'Tinstant_timestamptz'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION getTimestamp(ttext)
+  RETURNS timestamptz
+  AS 'MODULE_PATHNAME', 'Tinstant_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 -- values is a reserved word in SQL
@@ -651,6 +676,28 @@ CREATE FUNCTION valueSet(tbigint)
 CREATE FUNCTION valueSet(tfloat)
   RETURNS floatset
   AS 'MODULE_PATHNAME', 'Temporal_valueset'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- time is a reserved word in SQL
+CREATE FUNCTION getTime(tbool)
+  RETURNS tstzspanset
+  AS 'MODULE_PATHNAME', 'Temporal_time'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION getTime(tint)
+  RETURNS tstzspanset
+  AS 'MODULE_PATHNAME', 'Temporal_time'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION getTime(tbigint)
+  RETURNS tstzspanset
+  AS 'MODULE_PATHNAME', 'Temporal_time'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION getTime(tfloat)
+  RETURNS tstzspanset
+  AS 'MODULE_PATHNAME', 'Temporal_time'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION getTime(ttext)
+  RETURNS tstzspanset
+  AS 'MODULE_PATHNAME', 'Temporal_time'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION startValue(tbool)
@@ -693,6 +740,27 @@ CREATE FUNCTION endValue(tfloat)
 CREATE FUNCTION endValue(ttext)
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_end_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION valueN(tbool, int)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Temporal_value_n'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION valueN(tint, int)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Temporal_value_n'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION valueN(tbigint, int)
+  RETURNS bigint
+  AS 'MODULE_PATHNAME', 'Temporal_value_n'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION valueN(tfloat, int)
+  RETURNS float
+  AS 'MODULE_PATHNAME', 'Temporal_value_n'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION valueN(ttext, int)
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Temporal_value_n'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION minValue(tint)
@@ -742,27 +810,6 @@ CREATE FUNCTION avgValue(tfloat)
   AS 'MODULE_PATHNAME', 'Tnumber_avg_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION valueN(tbool, integer)
-  RETURNS bool
-  AS 'MODULE_PATHNAME', 'Temporal_value_n'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION valueN(tint, integer)
-  RETURNS integer
-  AS 'MODULE_PATHNAME', 'Temporal_value_n'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION valueN(tbigint, integer)
-  RETURNS bigint
-  AS 'MODULE_PATHNAME', 'Temporal_value_n'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION valueN(tfloat, integer)
-  RETURNS float
-  AS 'MODULE_PATHNAME', 'Temporal_value_n'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION valueN(ttext, integer)
-  RETURNS text
-  AS 'MODULE_PATHNAME', 'Temporal_value_n'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
 CREATE FUNCTION minInstant(tint)
   RETURNS tint
   AS 'MODULE_PATHNAME', 'Temporal_min_instant'
@@ -797,48 +844,25 @@ CREATE FUNCTION maxInstant(ttext)
   AS 'MODULE_PATHNAME', 'Temporal_max_instant'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
--- timestamp is a reserved word in SQL
-CREATE FUNCTION getTimestamp(tbool)
-  RETURNS timestamptz
-  AS 'MODULE_PATHNAME', 'Tinstant_timestamptz'
+CREATE FUNCTION valueAtTimestamp(tbool, timestamptz)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION getTimestamp(tint)
-  RETURNS timestamptz
-  AS 'MODULE_PATHNAME', 'Tinstant_timestamptz'
+CREATE FUNCTION valueAtTimestamp(tint, timestamptz)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION getTimestamp(tbigint)
-  RETURNS timestamptz
-  AS 'MODULE_PATHNAME', 'Tinstant_timestamptz'
+CREATE FUNCTION valueAtTimestamp(tbigint, timestamptz)
+  RETURNS bigint
+  AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION getTimestamp(tfloat)
-  RETURNS timestamptz
-  AS 'MODULE_PATHNAME', 'Tinstant_timestamptz'
+CREATE FUNCTION valueAtTimestamp(tfloat, timestamptz)
+  RETURNS float
+  AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION getTimestamp(ttext)
-  RETURNS timestamptz
-  AS 'MODULE_PATHNAME', 'Tinstant_timestamptz'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
--- time is a reserved word in SQL
-CREATE FUNCTION getTime(tbool)
-  RETURNS tstzspanset
-  AS 'MODULE_PATHNAME', 'Temporal_time'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION getTime(tint)
-  RETURNS tstzspanset
-  AS 'MODULE_PATHNAME', 'Temporal_time'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION getTime(tbigint)
-  RETURNS tstzspanset
-  AS 'MODULE_PATHNAME', 'Temporal_time'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION getTime(tfloat)
-  RETURNS tstzspanset
-  AS 'MODULE_PATHNAME', 'Temporal_time'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION getTime(ttext)
-  RETURNS tstzspanset
-  AS 'MODULE_PATHNAME', 'Temporal_time'
+CREATE FUNCTION valueAtTimestamp(ttext, timestamptz)
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION duration(tbool, boundspan boolean DEFAULT FALSE)
@@ -860,132 +884,6 @@ CREATE FUNCTION duration(tfloat, boundspan boolean DEFAULT FALSE)
 CREATE FUNCTION duration(ttext, boundspan boolean DEFAULT FALSE)
   RETURNS interval
   AS 'MODULE_PATHNAME', 'Temporal_duration'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-CREATE FUNCTION numSequences(tbool)
-  RETURNS integer
-  AS 'MODULE_PATHNAME', 'Temporal_num_sequences'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION numSequences(tint)
-  RETURNS integer
-  AS 'MODULE_PATHNAME', 'Temporal_num_sequences'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION numSequences(tbigint)
-  RETURNS integer
-  AS 'MODULE_PATHNAME', 'Temporal_num_sequences'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION numSequences(tfloat)
-  RETURNS integer
-  AS 'MODULE_PATHNAME', 'Temporal_num_sequences'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION numSequences(ttext)
-  RETURNS integer
-  AS 'MODULE_PATHNAME', 'Temporal_num_sequences'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-CREATE FUNCTION startSequence(tbool)
-  RETURNS tbool
-  AS 'MODULE_PATHNAME', 'Temporal_start_sequence'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION startSequence(tint)
-  RETURNS tint
-  AS 'MODULE_PATHNAME', 'Temporal_start_sequence'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION startSequence(tbigint)
-  RETURNS tbigint
-  AS 'MODULE_PATHNAME', 'Temporal_start_sequence'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION startSequence(tfloat)
-  RETURNS tfloat
-  AS 'MODULE_PATHNAME', 'Temporal_start_sequence'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION startSequence(ttext)
-  RETURNS ttext
-  AS 'MODULE_PATHNAME', 'Temporal_start_sequence'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-CREATE FUNCTION endSequence(tbool)
-  RETURNS tbool
-  AS 'MODULE_PATHNAME', 'Temporal_end_sequence'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION endSequence(tint)
-  RETURNS tint
-  AS 'MODULE_PATHNAME', 'Temporal_end_sequence'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION endSequence(tbigint)
-  RETURNS tbigint
-  AS 'MODULE_PATHNAME', 'Temporal_end_sequence'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION endSequence(tfloat)
-  RETURNS tfloat
-  AS 'MODULE_PATHNAME', 'Temporal_end_sequence'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION endSequence(ttext)
-  RETURNS ttext
-  AS 'MODULE_PATHNAME', 'Temporal_end_sequence'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-CREATE FUNCTION sequenceN(tbool, integer)
-  RETURNS tbool
-  AS 'MODULE_PATHNAME', 'Temporal_sequence_n'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION sequenceN(tint, integer)
-  RETURNS tint
-  AS 'MODULE_PATHNAME', 'Temporal_sequence_n'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION sequenceN(tbigint, integer)
-  RETURNS tbigint
-  AS 'MODULE_PATHNAME', 'Temporal_sequence_n'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION sequenceN(tfloat, integer)
-  RETURNS tfloat
-  AS 'MODULE_PATHNAME', 'Temporal_sequence_n'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION sequenceN(ttext, integer)
-  RETURNS ttext
-  AS 'MODULE_PATHNAME', 'Temporal_sequence_n'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-CREATE FUNCTION sequences(tbool)
-  RETURNS tbool[]
-  AS 'MODULE_PATHNAME', 'Temporal_sequences'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION sequences(tint)
-  RETURNS tint[]
-  AS 'MODULE_PATHNAME', 'Temporal_sequences'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION sequences(tbigint)
-  RETURNS tbigint[]
-  AS 'MODULE_PATHNAME', 'Temporal_sequences'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION sequences(tfloat)
-  RETURNS tfloat[]
-  AS 'MODULE_PATHNAME', 'Temporal_sequences'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION sequences(ttext)
-  RETURNS ttext[]
-  AS 'MODULE_PATHNAME', 'Temporal_sequences'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-CREATE FUNCTION segments(tbool)
-  RETURNS tbool[]
-  AS 'MODULE_PATHNAME', 'Temporal_segments'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION segments(tint)
-  RETURNS tint[]
-  AS 'MODULE_PATHNAME', 'Temporal_segments'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION segments(tbigint)
-  RETURNS tbigint[]
-  AS 'MODULE_PATHNAME', 'Temporal_segments'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION segments(tfloat)
-  RETURNS tfloat[]
-  AS 'MODULE_PATHNAME', 'Temporal_segments'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION segments(ttext)
-  RETURNS ttext[]
-  AS 'MODULE_PATHNAME', 'Temporal_segments'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION lowerInc(tbool)
@@ -1239,6 +1137,133 @@ CREATE FUNCTION timestamps(ttext)
   RETURNS timestamptz[]
   AS 'MODULE_PATHNAME', 'Temporal_timestamps'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION numSequences(tbool)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Temporal_num_sequences'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION numSequences(tint)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Temporal_num_sequences'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION numSequences(tbigint)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Temporal_num_sequences'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION numSequences(tfloat)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Temporal_num_sequences'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION numSequences(ttext)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Temporal_num_sequences'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION startSequence(tbool)
+  RETURNS tbool
+  AS 'MODULE_PATHNAME', 'Temporal_start_sequence'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION startSequence(tint)
+  RETURNS tint
+  AS 'MODULE_PATHNAME', 'Temporal_start_sequence'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION startSequence(tbigint)
+  RETURNS tbigint
+  AS 'MODULE_PATHNAME', 'Temporal_start_sequence'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION startSequence(tfloat)
+  RETURNS tfloat
+  AS 'MODULE_PATHNAME', 'Temporal_start_sequence'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION startSequence(ttext)
+  RETURNS ttext
+  AS 'MODULE_PATHNAME', 'Temporal_start_sequence'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION endSequence(tbool)
+  RETURNS tbool
+  AS 'MODULE_PATHNAME', 'Temporal_end_sequence'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION endSequence(tint)
+  RETURNS tint
+  AS 'MODULE_PATHNAME', 'Temporal_end_sequence'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION endSequence(tbigint)
+  RETURNS tbigint
+  AS 'MODULE_PATHNAME', 'Temporal_end_sequence'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION endSequence(tfloat)
+  RETURNS tfloat
+  AS 'MODULE_PATHNAME', 'Temporal_end_sequence'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION endSequence(ttext)
+  RETURNS ttext
+  AS 'MODULE_PATHNAME', 'Temporal_end_sequence'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION sequenceN(tbool, integer)
+  RETURNS tbool
+  AS 'MODULE_PATHNAME', 'Temporal_sequence_n'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION sequenceN(tint, integer)
+  RETURNS tint
+  AS 'MODULE_PATHNAME', 'Temporal_sequence_n'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION sequenceN(tbigint, integer)
+  RETURNS tbigint
+  AS 'MODULE_PATHNAME', 'Temporal_sequence_n'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION sequenceN(tfloat, integer)
+  RETURNS tfloat
+  AS 'MODULE_PATHNAME', 'Temporal_sequence_n'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION sequenceN(ttext, integer)
+  RETURNS ttext
+  AS 'MODULE_PATHNAME', 'Temporal_sequence_n'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION sequences(tbool)
+  RETURNS tbool[]
+  AS 'MODULE_PATHNAME', 'Temporal_sequences'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION sequences(tint)
+  RETURNS tint[]
+  AS 'MODULE_PATHNAME', 'Temporal_sequences'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION sequences(tbigint)
+  RETURNS tbigint[]
+  AS 'MODULE_PATHNAME', 'Temporal_sequences'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION sequences(tfloat)
+  RETURNS tfloat[]
+  AS 'MODULE_PATHNAME', 'Temporal_sequences'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION sequences(ttext)
+  RETURNS ttext[]
+  AS 'MODULE_PATHNAME', 'Temporal_sequences'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION segments(tbool)
+  RETURNS tbool[]
+  AS 'MODULE_PATHNAME', 'Temporal_segments'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION segments(tint)
+  RETURNS tint[]
+  AS 'MODULE_PATHNAME', 'Temporal_segments'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION segments(tbigint)
+  RETURNS tbigint[]
+  AS 'MODULE_PATHNAME', 'Temporal_segments'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION segments(tfloat)
+  RETURNS tfloat[]
+  AS 'MODULE_PATHNAME', 'Temporal_segments'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION segments(ttext)
+  RETURNS ttext[]
+  AS 'MODULE_PATHNAME', 'Temporal_segments'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+-- GENERATED-ACCESSORS-END temporal
 
 /*****************************************************************************
  * Transform a temporal value to a set of records
@@ -1890,27 +1915,6 @@ CREATE FUNCTION minusTime(tfloat, timestamptz)
 CREATE FUNCTION minusTime(ttext, timestamptz)
   RETURNS ttext
   AS 'MODULE_PATHNAME', 'Temporal_minus_timestamptz'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-CREATE FUNCTION valueAtTimestamp(tbool, timestamptz)
-  RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION valueAtTimestamp(tint, timestamptz)
-  RETURNS integer
-  AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION valueAtTimestamp(tbigint, timestamptz)
-  RETURNS bigint
-  AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION valueAtTimestamp(tfloat, timestamptz)
-  RETURNS float
-  AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION valueAtTimestamp(ttext, timestamptz)
-  RETURNS text
-  AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION atTime(tbool, tstzset)

--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -275,17 +275,122 @@ def _accessors_markers(family: str):
 
 
 def render_accessors(fam: dict) -> str:
-    """Render the accessor region for one family: the generic template with
-    {TEMP}/{BASE}/{BASESET} substituted, wrapped in the blank lines that separate
-    it from the surrounding markers (leading blank after BEGIN, trailing "\\n"
-    before END). Roundtrips byte-for-byte against the committed reference region.
-    {BASESET} is substituted before {BASE} to document the intent (the latter is
-    not a substring of the former)."""
-    body = (TEMPLATES / "accessors.sql.tmpl").read_text().strip("\n")
-    body = (body.replace("{TEMP}", fam["temp"])
-                .replace("{BASESET}", fam.get("baseset", ""))
-                .replace("{BASE}", fam.get("base", "")))
-    return "\n" + body + "\n"
+    """Render the accessor region for one family from its per-base-type `types`
+    table. ONE renderer serves every family: a spatial subtype is a single-element
+    `types` (one function per accessor, and — carrying no numeric/orderable flag —
+    none of the gated TNumber accessors), the base Temporal<T> is all five base
+    types. An old {temp/base/baseset} family is normalized to a one-element table,
+    so this reproduces the merged subtype regions byte-for-byte. Groups are emitted
+    accessor-outer / type-inner and separated by one blank line; the gated accessors
+    slot in at their canonical positions for the types that carry them."""
+    types = fam.get("types") or [{"temp": fam["temp"],
+                                  "base": fam.get("base", ""),
+                                  "baseset": fam.get("baseset", "")}]
+    pools = {"numeric": [t for t in types if t.get("numeric")],
+             "orderable": [t for t in types if t.get("orderable")]}
+    groups = []
+    for comment, fns, name in _accessor_blocks((TEMPLATES / "accessors.sql.tmpl").read_text()):
+        groups.append(_render_group(comment, fns, types))
+        for gname in _GATED_AFTER.get(name, []):
+            groups.append(_render_group("", _GATED[gname], pools[_GATED_PRESENCE[gname]]))
+    return "\n" + "\n\n".join(g for g in groups if g) + "\n"
+
+
+# --- SQL accessors: base Temporal<T> multi-base-type mode ----------------
+# The base type file (022_temporal) declares the SAME accessor surface, but for
+# EVERY base type (tbool/tint/tbigint/tfloat/ttext) in one region, grouped
+# accessor-outer / type-inner (all types' getValue, then all types' getTimestamp,
+# ...). It also carries the TNumber/orderable-only accessors that the spatial
+# subtypes lack: valueSet (the discrete value set, numeric only), minValue/maxValue
+# (orderable), avgValue (numeric) and minInstant/maxInstant (orderable). These are
+# emitted from the same canonical order as the shared template, with the gated
+# accessors slotted at their canonical positions (valueSet with the value-collection
+# group after getValues; the value/instant reductions after valueN, before
+# valueAtTimestamp — doc/temporal_alpha.xml `talpha_accessors`). A `temporal` family
+# in the manifest carries `types:` (a per-base-type token table) instead of the
+# single {TEMP}/{BASE}/{BASESET}, which selects this multi-type renderer.
+#
+# The gated fragments are NOT in the shared subtype template (the spatial families
+# have none of them), so they live here as literal blocks with their own tokens:
+# {VSET} = the discrete value-set type (intset/bigintset/floatset). getValue/
+# startValue/endValue/valueN/valueAtTimestamp/minValue/maxValue all return {BASE};
+# avgValue returns float; minInstant/maxInstant return {TEMP}.
+_GATED = {
+    "valueSet": ("CREATE FUNCTION valueSet({TEMP})\n"
+                 "  RETURNS {VSET}\n"
+                 "  AS 'MODULE_PATHNAME', 'Temporal_valueset'\n"
+                 "  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;"),
+    "minValue": ("CREATE FUNCTION minValue({TEMP})\n"
+                 "  RETURNS {BASE}\n"
+                 "  AS 'MODULE_PATHNAME', 'Temporal_min_value'\n"
+                 "  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;"),
+    "maxValue": ("CREATE FUNCTION maxValue({TEMP})\n"
+                 "  RETURNS {BASE}\n"
+                 "  AS 'MODULE_PATHNAME', 'Temporal_max_value'\n"
+                 "  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;"),
+    "avgValue": ("CREATE FUNCTION avgValue({TEMP})\n"
+                 "  RETURNS float\n"
+                 "  AS 'MODULE_PATHNAME', 'Tnumber_avg_value'\n"
+                 "  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;"),
+    "minInstant": ("CREATE FUNCTION minInstant({TEMP})\n"
+                   "  RETURNS {TEMP}\n"
+                   "  AS 'MODULE_PATHNAME', 'Temporal_min_instant'\n"
+                   "  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;"),
+    "maxInstant": ("CREATE FUNCTION maxInstant({TEMP})\n"
+                   "  RETURNS {TEMP}\n"
+                   "  AS 'MODULE_PATHNAME', 'Temporal_max_instant'\n"
+                   "  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;"),
+}
+# Which base types carry each gated accessor: `numeric` = tint/tbigint/tfloat
+# (a type entry sets numeric: true), `orderable` = those + ttext (orderable: true).
+_GATED_PRESENCE = {
+    "valueSet": "numeric", "avgValue": "numeric",
+    "minValue": "orderable", "maxValue": "orderable",
+    "minInstant": "orderable", "maxInstant": "orderable",
+}
+# Gated accessors inserted AFTER the named common accessor's group, in order.
+_GATED_AFTER = {
+    "getValues": ["valueSet"],
+    "valueN": ["minValue", "maxValue", "avgValue", "minInstant", "maxInstant"],
+}
+
+
+def _accessor_blocks(template_text: str):
+    """Split the shared template into ordered groups. Each group is
+    (lead_comment, fn_text, first_fn_name): the leading ``-- ...`` comment lines
+    (emitted once per group) and the CREATE FUNCTION body/bodies (one, or the
+    tempSubtype+tempBasetype pair) that repeat per base type."""
+    groups = []
+    for blk in template_text.strip("\n").split("\n\n"):
+        lines = blk.split("\n")
+        comment = "\n".join(l for l in lines if l.startswith("--"))
+        fns = "\n".join(l for l in lines if not l.startswith("--"))
+        name = next((l.split("(")[0].removeprefix("CREATE FUNCTION ").strip()
+                     for l in lines if l.startswith("CREATE FUNCTION")), "")
+        groups.append((comment, fns, name))
+    return groups
+
+
+def _sub_type(text: str, t: dict) -> str:
+    """Substitute one base type's tokens into a group/fragment body. {VSET} first
+    (it is only present in valueSet), then {BASESET}, then {BASE}, then {TEMP}.
+    {GVSYM} is the getValues C symbol: Temporal_valueset by default, but the value
+    domain of a number is a spanset, so a numeric type overrides it (Tnumber_valuespans)."""
+    return (text.replace("{VSET}", t.get("valueset", ""))
+                .replace("{GVSYM}", t.get("gvsym", "Temporal_valueset"))
+                .replace("{BASESET}", t.get("baseset", ""))
+                .replace("{BASE}", t["base"])
+                .replace("{TEMP}", t["temp"]))
+
+
+def _render_group(comment: str, fns: str, types: list) -> str:
+    """One canonical accessor group emitted for each applicable base type, the
+    lead comment printed once (house style: no blank line between the per-type
+    functions within a group)."""
+    if not types:
+        return ""
+    body = "\n".join(_sub_type(fns, t) for t in types)
+    return (comment + "\n" + body) if comment else body
 
 
 def splice_accessors(filetext: str, family: str, rendered: str) -> str:

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -266,16 +266,29 @@ spatialrel_families:
 # markers in `file`. `reference: true` = self-regen must reproduce the committed
 # region byte-for-byte.
 accessor_families:
+  # The base Temporal<T> file declares the accessor surface for EVERY base type;
+  # `types:` (per-base-type tokens) selects the multi-base-type renderer, which also
+  # emits the TNumber/orderable-only accessors (valueSet/minValue/maxValue/avgValue/
+  # minInstant/maxInstant) gated by the `numeric`/`orderable` flags. baseset = the
+  # getValues return (a spanset for numbers), valueset = the discrete valueSet return.
+  - family:    temporal
+    file:      mobilitydb/sql/temporal/022_temporal.in.sql
+    reference: true
+    types:
+      - {temp: tbool,   base: boolean, baseset: "boolean[]"}
+      - {temp: tint,    base: integer, baseset: intspanset,    valueset: intset,    gvsym: Tnumber_valuespans, numeric: true, orderable: true}
+      - {temp: tbigint, base: bigint,  baseset: bigintspanset, valueset: bigintset, gvsym: Tnumber_valuespans, numeric: true, orderable: true}
+      - {temp: tfloat,  base: float,   baseset: floatspanset,  valueset: floatset,  gvsym: Tnumber_valuespans, numeric: true, orderable: true}
+      - {temp: ttext,   base: text,    baseset: textset,       orderable: true}
+
   - family:    cbuffer
-    temp:      tcbuffer
-    base:      cbuffer
-    baseset:   cbufferset
     file:      mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
     reference: true
+    types:
+      - {temp: tcbuffer, base: cbuffer, baseset: cbufferset}
 
   - family:    npoint
-    temp:      tnpoint
-    base:      npoint
-    baseset:   npointset
     file:      mobilitydb/sql/npoint/302_tnpoint.in.sql
     reference: true
+    types:
+      - {temp: tnpoint, base: npoint, baseset: npointset}

--- a/tools/codegen/inherited/templates/accessors.sql.tmpl
+++ b/tools/codegen/inherited/templates/accessors.sql.tmpl
@@ -32,7 +32,7 @@ CREATE FUNCTION getTimestamp({TEMP})
 -- values is a reserved word in SQL
 CREATE FUNCTION getValues({TEMP})
   RETURNS {BASESET}
-  AS 'MODULE_PATHNAME', 'Temporal_valueset'
+  AS 'MODULE_PATHNAME', '{GVSYM}'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 -- time is a reserved word in SQL


### PR DESCRIPTION
This drives the inherited-accessor generator from a per-base-type `types` table, so one renderer serves every family. A spatial subtype is a single-element table (one function per accessor); the base Temporal file lists all five base types (`tbool`, `tint`, `tbigint`, `tfloat`, `ttext`). Numeric and orderable types additionally carry the gated accessors `valueSet`, `minValue`, `maxValue`, `avgValue`, `minInstant` and `maxInstant`, slotted at their canonical positions. `cbuffer` and `npoint` move to the single-element form with byte-for-byte identical generated output.

The accessor block of `022_temporal.in.sql` generates from this table in the one canonical order, placing `valueAtTimestamp` in the accessor block alongside the other value accessors. The base-specific `unnest` functions and their composite types remain hand-written outside the generated region.

`getValues` returns the value domain, whose C symbol is per base type: `Tnumber_valuespans` for the temporal numbers (returning a span set) and `Temporal_valueset` for `tbool`/`ttext`.

The function set is behaviourally identical. The only text changes are canonical spelling normalizations forced by the shared template — `valueN`'s argument becomes `int` and `valueN(tbool)` returns `boolean` — both PostgreSQL type aliases (`int`=`integer`, `bool`=`boolean`) with identical catalog signatures and no regression-output change.