### PR TITLE
Export the remaining catalog type predicates

### DIFF
--- a/meos/include/temporal/meos_catalog.h
+++ b/meos/include/temporal/meos_catalog.h
@@ -232,10 +232,8 @@ typedef struct
 
 /*****************************************************************************/
 
-#ifndef NDEBUG
 extern bool temptype_subtype(tempSubtype subtype);
 extern bool temptype_subtype_all(tempSubtype subtype);
-#endif
 extern const char *tempsubtype_name(tempSubtype subtype);
 extern bool tempsubtype_from_string(const char *str, int16 *subtype);
 extern const char *meosoper_name(MeosOper oper);
@@ -259,16 +257,12 @@ extern MeosType basetype_settype(MeosType type);
 
 extern bool tnumber_basetype(MeosType type);
 extern bool geo_basetype(MeosType type);
-#ifndef NDEBUG
 extern bool meos_basetype(MeosType type);
 extern bool alphanum_basetype(MeosType type);
 extern bool alphanum_temptype(MeosType type);
-#endif
 
 extern bool time_type(MeosType type);
-#ifndef NDEBUG
 extern bool set_basetype(MeosType type);
-#endif
 
 extern bool set_type(MeosType type);
 extern bool numset_type(MeosType type);
@@ -304,16 +298,12 @@ extern bool timespanset_type(MeosType type);
 extern bool ensure_timespanset_type(MeosType type);
 
 extern bool temporal_type(MeosType type);
-#ifndef NDEBUG
 extern bool temporal_basetype(MeosType type);
-#endif
 extern bool temptype_supports_linear(MeosType type);
 extern bool basetype_byvalue(MeosType type);
 extern bool basetype_varlength(MeosType type);
 extern int16 meostype_length(MeosType type);
-#ifndef NDEBUG
 extern bool talphanum_type(MeosType type);
-#endif
 extern bool talpha_type(MeosType type);
 extern bool tnumber_type(MeosType type);
 extern bool ensure_tnumber_type(MeosType type);

--- a/meos/src/temporal/meos_catalog.c
+++ b/meos/src/temporal/meos_catalog.c
@@ -422,12 +422,11 @@ tempsubtype_from_string(const char *str, int16_t *subtype)
   return false;
 }
 
-#ifndef NDEBUG
 /**
  * @brief Ensure that the subtype of a temporal value is valid
  * @note The function is used for the dispatch functions for temporal types
  */
-inline bool
+bool
 temptype_subtype(tempSubtype subtype)
 {
   return (subtype == TINSTANT || subtype == TSEQUENCE ||
@@ -438,13 +437,12 @@ temptype_subtype(tempSubtype subtype)
  * @brief Ensure that the subtype of a temporal value is valid
  * @note The function is used for the the analyze and selectivity functions
  */
-inline bool
+bool
 temptype_subtype_all(tempSubtype subtype)
 {
   return (subtype == ANYTEMPSUBTYPE ||
     subtype == TINSTANT || subtype == TSEQUENCE || subtype == TSEQUENCESET);
 }
-#endif
 
 /*****************************************************************************/
 
@@ -639,13 +637,11 @@ spantype_spansettype(MeosType type)
 
 /*****************************************************************************/
 
-#ifndef NDEBUG
 /**
  * @brief Return true if the type is a base type of one of the template types,
  * that is, @p Set, @p Span, @p SpanSet, and @p Temporal
- * @note This function is only used in the asserts
  */
-inline bool
+bool
 meos_basetype(MeosType type)
 {
   return (type == T_BOOL || type == T_DATE ||
@@ -657,7 +653,6 @@ meos_basetype(MeosType type)
     type == T_CBUFFER || type == T_JSONB || type == T_H3INDEX ||
     type == T_QUADBIN || type == T_PCPOINT || type == T_PCPATCH);
 }
-#endif
 
 /**
  * @brief Return true if the values of the base type are passed by value
@@ -728,12 +723,10 @@ meostype_length(MeosType type)
   return SHRT_MAX;
 }
 
-#ifndef NDEBUG
 /**
  * @brief Return true if the type is an alphanumeric base type
- * @note This function is only used in the asserts
  */
-inline bool
+bool
 alphanum_basetype(MeosType type)
 {
   return (type == T_BOOL || type == T_DATE || type == T_FLOAT8 ||
@@ -744,15 +737,13 @@ alphanum_basetype(MeosType type)
 
 /**
  * @brief Return true if the type is an alphanumeric base type
- * @note This function is only used in the asserts
  */
-inline bool
+bool
 alphanum_temptype(MeosType type)
 {
   return (type == T_TBOOL || type == T_TFLOAT || type == T_TINT ||
     type == T_TTEXT || type == T_TJSONB || type == T_TBIGINT);
 }
-#endif
 
 /**
  * @brief Return true if the type is a geo base type
@@ -789,12 +780,10 @@ time_type(MeosType type)
 
 /*****************************************************************************/
 
-#ifndef NDEBUG
 /**
  * @brief Return true if the type is a base type of a set type
- * @note This function is only used in the asserts
  */
-inline bool
+bool
 set_basetype(MeosType type)
 {
   return (type == T_DATE || type == T_FLOAT8 || type == T_INT4 ||
@@ -804,7 +793,6 @@ set_basetype(MeosType type)
     type == T_H3INDEX || type == T_QUADBIN || type == T_PCPOINT ||
     type == T_PCPATCH);
 }
-#endif
 
 /**
  * @brief Return true if the type is a set type
@@ -998,7 +986,6 @@ span_type(MeosType type)
 
 /**
  * @brief Return true if the type has a span type as bounding box
- * @note This function is only used in the asserts
  */
 bool
 type_span_bbox(MeosType type)
@@ -1009,7 +996,6 @@ type_span_bbox(MeosType type)
 
 /**
  * @brief Return true if the type can be converted to a temporal box
- * @note This function is only used in the asserts
  */
 bool
 span_tbox_type(MeosType type)
@@ -1020,7 +1006,6 @@ span_tbox_type(MeosType type)
 
 /**
  * @brief Return true if the type can be converted to a temporal box
- * @note This function is only used in the asserts
  */
 bool
 ensure_span_tbox_type(MeosType type)
@@ -1141,12 +1126,10 @@ temporal_type(MeosType type)
     type == T_TPCPOINT || type == T_TPCPATCH);
 }
 
-#ifndef NDEBUG
 /**
  * @brief Return true if the type is a temporal base type
- * @note This function is only used in the asserts
  */
-inline bool
+bool
 temporal_basetype(MeosType type)
 {
   return (type == T_BOOL ||
@@ -1158,7 +1141,6 @@ temporal_basetype(MeosType type)
     type == T_JSONB || type == T_QUADBIN || type == T_PCPOINT ||
     type == T_PCPATCH);
 }
-#endif
 
 /**
  * @brief Return true if the temporal type supports LINEAR interpolation
@@ -1180,9 +1162,8 @@ temptype_supports_linear(MeosType type)
 
 /**
  * @brief Return true if the type is a temporal alphanumeric type
- * @note This function is only used in the asserts
  */
-inline bool
+bool
 talphanum_type(MeosType type)
 {
   return (type == T_TBOOL || type == T_TFLOAT || type == T_TINT ||


### PR DESCRIPTION
Compiles eight type predicates unconditionally, so a Release libmeos exports the whole family rather than most of it.

`meos_catalog.h` declares sixty-one type predicates. Eight sit behind `#ifndef NDEBUG` — `meos_basetype`, `alphanum_basetype`, `alphanum_temptype`, `set_basetype`, `talphanum_type`, `temporal_basetype`, `temptype_subtype`, `temptype_subtype_all` — while their immediate siblings `tnumber_basetype`, `geo_basetype`, `span_basetype`, `spatial_basetype`, `pointcloud_basetype`, `timespan_basetype`, `talpha_type` and `temporal_type` are unconditional. Which type introspection a caller gets therefore depends on which member of one family it asks for.

The MEOS-API catalog derives from these headers and every binding projects that catalog, so the eight reach the bindings while the Release library exports none of them: GoMEOS emits `C.meos_basetype(...)` and `C.temptype_subtype(...)`, which cgo resolves at link time; PyMEOS-CFFI emits `_lib.meos_basetype(...)`; MobilityDuck and MobilitySpark carry them in their vendored `meos-idl.json`.

Being debug-only also keeps the eight out of every Release build, which is the gap an `alphanum_temptype` parse error passed through into a published pin.

The predicates are defined as plain `bool` like the rest of the family, and the `@note` marking them as assert-only is dropped.