### PR TITLE
Name the temporal subtype transformations with as instead of to

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -1419,9 +1419,9 @@ extern Temporal *temporal_scale_time(const Temporal *temp, const Interval *durat
 extern Temporal *temporal_set_interp(const Temporal *temp, interpType interp);
 extern Temporal *temporal_shift_scale_time(const Temporal *temp, const Interval *shift, const Interval *duration);
 extern Temporal *temporal_shift_time(const Temporal *temp, const Interval *shift);
-extern TInstant *temporal_to_tinstant(const Temporal *temp);
-extern TSequence *temporal_to_tsequence(const Temporal *temp, interpType interp);
-extern TSequenceSet *temporal_to_tsequenceset(const Temporal *temp, interpType interp);
+extern TInstant *temporal_as_tinstant(const Temporal *temp);
+extern TSequence *temporal_as_tsequence(const Temporal *temp, interpType interp);
+extern TSequenceSet *temporal_as_tsequenceset(const Temporal *temp, interpType interp);
 extern Temporal *tfloat_ceil(const Temporal *temp);
 extern Temporal *tfloat_degrees(const Temporal *temp, bool normalize);
 extern Temporal *tfloat_floor(const Temporal *temp);

--- a/meos/src/rgeo/trgeo_seqset.c
+++ b/meos/src/rgeo/trgeo_seqset.c
@@ -433,7 +433,7 @@ trgeoseq_to_tsequenceset(const TSequence *seq)
  * @ingroup meos_internal_rgeo_transf
  * @brief Return a temporal sequence transformed into a temporal sequence set
  * @param[in] seq Temporal sequence
- * @csqlfn #Temporal_to_tsequenceset()
+ * @csqlfn #Temporal_as_tsequenceset()
  */
 TSequenceSet *
 trgeoseq_to_tsequenceset_free(TSequence *seq)

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -1658,10 +1658,10 @@ temporal_restart(Temporal *temp, int count)
  * @ingroup meos_temporal_transf
  * @brief Return a temporal value transformed to a temporal instant
  * @param[in] temp Temporal value
- * @csqlfn #Temporal_to_tinstant()
+ * @csqlfn #Temporal_as_tinstant()
  */
 TInstant *
-temporal_to_tinstant(const Temporal *temp)
+temporal_as_tinstant(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(temp, NULL);
@@ -1683,7 +1683,7 @@ temporal_to_tinstant(const Temporal *temp)
  * @brief Return a temporal value transformed to a temporal sequence
  * @param[in] temp Temporal value
  * @param[in] interp Interpolation
- * @csqlfn #Temporal_to_tsequence()
+ * @csqlfn #Temporal_as_tsequence()
  */
 TSequence *
 temporal_tsequence(const Temporal *temp, interpType interp)
@@ -1725,10 +1725,10 @@ temporal_tsequence(const Temporal *temp, interpType interp)
  * @brief Return a temporal value transformed to a temporal sequence
  * @param[in] temp Temporal value
  * @param[in] interp Interpolation
- * @csqlfn #Temporal_to_tsequence()
+ * @csqlfn #Temporal_as_tsequence()
  */
 TSequence *
-temporal_to_tsequence(const Temporal *temp, interpType interp)
+temporal_as_tsequence(const Temporal *temp, interpType interp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(temp, NULL);
@@ -1749,7 +1749,7 @@ temporal_to_tsequence(const Temporal *temp, interpType interp)
  * @brief Return a temporal value transformed to a temporal sequence set
  * @param[in] temp Temporal value
  * @param[in] interp Interpolation
- * @csqlfn #Temporal_to_tsequenceset()
+ * @csqlfn #Temporal_as_tsequenceset()
  */
 TSequenceSet *
 temporal_tsequenceset(const Temporal *temp, interpType interp)
@@ -1785,10 +1785,10 @@ temporal_tsequenceset(const Temporal *temp, interpType interp)
  * @brief Return a temporal value transformed to a temporal sequence set
  * @param[in] temp Temporal value
  * @param[in] interp Interpolation
- * @csqlfn #Temporal_to_tsequenceset()
+ * @csqlfn #Temporal_as_tsequenceset()
  */
 TSequenceSet *
-temporal_to_tsequenceset(const Temporal *temp, interpType interp)
+temporal_as_tsequenceset(const Temporal *temp, interpType interp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(temp, NULL);

--- a/meos/src/temporal/tinstant.c
+++ b/meos/src/temporal/tinstant.c
@@ -498,7 +498,7 @@ tinstant_after_timestamptz(const TInstant *inst, TimestampTz t, bool strict)
  * @ingroup meos_internal_temporal_transf
  * @brief Return a temporal sequence transformed into a temporal instant
  * @param[in] seq Temporal sequence
- * @csqlfn #Temporal_to_tinstant()
+ * @csqlfn #Temporal_as_tinstant()
  */
 TInstant *
 tsequence_to_tinstant(const TSequence *seq)
@@ -517,7 +517,7 @@ tsequence_to_tinstant(const TSequence *seq)
  * @ingroup meos_internal_temporal_transf
  * @brief Return a temporal sequence set transformed into a temporal instant
  * @param[in] ss Temporal sequence set
- * @csqlfn #Temporal_to_tinstant()
+ * @csqlfn #Temporal_as_tinstant()
  */
 TInstant *
 tsequenceset_to_tinstant(const TSequenceSet *ss)

--- a/meos/src/temporal/tsequence.c
+++ b/meos/src/temporal/tsequence.c
@@ -1317,7 +1317,7 @@ tsequence_subseq(const TSequence *seq, int from, int to, bool lower_inc,
  * @brief Return a temporal instant transformed into a temporal sequence
  * @param[in] inst Temporal instant
  * @param[in] interp Interpolation
- * @csqlfn #Temporal_to_tsequence()
+ * @csqlfn #Temporal_as_tsequence()
  */
 TSequence *
 tinstant_to_tsequence(const TInstant *inst, interpType interp)
@@ -1332,7 +1332,7 @@ tinstant_to_tsequence(const TInstant *inst, interpType interp)
  * @brief Return a temporal instant transformed into a temporal sequence
  * @param[in] inst Temporal instant
  * @param[in] interp Interpolation
- * @csqlfn #Temporal_to_tsequence()
+ * @csqlfn #Temporal_as_tsequence()
  */
 TSequence *
 tinstant_to_tsequence_free(TInstant *inst, interpType interp)

--- a/meos/src/temporal/tsequenceset.c
+++ b/meos/src/temporal/tsequenceset.c
@@ -1443,7 +1443,7 @@ tsequenceset_restart(TSequenceSet *ss, int count)
  * @brief Return a temporal instant transformed into a temporal sequence set
  * @param[in] inst Temporal instant
  * @param[in] interp Interpolation
- * @csqlfn #Temporal_to_tsequenceset()
+ * @csqlfn #Temporal_as_tsequenceset()
  */
 TSequenceSet *
 tinstant_to_tsequenceset(const TInstant *inst, interpType interp)
@@ -1470,7 +1470,7 @@ tdiscseq_to_tsequenceset(const TSequence *seq, interpType interp)
  * @ingroup meos_internal_temporal_transf
  * @brief Return a temporal sequence transformed into a temporal sequence set
  * @param[in] seq Temporal sequence
- * @csqlfn #Temporal_to_tsequenceset()
+ * @csqlfn #Temporal_as_tsequenceset()
  */
 TSequenceSet *
 tsequence_to_tsequenceset(const TSequence *seq)
@@ -1490,7 +1490,7 @@ tsequence_to_tsequenceset(const TSequence *seq)
  * @ingroup meos_internal_temporal_transf
  * @brief Return a temporal sequence transformed into a temporal sequence set
  * @param[in] seq Temporal sequence
- * @csqlfn #Temporal_to_tsequenceset()
+ * @csqlfn #Temporal_as_tsequenceset()
  */
 TSequenceSet *
 tsequence_to_tsequenceset_free(TSequence *seq)
@@ -1506,7 +1506,7 @@ tsequence_to_tsequenceset_free(TSequence *seq)
  * @brief Return a temporal sequence transformed into a temporal sequence set
  * @param[in] seq Temporal sequence
  * @param[in] interp Interpolation
- * @csqlfn #Temporal_to_tsequenceset()
+ * @csqlfn #Temporal_as_tsequenceset()
  */
 TSequenceSet *
 tsequence_to_tsequenceset_interp(const TSequence *seq, interpType interp)
@@ -1530,7 +1530,7 @@ tsequence_to_tsequenceset_interp(const TSequence *seq, interpType interp)
  * @brief Return a temporal sequence set transformed into a temporal sequence
  * value
  * @param[in] ss Temporal sequence set
- * @csqlfn #Temporal_to_tsequence()
+ * @csqlfn #Temporal_as_tsequence()
  */
 TSequence *
 tsequenceset_to_tsequence(const TSequenceSet *ss)

--- a/meos/test/temporal_test.c
+++ b/meos/test/temporal_test.c
@@ -1341,22 +1341,22 @@ int main(void)
   printf("temporal_shift_time(%s, %s): %s\n", tfloat1_out, interv1_out, char_result);
   free(tfloat_result); free(char_result);
 
-  /* TInstant *temporal_to_tinstant(const Temporal *temp); */
-  tfloatinst_result = temporal_to_tinstant((Temporal *) tfloatinst1);
+  /* TInstant *temporal_as_tinstant(const Temporal *temp); */
+  tfloatinst_result = temporal_as_tinstant((Temporal *) tfloatinst1);
   char_result = tfloat_out((Temporal *) tfloatinst_result, 6);
-  printf("temporal_to_tinstant(%s): %s\n", tfloat1_out, char_result);
+  printf("temporal_as_tinstant(%s): %s\n", tfloat1_out, char_result);
   free(tfloatinst_result); free(char_result);
 
-  /* TSequence *temporal_to_tsequence(const Temporal *temp, interpType interp); */
-  tfloatseq_result = temporal_to_tsequence((Temporal *) tfloatinst1, LINEAR);
+  /* TSequence *temporal_as_tsequence(const Temporal *temp, interpType interp); */
+  tfloatseq_result = temporal_as_tsequence((Temporal *) tfloatinst1, LINEAR);
   char_result = tfloat_out((Temporal *) tfloatseq_result, 6);
-  printf("temporal_to_tsequence(%s, LINEAR): %s\n", tfloat1_out, char_result);
+  printf("temporal_as_tsequence(%s, LINEAR): %s\n", tfloat1_out, char_result);
   free(tfloatseq_result); free(char_result);
 
-  /* TSequenceSet *temporal_to_tsequenceset(const Temporal *temp, interpType interp); */
-  tfloatseqset_result = temporal_to_tsequenceset(tfloat1, LINEAR);
+  /* TSequenceSet *temporal_as_tsequenceset(const Temporal *temp, interpType interp); */
+  tfloatseqset_result = temporal_as_tsequenceset(tfloat1, LINEAR);
   char_result = tfloat_out((Temporal *) tfloatseqset_result, 6);
-  printf("temporal_to_tsequenceset(%s, LINEAR): %s\n", tfloat1_out, char_result);
+  printf("temporal_as_tsequenceset(%s, LINEAR): %s\n", tfloat1_out, char_result);
   free(tfloatseqset_result); free(char_result);
 
   /* Temporal *tfloat_ceil(const Temporal *temp); */

--- a/mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
+++ b/mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
@@ -433,17 +433,17 @@ CREATE FUNCTION expand(tcbuffer, float)
 
 CREATE FUNCTION tcbufferInst(tcbuffer)
   RETURNS tcbuffer
-  AS 'MODULE_PATHNAME', 'Temporal_to_tinstant'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tinstant'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- The function is not strict
 CREATE FUNCTION tcbufferSeq(tcbuffer, text DEFAULT NULL)
   RETURNS tcbuffer
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequence'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequence'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 -- The function is not strict
 CREATE FUNCTION tcbufferSeqSet(tcbuffer, text DEFAULT NULL)
   RETURNS tcbuffer
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequenceset'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequenceset'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE FUNCTION setInterp(tcbuffer, text)

--- a/mobilitydb/sql/geo/052_tgeo.in.sql
+++ b/mobilitydb/sql/geo/052_tgeo.in.sql
@@ -226,32 +226,32 @@ CREATE CAST (tgeography AS tstzspan) WITH FUNCTION timeSpan(tgeography);
 
 CREATE FUNCTION tgeometryInst(tgeometry)
   RETURNS tgeometry
-  AS 'MODULE_PATHNAME', 'Temporal_to_tinstant'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tinstant'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- The function is not strict
 CREATE FUNCTION tgeometrySeq(tgeometry, text DEFAULT NULL)
   RETURNS tgeometry
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequence'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequence'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 -- The function is not strict
 CREATE FUNCTION tgeometrySeqSet(tgeometry, text DEFAULT NULL)
   RETURNS tgeometry
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequenceset'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequenceset'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE FUNCTION tgeographyInst(tgeography)
   RETURNS tgeography
-  AS 'MODULE_PATHNAME', 'Temporal_to_tinstant'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tinstant'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- The function is not strict
 CREATE FUNCTION tgeographySeq(tgeography, text DEFAULT NULL)
   RETURNS tgeography
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequence'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequence'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 -- The function is not strict
 CREATE FUNCTION tgeographySeqSet(tgeography, text DEFAULT NULL)
   RETURNS tgeography
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequenceset'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequenceset'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE FUNCTION setInterp(tgeometry, text)

--- a/mobilitydb/sql/geo/052_tpoint.in.sql
+++ b/mobilitydb/sql/geo/052_tpoint.in.sql
@@ -218,32 +218,32 @@ CREATE CAST (tgeogpoint AS tstzspan) WITH FUNCTION timeSpan(tgeogpoint);
 
 CREATE FUNCTION tgeompointInst(tgeompoint)
   RETURNS tgeompoint
-  AS 'MODULE_PATHNAME', 'Temporal_to_tinstant'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tinstant'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- The function is not strict
 CREATE FUNCTION tgeompointSeq(tgeompoint, text DEFAULT NULL)
   RETURNS tgeompoint
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequence'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequence'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 -- The function is not strict
 CREATE FUNCTION tgeompointSeqSet(tgeompoint, text DEFAULT NULL)
   RETURNS tgeompoint
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequenceset'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequenceset'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE FUNCTION tgeogpointInst(tgeogpoint)
   RETURNS tgeogpoint
-  AS 'MODULE_PATHNAME', 'Temporal_to_tinstant'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tinstant'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- The function is not strict
 CREATE FUNCTION tgeogpointSeq(tgeogpoint, text DEFAULT NULL)
   RETURNS tgeogpoint
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequence'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequence'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 -- The function is not strict
 CREATE FUNCTION tgeogpointSeqSet(tgeogpoint, text DEFAULT NULL)
   RETURNS tgeogpoint
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequenceset'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequenceset'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE FUNCTION setInterp(tgeompoint, text)

--- a/mobilitydb/sql/h3/253_th3index.in.sql
+++ b/mobilitydb/sql/h3/253_th3index.in.sql
@@ -226,17 +226,17 @@ CREATE CAST (th3index AS tstzspan) WITH FUNCTION timeSpan(th3index);
 
 CREATE FUNCTION th3indexInst(th3index)
   RETURNS th3index
-  AS 'MODULE_PATHNAME', 'Temporal_to_tinstant'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tinstant'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- The function is not strict
 CREATE FUNCTION th3indexSeq(th3index, text DEFAULT NULL)
   RETURNS th3index
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequence'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequence'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 -- The function is not strict
 CREATE FUNCTION th3indexSeqSet(th3index, text DEFAULT NULL)
   RETURNS th3index
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequenceset'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequenceset'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE FUNCTION setInterp(th3index, text)

--- a/mobilitydb/sql/json/452_tjsonb.in.sql
+++ b/mobilitydb/sql/json/452_tjsonb.in.sql
@@ -373,17 +373,17 @@ CREATE FUNCTION segments(tjsonb)
 
 CREATE FUNCTION tjsonbInst(tjsonb)
   RETURNS tjsonb
-  AS 'MODULE_PATHNAME', 'Temporal_to_tinstant'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tinstant'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- The function is not strict
 CREATE FUNCTION tjsonbSeq(tjsonb, text DEFAULT NULL)
   RETURNS tjsonb
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequence'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequence'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 -- The function is not strict
 CREATE FUNCTION tjsonbSeqSet(tjsonb)
   RETURNS tjsonb
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequenceset'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequenceset'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE FUNCTION setInterp(tjsonb, text)

--- a/mobilitydb/sql/npoint/302_tnpoint.in.sql
+++ b/mobilitydb/sql/npoint/302_tnpoint.in.sql
@@ -187,17 +187,17 @@ CREATE CAST (tnpoint AS tstzspan) WITH FUNCTION timeSpan(tnpoint);
 
 CREATE FUNCTION tnpointInst(tnpoint)
   RETURNS tnpoint
-  AS 'MODULE_PATHNAME', 'Temporal_to_tinstant'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tinstant'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- The function is not strict
 CREATE FUNCTION tnpointSeq(tnpoint, text DEFAULT NULL)
   RETURNS tnpoint
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequence'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequence'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 -- The function is not strict
 CREATE FUNCTION tnpointSeqSet(tnpoint, text DEFAULT NULL)
   RETURNS tnpoint
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequenceset'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequenceset'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE FUNCTION setInterp(tnpoint, text)

--- a/mobilitydb/sql/pose/102_tpose.in.sql
+++ b/mobilitydb/sql/pose/102_tpose.in.sql
@@ -455,17 +455,17 @@ CREATE FUNCTION segments(tpose)
 
 CREATE FUNCTION tposeInst(tpose)
   RETURNS tpose
-  AS 'MODULE_PATHNAME', 'Temporal_to_tinstant'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tinstant'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- The function is not strict
 CREATE FUNCTION tposeSeq(tpose, text DEFAULT NULL)
   RETURNS tpose
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequence'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequence'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 -- The function is not strict
 CREATE FUNCTION tposeSeqSet(tpose, text DEFAULT NULL)
   RETURNS tpose
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequenceset'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequenceset'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE FUNCTION setInterp(tpose, text)

--- a/mobilitydb/sql/quadbin/353_tquadbin.in.sql
+++ b/mobilitydb/sql/quadbin/353_tquadbin.in.sql
@@ -186,17 +186,17 @@ CREATE CAST (tquadbin AS tstzspan) WITH FUNCTION timeSpan(tquadbin);
 
 CREATE FUNCTION tquadbinInst(tquadbin)
   RETURNS tquadbin
-  AS 'MODULE_PATHNAME', 'Temporal_to_tinstant'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tinstant'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- The function is not strict
 CREATE FUNCTION tquadbinSeq(tquadbin, text DEFAULT NULL)
   RETURNS tquadbin
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequence'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequence'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 -- The function is not strict
 CREATE FUNCTION tquadbinSeqSet(tquadbin, text DEFAULT NULL)
   RETURNS tquadbin
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequenceset'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequenceset'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE FUNCTION setInterp(tquadbin, text)

--- a/mobilitydb/sql/temporal/022_temporal.in.sql
+++ b/mobilitydb/sql/temporal/022_temporal.in.sql
@@ -1309,67 +1309,67 @@ CREATE FUNCTION unnest(ttext)
 
 CREATE FUNCTION tboolInst(tbool)
   RETURNS tbool
-  AS 'MODULE_PATHNAME', 'Temporal_to_tinstant'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tinstant'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION tintInst(tint)
   RETURNS tint
-  AS 'MODULE_PATHNAME', 'Temporal_to_tinstant'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tinstant'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION tbigintInst(tbigint)
   RETURNS tbigint
-  AS 'MODULE_PATHNAME', 'Temporal_to_tinstant'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tinstant'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION tfloatInst(tfloat)
   RETURNS tfloat
-  AS 'MODULE_PATHNAME', 'Temporal_to_tinstant'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tinstant'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION ttextInst(ttext)
   RETURNS ttext
-  AS 'MODULE_PATHNAME', 'Temporal_to_tinstant'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tinstant'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 -- The function is not strict
 CREATE FUNCTION tboolSeq(tbool, text DEFAULT NULL)
   RETURNS tbool
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequence'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequence'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION tintSeq(tint, text DEFAULT NULL)
   RETURNS tint
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequence'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequence'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION tbigintSeq(tbigint, text DEFAULT NULL)
   RETURNS tbigint
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequence'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequence'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION tfloatSeq(tfloat, text DEFAULT NULL)
   RETURNS tfloat
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequence'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequence'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION ttextSeq(ttext, text DEFAULT NULL)
   RETURNS ttext
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequence'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequence'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 -- The function is not strict
 CREATE FUNCTION tboolSeqSet(tbool)
   RETURNS tbool
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequenceset'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequenceset'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION tintSeqSet(tint)
   RETURNS tint
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequenceset'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequenceset'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION tbigintSeqSet(tbigint)
   RETURNS tbigint
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequenceset'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequenceset'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION tfloatSeqSet(tfloat, text DEFAULT NULL)
   RETURNS tfloat
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequenceset'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequenceset'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION ttextSeqSet(ttext)
   RETURNS ttext
-  AS 'MODULE_PATHNAME', 'Temporal_to_tsequenceset'
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequenceset'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE FUNCTION setInterp(tbool, text)

--- a/mobilitydb/src/temporal/temporal.c
+++ b/mobilitydb/src/temporal/temporal.c
@@ -1681,24 +1681,24 @@ Temporalarr_round(PG_FUNCTION_ARGS)
   PG_RETURN_ARRAYTYPE_P(result);
 }
 
-PGDLLEXPORT Datum Temporal_to_tinstant(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Temporal_to_tinstant);
+PGDLLEXPORT Datum Temporal_as_tinstant(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Temporal_as_tinstant);
 /**
  * @ingroup mobilitydb_temporal_transf
  * @brief Return a temporal value transformed to a temporal instant
  * @sqlfn tintInst(), tfloatInst(), ...
  */
 Datum
-Temporal_to_tinstant(PG_FUNCTION_ARGS)
+Temporal_as_tinstant(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
-  TInstant *result = temporal_to_tinstant(temp);
+  TInstant *result = temporal_as_tinstant(temp);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_TINSTANT_P(result);
 }
 
-PGDLLEXPORT Datum Temporal_to_tsequence(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Temporal_to_tsequence);
+PGDLLEXPORT Datum Temporal_as_tsequence(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Temporal_as_tsequence);
 /**
  * @ingroup mobilitydb_temporal_transf
  * @brief Return a temporal value transformed to a temporal sequence
@@ -1706,7 +1706,7 @@ PG_FUNCTION_INFO_V1(Temporal_to_tsequence);
  * @sqlfn tintSeq(), tfloatSeq(), ...
  */
 Datum
-Temporal_to_tsequence(PG_FUNCTION_ARGS)
+Temporal_as_tsequence(PG_FUNCTION_ARGS)
 {
   if (PG_ARGISNULL(0))
     PG_RETURN_NULL();
@@ -1715,13 +1715,13 @@ Temporal_to_tsequence(PG_FUNCTION_ARGS)
   interpType interp = INTERP_NONE;
   if (PG_NARGS() > 1 && ! PG_ARGISNULL(1))
     interp = input_interp_string(fcinfo, 1);
-  TSequence *result = temporal_to_tsequence(temp, interp);
+  TSequence *result = temporal_as_tsequence(temp, interp);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_TSEQUENCE_P(result);
 }
 
-PGDLLEXPORT Datum Temporal_to_tsequenceset(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Temporal_to_tsequenceset);
+PGDLLEXPORT Datum Temporal_as_tsequenceset(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Temporal_as_tsequenceset);
 /**
  * @ingroup mobilitydb_temporal_transf
  * @brief Return a temporal value transformed to a temporal sequence set
@@ -1729,7 +1729,7 @@ PG_FUNCTION_INFO_V1(Temporal_to_tsequenceset);
  * @sqlfn tintSeqSet(), tfloatSeqSet(), ...
  */
 Datum
-Temporal_to_tsequenceset(PG_FUNCTION_ARGS)
+Temporal_as_tsequenceset(PG_FUNCTION_ARGS)
 {
   if (PG_ARGISNULL(0))
     PG_RETURN_NULL();
@@ -1738,7 +1738,7 @@ Temporal_to_tsequenceset(PG_FUNCTION_ARGS)
   interpType interp = INTERP_NONE;
   if (PG_NARGS() > 1 && ! PG_ARGISNULL(1))
     interp = input_interp_string(fcinfo, 1);
-  TSequenceSet *result = temporal_to_tsequenceset(temp, interp);
+  TSequenceSet *result = temporal_as_tsequenceset(temp, interp);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_TSEQUENCESET_P(result);
 }


### PR DESCRIPTION
The functions that return a temporal value reshaped into a specific temporal subtype are named `temporal_to_tinstant`, `temporal_to_tsequence` and `temporal_to_tsequenceset`. The `to` spelling belongs to a type cast (`type1_to_type2`, surfacing as the target-type constructor and the `::` operator), but `tinstant`, `tsequence` and `tsequenceset` are subtypes of a single temporal type, not distinct types, so selecting a representation is a transformation and there is no cast to a subtype. This also matches the existing output family (`temporal_as_text`, `temporal_as_hexwkb`, ...), where `as` reads as "express this value as X".

Rename the three functions to `temporal_as_tinstant`, `temporal_as_tsequence` and `temporal_as_tsequenceset`, and rename the PostgreSQL wrappers to match. The SQL function names (`tintSeq`, `tfloatSeq`, ...) are unchanged; only the C symbols and their `@csqlfn` references move from `to` to `as`. The type casts (`temporal_to_tstzspan`, ...) keep the `to` spelling.