### PR TITLE
Free the tracked values after evaluating a JSON path exists predicate

### DIFF
--- a/pgtypes/utils/jsonpath_exec.c
+++ b/pgtypes/utils/jsonpath_exec.c
@@ -415,8 +415,9 @@ pg_jsonb_path_exists(const Jsonb *jb, const JsonPath *jp, const Jsonb *vars,
   bool silent, bool tz)
 {
   JsonPathExecResult res = executeJsonPath((JsonPath *) jp, (Jsonb *) vars,
-    getJsonPathVariableFromJsonb, countVariablesFromJsonb, (Jsonb *) jb, 
+    getJsonPathVariableFromJsonb, countVariablesFromJsonb, (Jsonb *) jb,
     ! silent, NULL, tz);
+  json_reset_tofree(); /* free the values tracked during execution */
   if (jperIsError(res))
     return -1;
   if (res == jperOk)


### PR DESCRIPTION
The JSON path executor records the values it allocates while resolving a path so they can be released together, and `pg_jsonb_path_match`, `pg_jsonb_path_query_array` and `pg_jsonb_path_query_first` call `json_reset_tofree` once execution finishes. `pg_jsonb_path_exists` omits that call, so every evaluation leaves its tracked pointers on the list. When the `@?` operator lifts the predicate over a temporal JSONB value the list keeps growing across instants and later references memory that has already been freed, which crashes with `repalloc called with invalid pointer`.

Call `json_reset_tofree` after `executeJsonPath` in `pg_jsonb_path_exists`, matching the sibling path functions. This is memory-management only; results are unchanged.