### PR TITLE
Add the covers predicates to the spatial index support function

### DIFF
--- a/mobilitydb/src/temporal/temporal_supportfn.c
+++ b/mobilitydb/src/temporal/temporal_supportfn.c
@@ -84,6 +84,9 @@ enum TEMPORAL_FUNCTION_IDX
   AINTERSECTS_IDX                = 10,
   ATOUCHES_IDX                   = 11,
   ADWITHIN_IDX                   = 12,
+  /* Covers (appended to keep the existing indexes stable) */
+  ECOVERS_IDX                    = 13,
+  ACOVERS_IDX                    = 14,
 };
 
 static const int16 TNumberStrategies[] =
@@ -110,6 +113,9 @@ static const int16 TSpatialStrategies[] =
   [AINTERSECTS_IDX]               = RTOverlapStrategyNumber,
   [ATOUCHES_IDX]                  = RTOverlapStrategyNumber,
   [ADWITHIN_IDX]                  = RTOverlapStrategyNumber,
+  /* Covers */
+  [ECOVERS_IDX]                   = RTOverlapStrategyNumber,
+  [ACOVERS_IDX]                   = RTOverlapStrategyNumber,
 };
 
 /*
@@ -135,12 +141,14 @@ static const IndexableFunction TSpatialIndexableFunctions[] = {
   {"aeq", ALWAYS_EQ_IDX, 2, 0},
   /* Ever spatial relationships */
   {"econtains", ECONTAINS_IDX, 2, 0},
+  {"ecovers", ECOVERS_IDX, 2, 0},
   {"edisjoint", EDISJOINT_IDX, 2, 0},
   {"eintersects", EINTERSECTS_IDX, 2, 0},
   {"etouches", ETOUCHES_IDX, 2, 0},
   {"edwithin", EDWITHIN_IDX, 3, 3},
   /* Always spatial relationships */
   {"acontains", ACONTAINS_IDX, 2, 0},
+  {"acovers", ACOVERS_IDX, 2, 0},
   {"adisjoint", ADISJOINT_IDX, 2, 0},
   {"aintersects", AINTERSECTS_IDX, 2, 0},
   {"atouches", ATOUCHES_IDX, 2, 0},


### PR DESCRIPTION
`eCovers`/`aCovers` (temporal geometry, temporal circular buffer, temporal rigid geometry) already declare `SUPPORT tspatial_supportfn` in the spatial relationship SQL, but the support function's indexable-function metadata (`TSpatialIndexableFunctions` in `temporal_supportfn.c`) does not list them. `func_needs_index` therefore rejects the call, emitting a `support function called from unsupported function` warning and returning no index condition, so `eCovers`/`aCovers` never benefit from the index.

This registers `ecovers`/`acovers` with the overlap strategy, exactly like the sibling `contains` predicates: if one value covers another they intersect, so their bounding boxes overlap, which makes `col && stbox(arg)` a sound index prefilter with the exact predicate kept as a recheck filter.

```
WHERE eCovers(geom, temp)
  Index Cond: (temp && stbox(geom))
  Filter: ecovers(geom, temp)
```

The new enum members are appended so the existing metadata indexes stay stable. The change is confined to the support function metadata: the predicates already carry the `SUPPORT` clause, so there is no SQL or expected-output change.
