### PR TITLE
Complete the tpcpoint accessor surface

### DIFF
--- a/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
+++ b/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
@@ -213,6 +213,16 @@ CREATE FUNCTION memSize(tpcpoint)
   AS 'MODULE_PATHNAME', 'Temporal_mem_size'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION getValue(tpcpoint)
+  RETURNS pcpoint
+  AS 'MODULE_PATHNAME', 'Tinstant_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION getTimestamp(tpcpoint)
+  RETURNS timestamptz
+  AS 'MODULE_PATHNAME', 'Tinstant_timestamptz'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE FUNCTION startValue(tpcpoint)
   RETURNS pcpoint
   AS 'MODULE_PATHNAME', 'Temporal_start_value'
@@ -291,6 +301,51 @@ CREATE FUNCTION timestampN(tpcpoint, integer)
 CREATE FUNCTION numTimestamps(tpcpoint)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Temporal_num_timestamps'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION lowerInc(tpcpoint)
+  RETURNS bool
+  AS 'MODULE_PATHNAME', 'Temporal_lower_inc'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION upperInc(tpcpoint)
+  RETURNS bool
+  AS 'MODULE_PATHNAME', 'Temporal_upper_inc'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION timestamps(tpcpoint)
+  RETURNS timestamptz[]
+  AS 'MODULE_PATHNAME', 'Temporal_timestamps'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION numSequences(tpcpoint)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Temporal_num_sequences'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION startSequence(tpcpoint)
+  RETURNS tpcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_start_sequence'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION endSequence(tpcpoint)
+  RETURNS tpcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_end_sequence'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION sequenceN(tpcpoint, integer)
+  RETURNS tpcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_sequence_n'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION sequences(tpcpoint)
+  RETURNS tpcpoint[]
+  AS 'MODULE_PATHNAME', 'Temporal_sequences'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION segments(tpcpoint)
+  RETURNS tpcpoint[]
+  AS 'MODULE_PATHNAME', 'Temporal_segments'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 -- Type-specific accessor

--- a/mobilitydb/test/pointcloud/expected/420_tpcpoint.test.out
+++ b/mobilitydb/test/pointcloud/expected/420_tpcpoint.test.out
@@ -24,6 +24,18 @@ SELECT tempBasetype(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '20
  pcpoint
 (1 row)
 
+SELECT getValue(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
+              getvalue              
+------------------------------------
+ 0101000000640000006400000064000000
+(1 row)
+
+SELECT getTimestamp(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
+         gettimestamp         
+------------------------------
+ Mon Jan 01 00:00:00 2024 PST
+(1 row)
+
 SELECT numInstants(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
  numinstants 
 -------------
@@ -76,6 +88,60 @@ SELECT pcid(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::flo
  pcid 
 ------
     1
+(1 row)
+
+SELECT lowerInc(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]));
+ lowerinc 
+----------
+ t
+(1 row)
+
+SELECT upperInc(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]));
+ upperinc 
+----------
+ t
+(1 row)
+
+SELECT timestamps(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]));
+                                           timestamps                                           
+------------------------------------------------------------------------------------------------
+ {"Mon Jan 01 00:00:00 2024 PST","Tue Jan 02 00:00:00 2024 PST","Wed Jan 03 00:00:00 2024 PST"}
+(1 row)
+
+SELECT numSequences(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]));
+ numsequences 
+--------------
+            1
+(1 row)
+
+SELECT startSequence(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]));
+                                                                                                              startsequence                                                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [5C00000001000000640000006400000064000000010000@Mon Jan 01 00:00:00 2024 PST, 5C00000001000000C8000000C8000000C8000000010000@Tue Jan 02 00:00:00 2024 PST, 5C000000010000002C0100002C0100002C010000010000@Wed Jan 03 00:00:00 2024 PST]
+(1 row)
+
+SELECT endSequence(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]));
+                                                                                                               endsequence                                                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [5C00000001000000640000006400000064000000000008@Mon Jan 01 00:00:00 2024 PST, 5C00000001000000C8000000C8000000C8000000000008@Tue Jan 02 00:00:00 2024 PST, 5C000000010000002C0100002C0100002C010000000008@Wed Jan 03 00:00:00 2024 PST]
+(1 row)
+
+SELECT sequenceN(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]), 1);
+                                                                                                                sequencen                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [5C00000001000000640000006400000064000000000008@Mon Jan 01 00:00:00 2024 PST, 5C00000001000000C8000000C8000000C8000000000008@Tue Jan 02 00:00:00 2024 PST, 5C000000010000002C0100002C0100002C010000000008@Wed Jan 03 00:00:00 2024 PST]
+(1 row)
+
+SELECT sequences(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]));
+                                                                                                                  sequences                                                                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"[5C00000001000000640000006400000064000000000008@Mon Jan 01 00:00:00 2024 PST, 5C00000001000000C8000000C8000000C8000000000008@Tue Jan 02 00:00:00 2024 PST, 5C000000010000002C0100002C0100002C010000000008@Wed Jan 03 00:00:00 2024 PST]"}
+(1 row)
+
+SELECT segments(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]));
+                                                                                                                                                                                                  segments                                                                                                                                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"[5C0000000100000064000000640000006400000004B102@Mon Jan 01 00:00:00 2024 PST, 5C0000000100000064000000640000006400000004B102@Tue Jan 02 00:00:00 2024 PST)","[5C00000001000000C8000000C8000000C800000004B102@Tue Jan 02 00:00:00 2024 PST, 5C00000001000000C8000000C8000000C800000004B102@Wed Jan 03 00:00:00 2024 PST)","[5C000000010000002C0100002C0100002C01000004B102@Wed Jan 03 00:00:00 2024 PST]"}
 (1 row)
 
 SELECT numInstants((tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz))::tgeompoint);

--- a/mobilitydb/test/pointcloud/queries/420_tpcpoint.test.sql
+++ b/mobilitydb/test/pointcloud/queries/420_tpcpoint.test.sql
@@ -54,6 +54,8 @@ SELECT tpcpoint(pcpoint(1, 1.0, 1.0, 1.0), '2024-01-01'::timestamptz)::text =
 
 SELECT pcid(:inst1);
 SELECT tempBasetype(:inst1);
+SELECT getValue(:inst1);
+SELECT getTimestamp(:inst1);
 SELECT numInstants(:inst1);
 SELECT numInstants(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]));
 SELECT numInstants(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3], 'discrete'));
@@ -73,6 +75,15 @@ SELECT startValue(getZ(:inst1));
 SELECT startTimestamp(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]));
 SELECT endTimestamp(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]));
 SELECT pcid(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]));
+SELECT lowerInc(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]));
+SELECT upperInc(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]));
+SELECT timestamps(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]));
+SELECT numSequences(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]));
+SELECT startSequence(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]));
+SELECT endSequence(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]));
+SELECT sequenceN(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]), 1);
+SELECT sequences(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]));
+SELECT segments(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]));
 
 -------------------------------------------------------------------------------
 -- Cast to tgeompoint preserves XYZ + timestamps


### PR DESCRIPTION
tpcpoint inherits the `Temporal<T>` accessor surface, but its hand-written block omits `getValue`, `getTimestamp`, `lowerInc`, `upperInc`, `timestamps`, `numSequences`, `startSequence`, `endSequence`, `sequenceN`, `sequences`, and `segments`.

This adds them, each backed by the family-agnostic `Tinstant_*` / `Temporal_*` symbols every other temporal family uses, with a test for each.