### PR TITLE
Use INT64_FORMAT for int64 values in printf-family calls

### DIFF
--- a/meos/src/npoint/ways.c
+++ b/meos/src/npoint/ways.c
@@ -114,7 +114,7 @@ route_exists(int64 rid)
 {
   char sql[SQL_ROUTE_MAXLEN];
   snprintf(sql, sizeof(sql),
-    "SELECT true FROM public.ways WHERE gid = %ld", rid);
+    "SELECT true FROM public.ways WHERE gid = " INT64_FORMAT, rid);
   bool isNull = true;
   bool result = false;
   SPI_connect();
@@ -142,7 +142,7 @@ route_length(int64 rid)
 {
   char sql[SQL_ROUTE_MAXLEN];
   snprintf(sql, sizeof(sql),
-    "SELECT length FROM public.ways WHERE gid = %ld", rid);
+    "SELECT length FROM public.ways WHERE gid = " INT64_FORMAT, rid);
   bool isNull = true;
   double result = 0.0;
   SPI_connect();
@@ -177,7 +177,7 @@ route_geom(int64 rid)
 {
   char sql[SQL_ROUTE_MAXLEN];
   snprintf(sql, sizeof(sql),
-    "SELECT the_geom FROM public.ways WHERE gid = %ld", rid);
+    "SELECT the_geom FROM public.ways WHERE gid = " INT64_FORMAT, rid);
   bool isNull = true;
   GSERIALIZED *result = NULL;
   SPI_connect();

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -501,7 +501,7 @@ ensure_not_negative_datum(Datum d, MeosType basetype)
   if (basetype == T_INT4)
     snprintf(str, sizeof(str), "%d", DatumGetInt32(d));
   else if (basetype == T_INT8)
-    snprintf(str, sizeof(str), "%ld", DatumGetInt64(d));
+    snprintf(str, sizeof(str), INT64_FORMAT, DatumGetInt64(d));
   else if (basetype == T_FLOAT8)
     snprintf(str, sizeof(str), "%f", DatumGetFloat8(d));
   else /* basetype == T_TIMESTAMPTZ */
@@ -546,7 +546,7 @@ ensure_positive_datum(Datum d, MeosType basetype)
   if (basetype == T_INT4)
     snprintf(str, sizeof(str), "%d", DatumGetInt32(d));
   else if (basetype == T_INT8)
-    snprintf(str, sizeof(str), "%ld", DatumGetInt64(d));
+    snprintf(str, sizeof(str), INT64_FORMAT, DatumGetInt64(d));
   else if (basetype == T_FLOAT8)
     snprintf(str, sizeof(str), "%f", DatumGetFloat8(d));
   meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,

--- a/meos/src/temporal/type_out.c
+++ b/meos/src/temporal/type_out.c
@@ -233,7 +233,7 @@ int32_as_mfjson_sb(stringbuffer_t *sb, int i)
 static void
 int64_as_mfjson_sb(stringbuffer_t *sb, int64 i)
 {
-  stringbuffer_aprintf(sb, "%ld", i);
+  stringbuffer_aprintf(sb, INT64_FORMAT, i);
   return;
 }
 


### PR DESCRIPTION
Replaces six hardcoded `%ld` format specifiers used for `int64` values with the portable `INT64_FORMAT` macro.

`%ld` is correct only where `int64` aliases `long` (LP64); on platforms where `int64` is `long long`, these `snprintf` / `stringbuffer_aprintf` calls trigger a `-Wformat` type mismatch (`format specifies type 'long' but the argument has type 'int64' (aka 'long long')`).

The affected calls format the route id (`meos/src/npoint/ways.c`), the `T_INT8` branch (`meos/src/temporal/temporal.c`), and the MF-JSON integer (`meos/src/temporal/type_out.c`). Each mirrors a sibling call in the same file that already uses `INT64_FORMAT`.