### PR TITLE
Give meos_error a printf format attribute and fix the mismatches it surfaces

### DIFF
--- a/meos/include/meos_error.h
+++ b/meos/include/meos_error.h
@@ -54,7 +54,22 @@ typedef enum
  * call did not return. This makes every callsite safe regardless of
  * which handler an embedder installs.
  */
-extern void meos_error(int errlevel, int errcode, const char *format, ...);
+extern void meos_error(int errlevel, int errcode, const char *format, ...)
+/*
+ * Give meos_error printf-style format checking. In the PostgreSQL-backed
+ * build pg_attribute_printf is available and selects the gnu_printf
+ * archetype (correct on MinGW, where the default printf archetype is MS
+ * semantics). This public header is also consumed standalone, where that
+ * macro may not be in scope, so fall back to the gnu_printf attribute
+ * directly under GCC/Clang, and to nothing on compilers that lack it.
+ */
+#if defined(pg_attribute_printf)
+  pg_attribute_printf(3, 4);
+#elif defined(__GNUC__)
+  __attribute__((format(gnu_printf, 3, 4)));
+#else
+  ;
+#endif
 
 /* Set or read error level */
 

--- a/meos/src/npoint/npoint.c
+++ b/meos/src/npoint/npoint.c
@@ -161,7 +161,7 @@ ensure_route_exists(int64 rid)
   if (! route_exists(rid))
   {
     meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
-      "There is no route with gid value %ld in table ways", rid);
+      "There is no route with gid value " INT64_FORMAT " in table ways", rid);
     return false;
   }
   return true;

--- a/meos/src/npoint/ways.c
+++ b/meos/src/npoint/ways.c
@@ -159,7 +159,7 @@ route_length(int64 rid)
   if (isNull)
   {
     meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
-      "Cannot get the length for route %ld", rid);
+      "Cannot get the length for route " INT64_FORMAT, rid);
     return -1.0;
   }
   return result;
@@ -200,7 +200,7 @@ route_geom(int64 rid)
   if (isNull)
   {
     meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
-      "Cannot get the geometry for route %ld", rid);
+      "Cannot get the geometry for route " INT64_FORMAT, rid);
     return NULL;
   }
   if (! ensure_not_empty(result))

--- a/meos/src/rgeo/trgeo_boxops.c
+++ b/meos/src/rgeo/trgeo_boxops.c
@@ -202,7 +202,7 @@ trgeoinstarr_compute_bbox(const GSERIALIZED *geom, TInstant **instants,
   }
   else
     meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
-      "unknown bounding box function for temporal type: %d",
+      "unknown bounding box function for temporal type: %s",
       meostype_name(instants[0]->temptype));
   return;
 }


### PR DESCRIPTION
Gives `meos_error` a printf format attribute so the compiler checks every callsite's format string against its arguments, and fixes the mismatches that surfaces.

`meos_error` is a printf-style variadic that carried no format attribute, so format bugs (wrong specifier, wrong argument type) passed silently. Adding `pg_attribute_printf(3, 4)` — the PostgreSQL macro, which selects the `gnu_printf` archetype on MinGW so the check is correct there too — makes every `meos_error` callsite format-checked.

Fixes the existing mismatches this surfaces:
- `ways.c` (route length / geometry) and `npoint.c` (route existence) format an `int64` route id with `%ld`, which is correct only where `int64` aliases `long` (LP64); replaced with the portable `INT64_FORMAT` macro.
- `trgeo_boxops.c` formats `meostype_name()` (a `const char *`) with `%d`, printing a pointer as an integer instead of the type name; replaced with `%s`.