### PR TITLE
Skip the value scan for a disjoint bounding box in the tcbuffer value restriction

### DIFF
--- a/meos/src/cbuffer/tcbuffer.c
+++ b/meos/src/cbuffer/tcbuffer.c
@@ -49,6 +49,7 @@
 #include "geo/tgeo_tempspatialrels.h"
 #include "geo/tspatial_parser.h"
 #include "cbuffer/cbuffer.h"
+#include "cbuffer/tcbuffer_boxops.h"
 #include "cbuffer/tcbuffer_tempspatialrels.h"
 
 /*****************************************************************************
@@ -1261,6 +1262,17 @@ tcbuffer_restrict_cbuffer(const Temporal *temp, const Cbuffer *cb, bool atfunc)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tcbuffer_cbuffer(temp, cb))
     return NULL;
+
+  /* Bounding box test: a temporal circular buffer equals a circular buffer
+   * value only at the instants where their positions and radii coincide, so a
+   * non-overlap of the (radius-aware) bounding boxes leaves no matching
+   * instant. Mirrors the geometry and box restrictions. */
+  STBox box1, box2;
+  tspatial_set_stbox(temp, &box1);
+  cbuffer_set_stbox(cb, &box2);
+  if (! overlaps_stbox_stbox(&box1, &box2))
+    return atfunc ? NULL : temporal_copy(temp);
+
   return temporal_restrict_value(temp, PointerGetDatum(cb), atfunc);
 }
 


### PR DESCRIPTION
`tcbuffer_restrict_cbuffer` (the `atValue`/`minusValue` restriction of a temporal circular buffer by a circular-buffer value) went straight to the generic value scan, which walks every instant comparing its circular buffer to the target — even when the temporal circular buffer's bounding box does not meet the value at all. The geometry restriction (`tcbuffer_restrict_geom`) and the spatiotemporal-box restriction (`tcbuffer_restrict_stbox`) already reject that case in constant time; the value restriction did not.

This adds the same bounding-box test:

```c
STBox box1, box2;
tspatial_set_stbox(temp, &box1);
cbuffer_set_stbox(cb, &box2);
if (! overlaps_stbox_stbox(&box1, &box2))
  return atfunc ? NULL : temporal_copy(temp);
```

A temporal circular buffer equals a circular-buffer value only at the instants where their positions and radii coincide, so a non-overlap of the radius-aware bounding boxes leaves no matching instant: `at` returns NULL and `minus` returns the whole value, which is exactly what the value scan produces. Overlapping cases still run the exact scan, so the result is unchanged.

`202_tcbuffer` passes with no expected-output change.
