### PR TITLE
Recase deployed SQL function and aggregate names to their canonical spelling

### DIFF
--- a/doc/data_generator.xml
+++ b/doc/data_generator.xml
@@ -488,7 +488,7 @@ SET inst = (SELECT inst FROM tbl_tbool_inst t2 WHERE t2.k = t1.k+perc)
 WHERE k in (SELECT i FROM generate_series(1 + 2*perc, 3*perc) i);
 /* Add perc rows with the same timestamp */
 UPDATE tbl_tbool_inst t1
-SET inst = (SELECT tboolinst(random_bool(), getTimestamp(inst))
+SET inst = (SELECT tboolInst(random_bool(), getTimestamp(inst))
   FROM tbl_tbool_inst t2 WHERE t2.k = t1.k+perc)
 WHERE k in (SELECT i FROM generate_series(1 + 4*perc, 5*perc) i);
 </programlisting>
@@ -549,11 +549,11 @@ SET seq = (SELECT seq + random_int(1, 2) FROM tbl_tfloat_seq t2 WHERE t2.k = t1.
 WHERE k in (SELECT i FROM generate_series(1 + 4*perc, 5*perc) i);
 /* Add perc tuples that meet */
 UPDATE tbl_tfloat_seq t1
-SET seq = (SELECT shift(seq, timespan(seq)) FROM tbl_tfloat_seq t2 WHERE t2.k = t1.k+perc)
+SET seq = (SELECT shift(seq, timeSpan(seq)) FROM tbl_tfloat_seq t2 WHERE t2.k = t1.k+perc)
 WHERE t1.k in (SELECT i FROM generate_series(1 + 6*perc, 7*perc) i);
 /* Add perc tuples that overlap */
 UPDATE tbl_tfloat_seq t1
-SET seq = (SELECT shift(seq, date_trunc('minute',timespan(seq)/2))
+SET seq = (SELECT shift(seq, date_trunc('minute',timeSpan(seq)/2))
   FROM tbl_tfloat_seq t2 WHERE t2.k = t1.k+perc)
 WHERE t1.k in (SELECT i FROM generate_series(1 + 8*perc, 9*perc) i);
 </programlisting>
@@ -578,11 +578,11 @@ SET ts = (SELECT ts || text 'A' FROM tbl_ttext_seqset t2 WHERE t2.k = t1.k+perc)
 WHERE k in (SELECT i FROM generate_series(1 + 4*perc, 5*perc) i);
 /* Add perc tuples that meet */
 UPDATE tbl_ttext_seqset t1
-SET ts = (SELECT shift(ts, timespan(ts)) FROM tbl_ttext_seqset t2 WHERE t2.k = t1.k+perc)
+SET ts = (SELECT shift(ts, timeSpan(ts)) FROM tbl_ttext_seqset t2 WHERE t2.k = t1.k+perc)
 WHERE t1.k in (SELECT i FROM generate_series(1 + 6*perc, 7*perc) i);
 /* Add perc tuples that overlap */
 UPDATE tbl_ttext_seqset t1
-SET ts = (SELECT shift(ts, date_trunc('minute', timespan(ts)/2))
+SET ts = (SELECT shift(ts, date_trunc('minute', timeSpan(ts)/2))
   FROM tbl_ttext_seqset t2 WHERE t2.k = t1.k+perc)
 WHERE t1.k in (SELECT i FROM generate_series(1 + 8*perc, 9*perc) i);
 </programlisting>
@@ -634,11 +634,11 @@ SET ts = (SELECT round(ts,3) FROM tbl_tgeompoint3D_seqset t2 WHERE t2.k = t1.k+p
 WHERE k IN (SELECT i FROM generate_series(1 + 2*perc, 3*perc) i);
 /* Add perc tuples that meet */
 UPDATE tbl_tgeompoint3D_seqset t1
-SET ts = (SELECT shift(ts, timespan(ts)) FROM tbl_tgeompoint3D_seqset t2 WHERE t2.k = t1.k+perc)
+SET ts = (SELECT shift(ts, timeSpan(ts)) FROM tbl_tgeompoint3D_seqset t2 WHERE t2.k = t1.k+perc)
 WHERE t1.k IN (SELECT i FROM generate_series(1 + 4*perc, 5*perc) i);
 /* Add perc tuples that overlap */
 UPDATE tbl_tgeompoint3D_seqset t1
-SET ts = (SELECT shift(ts, date_trunc('minute', timespan(ts)/2))
+SET ts = (SELECT shift(ts, date_trunc('minute', timeSpan(ts)/2))
   FROM tbl_tgeompoint3D_seqset t2 WHERE t2.k = t1.k+perc)
 WHERE t1.k IN (SELECT i FROM generate_series(1 + 6*perc, 7*perc) i);
 </programlisting>

--- a/doc/es/data_generator.xml
+++ b/doc/es/data_generator.xml
@@ -489,7 +489,7 @@ SET inst = (SELECT inst FROM tbl_tbool_inst t2 WHERE t2.k = t1.k+perc)
 WHERE k in (SELECT i FROM generate_series(1 + 2*perc, 3*perc) i);
 /* Add perc rows con the same timestamp */
 UPDATE tbl_tbool_inst t1
-SET inst = (SELECT tboolinst(random_bool(), getTimestamp(inst))
+SET inst = (SELECT tboolInst(random_bool(), getTimestamp(inst))
   FROM tbl_tbool_inst t2 WHERE t2.k = t1.k+perc)
 WHERE k in (SELECT i FROM generate_series(1 + 4*perc, 5*perc) i);
 </programlisting>
@@ -550,11 +550,11 @@ SET seq = (SELECT seq + random_int(1, 2) FROM tbl_tfloat_seq t2 WHERE t2.k = t1.
 WHERE k in (SELECT i FROM generate_series(1 + 4*perc, 5*perc) i);
 /* Add perc tuples that meet */
 UPDATE tbl_tfloat_seq t1
-SET seq = (SELECT shift(seq, timespan(seq)) FROM tbl_tfloat_seq t2 WHERE t2.k = t1.k+perc)
+SET seq = (SELECT shift(seq, timeSpan(seq)) FROM tbl_tfloat_seq t2 WHERE t2.k = t1.k+perc)
 WHERE t1.k in (SELECT i FROM generate_series(1 + 6*perc, 7*perc) i);
 /* Add perc tuples that overlap */
 UPDATE tbl_tfloat_seq t1
-SET seq = (SELECT shift(seq, date_trunc('minute',timespan(seq)/2))
+SET seq = (SELECT shift(seq, date_trunc('minute',timeSpan(seq)/2))
   FROM tbl_tfloat_seq t2 WHERE t2.k = t1.k+perc)
 WHERE t1.k in (SELECT i FROM generate_series(1 + 8*perc, 9*perc) i);
 </programlisting>
@@ -579,11 +579,11 @@ SET ts = (SELECT ts || text 'A' FROM tbl_ttext_seqset t2 WHERE t2.k = t1.k+perc)
 WHERE k in (SELECT i FROM generate_series(1 + 4*perc, 5*perc) i);
 /* Add perc tuples that meet */
 UPDATE tbl_ttext_seqset t1
-SET ts = (SELECT shift(ts, timespan(ts)) FROM tbl_ttext_seqset t2 WHERE t2.k = t1.k+perc)
+SET ts = (SELECT shift(ts, timeSpan(ts)) FROM tbl_ttext_seqset t2 WHERE t2.k = t1.k+perc)
 WHERE t1.k in (SELECT i FROM generate_series(1 + 6*perc, 7*perc) i);
 /* Add perc tuples that overlap */
 UPDATE tbl_ttext_seqset t1
-SET ts = (SELECT shift(ts, date_trunc('minute', timespan(ts)/2))
+SET ts = (SELECT shift(ts, date_trunc('minute', timeSpan(ts)/2))
   FROM tbl_ttext_seqset t2 WHERE t2.k = t1.k+perc)
 WHERE t1.k in (SELECT i FROM generate_series(1 + 8*perc, 9*perc) i);
 </programlisting>
@@ -635,11 +635,11 @@ SET ts = (SELECT round(ts,3) FROM tbl_tgeompoint3D_seqset t2 WHERE t2.k = t1.k+p
 WHERE k IN (SELECT i FROM generate_series(1 + 2*perc, 3*perc) i);
 /* Add perc tuples that meet */
 UPDATE tbl_tgeompoint3D_seqset t1
-SET ts = (SELECT shift(ts, timespan(ts)) FROM tbl_tgeompoint3D_seqset t2 WHERE t2.k = t1.k+perc)
+SET ts = (SELECT shift(ts, timeSpan(ts)) FROM tbl_tgeompoint3D_seqset t2 WHERE t2.k = t1.k+perc)
 WHERE t1.k IN (SELECT i FROM generate_series(1 + 4*perc, 5*perc) i);
 /* Add perc tuples that overlap */
 UPDATE tbl_tgeompoint3D_seqset t1
-SET ts = (SELECT shift(ts, date_trunc('minute', timespan(ts)/2))
+SET ts = (SELECT shift(ts, date_trunc('minute', timeSpan(ts)/2))
   FROM tbl_tgeompoint3D_seqset t2 WHERE t2.k = t1.k+perc)
 WHERE t1.k IN (SELECT i FROM generate_series(1 + 6*perc, 7*perc) i);
 </programlisting>

--- a/mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
+++ b/mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
@@ -42,7 +42,7 @@ CREATE FUNCTION tcbuffer_in(cstring, oid, integer)
   RETURNS tcbuffer
   AS 'MODULE_PATHNAME', 'Tcbuffer_in'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION Temporal_out(tcbuffer)
+CREATE FUNCTION temporal_out(tcbuffer)
   RETURNS cstring
   AS 'MODULE_PATHNAME', 'Temporal_out'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/cbuffer/211_tcbuffer_aggfuncs.in.sql
+++ b/mobilitydb/sql/cbuffer/211_tcbuffer_aggfuncs.in.sql
@@ -38,7 +38,7 @@ CREATE FUNCTION tcount_transfn(internal, tcbuffer)
   AS 'MODULE_PATHNAME', 'Temporal_tcount_transfn'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
-CREATE AGGREGATE tcount(tcbuffer) (
+CREATE AGGREGATE tCount(tcbuffer) (
   SFUNC = tcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tcount_combinefn,
@@ -54,7 +54,7 @@ CREATE FUNCTION wcount_transfn(internal, tcbuffer, interval)
   AS 'MODULE_PATHNAME', 'Temporal_wcount_transfn'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
-CREATE AGGREGATE wcount(tcbuffer, interval) (
+CREATE AGGREGATE wCount(tcbuffer, interval) (
   SFUNC = wcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tint_tsum_combinefn,

--- a/mobilitydb/sql/geo/068_tgeo_aggfuncs.in.sql
+++ b/mobilitydb/sql/geo/068_tgeo_aggfuncs.in.sql
@@ -68,7 +68,7 @@ CREATE FUNCTION tcount_transfn(internal, tgeography)
   AS 'MODULE_PATHNAME', 'Temporal_tcount_transfn'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
-CREATE AGGREGATE tcount(tgeometry) (
+CREATE AGGREGATE tCount(tgeometry) (
   SFUNC = tcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tcount_combinefn,
@@ -78,7 +78,7 @@ CREATE AGGREGATE tcount(tgeometry) (
   PARALLEL = SAFE
 );
 
-CREATE AGGREGATE tcount(tgeography) (
+CREATE AGGREGATE tCount(tgeography) (
   SFUNC = tcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tcount_combinefn,
@@ -98,7 +98,7 @@ CREATE FUNCTION wcount_transfn(internal, tgeography, interval)
   AS 'MODULE_PATHNAME', 'Temporal_wcount_transfn'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
-CREATE AGGREGATE wcount(tgeometry, interval) (
+CREATE AGGREGATE wCount(tgeometry, interval) (
   SFUNC = wcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tint_tsum_combinefn,
@@ -107,7 +107,7 @@ CREATE AGGREGATE wcount(tgeometry, interval) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
 );
-CREATE AGGREGATE wcount(tgeography, interval) (
+CREATE AGGREGATE wCount(tgeography, interval) (
   SFUNC = wcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tint_tsum_combinefn,

--- a/mobilitydb/sql/geo/068_tpoint_aggfuncs.in.sql
+++ b/mobilitydb/sql/geo/068_tpoint_aggfuncs.in.sql
@@ -68,7 +68,7 @@ CREATE FUNCTION tcount_transfn(internal, tgeogpoint)
   AS 'MODULE_PATHNAME', 'Temporal_tcount_transfn'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
-CREATE AGGREGATE tcount(tgeompoint) (
+CREATE AGGREGATE tCount(tgeompoint) (
   SFUNC = tcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tcount_combinefn,
@@ -78,7 +78,7 @@ CREATE AGGREGATE tcount(tgeompoint) (
   PARALLEL = SAFE
 );
 
-CREATE AGGREGATE tcount(tgeogpoint) (
+CREATE AGGREGATE tCount(tgeogpoint) (
   SFUNC = tcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tcount_combinefn,
@@ -98,7 +98,7 @@ CREATE FUNCTION wcount_transfn(internal, tgeogpoint, interval)
   AS 'MODULE_PATHNAME', 'Temporal_wcount_transfn'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
-CREATE AGGREGATE wcount(tgeompoint, interval) (
+CREATE AGGREGATE wCount(tgeompoint, interval) (
   SFUNC = wcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tint_tsum_combinefn,
@@ -107,7 +107,7 @@ CREATE AGGREGATE wcount(tgeompoint, interval) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
 );
-CREATE AGGREGATE wcount(tgeogpoint, interval) (
+CREATE AGGREGATE wCount(tgeogpoint, interval) (
   SFUNC = wcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tint_tsum_combinefn,
@@ -131,7 +131,7 @@ CREATE FUNCTION tcentroid_finalfn(internal)
   AS 'MODULE_PATHNAME', 'Tpoint_tcentroid_finalfn'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE AGGREGATE tcentroid(tgeompoint) (
+CREATE AGGREGATE tCentroid(tgeompoint) (
   SFUNC = tcentroid_transfn,
   STYPE = internal,
   COMBINEFUNC = tcentroid_combinefn,

--- a/mobilitydb/sql/json/464_tjsonb_aggfuncs.in.sql
+++ b/mobilitydb/sql/json/464_tjsonb_aggfuncs.in.sql
@@ -56,7 +56,7 @@ CREATE FUNCTION tjsonb_tagg_finalfn(internal)
   AS 'MODULE_PATHNAME', 'Temporal_tagg_finalfn'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE AGGREGATE tcount(tjsonb) (
+CREATE AGGREGATE tCount(tjsonb) (
   SFUNC = tcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tcount_combinefn,
@@ -72,7 +72,7 @@ CREATE FUNCTION wcount_transfn(internal, tjsonb, interval)
   AS 'MODULE_PATHNAME', 'Temporal_wcount_transfn'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
-CREATE AGGREGATE wcount(tjsonb, interval) (
+CREATE AGGREGATE wCount(tjsonb, interval) (
   SFUNC = wcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tint_tsum_combinefn,

--- a/mobilitydb/sql/npoint/300_npoint.in.sql
+++ b/mobilitydb/sql/npoint/300_npoint.in.sql
@@ -249,7 +249,7 @@ CREATE FUNCTION getPosition(npoint)
   AS 'MODULE_PATHNAME', 'Npoint_position'
   LANGUAGE C IMMUTABLE STRICT;
 
-CREATE FUNCTION srid(npoint)
+CREATE FUNCTION SRID(npoint)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Npoint_srid'
   LANGUAGE C IMMUTABLE STRICT;
@@ -269,7 +269,7 @@ CREATE FUNCTION endPosition(nsegment)
   AS 'MODULE_PATHNAME', 'Nsegment_end_position'
   LANGUAGE C IMMUTABLE STRICT;
 
-CREATE FUNCTION srid(nsegment)
+CREATE FUNCTION SRID(nsegment)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Nsegment_srid'
   LANGUAGE C IMMUTABLE STRICT;

--- a/mobilitydb/sql/npoint/302_tnpoint.in.sql
+++ b/mobilitydb/sql/npoint/302_tnpoint.in.sql
@@ -42,7 +42,7 @@ CREATE FUNCTION tnpoint_in(cstring, oid, integer)
   RETURNS tnpoint
   AS 'MODULE_PATHNAME', 'Tnpoint_in'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION Temporal_out(tnpoint)
+CREATE FUNCTION temporal_out(tnpoint)
   RETURNS cstring
   AS 'MODULE_PATHNAME', 'Temporal_out'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/npoint/312_tnpoint_distance.in.sql
+++ b/mobilitydb/sql/npoint/312_tnpoint_distance.in.sql
@@ -92,25 +92,25 @@ CREATE OPERATOR <-> (
  * Nearest approach instant
  *****************************************************************************/
 
-CREATE FUNCTION NearestApproachInstant(geometry, tnpoint)
+CREATE FUNCTION nearestApproachInstant(geometry, tnpoint)
   RETURNS tnpoint
   AS 'MODULE_PATHNAME', 'NAI_geo_tnpoint'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION NearestApproachInstant(tnpoint, geometry)
+CREATE FUNCTION nearestApproachInstant(tnpoint, geometry)
   RETURNS tnpoint
   AS 'MODULE_PATHNAME', 'NAI_tnpoint_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION NearestApproachInstant(npoint, tnpoint)
+CREATE FUNCTION nearestApproachInstant(npoint, tnpoint)
   RETURNS tnpoint
   AS 'MODULE_PATHNAME', 'NAI_npoint_tnpoint'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION NearestApproachInstant(tnpoint, npoint)
+CREATE FUNCTION nearestApproachInstant(tnpoint, npoint)
   RETURNS tnpoint
   AS 'MODULE_PATHNAME', 'NAI_tnpoint_npoint'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION NearestApproachInstant(tnpoint, tnpoint)
+CREATE FUNCTION nearestApproachInstant(tnpoint, tnpoint)
   RETURNS tnpoint
   AS 'MODULE_PATHNAME', 'NAI_tnpoint_tnpoint'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -135,11 +135,11 @@ CREATE FUNCTION nearestApproachDistance(tnpoint, stbox)
   RETURNS float
   AS 'MODULE_PATHNAME', 'NAD_tnpoint_stbox'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION NearestApproachDistance(npoint, tnpoint)
+CREATE FUNCTION nearestApproachDistance(npoint, tnpoint)
   RETURNS float
   AS 'MODULE_PATHNAME', 'NAD_npoint_tnpoint'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION NearestApproachDistance(tnpoint, npoint)
+CREATE FUNCTION nearestApproachDistance(tnpoint, npoint)
   RETURNS float
   AS 'MODULE_PATHNAME', 'NAD_tnpoint_npoint'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/npoint/314_tnpoint_aggfuncs.in.sql
+++ b/mobilitydb/sql/npoint/314_tnpoint_aggfuncs.in.sql
@@ -50,7 +50,7 @@ CREATE FUNCTION tcount_transfn(internal, tnpoint)
   AS 'MODULE_PATHNAME', 'Temporal_tcount_transfn'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
-CREATE AGGREGATE tcount(tnpoint) (
+CREATE AGGREGATE tCount(tnpoint) (
   SFUNC = tcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tcount_combinefn,
@@ -66,7 +66,7 @@ CREATE FUNCTION wcount_transfn(internal, tnpoint, interval)
   AS 'MODULE_PATHNAME', 'Temporal_wcount_transfn'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
-CREATE AGGREGATE wcount(tnpoint, interval) (
+CREATE AGGREGATE wCount(tnpoint, interval) (
   SFUNC = wcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tint_tsum_combinefn,
@@ -82,7 +82,7 @@ CREATE FUNCTION tcentroid_transfn(internal, tnpoint)
   AS 'MODULE_PATHNAME', 'Tnpoint_tcentroid_transfn'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
-CREATE AGGREGATE tcentroid(tnpoint) (
+CREATE AGGREGATE tCentroid(tnpoint) (
   SFUNC = tcentroid_transfn,
   STYPE = internal,
   COMBINEFUNC = tcentroid_combinefn,

--- a/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
+++ b/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
@@ -253,7 +253,7 @@ CREATE FUNCTION duration(tpcpoint, boundspan boolean DEFAULT FALSE)
   AS 'MODULE_PATHNAME', 'Temporal_duration'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION timespan(tpcpoint)
+CREATE FUNCTION timeSpan(tpcpoint)
   RETURNS tstzspan
   AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
+++ b/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
@@ -214,7 +214,7 @@ CREATE FUNCTION duration(tpcpatch, boundspan boolean DEFAULT FALSE)
   RETURNS interval
   AS 'MODULE_PATHNAME', 'Temporal_duration'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION timespan(tpcpatch)
+CREATE FUNCTION timeSpan(tpcpatch)
   RETURNS tstzspan
   AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/pointcloud/440_tpc_aggfuncs.in.sql
+++ b/mobilitydb/sql/pointcloud/440_tpc_aggfuncs.in.sql
@@ -69,7 +69,7 @@ CREATE FUNCTION tcount_transfn(internal, tpcpatch)
   AS 'MODULE_PATHNAME', 'Temporal_tcount_transfn'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
-CREATE AGGREGATE tcount(tpcpoint) (
+CREATE AGGREGATE tCount(tpcpoint) (
   SFUNC = tcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tcount_combinefn,
@@ -79,7 +79,7 @@ CREATE AGGREGATE tcount(tpcpoint) (
   PARALLEL = SAFE
 );
 
-CREATE AGGREGATE tcount(tpcpatch) (
+CREATE AGGREGATE tCount(tpcpatch) (
   SFUNC = tcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tcount_combinefn,
@@ -135,7 +135,7 @@ CREATE FUNCTION wcount_transfn(internal, tpcpatch, interval)
   AS 'MODULE_PATHNAME', 'Temporal_wcount_transfn'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
-CREATE AGGREGATE wcount(tpcpoint, interval) (
+CREATE AGGREGATE wCount(tpcpoint, interval) (
   SFUNC = wcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tint_tsum_combinefn,
@@ -145,7 +145,7 @@ CREATE AGGREGATE wcount(tpcpoint, interval) (
   PARALLEL = SAFE
 );
 
-CREATE AGGREGATE wcount(tpcpatch, interval) (
+CREATE AGGREGATE wCount(tpcpatch, interval) (
   SFUNC = wcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tint_tsum_combinefn,

--- a/mobilitydb/sql/pose/111_tpose_aggfuncs.in.sql
+++ b/mobilitydb/sql/pose/111_tpose_aggfuncs.in.sql
@@ -38,7 +38,7 @@ CREATE FUNCTION tcount_transfn(internal, tpose)
   AS 'MODULE_PATHNAME', 'Temporal_tcount_transfn'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
-CREATE AGGREGATE tcount(tpose) (
+CREATE AGGREGATE tCount(tpose) (
   SFUNC = tcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tcount_combinefn,
@@ -65,7 +65,7 @@ CREATE FUNCTION wcount_transfn(internal, tpose, interval)
   AS 'MODULE_PATHNAME', 'Temporal_wcount_transfn'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
-CREATE AGGREGATE wcount(tpose, interval) (
+CREATE AGGREGATE wCount(tpose, interval) (
   SFUNC = wcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tint_tsum_combinefn,

--- a/mobilitydb/sql/rgeo/168_trgeo_aggfuncs.in.sql
+++ b/mobilitydb/sql/rgeo/168_trgeo_aggfuncs.in.sql
@@ -38,7 +38,7 @@ CREATE FUNCTION tcount_transfn(internal, trgeometry)
   AS 'MODULE_PATHNAME', 'Temporal_tcount_transfn'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
-CREATE AGGREGATE tcount(trgeometry) (
+CREATE AGGREGATE tCount(trgeometry) (
   SFUNC = tcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tcount_combinefn,
@@ -54,7 +54,7 @@ CREATE FUNCTION wcount_transfn(internal, trgeometry, interval)
   AS 'MODULE_PATHNAME', 'Temporal_wcount_transfn'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
-CREATE AGGREGATE wcount(trgeometry, interval) (
+CREATE AGGREGATE wCount(trgeometry, interval) (
   SFUNC = wcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tint_tsum_combinefn,

--- a/mobilitydb/sql/temporal/040_temporal_aggfuncs.in.sql
+++ b/mobilitydb/sql/temporal/040_temporal_aggfuncs.in.sql
@@ -141,7 +141,7 @@ CREATE FUNCTION tbigint_tagg_finalfn(internal)
   AS 'MODULE_PATHNAME', 'Temporal_tagg_finalfn'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE AGGREGATE tcount(timestamptz) (
+CREATE AGGREGATE tCount(timestamptz) (
   SFUNC = tcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tcount_combinefn,
@@ -151,7 +151,7 @@ CREATE AGGREGATE tcount(timestamptz) (
   PARALLEL = SAFE
 );
 
-CREATE AGGREGATE tcount(tstzset) (
+CREATE AGGREGATE tCount(tstzset) (
   SFUNC = tcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tcount_combinefn,
@@ -161,7 +161,7 @@ CREATE AGGREGATE tcount(tstzset) (
   PARALLEL = SAFE
 );
 
-CREATE AGGREGATE tcount(tstzspan) (
+CREATE AGGREGATE tCount(tstzspan) (
   SFUNC = tcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tcount_combinefn,
@@ -171,7 +171,7 @@ CREATE AGGREGATE tcount(tstzspan) (
   PARALLEL = SAFE
 );
 
-CREATE AGGREGATE tcount(tstzspanset) (
+CREATE AGGREGATE tCount(tstzspanset) (
   SFUNC = tcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tcount_combinefn,
@@ -210,7 +210,7 @@ CREATE FUNCTION tbool_tagg_finalfn(internal)
   AS 'MODULE_PATHNAME', 'Temporal_tagg_finalfn'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE AGGREGATE tcount(tbool) (
+CREATE AGGREGATE tCount(tbool) (
   SFUNC = tcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tcount_combinefn,
@@ -220,7 +220,7 @@ CREATE AGGREGATE tcount(tbool) (
   PARALLEL = SAFE
 );
 
-CREATE AGGREGATE tand(tbool) (
+CREATE AGGREGATE tAnd(tbool) (
   SFUNC = tbool_tand_transfn,
   STYPE = internal,
   COMBINEFUNC = tbool_tand_combinefn,
@@ -229,7 +229,7 @@ CREATE AGGREGATE tand(tbool) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
 );
-CREATE AGGREGATE tor(tbool) (
+CREATE AGGREGATE tOr(tbool) (
   SFUNC = tbool_tor_transfn,
   STYPE = internal,
   COMBINEFUNC = tbool_tor_combinefn,
@@ -318,7 +318,7 @@ CREATE FUNCTION tavg_finalfn(internal)
   AS 'MODULE_PATHNAME', 'Tnumber_tavg_finalfn'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE AGGREGATE tcount(tint) (
+CREATE AGGREGATE tCount(tint) (
   SFUNC = tcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tcount_combinefn,
@@ -328,7 +328,7 @@ CREATE AGGREGATE tcount(tint) (
   PARALLEL = SAFE
 );
 
-CREATE AGGREGATE tcount(tbigint) (
+CREATE AGGREGATE tCount(tbigint) (
   SFUNC = tcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tcount_combinefn,
@@ -338,7 +338,7 @@ CREATE AGGREGATE tcount(tbigint) (
   PARALLEL = SAFE
 );
 
-CREATE AGGREGATE tmin(tint) (
+CREATE AGGREGATE tMin(tint) (
   SFUNC = tint_tmin_transfn,
   STYPE = internal,
   COMBINEFUNC = tint_tmin_combinefn,
@@ -349,7 +349,7 @@ CREATE AGGREGATE tmin(tint) (
   PARALLEL = SAFE
 );
 
-CREATE AGGREGATE tminAgg(tint) (
+CREATE AGGREGATE tMinAgg(tint) (
   SFUNC = tint_tmin_transfn,
   STYPE = internal,
   COMBINEFUNC = tint_tmin_combinefn,
@@ -359,7 +359,7 @@ CREATE AGGREGATE tminAgg(tint) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
 );
-CREATE AGGREGATE tmax(tint) (
+CREATE AGGREGATE tMax(tint) (
   SFUNC = tint_tmax_transfn,
   STYPE = internal,
   COMBINEFUNC = tint_tmax_combinefn,
@@ -370,7 +370,7 @@ CREATE AGGREGATE tmax(tint) (
   PARALLEL = SAFE
 );
 
-CREATE AGGREGATE tmaxAgg(tint) (
+CREATE AGGREGATE tMaxAgg(tint) (
   SFUNC = tint_tmax_transfn,
   STYPE = internal,
   COMBINEFUNC = tint_tmax_combinefn,
@@ -380,7 +380,7 @@ CREATE AGGREGATE tmaxAgg(tint) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
 );
-CREATE AGGREGATE tsum(tint) (
+CREATE AGGREGATE tSum(tint) (
   SFUNC = tint_tsum_transfn,
   STYPE = internal,
   COMBINEFUNC = tint_tsum_combinefn,
@@ -389,7 +389,7 @@ CREATE AGGREGATE tsum(tint) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
 );
-CREATE AGGREGATE tavg(tint) (
+CREATE AGGREGATE tAvg(tint) (
   SFUNC = tavg_transfn,
   STYPE = internal,
   COMBINEFUNC = tavg_combinefn,
@@ -399,7 +399,7 @@ CREATE AGGREGATE tavg(tint) (
   PARALLEL = SAFE
 );
 
-CREATE AGGREGATE tmin(tbigint) (
+CREATE AGGREGATE tMin(tbigint) (
   SFUNC = tbigint_tmin_transfn,
   STYPE = internal,
   COMBINEFUNC = tbigint_tmin_combinefn,
@@ -410,7 +410,7 @@ CREATE AGGREGATE tmin(tbigint) (
   PARALLEL = SAFE
 );
 
-CREATE AGGREGATE tminAgg(tbigint) (
+CREATE AGGREGATE tMinAgg(tbigint) (
   SFUNC = tbigint_tmin_transfn,
   STYPE = internal,
   COMBINEFUNC = tbigint_tmin_combinefn,
@@ -420,7 +420,7 @@ CREATE AGGREGATE tminAgg(tbigint) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
 );
-CREATE AGGREGATE tmax(tbigint) (
+CREATE AGGREGATE tMax(tbigint) (
   SFUNC = tbigint_tmax_transfn,
   STYPE = internal,
   COMBINEFUNC = tbigint_tmax_combinefn,
@@ -431,7 +431,7 @@ CREATE AGGREGATE tmax(tbigint) (
   PARALLEL = SAFE
 );
 
-CREATE AGGREGATE tmaxAgg(tbigint) (
+CREATE AGGREGATE tMaxAgg(tbigint) (
   SFUNC = tbigint_tmax_transfn,
   STYPE = internal,
   COMBINEFUNC = tbigint_tmax_combinefn,
@@ -441,7 +441,7 @@ CREATE AGGREGATE tmaxAgg(tbigint) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
 );
-CREATE AGGREGATE tsum(tbigint) (
+CREATE AGGREGATE tSum(tbigint) (
   SFUNC = tbigint_tsum_transfn,
   STYPE = internal,
   COMBINEFUNC = tbigint_tsum_combinefn,
@@ -450,7 +450,7 @@ CREATE AGGREGATE tsum(tbigint) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
 );
-CREATE AGGREGATE tavg(tbigint) (
+CREATE AGGREGATE tAvg(tbigint) (
   SFUNC = tavg_transfn,
   STYPE = internal,
   COMBINEFUNC = tavg_combinefn,
@@ -500,7 +500,7 @@ CREATE FUNCTION tavg_transfn(internal, tfloat)
   AS 'MODULE_PATHNAME', 'Tnumber_tavg_transfn'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
-CREATE AGGREGATE tcount(tfloat) (
+CREATE AGGREGATE tCount(tfloat) (
   SFUNC = tcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tcount_combinefn,
@@ -510,7 +510,7 @@ CREATE AGGREGATE tcount(tfloat) (
   PARALLEL = SAFE
 );
 
-CREATE AGGREGATE tmin(tfloat) (
+CREATE AGGREGATE tMin(tfloat) (
   SFUNC = tfloat_tmin_transfn,
   STYPE = internal,
   COMBINEFUNC = tfloat_tmin_combinefn,
@@ -521,7 +521,7 @@ CREATE AGGREGATE tmin(tfloat) (
   PARALLEL = SAFE
 );
 
-CREATE AGGREGATE tminAgg(tfloat) (
+CREATE AGGREGATE tMinAgg(tfloat) (
   SFUNC = tfloat_tmin_transfn,
   STYPE = internal,
   COMBINEFUNC = tfloat_tmin_combinefn,
@@ -531,7 +531,7 @@ CREATE AGGREGATE tminAgg(tfloat) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
 );
-CREATE AGGREGATE tmax(tfloat) (
+CREATE AGGREGATE tMax(tfloat) (
   SFUNC = tfloat_tmax_transfn,
   STYPE = internal,
   COMBINEFUNC = tfloat_tmax_combinefn,
@@ -542,7 +542,7 @@ CREATE AGGREGATE tmax(tfloat) (
   PARALLEL = SAFE
 );
 
-CREATE AGGREGATE tmaxAgg(tfloat) (
+CREATE AGGREGATE tMaxAgg(tfloat) (
   SFUNC = tfloat_tmax_transfn,
   STYPE = internal,
   COMBINEFUNC = tfloat_tmax_combinefn,
@@ -552,7 +552,7 @@ CREATE AGGREGATE tmaxAgg(tfloat) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
 );
-CREATE AGGREGATE tsum(tfloat) (
+CREATE AGGREGATE tSum(tfloat) (
   SFUNC = tfloat_tsum_transfn,
   STYPE = internal,
   COMBINEFUNC = tfloat_tsum_combinefn,
@@ -561,7 +561,7 @@ CREATE AGGREGATE tsum(tfloat) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
 );
-CREATE AGGREGATE tavg(tfloat) (
+CREATE AGGREGATE tAvg(tfloat) (
   SFUNC = tavg_transfn,
   STYPE = internal,
   COMBINEFUNC = tavg_combinefn,
@@ -600,7 +600,7 @@ CREATE FUNCTION ttext_tagg_finalfn(internal)
   AS 'MODULE_PATHNAME', 'Temporal_tagg_finalfn'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE AGGREGATE tcount(ttext) (
+CREATE AGGREGATE tCount(ttext) (
   SFUNC = tcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tcount_combinefn,
@@ -610,7 +610,7 @@ CREATE AGGREGATE tcount(ttext) (
   PARALLEL = SAFE
 );
 
-CREATE AGGREGATE tmin(ttext) (
+CREATE AGGREGATE tMin(ttext) (
   SFUNC = ttext_tmin_transfn,
   STYPE = internal,
   COMBINEFUNC = ttext_tmin_combinefn,
@@ -621,7 +621,7 @@ CREATE AGGREGATE tmin(ttext) (
   PARALLEL = SAFE
 );
 
-CREATE AGGREGATE tminAgg(ttext) (
+CREATE AGGREGATE tMinAgg(ttext) (
   SFUNC = ttext_tmin_transfn,
   STYPE = internal,
   COMBINEFUNC = ttext_tmin_combinefn,
@@ -631,7 +631,7 @@ CREATE AGGREGATE tminAgg(ttext) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
 );
-CREATE AGGREGATE tmax(ttext) (
+CREATE AGGREGATE tMax(ttext) (
   SFUNC = ttext_tmax_transfn,
   STYPE = internal,
   COMBINEFUNC = ttext_tmax_combinefn,
@@ -642,7 +642,7 @@ CREATE AGGREGATE tmax(ttext) (
   PARALLEL = SAFE
 );
 
-CREATE AGGREGATE tmaxAgg(ttext) (
+CREATE AGGREGATE tMaxAgg(ttext) (
   SFUNC = ttext_tmax_transfn,
   STYPE = internal,
   COMBINEFUNC = ttext_tmax_combinefn,

--- a/mobilitydb/sql/temporal/042_temporal_waggfuncs.in.sql
+++ b/mobilitydb/sql/temporal/042_temporal_waggfuncs.in.sql
@@ -53,7 +53,7 @@ CREATE FUNCTION wavg_transfn(internal, tint, interval)
   AS 'MODULE_PATHNAME', 'Tnumber_wavg_transfn'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
-CREATE AGGREGATE wmin(tint, interval) (
+CREATE AGGREGATE wMin(tint, interval) (
   SFUNC = tint_wmin_transfn,
   STYPE = internal,
   COMBINEFUNC = tint_tmin_combinefn,
@@ -62,7 +62,7 @@ CREATE AGGREGATE wmin(tint, interval) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
 );
-CREATE AGGREGATE wmax(tint, interval) (
+CREATE AGGREGATE wMax(tint, interval) (
   SFUNC = tint_wmax_transfn,
   STYPE = internal,
   COMBINEFUNC = tint_tmax_combinefn,
@@ -71,7 +71,7 @@ CREATE AGGREGATE wmax(tint, interval) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
 );
-CREATE AGGREGATE wsum(tint, interval) (
+CREATE AGGREGATE wSum(tint, interval) (
   SFUNC = tint_wsum_transfn,
   STYPE = internal,
   COMBINEFUNC = tint_tsum_combinefn,
@@ -80,7 +80,7 @@ CREATE AGGREGATE wsum(tint, interval) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
 );
-CREATE AGGREGATE wcount(tint, interval) (
+CREATE AGGREGATE wCount(tint, interval) (
   SFUNC = wcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tint_tsum_combinefn,
@@ -89,7 +89,7 @@ CREATE AGGREGATE wcount(tint, interval) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
 );
-CREATE AGGREGATE wavg(tint, interval) (
+CREATE AGGREGATE wAvg(tint, interval) (
   SFUNC = wavg_transfn,
   STYPE = internal,
   COMBINEFUNC = tavg_combinefn,
@@ -122,7 +122,7 @@ CREATE FUNCTION wavg_transfn(internal, tbigint, interval)
   AS 'MODULE_PATHNAME', 'Tnumber_wavg_transfn'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
-CREATE AGGREGATE wmin(tbigint, interval) (
+CREATE AGGREGATE wMin(tbigint, interval) (
   SFUNC = tbigint_wmin_transfn,
   STYPE = internal,
   COMBINEFUNC = tbigint_tmin_combinefn,
@@ -131,7 +131,7 @@ CREATE AGGREGATE wmin(tbigint, interval) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
 );
-CREATE AGGREGATE wmax(tbigint, interval) (
+CREATE AGGREGATE wMax(tbigint, interval) (
   SFUNC = tbigint_wmax_transfn,
   STYPE = internal,
   COMBINEFUNC = tbigint_tmax_combinefn,
@@ -140,7 +140,7 @@ CREATE AGGREGATE wmax(tbigint, interval) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
 );
-CREATE AGGREGATE wsum(tbigint, interval) (
+CREATE AGGREGATE wSum(tbigint, interval) (
   SFUNC = tbigint_wsum_transfn,
   STYPE = internal,
   COMBINEFUNC = tbigint_tsum_combinefn,
@@ -149,7 +149,7 @@ CREATE AGGREGATE wsum(tbigint, interval) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
 );
-CREATE AGGREGATE wcount(tbigint, interval) (
+CREATE AGGREGATE wCount(tbigint, interval) (
   SFUNC = wcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tbigint_tsum_combinefn,
@@ -158,7 +158,7 @@ CREATE AGGREGATE wcount(tbigint, interval) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
 );
-CREATE AGGREGATE wavg(tbigint, interval) (
+CREATE AGGREGATE wAvg(tbigint, interval) (
   SFUNC = wavg_transfn,
   STYPE = internal,
   COMBINEFUNC = tavg_combinefn,
@@ -191,7 +191,7 @@ CREATE FUNCTION wavg_transfn(internal, tfloat, interval)
   AS 'MODULE_PATHNAME', 'Tnumber_wavg_transfn'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
-CREATE AGGREGATE wmin(tfloat, interval) (
+CREATE AGGREGATE wMin(tfloat, interval) (
   SFUNC = tfloat_wmin_transfn,
   STYPE = internal,
   COMBINEFUNC = tfloat_tmin_combinefn,
@@ -200,7 +200,7 @@ CREATE AGGREGATE wmin(tfloat, interval) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
 );
-CREATE AGGREGATE wmax(tfloat, interval) (
+CREATE AGGREGATE wMax(tfloat, interval) (
   SFUNC = tfloat_wmax_transfn,
   STYPE = internal,
   COMBINEFUNC = tfloat_tmax_combinefn,
@@ -209,7 +209,7 @@ CREATE AGGREGATE wmax(tfloat, interval) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
 );
-CREATE AGGREGATE wsum(tfloat, interval) (
+CREATE AGGREGATE wSum(tfloat, interval) (
   SFUNC = tfloat_wsum_transfn,
   STYPE = internal,
   COMBINEFUNC = tfloat_tsum_combinefn,
@@ -218,7 +218,7 @@ CREATE AGGREGATE wsum(tfloat, interval) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
 );
-CREATE AGGREGATE wcount(tfloat, interval) (
+CREATE AGGREGATE wCount(tfloat, interval) (
   SFUNC = wcount_transfn,
   STYPE = internal,
   COMBINEFUNC = tint_tsum_combinefn,
@@ -227,7 +227,7 @@ CREATE AGGREGATE wcount(tfloat, interval) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = SAFE
 );
-CREATE AGGREGATE wavg(tfloat, interval) (
+CREATE AGGREGATE wAvg(tfloat, interval) (
   SFUNC = wavg_transfn,
   STYPE = internal,
   COMBINEFUNC = tavg_combinefn,


### PR DESCRIPTION
The catalog `@sqlfn` / `@csqlaggfn` tags and the reference documentation are the source of truth for a SQL routine's spelling, and the deployed `CREATE FUNCTION` / `CREATE AGGREGATE` name must match it case-sensitively so that case-sensitive binding generators resolve a single canonical name. PostgreSQL folds unquoted identifiers, so the deployed routines are unchanged — only the source spelling is corrected, and the C symbols in the `AS` clauses are untouched.

Recase the lagging function names to their documented spelling: `timeSpan` (tpcpoint, tpcpatch), `SRID` (npoint, nsegment), `nearestApproachInstant` and `nearestApproachDistance` (tnpoint), and the `temporal_out` type-output function (tcbuffer, tnpoint).

Recase the lagging aggregate names to the spelling documented in the aggregation chapter: `tCount`, `tSum`, `tAvg`, `tAnd`, `tOr`, `tMin`, `tMax`, `tMinAgg`, `tMaxAgg`, `tCentroid`, `wCount`, `wSum`, `wMin`, `wMax`, and `wAvg`, across every family. The aggregates the documentation spells in lower case (`extent`, `merge`, `tnpoints`, `tdensity`) are left unchanged.

Update the `timeSpan` and `tboolInst` calls in the data generator examples to match.
