### PR TITLE
Generate the tjsonb accessor surface from the canonical-order template

### DIFF
--- a/mobilitydb/sql/json/452_tjsonb.in.sql
+++ b/mobilitydb/sql/json/452_tjsonb.in.sql
@@ -203,9 +203,16 @@ CREATE CAST (ttext AS tjsonb) WITH FUNCTION tjsonb(ttext);
 
 -- Accessors for all temporal types
 
+-- GENERATED-ACCESSORS-BEGIN json — tools/codegen/inherited/generate.py from templates/accessors.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.yaml (accessor_families) and re-run.
+
 CREATE FUNCTION tempSubtype(tjsonb)
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_subtype'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION tempBasetype(tjsonb)
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Temporal_basetype_name'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION interp(tjsonb)
@@ -252,7 +259,7 @@ CREATE FUNCTION endValue(tjsonb)
   AS 'MODULE_PATHNAME', 'Temporal_end_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION valueN(tjsonb, integer)
+CREATE FUNCTION valueN(tjsonb, int)
   RETURNS jsonb
   AS 'MODULE_PATHNAME', 'Temporal_value_n'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -356,6 +363,7 @@ CREATE FUNCTION segments(tjsonb)
   RETURNS tjsonb[]
   AS 'MODULE_PATHNAME', 'Temporal_segments'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+-- GENERATED-ACCESSORS-END json
 
 /*****************************************************************************
  * Transformation functions

--- a/mobilitydb/test/json/expected/452_tjsonb.test.out
+++ b/mobilitydb/test/json/expected/452_tjsonb.test.out
@@ -430,6 +430,30 @@ SELECT tempSubtype(tjsonb '{[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(
  SequenceSet
 (1 row)
 
+SELECT tempBasetype(tjsonb '"{\"geom\": \"Point(1 1)\"}"@2000-01-01');
+ tempbasetype 
+--------------
+ jsonb
+(1 row)
+
+SELECT tempBasetype(tjsonb '{{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03}');
+ tempbasetype 
+--------------
+ jsonb
+(1 row)
+
+SELECT tempBasetype(tjsonb '[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03]');
+ tempbasetype 
+--------------
+ jsonb
+(1 row)
+
+SELECT tempBasetype(tjsonb '{[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03], [{"geom": "Point(2 2)"}@2000-01-04, {"geom": "Point(2 2)"}@2000-01-05]}');
+ tempbasetype 
+--------------
+ jsonb
+(1 row)
+
 SELECT memSize(tjsonb '"{\"geom\": \"Point(1 1)\"}"@2000-01-01');
  memsize 
 ---------

--- a/mobilitydb/test/json/queries/452_tjsonb.test.sql
+++ b/mobilitydb/test/json/queries/452_tjsonb.test.sql
@@ -169,6 +169,11 @@ SELECT tempSubtype(tjsonb '{{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1
 SELECT tempSubtype(tjsonb '[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03]');
 SELECT tempSubtype(tjsonb '{[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03], [{"geom": "Point(2 2)"}@2000-01-04, {"geom": "Point(2 2)"}@2000-01-05]}');
 
+SELECT tempBasetype(tjsonb '"{\"geom\": \"Point(1 1)\"}"@2000-01-01');
+SELECT tempBasetype(tjsonb '{{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03}');
+SELECT tempBasetype(tjsonb '[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03]');
+SELECT tempBasetype(tjsonb '{[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03], [{"geom": "Point(2 2)"}@2000-01-04, {"geom": "Point(2 2)"}@2000-01-05]}');
+
 SELECT memSize(tjsonb '"{\"geom\": \"Point(1 1)\"}"@2000-01-01');
 SELECT memSize(tjsonb '{{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03}');
 SELECT memSize(tjsonb '[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03]');

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -308,3 +308,9 @@ accessor_families:
     reference: true
     types:
       - {temp: trgeometry, base: pose, baseset: poseset, valret: geometry, valsym: Trgeometry}
+
+  - family:    json
+    file:      mobilitydb/sql/json/452_tjsonb.in.sql
+    reference: true
+    types:
+      - {temp: tjsonb, base: jsonb, baseset: jsonbset}


### PR DESCRIPTION
This widens the inherited-accessor generator to the `tjsonb` family. The type-agnostic accessors of `tjsonb` (`tempSubtype`..`segments`) emit from the shared per-base-type table via a `GENERATED-ACCESSORS` region in `452_tjsonb.in.sql`, matching the temporal/tcbuffer/tnpoint/tpose/trgeometry families.

`tjsonb` is the plain single-base-type case (`base` `jsonb`, `baseset` `jsonbset`), so it reproduces from the template with no per-family override tokens.

The canonical accessor surface also includes the `tempBasetype(tjsonb)` accessor, which every other `Temporal<T>` family exposes but which the hand-written `tjsonb` block omits; this adds it, with a `tempBasetype` test block alongside.

The generator's `--validate` reproduces the committed region byte-for-byte for every accessor family. The only other textual differences in `452_tjsonb.in.sql` are the region markers and the `int` -> `integer` normalization the shared template applies to `valueN`.