### PR TITLE
Name the internal temporal subtype conversions with as instead of to

### DIFF
--- a/meos/include/meos_internal.h
+++ b/meos/include/meos_internal.h
@@ -1195,9 +1195,9 @@ extern void temporal_restart(Temporal *temp, int count);
 extern TSequence *temporal_tsequence(const Temporal *temp, interpType interp);
 extern TSequenceSet *temporal_tsequenceset(const Temporal *temp, interpType interp);
 extern TInstant *tinstant_shift_time(const TInstant *inst, const Interval *interv);
-extern TSequence *tinstant_to_tsequence(const TInstant *inst, interpType interp);
+extern TSequence *tinstant_as_tsequence(const TInstant *inst, interpType interp);
 extern TSequence *tinstant_to_tsequence_free(TInstant *inst, interpType interp);
-extern TSequenceSet *tinstant_to_tsequenceset(const TInstant *inst, interpType interp);
+extern TSequenceSet *tinstant_as_tsequenceset(const TInstant *inst, interpType interp);
 extern Temporal *tnumber_shift_scale_value(const Temporal *temp, Datum shift, Datum width, bool hasshift, bool haswidth);
 extern TInstant *tnumberinst_shift_value(const TInstant *inst, Datum shift);
 extern TSequence *tnumberseq_shift_scale_value(const TSequence *seq, Datum shift, Datum width, bool hasshift, bool haswidth);
@@ -1206,8 +1206,8 @@ extern void tsequence_restart(TSequence *seq, int count);
 extern Temporal *tsequence_set_interp(const TSequence *seq, interpType interp);
 extern TSequence *tsequence_shift_scale_time(const TSequence *seq, const Interval *shift, const Interval *duration);
 extern TSequence *tsequence_subseq(const TSequence *seq, int from, int to, bool lower_inc, bool upper_inc);
-extern TInstant *tsequence_to_tinstant(const TSequence *seq);
-extern TSequenceSet *tsequence_to_tsequenceset(const TSequence *seq);
+extern TInstant *tsequence_as_tinstant(const TSequence *seq);
+extern TSequenceSet *tsequence_as_tsequenceset(const TSequence *seq);
 extern TSequenceSet *tsequence_to_tsequenceset_free(TSequence *seq);
 extern TSequenceSet *tsequence_to_tsequenceset_interp(const TSequence *seq, interpType interp);
 extern void tsequenceset_restart(TSequenceSet *ss, int count);
@@ -1216,8 +1216,8 @@ extern TSequenceSet *tsequenceset_shift_scale_time(const TSequenceSet *ss, const
 extern TSequence *tsequenceset_to_discrete(const TSequenceSet *ss);
 extern TSequenceSet *tsequenceset_to_linear(const TSequenceSet *ss);
 extern TSequenceSet *tsequenceset_to_step(const TSequenceSet *ss);
-extern TInstant *tsequenceset_to_tinstant(const TSequenceSet *ss);
-extern TSequence *tsequenceset_to_tsequence(const TSequenceSet *ss);
+extern TInstant *tsequenceset_as_tinstant(const TSequenceSet *ss);
+extern TSequence *tsequenceset_as_tsequence(const TSequenceSet *ss);
 
 /*****************************************************************************/
 

--- a/meos/include/rgeo/trgeo_inst.h
+++ b/meos/include/rgeo/trgeo_inst.h
@@ -56,8 +56,8 @@ extern TInstant *trgeoinst_make1(const GSERIALIZED *geom, const Pose *pose,
 
 /* Transformation functions */
 
-extern TInstant *trgeoseq_to_tinstant(const TSequence *seq);
-extern TInstant *trgeoseqset_to_tinstant(const TSequenceSet *ts);
+extern TInstant *trgeoseq_as_tinstant(const TSequence *seq);
+extern TInstant *trgeoseqset_as_tinstant(const TSequenceSet *ts);
 
 /*****************************************************************************/
 

--- a/meos/include/rgeo/trgeo_seq.h
+++ b/meos/include/rgeo/trgeo_seq.h
@@ -67,8 +67,8 @@ extern TSequence *trgeoseq_make_free(const GSERIALIZED *geom, TInstant **instant
 
 /* Transformation functions */
 
-extern TSequence *trgeoinst_to_tsequence(const TInstant *inst, interpType interp);
-extern TInstant *trgeoseq_to_tinstant(const TSequence *seq);
+extern TSequence *trgeoinst_as_tsequence(const TInstant *inst, interpType interp);
+extern TInstant *trgeoseq_as_tinstant(const TSequence *seq);
 
 /*****************************************************************************/
 

--- a/meos/include/rgeo/trgeo_seqset.h
+++ b/meos/include/rgeo/trgeo_seqset.h
@@ -58,7 +58,7 @@ extern TSequenceSet *trgeoseqset_make_free(const GSERIALIZED *geom,
 
 /* Transformation functions */
 
-extern TSequence *trgeoseqset_to_tsequence(const TSequenceSet *ss);
+extern TSequence *trgeoseqset_as_tsequence(const TSequenceSet *ss);
 
 /*****************************************************************************/
 

--- a/meos/src/geo/tgeo_restrict.c
+++ b/meos/src/geo/tgeo_restrict.c
@@ -1043,7 +1043,7 @@ tpointseq_linear_restrict_stbox(const TSequence *seq, const STBox *box,
 
   /* If "minus" restriction, compute the complement wrt time */
   if (! res_at)
-    return tsequence_to_tsequenceset(seq);
+    return tsequence_as_tsequenceset(seq);
 
   SpanSet *ss = tsequenceset_time(res_at);
   TSequenceSet *result = tcontseq_restrict_tstzspanset(seq, ss, atfunc);
@@ -1081,11 +1081,11 @@ tgeoseq_restrict_stbox(const TSequence *seq, const STBox *box,
       return NULL;
     if (tpoint_type(seq->temptype))
       return (interp == DISCRETE) ? (Temporal *) tsequence_copy(seq) :
-          (Temporal *) tsequence_to_tsequenceset(seq);
+          (Temporal *) tsequence_as_tsequenceset(seq);
     else
     {
-      TSequence *res1 = tinstant_to_tsequence(res, interp);
-      TSequenceSet *result = tsequence_to_tsequenceset(res1);
+      TSequence *res1 = tinstant_as_tsequence(res, interp);
+      TSequenceSet *result = tsequence_as_tsequenceset(res1);
       pfree(res); pfree(res1);
       return (Temporal *) result;
     }
@@ -1293,7 +1293,7 @@ tpointseq_at_stbox_segm(const TSequence *seq, const STBox *box,
   {
     if (tpointinst_restrict_stbox_iter(TSEQUENCE_INST_N(seq, 0), box,
         border_inc, REST_AT))
-      return tsequence_to_tsequenceset(seq);
+      return tsequence_as_tsequenceset(seq);
     return NULL;
   }
 
@@ -1639,7 +1639,7 @@ tgeoseq_step_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
   if (nseqs == 0)
   {
     pfree(sequences);
-    return atfunc ? NULL : tsequence_to_tsequenceset(seq);
+    return atfunc ? NULL : tsequence_as_tsequenceset(seq);
   }
 
   /* Construct the result for "at" restriction */
@@ -1963,7 +1963,7 @@ tpointseq_linear_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
 
   /* If "minus" restriction, compute the complement wrt time */
   if (! result_at)
-    return tsequence_to_tsequenceset(seq);
+    return tsequence_as_tsequenceset(seq);
 
   SpanSet *ss = tsequenceset_time(result_at);
   TSequenceSet *result = tcontseq_restrict_tstzspanset(seq, ss, atfunc);
@@ -1995,11 +1995,11 @@ tgeoseq_restrict_geom(const TSequence *seq, const GSERIALIZED *gs,
       return NULL;
     if (tpoint_type(seq->temptype))
       return (interp == DISCRETE) ? (Temporal *) tsequence_copy(seq) :
-          (Temporal *) tsequence_to_tsequenceset(seq);
+          (Temporal *) tsequence_as_tsequenceset(seq);
     else
     {
-      TSequence *res1 = tinstant_to_tsequence(res, interp);
-      TSequenceSet *result = tsequence_to_tsequenceset(res1);
+      TSequence *res1 = tinstant_as_tsequence(res, interp);
+      TSequenceSet *result = tsequence_as_tsequenceset(res1);
       pfree(res); pfree(res1);
       return (Temporal *) result;
     }

--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -2937,7 +2937,7 @@ tpoint_linear_restrict_geom(const Temporal *temp, const GSERIALIZED *gs,
      * container-consistent with tgeo_restrict_geom whether or not the geometry
      * is met. */
     return (temp->subtype == TSEQUENCE) ?
-      (Temporal *) tsequence_to_tsequenceset((const TSequence *) temp) :
+      (Temporal *) tsequence_as_tsequenceset((const TSequence *) temp) :
       temporal_copy(temp);
 
   SpanSet *ss = temporal_time(result_at);

--- a/meos/src/geo/tspatial_tempspatialrels.c
+++ b/meos/src/geo/tspatial_tempspatialrels.c
@@ -414,7 +414,7 @@ tinterrel_tspatialseqset_base(const TSequenceSet *ss, Datum base,
         DatumGetGserializedP(base), box, tinter, func);
     TSequence *res = tinterrel_tspatialseq_discstep_base(
       TSEQUENCESET_SEQ_N(ss, 0), base, tinter, func);
-    TSequenceSet *result = tsequence_to_tsequenceset(res);
+    TSequenceSet *result = tsequence_as_tsequenceset(res);
     pfree(res);
     return result;
   }
@@ -1290,7 +1290,7 @@ tdwithin_tlinearseq_tlinearseq_iter(const TSequence *seq1,
       {
         Datum value = func(ev1, ev2, dist);
         tinstant_set(instants[0], value, upper);
-        result[nseqs++] = tinstant_to_tsequence(instants[0], STEP);
+        result[nseqs++] = tinstant_as_tsequence(instants[0], STEP);
       }
     }
     sv1 = ev1;

--- a/meos/src/pose/tpose.c
+++ b/meos/src/pose/tpose.c
@@ -291,7 +291,7 @@ tposeseq_make(const TSequence *seq1, const TSequence *seq2)
   if (seq1->count == 1)
   {
     TInstant *inst = tgeompoint_tfloat_to_tposeinst(inst1, inst2);
-    TSequence *result = tinstant_to_tsequence(inst, interp);
+    TSequence *result = tinstant_as_tsequence(inst, interp);
     pfree(inst);
     return result;
   }
@@ -329,7 +329,7 @@ tposeseqset_make(const TSequenceSet *ss1, const TSequenceSet *ss2)
   if (ss1->count == 1)
   {
     TSequence *seq = tposeseq_make(seq1, seq2);
-    TSequenceSet *result = tsequence_to_tsequenceset(seq);
+    TSequenceSet *result = tsequence_as_tsequenceset(seq);
     pfree(seq);
     return result;
   }

--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -956,9 +956,9 @@ trgeometry_as_tinstant(const Temporal *temp)
     case TINSTANT:
       return tinstant_copy((TInstant *) temp);
     case TSEQUENCE:
-      return trgeoseq_to_tinstant((TSequence *) temp);
+      return trgeoseq_as_tinstant((TSequence *) temp);
     default: /* TSEQUENCESET */
-      return trgeoseqset_to_tinstant((TSequenceSet *) temp);
+      return trgeoseqset_as_tinstant((TSequenceSet *) temp);
   }
 }
 

--- a/meos/src/rgeo/trgeo_inst.c
+++ b/meos/src/rgeo/trgeo_inst.c
@@ -213,7 +213,7 @@ trgeometryinst_make(const GSERIALIZED *geom, const Pose *pose, TimestampTz t)
  * @param[in] seq Temporal sequence
  */
 TInstant *
-trgeoseq_to_tinstant(const TSequence *seq)
+trgeoseq_as_tinstant(const TSequence *seq)
 {
   assert(seq);
   if (seq->count != 1)
@@ -233,7 +233,7 @@ trgeoseq_to_tinstant(const TSequence *seq)
  * @param[in] ss Temporal sequence set
  */
 TInstant *
-trgeoseqset_to_tinstant(const TSequenceSet *ss)
+trgeoseqset_as_tinstant(const TSequenceSet *ss)
 {
   assert(ss);
   if (ss->totalcount != 1)

--- a/meos/src/rgeo/trgeo_seq.c
+++ b/meos/src/rgeo/trgeo_seq.c
@@ -353,7 +353,7 @@ trgeoseq_make_free(const GSERIALIZED *geom, TInstant **instants, int count,
  * @param[in] interp Interpolation
  */
 TSequence *
-trgeoinst_to_tsequence(const TInstant *inst, interpType interp)
+trgeoinst_as_tsequence(const TInstant *inst, interpType interp)
 {
   assert(inst);
   return trgeometryseq_make(trgeoinst_geom_p(inst), (TInstant **) &inst, 1, true,
@@ -366,7 +366,7 @@ trgeoinst_to_tsequence(const TInstant *inst, interpType interp)
  * @param[in] ss Temporal sequence set
  */
 TSequence *
-trgeoseqset_to_tsequence(const TSequenceSet *ss)
+trgeoseqset_as_tsequence(const TSequenceSet *ss)
 {
   assert(ss);
   if (ss->totalcount != 1)

--- a/meos/src/rgeo/trgeo_seqset.c
+++ b/meos/src/rgeo/trgeo_seqset.c
@@ -383,11 +383,11 @@ trgeometryseqset_make_gaps(const GSERIALIZED *geom, TInstant **instants,
  * @param[out] interp Interpolation
  */
 TSequenceSet *
-trgeoinst_to_tsequenceset(const TInstant *inst, interpType interp)
+trgeoinst_as_tsequenceset(const TInstant *inst, interpType interp)
 {
   assert(inst); assert(inst->temptype == T_TRGEOMETRY);
   assert(interp == STEP || interp == LINEAR);
-  TSequenceSet *res = tinstant_to_tsequenceset(inst, interp);
+  TSequenceSet *res = tinstant_as_tsequenceset(inst, interp);
   TSequenceSet *result = geo_tposeseqset_to_trgeo(trgeoinst_geom_p(inst), res);
   pfree(res);
   return result;
@@ -398,13 +398,13 @@ trgeoinst_to_tsequenceset(const TInstant *inst, interpType interp)
  * sequence set
  */
 TSequenceSet *
-trgeodiscseq_to_tsequenceset(const TSequence *seq, interpType interp)
+trgeodiscseq_as_tsequenceset(const TSequence *seq, interpType interp)
 {
   assert(seq); assert(seq->temptype == T_TRGEOMETRY);
   assert(interp == STEP || interp == LINEAR);
   TSequence **sequences = palloc(sizeof(TSequence *) * seq->count);
   for (int i = 0; i < seq->count; i++)
-    sequences[i] = trgeoinst_to_tsequence(TSEQUENCE_INST_N(seq, i), interp);
+    sequences[i] = trgeoinst_as_tsequence(TSEQUENCE_INST_N(seq, i), interp);
   return trgeoseqset_make_free(trgeoseq_geom_p(seq), sequences, seq->count,
     NORMALIZE_NO);
 }
@@ -415,7 +415,7 @@ trgeodiscseq_to_tsequenceset(const TSequence *seq, interpType interp)
  * @param[in] seq Temporal sequence
  */
 TSequenceSet *
-trgeoseq_to_tsequenceset(const TSequence *seq)
+trgeoseq_as_tsequenceset(const TSequence *seq)
 {
   assert(seq); assert(seq->temptype == T_TRGEOMETRY);
   /* For discrete sequences, each composing instant will be transformed in
@@ -423,7 +423,7 @@ trgeoseq_to_tsequenceset(const TSequence *seq)
   if (MEOS_FLAGS_DISCRETE_INTERP(seq->flags))
   {
     interpType interp = MEOS_FLAGS_GET_CONTINUOUS(seq->flags) ? LINEAR : STEP;
-    return trgeodiscseq_to_tsequenceset(seq, interp);
+    return trgeodiscseq_as_tsequenceset(seq, interp);
   }
   return trgeometryseqset_make(trgeoseq_geom_p(seq), (TSequence **) &seq, 1,
     NORMALIZE_NO);
@@ -439,7 +439,7 @@ TSequenceSet *
 trgeoseq_to_tsequenceset_free(TSequence *seq)
 {
   assert(seq); assert(seq->temptype == T_TRGEOMETRY);
-  TSequenceSet *result = trgeoseq_to_tsequenceset((const TSequence *) seq);
+  TSequenceSet *result = trgeoseq_as_tsequenceset((const TSequence *) seq);
   pfree(seq);
   return result;
 }

--- a/meos/src/temporal/lifting.c
+++ b/meos/src/temporal/lifting.c
@@ -1881,7 +1881,7 @@ tfunc_tcontseq_tcontseq(const TSequence *seq1, const TSequence *seq2,
     TSequenceSet *result = tsequenceset_make_free(sequences, nseqs, NORMALIZE);
     if (result->count == 1)
     {
-      Temporal *resultseq = (Temporal *) tsequenceset_to_tsequence(result);
+      Temporal *resultseq = (Temporal *) tsequenceset_as_tsequence(result);
       pfree(result);
       return resultseq;
     }

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -1672,9 +1672,9 @@ temporal_as_tinstant(const Temporal *temp)
     case TINSTANT:
       return tinstant_copy((TInstant *) temp);
     case TSEQUENCE:
-      return tsequence_to_tinstant((TSequence *) temp);
+      return tsequence_as_tinstant((TSequence *) temp);
     default: /* TSEQUENCESET */
-      return tsequenceset_to_tinstant((TSequenceSet *) temp);
+      return tsequenceset_as_tinstant((TSequenceSet *) temp);
   }
 }
 
@@ -1697,7 +1697,7 @@ temporal_tsequence(const Temporal *temp, interpType interp)
   switch (temp->subtype)
   {
     case TINSTANT:
-      return tinstant_to_tsequence((TInstant *) temp, interp);
+      return tinstant_as_tsequence((TInstant *) temp, interp);
     case TSEQUENCE:
     {
       interpType interp1 = MEOS_FLAGS_GET_INTERP(temp->flags);
@@ -1716,7 +1716,7 @@ temporal_tsequence(const Temporal *temp, interpType interp)
       return (TSequence *) tsequence_set_interp((TSequence *) temp, interp);
     }
     default: /* TSEQUENCESET */
-      return tsequenceset_to_tsequence((TSequenceSet *) temp);
+      return tsequenceset_as_tsequence((TSequenceSet *) temp);
   }
 }
 
@@ -1770,7 +1770,7 @@ temporal_tsequenceset(const Temporal *temp, interpType interp)
   switch (temp->subtype)
   {
     case TINSTANT:
-      return tinstant_to_tsequenceset((TInstant *) temp, interp);
+      return tinstant_as_tsequenceset((TInstant *) temp, interp);
     case TSEQUENCE:
       return tsequence_to_tsequenceset_interp((TSequence *) temp, interp);
     default: /* TSEQUENCESET */
@@ -1823,7 +1823,7 @@ temporal_set_interp(const Temporal *temp, interpType interp)
   switch (temp->subtype)
   {
     case TINSTANT:
-      return (Temporal *) tinstant_to_tsequence((TInstant *) temp, interp);
+      return (Temporal *) tinstant_as_tsequence((TInstant *) temp, interp);
     case TSEQUENCE:
       return (Temporal *) tsequence_set_interp((TSequence *) temp, interp);
     default: /* TSEQUENCESET */

--- a/meos/src/temporal/temporal_modif.c
+++ b/meos/src/temporal/temporal_modif.c
@@ -500,12 +500,12 @@ temporal_convert_same_subtype(const Temporal *temp1, const Temporal *temp2,
   {
     interpType interp = MEOS_FLAGS_GET_INTERP(new2->flags);
     if (new2->subtype == TSEQUENCE)
-      new = (Temporal *) tinstant_to_tsequence((TInstant *) new1, interp);
+      new = (Temporal *) tinstant_as_tsequence((TInstant *) new1, interp);
     else /* new2->subtype == TSEQUENCESET */
-      new = (Temporal *) tinstant_to_tsequenceset((TInstant *) new1, interp);
+      new = (Temporal *) tinstant_as_tsequenceset((TInstant *) new1, interp);
   }
   else /* new1->subtype == TSEQUENCE && new2->subtype == TSEQUENCESET */
-    new = (Temporal *) tsequence_to_tsequenceset((TSequence *) new1);
+    new = (Temporal *) tsequence_as_tsequenceset((TSequence *) new1);
   if (swap)
   {
     *out1 = (Temporal *) temp1;
@@ -595,14 +595,14 @@ temporalarr_convert_subtype(Temporal **temparr, int count, uint8 subtype,
     else if (subtype1 == TINSTANT)
     {
       if (subtype == TSEQUENCE)
-        result[i] = (Temporal *) tinstant_to_tsequence((TInstant *) temparr[i],
+        result[i] = (Temporal *) tinstant_as_tsequence((TInstant *) temparr[i],
           interp);
       else /* subtype == TSEQUENCESET */
-        result[i] = (Temporal *) tinstant_to_tsequenceset((TInstant *) temparr[i],
+        result[i] = (Temporal *) tinstant_as_tsequenceset((TInstant *) temparr[i],
           interp);
     }
     else /* subtype1 == TSEQUENCE && subtype == TSEQUENCESET */
-      result[i] = (Temporal *) tsequence_to_tsequenceset((TSequence *) temparr[i]);
+      result[i] = (Temporal *) tsequence_as_tsequenceset((TSequence *) temparr[i]);
   }
   return result;
 }
@@ -1696,7 +1696,7 @@ tsequence_append_tinstant(TSequence *seq, const TInstant *inst, double maxdist,
     {
       TSequence *sequences[2];
       sequences[0] = (TSequence *) seq;
-      sequences[1] = tinstant_to_tsequence(inst, LINEAR);
+      sequences[1] = tinstant_as_tsequence(inst, LINEAR);
       TSequenceSet *result = tsequenceset_make(sequences, 2, NORMALIZE_NO);
       pfree(sequences[1]);
       return (Temporal *) result;
@@ -2141,7 +2141,7 @@ temporal_append_tinstant(Temporal *temp, const TInstant *inst,
   {
     case TINSTANT:
     {
-      TSequence *seq = tinstant_to_tsequence((const TInstant *) temp, interp);
+      TSequence *seq = tinstant_as_tsequence((const TInstant *) temp, interp);
       Temporal *result = (Temporal *) tsequence_append_tinstant(seq, inst,
         maxdist, maxt, expand);
       pfree(seq);
@@ -2185,7 +2185,7 @@ temporal_append_tsequence(Temporal *temp, const TSequence *seq, bool expand)
   {
     case TINSTANT:
     {
-      TSequence *seq1 = tinstant_to_tsequence((const TInstant *) temp, interp2);
+      TSequence *seq1 = tinstant_as_tsequence((const TInstant *) temp, interp2);
       Temporal *result = (Temporal *) tsequence_append_tsequence(
         (const TSequence *) seq1, seq, expand);
       pfree(seq1);

--- a/meos/src/temporal/temporal_restrict.c
+++ b/meos/src/temporal/temporal_restrict.c
@@ -180,7 +180,7 @@ temporal_restrict_value(const Temporal *temp, Datum value, bool atfunc)
       return (temp->subtype != TSEQUENCE ||
           MEOS_FLAGS_DISCRETE_INTERP(temp->flags)) ?
         temporal_copy(temp) :
-        (Temporal *) tsequence_to_tsequenceset((TSequence *) temp);
+        (Temporal *) tsequence_as_tsequenceset((TSequence *) temp);
   }
 
   assert(temptype_subtype(temp->subtype));
@@ -260,7 +260,7 @@ temporal_restrict_values(const Temporal *temp, const Set *s, bool atfunc)
       return NULL;
     else
       return (temp->subtype != TSEQUENCE) ? temporal_copy(temp) :
-        (Temporal *) tsequence_to_tsequenceset((TSequence *) temp);
+        (Temporal *) tsequence_as_tsequenceset((TSequence *) temp);
   }
 
   assert(temptype_subtype(temp->subtype));
@@ -303,7 +303,7 @@ tnumber_restrict_span(const Temporal *temp, const Span *s, bool atfunc)
       return NULL;
     else
       return (temp->subtype == TSEQUENCE && interp != DISCRETE) ?
-        (Temporal *) tsequence_to_tsequenceset((TSequence *) temp) :
+        (Temporal *) tsequence_as_tsequenceset((TSequence *) temp) :
         temporal_copy(temp);
   }
 
@@ -351,7 +351,7 @@ tnumber_restrict_spanset(const Temporal *temp, const SpanSet *ss, bool atfunc)
     else
     {
       if (temp->subtype == TSEQUENCE && interp != DISCRETE)
-        return (Temporal *) tsequence_to_tsequenceset((TSequence *) temp);
+        return (Temporal *) tsequence_as_tsequenceset((TSequence *) temp);
       else
         return temporal_copy(temp);
     }
@@ -1064,21 +1064,21 @@ tsegment_restrict_value(const TInstant *inst1, const TInstant *inst2,
       pfree(instants[1]);
     }
     if (upper_inc && upper)
-      result[nseqs++] = tinstant_to_tsequence(inst2, STEP);
+      result[nseqs++] = tinstant_as_tsequence(inst2, STEP);
     return nseqs;
   }
 
   /* Linear interpolation: Test of bounds */
   if (atfunc && ((lower && lower_inc) || (upper && upper_inc)))
   {
-    result[0] = tinstant_to_tsequence(lower ? inst1 : inst2, LINEAR);
+    result[0] = tinstant_as_tsequence(lower ? inst1 : inst2, LINEAR);
     return 1;
   }
   /* Interpolation */
   if (atfunc)
   {
     TInstant *inst = tinstant_make_free(projvalue1, inst1->temptype, t1);
-    result[0] = tinstant_to_tsequence(inst, LINEAR);
+    result[0] = tinstant_as_tsequence(inst, LINEAR);
     pfree(inst);
     return 1;
   }
@@ -1296,7 +1296,7 @@ tcontseq_restrict_values(const TSequence *seq, const Set *s, bool atfunc)
    * Compute the complement of the previous value.
    */
   if (newcount == 0)
-    return tsequence_to_tsequenceset(seq);
+    return tsequence_as_tsequenceset(seq);
 
   SpanSet *ps1 = tsequenceset_time(atresult);
   SpanSet *ps2 = minus_span_spanset(&seq->period, ps1);
@@ -1438,7 +1438,7 @@ tnumbersegm_restrict_span(const TInstant *inst1, const TInstant *inst2,
     if (upper_inc &&
       ((atfunc && found) || (! atfunc && ! found)))
     {
-      result[nseqs++] = tinstant_to_tsequence(inst2, interp);
+      result[nseqs++] = tinstant_as_tsequence(inst2, interp);
     }
     return nseqs;
   }
@@ -1995,7 +1995,7 @@ tdiscseq_restrict_tstzset(const TSequence *seq, const Set *s, bool atfunc)
     if (temp == NULL || ! atfunc)
       return (TSequence *) temp;
     /* Transform the result of tdiscseq_at_timestamp into a sequence */
-    result = tinstant_to_tsequence((const TInstant *) temp, DISCRETE);
+    result = tinstant_as_tsequence((const TInstant *) temp, DISCRETE);
     pfree(temp);
     return result;
   }
@@ -2329,7 +2329,7 @@ tcontseq_at_tstzset(const TSequence *seq, const Set *s)
     inst = tsequence_at_timestamptz(seq, DatumGetTimestampTz(SET_VAL_N(s, 0)));
     if (inst == NULL)
       return NULL;
-    TSequence *result = tinstant_to_tsequence((const TInstant *) inst,
+    TSequence *result = tinstant_as_tsequence((const TInstant *) inst,
       DISCRETE);
     pfree(inst);
     return result;
@@ -2348,7 +2348,7 @@ tcontseq_at_tstzset(const TSequence *seq, const Set *s)
   {
     if (! contains_set_value(s, TimestampTzGetDatum(inst->t)))
       return NULL;
-    return tinstant_to_tsequence((const TInstant *) inst, DISCRETE);
+    return tinstant_as_tsequence((const TInstant *) inst, DISCRETE);
   }
 
   /* General case */
@@ -2543,7 +2543,7 @@ tcontseq_at_tstzspan(const TSequence *seq, const Span *s)
   if (inter.lower == inter.upper)
   {
     TInstant *inst = tcontseq_at_timestamptz(seq, inter.lower);
-    result = tinstant_to_tsequence(inst, interp);
+    result = tinstant_as_tsequence(inst, interp);
     pfree(inst);
     return result;
   }
@@ -2780,14 +2780,14 @@ tcontseq_restrict_tstzspanset(const TSequence *seq, const SpanSet *ss,
 
   /* Bounding box test */
   if (! overlaps_span_span(&seq->period, &ss->span))
-    return atfunc ? NULL : tsequence_to_tsequenceset(seq);
+    return atfunc ? NULL : tsequence_as_tsequenceset(seq);
 
   /* Instantaneous sequence */
   if (seq->count == 1)
   {
     if (contains_spanset_timestamptz(ss, TSEQUENCE_INST_N(seq, 0)->t))
-      return atfunc ? tsequence_to_tsequenceset(seq) : NULL;
-    return atfunc ? NULL : tsequence_to_tsequenceset(seq);
+      return atfunc ? tsequence_as_tsequenceset(seq) : NULL;
+    return atfunc ? NULL : tsequence_as_tsequenceset(seq);
   }
 
   /* General case */
@@ -3064,7 +3064,7 @@ tsequenceset_restrict_tstzset(const TSequenceSet *ss, const Set *s,
       DatumGetTimestampTz(SET_VAL_N(s, 0)), atfunc);
     if (atfunc && temp)
     {
-      Temporal *result = (Temporal *) tinstant_to_tsequence(
+      Temporal *result = (Temporal *) tinstant_as_tsequence(
         (const TInstant *) temp, DISCRETE);
       pfree(temp);
       return result;
@@ -3154,7 +3154,7 @@ tsequenceset_restrict_tstzspan(const TSequenceSet *ss, const Span *s,
     if (atfunc)
     {
       seq = tcontseq_at_tstzspan(TSEQUENCESET_SEQ_N(ss, 0), s);
-      result = tsequence_to_tsequenceset(seq);
+      result = tsequence_as_tsequenceset(seq);
       pfree(seq);
       return result;
     }
@@ -3462,7 +3462,7 @@ tsequence_before_timestamptz(const TSequence *seq, TimestampTz t, bool strict)
   {
     const TInstant *inst = TSEQUENCE_INST_N(seq, 0);
     if (inst->t == t && seq->period.lower_inc)
-      return tinstant_to_tsequence(inst, MEOS_FLAGS_GET_INTERP(seq->flags));
+      return tinstant_as_tsequence(inst, MEOS_FLAGS_GET_INTERP(seq->flags));
     inst = TSEQUENCE_INST_N(seq, seq->count - 1);
     if (inst->t == t)
       return tsequence_copy(seq);
@@ -3621,7 +3621,7 @@ tsequence_after_timestamptz(const TSequence *seq, TimestampTz t, bool strict)
       return tsequence_copy(seq);
     inst = TSEQUENCE_INST_N(seq, seq->count - 1);
     if (inst->t == t && seq->period.upper_inc)
-      return tinstant_to_tsequence(inst, MEOS_FLAGS_GET_INTERP(seq->flags));
+      return tinstant_as_tsequence(inst, MEOS_FLAGS_GET_INTERP(seq->flags));
   }
 
   /* Bounding box test */
@@ -3660,7 +3660,7 @@ tsequenceset_before_timestamptz(const TSequenceSet *ss, TimestampTz t,
   {
     const TInstant *inst = TSEQUENCE_INST_N(TSEQUENCESET_SEQ_N(ss, 0), 0);
     if (inst->t == t && ss->period.lower_inc)
-      return tinstant_to_tsequenceset(inst, MEOS_FLAGS_GET_INTERP(ss->flags));
+      return tinstant_as_tsequenceset(inst, MEOS_FLAGS_GET_INTERP(ss->flags));
     const TSequence *seq = TSEQUENCESET_SEQ_N(ss, ss->count - 1);
     inst = TSEQUENCE_INST_N(seq, seq->count - 1);
     if (inst->t == t)
@@ -3718,7 +3718,7 @@ tsequenceset_after_timestamptz(const TSequenceSet *ss, TimestampTz t,
     const TSequence *seq = TSEQUENCESET_SEQ_N(ss, ss->count - 1);
     inst = TSEQUENCE_INST_N(seq, seq->count - 1);
     if (inst->t == t && ss->period.upper_inc)
-      return tinstant_to_tsequenceset(inst, MEOS_FLAGS_GET_INTERP(ss->flags));
+      return tinstant_as_tsequenceset(inst, MEOS_FLAGS_GET_INTERP(ss->flags));
   }
 
   /* Bounding box test */

--- a/meos/src/temporal/temporal_tile_meos.c
+++ b/meos/src/temporal/temporal_tile_meos.c
@@ -870,7 +870,7 @@ tnumberseq_step_value_split(const TSequence *seq, Datum start_bin,
     bin_value = datum_bin(value, size, start_bin, basetype);
     bin_no = bin_position(bin_value, size, start_bin, basetype);
     seq_no = nseqs[bin_no]++;
-    result[bin_no * numcols + seq_no] = tinstant_to_tsequence(inst1, STEP);
+    result[bin_no * numcols + seq_no] = tinstant_as_tsequence(inst1, STEP);
   }
   pfree_array((void **) tofree, nfree);
   return;
@@ -1072,7 +1072,7 @@ tnumberseq_cont_value_split(const TSequence *seq, Datum start_bin, Datum size,
   {
     TSequenceSet **result = palloc(sizeof(TSequenceSet *));
     Datum *values = palloc(sizeof(Datum));
-    result[0] = tsequence_to_tsequenceset(seq);
+    result[0] = tsequence_as_tsequenceset(seq);
     Datum value = tinstant_value_p(TSEQUENCE_INST_N(seq, 0));
     values[0] = datum_bin(value, size, start_bin, basetype);
     *bins = values;

--- a/meos/src/temporal/tinstant.c
+++ b/meos/src/temporal/tinstant.c
@@ -501,7 +501,7 @@ tinstant_after_timestamptz(const TInstant *inst, TimestampTz t, bool strict)
  * @csqlfn #Temporal_as_tinstant()
  */
 TInstant *
-tsequence_to_tinstant(const TSequence *seq)
+tsequence_as_tinstant(const TSequence *seq)
 {
   assert(seq);
   if (seq->count != 1)
@@ -520,7 +520,7 @@ tsequence_to_tinstant(const TSequence *seq)
  * @csqlfn #Temporal_as_tinstant()
  */
 TInstant *
-tsequenceset_to_tinstant(const TSequenceSet *ss)
+tsequenceset_as_tinstant(const TSequenceSet *ss)
 {
   assert(ss);
   if (ss->totalcount != 1)

--- a/meos/src/temporal/tsequence.c
+++ b/meos/src/temporal/tsequence.c
@@ -1320,7 +1320,7 @@ tsequence_subseq(const TSequence *seq, int from, int to, bool lower_inc,
  * @csqlfn #Temporal_as_tsequence()
  */
 TSequence *
-tinstant_to_tsequence(const TInstant *inst, interpType interp)
+tinstant_as_tsequence(const TInstant *inst, interpType interp)
 {
   assert(inst);
   return tsequence_make((TInstant **) &inst, 1, true, true, interp,
@@ -1338,7 +1338,7 @@ TSequence *
 tinstant_to_tsequence_free(TInstant *inst, interpType interp)
 {
   assert(inst);
-  TSequence *result = tinstant_to_tsequence((const TInstant *) inst, interp);
+  TSequence *result = tinstant_as_tsequence((const TInstant *) inst, interp);
   pfree(inst);
   return result;
 }
@@ -1370,7 +1370,7 @@ tdiscseq_set_interp(const TSequence *seq, interpType interp)
   for (int i = 0; i < seq->count; i++)
   {
     inst = TSEQUENCE_INST_N(seq, i);
-    sequences[i] = tinstant_to_tsequence(inst, interp);
+    sequences[i] = tinstant_as_tsequence(inst, interp);
   }
   return (Temporal *) tsequenceset_make_free(sequences, seq->count,
     NORMALIZE_NO);
@@ -1389,7 +1389,7 @@ tcontseq_to_discrete(const TSequence *seq)
       "Cannot transform input value to a temporal discrete sequence");
     return NULL;
   }
-  return tinstant_to_tsequence(TSEQUENCE_INST_N(seq, 0), DISCRETE);
+  return tinstant_as_tsequence(TSEQUENCE_INST_N(seq, 0), DISCRETE);
 }
 
 /**
@@ -1469,7 +1469,7 @@ tstepseq_to_linear_iter(const TSequence *seq, TSequence **result)
     value1 = tinstant_value_p(TSEQUENCE_INST_N(seq, seq->count - 2));
     value2 = tinstant_value_p(inst2);
     if (datum_ne(value1, value2, basetype))
-      result[nseqs++] = tinstant_to_tsequence(inst2, LINEAR);
+      result[nseqs++] = tinstant_as_tsequence(inst2, LINEAR);
   }
   return nseqs;
 }
@@ -1979,7 +1979,7 @@ tsequence_segments_iter(const TSequence *seq, TSequence **result)
     inst1 = (TInstant *) TSEQUENCE_INST_N(seq, seq->count - 1);
     inst2 = (TInstant *) TSEQUENCE_INST_N(seq, seq->count - 2);
     if (! datum_eq(tinstant_value_p(inst1), tinstant_value_p(inst2), basetype))
-      result[nseqs++] = tinstant_to_tsequence(inst1, interp);
+      result[nseqs++] = tinstant_as_tsequence(inst1, interp);
   }
   return nseqs;
 }
@@ -2003,7 +2003,7 @@ tsequence_segments(const TSequence *seq, int *count)
     /* Discrete sequence */
     interpType interp = MEOS_FLAGS_GET_CONTINUOUS(seq->flags) ? LINEAR : STEP;
     for (int i = 0; i < seq->count; i++)
-      result[i] = tinstant_to_tsequence(TSEQUENCE_INST_N(seq, i), interp);
+      result[i] = tinstant_as_tsequence(TSEQUENCE_INST_N(seq, i), interp);
     *count = seq->count;
     return result;
   }
@@ -2271,8 +2271,8 @@ synchronize_tsequence_tsequence(const TSequence *seq1, const TSequence *seq2,
   {
     inst1 = tsequence_at_timestamptz(seq1, inter.lower);
     inst2 = tsequence_at_timestamptz(seq2, inter.lower);
-    *sync1 = tinstant_to_tsequence(inst1, interp1);
-    *sync2 = tinstant_to_tsequence(inst2, interp2);
+    *sync1 = tinstant_as_tsequence(inst1, interp1);
+    *sync2 = tinstant_as_tsequence(inst2, interp2);
     pfree(inst1); pfree(inst2);
     return true;
   }

--- a/meos/src/temporal/tsequenceset.c
+++ b/meos/src/temporal/tsequenceset.c
@@ -1446,10 +1446,10 @@ tsequenceset_restart(TSequenceSet *ss, int count)
  * @csqlfn #Temporal_as_tsequenceset()
  */
 TSequenceSet *
-tinstant_to_tsequenceset(const TInstant *inst, interpType interp)
+tinstant_as_tsequenceset(const TInstant *inst, interpType interp)
 {
   assert(inst); assert(interp == STEP || interp == LINEAR);
-  return tsequence_to_tsequenceset_free(tinstant_to_tsequence(inst, interp));
+  return tsequence_to_tsequenceset_free(tinstant_as_tsequence(inst, interp));
 }
 
 /**
@@ -1457,12 +1457,12 @@ tinstant_to_tsequenceset(const TInstant *inst, interpType interp)
  * sequence set
  */
 TSequenceSet *
-tdiscseq_to_tsequenceset(const TSequence *seq, interpType interp)
+tdiscseq_as_tsequenceset(const TSequence *seq, interpType interp)
 {
   assert(seq); assert(interp == STEP || interp == LINEAR);
   TSequence **sequences = palloc(sizeof(TSequence *) * seq->count);
   for (int i = 0; i < seq->count; i++)
-    sequences[i] = tinstant_to_tsequence(TSEQUENCE_INST_N(seq, i), interp);
+    sequences[i] = tinstant_as_tsequence(TSEQUENCE_INST_N(seq, i), interp);
   return tsequenceset_make_free(sequences, seq->count, NORMALIZE_NO);
 }
 
@@ -1473,7 +1473,7 @@ tdiscseq_to_tsequenceset(const TSequence *seq, interpType interp)
  * @csqlfn #Temporal_as_tsequenceset()
  */
 TSequenceSet *
-tsequence_to_tsequenceset(const TSequence *seq)
+tsequence_as_tsequenceset(const TSequence *seq)
 {
   assert(seq);
   /* For discrete sequences, each composing instant will be transformed in
@@ -1481,7 +1481,7 @@ tsequence_to_tsequenceset(const TSequence *seq)
   if (MEOS_FLAGS_DISCRETE_INTERP(seq->flags))
   {
     interpType interp = MEOS_FLAGS_GET_CONTINUOUS(seq->flags) ? LINEAR : STEP;
-    return tdiscseq_to_tsequenceset(seq, interp);
+    return tdiscseq_as_tsequenceset(seq, interp);
   }
   return tsequenceset_make((TSequence **) &seq, 1, NORMALIZE_NO);
 }
@@ -1496,7 +1496,7 @@ TSequenceSet *
 tsequence_to_tsequenceset_free(TSequence *seq)
 {
   assert(seq);
-  TSequenceSet *result = tsequence_to_tsequenceset((const TSequence *) seq);
+  TSequenceSet *result = tsequence_as_tsequenceset((const TSequence *) seq);
   pfree(seq);
   return result;
 }
@@ -1533,7 +1533,7 @@ tsequence_to_tsequenceset_interp(const TSequence *seq, interpType interp)
  * @csqlfn #Temporal_as_tsequence()
  */
 TSequence *
-tsequenceset_to_tsequence(const TSequenceSet *ss)
+tsequenceset_as_tsequence(const TSequenceSet *ss)
 {
   assert(ss);
   if (ss->count != 1)


### PR DESCRIPTION
The public temporal subtype transformations use `as` (`temporal_as_tsequence`, `trgeometry_as_tsequence`), reserving `to` for type casts. The internal leaf conversions between concrete subtypes that back them still spell the same operation with `to`: `tinstant_to_tsequence`, `tsequence_to_tsequenceset`, `tsequenceset_to_tinstant`, `tdiscseq_to_tsequenceset` and their `trgeo*` counterparts.

Rename these internal conversions to the `as` spelling so the whole subtype transformation family reads consistently. The functions keep their abbreviated internal prefixes and internal Doxygen groups; only `to` becomes `as`. The type casts (`temporal_to_tstzspan`, `trgeometry_to_tgeometry`/`tpoint`/`tpose`) keep `to`.