### PR TITLE
Expose eCovers, aCovers and tCovers for a geometry and a temporal geometry point

### DIFF
--- a/mobilitydb/sql/geo/070_tpoint_spatialrels.in.sql
+++ b/mobilitydb/sql/geo/070_tpoint_spatialrels.in.sql
@@ -52,6 +52,24 @@ CREATE FUNCTION aContains(geometry, tgeompoint)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************
+ * eCovers, aCovers
+ *****************************************************************************/
+
+CREATE FUNCTION eCovers(geometry, tgeompoint)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Ecovers_geo_tgeo'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/*****************************************************************************/
+
+CREATE FUNCTION aCovers(geometry, tgeompoint)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Acovers_geo_tgeo'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/*****************************************************************************
  * eDisjoint, aDisjoint
  *****************************************************************************/
 

--- a/mobilitydb/sql/geo/072_tpoint_tempspatialrels.in.sql
+++ b/mobilitydb/sql/geo/072_tpoint_tempspatialrels.in.sql
@@ -42,6 +42,15 @@ CREATE FUNCTION tContains(geometry, tgeompoint)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************
+ * tCovers
+ *****************************************************************************/
+
+CREATE FUNCTION tCovers(geometry, tgeompoint)
+  RETURNS tbool
+  AS 'MODULE_PATHNAME', 'Tcovers_geo_tgeo'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/*****************************************************************************
  * tDisjoint
  *****************************************************************************/
 


### PR DESCRIPTION
The temporal geometry point exposes `eContains`, `aContains` and `tContains` with a `geometry` first argument, but not the matching covers predicates. Covers and contains are both meaningful when the first argument is an area: the `geometry` carries the interior/boundary distinction, independently of the point operand. So `covers(geometry, tgeompoint)` is missing while covers exists for every other spatial family and while `contains(geometry, tgeompoint)` exists.

Add `eCovers`, `aCovers` and `tCovers` with signature `(geometry, tgeompoint)`, binding the generic `Ecovers_geo_tgeo`, `Acovers_geo_tgeo` and `Tcovers_geo_tgeo` wrappers that already back the `tgeometry` covers predicates. Only the areal-container direction is added, mirroring how contains is exposed for the point family.