### PR TITLE
Restrict the tcbuffer to an stbox without rebuilding it from projections

### DIFF
--- a/meos/src/cbuffer/tcbuffer.c
+++ b/meos/src/cbuffer/tcbuffer.c
@@ -1330,17 +1330,21 @@ tcbuffer_restrict_stbox(const Temporal *temp, const STBox *box,
   if (! overlaps_stbox_stbox(&box1, box))
     return atfunc ? NULL : temporal_copy(temp);
 
+  /* Restrict the centre trajectory to the box with the same semantics as
+   * before (for both at and minus), then slice the original buffer to the
+   * sub-periods that survive instead of rebuilding it from its point and
+   * radius projections with tcbuffer_make: restricting the temporal circular
+   * buffer to those periods keeps the radius without reconstructing the value,
+   * and interpolates the same point and radius at any box-boundary crossing. */
   Temporal *tpoint = tcbuffer_to_tgeompoint(temp);
-  Temporal *tfloat = tcbuffer_to_tfloat(temp);
   Temporal *tpoint_rest = tgeo_restrict_stbox(tpoint, box, NULL, atfunc);
   pfree(tpoint);
   if (! tpoint_rest)
-  {
-    pfree(tfloat);
     return NULL;
-  }
-  Temporal *result = tcbuffer_make(tpoint_rest, tfloat);
-  pfree(tfloat); pfree(tpoint_rest);
+  SpanSet *ss = temporal_time(tpoint_rest);
+  pfree(tpoint_rest);
+  Temporal *result = temporal_restrict_tstzspanset(temp, ss, REST_AT);
+  pfree(ss);
   return result;
 }
 


### PR DESCRIPTION
`tcbuffer_restrict_stbox` (the `atStbox`/`minusStbox` restriction of a temporal circular buffer by a spatiotemporal box) converted the buffer to its centre point and radius, restricted the point to the box, and reassembled a new temporal circular buffer with `tcbuffer_make`:

```c
Temporal *tpoint = tcbuffer_to_tgeompoint(temp);
Temporal *tfloat = tcbuffer_to_tfloat(temp);
Temporal *tpoint_rest = tgeo_restrict_stbox(tpoint, box, NULL, atfunc);
result = tcbuffer_make(tpoint_rest, tfloat);   // rebuild the whole buffer
```

The reconstruction is unnecessary: the original buffer already carries the point and the radius, so once the box restriction has determined which sub-periods survive, slicing the original to those periods reproduces the same result. This restricts the centre trajectory to the box as before (keeping the same `at`/`minus` semantics, including the space-and-time combined restriction), then slices with `temporal_restrict_tstzspanset`, mirroring the existing `tcbuffer_restrict_geom` path:

```c
Temporal *tpoint = tcbuffer_to_tgeompoint(temp);
Temporal *tpoint_rest = tgeo_restrict_stbox(tpoint, box, NULL, atfunc);
SpanSet *ss = temporal_time(tpoint_rest);
result = temporal_restrict_tstzspanset(temp, ss, REST_AT);
```

Slicing the original interpolates the same point and radius at any box-boundary crossing that the restriction introduces, so the result is unchanged; the radius-aware bounding-box short-circuit (`at` → NULL, `minus` → the whole value on a disjoint box) is retained. On a real AIS acoustic dataset (SF1, ~2790-instant trajectories) this drops `minusStbox` by roughly 10–15% by not rebuilding the mostly-surviving buffer per pair.

`202_tcbuffer` passes with no expected-output change.
