### PR TITLE
Promote the H3 grid set-op exports to the public meos_h3.h umbrella

### DIFF
--- a/meos/include/h3/h3index_sets.h
+++ b/meos/include/h3/h3index_sets.h
@@ -68,33 +68,8 @@
  * a `meos_error`.
  *****************************************************************************/
 
-/**
- * Return all cells at exactly `k` grid steps from `origin`.
- * Fails near pentagons (libh3's unsafe ring).
- */
-extern Set *h3_grid_ring(H3Index origin, int k);
-
-/**
- * Return the cells on the inclusive path from `start` to `end`.
- * Fails on non-comparable resolutions or paths crossing pentagons.
- */
-extern Set *h3_grid_path_cells(H3Index start, H3Index end);
-
-/**
- * Return all outgoing directed edges of `origin` (up to 6;
- * pentagons have 5).
- */
-extern Set *h3_origin_to_directed_edges(H3Index origin);
-
-/**
- * Return all vertexes of `cell` (up to 6; pentagons have 5).
- */
-extern Set *h3_cell_to_vertexes(H3Index cell);
-
-/**
- * Return the icosahedron face indexes intersected by `cell` as
- * an intset. Each face index is in 0..19.
- */
-extern Set *h3_get_icosahedron_faces(H3Index cell);
+/* h3_grid_ring / h3_grid_path_cells / h3_origin_to_directed_edges /
+ * h3_cell_to_vertexes / h3_get_icosahedron_faces are public cell-set
+ * operations declared in the umbrella header meos_h3.h (included above). */
 
 #endif /* __H3INDEX_SETS_H__ */

--- a/meos/include/meos_h3.h
+++ b/meos/include/meos_h3.h
@@ -124,6 +124,25 @@ extern Set *h3_compact_cells(const Set *cells);
  * (fails if any input is finer than `res`). */
 extern Set *h3_uncompact_cells(const Set *cells, int res);
 
+/** Return all cells at exactly `k` grid steps from `origin`.
+ * Fails near pentagons (libh3's unsafe ring). */
+extern Set *h3_grid_ring(H3Index origin, int k);
+
+/** Return the cells on the inclusive path from `start` to `end`.
+ * Fails on non-comparable resolutions or paths crossing pentagons. */
+extern Set *h3_grid_path_cells(H3Index start, H3Index end);
+
+/** Return all outgoing directed edges of `origin` (up to 6;
+ * pentagons have 5). */
+extern Set *h3_origin_to_directed_edges(H3Index origin);
+
+/** Return all vertexes of `cell` (up to 6; pentagons have 5). */
+extern Set *h3_cell_to_vertexes(H3Index cell);
+
+/** Return the icosahedron face indexes intersected by `cell` as an
+ * intset. Each face index is in 0..19. */
+extern Set *h3_get_icosahedron_faces(H3Index cell);
+
 /*****************************************************************************
  * Type inheritance (analogue of meos_cbuffer.h's tcbuffer section)
  *****************************************************************************/

--- a/meos/src/h3/h3index_sets.c
+++ b/meos/src/h3/h3index_sets.c
@@ -136,6 +136,12 @@ h3_grid_disk(H3Index origin, int k)
   return h3index_set_from_buffer(cells, max);
 }
 
+/**
+ * @ingroup meos_h3_traversal
+ * @brief Return the set of H3 cells at exactly grid distance k from an origin
+ * cell
+ * @csqlfn #H3_grid_ring()
+ */
 Set *
 h3_grid_ring(H3Index origin, int k)
 {
@@ -170,6 +176,11 @@ h3_grid_ring(H3Index origin, int k)
   return h3index_set_from_buffer(cells, ring);
 }
 
+/**
+ * @ingroup meos_h3_traversal
+ * @brief Return the set of H3 cells on the path from a start to an end cell
+ * @csqlfn #H3_grid_path_cells()
+ */
 Set *
 h3_grid_path_cells(H3Index start, H3Index end)
 {
@@ -296,6 +307,11 @@ h3_uncompact_cells(const Set *cells, int res)
  * Edges and vertexes
  *****************************************************************************/
 
+/**
+ * @ingroup meos_h3_edges
+ * @brief Return the set of directed edges originating from an H3 cell
+ * @csqlfn #H3_origin_to_directed_edges()
+ */
 Set *
 h3_origin_to_directed_edges(H3Index origin)
 {
@@ -311,6 +327,11 @@ h3_origin_to_directed_edges(H3Index origin)
   return h3index_set_from_buffer(edges, 6);
 }
 
+/**
+ * @ingroup meos_h3_vertex
+ * @brief Return the set of vertexes of an H3 cell
+ * @csqlfn #H3_cell_to_vertexes()
+ */
 Set *
 h3_cell_to_vertexes(H3Index cell)
 {
@@ -330,6 +351,11 @@ h3_cell_to_vertexes(H3Index cell)
  * Icosahedron faces
  *****************************************************************************/
 
+/**
+ * @ingroup meos_h3_inspection
+ * @brief Return the set of icosahedron face indexes intersected by an H3 cell
+ * @csqlfn #H3_get_icosahedron_faces()
+ */
 Set *
 h3_get_icosahedron_faces(H3Index cell)
 {


### PR DESCRIPTION
Promote the five H3 grid set-op exports from the internal `h3/h3index_sets.h` header to the public umbrella `meos_h3.h`, so they project into the language bindings like the rest of the h3 surface rather than staying stranded as internal-only symbols.

The functions — `h3_grid_ring`, `h3_grid_path_cells`, `h3_origin_to_directed_edges`, `h3_cell_to_vertexes` and `h3_get_icosahedron_faces` — are typed, non-`Datum` public wrappers returning a `Set *`, and belong in the family umbrella like every other h3 export. This matches the North-Star shape every family follows (`meos_h3.h`, `meos_quadbin.h`): the typed wrapper is the public export, the `Datum`/out-parameter kernel stays internal.

Changes:
- `meos/include/meos_h3.h` — adds the five `extern` declarations, grouped under their traversal / edges / vertex / inspection `@defgroup`s.
- `meos/include/h3/h3index_sets.h` — drops the five declarations (now in the umbrella; a comment points to it).
- `meos/src/h3/h3index_sets.c` — adds the matching `@ingroup meos_h3_traversal` / `_edges` / `_vertex` / `_inspection` and `@csqlfn #H3_grid_ring()` … tags to the five implementations, linking each MEOS symbol to its PG wrapper in the catalog.

No behaviour change — the symbols, signatures and bodies are identical; only their declared home and doc-group/`@csqlfn` tags change. Expected regression outputs are unchanged.
