### PR TITLE
Correct the api attribution of public functions in subdir headers

### DIFF
--- a/meos/CMakeLists.txt
+++ b/meos/CMakeLists.txt
@@ -334,6 +334,9 @@ if(MEOS)
   install(
     FILES "${CMAKE_SOURCE_DIR}/meos/include/meos_tls.h"
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+  install(
+    FILES "${CMAKE_SOURCE_DIR}/meos/include/meos_cellindex.h"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
   # Files from ${CMAKE_SOURCE_DIR}
 

--- a/meos/include/meos_cellindex.h
+++ b/meos/include/meos_cellindex.h
@@ -1,0 +1,62 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Public MEOS API for temporal cell index types
+ *
+ * The temporal cell index (tcellindex) is the abstract temporal type shared by
+ * the concrete cell index families (tquadbin, th3index): its accessors are
+ * declared once here and overload on the concrete temporal type in the SQL and
+ * binding layers.
+ */
+
+#ifndef __MEOS_CELLINDEX_H__
+#define __MEOS_CELLINDEX_H__
+
+#include <stdbool.h>
+#include <stdint.h>
+/* MEOS */
+#include <meos.h>
+
+/*****************************************************************************
+ * Accessor functions for temporal cell indices
+ *****************************************************************************/
+
+extern Temporal *tcellindex_get_resolution(const Temporal *temp);
+extern Temporal *tcellindex_is_valid_cell(const Temporal *temp);
+extern Temporal *tcellindex_cell_to_parent(const Temporal *temp,
+  int32 resolution);
+extern Temporal *tcellindex_cell_to_point(const Temporal *temp);
+extern Temporal *tcellindex_cell_to_boundary(const Temporal *temp);
+extern Temporal *tcellindex_cell_area(const Temporal *temp);
+
+/*****************************************************************************/
+
+#endif /* __MEOS_CELLINDEX_H__ */

--- a/meos/include/temporal/tcellindex.h
+++ b/meos/include/temporal/tcellindex.h
@@ -74,6 +74,9 @@
 #include <postgres.h>
 /* MEOS */
 #include <meos.h>
+/* The public generic accessors (tcellindex_get_resolution, …) are declared in
+ * the umbrella header so bindings pick them up from it. */
+#include <meos_cellindex.h>
 #include "temporal/meos_catalog.h"
 
 /*****************************************************************************
@@ -136,12 +139,6 @@ extern const DggsCellOps *dggs_cellops(MeosType temptype);
  * these once and overload on the concrete temporal type.
  *****************************************************************************/
 
-extern Temporal *tcellindex_get_resolution(const Temporal *temp);
-extern Temporal *tcellindex_is_valid_cell(const Temporal *temp);
-extern Temporal *tcellindex_cell_to_parent(const Temporal *temp,
-  int32 resolution);
-extern Temporal *tcellindex_cell_to_point(const Temporal *temp);
-extern Temporal *tcellindex_cell_to_boundary(const Temporal *temp);
-extern Temporal *tcellindex_cell_area(const Temporal *temp);
+/* Declared in the umbrella header <meos_cellindex.h> (included above). */
 
 #endif /* __TCELLINDEX_H__ */

--- a/meos/src/cbuffer/tcbuffer_spatialfuncs.c
+++ b/meos/src/cbuffer/tcbuffer_spatialfuncs.c
@@ -534,7 +534,7 @@ tcbufferseq_linear_traversed_area(const TSequence *seq, GSERIALIZED **result)
 }
 
 /**
- * @ingroup meos_cbuffer_spatial_accessor
+ * @ingroup meos_internal_cbuffer_spatial_accessor
  * @brief Return the traversed area of a temporal circular buffer sequence
  * @param[in] seq Temporal circular buffer
  * @param[in] unary_union True when the traversed area is a single geometry

--- a/meos/src/rgeo/trgeo_seq.c
+++ b/meos/src/rgeo/trgeo_seq.c
@@ -322,7 +322,7 @@ trgeoseq_make_free_exp(const GSERIALIZED *geom, TInstant **instants, int count,
 }
 
 /**
- * @ingroup meos_rgeo_constructor
+ * @ingroup meos_internal_rgeo_constructor
  * @brief Construct a temporal sequence from an array of temporal instants
  * and free the array and the instants after the creation
  * @param[in] geom Reference geometry

--- a/meos/src/rgeo/trgeo_seqset.c
+++ b/meos/src/rgeo/trgeo_seqset.c
@@ -249,7 +249,7 @@ trgeometryseqset_make(const GSERIALIZED *geom, TSequence **sequences, int count,
 }
 
 /**
- * @ingroup meos_rgeo_constructor
+ * @ingroup meos_internal_rgeo_constructor
  * @brief Construct a temporal sequence set from an array of temporal
  * sequences and free the array and the sequences after the creation
  * @param[in] geom Reference geometry

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -2332,7 +2332,7 @@ temporal_min_instant(const Temporal *temp)
 }
 
 /**
- * @ingroup meos_temporal_accessor
+ * @ingroup meos_internal_temporal_accessor
  * @brief Return a copy of the instant with maximum base value of a temporal
  * value
  * @param[in] temp Temporal value


### PR DESCRIPTION
Several functions are public API but declared only in internal or subdir
headers, so a binding that mirrors the public umbrella headers cannot reach them
and the catalog attributes them outside the public umbrella surface. This
corrects the attribution of two such groups:

- Retag four internal helpers as internal: `tcbufferseq_traversed_area` (the
  TSequence-level helper behind the public `tcbuffer_traversed_area`),
  `trgeoseq_make_free` and `trgeoseqset_make_free` (the free-on-error
  constructor helpers behind the public `trgeometryseq_make` /
  `trgeometryseqset_make`), and `temporal_max_inst_p` (an internal pointer
  accessor). They carry a public `@ingroup` although their siblings are internal.
- Add the public umbrella header `meos_cellindex.h` for the six temporal
  cell-index accessors (`tcellindex_get_resolution` and siblings), moved from the
  internal `temporal/tcellindex.h` and re-included there so its internal
  consumers keep the declarations, and installed alongside the other public
  headers.

The change is limited to doxygen comments and header organization; there is no
code change.
