### PR TITLE
Remove the unsound bounding-box index support of the always-disjoint predicate

### DIFF
--- a/mobilitydb/sql/geo/070_tgeo_spatialrels.in.sql
+++ b/mobilitydb/sql/geo/070_tgeo_spatialrels.in.sql
@@ -207,23 +207,19 @@ CREATE FUNCTION eDisjoint(tgeography, tgeography)
 CREATE FUNCTION aDisjoint(geometry, tgeometry)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adisjoint_geo_tgeo'
-  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION aDisjoint(tgeometry, geometry)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adisjoint_tgeo_geo'
-  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION aDisjoint(tgeometry, tgeometry)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adisjoint_tgeo_tgeo'
-  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION aDisjoint(geography, tgeography)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adisjoint_geo_tgeo'
-  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION aDisjoint(tgeography, geography)
   RETURNS boolean
@@ -232,7 +228,6 @@ CREATE FUNCTION aDisjoint(tgeography, geography)
 CREATE FUNCTION aDisjoint(tgeography, tgeography)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adisjoint_tgeo_tgeo'
-  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************

--- a/mobilitydb/sql/geo/070_tpoint_spatialrels.in.sql
+++ b/mobilitydb/sql/geo/070_tpoint_spatialrels.in.sql
@@ -149,23 +149,19 @@ CREATE FUNCTION eDisjoint(tgeogpoint, tgeogpoint)
 CREATE FUNCTION aDisjoint(geometry, tgeompoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adisjoint_geo_tgeo'
-  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION aDisjoint(tgeompoint, geometry)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adisjoint_tgeo_geo'
-  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION aDisjoint(tgeompoint, tgeompoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adisjoint_tgeo_tgeo'
-  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION aDisjoint(geography, tgeogpoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adisjoint_geo_tgeo'
-  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION aDisjoint(tgeogpoint, geography)
   RETURNS boolean
@@ -174,7 +170,6 @@ CREATE FUNCTION aDisjoint(tgeogpoint, geography)
 CREATE FUNCTION aDisjoint(tgeogpoint, tgeogpoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adisjoint_tgeo_tgeo'
-  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************


### PR DESCRIPTION
`aDisjoint` (always disjoint) carried `SUPPORT tspatial_supportfn`, which at plan time rewrites the predicate into the overlap index condition `col && stbox(arg)` and keeps the exact predicate only as a recheck filter. That prefilter is unsound for disjoint: a temporal value that is *always* disjoint from the argument typically has a bounding box that does **not** overlap it, so the index scan prunes exactly the pairs the predicate should return.

With a GiST index on the trajectory:

```
WHERE aDisjoint(trip, geom)
  Index Cond: (trip && stbox(geom))     -- prunes the far-apart (always-disjoint) pairs
  Filter: adisjoint(trip, geom)
```

returns far fewer rows than a sequential scan of the same data (on one dataset, 473 instead of 9980), and the result depends on whether the planner chooses the index.

Its ever counterpart `eDisjoint` carries no such support — it relies on the sound SQL bounding-box short-circuit `NOT(a && b) OR _edisjoint(a, b)`, and the temporal circular buffer disjoint predicates are plain functions with no index support. This drops the `SUPPORT` clause from `aDisjoint` so it is evaluated exactly, consistent with those.

The predicate itself is untouched, so its results are unchanged; only the unsound index rewrite is removed. There is no expected-output change.
