### PR TITLE
Generate the tcbuffer contains and covers PG wrappers

### DIFF
--- a/mobilitydb/src/cbuffer/tcbuffer_spatialrels.c
+++ b/mobilitydb/src/cbuffer/tcbuffer_spatialrels.c
@@ -39,14 +39,9 @@
  * `eCovers`, `aCovers`, `eDisjoint`, `aDisjoint`, `eIntersects`, 
  * `aIntersects`, `eTouches`, `aTouches`, `eDwithin`, and `aDwithin`.
  *
- * Most of these relationships support the following combination of arguments
- * `({geo, cbuffer, tcbuffer}, {geo, cbuffer, tcbuffer})`.
- * One exception is for the non-symmetric relationships `eContains` and 
- * `eCovers` since there is no efficient algorithm for enabling the
- * combination of arguments `(geo, tcbuffer)`.
- * Another exception is that only `eDisjoint`, `aDisjoint`, `eIntersects`,
- * `aIntersects`, `eDwithin`, and `aDwithin` support the following arguments
- * `(tcbuffer, tcbuffer)`.
+ * All these relationships support the following combinations of arguments
+ * `({geo, cbuffer, tcbuffer}, {geo, cbuffer, tcbuffer})` in which at least one
+ * argument is a temporal circular buffer.
  */
 
 #include "cbuffer/tcbuffer_spatialrels.h"
@@ -101,6 +96,8 @@ EA_spatialrel_tcbuffer_cbuffer(FunctionCallInfo fcinfo,
   PG_RETURN_INT32(result);
 }
 
+/* GENERATED-SPATIALRELS-BEGIN cbuffer_ea_contains_covers — tools/codegen/inherited/generate.py from templates/spatialrels.c.tmpl;
+ * DO NOT EDIT BY HAND; edit the template + manifest.yaml (spatialrel_families) and re-run. */
 /*****************************************************************************
  * Ever/always contains
  *****************************************************************************/
@@ -157,13 +154,12 @@ Acontains_tcbuffer_geo(PG_FUNCTION_ARGS)
   return EA_spatialrel_tspatial_geo(fcinfo, &ea_contains_tcbuffer_geo, ALWAYS);
 }
 
-/*****************************************************************************/
-
 PGDLLEXPORT Datum Econtains_cbuffer_tcbuffer(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Econtains_cbuffer_tcbuffer);
 /**
  * @ingroup mobilitydb_cbuffer_rel_ever
- * @brief Return true if a geometry ever contains a temporal circular buffer
+ * @brief Return true if a circular buffer ever contains a temporal circular
+ * buffer
  * @sqlfn eContains()
  */
 inline Datum
@@ -177,7 +173,8 @@ PGDLLEXPORT Datum Acontains_cbuffer_tcbuffer(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Acontains_cbuffer_tcbuffer);
 /**
  * @ingroup mobilitydb_cbuffer_rel_ever
- * @brief Return true if a geometry always contains a temporal circular buffer
+ * @brief Return true if a circular buffer always contains a temporal circular
+ * buffer
  * @sqlfn aContains()
  */
 inline Datum
@@ -191,7 +188,8 @@ PGDLLEXPORT Datum Econtains_tcbuffer_cbuffer(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Econtains_tcbuffer_cbuffer);
 /**
  * @ingroup mobilitydb_cbuffer_rel_ever
- * @brief Return true if a temporal circular buffer ever contains a geometry
+ * @brief Return true if a temporal circular buffer ever contains a circular
+ * buffer
  * @sqlfn eContains()
  */
 inline Datum
@@ -205,7 +203,8 @@ PGDLLEXPORT Datum Acontains_tcbuffer_cbuffer(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Acontains_tcbuffer_cbuffer);
 /**
  * @ingroup mobilitydb_cbuffer_rel_ever
- * @brief Return true if a temporal circular buffer always contains a geometry
+ * @brief Return true if a temporal circular buffer always contains a circular
+ * buffer
  * @sqlfn aContains()
  */
 inline Datum
@@ -214,8 +213,6 @@ Acontains_tcbuffer_cbuffer(PG_FUNCTION_ARGS)
   return EA_spatialrel_tcbuffer_cbuffer(fcinfo, &ea_contains_tcbuffer_cbuffer,
     ALWAYS);
 }
-
-/*****************************************************************************/
 
 PGDLLEXPORT Datum Econtains_tcbuffer_tcbuffer(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Econtains_tcbuffer_tcbuffer);
@@ -301,13 +298,12 @@ Acovers_tcbuffer_geo(PG_FUNCTION_ARGS)
   return EA_spatialrel_tspatial_geo(fcinfo, &ea_covers_tcbuffer_geo, ALWAYS);
 }
 
-/*****************************************************************************/
-
 PGDLLEXPORT Datum Ecovers_cbuffer_tcbuffer(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Ecovers_cbuffer_tcbuffer);
 /**
  * @ingroup mobilitydb_cbuffer_rel_ever
- * @brief Return true if a geometry ever covers a temporal circular buffer
+ * @brief Return true if a circular buffer ever covers a temporal circular
+ * buffer
  * @sqlfn eCovers()
  */
 inline Datum
@@ -321,7 +317,8 @@ PGDLLEXPORT Datum Acovers_cbuffer_tcbuffer(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Acovers_cbuffer_tcbuffer);
 /**
  * @ingroup mobilitydb_cbuffer_rel_ever
- * @brief Return true if a geometry always covers a temporal circular buffer
+ * @brief Return true if a circular buffer always covers a temporal circular
+ * buffer
  * @sqlfn aCovers()
  */
 inline Datum
@@ -335,7 +332,8 @@ PGDLLEXPORT Datum Ecovers_tcbuffer_cbuffer(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Ecovers_tcbuffer_cbuffer);
 /**
  * @ingroup mobilitydb_cbuffer_rel_ever
- * @brief Return true if a temporal circular buffer ever covers a geometry
+ * @brief Return true if a temporal circular buffer ever covers a circular
+ * buffer
  * @sqlfn eCovers()
  */
 inline Datum
@@ -349,7 +347,8 @@ PGDLLEXPORT Datum Acovers_tcbuffer_cbuffer(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Acovers_tcbuffer_cbuffer);
 /**
  * @ingroup mobilitydb_cbuffer_rel_ever
- * @brief Return true if a temporal circular buffer always covers a geometry
+ * @brief Return true if a temporal circular buffer always covers a circular
+ * buffer
  * @sqlfn aCovers()
  */
 inline Datum
@@ -359,14 +358,11 @@ Acovers_tcbuffer_cbuffer(PG_FUNCTION_ARGS)
     ALWAYS);
 }
 
-/*****************************************************************************/
-
 PGDLLEXPORT Datum Ecovers_tcbuffer_tcbuffer(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Ecovers_tcbuffer_tcbuffer);
 /**
  * @ingroup mobilitydb_cbuffer_rel_ever
- * @brief Return true if a temporal circular buffer and a circular buffer 
- * ever cover
+ * @brief Return true if a temporal circular buffer ever covers another one
  * @sqlfn eCovers()
  */
 inline Datum
@@ -380,8 +376,7 @@ PGDLLEXPORT Datum Acovers_tcbuffer_tcbuffer(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Acovers_tcbuffer_tcbuffer);
 /**
  * @ingroup mobilitydb_cbuffer_rel_ever
- * @brief Return true if a temporal circular buffer and a circular buffer 
- * always cover
+ * @brief Return true if a temporal circular buffer always covers another one
  * @sqlfn aCovers()
  */
 inline Datum
@@ -390,6 +385,7 @@ Acovers_tcbuffer_tcbuffer(PG_FUNCTION_ARGS)
   return EA_spatialrel_tspatial_tspatial(fcinfo, &ea_covers_tcbuffer_tcbuffer,
     ALWAYS);
 }
+/* GENERATED-SPATIALRELS-END cbuffer_ea_contains_covers */
 /*****************************************************************************
  * Ever/always disjoint
  *****************************************************************************/

--- a/mobilitydb/src/geo/tgeo_spatialrels.c
+++ b/mobilitydb/src/geo/tgeo_spatialrels.c
@@ -246,7 +246,8 @@ PG_FUNCTION_INFO_V1(Acontains_tgeo_tgeo);
 inline Datum
 Acontains_tgeo_tgeo(PG_FUNCTION_ARGS)
 {
-  return EA_spatialrel_tspatial_tspatial(fcinfo, &ea_contains_tgeo_tgeo, ALWAYS);
+  return EA_spatialrel_tspatial_tspatial(fcinfo, &ea_contains_tgeo_tgeo,
+    ALWAYS);
 }
 
 /*****************************************************************************
@@ -417,7 +418,8 @@ PG_FUNCTION_INFO_V1(Adisjoint_tgeo_tgeo);
 inline Datum
 Adisjoint_tgeo_tgeo(PG_FUNCTION_ARGS)
 {
-  return EA_spatialrel_tspatial_tspatial(fcinfo, &ea_disjoint_tgeo_tgeo, ALWAYS);
+  return EA_spatialrel_tspatial_tspatial(fcinfo, &ea_disjoint_tgeo_tgeo,
+    ALWAYS);
 }
 
 /*****************************************************************************
@@ -490,7 +492,8 @@ PG_FUNCTION_INFO_V1(Eintersects_tgeo_tgeo);
 inline Datum
 Eintersects_tgeo_tgeo(PG_FUNCTION_ARGS)
 {
-  return EA_spatialrel_tspatial_tspatial(fcinfo, &ea_intersects_tgeo_tgeo, EVER);
+  return EA_spatialrel_tspatial_tspatial(fcinfo, &ea_intersects_tgeo_tgeo,
+    EVER);
 }
 
 PGDLLEXPORT Datum Aintersects_tgeo_tgeo(PG_FUNCTION_ARGS);
@@ -503,7 +506,8 @@ PG_FUNCTION_INFO_V1(Aintersects_tgeo_tgeo);
 inline Datum
 Aintersects_tgeo_tgeo(PG_FUNCTION_ARGS)
 {
-  return EA_spatialrel_tspatial_tspatial(fcinfo, &ea_intersects_tgeo_tgeo, ALWAYS);
+  return EA_spatialrel_tspatial_tspatial(fcinfo, &ea_intersects_tgeo_tgeo,
+    ALWAYS);
 }
 /* GENERATED-SPATIALRELS-END geo_ea_disjoint_intersects */
 

--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -231,27 +231,41 @@ def _wrap_brief(text: str, width: int = 80) -> str:
 
 def render_spatialrels(fam: dict) -> str:
     """Render the ever/always PG wrapper region for one family: per predicate a
-    banner + 6 wrapper blocks (3 directions x ever/always). Roundtrips exactly."""
+    banner + wrapper blocks (one per direction x ever/always). Roundtrips exactly."""
     banner_t, block_t = (TEMPLATES / "spatialrels.c.tmpl").read_text().split("\n\n")
     block_t = block_t.rstrip("\n")
+    # A family whose type is not tgeo (e.g. tcbuffer) overrides the geo defaults:
+    # its own @ingroup (mobilitydb_<fam>_rel_ever), its own direction order (the
+    # cbuffer 5-direction shape adds the base-value directions), and its own
+    # dispatcher map. contains/covers/... inherit these; a predicate may still
+    # subset the directions or swap one dispatcher.
+    ingroup = fam.get("ingroup", "mobilitydb_geo_rel_ever")
+    order = fam.get("order", _SR_ORDER)
+    disp_map = fam.get("disp", _SR_DISP)
     out = []
     for pred in fam["predicates"]:
         out.append(banner_t.replace("{BANNER}", pred["banner"]))
         disp_over = pred.get("disp", {})
         meos_fixed = pred.get("meos_fixed")
-        for direc in pred.get("directions", _SR_ORDER):
-            disp = disp_over.get(direc, _SR_DISP[direc])
+        for direc in pred.get("directions", order):
+            disp = disp_over.get(direc, disp_map[direc])
             meos = meos_fixed or f"ea_{pred['rel']}_{direc}"
             for ea, word, low in (("E", "ever", "e"), ("A", "always", "a")):
                 brief = _wrap_brief(
                     "Return true if " + pred["briefs"][direc].replace("{word}", word))
+                # The return statement wraps to the 80-column house style when the
+                # dispatcher + kernel names are long (the cbuffer base-value
+                # directions); the geo directions stay on one line unchanged.
+                eaq = "EVER" if ea == "E" else "ALWAYS"
+                ret = f"  return {disp}(fcinfo, &{meos}, {eaq});"
+                if len(ret) > 80:
+                    ret = f"  return {disp}(fcinfo, &{meos},\n    {eaq});"
                 sub = {
                     "FN": f"{ea}{pred['rel']}_{direc}",
                     "BRIEF": brief,
                     "SQLFN": f"{low}{pred['Rel']}",
-                    "DISP": disp,
-                    "MEOS": meos,
-                    "EA": "EVER" if ea == "E" else "ALWAYS",
+                    "RETURN": ret,
+                    "INGROUP": ingroup,
                 }
                 frag = block_t
                 for k, v in sub.items():

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -271,6 +271,42 @@ spatialrel_families:
           geo_tgeo:  "a geometry/geography and a temporal geometry are {word} within a distance"
           tgeo_geo:  "a temporal geometry and a geometry/geography are {word} within a distance"
 
+  # tcbuffer carries the fuller 5-direction shape (it adds the base-value cbuffer
+  # directions on top of geo/temporal), its own @ingroup, and its own dispatcher
+  # map. The base-value briefs are corrected here: the hand-written wrappers reused
+  # the "a geometry" wording for the (cbuffer, tcbuffer) / (tcbuffer, cbuffer)
+  # directions — the argument is a circular buffer, not a geometry.
+  - family:    cbuffer_ea_contains_covers
+    file:      mobilitydb/src/cbuffer/tcbuffer_spatialrels.c
+    reference: true
+    ingroup:   mobilitydb_cbuffer_rel_ever
+    order:     [geo_tcbuffer, tcbuffer_geo, cbuffer_tcbuffer, tcbuffer_cbuffer, tcbuffer_tcbuffer]
+    disp:
+      geo_tcbuffer:      EA_spatialrel_geo_tspatial
+      tcbuffer_geo:      EA_spatialrel_tspatial_geo
+      cbuffer_tcbuffer:  EA_spatialrel_cbuffer_tcbuffer
+      tcbuffer_cbuffer:  EA_spatialrel_tcbuffer_cbuffer
+      tcbuffer_tcbuffer: EA_spatialrel_tspatial_tspatial
+    predicates:
+      - rel: contains
+        Rel: Contains
+        banner: "Ever/always contains"
+        briefs:
+          geo_tcbuffer:      "a geometry {word} contains a temporal circular buffer"
+          tcbuffer_geo:      "a temporal circular buffer {word} contains a geometry"
+          cbuffer_tcbuffer:  "a circular buffer {word} contains a temporal circular buffer"
+          tcbuffer_cbuffer:  "a temporal circular buffer {word} contains a circular buffer"
+          tcbuffer_tcbuffer: "a temporal circular buffer {word} contains another one"
+      - rel: covers
+        Rel: Covers
+        banner: "Ever/always covers"
+        briefs:
+          geo_tcbuffer:      "a geometry {word} covers a temporal circular buffer"
+          tcbuffer_geo:      "a temporal circular buffer {word} covers a geometry"
+          cbuffer_tcbuffer:  "a circular buffer {word} covers a temporal circular buffer"
+          tcbuffer_cbuffer:  "a temporal circular buffer {word} covers a circular buffer"
+          tcbuffer_tcbuffer: "a temporal circular buffer {word} covers another one"
+
 # ---------------------------------------------------------------------------
 # Accessor axis (SQL, per-family, region-in-file). The whole Temporal<T> accessor
 # surface (tempSubtype..segments) lives INLINE in each family's type file and

--- a/tools/codegen/inherited/templates/spatialrels.c.tmpl
+++ b/tools/codegen/inherited/templates/spatialrels.c.tmpl
@@ -5,12 +5,12 @@
 PGDLLEXPORT Datum {FN}(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1({FN});
 /**
- * @ingroup mobilitydb_geo_rel_ever
+ * @ingroup {INGROUP}
  * @brief {BRIEF}
  * @sqlfn {SQLFN}()
  */
 inline Datum
 {FN}(PG_FUNCTION_ARGS)
 {
-  return {DISP}(fcinfo, &{MEOS}, {EA});
+{RETURN}
 }


### PR DESCRIPTION
Bring the tcbuffer ever/always `contains` and `covers` PG wrapper region onto the shared inherited-behaviour generator — the same one that already emits the geo ever/always wrappers (`spatialrels.c.tmpl` + the `spatialrel_families` manifest axis).

tcbuffer carries a fuller five-direction shape than geo: on top of the `geo`/`temporal` directions it adds the base-value circular-buffer directions `(cbuffer, tcbuffer)` and `(tcbuffer, cbuffer)`. The template gains an `{INGROUP}` token plus family-level `order` and dispatcher (`disp`) maps, so a family declares its own `@ingroup`, direction order and dispatchers; the geo families keep the defaults and regenerate byte-for-byte.

The return statement wraps to the 80-column house style when the dispatcher and kernel names are long. This reproduces the tcbuffer base-value wrappers (whose names overflow a single line) and, applying the same rule uniformly, wraps the four geo return lines that exceed 80 columns — a whitespace-only change, the geo file is otherwise identical.

Generating the region also brings the hand-written documentation in line, with no change to behaviour or the catalog (the `@sqlfn` tags and dispatch stay identical):

- The base-value briefs read "a circular buffer" for the circular-buffer argument (not "a geometry").
- The two-temporal covers brief matches its siblings ("… ever covers another one").
- The file header states that every relationship supports the `(geometry, tcbuffer)` and `(tcbuffer, tcbuffer)` directions, with no exceptions.

The generator's `--validate` reproduces all four spatial-relationship regions (three geo + the new tcbuffer contains/covers) exactly. disjoint / intersects / touches / dwithin for tcbuffer are a later slice, mirroring how the geo side splits.
