### PR TITLE
Drop the GSERIALIZED token from the H3 point/cell geometry names

### DIFF
--- a/meos/include/h3/th3index_internal.h
+++ b/meos/include/h3/th3index_internal.h
@@ -84,8 +84,8 @@ typedef enum
  *****************************************************************************/
 
 /* Point / polygon conversions — bodies in th3index_latlng.c. */
-extern GSERIALIZED *h3_cell_to_gs_point(H3Index cell);
-extern GSERIALIZED *h3_cell_to_gs_boundary(H3Index cell);
+extern GSERIALIZED *h3_cell_to_geompoint(H3Index cell);
+extern GSERIALIZED *h3_cell_to_geom(H3Index cell);
 
 /* Shared helper: build a geodetic SRID 4326 LWPOLY from a libh3
  * CellBoundary and serialise. Primary definition in

--- a/meos/include/meos_h3.h
+++ b/meos/include/meos_h3.h
@@ -239,7 +239,7 @@ extern Temporal *th3index_to_tgeompoint(const Temporal *temp);
 extern Temporal *th3index_cell_to_boundary(const Temporal *temp);
 
 /* Static geometry → H3 cell / cell set.  See meos/src/h3/h3_geo.c. */
-extern H3Index h3_gs_point_to_cell(const GSERIALIZED *point, int32 resolution);
+extern H3Index geo_to_h3index_cell(const GSERIALIZED *point, int32 resolution);
 extern Set    *geo_to_h3index_set(const GSERIALIZED *gs,    int32 resolution);
 extern int     ever_eq_h3indexset_th3index(const Set *cells,
                                                   const Temporal *th3idx);

--- a/meos/src/h3/h3_geo.c
+++ b/meos/src/h3/h3_geo.c
@@ -33,7 +33,7 @@
  *
  * Covers every WKT/GSERIALIZED geometry type:
  *
- *   POINT             — single H3 cell via h3_gs_point_to_cell.
+ *   POINT             — single H3 cell via geo_to_h3index_cell.
  *   LINESTRING        — sample each segment at edge_length(res)/2 spacing
  *                       (Nyquist), latLngToCell per sample, dedup.
  *   POLYGON           — outer + holes converted to GeoPolygon in radians,
@@ -182,7 +182,7 @@ h3_latlng_deg_to_cell(double lat_deg, double lng_deg, int32 resolution)
 }
 
 /*****************************************************************************
- * POINT — single cell.  Uses the existing h3_gs_point_to_cell which has
+ * POINT — single cell.  Uses the existing geo_to_h3index_cell which has
  * the SRID guard.
  *****************************************************************************/
 

--- a/meos/src/h3/h3index.c
+++ b/meos/src/h3/h3index.c
@@ -543,21 +543,21 @@ Datum
 datum_h3_latlng_to_cell(Datum point_d, Datum res_d)
 {
   const GSERIALIZED *point = (GSERIALIZED *) DatumGetPointer(point_d);
-  return H3IndexGetDatum(h3_gs_point_to_cell(point,
+  return H3IndexGetDatum(geo_to_h3index_cell(point,
     DatumGetInt32(res_d)));
 }
 
 Datum
 datum_h3_cell_to_latlng(Datum d)
 {
-  GSERIALIZED *gs = h3_cell_to_gs_point(DatumGetH3Index(d));
+  GSERIALIZED *gs = h3_cell_to_geompoint(DatumGetH3Index(d));
   return PointerGetDatum(gs);
 }
 
 Datum
 datum_h3_cell_to_boundary(Datum d)
 {
-  GSERIALIZED *gs = h3_cell_to_gs_boundary(DatumGetH3Index(d));
+  GSERIALIZED *gs = h3_cell_to_geom(DatumGetH3Index(d));
   return PointerGetDatum(gs);
 }
 

--- a/meos/src/h3/th3index_edges.c
+++ b/meos/src/h3/th3index_edges.c
@@ -69,7 +69,7 @@ h3_directed_edge_to_gs_boundary(H3Index edge)
    * as cells), swapping lat/lng in the process — a known upstream
    * quirk. We emit a closed POLYGON too so consumers see a uniform
    * shape, but keep x = lng, y = lat as in
-   * `h3_cell_to_gs_boundary`. */
+   * `h3_cell_to_geom`. */
   return cell_boundary_to_gs(&bnd);
 }
 

--- a/meos/src/h3/th3index_latlng.c
+++ b/meos/src/h3/th3index_latlng.c
@@ -32,8 +32,8 @@
  * @brief MEOS lifting for lat/lng conversions, plus the static
  * adapter bodies that back them.
  *
- * The static h3 conversions `h3_gs_point_to_cell`,
- * `h3_cell_to_gs_point`, and `h3_cell_to_gs_boundary` live here
+ * The static h3 conversions `geo_to_h3index_cell`,
+ * `h3_cell_to_geompoint`, and `h3_cell_to_geom` live here
  * alongside the lifted entries that consume them. Point reads use
  * the MobilityDB peek macro `GSERIALIZED_POINT2D_P` rather than
  * `lwgeom_from_gserialized` — approved by the PostGIS team and a
@@ -69,10 +69,10 @@
  * @brief Single H3 cell covering a POINT geometry at the given resolution
  * @param[in] point      The POINT geometry.
  * @param[in] resolution H3 resolution (0..15).
- * @csqlfn #Geo_gs_point_to_h3index()
+ * @csqlfn #Geo_point_to_h3index()
  */
 H3Index
-h3_gs_point_to_cell(const GSERIALIZED *point, int32 resolution)
+geo_to_h3index_cell(const GSERIALIZED *point, int32 resolution)
 {
   if (! ensure_srid_is_latlong(gserialized_get_srid(point)))
     return (H3Index) 0;
@@ -88,7 +88,7 @@ h3_gs_point_to_cell(const GSERIALIZED *point, int32 resolution)
 }
 
 GSERIALIZED *
-h3_cell_to_gs_point(H3Index cell)
+h3_cell_to_geompoint(H3Index cell)
 {
   LatLng ll;
   if (cellToLatLng(cell, &ll) != E_SUCCESS)
@@ -136,7 +136,7 @@ cell_boundary_to_gs(const CellBoundary *bnd)
 }
 
 GSERIALIZED *
-h3_cell_to_gs_boundary(H3Index cell)
+h3_cell_to_geom(H3Index cell)
 {
   CellBoundary bnd;
   if (cellToBoundary(cell, &bnd) != E_SUCCESS)
@@ -175,13 +175,13 @@ h3_cell_to_gs_boundary(H3Index cell)
 /**
  * @brief One-instant conversion. The Datum carries a GSERIALIZED point
  * in SRID 4326 (either tgeompoint or tgeogpoint encoding); the SRID
- * guard lives in the static adapter `h3_gs_point_to_cell`.
+ * guard lives in the static adapter `geo_to_h3index_cell`.
  */
 static TInstant *
 tpointinst_to_th3index(const TInstant *inst, int32 resolution)
 {
   const GSERIALIZED *gs = DatumGetGserializedP(tinstant_value(inst));
-  H3Index cell = h3_gs_point_to_cell(gs, resolution);
+  H3Index cell = geo_to_h3index_cell(gs, resolution);
   return tinstant_make(H3IndexGetDatum(cell), T_TH3INDEX, inst->t);
 }
 
@@ -228,7 +228,7 @@ tpointseq_densify_to_th3index(const TSequence *seq, int32 resolution)
     {
       const TInstant *inst = TSEQUENCE_INST_N(seq, i);
       const GSERIALIZED *gs = DatumGetGserializedP(tinstant_value(inst));
-      H3Index cell = h3_gs_point_to_cell(gs, resolution);
+      H3Index cell = geo_to_h3index_cell(gs, resolution);
       PUSH_INSTANT(cell, inst->t);
     }
   }
@@ -239,14 +239,14 @@ tpointseq_densify_to_th3index(const TSequence *seq, int32 resolution)
       step_deg = 1e-5;   /* defensive */
 
     /* Emit the first instant's cell. Routing the first lookup through
-     * h3_gs_point_to_cell applies the lon/lat SRID guard once for the
+     * geo_to_h3index_cell applies the lon/lat SRID guard once for the
      * whole sequence: SRID is a type-level property uniform across every
      * instant, so validating it here is sufficient and the interpolated
      * per-sample lookups below can use the cheaper raw-coordinate path. */
     {
       const TInstant *inst0 = TSEQUENCE_INST_N(seq, 0);
       const GSERIALIZED *gs0 = DatumGetGserializedP(tinstant_value(inst0));
-      H3Index cell0 = h3_gs_point_to_cell(gs0, resolution);
+      H3Index cell0 = geo_to_h3index_cell(gs0, resolution);
       PUSH_INSTANT(cell0, inst0->t);
       last_cell = cell0;
       have_last = true;
@@ -331,7 +331,7 @@ tpointseqset_densify_to_th3index(const TSequenceSet *ss, int32 resolution)
  * @brief Subtype-dispatching wrapper used by both tgeompoint and
  * tgeogpoint entrypoints.
  *
- * Every path validates the lon/lat SRID through `h3_gs_point_to_cell`
+ * Every path validates the lon/lat SRID through `geo_to_h3index_cell`
  * (the instant adapter, the non-densify branch, and the first lookup of
  * the densify walker), so non lon/lat input is rejected before any cell
  * is produced and the dispatcher itself needs no separate guard.
@@ -356,7 +356,7 @@ tpoint_to_th3index_dense(const Temporal *temp, int32 resolution)
 /*****************************************************************************
  * tgeompoint_to_th3index(tgeompoint, integer) — densifying conversion
  *
- * The adapter `h3_gs_point_to_cell` (called from `tpointinst_to_th3index`)
+ * The adapter `geo_to_h3index_cell` (called from `tpointinst_to_th3index`)
  * verifies SRID 4326 and raises on mismatch.
  *****************************************************************************/
 
@@ -421,7 +421,7 @@ th3index_to_tgeogpoint(const Temporal *temp)
 /*****************************************************************************
  * th3CellToLatlng (planar output, SRID 4326 overload)
  *
- * Both overloads share the same static adapter `h3_cell_to_gs_point`,
+ * Both overloads share the same static adapter `h3_cell_to_geompoint`,
  * which emits an SRID-4326 point. The geography-vs-geometry nature
  * of the result is disambiguated at the lifting layer via the
  * `restype` setting — downstream consumers see the intended type.

--- a/mobilitydb/sql/h3/252_h3index_ops.in.sql
+++ b/mobilitydb/sql/h3/252_h3index_ops.in.sql
@@ -50,7 +50,7 @@
 
 CREATE FUNCTION geoToH3Cell(geometry, integer)
   RETURNS h3index
-  AS 'MODULE_PATHNAME', 'Geo_gs_point_to_h3index'
+  AS 'MODULE_PATHNAME', 'Geo_point_to_h3index'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION geoToH3IndexSet(geometry, integer)

--- a/mobilitydb/src/h3/h3_geo.c
+++ b/mobilitydb/src/h3/h3_geo.c
@@ -47,19 +47,19 @@
 #include "pg_temporal/temporal.h"     /* PG_GETARG_TEMPORAL_P */
 #include "pg_geo/postgis.h"           /* PG_GETARG_GSERIALIZED_P */
 
-PGDLLEXPORT Datum Geo_gs_point_to_h3index(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Geo_gs_point_to_h3index);
+PGDLLEXPORT Datum Geo_point_to_h3index(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Geo_point_to_h3index);
 /**
  * @ingroup mobilitydb_h3_conversion
  * @brief Single H3 cell covering a POINT geometry at the given resolution
  * @sqlfn geoToH3Cell()
  */
 Datum
-Geo_gs_point_to_h3index(PG_FUNCTION_ARGS)
+Geo_point_to_h3index(PG_FUNCTION_ARGS)
 {
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(0);
   int32 resolution = PG_GETARG_INT32(1);
-  H3Index cell = h3_gs_point_to_cell(gs, resolution);
+  H3Index cell = geo_to_h3index_cell(gs, resolution);
   PG_FREE_IF_COPY(gs, 0);
   if (cell == (H3Index) 0)
     PG_RETURN_NULL();

--- a/mobilitydb/test/h3/queries/282_th3index_latlng.test.sql
+++ b/mobilitydb/test/h3/queries/282_th3index_latlng.test.sql
@@ -7,8 +7,8 @@
 -------------------------------------------------------------------------------
 
 -- §1.1 Lat/Lng conversions — five lifts, all backed by adapters in
--- h3_adapter.c (h3_gs_point_to_cell / h3_cell_to_gs_point /
--- h3_cell_to_gs_boundary). Round-trip identities are the most
+-- th3index_latlng.c (geo_to_h3index_cell / h3_cell_to_geompoint /
+-- h3_cell_to_geom). Round-trip identities are the most
 -- robust assertions because they hold without us hard-coding any
 -- specific lat/lng coordinates.
 --


### PR DESCRIPTION
Rename the H3 geometry-adapter exports so the public MEOS API names its geometry arguments and results with the family token (`geo` / `geom` / `geompoint`) rather than the PostGIS-internal `gserialized` abbreviation.

The `_gs_` token leaks the PostGIS `GSERIALIZED` implementation detail into the MEOS surface — the same detail the family convention elsewhere hides behind `geo` / `geom` / `geog`. These renames bring the H3 point/cell conversions in line with that convention and with the quadbin siblings (`geo_to_quadbin_cell`, `quadbin_cell_to_geompoint`, `quadbin_cell_to_geom`) and the existing h3 set export `geo_to_h3index_set`:

- `h3_gs_point_to_cell` → `geo_to_h3index_cell` (public, mirrors `geo_to_h3index_set` + `geo_to_quadbin_cell`)
- `h3_cell_to_gs_point` → `h3_cell_to_geompoint` (internal, mirrors `quadbin_cell_to_geompoint`)
- `h3_cell_to_gs_boundary` → `h3_cell_to_geom` (internal, mirrors `quadbin_cell_to_geom`)
- `Geo_gs_point_to_h3index` → `Geo_point_to_h3index` (PG wrapper C symbol)

The user-facing SQL functions (`geoToH3Cell`, …) keep their names; only the C symbols and the `MODULE_PATHNAME` link string change, so the rename is behaviour-neutral and the expected regression outputs are unchanged.
