### PR TITLE
Document the aggregate function naming and add the Spanish Portable SQL chapter

### DIFF
--- a/doc/es/mobilitydb-manual.xml
+++ b/doc/es/mobilitydb-manual.xml
@@ -32,6 +32,7 @@
 <!ENTITY temporal_pointcloud SYSTEM "temporal_pointcloud.xml">
 <!ENTITY temporal_raster SYSTEM "temporal_raster.xml">
 <!ENTITY reference SYSTEM "reference.xml">
+<!ENTITY portable_sql SYSTEM "portable_sql.xml">
 <!ENTITY data_generator SYSTEM "data_generator.xml">
 
 <!ENTITY geography_support
@@ -140,6 +141,7 @@
 	&temporal_pointcloud;
 	&temporal_raster;
 	&reference;
+	&portable_sql;
 	&data_generator;
 	<index />
 

--- a/doc/es/portable_sql.xml
+++ b/doc/es/portable_sql.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   ****************************************************************************
+    MobilityDB Manual
+    Copyright(c) MobilityDB Contributors
+
+    This documentation is licensed under a Creative Commons Attribution-Share
+    Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
+   ****************************************************************************
+-->
+<chapter xml:id="portable_sql">
+	<title>Dialecto Portable de Funciones con Nombre</title>
+
+	<para>Todo operador de MobilityDB puede invocarse también como una función con nombre. Una consulta escrita únicamente con funciones con nombre, sin símbolos de operador, es portable: el mismo SQL se ejecuta sin cambios en todo el ecosistema MobilityDB — los motores de base de datos MobilityDB (PostgreSQL), MobilityDuck (DuckDB) y MobilitySpark (Apache Spark), y los motores de <foreignphrase>streaming</foreignphrase> —, varios de los cuales no pueden registrar símbolos de operador de PostgreSQL. Cada alias con nombre reutiliza la propia implementación del operador, por lo que devuelve exactamente el mismo resultado que el operador.</para>
+
+	<para>Este capítulo es la referencia canónica, a nivel de todo el ecosistema, de esa correspondencia. Un motor que no acepte un operador dado puede consultarlo aquí y usar la forma de función en su lugar. Por ejemplo, DuckDB no acepta ningún operador que contenga <literal>#</literal> (reserva <literal>#</literal> para las referencias posicionales de columna), de modo que en MobilityDuck las comparaciones temporales (<literal>#=</literal>, …) se escriben <varname>tEq</varname>, … y las pruebas de posición temporal (<literal>&lt;&lt;#</literal>, <literal>#&gt;&gt;</literal>, <literal>&amp;&lt;#</literal>, <literal>#&amp;&gt;</literal>) se escriben <varname>before</varname>, <varname>after</varname>, <varname>overbefore</varname>, <varname>overafter</varname>, mientras que los operadores que sí acepta pueden usarse directamente.</para>
+
+	<para>Las funciones de relación espacial (<varname>eIntersects</varname>, <varname>aIntersects</varname>, <varname>eTouches</varname>, <varname>eDwithin</varname>, …) y las funciones de restricción (<varname>atTime</varname>, <varname>atGeometry</varname>, <varname>atValue</varname>, …) son siempre funciones con nombre (no tienen operador). El comparador de ordenación de árbol B es asimismo la función con nombre <varname>cmp(a, b)</varname>, que devuelve <literal>-1</literal>, <literal>0</literal> o <literal>1</literal> y no tiene operador. Cada operador se corresponde con un nombre simple de la manera siguiente; para los operadores aritméticos y de teoría de conjuntos el nombre de la función lleva el prefijo de la familia de tipos del operando (<varname>set</varname>, <varname>span</varname> o <varname>spanset</varname>, y <varname>t</varname> para los números temporales).</para>
+
+	<informaltable frame="all" colsep="1" rowsep="1">
+		<?dblatex table-width="autowidth.column: 1 2 3"?>
+		<tgroup cols="3" align="left" colsep="1" rowsep="1">
+			<thead>
+				<row>
+					<entry>Categoría</entry>
+					<entry>Operador</entry>
+					<entry>Función portable</entry>
+				</row>
+			</thead>
+			<tbody>
+				<row><entry>Topología</entry><entry>&amp;&amp;</entry><entry>overlaps(a, b)</entry></row>
+				<row><entry></entry><entry>@&gt;</entry><entry>contains(a, b)</entry></row>
+				<row><entry></entry><entry>&lt;@</entry><entry>contained(a, b)</entry></row>
+				<row><entry></entry><entry>-|-</entry><entry>adjacent(a, b)</entry></row>
+				<row><entry>Posición temporal</entry><entry>&lt;&lt;#</entry><entry>before(a, b)</entry></row>
+				<row><entry></entry><entry>#&gt;&gt;</entry><entry>after(a, b)</entry></row>
+				<row><entry></entry><entry>&amp;&lt;#</entry><entry>overbefore(a, b)</entry></row>
+				<row><entry></entry><entry>#&amp;&gt;</entry><entry>overafter(a, b)</entry></row>
+				<row><entry>Espacio, eje X</entry><entry>&lt;&lt;</entry><entry>left(a, b)</entry></row>
+				<row><entry></entry><entry>&gt;&gt;</entry><entry>right(a, b)</entry></row>
+				<row><entry></entry><entry>&amp;&lt;</entry><entry>overleft(a, b)</entry></row>
+				<row><entry></entry><entry>&amp;&gt;</entry><entry>overright(a, b)</entry></row>
+				<row><entry>Espacio, eje Y</entry><entry>&lt;&lt;|</entry><entry>below(a, b)</entry></row>
+				<row><entry></entry><entry>|&gt;&gt;</entry><entry>above(a, b)</entry></row>
+				<row><entry></entry><entry>&amp;&lt;|</entry><entry>overbelow(a, b)</entry></row>
+				<row><entry></entry><entry>|&amp;&gt;</entry><entry>overabove(a, b)</entry></row>
+				<row><entry>Espacio, eje Z</entry><entry>&lt;&lt;/</entry><entry>front(a, b)</entry></row>
+				<row><entry></entry><entry>/&gt;&gt;</entry><entry>back(a, b)</entry></row>
+				<row><entry></entry><entry>&amp;&lt;/</entry><entry>overfront(a, b)</entry></row>
+				<row><entry></entry><entry>/&amp;&gt;</entry><entry>overback(a, b)</entry></row>
+				<row><entry>Comparación temporal</entry><entry>#=</entry><entry>tEq(a, b)</entry></row>
+				<row><entry></entry><entry>#&lt;&gt;</entry><entry>tNe(a, b)</entry></row>
+				<row><entry></entry><entry>#&lt;</entry><entry>tLt(a, b)</entry></row>
+				<row><entry></entry><entry>#&lt;=</entry><entry>tLe(a, b)</entry></row>
+				<row><entry></entry><entry>#&gt;</entry><entry>tGt(a, b)</entry></row>
+				<row><entry></entry><entry>#&gt;=</entry><entry>tGe(a, b)</entry></row>
+				<row><entry>Distancia</entry><entry>&lt;-&gt;</entry><entry>tDistance(a, b)</entry></row>
+				<row><entry></entry><entry>|=|</entry><entry>nearestApproachDistance(a, b)</entry></row>
+				<row><entry>Igual</entry><entry>~=</entry><entry>same(a, b)</entry></row>
+				<row><entry>Comparación tradicional</entry><entry>=</entry><entry>eq(a, b)</entry></row>
+				<row><entry></entry><entry>&lt;&gt;</entry><entry>ne(a, b)</entry></row>
+				<row><entry></entry><entry>&lt;</entry><entry>lt(a, b)</entry></row>
+				<row><entry></entry><entry>&lt;=</entry><entry>le(a, b)</entry></row>
+				<row><entry></entry><entry>&gt;</entry><entry>gt(a, b)</entry></row>
+				<row><entry></entry><entry>&gt;=</entry><entry>ge(a, b)</entry></row>
+				<row><entry>Comparación alguna vez</entry><entry>?=</entry><entry>eEq(a, b)</entry></row>
+				<row><entry></entry><entry>?&lt;&gt;</entry><entry>eNe(a, b)</entry></row>
+				<row><entry></entry><entry>?&lt;</entry><entry>eLt(a, b)</entry></row>
+				<row><entry></entry><entry>?&lt;=</entry><entry>eLe(a, b)</entry></row>
+				<row><entry></entry><entry>?&gt;</entry><entry>eGt(a, b)</entry></row>
+				<row><entry></entry><entry>?&gt;=</entry><entry>eGe(a, b)</entry></row>
+				<row><entry>Comparación siempre</entry><entry>%=</entry><entry>aEq(a, b)</entry></row>
+				<row><entry></entry><entry>%&lt;&gt;</entry><entry>aNe(a, b)</entry></row>
+				<row><entry></entry><entry>%&lt;</entry><entry>aLt(a, b)</entry></row>
+				<row><entry></entry><entry>%&lt;=</entry><entry>aLe(a, b)</entry></row>
+				<row><entry></entry><entry>%&gt;</entry><entry>aGt(a, b)</entry></row>
+				<row><entry></entry><entry>%&gt;=</entry><entry>aGe(a, b)</entry></row>
+				<row><entry>Aritmética (números temporales)</entry><entry>+</entry><entry>tAdd(a, b)</entry></row>
+				<row><entry></entry><entry>-</entry><entry>tSub(a, b)</entry></row>
+				<row><entry></entry><entry>*</entry><entry>tMul(a, b)</entry></row>
+				<row><entry></entry><entry>/</entry><entry>tDiv(a, b)</entry></row>
+				<row><entry>Unión (set / span / span set)</entry><entry>+</entry><entry>setUnion / spanUnion / spansetUnion (a, b)</entry></row>
+				<row><entry>Intersección (set / span / span set)</entry><entry>*</entry><entry>setIntersection / spanIntersection / spansetIntersection (a, b)</entry></row>
+				<row><entry>Diferencia (set / span / span set)</entry><entry>-</entry><entry>setMinus / spanMinus / spansetMinus (a, b)</entry></row>
+			</tbody>
+		</tgroup>
+	</informaltable>
+
+	<para>Por ejemplo, la superposición de cajas envolventes <literal>t1.trip &amp;&amp; t2.trip</literal> se escribe de forma portable como <literal>overlaps(t1.trip, t2.trip)</literal>, y la prueba temporal «antes» <literal>p1.period &lt;&lt;# p2.period</literal> como <literal>before(p1.period, p2.period)</literal>.</para>
+
+	<para>Las funciones de agregación siguen el mismo principio. Una agregación SQL se compone de hasta tres funciones de la maquinaria de PostgreSQL, cada una expuesta bajo un nombre canónico formado a partir del nombre de la agregación y su rol: una función de transición <varname>&lt;agregación&gt;Transition</varname>, una función de combinación opcional <varname>&lt;agregación&gt;Combine</varname> usada para la agregación en paralelo, y una función final <varname>&lt;agregación&gt;Final</varname>. Los tres roles se mantienen distintos y con un nombre uniforme para que cada <foreignphrase>binding</foreignphrase> pueda reconstruir la agregación a partir del catálogo. Por ejemplo, las agregaciones de unión exponen las funciones de transición <varname>setUnionTransition</varname>, <varname>spanUnionTransition</varname> y <varname>spansetUnionTransition</varname> y las funciones finales <varname>setUnionFinal</varname>, <varname>spanUnionFinal</varname> y <varname>spansetUnionFinal</varname>; una función de combinación, cuando una agregación admite la ejecución en paralelo, toma la forma correspondiente <varname>&lt;agregación&gt;Combine</varname>.</para>
+</chapter>

--- a/doc/portable_sql.xml
+++ b/doc/portable_sql.xml
@@ -87,4 +87,6 @@
 	</informaltable>
 
 	<para>For example, the bounding-box overlap <literal>t1.trip &amp;&amp; t2.trip</literal> is written portably as <literal>overlaps(t1.trip, t2.trip)</literal>, and the temporal-before test <literal>p1.period &lt;&lt;# p2.period</literal> as <literal>before(p1.period, p2.period)</literal>.</para>
+
+	<para>Aggregate functions follow the same principle. A SQL aggregate is assembled from up to three PostgreSQL machinery functions, each exposed under a canonical name built from the aggregate name and its role: a transition function <varname>&lt;aggregate&gt;Transition</varname>, an optional combine function <varname>&lt;aggregate&gt;Combine</varname> used for parallel aggregation, and a final function <varname>&lt;aggregate&gt;Final</varname>. The three roles stay distinct and uniformly named so that every binding can reconstruct the aggregate from the catalog. For example, the union aggregates expose the transition functions <varname>setUnionTransition</varname>, <varname>spanUnionTransition</varname> and <varname>spansetUnionTransition</varname> and the final functions <varname>setUnionFinal</varname>, <varname>spanUnionFinal</varname> and <varname>spansetUnionFinal</varname>; a combine function, where an aggregate supports parallel execution, takes the matching <varname>&lt;aggregate&gt;Combine</varname> form.</para>
 </chapter>


### PR DESCRIPTION
Documents the aggregate function naming in the Portable Named-Function Dialect chapter, and adds the Spanish translation of that chapter.

- A SQL aggregate exposes its three PostgreSQL machinery functions under canonical role names: `<aggregate>Transition`, `<aggregate>Combine`, and `<aggregate>Final`. The union aggregates illustrate the convention (`setUnionTransition`/`setUnionFinal`, and the `spanUnion`/`spansetUnion` counterparts).
- `doc/es/portable_sql.xml` provides the Spanish chapter and wires it into the Spanish manual, so both the English and Spanish manuals carry the Portable SQL chapter.