### PR TITLE
Fix compiler warnings in core and vendored format strings

### DIFF
--- a/meos/src/temporal/meos.c
+++ b/meos/src/temporal/meos.c
@@ -408,7 +408,7 @@ check_datestyle(const char **newval, void **extra)
   if (!(elemlist && elemlist->str && elemlist->str[0]))
   {
     meos_error(ERROR, MEOS_ERR_TEXT_INPUT,
-      "Invalid datestyle value: \"%s\"", newval);
+      "Invalid datestyle value: \"%s\"", *newval);
     return false;
   }
 

--- a/meos/src/temporal/tcellindex.c
+++ b/meos/src/temporal/tcellindex.c
@@ -60,7 +60,7 @@ extern const DggsCellOps quadbin_cellops;
  * @brief Return true if @p type is a temporal DGGS cell-index type.
  */
 bool
-tcellindex_type(MeosType type)
+tcellindex_type(MeosType type UNUSED)
 {
   return
 #if QUADBIN

--- a/pgtypes/utils/date.c
+++ b/pgtypes/utils/date.c
@@ -77,7 +77,7 @@ anytime_typmod_check(bool istz, int32 typmod)
   {
     meos_error(WARNING, MEOS_ERR_INTERNAL_ERROR,
       "TIME(%d)%s precision reduced to maximum allowed, %d",
-      typmod, (istz ? " WITH TIME ZONE" : ""));
+      typmod, (istz ? " WITH TIME ZONE" : ""), MAX_TIME_PRECISION); /* MEOS */
     typmod = MAX_TIME_PRECISION;
   }
 

--- a/pgtypes/utils/pg_locale.c
+++ b/pgtypes/utils/pg_locale.c
@@ -1285,7 +1285,7 @@ meos_initialize_collation(void)
     result = create_pg_locale_libc(DEFAULT_COLLATION_OID);
   else
     /* shouldn't happen */
-    PGLOCALE_SUPPORT_ERROR(database_locprovider);
+    PGLOCALE_SUPPORT_ERROR(database_locprovider[0]); /* MEOS */
 
   result->is_default = true;
   if (default_locale != NULL)


### PR DESCRIPTION
Four format-string and unused-parameter fixes that make the full build
warning-clean under `-Wformat` / `-Wunused-parameter`:

- `meos.c` `check_datestyle`: pass `*newval` (the datestyle string) to the `%s`
  conversion; `newval` is a `const char **`.
- `tcellindex.c` `tcellindex_type`: mark the `type` parameter `UNUSED`; it is
  referenced only in the QUADBIN build.
- `pgtypes/utils/date.c` `anytime_typmod_check`: supply `MAX_TIME_PRECISION` for
  the trailing `%d` in the "reduced to maximum allowed" message.
- `pgtypes/utils/pg_locale.c`: pass `database_locprovider[0]` (the provider code
  character) to the `%c` conversion, matching the `char` `provider` that every
  other caller passes.

The two vendored `pgtypes` edits carry a `/* MEOS */` marker.
