### PR TITLE
Accelerate the native intersects containment test with the edge R-tree

### DIFF
--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -437,12 +437,28 @@ point_on_segment(double px, double py, double x1, double y1, double x2,
  * @brief Return true if a point is located in a polygon 
  */
 static inline int
-point_in_polygon(double x, double y, Edge **edges, int nedges)
+point_in_polygon_impl(double x, double y, Edge **edges, int nedges,
+  const RTree *rtree, int32 srid, double xmax)
 {
   int inside = 0;
-  for (int i = 0; i < nedges; i++)
+  int n = nedges;
+  if (rtree)
   {
-    const Edge *restrict e = edges[i];
+    /* Only edges whose bounding box meets the +x ray from (x,y) can cross it
+     * or contain the point; querying the R-tree for those instead of scanning
+     * every edge turns the O(nedges) test into O(log nedges + candidates).
+     * The even-odd parity is order-independent and every excluded edge lies
+     * left of x or off the ray's height, so it can neither cross the +x ray
+     * nor contain the point -- the result is identical to the full scan. */
+    STBox query;
+    double xhi = (x > xmax) ? x : xmax;
+    stbox_set(true, false, false, srid, x, xhi, y, y, 0, 0, NULL, &query);
+    n = rtree_search(rtree, RTREE_OVERLAPS, &query, rtree_results);
+  }
+  for (int i = 0; i < n; i++)
+  {
+    const Edge *restrict e = rtree ?
+      edges[*(int *) meos_array_get(rtree_results, i)] : edges[i];
 
     /* Only polygon boundary edges bound a region. Point, line, and standalone
      * (1D) arc edges are ignored by the even-odd containment test */
@@ -523,6 +539,15 @@ point_in_polygon(double x, double y, Edge **edges, int nedges)
     }
   }
   return inside;
+}
+
+/**
+ * @brief Return true if a point is located in a polygon, scanning every edge
+ */
+static inline int
+point_in_polygon(double x, double y, Edge **edges, int nedges)
+{
+  return point_in_polygon_impl(x, y, edges, nedges, NULL, 0, 0.0);
 }
 
 /**
@@ -1649,7 +1674,8 @@ geo_intersects2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
    * polygonal interior (only meaningful when the other has area) */
   if (! result && edges_have_area(ptr2, n2))
     for (int i = 0; i < n1 && ! result; i++)
-      if (point_in_polygon(ptr1[i]->x1, ptr1[i]->y1, ptr2, n2))
+      if (point_in_polygon_impl(ptr1[i]->x1, ptr1[i]->y1, ptr2, n2,
+            rtree, srid2, box2.xmax))
         result = true;
   if (! result && edges_have_area(ptr1, n1))
     for (int i = 0; i < n2 && ! result; i++)


### PR DESCRIPTION
The containment phase of `geo_intersects2d` tested every vertex of the first
geometry against every edge of the second polygon (`point_in_polygon` scanning
all edges) — an O(n1 * n2) cost that dominated `eIntersects`/`eTouches` on large
disjoint but bounding-box-overlapping pairs, e.g. a ship trajectory whose
bounding box meets a coastal area it never enters.

This reuses the edge R-tree already built for the boundary-crossing phase to
restrict the ray cast to the edges whose bounding box meets the +x ray from the
tested point. Only those edges can cross that ray or contain the point, and the
even-odd parity is order independent, so the result is identical to the full
scan. The R-tree-less wrapper keeps the exact behaviour of every other caller.

Measured on the tcbuffer benchmark geometries (100 trajectories x 100 areas):
the `eIntersects(geom, Trip)` kernel drops from 9232 ms to 6151 ms, and the
worst single pair from 276 ms to 28.6 ms. Results are byte-identical to the full
scan over 20000 real pairs (multipolygons, holes, multi-component trajectories,
and covers). No SQL or output change.
