### PR TITLE
Add the ever and always contains for two temporal circular buffers

### DIFF
--- a/meos/include/cbuffer/tcbuffer_spatialrels.h
+++ b/meos/include/cbuffer/tcbuffer_spatialrels.h
@@ -50,8 +50,8 @@ extern int ea_contains_tcbuffer_cbuffer(const Temporal *temp,
   const Cbuffer *cb, bool ever);
 extern int ea_contains_cbuffer_tcbuffer(const Cbuffer *cb,
   const Temporal *temp, bool ever);
-// extern int ea_contains_tcbuffer_tcbuffer(const Temporal *temp1,
-//   const Temporal *temp2, bool ever);
+extern int ea_contains_tcbuffer_tcbuffer(const Temporal *temp1,
+  const Temporal *temp2, bool ever);
 
 extern int ea_covers_geo_tcbuffer(const GSERIALIZED *gs,
   const Temporal *temp, bool ever);

--- a/meos/include/meos_cbuffer.h
+++ b/meos/include/meos_cbuffer.h
@@ -325,6 +325,7 @@ extern int acontains_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp);
 extern int acontains_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp);
 extern int acontains_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb);
 extern int acontains_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs);
+extern int acontains_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2);
 extern int acovers_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp);
 extern int acovers_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp);
 extern int acovers_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb);
@@ -345,6 +346,7 @@ extern int atouches_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *tem
 extern int econtains_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp);
 extern int econtains_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb);
 extern int econtains_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs);
+extern int econtains_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2);
 extern int ecovers_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp);
 extern int ecovers_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp);
 extern int ecovers_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb);

--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -718,6 +718,48 @@ acontains_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
   return ea_contains_tcbuffer_cbuffer(temp, cb, ALWAYS);
 }
 
+/**
+ * @ingroup meos_internal_cbuffer_rel_ever
+ * @brief Return 1 if a temporal circular buffer ever/always contains another
+ * one, 0 if not, and -1 on error
+ * @param[in] temp1,temp2 Temporal circular buffers
+ * @param[in] ever True for the ever semantics, false for the always semantics
+ * @csqlfn #Econtains_tcbuffer_tcbuffer(), #Acontains_tcbuffer_tcbuffer()
+ */
+int
+ea_contains_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
+  bool ever)
+{
+  return ea_spatialrel_tcbuffer_tcbuffer(temp1, temp2, &datum_cbuffer_contains,
+    ever, true);
+}
+
+/**
+ * @ingroup meos_geo_rel_ever
+ * @brief Return 1 if a temporal circular buffer ever contains another one, 0 if not,
+ * and -1 on error
+ * @param[in] temp1,temp2 Temporal geos
+ * @csqlfn #Econtains_tcbuffer_tcbuffer()
+ */
+int
+econtains_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
+{
+  return ea_contains_tcbuffer_tcbuffer(temp1, temp2, EVER);
+}
+
+/**
+ * @ingroup meos_geo_rel_ever
+ * @brief Return 1 if a temporal circular buffer always contains another one, 0 if not,
+ * and -1 on error
+ * @param[in] temp1,temp2 Temporal geos
+ * @csqlfn #Acontains_tcbuffer_tcbuffer()
+ */
+int
+acontains_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
+{
+  return ea_contains_tcbuffer_tcbuffer(temp1, temp2, ALWAYS);
+}
+
 /*****************************************************************************
  * Ever/always covers
  *****************************************************************************/

--- a/mobilitydb/sql/cbuffer/212_tcbuffer_spatialrels.in.sql
+++ b/mobilitydb/sql/cbuffer/212_tcbuffer_spatialrels.in.sql
@@ -61,6 +61,11 @@ CREATE FUNCTION eContains(tcbuffer, cbuffer)
   AS 'MODULE_PATHNAME', 'Econtains_tcbuffer_cbuffer'
   SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION eContains(tcbuffer, tcbuffer)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Econtains_tcbuffer_tcbuffer'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************/
 
@@ -88,6 +93,11 @@ CREATE FUNCTION aContains(tcbuffer, geometry)
 CREATE FUNCTION aContains(tcbuffer, cbuffer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Acontains_tcbuffer_cbuffer'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION aContains(tcbuffer, tcbuffer)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Acontains_tcbuffer_tcbuffer'
   SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 

--- a/mobilitydb/src/cbuffer/tcbuffer_spatialrels.c
+++ b/mobilitydb/src/cbuffer/tcbuffer_spatialrels.c
@@ -215,6 +215,36 @@ Acontains_tcbuffer_cbuffer(PG_FUNCTION_ARGS)
     ALWAYS);
 }
 
+/*****************************************************************************/
+
+PGDLLEXPORT Datum Econtains_tcbuffer_tcbuffer(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Econtains_tcbuffer_tcbuffer);
+/**
+ * @ingroup mobilitydb_cbuffer_rel_ever
+ * @brief Return true if a temporal circular buffer ever contains another one
+ * @sqlfn eContains()
+ */
+inline Datum
+Econtains_tcbuffer_tcbuffer(PG_FUNCTION_ARGS)
+{
+  return EA_spatialrel_tspatial_tspatial(fcinfo, &ea_contains_tcbuffer_tcbuffer,
+    EVER);
+}
+
+PGDLLEXPORT Datum Acontains_tcbuffer_tcbuffer(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Acontains_tcbuffer_tcbuffer);
+/**
+ * @ingroup mobilitydb_cbuffer_rel_ever
+ * @brief Return true if a temporal circular buffer always contains another one
+ * @sqlfn aContains()
+ */
+inline Datum
+Acontains_tcbuffer_tcbuffer(PG_FUNCTION_ARGS)
+{
+  return EA_spatialrel_tspatial_tspatial(fcinfo, &ea_contains_tcbuffer_tcbuffer,
+    ALWAYS);
+}
+
 /*****************************************************************************
  * Ever/always covers
  *****************************************************************************/

--- a/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels.test.out
@@ -70,6 +70,18 @@ SELECT eContains(tcbuffer '[Cbuffer(Point(1 4),0.5)@2000-01-01, Cbuffer(Point(4 
  t
 (1 row)
 
+SELECT eContains(tcbuffer 'Cbuffer(Point(1 1),1)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer '[Cbuffer(Point(1 1),1)@2000-01-01, Cbuffer(Point(2 2),1)@2000-01-02]', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02]');
+ econtains 
+-----------
+ t
+(1 row)
+
 /* Errors */
 SELECT eContains(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=3812;Point(1 1)');
 ERROR:  Operation on mixed SRID

--- a/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels_tbl.test.out
@@ -40,6 +40,18 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aContains(temp, cb);
      9
 (1 row)
 
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE eContains(t1.temp, t2.temp);
+ count 
+-------
+    46
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE aContains(t1.temp, t2.temp);
+ count 
+-------
+    12
+(1 row)
+
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aCovers(g, temp);
  count 
 -------

--- a/mobilitydb/test/cbuffer/queries/212_tcbuffer_spatialrels.test.sql
+++ b/mobilitydb/test/cbuffer/queries/212_tcbuffer_spatialrels.test.sql
@@ -46,6 +46,9 @@ SELECT eContains(tcbuffer '[Cbuffer(Point(4 2),0.5)@2000-01-01, Cbuffer(Point(2 
 SELECT eContains(tcbuffer '[Cbuffer(Point(0 1),0.5)@2000-01-01, Cbuffer(Point(4 1),0.5)@2000-01-02]', geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))');
 SELECT eContains(tcbuffer '[Cbuffer(Point(1 4),0.5)@2000-01-01, Cbuffer(Point(4 1),0.5)@2000-01-02]', geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))');
 
+SELECT eContains(tcbuffer 'Cbuffer(Point(1 1),1)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
+SELECT eContains(tcbuffer '[Cbuffer(Point(1 1),1)@2000-01-01, Cbuffer(Point(2 2),1)@2000-01-02]', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02]');
+
 /* Errors */
 SELECT eContains(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=3812;Point(1 1)');
 

--- a/mobilitydb/test/cbuffer/queries/212_tcbuffer_spatialrels_tbl.test.sql
+++ b/mobilitydb/test/cbuffer/queries/212_tcbuffer_spatialrels_tbl.test.sql
@@ -42,6 +42,9 @@ SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aContains(cb, temp);
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eContains(temp, cb);
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aContains(temp, cb);
 
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE eContains(t1.temp, t2.temp);
+SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE aContains(t1.temp, t2.temp);
+
 -------------------------------------------------------------------------------
 -- eCovers, aCovers
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Add the ever and always `contains` predicate for two temporal circular buffers.

Every other tcbuffer areal predicate carries the `(tcbuffer, tcbuffer)` direction — `eCovers`/`aCovers`, `eDisjoint`/`aDisjoint`, `eIntersects`/`aIntersects`, `eTouches`/`aTouches` — and the temporal-Boolean `tContains(tcbuffer, tcbuffer)` is present, so the ever/always `eContains(tcbuffer, tcbuffer)` / `aContains(tcbuffer, tcbuffer)` completes the set. The reference `tgeometry` family and the sibling `tpose` and `trgeometry` families all expose the two-temporal contains direction. A moving circular buffer is areal, so one containing another is meaningful — a larger disk that keeps a smaller disk in its interior over a shared period.

The kernel follows the covers-of-two-temporal-buffers path, reusing the shared `datum_cbuffer_contains` predicate that also backs `tContains(tcbuffer, tcbuffer)`:

- `ea_contains_tcbuffer_tcbuffer` dispatches through `ea_spatialrel_tcbuffer_tcbuffer` with a bounding-box short-circuit; `econtains`/`acontains_tcbuffer_tcbuffer` select the ever / always semantics.
- The PG wrappers `Econtains`/`Acontains_tcbuffer_tcbuffer` bind through `EA_spatialrel_tspatial_tspatial`.
- The SQL `eContains(tcbuffer, tcbuffer)` / `aContains(tcbuffer, tcbuffer)` carry `SUPPORT tspatial_supportfn` like their sibling directions, since contains implies bounding-box overlap and the index prefilter stays sound.

Tests exercise the new direction on instant and sequence buffers and in the table-count form, mirroring the covers coverage.
