### PR TITLE
Mark two unbindable generic helpers as internal

### DIFF
--- a/meos/src/geo/tspatial_tempspatialrels.c
+++ b/meos/src/geo/tspatial_tempspatialrels.c
@@ -1477,7 +1477,7 @@ tdwithin_tlinearseqset_base(const TSequenceSet *ss, Datum point, Datum dist,
 /*****************************************************************************/
 
 /**
- * @ingroup meos_geo_rel_temp
+ * @ingroup meos_internal_geo_rel_temp
  * @brief Return a temporal Boolean that states whether a spatiotemporal value
  * and a base value are within a distance
  * @param[in] temp Spatiotemporal value

--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -2704,7 +2704,7 @@ type_from_hexwkb(const char *hexwkb, size_t size, MeosType type)
 }
 
 /**
- * @ingroup meos_setspan_inout
+ * @ingroup meos_internal_setspan_inout
  * @brief Return the MEOS type tag encoded in the header of a hex-encoded
  * Well-Known Binary (WKB) string, without parsing the whole value
  * @details Sets, spans, span sets, and temporal values write their concrete


### PR DESCRIPTION
meos_typeof_hexwkb and tdwithin_tspatial_spatial are tagged public but cannot belong to the public C surface a binding projects. meos_typeof_hexwkb returns a MeosType, an enum the umbrella header meos.h does not expose, so a binding has no type to receive it. tdwithin_tspatial_spatial takes Datum arguments and function pointers (datum_func3, tpfunc_temp) and is the generic implementation that the typed public wrappers tdwithin_tgeo_geo, tdwithin_geo_tgeo and tdwithin_tgeo_tgeo dispatch through.

Tag both with the matching internal Doxygen groups (meos_internal_setspan_inout and meos_internal_geo_rel_temp) so the catalog classifies them as internal and the public binding surface omits them.