### PR TITLE
Export the quadbin cell geometry conversions from MEOS

### DIFF
--- a/meos/include/meos_quadbin.h
+++ b/meos/include/meos_quadbin.h
@@ -116,6 +116,12 @@ extern void quadbin_cell_to_point(Quadbin cell, double *longitude,
 extern void quadbin_cell_to_bounding_box(Quadbin cell, double *xmin,
   double *ymin, double *xmax, double *ymax);
 
+/* Geometry (lon/lat, SRID 4326) */
+extern Quadbin geo_to_quadbin_cell(const GSERIALIZED *point,
+  int32 resolution);
+extern GSERIALIZED *quadbin_cell_to_geompoint(Quadbin cell);
+extern GSERIALIZED *quadbin_cell_to_geom(Quadbin cell);
+
 /* Metrics */
 extern double quadbin_cell_area(Quadbin cell);
 
@@ -226,8 +232,7 @@ extern Temporal *tquadbin_cell_to_quadkey(const Temporal *temp);
 //   const Temporal *dest);
 // extern Temporal *tquadbin_cell_area(const Temporal *temp);
 
-/* Static geometry → quadbin cell / cell set + ever-intersects predicate */
-// extern Quadbin quadbin_gs_point_to_cell(const GSERIALIZED *point, int32 resolution);
+/* Static geometry → quadbin cell set + ever-intersects predicate */
 // extern Set *geo_to_quadbin_set(const GSERIALIZED *gs, int32 resolution);
 // extern int ever_eq_quadbinset_tquadbin(const Set *cells, const Temporal *tqb);
 

--- a/meos/src/quadbin/CMakeLists.txt
+++ b/meos/src/quadbin/CMakeLists.txt
@@ -4,6 +4,11 @@ set(QUADBIN_SRCS
   # hierarchy, traversal, Web-Mercator lat/lng, metrics, serialization.
   quadbin.c
 
+  # Geometry adapters between a quadbin cell and PostGIS geometries (the
+  # lon/lat coupling the geo-free kernel deliberately excludes; the h3
+  # analogue is th3index_latlng.c).
+  quadbin_geo.c
+
   # Static `quadbin` SQL type — validating parser plus comparison / hash
   # helpers consumed by the central temporal type I/O dispatch.
   quadbin_meos.c

--- a/meos/src/quadbin/quadbin.c
+++ b/meos/src/quadbin/quadbin.c
@@ -363,7 +363,8 @@ quadbin_point_to_cell(double longitude, double latitude, uint32_t resolution)
 /**
  * @ingroup meos_quadbin
  * @brief Return the lon/lat centroid of a quadbin cell
- * @csqlfn #Quadbin_cell_to_point()
+ * @details Out-parameter helper; the geometry projection quadbinCellToPoint
+ * is backed by quadbin_cell_to_geompoint in quadbin_geo.c.
  */
 void
 quadbin_cell_to_point(Quadbin cell, double *longitude, double *latitude)
@@ -379,7 +380,9 @@ quadbin_cell_to_point(Quadbin cell, double *longitude, double *latitude)
 /**
  * @ingroup meos_quadbin
  * @brief Return the lon/lat bounding box (xmin, ymin, xmax, ymax) of a cell
- * @csqlfn #Quadbin_cell_to_bounding_box()
+ * @details Out-parameter helper; the geometry projections quadbinCellToBoundary
+ * and quadbinCellToBoundingBox are backed by quadbin_cell_to_geom in
+ * quadbin_geo.c.
  */
 void
 quadbin_cell_to_bounding_box(Quadbin cell, double *xmin, double *ymin,

--- a/meos/src/quadbin/quadbin_geo.c
+++ b/meos/src/quadbin/quadbin_geo.c
@@ -1,0 +1,121 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Geometry adapters between a QUADBIN cell and PostGIS geometries.
+ *
+ * These typed wrappers keep the geometry construction inside MEOS so the
+ * SQL cell/geometry conversions are pure catalog projections (the PG V1
+ * wrappers in mobilitydb/src/quadbin/quadbin_ops.c are thin). The pure
+ * cell kernel meos/src/quadbin/quadbin.c stays free of any geometry
+ * dependency; the lon/lat coupling lives here, mirroring the h3 split
+ * between h3index.c and th3index_latlng.c.
+ */
+
+#include "quadbin/quadbin.h"
+
+/* PostGIS */
+#include <liblwgeom.h>
+/* MEOS */
+#include <meos.h>
+#include <meos_geo.h>
+#include <meos_internal_geo.h>  /* GSERIALIZED_POINT2D_P */
+#include <meos_quadbin.h>
+#include "geo/tgeo_spatialfuncs.h"
+
+/*****************************************************************************
+ * Geometry to cell
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_quadbin
+ * @brief Return the quadbin cell covering a lon/lat point at a resolution
+ * @param[in] point Point geometry in a lon/lat (SRID 4326) reference system
+ * @param[in] resolution Quadbin resolution
+ * @csqlfn #Quadbin_point_to_cell()
+ */
+Quadbin
+geo_to_quadbin_cell(const GSERIALIZED *point, int32 resolution)
+{
+  if (! ensure_srid_is_latlong(gserialized_get_srid(point)))
+    return (Quadbin) 0;
+  const POINT2D *p = GSERIALIZED_POINT2D_P(point);
+  return quadbin_point_to_cell(p->x, p->y, (uint32_t) resolution);
+}
+
+/*****************************************************************************
+ * Cell to geometry
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_quadbin
+ * @brief Return the centroid of a quadbin cell as a lon/lat point (SRID 4326)
+ * @param[in] cell Quadbin cell
+ * @csqlfn #Quadbin_cell_to_point()
+ */
+GSERIALIZED *
+quadbin_cell_to_geompoint(Quadbin cell)
+{
+  double lon, lat;
+  quadbin_cell_to_point(cell, &lon, &lat);
+  /* Planar (non-geodetic) lon/lat point */
+  return geopoint_make(lon, lat, 0.0, false, false, 4326);
+}
+
+/**
+ * @ingroup meos_quadbin
+ * @brief Return the boundary of a quadbin cell as a square polygon (SRID 4326)
+ * @details A quadbin cell is an axis-aligned square tile, so in a lon/lat
+ * reference system its boundary polygon coincides with its envelope; it is
+ * built from the cell extent as a closed 5-point ring.
+ * @param[in] cell Quadbin cell
+ * @csqlfn #Quadbin_cell_to_boundary(), #Quadbin_cell_to_bounding_box()
+ */
+GSERIALIZED *
+quadbin_cell_to_geom(Quadbin cell)
+{
+  double xmin, ymin, xmax, ymax;
+  quadbin_cell_to_bounding_box(cell, &xmin, &ymin, &xmax, &ymax);
+  POINTARRAY *pa = ptarray_construct_empty(LW_FALSE, LW_FALSE, 5);
+  POINT4D pt;
+  pt.z = 0.0; pt.m = 0.0;
+  pt.x = xmin; pt.y = ymin; ptarray_append_point(pa, &pt, LW_TRUE);
+  pt.x = xmax; pt.y = ymin; ptarray_append_point(pa, &pt, LW_TRUE);
+  pt.x = xmax; pt.y = ymax; ptarray_append_point(pa, &pt, LW_TRUE);
+  pt.x = xmin; pt.y = ymax; ptarray_append_point(pa, &pt, LW_TRUE);
+  pt.x = xmin; pt.y = ymin; ptarray_append_point(pa, &pt, LW_TRUE); /* close */
+  LWPOLY *poly = lwpoly_construct_empty(4326, LW_FALSE, LW_FALSE);
+  lwpoly_add_ring(poly, pa);
+  GSERIALIZED *gs = geo_serialize(lwpoly_as_lwgeom(poly));
+  lwpoly_free(poly);
+  return gs;
+}
+
+/*****************************************************************************/

--- a/mobilitydb/src/quadbin/quadbin_ops.c
+++ b/mobilitydb/src/quadbin/quadbin_ops.c
@@ -181,11 +181,7 @@ Quadbin_point_to_cell(PG_FUNCTION_ARGS)
 {
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(0);
   int32 resolution = PG_GETARG_INT32(1);
-  LWGEOM *geom = lwgeom_from_gserialized(gs);
-  POINT2D pt;
-  lwpoint_getPoint2d_p((LWPOINT *) geom, &pt);
-  Quadbin result = quadbin_point_to_cell(pt.x, pt.y, (uint32_t) resolution);
-  lwgeom_free(geom);
+  Quadbin result = geo_to_quadbin_cell(gs, resolution);
   PG_FREE_IF_COPY(gs, 0);
   PG_RETURN_QUADBIN(result);
 }
@@ -201,45 +197,16 @@ Datum
 Quadbin_cell_to_point(PG_FUNCTION_ARGS)
 {
   Quadbin cell = PG_GETARG_QUADBIN(0);
-  double lon, lat;
-  quadbin_cell_to_point(cell, &lon, &lat);
-  /* Planar (non-geodetic) lon/lat point; geopoint_make is available in the
-   * MEOS=OFF extension build, unlike the MEOS-only geompoint_make2d. */
-  GSERIALIZED *result = geopoint_make(lon, lat, 0.0, false, false, 4326);
-  PG_RETURN_GSERIALIZED_P(result);
+  PG_RETURN_GSERIALIZED_P(quadbin_cell_to_geompoint(cell));
 }
 
 /*****************************************************************************
  * Boundary / bounding box
  *
- * A quadbin cell is an axis-aligned square tile, so its boundary
- * polygon and its envelope geometry coincide; both are built from the
- * `quadbin_cell_to_bounding_box` extent as a closed 5-point ring.
+ * A quadbin cell is an axis-aligned square tile, so its boundary polygon
+ * and its envelope geometry coincide; the geometry is constructed by the
+ * MEOS export quadbin_cell_to_geom.
  *****************************************************************************/
-
-/**
- * @brief Build the closed square boundary polygon (SRID 4326) of a
- * quadbin cell from its lon/lat extent
- */
-static GSERIALIZED *
-quadbin_cell_envelope(Quadbin cell)
-{
-  double xmin, ymin, xmax, ymax;
-  quadbin_cell_to_bounding_box(cell, &xmin, &ymin, &xmax, &ymax);
-  POINTARRAY *pa = ptarray_construct_empty(LW_FALSE, LW_FALSE, 5);
-  POINT4D pt;
-  pt.z = 0.0; pt.m = 0.0;
-  pt.x = xmin; pt.y = ymin; ptarray_append_point(pa, &pt, LW_TRUE);
-  pt.x = xmax; pt.y = ymin; ptarray_append_point(pa, &pt, LW_TRUE);
-  pt.x = xmax; pt.y = ymax; ptarray_append_point(pa, &pt, LW_TRUE);
-  pt.x = xmin; pt.y = ymax; ptarray_append_point(pa, &pt, LW_TRUE);
-  pt.x = xmin; pt.y = ymin; ptarray_append_point(pa, &pt, LW_TRUE); /* close */
-  LWPOLY *poly = lwpoly_construct_empty(4326, LW_FALSE, LW_FALSE);
-  lwpoly_add_ring(poly, pa);
-  GSERIALIZED *gs = geo_serialize(lwpoly_as_lwgeom(poly));
-  lwpoly_free(poly);
-  return gs;
-}
 
 PGDLLEXPORT Datum Quadbin_cell_to_boundary(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Quadbin_cell_to_boundary);
@@ -252,7 +219,7 @@ Datum
 Quadbin_cell_to_boundary(PG_FUNCTION_ARGS)
 {
   Quadbin cell = PG_GETARG_QUADBIN(0);
-  PG_RETURN_GSERIALIZED_P(quadbin_cell_envelope(cell));
+  PG_RETURN_GSERIALIZED_P(quadbin_cell_to_geom(cell));
 }
 
 PGDLLEXPORT Datum Quadbin_cell_to_bounding_box(PG_FUNCTION_ARGS);
@@ -266,7 +233,7 @@ Datum
 Quadbin_cell_to_bounding_box(PG_FUNCTION_ARGS)
 {
   Quadbin cell = PG_GETARG_QUADBIN(0);
-  PG_RETURN_GSERIALIZED_P(quadbin_cell_envelope(cell));
+  PG_RETURN_GSERIALIZED_P(quadbin_cell_to_geom(cell));
 }
 
 /*****************************************************************************


### PR DESCRIPTION
Bring the quadbin cell/geometry conversions onto typed public MEOS exports, so `352_quadbin_ops` is a pure catalog projection that every language binding generates rather than a set of PG-wrapper-local geometry helpers.

Three exports live in a new geo-adapter file `meos/src/quadbin/quadbin_geo.c`, which keeps the geometry dependency out of the geo-free cell kernel `quadbin.c` — mirroring the h3 split between `h3index.c` and `th3index_latlng.c`:

- `geo_to_quadbin_cell(const GSERIALIZED *point, int32 resolution)` — the cell covering a lon/lat point. It validates that the point is in a lon/lat reference system, matching the mixed-SRID error contract.
- `quadbin_cell_to_geompoint(Quadbin cell)` — the cell centroid as a point geometry.
- `quadbin_cell_to_geom(Quadbin cell)` — the cell boundary as a square polygon.

The geometry-token naming follows the family convention — `geo` / `geompoint` / `geom`, never the PostGIS-internal `gserialized` — mirroring the sibling exports `geo_to_h3index_set`, `npoint_to_geompoint` and `cbuffer_to_geom`.

The PG V1 wrappers are thin calls onto these exports, and the `@csqlfn` tags sit on the geometry exports rather than the void out-parameter kernels (`quadbin_cell_to_point` / `quadbin_cell_to_bounding_box`).

The geometry the exports build is identical to what the wrappers build today — the construction is the same, relocated into MEOS — so the expected regression outputs are unchanged.
