### PR TITLE
Name the trgeometry subtype transformations uniformly with as

### DIFF
--- a/meos/include/meos_rgeo.h
+++ b/meos/include/meos_rgeo.h
@@ -146,7 +146,9 @@ extern Temporal *trgeometry_delete_tstzspan(const Temporal *temp, const Span *s,
 extern Temporal *trgeometry_delete_tstzspanset(const Temporal *temp, const SpanSet *ss, bool connect);
 extern Temporal *trgeometry_round(const Temporal *temp, int maxdd);
 extern Temporal *trgeometry_set_interp(const Temporal *temp, interpType interp);
-extern TInstant *trgeometry_to_tinstant(const Temporal *temp);
+extern TInstant *trgeometry_as_tinstant(const Temporal *temp);
+extern TSequence *trgeometry_as_tsequence(const Temporal *temp, const char *interp_str);
+extern TSequenceSet *trgeometry_as_tsequenceset(const Temporal *temp, const char *interp_str);
 
 /*****************************************************************************
  * Restriction functions

--- a/meos/include/rgeo/trgeo_seqset.h
+++ b/meos/include/rgeo/trgeo_seqset.h
@@ -59,10 +59,6 @@ extern TSequenceSet *trgeoseqset_make_free(const GSERIALIZED *geom,
 /* Transformation functions */
 
 extern TSequence *trgeoseqset_to_tsequence(const TSequenceSet *ss);
-extern TSequence *trgeo_to_tsequence(const Temporal *temp,
-  const char *interp_str);
-extern TSequenceSet *trgeo_to_tsequenceset(const Temporal *temp,
-  const char *interp_str);
 
 /*****************************************************************************/
 

--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -941,10 +941,10 @@ trgeometry_round(const Temporal *temp, int maxdd)
  * @ingroup meos_rgeo_transf
  * @brief Return a temporal rigid geometry transformed to a temporal instant
  * @param[in] temp Temporal rigid geometry
- * @csqlfn #Trgeometry_to_tinstant()
+ * @csqlfn #Trgeometry_as_tinstant()
  */
 TInstant *
-trgeometry_to_tinstant(const Temporal *temp)
+trgeometry_as_tinstant(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
 
@@ -967,10 +967,10 @@ trgeometry_to_tinstant(const Temporal *temp)
  * @brief Return a temporal rigid geometry transformed to a temporal sequence
  * @param[in] temp Temporal rigid geometry
  * @param[in] interp_str Interpolation string, may be NULL
- * @csqlfn #Trgeometry_to_tsequence()
+ * @csqlfn #Trgeometry_as_tsequence()
  */
 TSequence *
-trgeo_to_tsequence(const Temporal *temp, const char *interp_str)
+trgeometry_as_tsequence(const Temporal *temp, const char *interp_str)
 {
   /* Ensure the validity of the arguments */
 
@@ -999,10 +999,10 @@ trgeo_to_tsequence(const Temporal *temp, const char *interp_str)
  * @brief Return a temporal rigid geometry transformed to a temporal sequence set
  * @param[in] temp Temporal rigid geometry
  * @param[in] interp_str Interpolation string, may be @p NULL
- * @csqlfn #Trgeometry_to_tsequenceset()
+ * @csqlfn #Trgeometry_as_tsequenceset()
  */
 TSequenceSet *
-trgeo_to_tsequenceset(const Temporal *temp, const char *interp_str)
+trgeometry_as_tsequenceset(const Temporal *temp, const char *interp_str)
 {
   /* Ensure the validity of the arguments */
 

--- a/mobilitydb/sql/rgeo/150_trgeo.in.sql
+++ b/mobilitydb/sql/rgeo/150_trgeo.in.sql
@@ -428,17 +428,17 @@ CREATE FUNCTION segments(trgeometry)
 
 CREATE FUNCTION trgeometryInst(trgeometry)
   RETURNS trgeometry
-  AS 'MODULE_PATHNAME', 'Trgeometry_to_tinstant'
+  AS 'MODULE_PATHNAME', 'Trgeometry_as_tinstant'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- The function is not strict
 CREATE FUNCTION trgeometrySeq(trgeometry, text DEFAULT NULL)
   RETURNS trgeometry
-  AS 'MODULE_PATHNAME', 'Trgeometry_to_tsequence'
+  AS 'MODULE_PATHNAME', 'Trgeometry_as_tsequence'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 -- The function is not strict
 CREATE FUNCTION trgeometrySeqSet(trgeometry, text DEFAULT NULL)
   RETURNS trgeometry
-  AS 'MODULE_PATHNAME', 'Trgeometry_to_tsequenceset'
+  AS 'MODULE_PATHNAME', 'Trgeometry_as_tsequenceset'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE FUNCTION setInterp(trgeometry, text)

--- a/mobilitydb/src/rgeo/trgeo.c
+++ b/mobilitydb/src/rgeo/trgeo.c
@@ -580,24 +580,24 @@ Trgeometry_value_at_timestamptz(PG_FUNCTION_ARGS)
  * Transformation Functions
  *****************************************************************************/
 
-PGDLLEXPORT Datum Trgeometry_to_tinstant(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Trgeometry_to_tinstant);
+PGDLLEXPORT Datum Trgeometry_as_tinstant(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Trgeometry_as_tinstant);
 /**
  * @ingroup mobilitydb_rgeo_transf
  * @brief Return a temporal rigid geometry transformed into a temporal instant
  * @sqlfn trgeometryInst()
  */
 Datum
-Trgeometry_to_tinstant(PG_FUNCTION_ARGS)
+Trgeometry_as_tinstant(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
-  TInstant *result = trgeometry_to_tinstant(temp);
+  TInstant *result = trgeometry_as_tinstant(temp);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_TINSTANT_P(result);
 }
 
-PGDLLEXPORT Datum Trgeometry_to_tsequence(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Trgeometry_to_tsequence);
+PGDLLEXPORT Datum Trgeometry_as_tsequence(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Trgeometry_as_tsequence);
 /**
  * @ingroup mobilitydb_rgeo_transf
  * @brief Return a temporal rigid geometry transformed into a temporal sequence
@@ -605,7 +605,7 @@ PG_FUNCTION_INFO_V1(Trgeometry_to_tsequence);
  * @sqlfn trgeometrySeq()
  */
 Datum
-Trgeometry_to_tsequence(PG_FUNCTION_ARGS)
+Trgeometry_as_tsequence(PG_FUNCTION_ARGS)
 {
   if (PG_ARGISNULL(0))
     PG_RETURN_NULL();
@@ -617,13 +617,13 @@ Trgeometry_to_tsequence(PG_FUNCTION_ARGS)
     text *interp_txt = PG_GETARG_TEXT_P(1);
     interp_str = text_to_cstring(interp_txt);
   }
-  TSequence *result = trgeo_to_tsequence(temp, interp_str);
+  TSequence *result = trgeometry_as_tsequence(temp, interp_str);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_TSEQUENCE_P(result);
 }
 
-PGDLLEXPORT Datum Trgeometry_to_tsequenceset(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Trgeometry_to_tsequenceset);
+PGDLLEXPORT Datum Trgeometry_as_tsequenceset(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Trgeometry_as_tsequenceset);
 /**
  * @ingroup mobilitydb_rgeo_transf
  * @brief Return a temporal rigid geometry transformed into a temporal sequence
@@ -632,7 +632,7 @@ PG_FUNCTION_INFO_V1(Trgeometry_to_tsequenceset);
  * @sqlfn trgeometrySeqSet()
  */
 Datum
-Trgeometry_to_tsequenceset(PG_FUNCTION_ARGS)
+Trgeometry_as_tsequenceset(PG_FUNCTION_ARGS)
 {
   if (PG_ARGISNULL(0))
     PG_RETURN_NULL();
@@ -644,7 +644,7 @@ Trgeometry_to_tsequenceset(PG_FUNCTION_ARGS)
     text *interp_txt = PG_GETARG_TEXT_P(1);
     interp_str = text_to_cstring(interp_txt);
   }
-  TSequenceSet *result = trgeo_to_tsequenceset(temp, interp_str);
+  TSequenceSet *result = trgeometry_as_tsequenceset(temp, interp_str);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_TSEQUENCESET_P(result);
 }


### PR DESCRIPTION
The temporal rigid geometry exposes three subtype transformations with inconsistent names: `trgeometry_to_tinstant` uses the full type prefix and the public umbrella header, while `trgeo_to_tsequence` and `trgeo_to_tsequenceset` use the abbreviated internal prefix and are declared only in the subdir header. The `to` spelling also belongs to type casts, not to selecting a temporal subtype.

Rename the three to `trgeometry_as_tinstant`, `trgeometry_as_tsequence` and `trgeometry_as_tsequenceset`, matching the generic `temporal_as_*` transformations, and declare all three together in `meos_rgeo.h` so the public rigid-geometry API is reachable from the umbrella header like its siblings. The type casts `trgeometry_to_tgeometry`/`tpoint`/`tpose` keep the `to` spelling, and the internal subtype leaves keep their abbreviated `trgeo*` prefix. The SQL function names (`trgeometryInst`, `trgeometrySeq`, `trgeometrySeqSet`) are unchanged.