### PR TITLE
Generate the timeSpan accessor for all temporal families

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -758,6 +758,10 @@
 				</listitem>
 
 				<listitem>
+					<para><link linkend="ttype_timeSpan"><varname>timeSpan</varname></link>: Devuelve el período delimitador en el que se define el valor temporal</para>
+				</listitem>
+
+				<listitem>
 					<para><link linkend="ttype_startValue"><varname>startValue</varname>, <varname>endValue</varname>, <varname>valueN</varname></link>: Devuelve el valor inicial, final o enésimo</para>
 				</listitem>
 

--- a/doc/es/temporal_types_p1.xml
+++ b/doc/es/temporal_types_p1.xml
@@ -933,6 +933,18 @@ SELECT getTime(tfloat '{[1@2001-01-01, 1@2001-01-10), [12@2001-01-12, 12@2001-01
 </programlisting>
 			</listitem>
 
+			<listitem xml:id="ttype_timeSpan">
+				<indexterm significance="normal"><primary><varname>timeSpan</varname></primary></indexterm>
+				<para>Devuelve el período delimitador en el que se define el valor temporal</para>
+				<para><varname>timeSpan(ttype) → tstzspan</varname></para>
+				<programlisting language="sql" xml:space="preserve">
+SELECT timeSpan(tfloat '{1@2001-01-01, 2@2001-01-02, 1@2001-01-03}');
+-- [2001-01-01, 2001-01-03]
+SELECT timeSpan(tint '[1@2001-01-01, 1@2001-01-15)');
+-- [2001-01-01, 2001-01-15)
+</programlisting>
+			</listitem>
+
 			<listitem xml:id="ttype_startValue">
 				<indexterm significance="normal"><primary><varname>startValue</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>endValue</varname></primary></indexterm>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -737,6 +737,10 @@
 				</listitem>
 
 				<listitem>
+					<para><link linkend="ttype_timeSpan"><varname>timeSpan</varname></link>: Return the bounding period on which the temporal value is defined</para>
+				</listitem>
+
+				<listitem>
 					<para><link linkend="ttype_startValue"><varname>startValue</varname>, <varname>endValue</varname>, <varname>valueN</varname></link>: Return the start, end, or n-th value</para>
 				</listitem>
 

--- a/doc/temporal_types_p1.xml
+++ b/doc/temporal_types_p1.xml
@@ -925,6 +925,18 @@ SELECT getTime(tfloat '{[1@2001-01-01, 1@2001-01-10), [12@2001-01-12, 12@2001-01
 </programlisting>
 			</listitem>
 
+			<listitem xml:id="ttype_timeSpan">
+				<indexterm significance="normal"><primary><varname>timeSpan</varname></primary></indexterm>
+				<para>Return the bounding period on which a temporal value is defined</para>
+				<para><varname>timeSpan(ttype) → tstzspan</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT timeSpan(tfloat '{1@2001-01-01, 2@2001-01-02, 1@2001-01-03}');
+-- [2001-01-01, 2001-01-03]
+SELECT timeSpan(tint '[1@2001-01-01, 1@2001-01-15)');
+-- [2001-01-01, 2001-01-15)
+</programlisting>
+			</listitem>
+
 			<listitem xml:id="ttype_startValue">
 				<indexterm significance="normal"><primary><varname>startValue</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>endValue</varname></primary></indexterm>

--- a/mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
+++ b/mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
@@ -211,10 +211,6 @@ CREATE FUNCTION tcbuffer(tgeompoint, tfloat)
  * Conversions
  *****************************************************************************/
 
-CREATE FUNCTION timeSpan(tcbuffer)
-  RETURNS tstzspan
-  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION tgeompoint(tcbuffer)
   RETURNS tgeompoint
   AS 'MODULE_PATHNAME', 'Tcbuffer_to_tgeompoint'
@@ -233,7 +229,6 @@ CREATE FUNCTION tcbuffer(tgeometry)
   AS 'MODULE_PATHNAME', 'Tgeometry_to_tcbuffer'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE CAST (tcbuffer AS tstzspan) WITH FUNCTION timeSpan(tcbuffer);
 CREATE CAST (tcbuffer AS tgeompoint) WITH FUNCTION tgeompoint(tcbuffer);
 CREATE CAST (tcbuffer AS tfloat) WITH FUNCTION tfloat(tcbuffer);
 CREATE CAST (tgeompoint AS tcbuffer) WITH FUNCTION tcbuffer(tgeompoint);
@@ -301,6 +296,12 @@ CREATE FUNCTION getValues(tcbuffer)
 CREATE FUNCTION getTime(tcbuffer)
   RETURNS tstzspanset
   AS 'MODULE_PATHNAME', 'Temporal_time'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- timeSpan is the bounding period, the tstzspan extent of the temporal value
+CREATE FUNCTION timeSpan(tcbuffer)
+  RETURNS tstzspan
+  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION startValue(tcbuffer)
@@ -418,6 +419,9 @@ CREATE FUNCTION segments(tcbuffer)
   AS 'MODULE_PATHNAME', 'Temporal_segments'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- GENERATED-ACCESSORS-END cbuffer
+
+-- The tstzspan cast is backed by the generated timeSpan accessor.
+CREATE CAST (tcbuffer AS tstzspan) WITH FUNCTION timeSpan(tcbuffer);
 
 /*****************************************************************************
  * Transformation functions

--- a/mobilitydb/sql/h3/253_th3index.in.sql
+++ b/mobilitydb/sql/h3/253_th3index.in.sql
@@ -210,17 +210,6 @@ CREATE FUNCTION th3indexSeqSetGaps(th3index[], maxt interval DEFAULT NULL)
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 /******************************************************************************
- * Conversions
- ******************************************************************************/
-
-CREATE FUNCTION timeSpan(th3index)
-  RETURNS tstzspan
-  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-CREATE CAST (th3index AS tstzspan) WITH FUNCTION timeSpan(th3index);
-
-/******************************************************************************
  * Transformations
  ******************************************************************************/
 
@@ -333,6 +322,12 @@ CREATE FUNCTION getValues(th3index)
 CREATE FUNCTION getTime(th3index)
   RETURNS tstzspanset
   AS 'MODULE_PATHNAME', 'Temporal_time'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- timeSpan is the bounding period, the tstzspan extent of the temporal value
+CREATE FUNCTION timeSpan(th3index)
+  RETURNS tstzspan
+  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION startValue(th3index)
@@ -450,6 +445,9 @@ CREATE FUNCTION segments(th3index)
   AS 'MODULE_PATHNAME', 'Temporal_segments'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- GENERATED-ACCESSORS-END h3
+
+-- The tstzspan cast is backed by the generated timeSpan accessor.
+CREATE CAST (th3index AS tstzspan) WITH FUNCTION timeSpan(th3index);
 
 /******************************************************************************
  * Unnest

--- a/mobilitydb/sql/json/452_tjsonb.in.sql
+++ b/mobilitydb/sql/json/452_tjsonb.in.sql
@@ -178,13 +178,6 @@ CREATE FUNCTION tjsonbSeqSetGaps(tjsonb[], maxt interval DEFAULT NULL)
  * Conversions
  *****************************************************************************/
 
-CREATE FUNCTION timeSpan(tjsonb)
-  RETURNS tstzspan
-  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-CREATE CAST (tjsonb AS tstzspan) WITH FUNCTION timeSpan(tjsonb);
-
 CREATE FUNCTION ttext(tjsonb)
   RETURNS ttext
   AS 'MODULE_PATHNAME', 'Tjsonb_as_ttext'
@@ -247,6 +240,12 @@ CREATE FUNCTION getValues(tjsonb)
 CREATE FUNCTION getTime(tjsonb)
   RETURNS tstzspanset
   AS 'MODULE_PATHNAME', 'Temporal_time'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- timeSpan is the bounding period, the tstzspan extent of the temporal value
+CREATE FUNCTION timeSpan(tjsonb)
+  RETURNS tstzspan
+  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION startValue(tjsonb)
@@ -364,6 +363,9 @@ CREATE FUNCTION segments(tjsonb)
   AS 'MODULE_PATHNAME', 'Temporal_segments'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- GENERATED-ACCESSORS-END json
+
+-- The tstzspan cast is backed by the generated timeSpan accessor.
+CREATE CAST (tjsonb AS tstzspan) WITH FUNCTION timeSpan(tjsonb);
 
 /*****************************************************************************
  * Transformation functions

--- a/mobilitydb/sql/npoint/302_tnpoint.in.sql
+++ b/mobilitydb/sql/npoint/302_tnpoint.in.sql
@@ -172,14 +172,9 @@ CREATE FUNCTION tnpoint(tgeompoint)
   RETURNS tnpoint
   AS 'MODULE_PATHNAME', 'Tgeompoint_to_tnpoint'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION timeSpan(tnpoint)
-  RETURNS tstzspan
-  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE CAST (tnpoint AS tgeompoint) WITH FUNCTION tgeompoint(tnpoint);
 CREATE CAST (tgeompoint AS tnpoint) WITH FUNCTION tnpoint(tgeompoint);
-CREATE CAST (tnpoint AS tstzspan) WITH FUNCTION timeSpan(tnpoint);
 
 /******************************************************************************
  * Transformation functions
@@ -311,6 +306,12 @@ CREATE FUNCTION getTime(tnpoint)
   AS 'MODULE_PATHNAME', 'Temporal_time'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+-- timeSpan is the bounding period, the tstzspan extent of the temporal value
+CREATE FUNCTION timeSpan(tnpoint)
+  RETURNS tstzspan
+  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE FUNCTION startValue(tnpoint)
   RETURNS npoint
   AS 'MODULE_PATHNAME', 'Temporal_start_value'
@@ -426,6 +427,9 @@ CREATE FUNCTION segments(tnpoint)
   AS 'MODULE_PATHNAME', 'Temporal_segments'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- GENERATED-ACCESSORS-END npoint
+
+-- The tstzspan cast is backed by the generated timeSpan accessor.
+CREATE CAST (tnpoint AS tstzspan) WITH FUNCTION timeSpan(tnpoint);
 
 /*****************************************************************************
  * Transformation functions

--- a/mobilitydb/sql/pose/102_tpose.in.sql
+++ b/mobilitydb/sql/pose/102_tpose.in.sql
@@ -222,10 +222,6 @@ CREATE FUNCTION tposeSeqSetGaps(tpose[], maxt interval DEFAULT NULL,
  * Conversions
  ******************************************************************************/
 
-CREATE FUNCTION timeSpan(tpose)
-  RETURNS tstzspan
-  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION tgeompoint(tpose)
   RETURNS tgeompoint
   AS 'MODULE_PATHNAME', 'Tpose_to_tpoint'
@@ -235,7 +231,6 @@ CREATE FUNCTION tgeogpoint(tpose)
   AS 'MODULE_PATHNAME', 'Tpose_to_tpoint'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE CAST (tpose AS tstzspan) WITH FUNCTION timeSpan(tpose);
 CREATE CAST (tpose AS tgeompoint) WITH FUNCTION tgeompoint(tpose);
 CREATE CAST (tpose AS tgeogpoint) WITH FUNCTION tgeogpoint(tpose);
 
@@ -331,6 +326,12 @@ CREATE FUNCTION getValues(tpose)
 CREATE FUNCTION getTime(tpose)
   RETURNS tstzspanset
   AS 'MODULE_PATHNAME', 'Temporal_time'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- timeSpan is the bounding period, the tstzspan extent of the temporal value
+CREATE FUNCTION timeSpan(tpose)
+  RETURNS tstzspan
+  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION startValue(tpose)
@@ -448,6 +449,9 @@ CREATE FUNCTION segments(tpose)
   AS 'MODULE_PATHNAME', 'Temporal_segments'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- GENERATED-ACCESSORS-END pose
+
+-- The tstzspan cast is backed by the generated timeSpan accessor.
+CREATE CAST (tpose AS tstzspan) WITH FUNCTION timeSpan(tpose);
 
 /******************************************************************************
  * Transformation functions

--- a/mobilitydb/sql/quadbin/353_tquadbin.in.sql
+++ b/mobilitydb/sql/quadbin/353_tquadbin.in.sql
@@ -170,17 +170,6 @@ CREATE FUNCTION tquadbinSeqSetGaps(tquadbin[], maxt interval DEFAULT NULL)
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 /******************************************************************************
- * Conversions
- ******************************************************************************/
-
-CREATE FUNCTION timeSpan(tquadbin)
-  RETURNS tstzspan
-  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-CREATE CAST (tquadbin AS tstzspan) WITH FUNCTION timeSpan(tquadbin);
-
-/******************************************************************************
  * Transformations
  ******************************************************************************/
 
@@ -295,6 +284,12 @@ CREATE FUNCTION getValues(tquadbin)
 CREATE FUNCTION getTime(tquadbin)
   RETURNS tstzspanset
   AS 'MODULE_PATHNAME', 'Temporal_time'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- timeSpan is the bounding period, the tstzspan extent of the temporal value
+CREATE FUNCTION timeSpan(tquadbin)
+  RETURNS tstzspan
+  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION startValue(tquadbin)
@@ -412,6 +407,9 @@ CREATE FUNCTION segments(tquadbin)
   AS 'MODULE_PATHNAME', 'Temporal_segments'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- GENERATED-ACCESSORS-END quadbin
+
+-- The tstzspan cast is backed by the generated timeSpan accessor.
+CREATE CAST (tquadbin AS tstzspan) WITH FUNCTION timeSpan(tquadbin);
 
 /******************************************************************************
  * Unnest

--- a/mobilitydb/sql/rgeo/150_trgeo.in.sql
+++ b/mobilitydb/sql/rgeo/150_trgeo.in.sql
@@ -194,13 +194,6 @@ CREATE FUNCTION trgeometry(geometry, tpose)
  * Conversion functions
  ******************************************************************************/
 
-CREATE FUNCTION timeSpan(trgeometry)
-  RETURNS tstzspan
-  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-CREATE CAST (trgeometry AS tstzspan) WITH FUNCTION timeSpan(trgeometry);
-
 CREATE FUNCTION tpose(trgeometry)
   RETURNS tpose
   AS 'MODULE_PATHNAME', 'Trgeometry_to_tpose'
@@ -304,6 +297,12 @@ CREATE FUNCTION getValues(trgeometry)
 CREATE FUNCTION getTime(trgeometry)
   RETURNS tstzspanset
   AS 'MODULE_PATHNAME', 'Temporal_time'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- timeSpan is the bounding period, the tstzspan extent of the temporal value
+CREATE FUNCTION timeSpan(trgeometry)
+  RETURNS tstzspan
+  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION startValue(trgeometry)
@@ -421,6 +420,9 @@ CREATE FUNCTION segments(trgeometry)
   AS 'MODULE_PATHNAME', 'Temporal_segments'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- GENERATED-ACCESSORS-END rgeo
+
+-- The tstzspan cast is backed by the generated timeSpan accessor.
+CREATE CAST (trgeometry AS tstzspan) WITH FUNCTION timeSpan(trgeometry);
 
 /******************************************************************************
  * Transformation functions

--- a/mobilitydb/sql/temporal/022_temporal.in.sql
+++ b/mobilitydb/sql/temporal/022_temporal.in.sql
@@ -410,27 +410,6 @@ CREATE FUNCTION ttextSeqSetGaps(ttext[], maxt interval DEFAULT NULL)
  * Conversion functions
  ******************************************************************************/
 
-CREATE FUNCTION timeSpan(tbool)
-  RETURNS tstzspan
-  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION timeSpan(tint)
-  RETURNS tstzspan
-  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION timeSpan(tbigint)
-  RETURNS tstzspan
-  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION timeSpan(tfloat)
-  RETURNS tstzspan
-  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION timeSpan(ttext)
-  RETURNS tstzspan
-  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
 CREATE FUNCTION valueSpan(tint)
   RETURNS intspan
   AS 'MODULE_PATHNAME', 'Tnumber_to_span'
@@ -443,12 +422,6 @@ CREATE FUNCTION valueSpan(tfloat)
   RETURNS floatspan
   AS 'MODULE_PATHNAME', 'Tnumber_to_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-CREATE CAST (tbool AS tstzspan) WITH FUNCTION timeSpan(tbool);
-CREATE CAST (tint AS tstzspan) WITH FUNCTION timeSpan(tint);
-CREATE CAST (tbigint AS tstzspan) WITH FUNCTION timeSpan(tbigint);
-CREATE CAST (tfloat AS tstzspan) WITH FUNCTION timeSpan(tfloat);
-CREATE CAST (ttext AS tstzspan) WITH FUNCTION timeSpan(ttext);
 
 CREATE CAST (tint AS intspan) WITH FUNCTION valueSpan(tint);
 CREATE CAST (tbigint AS bigintspan) WITH FUNCTION valueSpan(tbigint);
@@ -698,6 +671,28 @@ CREATE FUNCTION getTime(tfloat)
 CREATE FUNCTION getTime(ttext)
   RETURNS tstzspanset
   AS 'MODULE_PATHNAME', 'Temporal_time'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- timeSpan is the bounding period, the tstzspan extent of the temporal value
+CREATE FUNCTION timeSpan(tbool)
+  RETURNS tstzspan
+  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION timeSpan(tint)
+  RETURNS tstzspan
+  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION timeSpan(tbigint)
+  RETURNS tstzspan
+  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION timeSpan(tfloat)
+  RETURNS tstzspan
+  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION timeSpan(ttext)
+  RETURNS tstzspan
+  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION startValue(tbool)
@@ -1264,6 +1259,13 @@ CREATE FUNCTION segments(ttext)
   AS 'MODULE_PATHNAME', 'Temporal_segments'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- GENERATED-ACCESSORS-END temporal
+
+-- The tstzspan cast is backed by the generated timeSpan accessor.
+CREATE CAST (tbool AS tstzspan) WITH FUNCTION timeSpan(tbool);
+CREATE CAST (tint AS tstzspan) WITH FUNCTION timeSpan(tint);
+CREATE CAST (tbigint AS tstzspan) WITH FUNCTION timeSpan(tbigint);
+CREATE CAST (tfloat AS tstzspan) WITH FUNCTION timeSpan(tfloat);
+CREATE CAST (ttext AS tstzspan) WITH FUNCTION timeSpan(ttext);
 
 /*****************************************************************************
  * Transform a temporal value to a set of records

--- a/tools/codegen/inherited/templates/accessors.sql.tmpl
+++ b/tools/codegen/inherited/templates/accessors.sql.tmpl
@@ -41,6 +41,12 @@ CREATE FUNCTION getTime({TEMP})
   AS 'MODULE_PATHNAME', 'Temporal_time'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+-- timeSpan is the bounding period, the tstzspan extent of the temporal value
+CREATE FUNCTION timeSpan({TEMP})
+  RETURNS tstzspan
+  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE FUNCTION startValue({TEMP})
   RETURNS {VALRET}
   AS 'MODULE_PATHNAME', '{VALSYM}_start_value'


### PR DESCRIPTION
`timeSpan(ttype)` returns the bounding period, the `tstzspan` extent of a temporal value — the bounding-box counterpart of `getTime`. It is part of the canonical `Temporal<T>` accessor surface, so it is emitted from the shared inherited-accessor template alongside the other accessors instead of being written by hand in each family.

- Add `timeSpan` to `tools/codegen/inherited/templates/accessors.sql.tmpl` right after `getTime`.
- Splice the generated accessor into every accessor family: temporal, cbuffer, npoint, pose, rgeo, json, quadbin, and h3. The per-type `tstzspan` cast is backed by the generated accessor.
- Document `timeSpan` in the Accessors section of the temporal-types chapter and in the reference summary, in English and Spanish.

The change is a pure relocation: the set of `timeSpan` functions and `tstzspan` casts is identical to before, so behavior is unchanged.
