### PR TITLE
Classify the pgtypes base functions as public or internal

### DIFF
--- a/meos/include/temporal/doxygen_meos_internal.h
+++ b/meos/include/temporal/doxygen_meos_internal.h
@@ -68,6 +68,42 @@
  * @defgroup meos_internal_rgeo Functions for temporal rigid geometries
  * @ingroup meos_internal
  * @brief Functions for temporal rigid geometries
+ *
+ * @defgroup meos_internal_base Functions for base and time types
+ * @ingroup meos_internal
+ * @brief Functions for base and time types
+ *
+ *   @defgroup meos_internal_int Functions for the integer type
+ *   @ingroup meos_internal_base
+ *   @brief Functions for the integer type
+ *
+ *   @defgroup meos_internal_int16 Functions for the small integer type
+ *   @ingroup meos_internal_base
+ *   @brief Functions for the small integer type
+ *
+ *   @defgroup meos_internal_bigint Functions for the big integer type
+ *   @ingroup meos_internal_base
+ *   @brief Functions for the big integer type
+ *
+ *   @defgroup meos_internal_float Functions for the float type
+ *   @ingroup meos_internal_base
+ *   @brief Functions for the float type
+ *
+ *   @defgroup meos_internal_float4 Functions for the real type
+ *   @ingroup meos_internal_base
+ *   @brief Functions for the real type
+ *
+ *   @defgroup meos_internal_numeric Functions for the numeric type
+ *   @ingroup meos_internal_base
+ *   @brief Functions for the numeric type
+ *
+ *   @defgroup meos_internal_char Functions for the char type
+ *   @ingroup meos_internal_base
+ *   @brief Functions for the char type
+ *
+ *   @defgroup meos_internal_text Functions for the text type
+ *   @ingroup meos_internal_base
+ *   @brief Functions for the text type
  */
 
 /*****************************************************************************/

--- a/pgtypes/access/hashfunc.c
+++ b/pgtypes/access/hashfunc.c
@@ -43,7 +43,7 @@
  */
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_char
  * @brief Return the 32-bit hash of a character
  * @note Derived from PostgreSQL function @p hashchar()
  */
@@ -55,7 +55,7 @@ char_hash(char c)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_char
  * @brief Return the 64-bit hash of a character using a seed
  * @note Derived from PostgreSQL function @p hashchar()
  */
@@ -66,7 +66,7 @@ char_hash_extended(char c, uint64 seed)
 }
 
 /**
- * @ingroup meos_base_integer
+ * @ingroup meos_internal_int16
  * @brief Return the 32-bit hash of an int16
  * @note Derived from PostgreSQL function @p hashint2()
  */
@@ -77,7 +77,7 @@ int16_hash(int16 val)
 }
 
 /**
- * @ingroup meos_base_integer
+ * @ingroup meos_internal_int16
  * @brief Return the 64-bit hash of an int16 using a seed
  * @note Derived from PostgreSQL function @p hashint2extended()
  */
@@ -88,7 +88,7 @@ int16_hash_extended(int16 val, uint64 seed)
 }
 
 /**
- * @ingroup meos_base_integer
+ * @ingroup meos_base_int
  * @brief Return the 32-bit hash of an int32
  * @note Derived from PostgreSQL function @p hashint4()
  */
@@ -99,7 +99,7 @@ int32_hash(int32 val)
 }
 
 /**
- * @ingroup meos_base_integer
+ * @ingroup meos_base_int
  * @brief Return the 64-bit hash of an int32 using a seed
  * @note Derived from PostgreSQL function @p hashint4extended()
  */
@@ -110,7 +110,7 @@ int32_hash_extended(int32 val, uint64 seed)
 }
 
 /**
- * @ingroup meos_base_integer
+ * @ingroup meos_base_int
  * @brief Return the 32-bit hash of an int64
  * @note Derived from PostgreSQL function @p hashint8()
  */
@@ -132,7 +132,7 @@ int64_hash(int64 val)
 }
 
 /**
- * @ingroup meos_base_integer
+ * @ingroup meos_base_int
  * @brief Return the 64-bit hash of an int64 using a seed
  * @note Derived from PostgreSQL function @p hashint8extended()
  */
@@ -147,7 +147,7 @@ int64_hash_extended(int64 val, uint64 seed)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float4
  * @brief Return the 32-bit hash of a float4
  * @note Derived from PostgreSQL function @p hashfloat4()
  */
@@ -185,7 +185,7 @@ float4_hash(float4 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float4
  * @brief Return the 64-bit hash of a float4 using a seed
  * @note Derived from PostgreSQL function @p hashfloat4extended()
  */

--- a/pgtypes/utils/float.c
+++ b/pgtypes/utils/float.c
@@ -297,7 +297,7 @@ pg_float4in_internal(char *num, char **endptr_p, const char *type_name,
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float4
  * @brief Return a float4 number from its string representation
  * @note Derived from PostgreSQL function @p float4in()
  */
@@ -308,7 +308,7 @@ float4_in(const char *num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float4
  * @brief Return the string representation of a float4 number
  * @note Derived from PostgreSQL function @p float4out()
  */
@@ -604,7 +604,7 @@ float8out_internal(double num)
 }
 
 /**
- * @ingroup meos_base_types
+ * @ingroup meos_base_float
  * @brief Return the string representation of a float8 number
  * @details This function uses the PostGIS function lwprint_double to print an
  * ordinate value using at most **maxdd** number of decimal digits. The actual 
@@ -631,7 +631,7 @@ float8_out(double num, int maxdd)
  */
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float4
  * @brief Return the absolute value of a float4 number
  * @note Derived from PostgreSQL function @p float8abs()
  */
@@ -642,7 +642,7 @@ float4_abs(float4 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float4
  * @brief Return the unary minus of a float4 number
  * @note Derived from PostgreSQL function @p float8um()
  */
@@ -653,7 +653,7 @@ float4_um(float4 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float4
  * @brief Return the unary plus of a float4 number
  * @note Derived from PostgreSQL function @p float8up()
  */
@@ -664,7 +664,7 @@ float4_up(float4 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float4
  * @brief Return the larger of two float4 numbers
  * @note Derived from PostgreSQL function @p float8larger()
  */
@@ -680,7 +680,7 @@ float4_larger(float4 num1, float4 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float4
  * @brief Return the smaller of two float4 numbers
  * @note Derived from PostgreSQL function @p float8smaller()
  */
@@ -713,7 +713,7 @@ float8_abs(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the unary minus of a float8 number
  * @note Derived from PostgreSQL function @p float8um()
  */
@@ -724,7 +724,7 @@ float8_um(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the unary plus a float8 number
  * @note Derived from PostgreSQL function @p float8up()
  */
@@ -735,7 +735,7 @@ float8_up(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the larger of two float8 numbers
  * @note Derived from PostgreSQL function @p float8larger()
  */
@@ -751,7 +751,7 @@ float8_larger(float8 num1, float8 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the smaller of two float8 numbers
  * @note Derived from PostgreSQL function @p float8smaller()
  */
@@ -780,7 +780,7 @@ float8_smaller(float8 num1, float8 num2)
  */
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float4
  * @brief Return the addition of two float4 numbers
  * @note Derived from PostgreSQL function @p float4pl()
  */
@@ -791,7 +791,7 @@ add_float4_float4(float4 num1, float4 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float4
  * @brief Return the subtraction of two float4 numbers
  * @note Derived from PostgreSQL function @p float4mi()
  */
@@ -802,7 +802,7 @@ minus_float4_float4(float4 num1, float4 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float4
  * @brief Return the multiplication of two float4 numbers
  * @note Derived from PostgreSQL function @p float4mul()
  */
@@ -813,7 +813,7 @@ mul_float4_float4(float4 num1, float4 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float4
  * @brief Return the division of two float4 numbers
  * @note Derived from PostgreSQL function @p float4div()
  */
@@ -885,7 +885,7 @@ div_float8_float8(float8 num1, float8 num2)
  */
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float4
  * @brief Return -1, 0, or 1 depending on whether the first float4 number is
  * less than, equal, or greater than the second one
  * @note Derived from PostgreSQL function @p float4_cmp_internal
@@ -908,7 +908,7 @@ pg_float4_cmp(float4 num1, float4 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float4
  * @brief Return true if a float4 number is equal to another one
  * @note Derived from PostgreSQL function @p float4eq()
  */
@@ -919,7 +919,7 @@ eq_float4_float4(float4 num1, float4 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float4
  * @brief Return true if a float4 number is not equal to another one
  * @note Derived from PostgreSQL function @p float4ne()
  */
@@ -930,7 +930,7 @@ ne_float4_float4(float4 num1, float4 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float4
  * @brief Return true if a float4 number is less than another one
  * @note Derived from PostgreSQL function @p float4lt()
  */
@@ -941,7 +941,7 @@ lt_float4_float4(float4 num1, float4 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float4
  * @brief Return true if a float4 number is less than or equal to another one
  * @note Derived from PostgreSQL function @p float4le()
  */
@@ -952,7 +952,7 @@ le_float4_float4(float4 num1, float4 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float4
  * @brief Return true if a float4 number is greater than another one
  * @note Derived from PostgreSQL function @p float4gt()
  */
@@ -963,7 +963,7 @@ gt_float4_float4(float4 num1, float4 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float4
  * @brief Return true if a float4 number is greater than or equal to another one
  * @note Derived from PostgreSQL function @p float4ge()
  */
@@ -1073,7 +1073,7 @@ ge_float8_float8(float8 num1, float8 num2)
  */
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Convert a float4 number into a float8 number
  * @note Derived from PostgreSQL function @p ftod()
  */
@@ -1084,7 +1084,7 @@ float4_to_float8(float4 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Convert a float8 number into a float4 number
  * @note Derived from PostgreSQL function @p dtof()
  */
@@ -1108,7 +1108,7 @@ float8_to_float4(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_int
  * @brief Convert a float8 number into an int32 number
  * @note Derived from PostgreSQL function @p dtoi4()
  */
@@ -1134,7 +1134,7 @@ float8_to_int32(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_int16
  * @brief Convert a float8 number into an int16 number
  * @note Derived from PostgreSQL function @p dtoi2()
  */
@@ -1160,7 +1160,7 @@ float8_to_int16(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_int
  * @brief Convert an int32 number into a float8 number
  * @note Derived from PostgreSQL function @p i4tod()
  */
@@ -1171,7 +1171,7 @@ int32_to_float8(int32 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_int16
  * @brief Convert an int16 number into a float8 number
  * @note Derived from PostgreSQL function @p i2tod()
  */
@@ -1182,7 +1182,7 @@ int16_to_float8(int16 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_int
  * @brief Convert a float4 number into an int32 number
  * @note Derived from PostgreSQL function @p ftoi4()
  */
@@ -1208,7 +1208,7 @@ float4_to_int32(float4 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_int16
  * @brief Convert a float4 number into an int16 number
  * @note Derived from PostgreSQL function @p ftoi2()
  */
@@ -1234,7 +1234,7 @@ float4_to_int16(float4 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_int
  * @brief Convert an int32 number into a float4 number
  * @note Derived from PostgreSQL function @p i4tof()
  */
@@ -1245,7 +1245,7 @@ int32_to_float4(int32 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_int16
  * @brief Convert an int16 number into a float4 number
  * @note Derived from PostgreSQL function @p i2tof()
  */
@@ -1263,7 +1263,7 @@ int16_to_float4(int16 num)
  */
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Round a float8 number to the nearest integer
  * @note PostgreSQL function: @p dround()
  */
@@ -1274,7 +1274,7 @@ float8_rint(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return a float number rounded to a given number of decimal places
  * @note MEOS function
  */
@@ -1320,7 +1320,7 @@ float8_floor(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return -1 if a float8 number is less than 0, 0 if it is equal to 0,
  * and 1 if it is greater than zero
  * @note PostgreSQL function: @p dsign()
@@ -1339,7 +1339,7 @@ float8_sign(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the truncation-towards-zero of a float8 number
  * @details If num1 >= 0 return the greatest integer less than or equal to num1,
  * if num1 < 0  return the least integer greater than or equal to num1
@@ -1357,7 +1357,7 @@ float8_trunc(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the square root of a float8 number
  * @note PostgreSQL function: @p dsqrt()
  */
@@ -1388,7 +1388,7 @@ float8_sqrt(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the cube root of a float8 number
  * @note PostgreSQL function: @p dcbrt()
  */
@@ -1412,7 +1412,7 @@ float8_cbrt(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the first float8 number powered to the second one
  * @note PostgreSQL function: @p dpow()
  */
@@ -1735,7 +1735,7 @@ float8_log10(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the arccos of a float8 number (radians)
  * @note PostgreSQL function: @p dacos()
  */
@@ -1768,7 +1768,7 @@ float8_acos(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the arcsin of a float8 number (radians)
  * @note PostgreSQL function: @p dasin()
  */
@@ -1803,7 +1803,7 @@ float8_asin(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the arctan of a double (radians)
  * @note PostgreSQL function: @p datan()
  */
@@ -1831,7 +1831,7 @@ float8_atan(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the arctan of two float8 numbers (radians)
  * @note PostgreSQL function: @p datan2d()
  */
@@ -1904,7 +1904,7 @@ float8_cos(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the cotangent of a float8 number (radians)
  * @return On error return @p DBL_MAX
  * @note PostgreSQL function: @p dcot()
@@ -2098,7 +2098,7 @@ acosd_q1(double x)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the arccos of a float8 number (degrees)
  * @note Derived from PostgreSQL function @p dacosd()
  */
@@ -2139,7 +2139,7 @@ float8_acosd(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the arcsin of a float8 number (degrees)
  * @note Derived from PostgreSQL function @p dasind()
  */
@@ -2180,7 +2180,7 @@ float8_asind(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the arctan of a float8 number (degrees)
  * @note Derived from PostgreSQL function @p datand()
  */
@@ -2211,7 +2211,7 @@ float8_atand(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the arctan of two float8 numbers (degrees)
  * @note Derived from PostgreSQL function @p atan2d()
  */
@@ -2307,7 +2307,7 @@ cosd_q1(double x)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the cosine of a float8 number (degrees)
  * @note Derived from PostgreSQL function @p dcosd()
  */
@@ -2364,7 +2364,7 @@ float8_cosd(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the cotangent of a float8 number (degrees)
  * @note Derived from PostgreSQL function @p dcotd()
  */
@@ -2427,7 +2427,7 @@ float8_cotd(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the sine of a float8 number (degrees)
  * @note Derived from PostgreSQL function @p dsind()
  */
@@ -2483,7 +2483,7 @@ float8_sind(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the tangent of a float8 number (degrees)
  * @note Derived from PostgreSQL function @p dtand()
  */
@@ -2552,7 +2552,7 @@ float8_degrees(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the constant PI
  * @note Derived from PostgreSQL function @p dpi()
  */
@@ -2576,7 +2576,7 @@ float8_radians(float8 num)
 /* ========== HYPERBOLIC FUNCTIONS ========== */
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the hyperbolic sine of a float8 number
  * @note Derived from PostgreSQL function @p dsinh()
  */
@@ -2601,7 +2601,7 @@ float8_sinh(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the hyperbolic cosine of a float8 number
  * @note Derived from PostgreSQL function @p dcosh()
  */
@@ -2626,7 +2626,7 @@ float8_cosh(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the hyperbolic tangent of a float8 number
  * @note Derived from PostgreSQL function @p dtanh()
  */
@@ -2647,7 +2647,7 @@ float8_tanh(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the inverse hyperbolic sine of a float8 number
  * @note Derived from PostgreSQL function @p dasinh()
  */
@@ -2662,7 +2662,7 @@ float8_asinh(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the inverse hyperbolic cosine of a float8 number
  * @note Derived from PostgreSQL function @p dacosh()
  */
@@ -2686,7 +2686,7 @@ float8_acosh(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the inverse hyperbolic tangent of a float8 number
  * @note Derived from PostgreSQL function @p datanh()
  */
@@ -2723,7 +2723,7 @@ float8_atanh(float8 num)
 /* ========== GAMMA FUNCTIONS ========== */
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the gamma function of a float8 number
  * @note Derived from PostgreSQL function @p dgamma()
  */
@@ -2787,7 +2787,7 @@ float8_gamma(float8 num)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the natural logarithm of absolute value of gamma of a float8
  * number
  * @note Derived from PostgreSQL function @p dlgamma()
@@ -2832,7 +2832,7 @@ float8_lgamma(float8 num)
  */
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the addition of a float4 number and a float8 number
  * @note Derived from PostgreSQL function @p float48pl()
  */
@@ -2843,7 +2843,7 @@ add_float4_float8(float4 num1, float8 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the subtraction of a float4 number and a float8 number
  * @note Derived from PostgreSQL function @p float48mi()
  */
@@ -2854,7 +2854,7 @@ minus_float4_float8(float4 num1, float8 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the multiplication of a float4 number and a float8 number
  * @note Derived from PostgreSQL function @p float48mul()
  */
@@ -2865,7 +2865,7 @@ mul_float4_float8(float4 num1, float8 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the division of a float4 number and a float8 number
  * @note Derived from PostgreSQL function @p float48div()
  */
@@ -2883,7 +2883,7 @@ div_float4_float8(float4 num1, float8 num2)
  */
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the addition of a float8 number and a float4 number
  * @note Derived from PostgreSQL function @p float84pl()
  */
@@ -2894,7 +2894,7 @@ add_float8_float4(float8 num1, float4 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the subtraction of a float8 number and a float4 number
  * @note Derived from PostgreSQL function @p float84mi()
  */
@@ -2905,7 +2905,7 @@ minus_float8_float4(float8 num1, float4 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the multiplication of a float8 number and a float4 number
  * @note Derived from PostgreSQL function @p float84mul()
  */
@@ -2916,7 +2916,7 @@ mul_float8_float4(float8 num1, float4 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the division of a float8 number and a float4 number
  * @note Derived from PostgreSQL function @p float84div()
  */
@@ -2937,7 +2937,7 @@ div_float8_float4(float8 num1, float4 num2)
  */
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return true if a float4 number is equal to a float8 number
  * @note Derived from PostgreSQL function @p float48eq()
  */
@@ -2948,7 +2948,7 @@ eq_float4_float8(float4 num1, float8 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return true if a float4 number is not equal to a float8 number
  * @note Derived from PostgreSQL function @p float48ne()
  */
@@ -2959,7 +2959,7 @@ ne_float4_float8(float4 num1, float8 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return true if a float4 number is less than a float8 number
  * @note Derived from PostgreSQL function @p float48lt()
  */
@@ -2970,7 +2970,7 @@ lt_float4_float8(float4 num1, float8 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return true if a float4 number is less than or equal to a float8
  * number
  * @note Derived from PostgreSQL function @p float48le()
@@ -2982,7 +2982,7 @@ le_float4_float8(float4 num1, float8 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return true if a float4 number is greater than a float8 number
  * @note Derived from PostgreSQL function @p float48gt()
  */
@@ -2993,7 +2993,7 @@ gt_float4_float8(float4 num1, float8 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return true if a float4 number is greater than or equal to a float8
  * number
  * @note Derived from PostgreSQL function @p float48ge()
@@ -3009,7 +3009,7 @@ ge_float4_float8(float4 num1, float8 num2)
  */
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return true if a float8 number is equal to a float4 number
  * @note Derived from PostgreSQL function @p float84eq()
  */
@@ -3020,7 +3020,7 @@ eq_float8_float4(float8 num1, float4 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return true if a float8 number is not equal to a float4 number
  * @note Derived from PostgreSQL function @p float84ne()
  */
@@ -3031,7 +3031,7 @@ ne_float8_float4(float8 num1, float4 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return true if a float8 number is less than a float4 number
  * @note Derived from PostgreSQL function @p float84lt()
  */
@@ -3042,7 +3042,7 @@ lt_float8_float4(float8 num1, float4 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return true if a float8 number is less than or equal to a float4
  * number
  * @note Derived from PostgreSQL function @p float84le()
@@ -3054,7 +3054,7 @@ le_float8_float4(float8 num1, float4 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return true if a float8 number is greater than a float4 number
  * @note Derived from PostgreSQL function @p float84gt()
  */
@@ -3065,7 +3065,7 @@ gt_float8_float4(float8 num1, float4 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return true if a float8 number is greater than or equal to a float4
  * number
  * @note Derived from PostgreSQL function @p float84ge()
@@ -3077,7 +3077,7 @@ ge_float8_float4(float8 num1, float4 num2)
 }
 
 /**
- * @ingroup meos_base_float
+ * @ingroup meos_internal_float
  * @brief Return the number of the bucket in which a float8 value falls in a
  * histogram having count equal-width buckets spanning the range low to high
  * @details Implements the float8 version of the width_bucket() function

--- a/pgtypes/utils/formatting.c
+++ b/pgtypes/utils/formatting.c
@@ -6029,7 +6029,7 @@ do { \
 } while (0)
 
 /**
- * @ingroup meos_base_date
+ * @ingroup meos_internal_numeric
  * @brief Convert a text representing a numeric to a numeric
  * @note Derived from PostgreSQL function @p numeric_to_number()
  */
@@ -6068,7 +6068,7 @@ pg_numeric_to_number(text *txt, text *fmt)
 }
 
 /**
- * @ingroup meos_base_date
+ * @ingroup meos_internal_numeric
  * @brief Return a date from the arguments
  * @note Derived from PostgreSQL function @p numeric_to_char()
  */
@@ -6181,7 +6181,7 @@ numeric_to_char(Numeric value, text *fmt)
 }
 
 /**
- * @ingroup meos_base_date
+ * @ingroup meos_internal_int
  * @brief Return a date from the arguments
  * @note Derived from PostgreSQL function @p int4_to_char()
  */
@@ -6267,7 +6267,7 @@ int4_to_char(int32 value, text *fmt)
 }
 
 /**
- * @ingroup meos_base_date
+ * @ingroup meos_internal_bigint
  * @brief Return a date from the arguments
  * @note Derived from PostgreSQL function @p int8_to_char()
  */
@@ -6371,7 +6371,7 @@ int8_to_char(int64 value, text *fmt)
 }
 
 /**
- * @ingroup meos_base_date
+ * @ingroup meos_internal_float4
  * @brief Return a date from the arguments
  * @note Derived from PostgreSQL function @p float4_to_char()
  */
@@ -6483,7 +6483,7 @@ float4_to_char(float4 value, text *fmt)
 }
 
 /**
- * @ingroup meos_base_date
+ * @ingroup meos_internal_float
  * @brief Return a date from the arguments
  * @note Derived from PostgreSQL function @p float8_to_char()
  */

--- a/pgtypes/utils/int.c
+++ b/pgtypes/utils/int.c
@@ -40,7 +40,7 @@
  *****************************************************************************/
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return an int16 number from its string representation
  * @note Derived from PostgreSQL function @p int2in()
  */
@@ -51,7 +51,7 @@ int16_in(const char *str)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the string representation of an int16 number
  * @note Derived from PostgreSQL function @p int2out()
  */
@@ -99,7 +99,7 @@ int32_out(int32 num)
  */
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Convert an int16 number into an int32 number
  * @note Derived from PostgreSQL function @p i2toi4()
  */
@@ -110,7 +110,7 @@ int16_to_int32(int16 num)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Convert an int32 number into an int16 number
  * @note Derived from PostgreSQL function @p i4toi2()
  */
@@ -127,7 +127,7 @@ int32_to_int16(int32 num)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int
  * @brief Convert an int32 number into a boolean value
  * @note Derived from PostgreSQL function @p int4bool()
  */
@@ -141,7 +141,7 @@ int32_to_bool(int32 num)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int
  * @brief Convert a boolean value into an int32 number
  * @note Derived from PostgreSQL function @p boolint4()
  */
@@ -238,7 +238,7 @@ ge_int32_int32(int32 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if two int16 numbers are equal
  * @note Derived from PostgreSQL function @p int2eq()
  */
@@ -249,7 +249,7 @@ eq_int16_int16(int16 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if two int16 numbers are not equal
  * @note Derived from PostgreSQL function @p int2ne()
  */
@@ -260,7 +260,7 @@ ne_int16_int16(int16 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if the first int16 number is less than the second one
  * @note Derived from PostgreSQL function @p int2lt()
  */
@@ -271,7 +271,7 @@ lt_int16_int16(int16 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if the first int16 number is less than or equal to the
  * second one
  * @note Derived from PostgreSQL function @p int2le()
@@ -283,7 +283,7 @@ le_int16_int16(int16 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if the first int16 number is greater than the second one
  * @note Derived from PostgreSQL function @p int2gt()
  */
@@ -294,7 +294,7 @@ gt_int16_int16(int16 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if the first int16 number is greater than or equal to the
  * second one
  * @note Derived from PostgreSQL function @p int2ge()
@@ -306,7 +306,7 @@ ge_int16_int16(int16 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if an int16 number and an int32 number are equal
  * @note Derived from PostgreSQL function @p int24eq()
  */
@@ -317,7 +317,7 @@ eq_int16_int32(int16 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if an int16 number and an int32 number are not equal
  * @note Derived from PostgreSQL function @p int24ne()
  */
@@ -328,7 +328,7 @@ ne_int16_int32(int16 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if an int16 number is less than an int32 number
  * @note Derived from PostgreSQL function @p int24lt()
  */
@@ -339,7 +339,7 @@ lt_int16_int32(int16 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if an int16 number is less than or equal to an int32
  * number
  * @note Derived from PostgreSQL function @p int24le()
@@ -351,7 +351,7 @@ le_int16_int32(int16 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if an int16 number is greater than an int32 number
  * @note Derived from PostgreSQL function @p int24gt()
  */
@@ -362,7 +362,7 @@ gt_int16_int32(int16 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if an int16 number is greater than or equal to an int32
  * number
  * @note Derived from PostgreSQL function @p int24ge()
@@ -374,7 +374,7 @@ ge_int16_int32(int16 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if an int32 number and an int16 number are equal
  * @note Derived from PostgreSQL function @p int42eq()
  */
@@ -385,7 +385,7 @@ eq_int32_int16(int32 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if an int32 number and an int16 number are not equal
  * @note Derived from PostgreSQL function @p int42ne()
  */
@@ -396,7 +396,7 @@ ne_int32_int16(int32 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if an int32 number is less than an int16 number
  * @note Derived from PostgreSQL function @p int42lt()
  */
@@ -407,7 +407,7 @@ lt_int32_int16(int32 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if an int32 number is less than or equal to an int16
  * number
  * @note Derived from PostgreSQL function @p int42le()
@@ -419,7 +419,7 @@ le_int32_int16(int32 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if an int32 number is greater than an int16 number
  * @note Derived from PostgreSQL function @p int42gt()
  */
@@ -430,7 +430,7 @@ gt_int32_int16(int32 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if an int32 number is less than or equal to an int16
  * number
  * @note Derived from PostgreSQL function @p int42ge()
@@ -452,7 +452,7 @@ ge_int32_int16(int32 num1, int16 num2)
  */
  
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int
  * @brief Return the unary minus of an int32 number
  * @note Derived from PostgreSQL function @p int4um()
  */
@@ -469,7 +469,7 @@ int32_uminus(int32 num)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int
  * @brief Return the unary plus of an int32 number
  * @note Derived from PostgreSQL function @p int4up()
  */
@@ -579,7 +579,7 @@ div_int32_int32(int32 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int
  * @brief Return an int32 number incremented by one
  * @note Derived from PostgreSQL function @p int4inc()
  */
@@ -598,7 +598,7 @@ int32_inc(int32 num)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the unary minus of an int16 number
  * @note Derived from PostgreSQL function @p int2um()
  */
@@ -615,7 +615,7 @@ int16_uminus(int16 num)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the unary plus of an int16 number
  * @note Derived from PostgreSQL function @p int2up()
  */
@@ -626,7 +626,7 @@ int16_uplus(int16 num)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the addition of two int16 numbers
  * @note Derived from PostgreSQL function @p int2pl()
  */
@@ -645,7 +645,7 @@ add_int16_int16(int16 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the subtraction of two int16 numbers
  * @note Derived from PostgreSQL function @p int2mi()
  */
@@ -664,7 +664,7 @@ minus_int16_int16(int16 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the multiplication of two int16 numbers
  * @note Derived from PostgreSQL function @p int2mul()
  */
@@ -684,7 +684,7 @@ mul_int16_int16(int16 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the division of two int16 numbers
  * @note Derived from PostgreSQL function @p int2div()
  */
@@ -726,7 +726,7 @@ div_int16_int16(int16 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the addition of an int16 and an int32 numbers
  * @note Derived from PostgreSQL function @p int24pl()
  */
@@ -745,7 +745,7 @@ add_int16_int32(int16 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the subtraction of an int16 and an int32 numbers
  * @note Derived from PostgreSQL function @p int24mi()
  */
@@ -764,7 +764,7 @@ minus_int16_int32(int16 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the multiplication of an int16 and an int32 numbers
  * @note Derived from PostgreSQL function @p int24mul()
  */
@@ -783,7 +783,7 @@ mul_int16_int32(int16 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the division of an int16 and an int32 numbers
  * @note Derived from PostgreSQL function @p int24div()
  */
@@ -802,7 +802,7 @@ div_int16_int32(int16 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the addition of an int32 and an int16 numbers
  * @note Derived from PostgreSQL function @p int42pl()
  */
@@ -821,7 +821,7 @@ add_int32_int16(int32 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the subtraction of an int32 and an int16 numbers
  * @note Derived from PostgreSQL function @p int42mi()
  */
@@ -840,7 +840,7 @@ minus_int32_int16(int32 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the multiplication of an int32 and an int16 numbers
  * @note Derived from PostgreSQL function @p int42mul()
  */
@@ -859,7 +859,7 @@ mul_int32_int16(int32 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the division of an int32 and an int16 numbers
  * @note Derived from PostgreSQL function @p int42div()
  */
@@ -901,7 +901,7 @@ div_int32_int16(int32 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int
  * @brief Return the modulo of two int32 numbers
  * @note Derived from PostgreSQL function @p int4mod()
  */
@@ -929,7 +929,7 @@ int32_mod(int32 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the modulo of two int16 numbers
  * @note Derived from PostgreSQL function @p int2mod()
  */
@@ -978,7 +978,7 @@ int32_abs(int32 num)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the absolute value of an int16 number
  * @note Derived from PostgreSQL function @p int2abs()
  */
@@ -1075,7 +1075,7 @@ int4gcd_internal(int32 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int
  * @brief Return the greatest common denominator of two int32 numbers
  * @note Derived from PostgreSQL function @p int4gcd()
  */
@@ -1087,7 +1087,7 @@ int32_gcd(int32 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int
  * @brief Return the least common multiple of two int32 numbers
  * @note Derived from PostgreSQL function @p int4lcm()
  */
@@ -1131,7 +1131,7 @@ int32_lcm(int32 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the larger of two int16 numbers
  * @note Derived from PostgreSQL function @p int2larger()
  */
@@ -1142,7 +1142,7 @@ int16_larger(int16 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the smaller of two int16 numbers
  * @note Derived from PostgreSQL function @p int2smaller()
  */
@@ -1153,7 +1153,7 @@ int16_smaller(int16 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int
  * @brief Return the larger of two int32 numbers
  * @note Derived from PostgreSQL function @p int4larger()
  */
@@ -1164,7 +1164,7 @@ int32_larger(int32 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int
  * @brief Return the smaller of two int32 numbers
  * @note Derived from PostgreSQL function @p int4smaller()
  */
@@ -1186,7 +1186,7 @@ int32_smaller(int32 num1, int32 num2)
  */
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int
  * @brief Return the binary and of two int32 numbers
  * @note Derived from PostgreSQL function @p int4and()
  */
@@ -1197,7 +1197,7 @@ int32_and(int32 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int
  * @brief Return the binary or of two int32 numbers
  * @note Derived from PostgreSQL function @p int4or()
  */
@@ -1208,7 +1208,7 @@ int32_or(int32 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int
  * @brief Return the binary xor of two int32 numbers
  * @note Derived from PostgreSQL function @p int4xor()
  */
@@ -1219,7 +1219,7 @@ int32_xor(int32 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int
  * @brief Return the first int32 number shifted to the left by the second one
  * @note Derived from PostgreSQL function @p int4shl()
  */
@@ -1230,7 +1230,7 @@ int32_shl(int32 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int
  * @brief Return the first int32 number shifted to the right by the second one
  * @note Derived from PostgreSQL function @p int4shr()
  */
@@ -1241,7 +1241,7 @@ int32_shr(int32 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int
  * @brief Return the binary not of a int32 number
  * @note Derived from PostgreSQL function @p int4not()
  */
@@ -1252,7 +1252,7 @@ int32_not(int32 num)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the binary and of two int16 numbers
  * @note Derived from PostgreSQL function @p int2and()
  */
@@ -1263,7 +1263,7 @@ int16_and(int16 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the binary or of two int16 numbers
  * @note Derived from PostgreSQL function @p int2or()
  */
@@ -1274,7 +1274,7 @@ int16_or(int16 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the binary xor of two int16 numbers
  * @note Derived from PostgreSQL function @p int2xor()
  */
@@ -1285,7 +1285,7 @@ int16_xor(int16 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the binary not of an int16 number
  * @note Derived from PostgreSQL function @p int2not()
  */
@@ -1296,7 +1296,7 @@ int16_not(int16 num)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the first int16 number shifted to the left by the second one
  * @note Derived from PostgreSQL function @p int2shl()
  */
@@ -1307,7 +1307,7 @@ int16_shl(int16 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the first int16 number shifted to the right by the second one
  * @note Derived from PostgreSQL function @p int2shr()
  */

--- a/pgtypes/utils/int8.c
+++ b/pgtypes/utils/int8.c
@@ -278,7 +278,7 @@ ge_int32_int64(int32 num1, int64 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if an int64 number is equal to an int16 number
  * @note Derived from PostgreSQL function @p int82eq()
  */
@@ -289,7 +289,7 @@ eq_int64_int16(int64 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if an int64 number is not equal to an int16 number
  * @note Derived from PostgreSQL function @p int82ne()
  */
@@ -300,7 +300,7 @@ ne_int64_int16(int64 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if an int64 number is less than an int16 number
  * @note Derived from PostgreSQL function @p int82lt()
  */
@@ -311,7 +311,7 @@ lt_int64_int16(int64 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if an int64 number is greater than an int16 number
  * @note Derived from PostgreSQL function @p int82gt()
  */
@@ -322,7 +322,7 @@ gt_int64_int16(int64 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if an int64 number is less than or equal to an int16
  * number
  * @note Derived from PostgreSQL function @p int82le()
@@ -334,7 +334,7 @@ le_int64_int16(int64 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if an int64 number is greater than or equal to an int16
  * number
  * @note Derived from PostgreSQL function @p int82ge()
@@ -346,7 +346,7 @@ ge_int64_int16(int64 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if an int16 number is equal to an int64 number
  * @note Derived from PostgreSQL function @p int28eq()
  */
@@ -357,7 +357,7 @@ eq_int16_int64(int16 num1, int64 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if an int16 number is not equal to an int64 number
  * @note Derived from PostgreSQL function @p int28ne()
  */
@@ -368,7 +368,7 @@ ne_int16_int64(int16 num1, int64 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if an int16 number is less than an int64 number
  * @note Derived from PostgreSQL function @p int28lt()
  */
@@ -379,7 +379,7 @@ lt_int16_int64(int16 num1, int64 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if an int16 number is greater than an int64 number
  * @note Derived from PostgreSQL function @p int28gt()
  */
@@ -390,7 +390,7 @@ gt_int16_int64(int16 num1, int64 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if an int16 number is less than or equal to an int64
  * number
  * @note Derived from PostgreSQL function @p int28le()
@@ -402,7 +402,7 @@ le_int16_int64(int16 num1, int64 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return true if an int16 number is greater than or equal to an int64
  * number
  * @note Derived from PostgreSQL function @p int28ge()
@@ -418,7 +418,7 @@ ge_int16_int64(int16 num1, int64 num2)
  *---------------------------------------------------------*/
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_bigint
  * @brief Return the unary minus of an int64 number
  * @note Derived from PostgreSQL function @p int8um()
  */
@@ -437,7 +437,7 @@ int64_uminus(int64 num)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_bigint
  * @brief Return the unary plus of an int64 number
  * @note Derived from PostgreSQL function @p int8up()
  */
@@ -558,7 +558,7 @@ int64_abs(int64 num)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_bigint
  * @brief Return the modulo of two int64 numbers
  * @note Derived from PostgreSQL function @p int8mod()
  */
@@ -664,7 +664,7 @@ int8gcd_internal(int64 num1, int64 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_bigint
  * @brief Return the greatest common denominator of an int64 number
  * @note Derived from PostgreSQL function @p int8gcd()
  */
@@ -675,7 +675,7 @@ int64_gcd(int64 num1, int64 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_bigint
  * @brief Return the least common multiple of an int64 number
  * @note Derived from PostgreSQL function @p int8lcm()
  */
@@ -719,7 +719,7 @@ int64_lcm(int64 num1, int64 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_bigint
  * @brief Return an int64 number incremented by one
  * @note Derived from PostgreSQL function @p int8inc()
  */
@@ -737,7 +737,7 @@ int64_inc(int64 num)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_bigint
  * @brief Return an int64 number decremented by one
  * @note Derived from PostgreSQL function @p int8dec()
  */
@@ -755,7 +755,7 @@ int64_dec(int64 num)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_bigint
  * @brief Return the larger of two int64 numbers
  * @note Derived from PostgreSQL function @p int8larger()
  */
@@ -766,7 +766,7 @@ int64_larger(int64 num1, int64 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_bigint
  * @brief Return the smaller of two int64 numbers
  * @note Derived from PostgreSQL function @p int8smaller()
  */
@@ -777,7 +777,7 @@ int64_smaller(int64 num1, int64 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int
  * @brief Return the addition of an int64 number and an int32 number
  * @note Derived from PostgreSQL function @p int84pl()
  */
@@ -795,7 +795,7 @@ add_int64_int32(int64 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int
  * @brief Return the subtraction of an int64 number and an int32 number
  * @note Derived from PostgreSQL function @p int84mi()
  */
@@ -813,7 +813,7 @@ minus_int64_int32(int64 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int
  * @brief Return the multiplication of an int64 number and an int32 number
  * @note Derived from PostgreSQL function @p int84mul()
  */
@@ -831,7 +831,7 @@ mul_int64_int32(int64 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int
  * @brief Return the division of an int64 number and an int32 number
  * @note Derived from PostgreSQL function @p int84div()
  */
@@ -869,7 +869,7 @@ div_int64_int32(int64 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int
  * @brief Return the addition of an int32 number and an int64 number
  * @note Derived from PostgreSQL function @p int48pl()
  */
@@ -887,7 +887,7 @@ add_int32_int64(int32 num1, int64 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int
  * @brief Return the subtraction of an int32 number and an int64 number
  * @note Derived from PostgreSQL function @p int48mi()
  */
@@ -905,7 +905,7 @@ minus_int32_int64(int32 num1, int64 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int
  * @brief Return the multiplication of an int32 number and an int64 number
  * @note Derived from PostgreSQL function @p int48mul()
  */
@@ -923,7 +923,7 @@ mul_int32_int64(int32 num1, int64 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int
  * @brief Return the division of an int32 number and an int64 number
  * @note Derived from PostgreSQL function @p int48div()
  */
@@ -942,7 +942,7 @@ div_int32_int64(int32 num1, int64 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the addition of an int64 number and an int16 number
  * @note Derived from PostgreSQL function @p int82pl()
  */
@@ -960,7 +960,7 @@ add_int64_int16(int64 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the subtraction of an int64 number and an int16 number
  * @note Derived from PostgreSQL function @p int82mi()
  */
@@ -978,7 +978,7 @@ minus_int64_int16(int64 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the multiplication of an int64 number and an int16 number
  * @note Derived from PostgreSQL function @p int82mul()
  */
@@ -996,7 +996,7 @@ mul_int64_int16(int64 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the division of an int64 number and an int16 number
  * @note Derived from PostgreSQL function @p int82div()
  */
@@ -1033,7 +1033,7 @@ div_int64_int16(int64 num1, int16 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the addition of an int16 number and an int64 number
  * @note Derived from PostgreSQL function @p int28pl()
  */
@@ -1051,7 +1051,7 @@ add_int16_int64(int16 num1, int64 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the subraction of an int16 number and an int64 number
  * @note Derived from PostgreSQL function @p int28mi()
  */
@@ -1069,7 +1069,7 @@ minus_int16_int64(int16 num1, int64 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the multiplication of an int16 number and an int64 number
  * @note Derived from PostgreSQL function @p int28mul()
  */
@@ -1087,7 +1087,7 @@ mul_int16_int64(int16 num1, int64 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Return the division of an int16 number and an int64 number
  * @note Derived from PostgreSQL function @p int28div()
  */
@@ -1115,7 +1115,7 @@ div_int16_int64(int16 num1, int64 num2)
  */
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_bigint
  * @brief Return the binary and of two int64 numbers
  * @note Derived from PostgreSQL function @p int8and()
  */
@@ -1126,7 +1126,7 @@ int64_and(int64 num1, int64 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_bigint
  * @brief Return the binary or of two int64 numbers
  * @note Derived from PostgreSQL function @p int8or()
  */
@@ -1137,7 +1137,7 @@ int64_or(int64 num1, int64 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_bigint
  * @brief Return the binary xor of two int64 numbers
  * @note Derived from PostgreSQL function @p int8xor()
  */
@@ -1148,7 +1148,7 @@ int64_xor(int64 num1, int64 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_bigint
  * @brief Return the binary not of an int64 number
  * @note Derived from PostgreSQL function @p int8not()
  */
@@ -1159,7 +1159,7 @@ int64_not(int64 num)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_bigint
  * @brief Return an int64 number shifted to the left by another one
  * @note Derived from PostgreSQL function @p int8shl()
  */
@@ -1170,7 +1170,7 @@ int64_shl(int64 num1, int32 num2)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_bigint
  * @brief Return an int64 number shifted to the right by another one
  * @note Derived from PostgreSQL function @p int8shr()
  */
@@ -1185,7 +1185,7 @@ int64_shr(int64 num1, int32 num2)
  *---------------------------------------------------------*/
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int
  * @brief Convert an int32 number into an int64 number
  * @note Derived from PostgreSQL function @p int48()
  */
@@ -1196,7 +1196,7 @@ int32_to_int64(int32 num)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int
  * @brief Convert an int64 number into an int32 number
  * @note Derived from PostgreSQL function @p int84()
  */
@@ -1213,7 +1213,7 @@ int64_to_int32(int64 num)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Convert a int16 number into an int64 number
  * @note Derived from PostgreSQL function @p int28()
  */
@@ -1224,7 +1224,7 @@ int16_to_int64(int16 num)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_int16
  * @brief Convert an int64 number into an int16 number
  * @note Derived from PostgreSQL function @p int82()
  */
@@ -1241,7 +1241,7 @@ int64_to_int16(int64 num)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_bigint
  * @brief Convert an int64 number into a float4 number
  * @note Derived from PostgreSQL function @p i8tod()
  */
@@ -1253,7 +1253,7 @@ int64_to_float8(int64 num)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_bigint
  * @brief Convert a float8 number into an int64 number
  * @note Derived from PostgreSQL function @p dtoi8()
  */
@@ -1277,7 +1277,7 @@ float8_to_int64(float8 num)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_bigint
  * @brief Convert an int64 number into a float4 number
  * @note Derived from PostgreSQL function @p i8tof()
  */
@@ -1288,7 +1288,7 @@ int64_to_float4(int64 num)
 }
 
 /**
- * @ingroup meos_base_int
+ * @ingroup meos_internal_bigint
  * @brief Convert a float4 number into an int64 number
  * @note Derived from PostgreSQL function @p ftoi8()
  */

--- a/pgtypes/utils/numeric.c
+++ b/pgtypes/utils/numeric.c
@@ -531,7 +531,7 @@ static void compute_bucket(Numeric operand, Numeric bound1, Numeric bound2,
 /*****************************************************************************/
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return a numeric value from its string representation
  * @param[in] str String
  * @param[in] typmod Typmod
@@ -711,7 +711,7 @@ invalid_syntax:
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return the string representation a numeric value
  * @note Derived from PostgreSQL function @p numeric_out()
  */
@@ -750,7 +750,7 @@ pg_numeric_out(Numeric num)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return a copy of a temporal value
  * @param[in] num Temporal value
  */
@@ -989,7 +989,7 @@ numeric_normalize(Numeric num)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return a numeric value with the given precision and scale
  * @note Derived from PostgreSQL function @p numeric()
  */
@@ -1147,7 +1147,7 @@ pg_numeric_typmodout(int32 typmod)
  */
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return the absolute value of a numeric value
  * @note Derived from PostgreSQL function @p numeric_abs()
  */
@@ -1182,7 +1182,7 @@ pg_numeric_abs(Numeric num)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return the unary plus of a numeric value
  * @note Derived from PostgreSQL function @p numeric_uplus()
  */
@@ -1200,7 +1200,7 @@ pg_numeric_uplus(Numeric num)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return the unary minus of a numeric value
  * @note Derived from PostgreSQL function @p numeric_uminus()
  */
@@ -1278,7 +1278,7 @@ numeric_sign_internal(Numeric num)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return  -1 if the numeric value is less than 0, 0 if it is equal
  * to 0, and 1 if it is greater than zero
  * @note Derived from PostgreSQL function @p numeric_sign()
@@ -1314,7 +1314,7 @@ pg_numeric_sign(Numeric num)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Round a numeric value to have 'scale' digits after the decimal point
  * @details We allow negative 'scale', implying rounding before the decimal
  * point --- Oracle interprets rounding that way.
@@ -1366,7 +1366,7 @@ pg_numeric_round(Numeric num, int32 scale)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Truncate a value to have 'scale' digits after the decimal point
  * @details We allow negative 'scale', implying a truncation before the decimal
  *  point --- Oracle interprets truncation that way
@@ -1409,7 +1409,7 @@ pg_numeric_trunc(Numeric num, int32 scale)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return the smallest integer greater than or equal to the argument
  * @note Derived from PostgreSQL function @p numeric_ceil()
  */
@@ -1435,7 +1435,7 @@ pg_numeric_ceil(Numeric num)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return the largest integer equal to or less than a numeric value
  * @note Derived from PostgreSQL function @p numeric_floor()
  */
@@ -1463,7 +1463,7 @@ pg_numeric_floor(Numeric num)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return the number of the bucket in which a numeric value falls in a
  * histogram having count equal-width buckets spanning the range low to high
  * @details Implements the numeric version of the width_bucket() function
@@ -1626,7 +1626,7 @@ compute_bucket(Numeric operand, Numeric bound1, Numeric bound2,
  */
  
  /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return -1, 0, or 1 depending on whether the first numeric value is
  * less than, equal, or greater than the second one
  * @note Derived from PostgreSQL function @p numeric_cmp()
@@ -1645,7 +1645,7 @@ pg_numeric_cmp(Numeric num1, Numeric num2)
 }
 
  /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return true if two numeric values are equal
  * @note Derived from PostgreSQL function @p numeric_eq()
  */
@@ -1663,7 +1663,7 @@ pg_numeric_eq(Numeric num1, Numeric num2)
 }
 
  /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return true if two numeric values are not equal
  * @note Derived from PostgreSQL function @p numeric_ne()
  */
@@ -1681,7 +1681,7 @@ pg_numeric_ne(Numeric num1, Numeric num2)
 }
 
  /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return true if a numeric value is greater than another one
  * @note Derived from PostgreSQL function @p numeric_gt()
  */
@@ -1699,7 +1699,7 @@ pg_numeric_gt(Numeric num1, Numeric num2)
 }
 
  /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return true if a numeric value is greater than or equal to another one
  * @note Derived from PostgreSQL function @p numeric_ge()
  */
@@ -1717,7 +1717,7 @@ pg_numeric_ge(Numeric num1, Numeric num2)
 }
 
  /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return true if a numeric value is less than another one
  * @note Derived from PostgreSQL function @p numeric_lt()
  */
@@ -1735,7 +1735,7 @@ pg_numeric_lt(Numeric num1, Numeric num2)
 }
 
  /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return true if a numeric value is less than or equal to another one
  * @note Derived from PostgreSQL function @p numeric_le()
  */
@@ -1805,7 +1805,7 @@ cmp_numerics(Numeric num1, Numeric num2)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return the 32-bit hash value of a numeric value
  * @note Derived from PostgreSQL function @p hash_numeric()
  */
@@ -1879,7 +1879,7 @@ numeric_hash(Numeric num)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return the 64-bit hash value of a numeric value with a seed
  * @note Derived from PostgreSQL function @p hash_numeric_extended()
  */
@@ -1935,7 +1935,7 @@ numeric_hash_extended(Numeric num, uint64 seed)
  */
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return the addition of two numeric values
  * @note Derived from PostgreSQL function @p numeric_add()
  */
@@ -2001,7 +2001,7 @@ numeric_add_opt_error(Numeric num1, Numeric num2, bool *have_error)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return the subtraction of two numeric values
  * @note Derived from PostgreSQL function @p numeric_sub()
  */
@@ -2067,7 +2067,7 @@ numeric_sub_opt_error(Numeric num1, Numeric num2, bool *have_error)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return the product of two numeric values
  * @note Derived from PostgreSQL function @p numeric_mul()
  */
@@ -2182,7 +2182,7 @@ numeric_mul_opt_error(Numeric num1, Numeric num2, bool *have_error)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return the division of one numeric by another
  * @note Derived from PostgreSQL function @p numeric_div()
  */
@@ -2308,7 +2308,7 @@ numeric_div_opt_error(Numeric num1, Numeric num2, bool *have_error)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return the division of one numeric by another, truncating the result
  * to an integer
  * @note Derived from PostgreSQL function @p numeric_div_trunc()
@@ -2400,7 +2400,7 @@ pg_numeric_div_trunc(Numeric num1, Numeric num2)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return modulo of two numeric values
  * @note Derived from PostgreSQL function @p numeric_mod()
  */
@@ -2485,7 +2485,7 @@ numeric_mod_opt_error(Numeric num1, Numeric num2, bool *have_error)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return a numeric value incremented by one
  * @note Derived from PostgreSQL function @p numeric_inc()
  */
@@ -2523,7 +2523,7 @@ pg_numeric_inc(Numeric num)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return the smaller of two numeric values
  * @note Derived from PostgreSQL function @p numeric_smaller()
  */
@@ -2548,7 +2548,7 @@ pg_numeric_smaller(Numeric num1, Numeric num2)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return the larger of two numeric values
  * @note Derived from PostgreSQL function @p numeric_larger()
  */
@@ -2580,7 +2580,7 @@ pg_numeric_larger(Numeric num1, Numeric num2)
  */
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return the greatest common divisor of two numeric values
  * @note Derived from PostgreSQL function @p numeric_gcd()
  */
@@ -2627,7 +2627,7 @@ pg_numeric_gcd(Numeric num1, Numeric num2)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return the least common multiple of two numeric values
  * @note Derived from PostgreSQL function @p numeric_lcm()
  */
@@ -2691,7 +2691,7 @@ pg_numeric_lcm(Numeric num1, Numeric num2)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return the factorial of a numeric value
  * @note Derived from PostgreSQL function @p numeric_fac()
  */
@@ -2748,7 +2748,7 @@ pg_numeric_fac(int64 num)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return the square root of a numeric
  * @note Derived from PostgreSQL function @p numeric_sqrt()
  */
@@ -2827,7 +2827,7 @@ pg_numeric_sqrt(Numeric num)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return e raised to the power of a numeric value
  * @note Derived from PostgreSQL function @p numeric_exp()
  */
@@ -2899,7 +2899,7 @@ pg_numeric_exp(Numeric num)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return the natural logarithm of a numeric value
  * @note Derived from PostgreSQL function @p numeric_ln()
  */
@@ -2955,7 +2955,7 @@ pg_numeric_ln(Numeric num)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Return the logarithm of x in a given base
  * @note Derived from PostgreSQL function @p numeric_log()
  */
@@ -3035,7 +3035,7 @@ pg_numeric_log(Numeric num1, Numeric num2)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Raise x to the power of y
  * @note Derived from PostgreSQL function @p numeric_power()
  */
@@ -3223,7 +3223,7 @@ numeric_pow(Numeric num1, Numeric num2)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Returns the scale, i.e., the count of decimal digits in the
  * fractional part
  * @note Derived from PostgreSQL function @p numeric_scale()
@@ -3295,7 +3295,7 @@ get_min_scale(NumericVar *var)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Returns minimum scale required to represent the numeric value without loss
  * @note Derived from PostgreSQL function @p numeric_min_scale()
  */
@@ -3323,7 +3323,7 @@ pg_numeric_min_scale(Numeric num)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_numeric
  * @brief Reduce scale of numeric value to represent it without loss
  * @note Derived from PostgreSQL function @p numeric_trim_scale()
  */
@@ -3444,7 +3444,7 @@ int64_div_fast_to_numeric(int64 val1, int log10val2)
  */
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_bigint
  * @brief Transform an int64 number into a numeric value
  * @note Existing PostgreSQL function
  */
@@ -3509,7 +3509,7 @@ pg_numeric_int8_opt_error(Numeric num, bool *have_error)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_bigint
  * @brief Transform a numeric value into an int64 number
  * @note Derived from PostgreSQL function @p numeric_int8()
  */
@@ -3520,7 +3520,7 @@ numeric_to_int64(Numeric num)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_int
  * @brief Transform an int32 number into a numeric value
  * @note Existing PostgreSQL function
  */
@@ -3598,7 +3598,7 @@ pg_numeric_int4_opt_error(Numeric num, bool *have_error)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_int
  * @brief Transform a numeric value into an int32 number
  * @note Derived from PostgreSQL function @p numeric_int4()
  */
@@ -3609,7 +3609,7 @@ numeric_to_int32(Numeric num)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_int16
  * @brief Transform an int2 value into a numeric value
  * @note Derived from PostgreSQL function @p numeric_int8()
  */
@@ -3620,7 +3620,7 @@ int16_to_numeric(int16 num)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_int16
  * @brief Transform a numeric value into an int2 value
  * @note Derived from PostgreSQL function @p numeric_int2()
  */
@@ -3660,7 +3660,7 @@ numeric_to_int16(Numeric num)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_float
  * @brief Transform a float8 value into a numeric value
  * @note Derived from PostgreSQL function @p numeric_float8()
  */
@@ -3692,7 +3692,7 @@ float8_to_numeric(float8 num)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_float
  * @brief Transform a numeric value into a float8 value
  * @note Derived from PostgreSQL function @p numeric_float8()
  */
@@ -3742,7 +3742,7 @@ numeric_float8_no_overflow_internal(Numeric num)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_float4
  * @brief Transform a float4 value into a numeric value
  * @note Derived from PostgreSQL function @p float4_numeric()
  */
@@ -3772,7 +3772,7 @@ float4_to_numeric(float4 num)
 }
 
 /**
- * @ingroup meos_base_numeric
+ * @ingroup meos_internal_float4
  * @brief Transform a numeric value into a float4 value
  * @note Derived from PostgreSQL function @p numeric_float4()
  */

--- a/pgtypes/utils/varlena.c
+++ b/pgtypes/utils/varlena.c
@@ -186,7 +186,7 @@ pg_cstring_to_text(const char *str)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Convert a text into a C string
  * @param[in] txt Text
  * @note Function taken from PostGIS file @p lwgeom_in_geojson.c
@@ -270,7 +270,7 @@ text_out(const text *txt)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Copy a text value
  * @param[in] txt Text
  */
@@ -299,7 +299,7 @@ bytea_copy(const bytea *ba)
 /* ========== PUBLIC ROUTINES ========== */
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Return the logical length of a text value (which is less than the
  * VARSIZE of the text)
  * @note Derived from PostgreSQL function @p textlen()
@@ -333,7 +333,7 @@ text_length(const text *txt)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Return the logical length of a text value (which is less than the
  * VARSIZE of the text)
  * @note Derived from PostgreSQL function @p textoctetlen()
@@ -345,7 +345,7 @@ text_octetlen(const text *txt)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Concatenate two text values
  * @note Derived from PostgreSQL function @p textcat()
  */
@@ -679,7 +679,7 @@ text_substring(const text *txt, int32 start, int32 length,
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Return a substring starting at the specified position
  * @param[in] txt String
  * @param[in] start Starting position (one-based)
@@ -704,7 +704,7 @@ pg_text_substr(const text *txt, int32 start, int32 length)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Return a substring starting at the specified position
  * @note Derived from PostgreSQL function @p text_substr_no_len()
  */
@@ -722,7 +722,7 @@ pg_text_substr_no_len(const text *txt, int32 start)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Replace a specified substring of the first string with the second one
  * @details The SQL standard defines OVERLAY() in terms of substring and
  * concatenation. This code is a direct implementation of what the standard says.
@@ -759,7 +759,7 @@ text_overlay(const text *txt1, const text *txt2, int from, int count)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Replace a specified substring of the first string with the second one
  * @note Derived from PostgreSQL function @p textoverlay_no_len()
  */
@@ -814,7 +814,7 @@ text_position(const text *txt1, const text *txt2, Oid collid)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Return the position of the specified substring
  * @brief Implements the SQL POSITION() function.
  * Ref: A Guide To The SQL Standard, Date & Darwen, 1997
@@ -1403,7 +1403,7 @@ pg_text_ge(const text *txt1, const text *txt2)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Return true if the first text starts with the second one
  * @note Derived from PostgreSQL function @p text_starts_with()
  */
@@ -1444,7 +1444,7 @@ pg_text_starts_with(const text *txt1, const text *txt2)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Return the larger from two texts
  * @note Derived from PostgreSQL function @p text_larger()
  */
@@ -1463,7 +1463,7 @@ pg_text_larger(const text *txt1, const text *txt2)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Return the smaller from two texts
  * @note Derived from PostgreSQL function @p text_smaller()
  */
@@ -1589,7 +1589,7 @@ appendStringInfoText(StringInfo str, const text *t)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Return all occurrences of 'old_sub_str' in 'orig_str'
  * with 'new_sub_str' to form 'new_str'
  * @details Return 'orig_str' if 'old_sub_str' == '' or 'orig_str' == ''
@@ -1924,7 +1924,7 @@ replace_text_regexp(text *src_text, text *pattern_text, text *replace_text,
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Split string on delimiter and return the n-th item (1-based), 
  * negative counts from end
  * @note Derived from PostgreSQL function @p split_part()
@@ -2079,7 +2079,7 @@ convert_to_base(uint64 value, int base)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_int
  * @brief Convert an int32 to a string containing a base-2 (binary)
  * representation of the number
  * @note Derived from PostgreSQL function @p to_bin32()
@@ -2092,7 +2092,7 @@ int32_to_bin(int32 num)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_bigint
  * @brief Convert an int64 to a string containing a base-2 (binary)
  * representation of the number
  * @note Derived from PostgreSQL function @p to_bin64()
@@ -2105,7 +2105,7 @@ int64_to_bin(int64 num)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_int
  * @brief Convert an int32 to a string containing a base-8 (oct)
  * representation of the number
  * @note Derived from PostgreSQL function @p to_oct32()
@@ -2118,7 +2118,7 @@ int32_to_oct(int32 num)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_bigint
  * @brief Convert an int64 to a string containing a base-8 (oct) 
  * representation of the number
  * @note Derived from PostgreSQL function @p to_oct64()
@@ -2131,7 +2131,7 @@ int64_to_oct(int64 num)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_int
  * @brief Convert an int32 to a string containing a base-16 (hex) 
  * representation of the number
  * @note Derived from PostgreSQL function @p to_hex32()
@@ -2144,7 +2144,7 @@ int32_to_hex(int32 num)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_bigint
  * @brief Convert an int64 to a string containing a base-16 (hex) 
  * representation of the number
  * @note Derived from PostgreSQL function @p to_hex64()
@@ -2204,7 +2204,7 @@ textarr_to_text(text **textarr, int count, const char *sep,
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Concatenate all arguments
  * @note Derived from PostgreSQL function @p text_concat()
  */
@@ -2222,7 +2222,7 @@ pg_text_concat(text **textarr, int count)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Concatenate all but first argument value with separators. The first
  * parameter is used as the separator.
  * @note Derived from PostgreSQL function @p text_concat_ws()
@@ -2245,7 +2245,7 @@ pg_text_concat_ws(text **textarr, int count, const text *sep)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Return the first n characters in the string. When n is negative, 
  * return all but the last |n| characters.
  * @note Derived from PostgreSQL function @p text_left()
@@ -2273,7 +2273,7 @@ pg_text_left(const text *txt, int n)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Return  the last n characters in the string. When n is negative,
  * return all but first |n| characters.
  * @note Derived from PostgreSQL function @p text_right()
@@ -2299,7 +2299,7 @@ pg_text_right(const text *txt, int n)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Return a text reversed
  * @note Derived from PostgreSQL function @p text_reverse()
  */
@@ -2354,7 +2354,7 @@ pg_text_reverse(const text *txt)
 
 #if 0 /* NOT USED */
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Returns a formatted string
  * @note Derived from PostgreSQL function @p text_format()
  */
@@ -2813,7 +2813,7 @@ unicode_norm_form_from_string(const char *formstr)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Returns version of Unicode used by Postgres in "major.minor" format 
  * (the same format as the Unicode version reported by ICU)
  * @details The third component ("update version") never involves additions to
@@ -2835,7 +2835,7 @@ pg_unicode_version(void)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Returns version of Unicode used by ICU, if enabled; otherwise NULL
  * @note Derived from PostgreSQL function @p icu_unicode_version()
  */
@@ -2857,7 +2857,7 @@ pg_icu_unicode_version(void)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Return true if a text contains only assigned Unicode code points
  * @details Requires that the encoding is UTF-8
  * @note Derived from PostgreSQL function @p unicode_assigned()
@@ -2894,7 +2894,7 @@ pg_unicode_assigned(const text *txt)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Return a Unicode text normalized
  * @note Derived from PostgreSQL function @p unicode_normalize_func()
  */
@@ -2949,7 +2949,7 @@ pg_unicode_normalize_func(const text *txt, const text *fmt)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Return true if a text is in the specified Unicode normalization form
  * @details This is done by converting the string to the specified normal form 
  * and then comparing that to the original string.  To speed that up, we also 
@@ -3047,7 +3047,7 @@ hexval_n(const char *instr, size_t n)
 }
 
 /**
- * @ingroup meos_base_text
+ * @ingroup meos_internal_text
  * @brief Return a text where the Unicode escape sequences are replaced by
  * Unicode characters
  * @note Derived from PostgreSQL function @p unistr()


### PR DESCRIPTION
The vendored pgtypes base-type functions all carry `@ingroup meos_base_*`
doxygen tags that expose them as public API. Most are PostgreSQL plumbing
(bitwise operators, cross-type arithmetic, string manipulation, and numeric
and formatting helpers) that no MEOS binding needs.

This retags the out-of-scope functions to `meos_internal_<type>` so the
catalog and the reference manual treat them as internal. The public base
surface keeps:

- the input and output family (constructors, and the output and input
  representations that back `asText`/`asWKB`/`fromMFJSON` and their kin);
- the comparison and hash operators (the hashes back hash indexes on the
  base type and its temporal type);
- the temporalized operators (those with a temporal counterpart); and
- the whole time dimension — date, time, timestamp, and interval — with all
  its arithmetic, extraction, and formatting operations, which is central to
  the temporal model (for example, the difference between two timestamps is an
  interval).

The diff is limited to `@ingroup` doxygen comments, plus the new
`meos_internal_base` group and its per-type children in the internal doxygen
header. There is no code change.

Across the pgtypes base functions this leaves 386 public (310 base plus 76
json) and 292 internal.
