### PR TITLE
Generate the tpcpoint and tpcpatch accessor regions

### DIFF
--- a/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
+++ b/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
@@ -194,6 +194,9 @@ CREATE FUNCTION tpcpointSeqSet(tpcpoint[])
  * Accessors — generic Temporal_* wrappers where possible
  ******************************************************************************/
 
+-- GENERATED-ACCESSORS-BEGIN pointcloud — tools/codegen/inherited/generate.py from templates/accessors.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.yaml (accessor_families) and re-run.
+
 CREATE FUNCTION tempSubtype(tpcpoint)
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_subtype'
@@ -213,14 +216,34 @@ CREATE FUNCTION memSize(tpcpoint)
   AS 'MODULE_PATHNAME', 'Temporal_mem_size'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+-- value is a reserved word in SQL
 CREATE FUNCTION getValue(tpcpoint)
   RETURNS pcpoint
   AS 'MODULE_PATHNAME', 'Tinstant_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+-- timestamp is a reserved word in SQL
 CREATE FUNCTION getTimestamp(tpcpoint)
   RETURNS timestamptz
   AS 'MODULE_PATHNAME', 'Tinstant_timestamptz'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- values is a reserved word in SQL
+CREATE FUNCTION getValues(tpcpoint)
+  RETURNS pcpointset
+  AS 'MODULE_PATHNAME', 'Temporal_valueset'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- time is a reserved word in SQL
+CREATE FUNCTION getTime(tpcpoint)
+  RETURNS tstzspanset
+  AS 'MODULE_PATHNAME', 'Temporal_time'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- timeSpan is the bounding period, the tstzspan extent of the temporal value
+CREATE FUNCTION timeSpan(tpcpoint)
+  RETURNS tstzspan
+  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION startValue(tpcpoint)
@@ -233,19 +256,14 @@ CREATE FUNCTION endValue(tpcpoint)
   AS 'MODULE_PATHNAME', 'Temporal_end_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION valueN(tpcpoint, integer)
+CREATE FUNCTION valueN(tpcpoint, int)
   RETURNS pcpoint
   AS 'MODULE_PATHNAME', 'Temporal_value_n'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION getValues(tpcpoint)
-  RETURNS pcpointset
-  AS 'MODULE_PATHNAME', 'Temporal_valueset'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-CREATE FUNCTION getTime(tpcpoint)
-  RETURNS tstzspanset
-  AS 'MODULE_PATHNAME', 'Temporal_time'
+CREATE FUNCTION valueAtTimestamp(tpcpoint, timestamptz)
+  RETURNS pcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION duration(tpcpoint, boundspan boolean DEFAULT FALSE)
@@ -253,9 +271,14 @@ CREATE FUNCTION duration(tpcpoint, boundspan boolean DEFAULT FALSE)
   AS 'MODULE_PATHNAME', 'Temporal_duration'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION timeSpan(tpcpoint)
-  RETURNS tstzspan
-  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
+CREATE FUNCTION lowerInc(tpcpoint)
+  RETURNS bool
+  AS 'MODULE_PATHNAME', 'Temporal_lower_inc'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION upperInc(tpcpoint)
+  RETURNS bool
+  AS 'MODULE_PATHNAME', 'Temporal_upper_inc'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION numInstants(tpcpoint)
@@ -283,6 +306,11 @@ CREATE FUNCTION instants(tpcpoint)
   AS 'MODULE_PATHNAME', 'Temporal_instants'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION numTimestamps(tpcpoint)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Temporal_num_timestamps'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE FUNCTION startTimestamp(tpcpoint)
   RETURNS timestamptz
   AS 'MODULE_PATHNAME', 'Temporal_start_timestamptz'
@@ -296,21 +324,6 @@ CREATE FUNCTION endTimestamp(tpcpoint)
 CREATE FUNCTION timestampN(tpcpoint, integer)
   RETURNS timestamptz
   AS 'MODULE_PATHNAME', 'Temporal_timestamptz_n'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-CREATE FUNCTION numTimestamps(tpcpoint)
-  RETURNS integer
-  AS 'MODULE_PATHNAME', 'Temporal_num_timestamps'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-CREATE FUNCTION lowerInc(tpcpoint)
-  RETURNS bool
-  AS 'MODULE_PATHNAME', 'Temporal_lower_inc'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-CREATE FUNCTION upperInc(tpcpoint)
-  RETURNS bool
-  AS 'MODULE_PATHNAME', 'Temporal_upper_inc'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION timestamps(tpcpoint)
@@ -347,6 +360,7 @@ CREATE FUNCTION segments(tpcpoint)
   RETURNS tpcpoint[]
   AS 'MODULE_PATHNAME', 'Temporal_segments'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+-- GENERATED-ACCESSORS-END pointcloud
 
 -- Type-specific accessor
 CREATE FUNCTION pcid(tpcpoint)
@@ -388,13 +402,8 @@ CREATE FUNCTION tgeompoint(tpcpoint)
 CREATE CAST (tpcpoint AS tgeompoint) WITH FUNCTION tgeompoint(tpcpoint);
 
 /******************************************************************************
- * Value-at-timestamp / restriction
+ * Restrictions
  ******************************************************************************/
-
-CREATE FUNCTION valueAtTimestamp(tpcpoint, timestamptz)
-  RETURNS pcpoint
-  AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION atTime(tpcpoint, timestamptz)
   RETURNS tpcpoint

--- a/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
+++ b/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
@@ -178,82 +178,173 @@ CREATE FUNCTION tpcpatchSeqSet(tpcpatch[])
  * Accessors
  ******************************************************************************/
 
+-- GENERATED-ACCESSORS-BEGIN pointcloud_patch — tools/codegen/inherited/generate.py from templates/accessors.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.yaml (accessor_families) and re-run.
+
 CREATE FUNCTION tempSubtype(tpcpatch)
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_subtype'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION tempBasetype(tpcpatch)
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Temporal_basetype_name'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE FUNCTION interp(tpcpatch)
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_interp'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE FUNCTION memSize(tpcpatch)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Temporal_mem_size'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION startValue(tpcpatch)
+
+-- value is a reserved word in SQL
+CREATE FUNCTION getValue(tpcpatch)
   RETURNS pcpatch
-  AS 'MODULE_PATHNAME', 'Temporal_start_value'
+  AS 'MODULE_PATHNAME', 'Tinstant_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION endValue(tpcpatch)
-  RETURNS pcpatch
-  AS 'MODULE_PATHNAME', 'Temporal_end_value'
+
+-- timestamp is a reserved word in SQL
+CREATE FUNCTION getTimestamp(tpcpatch)
+  RETURNS timestamptz
+  AS 'MODULE_PATHNAME', 'Tinstant_timestamptz'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION valueN(tpcpatch, integer)
-  RETURNS pcpatch
-  AS 'MODULE_PATHNAME', 'Temporal_value_n'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- values is a reserved word in SQL
 CREATE FUNCTION getValues(tpcpatch)
   RETURNS pcpatchset
   AS 'MODULE_PATHNAME', 'Temporal_valueset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- time is a reserved word in SQL
 CREATE FUNCTION getTime(tpcpatch)
   RETURNS tstzspanset
   AS 'MODULE_PATHNAME', 'Temporal_time'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION duration(tpcpatch, boundspan boolean DEFAULT FALSE)
-  RETURNS interval
-  AS 'MODULE_PATHNAME', 'Temporal_duration'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- timeSpan is the bounding period, the tstzspan extent of the temporal value
 CREATE FUNCTION timeSpan(tpcpatch)
   RETURNS tstzspan
   AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION startValue(tpcpatch)
+  RETURNS pcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_start_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION endValue(tpcpatch)
+  RETURNS pcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_end_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION valueN(tpcpatch, int)
+  RETURNS pcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_value_n'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION valueAtTimestamp(tpcpatch, timestamptz)
+  RETURNS pcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION duration(tpcpatch, boundspan boolean DEFAULT FALSE)
+  RETURNS interval
+  AS 'MODULE_PATHNAME', 'Temporal_duration'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION lowerInc(tpcpatch)
+  RETURNS bool
+  AS 'MODULE_PATHNAME', 'Temporal_lower_inc'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION upperInc(tpcpatch)
+  RETURNS bool
+  AS 'MODULE_PATHNAME', 'Temporal_upper_inc'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE FUNCTION numInstants(tpcpatch)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Temporal_num_instants'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE FUNCTION startInstant(tpcpatch)
   RETURNS tpcpatch
   AS 'MODULE_PATHNAME', 'Temporal_start_instant'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE FUNCTION endInstant(tpcpatch)
   RETURNS tpcpatch
   AS 'MODULE_PATHNAME', 'Temporal_end_instant'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE FUNCTION instantN(tpcpatch, integer)
   RETURNS tpcpatch
   AS 'MODULE_PATHNAME', 'Temporal_instant_n'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE FUNCTION instants(tpcpatch)
   RETURNS tpcpatch[]
   AS 'MODULE_PATHNAME', 'Temporal_instants'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION startTimestamp(tpcpatch)
-  RETURNS timestamptz
-  AS 'MODULE_PATHNAME', 'Temporal_start_timestamptz'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION endTimestamp(tpcpatch)
-  RETURNS timestamptz
-  AS 'MODULE_PATHNAME', 'Temporal_end_timestamptz'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION timestampN(tpcpatch, integer)
-  RETURNS timestamptz
-  AS 'MODULE_PATHNAME', 'Temporal_timestamptz_n'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE FUNCTION numTimestamps(tpcpatch)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Temporal_num_timestamps'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION startTimestamp(tpcpatch)
+  RETURNS timestamptz
+  AS 'MODULE_PATHNAME', 'Temporal_start_timestamptz'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION endTimestamp(tpcpatch)
+  RETURNS timestamptz
+  AS 'MODULE_PATHNAME', 'Temporal_end_timestamptz'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION timestampN(tpcpatch, integer)
+  RETURNS timestamptz
+  AS 'MODULE_PATHNAME', 'Temporal_timestamptz_n'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION timestamps(tpcpatch)
+  RETURNS timestamptz[]
+  AS 'MODULE_PATHNAME', 'Temporal_timestamps'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION numSequences(tpcpatch)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Temporal_num_sequences'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION startSequence(tpcpatch)
+  RETURNS tpcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_start_sequence'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION endSequence(tpcpatch)
+  RETURNS tpcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_end_sequence'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION sequenceN(tpcpatch, integer)
+  RETURNS tpcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_sequence_n'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION sequences(tpcpatch)
+  RETURNS tpcpatch[]
+  AS 'MODULE_PATHNAME', 'Temporal_sequences'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION segments(tpcpatch)
+  RETURNS tpcpatch[]
+  AS 'MODULE_PATHNAME', 'Temporal_segments'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+-- GENERATED-ACCESSORS-END pointcloud_patch
 
 -- Type-specific
 CREATE FUNCTION pcid(tpcpatch)
@@ -277,13 +368,8 @@ CREATE FUNCTION numPoints(tpcpatch)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /******************************************************************************
- * Value-at-timestamp / restriction
+ * Restrictions
  ******************************************************************************/
-
-CREATE FUNCTION valueAtTimestamp(tpcpatch, timestamptz)
-  RETURNS pcpatch
-  AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION atTime(tpcpatch, timestamptz)
   RETURNS tpcpatch

--- a/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
+++ b/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
@@ -43,6 +43,78 @@ SELECT numInstants(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARR
            2
 (1 row)
 
+SELECT tempBasetype(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz));
+ tempbasetype 
+--------------
+ pcpatch
+(1 row)
+
+SELECT getTimestamp(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz));
+         gettimestamp         
+------------------------------
+ Mon Jan 01 00:00:00 2024 PST
+(1 row)
+
+SELECT numPoints(tpcpatch(getValue(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz)), '2024-01-05'::timestamptz));
+ numpoints 
+-----------
+         2
+(1 row)
+
+SELECT lowerInc(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)]));
+ lowerinc 
+----------
+ t
+(1 row)
+
+SELECT upperInc(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)]));
+ upperinc 
+----------
+ t
+(1 row)
+
+SELECT timestamps(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)]));
+                                           timestamps                                           
+------------------------------------------------------------------------------------------------
+ {"Mon Jan 01 00:00:00 2024 PST","Tue Jan 02 00:00:00 2024 PST","Wed Jan 03 00:00:00 2024 PST"}
+(1 row)
+
+SELECT numSequences(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)]));
+ numsequences 
+--------------
+            1
+(1 row)
+
+SELECT numInstants(startSequence(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)])));
+ numinstants 
+-------------
+           3
+(1 row)
+
+SELECT numInstants(endSequence(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)])));
+ numinstants 
+-------------
+           3
+(1 row)
+
+SELECT numInstants(sequenceN(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)]), 1));
+ numinstants 
+-------------
+           3
+(1 row)
+
+SELECT array_length(sequences(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)])), 1);
+ array_length 
+--------------
+            1
+(1 row)
+
+SELECT array_length(segments(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)])), 1);
+ array_length 
+--------------
+            3
+(1 row)
+
 SELECT numPoints(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz));
  numpoints 
 -----------

--- a/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
+++ b/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
@@ -48,6 +48,23 @@ SELECT numInstants(:inst1);
 SELECT numInstants(tpcpatchSeq(ARRAY[:inst1, :inst2]));
 
 -------------------------------------------------------------------------------
+-- Inherited Temporal<T> accessors
+-------------------------------------------------------------------------------
+
+SELECT tempBasetype(:inst1);
+SELECT getTimestamp(:inst1);
+SELECT numPoints(tpcpatch(getValue(:inst1), '2024-01-05'::timestamptz));
+SELECT lowerInc(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3]));
+SELECT upperInc(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3]));
+SELECT timestamps(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3]));
+SELECT numSequences(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3]));
+SELECT numInstants(startSequence(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3])));
+SELECT numInstants(endSequence(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3])));
+SELECT numInstants(sequenceN(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3]), 1));
+SELECT array_length(sequences(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3])), 1);
+SELECT array_length(segments(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3])), 1);
+
+-------------------------------------------------------------------------------
 -- numPoints(tpcpatch) — total points across every instant
 -------------------------------------------------------------------------------
 

--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -13,6 +13,7 @@
 from __future__ import annotations
 import argparse
 import pathlib
+import re
 import sys
 
 try:
@@ -414,6 +415,52 @@ def extract_accessors(filetext: str, family: str) -> str:
     return filetext[b:e]
 
 
+def _accessor_names() -> set:
+    """Every SQL function name the generated accessor region can carry: the shared
+    template's functions plus the gated TNumber/orderable reductions. Used to find and
+    remove the pre-existing hand-written definitions when bootstrapping a new family.
+    # BINDING-HEADER-PARSE-OK: reads the SQL accessors.sql.tmpl template (not a C
+    # header), exactly as render_accessors/_accessor_blocks already do; this is the
+    # inherited SQL-region generator, not a catalog-consuming binding."""
+    tmpl = (TEMPLATES / "accessors.sql.tmpl").read_text()
+    return set(re.findall(r"CREATE FUNCTION (\w+)\(", tmpl)) | set(_GATED)
+
+
+def bootstrap_accessors(filetext: str, fam: dict, rendered: str) -> str:
+    """Create the GENERATED-ACCESSORS region for a family that does not have one yet,
+    so adding an accessor family is fully declarative (a manifest entry) with NO
+    hand-placed marker. The region is inserted where the family's FIRST canonical
+    accessor is currently hand-written, and every hand-written definition of a canonical
+    accessor (for the family's temporal type(s), wherever it sits in the file — e.g. a
+    `valueAtTimestamp` parked in a restriction section) is removed so the region is the
+    single source. Idempotent on the next run: the markers now exist, so the normal
+    splice/validate path takes over."""
+    temps = [t["temp"] for t in (fam.get("types") or [{"temp": fam["temp"]}])]
+    names = _accessor_names()
+
+    def block_re(name: str, temp: str):
+        return re.compile(rf"^CREATE FUNCTION {re.escape(name)}\({re.escape(temp)}\b"
+                          rf"[^;]*?LANGUAGE[^;]*;\n", re.S | re.M)
+
+    first = None
+    for name in names:
+        for temp in temps:
+            m = block_re(name, temp).search(filetext)
+            if m and (first is None or m.start() < first):
+                first = m.start()
+    if first is None:
+        raise SystemExit(f"bootstrap accessors {fam['family']}: no canonical accessor "
+                         f"of {temps} found in {fam['file']}")
+    prefix, rest = filetext[:first], filetext[first:]
+    for name in names:
+        for temp in temps:
+            rest = block_re(name, temp).sub("", rest)
+    rest = re.sub(r"\A\n+", "", rest)  # the region supplies its own leading blank line
+    begin, end = _accessors_markers(fam["family"])
+    text = prefix + begin + rendered + end + "\n" + rest
+    return re.sub(r"\n\n\n+", "\n\n", text)  # tidy the blank runs left by the removals
+
+
 def target_path(behaviour: str, sub: dict, positions: dict) -> pathlib.Path:
     # The within-50-bin offset defaults to the shared `positions` map (the tight
     # cbuffer-anchored layout); a family on the tgeo-aligned layout overrides a
@@ -568,14 +615,24 @@ def main() -> int:
         print(f"spliced spatialrels {fam['family']} -> {fam['file']}")
 
     for fam in mf.get("accessor_families", []):
+        p = ROOT / fam["file"]
+        text = p.read_text()
+        begin, _ = _accessors_markers(fam["family"])
+        if begin not in text:
+            # No region yet -> BOOTSTRAP it once from the manifest entry (no hand-placed
+            # marker). After this the markers exist and the reference/splice path owns it.
+            if args.check:
+                print(f"would bootstrap accessors {fam['family']} -> {fam['file']}")
+                continue
+            p.write_text(bootstrap_accessors(text, fam, render_accessors(fam)))
+            print(f"bootstrapped accessors {fam['family']} -> {fam['file']}")
+            continue
         if fam.get("reference"):
             continue
-        p = ROOT / fam["file"]
         if args.check:
             print(f"would splice accessors {fam['family']} -> {fam['file']}")
             continue
-        p.write_text(splice_accessors(p.read_text(), fam["family"],
-                                      render_accessors(fam)))
+        p.write_text(splice_accessors(text, fam["family"], render_accessors(fam)))
         print(f"spliced accessors {fam['family']} -> {fam['file']}")
     return 0
 

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -325,3 +325,13 @@ accessor_families:
     reference: true
     types:
       - {temp: th3index, base: h3index, baseset: h3indexset}
+  - family:    pointcloud
+    file:      mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
+    reference: true
+    types:
+      - {temp: tpcpoint, base: pcpoint, baseset: pcpointset}
+  - family:    pointcloud_patch
+    file:      mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
+    reference: true
+    types:
+      - {temp: tpcpatch, base: pcpatch, baseset: pcpatchset}


### PR DESCRIPTION
Bring the pointcloud temporal types onto the shared inherited-accessor generator. A declarative `accessor_families` entry per type replaces the hand-written accessor block in `420_tpcpoint.in.sql` and `430_tpcpatch.in.sql`, so the surface is emitted from the one template every temporal family already uses.

The generator gains a bootstrap path: adding an accessor family needs only the manifest entry, with no hand-placed region marker. When a family's file has no `GENERATED-ACCESSORS` region yet, `generate.py` inserts it where the family's first canonical accessor is currently written and removes every hand-written definition of a canonical accessor for that type — including a `valueAtTimestamp` parked in a restriction section — so the region is the single source. The run is idempotent: once the markers exist, the normal splice/validate path owns it.

For `tpcpoint` the change is behavior-neutral: the function set is identical, the accessors are reordered to the canonical order, `valueAtTimestamp` moves into the Accessors region (matching its documented classification), and `valueN` spells the `int` alias the template uses.

For `tpcpatch` the region carries the full inherited `Temporal<T>` surface, so the type now exposes the accessors the rest of the temporal families have — `tempBasetype`, `getValue`, `getTimestamp`, `lowerInc`, `upperInc`, `timestamps`, `numSequences`, `startSequence`, `endSequence`, `sequenceN`, `sequences`, `segments` — wired to the same generic `Temporal_*` symbols every family uses. A test block exercises them.
