### PR TITLE
Fix swapped @csqlfn tags on the ge and gt comparisons of spans and temporals

### DIFF
--- a/meos/src/temporal/span.c
+++ b/meos/src/temporal/span.c
@@ -1682,7 +1682,7 @@ span_cmp(const Span *s1, const Span *s2)
 /**
  * @ingroup meos_setspan_comp
  * @brief Return true if the first span is less than the second one
- * @param[in] s1,s2 Sets
+ * @param[in] s1,s2 Spans
  * @csqlfn #Span_lt()
  */
 inline bool
@@ -1694,7 +1694,7 @@ span_lt(const Span *s1, const Span *s2)
 /**
  * @ingroup meos_setspan_comp
  * @brief Return true if the first span is less than or equal to the second one
- * @param[in] s1,s2 Sets
+ * @param[in] s1,s2 Spans
  * @csqlfn #Span_le()
  */
 inline bool
@@ -1707,8 +1707,8 @@ span_le(const Span *s1, const Span *s2)
  * @ingroup meos_setspan_comp
  * @brief Return true if the first span is greater than or equal to the second
  * one
- * @param[in] s1,s2 Sets
- * @csqlfn #Span_gt()
+ * @param[in] s1,s2 Spans
+ * @csqlfn #Span_ge()
  */
 inline bool
 span_ge(const Span *s1, const Span *s2)
@@ -1719,8 +1719,8 @@ span_ge(const Span *s1, const Span *s2)
 /**
  * @ingroup meos_setspan_comp
  * @brief Return true if the first span is greater than the second one
- * @param[in] s1,s2 Sets
- * @csqlfn #Span_ge()
+ * @param[in] s1,s2 Spans
+ * @csqlfn #Span_gt()
  */
 inline bool
 span_gt(const Span *s1, const Span *s2)

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -3670,7 +3670,7 @@ temporal_le(const Temporal *temp1, const Temporal *temp2)
  * @brief Return true if the first temporal value is greater than or equal to
  * the second one
  * @param[in] temp1,temp2 Temporal values
- * @csqlfn #Temporal_gt()
+ * @csqlfn #Temporal_ge()
  */
 inline bool
 temporal_ge(const Temporal *temp1, const Temporal *temp2)
@@ -3682,7 +3682,7 @@ temporal_ge(const Temporal *temp1, const Temporal *temp2)
  * @ingroup meos_temporal_comp_trad
  * @brief Return true if the first temporal value is greater than the second one
  * @param[in] temp1,temp2 Temporal values
- * @csqlfn #Temporal_ge()
+ * @csqlfn #Temporal_gt()
  */
 inline bool
 temporal_gt(const Temporal *temp1, const Temporal *temp2)


### PR DESCRIPTION
The @csqlfn cross-reference tags on the greater-than comparisons of spans and
temporal values are swapped. `span_ge` and `temporal_ge` compute `cmp >= 0` but
point at `#Span_gt()`/`#Temporal_gt()`, while `span_gt` and `temporal_gt`
compute `cmp > 0` but point at `#Span_ge()`/`#Temporal_ge()`.

The MEOS-API catalog derives each MEOS function`s SQL name from its `@csqlfn`
wrapper, so the catalog records the `>=` functions as `gt` and the `>` functions
as `ge`. Every catalog-generated binding then emits `ge`/`>=` and `gt`/`>` with
their computations swapped, across spans (`intspan`, `floatspan`, `tstzspan`, …)
and the entire temporal comparison surface (`tint`, `tfloat`, `ttext`,
`tgeompoint`, …). The PostgreSQL extension is unaffected: its own wrappers bind
the correct `CREATE FUNCTION` names directly.

Point `span_ge`/`temporal_ge` at `#Span_ge()`/`#Temporal_ge()` and
`span_gt`/`temporal_gt` at `#Span_gt()`/`#Temporal_gt()`, matching the
`CREATE FUNCTION ge`/`gt` bindings in the `.in.sql` files and the correct sibling
families `set.c` and `spanset.c`, which carry the correct tags. Also correct the
`@param` description on the four span comparison functions to read `Spans`
rather than `Sets`.

Doc-comment only; no code or behaviour change in MEOS-C or the extension.