### PR TITLE
Add the meos_version and meos_full_version library accessors

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -415,6 +415,15 @@ extern void meos_set_ways_csv(const char* path);
 extern void meos_initialize(void);
 extern void meos_finalize(void);
 
+/*****************************************************************************
+ * Version functions
+ *****************************************************************************/
+
+extern char *meos_version(void);
+extern char *meos_full_version(void);
+extern char *mobilitydb_version(void);
+extern char *mobilitydb_full_version(void);
+
 /*============================================================================
  * Functions for set and span types
   ===========================================================================*/

--- a/meos/include/temporal/temporal.h
+++ b/meos/include/temporal/temporal.h
@@ -435,11 +435,6 @@ extern void *temporal_bbox_ptr(const Temporal *temp);
 extern bool intersection_temporal_temporal(const Temporal *temp1,
 const Temporal *temp2, SyncMode mode, Temporal **inter1, Temporal **inter2);
 
-/* Version functions */
-
-extern char *mobilitydb_version(void);
-extern char *mobilitydb_full_version(void);
-
 /* Transformations */
 
 extern datum_func2 round_fn(MeosType basetype);

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -762,22 +762,20 @@ intersection_temporal_temporal(const Temporal *temp1, const Temporal *temp2,
 #define MOBDB_VERSION_STR_MAXLEN 256
 /**
  * @ingroup meos_misc
- * @brief Return the version of the MobilityDB extension
- * @csqlfn #Mobilitydb_version()
+ * @brief Return the version of the MEOS library
  */
 char *
-mobilitydb_version(void)
+meos_version(void)
 {
   return MOBILITYDB_VERSION_STRING;
 }
 
 /**
  * @ingroup meos_misc
- * @brief Return the versions of the MobilityDB extension and its dependencies
- * @csqlfn #Mobilitydb_full_version()
+ * @brief Return the versions of the MEOS library and its dependencies
  */
 char *
-mobilitydb_full_version(void)
+meos_full_version(void)
 {
   const char *proj_vers;
 #if POSTGIS_PROJ_VERSION < 61
@@ -797,6 +795,28 @@ mobilitydb_full_version(void)
     GSL_VERSION_STRING);
   result[len] = '\0';
   return result;
+}
+
+/**
+ * @ingroup meos_misc
+ * @brief Return the version of the MobilityDB extension
+ * @csqlfn #Mobilitydb_version()
+ */
+char *
+mobilitydb_version(void)
+{
+  return meos_version();
+}
+
+/**
+ * @ingroup meos_misc
+ * @brief Return the versions of the MobilityDB extension and its dependencies
+ * @csqlfn #Mobilitydb_full_version()
+ */
+char *
+mobilitydb_full_version(void)
+{
+  return meos_full_version();
 }
 
 /*****************************************************************************


### PR DESCRIPTION
The library reports its version only through `mobilitydb_version()` and `mobilitydb_full_version()`, whose names describe the PostgreSQL extension rather than the MEOS library that the C API and its bindings link against. A program that uses MEOS standalone has no version accessor named for the library it calls.

Add `meos_version()` and `meos_full_version()` as the canonical library version accessors, holding the version-string logic, and redefine `mobilitydb_version()` and `mobilitydb_full_version()` as thin forwarders to them so the PostgreSQL SQL functions keep their names and behaviour with the logic living in one place. Declare all four in the `meos.h` umbrella so bindings reach them from the public header (the `mobilitydb_*` pair moves there from `temporal/temporal.h`).

Documentation-and-signature only on the public surface; no behaviour change in MEOS-C or the extension.