### PR TITLE
Give the numeric addition and subtraction their pg_ twins

### DIFF
--- a/pgtypes/utils/numeric.c
+++ b/pgtypes/utils/numeric.c
@@ -1939,8 +1939,15 @@ numeric_hash_extended(Numeric num, uint64 seed)
  * @brief Return the addition of two numeric values
  * @note Derived from PostgreSQL function @p numeric_add()
  */
+#if MEOS
 Numeric
 numeric_add(Numeric num1, Numeric num2)
+{
+  return pg_numeric_add(num1, num2);
+}
+#endif
+Numeric
+pg_numeric_add(Numeric num1, Numeric num2)
 {
   return numeric_add_opt_error(num1, num2, NULL);
 }
@@ -2005,8 +2012,15 @@ numeric_add_opt_error(Numeric num1, Numeric num2, bool *have_error)
  * @brief Return the subtraction of two numeric values
  * @note Derived from PostgreSQL function @p numeric_sub()
  */
+#if MEOS
 Numeric
 numeric_minus(Numeric num1, Numeric num2)
+{
+  return pg_numeric_sub(num1, num2);
+}
+#endif
+Numeric
+pg_numeric_sub(Numeric num1, Numeric num2)
 {
   return numeric_sub_opt_error(num1, num2, NULL);
 }


### PR DESCRIPTION
Gives the numeric addition and subtraction the twin pair every sibling operation has.

Each numeric operation whose name collides with PostgreSQL's own is a pair: a `pg_`-prefixed implementation carrying the upstream PostgreSQL name, and a clean MEOS name defined under `#if MEOS` that forwards to it, so the extension build exposes only the `pg_` spelling. `numeric_mul`/`pg_numeric_mul`, `numeric_div`/`pg_numeric_div`, `numeric_cmp`/`pg_numeric_cmp` and some thirty siblings follow it.

The addition and the subtraction have only the clean half. `numeric_add` and `numeric_minus` are compiled unconditionally, so the extension build defines `numeric_add` alongside the PostgreSQL function of that name — the collision the prefix exists to avoid — and `pg_numeric_add` and `pg_numeric_sub`, declared by `pgtypes.h` and `pgtypes/utils/numeric.h`, name a symbol nothing defines. The MEOS-API catalog derives from those headers, so both reach the generated bindings, where a lazily bound call such as JMEOS's resolves at run time against a symbol that is not there.

Both implementations move to their `pg_` names and gain the `#if MEOS` forwarders; the headers are unchanged, since they already declared the twins. A `-DMEOS=ON -DALL=ON` build then exports `numeric_add`, `pg_numeric_add`, `numeric_minus` and `pg_numeric_sub` beside `numeric_mul`/`pg_numeric_mul`.