### PR TITLE
Generate the tpose temporal accessors from the canonical-order template

### DIFF
--- a/mobilitydb/sql/pose/102_tpose.in.sql
+++ b/mobilitydb/sql/pose/102_tpose.in.sql
@@ -287,6 +287,9 @@ CREATE FUNCTION angularSpeed(tpose)
 /******************************************************************************/
 -- Accessors for all temporal types
 
+-- GENERATED-ACCESSORS-BEGIN pose — tools/codegen/inherited/generate.py from templates/accessors.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.yaml (accessor_families) and re-run.
+
 CREATE FUNCTION tempSubtype(tpose)
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_subtype'
@@ -444,6 +447,7 @@ CREATE FUNCTION segments(tpose)
   RETURNS tpose[]
   AS 'MODULE_PATHNAME', 'Temporal_segments'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+-- GENERATED-ACCESSORS-END pose
 
 /******************************************************************************
  * Transformation functions

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -292,3 +292,9 @@ accessor_families:
     reference: true
     types:
       - {temp: tnpoint, base: npoint, baseset: npointset}
+
+  - family:    pose
+    file:      mobilitydb/sql/pose/102_tpose.in.sql
+    reference: true
+    types:
+      - {temp: tpose, base: pose, baseset: poseset}


### PR DESCRIPTION
This widens the inherited-accessor generator to the pose family. The type-agnostic accessors of `tpose` (`tempSubtype`..`segments`) emit from the shared per-base-type table via a `GENERATED-ACCESSORS` region in `102_tpose.in.sql`. The pose-specific accessors (`points`, `rotation`, `yaw`, `pitch`, `roll`, `speed`, `angularSpeed`) stay hand-written.

The `tpose` accessor block already follows the canonical order, so the SQL is byte-identical apart from the region markers and the behaviour is unchanged: the generator's `--validate` reproduces the committed region byte-for-byte and the sorted function set matches the previous file exactly.