### PR TITLE
Fix the parameter count of the temporal JSONB path functions

### DIFF
--- a/meos/src/json/tjsonb_jsonfuncs.c
+++ b/meos/src/json/tjsonb_jsonfuncs.c
@@ -1468,7 +1468,7 @@ tjsonb_path_exists(const Temporal *temp, const JsonPath *jp, const Jsonb *vars,
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) &datum_jsonb_path_exists;
   lfinfo.argtype[0] = T_TJSONB;
-  lfinfo.numparam = 3;
+  lfinfo.numparam = 4;
   lfinfo.param[0] = PointerGetDatum(jp);
   lfinfo.param[1] = PointerGetDatum(vars);
   lfinfo.param[2] = BoolGetDatum(silent);
@@ -1504,7 +1504,7 @@ tjsonb_path_match(const Temporal *temp, const JsonPath *jp, const Jsonb *vars,
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) &datum_jsonb_path_match;
   lfinfo.argtype[0] = T_TJSONB;
-  lfinfo.numparam = 3;
+  lfinfo.numparam = 4;
   lfinfo.param[0] = PointerGetDatum(jp);
   lfinfo.param[1] = PointerGetDatum(vars);
   lfinfo.param[2] = BoolGetDatum(silent);
@@ -1539,7 +1539,7 @@ tjsonb_path_query_array(const Temporal *temp, const JsonPath *jp,
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) &datum_jsonb_path_query_array;
   lfinfo.argtype[0] = T_TJSONB;
-  lfinfo.numparam = 3;
+  lfinfo.numparam = 4;
   lfinfo.param[0] = PointerGetDatum(jp);
   lfinfo.param[1] = PointerGetDatum(vars);
   lfinfo.param[2] = BoolGetDatum(silent);
@@ -1575,7 +1575,7 @@ tjsonb_path_query_first(const Temporal *temp, const JsonPath *jp,
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) &datum_jsonb_path_query_first;
   lfinfo.argtype[0] = T_TJSONB;
-  lfinfo.numparam = 3;
+  lfinfo.numparam = 4;
   lfinfo.param[0] = PointerGetDatum(jp);
   lfinfo.param[1] = PointerGetDatum(vars);
   lfinfo.param[2] = BoolGetDatum(silent);


### PR DESCRIPTION
The functions `tjsonb_path_exists`, `tjsonb_path_match`, `tjsonb_path_query_array` and `tjsonb_path_query_first` lift a leaf that takes four parameters (the JSON path, the variables, the silent flag and the timezone flag) and fill `param[0]` through `param[3]`, but they set `numparam` to 3. The lifting dispatch then calls the five-argument leaf as a four-argument function, so its last argument (the timezone flag) is read from an uninitialised register. The resulting undefined behaviour corrupts memory and surfaces later as `repalloc called with invalid pointer` on any query using the `@?` operator or the other path functions.

Set `numparam` to 4 so the dispatch passes `param[3]` and the leaf receives all its arguments.