### PR TITLE
Define the missing Doxygen groups for all families

### DIFF
--- a/meos/include/cbuffer/doxygen_meos_cbuffer.h
+++ b/meos/include/cbuffer/doxygen_meos_cbuffer.h
@@ -154,3 +154,13 @@
  */
 
 /*****************************************************************************/
+
+/**
+ * @defgroup meos_cbuffer_box Box functions
+ * @ingroup meos_cbuffer
+ * @brief Box functions for temporal circular buffers
+ *
+ * @defgroup meos_cbuffer_spatial_accessor Spatial accessor functions
+ * @ingroup meos_cbuffer
+ * @brief Spatial accessor functions for temporal circular buffers
+ */

--- a/meos/include/cbuffer/doxygen_meos_internal_cbuffer.h
+++ b/meos/include/cbuffer/doxygen_meos_internal_cbuffer.h
@@ -138,3 +138,17 @@
  */
 
 /*****************************************************************************/
+
+/**
+ * @defgroup meos_internal_cbuffer_base_rel Spatial relationship functions
+ * @ingroup meos_internal_cbuffer_base
+ * @brief Spatial relationship functions for static circular buffers
+ *
+ * @defgroup meos_internal_cbuffer_spatial_accessor Spatial accessor functions
+ * @ingroup meos_internal_cbuffer
+ * @brief Spatial accessor functions for temporal circular buffers
+ *
+ * @defgroup meos_internal_cbuffer_spatial_rel_ever Ever/always relationship functions
+ * @ingroup meos_internal_cbuffer
+ * @brief Ever/always spatial relationship functions for temporal circular buffers
+ */

--- a/meos/include/geo/doxygen_meos_internal_geo.h
+++ b/meos/include/geo/doxygen_meos_internal_geo.h
@@ -234,3 +234,9 @@
  */
 
 /*****************************************************************************/
+
+/**
+ * @defgroup meos_internal_geo_spatial_rel_ever Ever/always relationship functions
+ * @ingroup meos_internal_geo
+ * @brief Ever/always spatial relationship functions for temporal geometries
+ */

--- a/meos/include/json/doxygen_meos_internal_json.h
+++ b/meos/include/json/doxygen_meos_internal_json.h
@@ -130,3 +130,9 @@
  */
 
 /*****************************************************************************/
+
+/**
+ * @defgroup meos_internal_json Functions for temporal JSON types
+ * @ingroup meos_internal
+ * @brief Functions for temporal JSON types
+ */

--- a/meos/include/json/doxygen_meos_json.h
+++ b/meos/include/json/doxygen_meos_json.h
@@ -134,3 +134,17 @@
  */
 
 /*****************************************************************************/
+
+/**
+ * @defgroup meos_json_json JSON processing functions
+ * @ingroup meos_json
+ * @brief JSON processing functions for temporal JSON
+ *
+ * @defgroup meos_json_set_json JSON processing functions
+ * @ingroup meos_json_set
+ * @brief JSON processing functions for JSON sets
+ *
+ * @defgroup meos_json_base_jsonpath JSON path functions
+ * @ingroup meos_json_base
+ * @brief JSON path functions for static JSON types
+ */

--- a/meos/include/npoint/doxygen_meos_npoint.h
+++ b/meos/include/npoint/doxygen_meos_npoint.h
@@ -134,3 +134,13 @@
  */
 
 /*****************************************************************************/
+
+/**
+ * @defgroup meos_npoint_constructor Constructor functions
+ * @ingroup meos_npoint
+ * @brief Constructor functions for temporal network points
+ *
+ * @defgroup meos_npoint_base_bbox Bounding box functions
+ * @ingroup meos_npoint_base
+ * @brief Bounding box functions for static network points
+ */

--- a/meos/include/pointcloud/doxygen_meos_pointcloud.h
+++ b/meos/include/pointcloud/doxygen_meos_pointcloud.h
@@ -152,3 +152,25 @@
  */
 
 /*****************************************************************************/
+
+/**
+ * @defgroup meos_pointcloud_constructor Constructor functions
+ * @ingroup meos_pointcloud
+ * @brief Constructor functions for temporal pgpointcloud types
+ *
+ * @defgroup meos_pointcloud_dist Distance functions
+ * @ingroup meos_pointcloud
+ * @brief Distance functions for temporal pgpointcloud types
+ *
+ * @defgroup meos_pointcloud_ever Ever and always comparison functions
+ * @ingroup meos_pointcloud
+ * @brief Ever and always comparison functions for temporal pgpointcloud types
+ *
+ * @defgroup meos_internal_pointcloud Functions for temporal pgpointcloud types
+ * @ingroup meos_internal
+ * @brief Functions for temporal pgpointcloud types
+ *
+ *   @defgroup meos_internal_pointcloud_box_setops Set functions
+ *   @ingroup meos_internal_pointcloud
+ *   @brief Set functions for pgpointcloud boxes
+ */

--- a/meos/include/pose/doxygen_meos_internal_pose.h
+++ b/meos/include/pose/doxygen_meos_internal_pose.h
@@ -122,3 +122,9 @@
  */
 
 /*****************************************************************************/
+
+/**
+ * @defgroup meos_internal_pose_dist Distance functions
+ * @ingroup meos_internal_pose
+ * @brief Distance functions for temporal poses
+ */

--- a/meos/include/pose/doxygen_meos_pose.h
+++ b/meos/include/pose/doxygen_meos_pose.h
@@ -147,3 +147,9 @@
  */
 
 /*****************************************************************************/
+
+/**
+ * @defgroup meos_pose_base_dist Distance functions
+ * @ingroup meos_pose_base
+ * @brief Distance functions for static poses
+ */

--- a/meos/include/quadbin/doxygen_meos_quadbin.h
+++ b/meos/include/quadbin/doxygen_meos_quadbin.h
@@ -1,0 +1,90 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief MEOS Developer's Documentation: Functions for temporal CARTO QUADBIN
+ * cell indices
+ */
+
+/*****************************************************************************
+ * Sections of the temporal QUADBIN cell index functions
+ *****************************************************************************/
+
+/**
+ * @defgroup meos_quadbin_base Functions for static QUADBIN cell indices
+ * @ingroup meos_quadbin
+ * @brief Functions for static QUADBIN cell indices
+ *
+ * @defgroup meos_quadbin_inout Input and output functions
+ * @ingroup meos_quadbin
+ * @brief Input and output functions for temporal QUADBIN cell indices
+ *
+ * @defgroup meos_quadbin_constructor Constructor functions
+ * @ingroup meos_quadbin
+ * @brief Constructor functions for temporal QUADBIN cell indices
+ *
+ * @defgroup meos_quadbin_conversion Conversion functions
+ * @ingroup meos_quadbin
+ * @brief Conversion functions for temporal QUADBIN cell indices
+ *
+ * @defgroup meos_quadbin_accessor Accessor functions
+ * @ingroup meos_quadbin
+ * @brief Accessor functions for temporal QUADBIN cell indices
+ *
+ * @defgroup meos_quadbin_comp Comparison functions
+ * @ingroup meos_quadbin
+ * @brief Comparison functions for temporal QUADBIN cell indices
+ *
+ *   @defgroup meos_quadbin_comp_ever Ever and always comparison functions
+ *   @ingroup meos_quadbin_comp
+ *   @brief Ever and always comparison functions for temporal QUADBIN cell indices
+ *
+ *   @defgroup meos_quadbin_comp_temp Temporal comparison functions
+ *   @ingroup meos_quadbin_comp
+ *   @brief Temporal comparison functions for temporal QUADBIN cell indices
+ */
+
+/*****************************************************************************/
+
+/**
+ * @defgroup meos_quadbin_base_inout Input and output functions
+ * @ingroup meos_quadbin_base
+ * @brief Input and output functions for static QUADBIN cell indices
+ *
+ * @defgroup meos_quadbin_base_accessor Accessor functions
+ * @ingroup meos_quadbin_base
+ * @brief Accessor functions for static QUADBIN cell indices
+ *
+ * @defgroup meos_quadbin_base_comp Comparison functions
+ * @ingroup meos_quadbin_base
+ * @brief Comparison functions for static QUADBIN cell indices
+ */
+
+/*****************************************************************************/

--- a/meos/include/raster/doxygen_meos_raster.h
+++ b/meos/include/raster/doxygen_meos_raster.h
@@ -1,0 +1,65 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief MEOS Developer's Documentation: Functions for temporal rasters
+ */
+
+/*****************************************************************************
+ * Sections of the temporal raster functions
+ *****************************************************************************/
+
+/**
+ * @defgroup meos_raster_base Functions for static rasters
+ * @ingroup meos_raster
+ * @brief Functions for static rasters
+ */
+
+/*****************************************************************************/
+
+/**
+ * @defgroup meos_raster_base_inout Input and output functions
+ * @ingroup meos_raster_base
+ * @brief Input and output functions for static rasters
+ *
+ * @defgroup meos_raster_base_constructor Constructor functions
+ * @ingroup meos_raster_base
+ * @brief Constructor functions for static rasters
+ *
+ * @defgroup meos_raster_base_accessor Accessor functions
+ * @ingroup meos_raster_base
+ * @brief Accessor functions for static rasters
+ *
+ * @defgroup meos_raster_base_comp Comparison functions
+ * @ingroup meos_raster_base
+ * @brief Comparison functions for static rasters
+ */
+
+/*****************************************************************************/

--- a/meos/include/rgeo/doxygen_meos_internal_rgeo.h
+++ b/meos/include/rgeo/doxygen_meos_internal_rgeo.h
@@ -66,3 +66,13 @@
  */
 
 /*****************************************************************************/
+
+/**
+ * @defgroup meos_internal_rgeo_constructor Constructor functions
+ * @ingroup meos_internal_rgeo
+ * @brief Constructor functions for temporal rigid geometries
+ *
+ * @defgroup meos_internal_rgeo_transf Transformation functions
+ * @ingroup meos_internal_rgeo
+ * @brief Transformation functions for temporal rigid geometries
+ */

--- a/meos/include/rgeo/doxygen_meos_rgeo.h
+++ b/meos/include/rgeo/doxygen_meos_rgeo.h
@@ -62,3 +62,45 @@
  */
 
 /*****************************************************************************/
+
+/**
+ * @defgroup meos_rgeo_constructor Constructor functions
+ * @ingroup meos_rgeo
+ * @brief Constructor functions for temporal rigid geometries
+ *
+ * @defgroup meos_rgeo_transf Transformation functions
+ * @ingroup meos_rgeo
+ * @brief Transformation functions for temporal rigid geometries
+ *
+ * @defgroup meos_rgeo_modif Modification functions
+ * @ingroup meos_rgeo
+ * @brief Modification functions for temporal rigid geometries
+ *
+ * @defgroup meos_rgeo_spatialfuncs Spatial functions
+ * @ingroup meos_rgeo
+ * @brief Spatial functions for temporal rigid geometries
+ *
+ * @defgroup meos_rgeo_tile Tile functions
+ * @ingroup meos_rgeo
+ * @brief Tile functions for temporal rigid geometries
+ *
+ * @defgroup meos_rgeo_analytics_similarity Similarity functions
+ * @ingroup meos_rgeo
+ * @brief Similarity functions for temporal rigid geometries
+ *
+ * @defgroup meos_rgeo_bbox Bounding box functions
+ * @ingroup meos_rgeo
+ * @brief Bounding box functions for temporal rigid geometries
+ *
+ *   @defgroup meos_rgeo_bbox_split Split functions
+ *   @ingroup meos_rgeo_bbox
+ *   @brief Split functions for temporal rigid geometries
+ *
+ * @defgroup meos_rgeo_rel Spatial relationship functions
+ * @ingroup meos_rgeo
+ * @brief Spatial relationship functions for temporal rigid geometries
+ *
+ *   @defgroup meos_rgeo_rel_ever Ever/always relationship functions
+ *   @ingroup meos_rgeo_rel
+ *   @brief Ever/always relationship functions for temporal rigid geometries
+ */

--- a/meos/include/temporal/doxygen_meos.h
+++ b/meos/include/temporal/doxygen_meos.h
@@ -166,9 +166,29 @@
  * @brief Functions for static, set, box, and temporal pgpointcloud types
  *   (pcpoint, pcpatch, pcpointset, pcpatchset, tpcbox, tpcpoint, tpcpatch)
  *
+ * @defgroup meos_h3 Functions for temporal H3 cell indices
+ * @ingroup meos_api
+ * @brief Functions for temporal H3 cell indices
+ *
+ * @defgroup meos_quadbin Functions for temporal CARTO QUADBIN cell indices
+ * @ingroup meos_api
+ * @brief Functions for temporal CARTO QUADBIN cell indices
+ *
+ * @defgroup meos_cellindex Functions for temporal cell indices
+ * @ingroup meos_api
+ * @brief Functions for temporal cell indices common to H3 and QUADBIN
+ *
+ * @defgroup meos_raster Functions for temporal rasters
+ * @ingroup meos_api
+ * @brief Functions for temporal rasters
+ *
  * @defgroup meos_misc Miscellaneous functions
  * @ingroup meos_api
  * @brief Miscellaneous functions
+ *
+ * @defgroup meos_setup Setup functions
+ * @ingroup meos_api
+ * @brief Setup functions
  */
 
 /*****************************************************************************/
@@ -388,3 +408,13 @@
  */
 
 /*****************************************************************************/
+
+/**
+ * @defgroup meos_temporal_box_index Index functions
+ * @ingroup meos_temporal
+ * @brief Index functions for temporal types
+ *
+ * @defgroup meos_temporal_spatial_rel_ever Ever/always spatial relationship functions
+ * @ingroup meos_temporal
+ * @brief Ever/always spatial relationship functions for temporal types
+ */

--- a/meos/include/temporal/doxygen_meos_internal.h
+++ b/meos/include/temporal/doxygen_meos_internal.h
@@ -255,3 +255,21 @@
  */
 
 /*****************************************************************************/
+
+/**
+ * @defgroup meos_internal_setspan_bin Bin functions
+ * @ingroup meos_internal_setspan
+ * @brief Bin functions for set and span types
+ *
+ * @defgroup meos_internal_box_accessor Accessor functions
+ * @ingroup meos_internal_box
+ * @brief Accessor functions for temporal boxes
+ *
+ * @defgroup meos_internal_temporal_tile Tile functions
+ * @ingroup meos_internal_temporal
+ * @brief Tile functions for temporal types
+ *
+ * @defgroup meos_internal_temporal_analytics_tile Tile functions
+ * @ingroup meos_internal_temporal
+ * @brief Tile functions for temporal analytics
+ */

--- a/meos/src/cbuffer/cbuffer.c
+++ b/meos/src/cbuffer/cbuffer.c
@@ -705,7 +705,7 @@ cbuffer_to_stbox(const Cbuffer *cb)
  *****************************************************************************/
 
 /**
- * @ingroup meos_internal_base_accessor
+ * @ingroup meos_internal_cbuffer_base_accessor
  * @brief Return a pointer to the point of a circular buffer
  * @param[in] cb Circular buffer
  * @csqlfn #Cbuffer_point()

--- a/meos/src/cbuffer/tcbuffer_spatialfuncs.c
+++ b/meos/src/cbuffer/tcbuffer_spatialfuncs.c
@@ -412,7 +412,7 @@ tcbufferinst_traversed_area(const TInstant *inst)
 }
 
 /**
- * @ingroup meos_interal_cbuffer_spatial_accessor
+ * @ingroup meos_internal_cbuffer_spatial_accessor
  * @brief Return the traversed area of a temporal circular buffer sequence with
  * discrete or step interpolation
  * @param[in] seq Temporal circular buffer

--- a/mobilitydb/pg_include/pg_json/doxygen_mobilitydb_json.h
+++ b/mobilitydb/pg_include/pg_json/doxygen_mobilitydb_json.h
@@ -86,3 +86,9 @@
 
 /*****************************************************************************/
 
+
+/**
+ * @defgroup mobilitydb_json_jsonbset Set functions
+ * @ingroup mobilitydb_json
+ * @brief Set functions for JSON sets
+ */

--- a/mobilitydb/pg_include/pg_pointcloud/doxygen_mobilitydb_pointcloud.h
+++ b/mobilitydb/pg_include/pg_pointcloud/doxygen_mobilitydb_pointcloud.h
@@ -123,3 +123,9 @@
  */
 
 /*****************************************************************************/
+
+/**
+ * @defgroup mobilitydb_pointcloud_box_conversion Conversion functions
+ * @ingroup mobilitydb_pointcloud_box
+ * @brief Conversion functions for pgpointcloud boxes
+ */

--- a/mobilitydb/pg_include/pg_pose/doxygen_mobilitydb_pose.h
+++ b/mobilitydb/pg_include/pg_pose/doxygen_mobilitydb_pose.h
@@ -148,3 +148,9 @@
 
 /*****************************************************************************/
 
+
+/**
+ * @defgroup mobilitydb_pose_base_geopose OGC GeoPose support
+ * @ingroup mobilitydb_pose_base
+ * @brief Functions implementing the OGC GeoPose v1.0 standard for static poses
+ */

--- a/mobilitydb/pg_include/pg_quadbin/doxygen_mobilitydb_quadbin.h
+++ b/mobilitydb/pg_include/pg_quadbin/doxygen_mobilitydb_quadbin.h
@@ -1,0 +1,90 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief MobilityDB Documentation: Functions for temporal CARTO QUADBIN cell
+ * indices
+ */
+
+/*****************************************************************************
+ * Sections of the temporal QUADBIN cell index functions
+ *****************************************************************************/
+
+/**
+ * @defgroup mobilitydb_quadbin_base Functions for static QUADBIN cell indices
+ * @ingroup mobilitydb_quadbin
+ * @brief Functions for static QUADBIN cell indices
+ *
+ * @defgroup mobilitydb_quadbin_accessor Accessor functions
+ * @ingroup mobilitydb_quadbin
+ * @brief Accessor functions for temporal QUADBIN cell indices
+ *
+ * @defgroup mobilitydb_quadbin_conversion Conversion functions
+ * @ingroup mobilitydb_quadbin
+ * @brief Conversion functions for temporal QUADBIN cell indices
+ *
+ * @defgroup mobilitydb_quadbin_hierarchy Hierarchy functions
+ * @ingroup mobilitydb_quadbin
+ * @brief Hierarchy functions for temporal QUADBIN cell indices
+ *
+ * @defgroup mobilitydb_quadbin_set Set functions
+ * @ingroup mobilitydb_quadbin
+ * @brief Set functions for temporal QUADBIN cell indices
+ *
+ * @defgroup mobilitydb_quadbin_comp Comparison functions
+ * @ingroup mobilitydb_quadbin
+ * @brief Comparison functions for temporal QUADBIN cell indices
+ *
+ *   @defgroup mobilitydb_quadbin_comp_ever Ever and always comparison functions
+ *   @ingroup mobilitydb_quadbin_comp
+ *   @brief Ever and always comparison functions for temporal QUADBIN cell indices
+ *
+ *   @defgroup mobilitydb_quadbin_comp_temp Temporal comparison functions
+ *   @ingroup mobilitydb_quadbin_comp
+ *   @brief Temporal comparison functions for temporal QUADBIN cell indices
+ */
+
+/*****************************************************************************/
+
+/**
+ * @defgroup mobilitydb_quadbin_base_inout Input and output functions
+ * @ingroup mobilitydb_quadbin_base
+ * @brief Input and output functions for static QUADBIN cell indices
+ *
+ * @defgroup mobilitydb_quadbin_base_accessor Accessor functions
+ * @ingroup mobilitydb_quadbin_base
+ * @brief Accessor functions for static QUADBIN cell indices
+ *
+ * @defgroup mobilitydb_quadbin_base_comp Comparison functions
+ * @ingroup mobilitydb_quadbin_base
+ * @brief Comparison functions for static QUADBIN cell indices
+ */
+
+/*****************************************************************************/

--- a/mobilitydb/pg_include/pg_rgeo/doxygen_mobilitydb_rgeo.h
+++ b/mobilitydb/pg_include/pg_rgeo/doxygen_mobilitydb_rgeo.h
@@ -101,3 +101,21 @@
 
 /*****************************************************************************/
 
+
+/**
+ * @defgroup mobilitydb_rgeo_spatialfuncs Spatial functions
+ * @ingroup mobilitydb_rgeo
+ * @brief Spatial functions for temporal rigid geometries
+ *
+ * @defgroup mobilitydb_rgeo_bbox Bounding box functions
+ * @ingroup mobilitydb_rgeo
+ * @brief Bounding box functions for temporal rigid geometries
+ *
+ * @defgroup mobilitydb_rgeo_tile Tile functions
+ * @ingroup mobilitydb_rgeo
+ * @brief Tile functions for temporal rigid geometries
+ *
+ * @defgroup mobilitydb_rgeo_analytics_similarity Similarity functions
+ * @ingroup mobilitydb_rgeo
+ * @brief Similarity functions for temporal rigid geometries
+ */

--- a/mobilitydb/pg_include/pg_temporal/doxygen_mobilitydb.h
+++ b/mobilitydb/pg_include/pg_temporal/doxygen_mobilitydb.h
@@ -81,6 +81,22 @@
  * @brief Functions for static, set, box, and temporal pgpointcloud types
  *   (pcpoint, pcpatch, pcpointset, pcpatchset, tpcbox, tpcpoint, tpcpatch)
  *
+ * @defgroup mobilitydb_json Functions for temporal JSON types
+ * @ingroup mobilitydb_api
+ * @brief Functions for temporal JSON types
+ *
+ * @defgroup mobilitydb_h3 Functions for temporal H3 cell indices
+ * @ingroup mobilitydb_api
+ * @brief Functions for temporal H3 cell indices
+ *
+ * @defgroup mobilitydb_quadbin Functions for temporal CARTO QUADBIN cell indices
+ * @ingroup mobilitydb_api
+ * @brief Functions for temporal CARTO QUADBIN cell indices
+ *
+ * @defgroup mobilitydb_raster Functions for temporal rasters
+ * @ingroup mobilitydb_api
+ * @brief Functions for temporal rasters
+ *
  * @defgroup mobilitydb_misc Miscellaneous functions
  * @ingroup mobilitydb_api
  * @brief Miscellaneous functions
@@ -287,3 +303,13 @@
  */
 
 /*****************************************************************************/
+
+/**
+ * @defgroup mobilitydb_temporal_box_comp Comparison functions
+ * @ingroup mobilitydb_temporal
+ * @brief Comparison functions for temporal boxes
+ *
+ * @defgroup mobilitydb_temporal_jsonb Functions for temporal JSON types
+ * @ingroup mobilitydb_temporal
+ * @brief Functions for temporal JSON types
+ */


### PR DESCRIPTION
Many functions carry an `@ingroup` tag whose group has no matching `@defgroup`,
so those subfamilies never appear in the generated Doxygen documentation. A scan
of `@ingroup` versus `@defgroup` across `meos/`, `mobilitydb/`, and `pgtypes/`
finds 75 such referenced-but-undefined groups spanning the H3, QUADBIN, raster,
cell-index, rigid-geometry, circular-buffer, network-point, pgpointcloud, pose,
and JSON families, plus several temporal, box, and set and span sections.

This defines the missing groups so every referenced subfamily renders:

- Register the `meos_h3`, `meos_quadbin`, `meos_cellindex`, and `meos_raster`
  top-level families under the MEOS API (and `mobilitydb_json`, `mobilitydb_h3`,
  `mobilitydb_quadbin`, `mobilitydb_raster` under the MobilityDB API), and add the
  QUADBIN and raster subgroup trees in new Doxygen headers.
- Add the remaining subgroups to the existing family headers, following the group
  structure of the temporal geometry family (for example, `meos_rgeo_rel_ever`
  under a `meos_rgeo_rel` node and `meos_rgeo_bbox_split` under `meos_rgeo_bbox`,
  mirroring `meos_geo_rel` and `meos_geo_bbox`).
- Fix two mistagged `@ingroup` lines in the circular-buffer sources: a
  `meos_interal_...` typo, and a generic `meos_internal_base_accessor` that belongs
  to `meos_internal_cbuffer_base_accessor`.

After the change, the `@ingroup` versus `@defgroup` scan reports zero
referenced-but-undefined groups.

The change is limited to Doxygen comments; there is no code change.

A few naming choices worth a look during review:
- `meos_cellindex` and `meos_setup` are registered as top-level MEOS families
  (their functions tag them as top-level groups — the cell-index accessors shared
  by H3 and QUADBIN, and `meos_set_ways_csv`).
- The oddly-named `meos_json_json` (32 functions) and `meos_json_set_json` are
  kept as-is and defined as "JSON processing functions" under `meos_json` and
  `meos_json_set`; renaming their tags could be a follow-up.
