### PR TITLE
Tag the public lifecycle and family functions with @ingroup

### DIFF
--- a/meos/src/geo/tgeo_tile.c
+++ b/meos/src/geo/tgeo_tile.c
@@ -938,6 +938,7 @@ stbox_get_time_tile(TimestampTz t, const Interval *duration,
  *****************************************************************************/
 
 /**
+ * @ingroup meos_geo_bbox_split
  * @brief Return the spatiotemporal boxes of a temporal point split with
  * respect to a space and possibly a time grid
  * @param[in] temp Temporal point

--- a/meos/src/geo/tspatial_transform_meos.c
+++ b/meos/src/geo/tspatial_transform_meos.c
@@ -103,6 +103,7 @@ typedef struct
 char *SPATIAL_REF_SYS_CSV = "/usr/local/share/spatial_ref_sys.csv";
 
 /**
+ * @ingroup meos_setup
  * @brief Set the location of the SPATIAL_REF_SYS_CSV files
  */
 void
@@ -165,6 +166,7 @@ GetMEOSPROJSRSCache()
 }
 
 /**
+ * @ingroup meos_setup
  * @brief Destroy all the malloc'ed PROJ objects stored in the PROJSRSCache
  */
 void

--- a/meos/src/h3/h3index_sets.c
+++ b/meos/src/h3/h3index_sets.c
@@ -104,6 +104,11 @@ h3index_set_from_buffer(H3Index *cells, int64_t max)
  * Grid traversal
  *****************************************************************************/
 
+/**
+ * @ingroup meos_h3_traversal
+ * @brief Return the set of H3 cells within grid distance k of an origin cell
+ * @csqlfn #H3_grid_disk()
+ */
 Set *
 h3_grid_disk(H3Index origin, int k)
 {
@@ -191,6 +196,11 @@ h3_grid_path_cells(H3Index start, H3Index end)
  * Hierarchy
  *****************************************************************************/
 
+/**
+ * @ingroup meos_h3_hierarchy
+ * @brief Return the set of children of an H3 cell at a finer resolution
+ * @csqlfn #H3_cell_to_children()
+ */
 Set *
 h3_cell_to_children(H3Index origin, int childRes)
 {
@@ -213,6 +223,11 @@ h3_cell_to_children(H3Index origin, int childRes)
   return h3index_set_from_buffer(cells, max);
 }
 
+/**
+ * @ingroup meos_h3_hierarchy
+ * @brief Return the compacted representation of a set of H3 cells
+ * @csqlfn #H3_compact_cells()
+ */
 Set *
 h3_compact_cells(const Set *cells)
 {
@@ -238,6 +253,11 @@ h3_compact_cells(const Set *cells)
   return h3index_set_from_buffer(out, n);
 }
 
+/**
+ * @ingroup meos_h3_hierarchy
+ * @brief Return the uncompacted set of a set of H3 cells at a given resolution
+ * @csqlfn #H3_uncompact_cells()
+ */
 Set *
 h3_uncompact_cells(const Set *cells, int res)
 {

--- a/meos/src/json/jsonbset_jsonfuncs.c
+++ b/meos/src/json/jsonbset_jsonfuncs.c
@@ -335,6 +335,7 @@ jsonbset_set(const Set *set, text **keys, int count, const Jsonb *newjb,
 /*****************************************************************************/
 
 /**
+ * @ingroup meos_json_set_conversion
  * @brief Convert a JSONB set into a alphanumeric set by extracting one key
  * @param[in] set JSONB set
  * @param[in] key Key to extract from the JSONB object

--- a/meos/src/npoint/ways_meos.c
+++ b/meos/src/npoint/ways_meos.c
@@ -159,6 +159,7 @@ GetWaysCache()
 }
 
 /**
+ * @ingroup meos_setup
  * @brief Destroy the ways cache
  */
 void

--- a/meos/src/pointcloud/pcpatch.c
+++ b/meos/src/pointcloud/pcpatch.c
@@ -218,6 +218,7 @@ pcpatch_as_hexwkb(const Pcpatch *pa)
  *****************************************************************************/
 
 /**
+ * @ingroup meos_pointcloud_constructor
  * @brief Return a palloc'd copy of a pcpatch
  */
 Pcpatch *

--- a/meos/src/pointcloud/pcpoint.c
+++ b/meos/src/pointcloud/pcpoint.c
@@ -263,6 +263,7 @@ pcpoint_as_hexwkb(const Pcpoint *pt)
  *****************************************************************************/
 
 /**
+ * @ingroup meos_pointcloud_constructor
  * @brief Return a palloc'd copy of a pcpoint
  */
 Pcpoint *

--- a/meos/src/quadbin/quadbinset_meos.c
+++ b/meos/src/quadbin/quadbinset_meos.c
@@ -83,6 +83,10 @@ quadbinset_from_buffer(Quadbin *cells, int count)
  * @csqlfn #Quadbin_grid_disk()
  *****************************************************************************/
 
+/**
+ * @ingroup meos_quadbin_accessor
+ * @brief Return the set of QUADBIN cells within grid distance k of an origin cell
+ */
 Set *
 quadbin_grid_disk(Quadbin origin, int k)
 {
@@ -102,6 +106,10 @@ quadbin_grid_disk(Quadbin origin, int k)
  * @csqlfn #Quadbin_cell_to_children()
  *****************************************************************************/
 
+/**
+ * @ingroup meos_quadbin_accessor
+ * @brief Return the set of children of a QUADBIN cell at a finer resolution
+ */
 Set *
 quadbin_cell_to_children_set(Quadbin origin, int children_resolution)
 {

--- a/meos/src/raster/raster_quadbin.c
+++ b/meos/src/raster/raster_quadbin.c
@@ -275,7 +275,7 @@ read_pixel(const uint8_t *pixels, int col, int row, int width,
  *****************************************************************************/
 
 /**
- * @ingroup mobilitydb_raster
+ * @ingroup meos_raster_base_accessor
  * @brief Sample a Raquet raster chip along a tgeompoint trajectory.
  *
  * The chip is identified by its QUADBIN cell, which encodes the Web-Mercator
@@ -361,7 +361,7 @@ raster_tile_value_quadbin(const uint8_t *pixels, uint16_t width,
  *****************************************************************************/
 
 /**
- * @ingroup mobilitydb_raster
+ * @ingroup meos_raster_base_accessor
  * @brief Return the unique QUADBIN cells at @p zoom covered by a trajectory.
  *
  * Suitable for use as the WHERE-clause argument when joining against a Raquet

--- a/meos/src/temporal/error.c
+++ b/meos/src/temporal/error.c
@@ -56,6 +56,7 @@
 static MEOS_TLS int MEOS_ERR_NO = 0;
 
 /**
+ * @ingroup meos_misc
  * @brief Read an error number
  */
 int
@@ -66,6 +67,7 @@ meos_errno(void)
 
 #if MEOS
 /**
+ * @ingroup meos_misc
  * @brief Set an error number
  */
 int
@@ -80,6 +82,7 @@ meos_errno_set(int err)
 }
 
 /**
+ * @ingroup meos_misc
  * @brief Set an error number
  * @details Use #meos_errno_restore when the current function succeeds, but the
  * error flag was set on entry, and stored/reset using #meos_errno_reset in
@@ -124,6 +127,10 @@ meos_errno_restore(int err)
  * @endcode
  */
 
+/**
+ * @ingroup meos_misc
+ * @brief Reset the error number to zero and return its previous value
+ */
 int meos_errno_reset(void)
 {
   int last_errno = meos_errno();
@@ -167,8 +174,9 @@ error_handler_errno(int errlevel pg_attribute_unused(), int errcode,
   return;
 }
 
-/*
- * Initialize error handler function
+/**
+ * @ingroup meos_setup
+ * @brief Initialize error handler function
  */
 void
 meos_initialize_error_handler(error_handler_fn err_handler)
@@ -197,6 +205,7 @@ noexit_error_handler(int errlevel __attribute__((__unused__)), int errcode,
 }
 
 /**
+ * @ingroup meos_setup
  * @brief Install the no-exit error handler
  * @details Safe to call from multiple threads -- the underlying atomic
  * store is idempotent and always sets the same function pointer.
@@ -224,6 +233,7 @@ pg_error(int errlevel, const char *errmsg)
 #endif /* ! MEOS */
 
 /**
+ * @ingroup meos_misc
  * @brief Function handling error messages
  *
  * @note Return-or-not contract is *undefined*: depending on the

--- a/meos/src/temporal/meos.c
+++ b/meos/src/temporal/meos.c
@@ -529,6 +529,7 @@ check_datestyle(const char **newval, void **extra)
 }
 
 /**
+ * @ingroup meos_setup
  * @brief Set the DateStyle
  */
 bool
@@ -544,6 +545,7 @@ meos_set_datestyle(const char *newval, void *extra)
 }
 
 /**
+ * @ingroup meos_setup
  * @brief Get the DateStyle
  */
 char *
@@ -588,6 +590,7 @@ check_intervalstyle(const char *newval, int *extra)
 }
 
 /**
+ * @ingroup meos_setup
  * @brief Set the IntervalStyle
  */
 bool
@@ -601,6 +604,7 @@ meos_set_intervalstyle(const char *newval, int extra)
 }
 
 /**
+ * @ingroup meos_setup
  * @brief Get the IntervalStyle
  */
 char *
@@ -618,8 +622,9 @@ meos_get_intervalstyle(void)
 
 extern void init_database_collation(void);
 
-/*
- * Initialize MEOS library
+/**
+ * @ingroup meos_setup
+ * @brief Initialize MEOS library
  */
 void
 meos_initialize(void)
@@ -645,8 +650,9 @@ meos_initialize(void)
   return;
 }
 
-/*
- * Free the timezone cache
+/**
+ * @ingroup meos_setup
+ * @brief Free the timezone cache
  */
 void
 meos_finalize(void)

--- a/meos/src/temporal/temporal_rtree.c
+++ b/meos/src/temporal/temporal_rtree.c
@@ -846,6 +846,7 @@ rtree_create(MeosType bboxtype)
 }
 
 /**
+ * @ingroup meos_misc
  * @brief Creates an RTree index for integer spans
  * @return RTree initialized
  */
@@ -856,6 +857,7 @@ rtree_create_intspan()
 }
 
 /**
+ * @ingroup meos_misc
  * @brief Creates an RTree index for big integer spans
  * @return RTree initialized
  */
@@ -866,6 +868,7 @@ rtree_create_bigintspan()
 }
 
 /**
+ * @ingroup meos_misc
  * @brief Creates an RTree index for float spans
  * @return RTree initialized
  */
@@ -876,6 +879,7 @@ rtree_create_floatspan()
 }
 
 /**
+ * @ingroup meos_misc
  * @brief Creates an RTree index for temporal boxes
  * @return RTree initialized
  */
@@ -886,6 +890,7 @@ rtree_create_datespan()
 }
 
 /**
+ * @ingroup meos_misc
  * @brief Creates an RTree index for temporal boxes
  * @return RTree initialized
  */
@@ -896,6 +901,7 @@ rtree_create_tstzspan()
 }
 
 /**
+ * @ingroup meos_misc
  * @brief Creates an RTree index for temporal boxes
  * @return RTree initialized
  */
@@ -906,6 +912,7 @@ rtree_create_tbox()
 }
 
 /**
+ * @ingroup meos_misc
  * @brief Creates an RTree index for spatiotemporal boxes
  * @return RTree initialized
  */

--- a/pgtypes/common/fe_memutils.c
+++ b/pgtypes/common/fe_memutils.c
@@ -31,6 +31,10 @@ static meos_malloc_fn  MEOS_MALLOC  = &malloc;
 static meos_realloc_fn MEOS_REALLOC = &realloc;
 static meos_free_fn    MEOS_FREE    = &free;
 
+/**
+ * @ingroup meos_setup
+ * @brief Install the memory allocator hooks used by MEOS
+ */
 void
 meos_initialize_allocator(meos_malloc_fn malloc_fn,
 	meos_realloc_fn realloc_fn, meos_free_fn free_fn)

--- a/pgtypes/timezone/pgtz.c
+++ b/pgtypes/timezone/pgtz.c
@@ -500,8 +500,9 @@ meos_default_timezone(void)  /* MEOS: probe the OS default zone once, process-wi
   return meos_default_tz_name[0] ? meos_default_tz_name : NULL;
 }
 
-/*
- * Initialize timezone cache
+/**
+ * @ingroup meos_setup
+ * @brief Initialize timezone cache
  */
 void
 meos_initialize_timezone(const char *tz_str)
@@ -541,8 +542,9 @@ meos_ensure_timezone(void)
   return;
 }
 
-/*
- * Free the timezone cache
+/**
+ * @ingroup meos_setup
+ * @brief Free the timezone cache
  */
 void
 meos_finalize_timezone(void)

--- a/pgtypes/utils/pg_locale.c
+++ b/pgtypes/utils/pg_locale.c
@@ -1268,8 +1268,9 @@ create_pg_locale(Oid collid)
   return result;
 }
 
-/*
- * Initialize default_locale with database locale settings.
+/**
+ * @ingroup meos_setup
+ * @brief Initialize default_locale with database locale settings.
  */
 void
 meos_initialize_collation(void)
@@ -1293,8 +1294,9 @@ meos_initialize_collation(void)
   return;
 }
 
-/*
- * Free default_locale 
+/**
+ * @ingroup meos_setup
+ * @brief Free default_locale
  */
 void
 meos_finalize_collation(void)


### PR DESCRIPTION
Several essential public functions carry no `@ingroup` doxygen tag (or a
MobilityDB group that the MEOS catalog scanner does not capture, since it keys on
`meos_*` groups), so the catalog records no group for them. Under the pure-group
api rule this classifies them as internal, which would hide them from the
language bindings.

This tags each with its MEOS group so the catalog exposes it as public and the
bindings generate it:

- the MEOS lifecycle and local-cache setup functions — `meos_initialize`,
  `meos_finalize`, and the allocator, collation, timezone, PROJ-SRS, and ways
  cache initialize/finalize functions (the TLS per-thread caches MEOS keeps
  independently of PostgreSQL, so it runs multithreaded) — under `meos_setup`;
- the error-number and RTree-index helpers under `meos_misc`;
- the H3, QUADBIN, raster, geo, JSON, and pgpointcloud static operations under
  their family groups;
- and two raster functions that carry `mobilitydb_raster` (a MobilityDB group)
  though they are MEOS functions, corrected to `meos_raster_base_accessor`.

The PostGIS-internal prototypes in the vendored `meos_transform.h`
(`lwproj_lookup`, `spheroid_init_from_srid`, `srid_check_latlong`,
`srid_is_latlong`) stay untagged, so they remain internal.

The change is limited to doxygen comments; there is no code change. Every group
referenced is defined.
