### PR TITLE
Add the base-to-stbox exports for the h3index and quadbin cell types

### DIFF
--- a/meos/include/meos_h3.h
+++ b/meos/include/meos_h3.h
@@ -241,6 +241,9 @@ extern Temporal *th3index_cell_to_boundary(const Temporal *temp);
 /* Static geometry → H3 cell / cell set.  See meos/src/h3/h3_geo.c. */
 extern H3Index geo_to_h3index_cell(const GSERIALIZED *point, int32 resolution);
 extern Set    *geo_to_h3index_set(const GSERIALIZED *gs,    int32 resolution);
+extern STBox  *h3index_to_stbox(H3Index cell);
+extern STBox  *h3index_timestamptz_to_stbox(H3Index cell, TimestampTz t);
+extern STBox  *h3index_tstzspan_to_stbox(H3Index cell, const Span *s);
 extern int     ever_eq_h3indexset_th3index(const Set *cells,
                                                   const Temporal *th3idx);
 

--- a/meos/include/meos_internal_geo.h
+++ b/meos/include/meos_internal_geo.h
@@ -134,6 +134,7 @@ extern void spatialset_set_stbox(const Set *set, STBox *result);
 extern void stbox_set_box3d(const STBox *box, BOX3D *result);
 extern void stbox_set_gbox(const STBox *box, GBOX *result);
 extern void tstzset_set_stbox(const Set *s, STBox *result);
+extern void timestamptz_set_stbox(TimestampTz t, STBox *result);
 extern void tstzspan_set_stbox(const Span *s, STBox *result);
 extern void tstzspanset_set_stbox(const SpanSet *s, STBox *result);
 

--- a/meos/include/meos_quadbin.h
+++ b/meos/include/meos_quadbin.h
@@ -122,6 +122,11 @@ extern Quadbin geo_to_quadbin_cell(const GSERIALIZED *point,
 extern GSERIALIZED *quadbin_cell_to_geompoint(Quadbin cell);
 extern GSERIALIZED *quadbin_cell_to_geom(Quadbin cell);
 
+/* Bounding box */
+extern STBox *quadbin_to_stbox(Quadbin cell);
+extern STBox *quadbin_timestamptz_to_stbox(Quadbin cell, TimestampTz t);
+extern STBox *quadbin_tstzspan_to_stbox(Quadbin cell, const Span *s);
+
 /* Metrics */
 extern double quadbin_cell_area(Quadbin cell);
 

--- a/meos/src/h3/th3index_boxops.c
+++ b/meos/src/h3/th3index_boxops.c
@@ -130,6 +130,57 @@ h3index_set_stbox(H3Index cell, STBox *box)
 }
 
 /**
+ * @ingroup meos_h3_conversion
+ * @brief Return the spatiotemporal bounding box of an H3 cell
+ * @param[in] cell H3 cell index
+ * @return The geodetic X/Y bounding box of the cell (SRID 4326, no T dimension)
+ * @csqlfn #H3index_to_stbox()
+ */
+STBox *
+h3index_to_stbox(H3Index cell)
+{
+  STBox box;
+  if (! h3index_set_stbox(cell, &box))
+    return NULL;
+  return stbox_copy(&box);
+}
+
+/**
+ * @ingroup meos_h3_conversion
+ * @brief Return the spatiotemporal bounding box of an H3 cell and a timestamptz
+ * @param[in] cell H3 cell index
+ * @param[in] t Timestamp
+ * @csqlfn #H3index_timestamptz_to_stbox()
+ */
+STBox *
+h3index_timestamptz_to_stbox(H3Index cell, TimestampTz t)
+{
+  STBox box;
+  if (! h3index_set_stbox(cell, &box))
+    return NULL;
+  timestamptz_set_stbox(t, &box);
+  return stbox_copy(&box);
+}
+
+/**
+ * @ingroup meos_h3_conversion
+ * @brief Return the spatiotemporal bounding box of an H3 cell and a timestamptz
+ * span
+ * @param[in] cell H3 cell index
+ * @param[in] s Timestamptz span
+ * @csqlfn #H3index_tstzspan_to_stbox()
+ */
+STBox *
+h3index_tstzspan_to_stbox(H3Index cell, const Span *s)
+{
+  STBox box;
+  if (! h3index_set_stbox(cell, &box))
+    return NULL;
+  tstzspan_set_stbox(s, &box);
+  return stbox_copy(&box);
+}
+
+/**
  * @ingroup meos_internal_box_conversion
  * @brief Return in the last argument a spatiotemporal box constructed from an
  * array of H3 cells (the geodetic X/Y union, no T dimension)

--- a/meos/src/quadbin/tquadbin_boxops.c
+++ b/meos/src/quadbin/tquadbin_boxops.c
@@ -110,6 +110,58 @@ quadbin_set_stbox(Quadbin cell, STBox *box)
 }
 
 /**
+ * @ingroup meos_quadbin
+ * @brief Return the spatiotemporal bounding box of a quadbin cell
+ * @param[in] cell Quadbin cell index
+ * @return The planar X/Y bounding box of the cell (SRID 4326, no T dimension)
+ * @csqlfn #Quadbin_to_stbox()
+ */
+STBox *
+quadbin_to_stbox(Quadbin cell)
+{
+  STBox box;
+  if (! quadbin_set_stbox(cell, &box))
+    return NULL;
+  return stbox_copy(&box);
+}
+
+/**
+ * @ingroup meos_quadbin
+ * @brief Return the spatiotemporal bounding box of a quadbin cell and a
+ * timestamptz
+ * @param[in] cell Quadbin cell index
+ * @param[in] t Timestamp
+ * @csqlfn #Quadbin_timestamptz_to_stbox()
+ */
+STBox *
+quadbin_timestamptz_to_stbox(Quadbin cell, TimestampTz t)
+{
+  STBox box;
+  if (! quadbin_set_stbox(cell, &box))
+    return NULL;
+  timestamptz_set_stbox(t, &box);
+  return stbox_copy(&box);
+}
+
+/**
+ * @ingroup meos_quadbin
+ * @brief Return the spatiotemporal bounding box of a quadbin cell and a
+ * timestamptz span
+ * @param[in] cell Quadbin cell index
+ * @param[in] s Timestamptz span
+ * @csqlfn #Quadbin_tstzspan_to_stbox()
+ */
+STBox *
+quadbin_tstzspan_to_stbox(Quadbin cell, const Span *s)
+{
+  STBox box;
+  if (! quadbin_set_stbox(cell, &box))
+    return NULL;
+  tstzspan_set_stbox(s, &box);
+  return stbox_copy(&box);
+}
+
+/**
  * @ingroup meos_internal_box_conversion
  * @brief Return in the last argument a spatiotemporal box constructed from an
  * array of quadbin cells (the planar X/Y union, no T dimension)

--- a/mobilitydb/src/h3/h3_geo.c
+++ b/mobilitydb/src/h3/h3_geo.c
@@ -38,14 +38,21 @@
 
 #include <postgres.h>
 #include <fmgr.h>
+#include <utils/timestamp.h>
 
 #include <meos.h>
 #include <meos_geo.h>
 #include <meos_h3.h>
 
+#include "geo/stbox.h"                /* PG_RETURN_STBOX_P */
 #include "temporal/set.h"             /* PG_GETARG_SET_P / PG_RETURN_SET_P */
+#include "temporal/span.h"            /* PG_GETARG_SPAN_P */
 #include "pg_temporal/temporal.h"     /* PG_GETARG_TEMPORAL_P */
 #include "pg_geo/postgis.h"           /* PG_GETARG_GSERIALIZED_P */
+
+/* h3index is stored on the int8 payload; DatumGetH3Index lives in
+ * h3/h3index.h but this file only needs the fmgr-layer getter. */
+#define PG_GETARG_H3INDEX(n) ((H3Index) PG_GETARG_INT64(n))
 
 PGDLLEXPORT Datum Geo_point_to_h3index(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Geo_point_to_h3index);
@@ -114,4 +121,53 @@ Ever_eq_h3indexset_th3index(PG_FUNCTION_ARGS)
   if (r < 0)
     PG_RETURN_NULL();
   PG_RETURN_BOOL(r == 1);
+}
+
+/*****************************************************************************
+ * Bounding box
+ *****************************************************************************/
+
+PGDLLEXPORT Datum H3index_to_stbox(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(H3index_to_stbox);
+/**
+ * @ingroup mobilitydb_h3_conversion
+ * @brief Return the spatiotemporal bounding box of an H3 cell
+ * @sqlfn stbox()
+ * @sqlop @p ::
+ */
+Datum
+H3index_to_stbox(PG_FUNCTION_ARGS)
+{
+  PG_RETURN_STBOX_P(h3index_to_stbox(PG_GETARG_H3INDEX(0)));
+}
+
+PGDLLEXPORT Datum H3index_timestamptz_to_stbox(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(H3index_timestamptz_to_stbox);
+/**
+ * @ingroup mobilitydb_h3_conversion
+ * @brief Return the spatiotemporal bounding box of an H3 cell and a timestamptz
+ * @sqlfn stbox()
+ */
+Datum
+H3index_timestamptz_to_stbox(PG_FUNCTION_ARGS)
+{
+  H3Index cell = PG_GETARG_H3INDEX(0);
+  TimestampTz t = PG_GETARG_TIMESTAMPTZ(1);
+  PG_RETURN_STBOX_P(h3index_timestamptz_to_stbox(cell, t));
+}
+
+PGDLLEXPORT Datum H3index_tstzspan_to_stbox(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(H3index_tstzspan_to_stbox);
+/**
+ * @ingroup mobilitydb_h3_conversion
+ * @brief Return the spatiotemporal bounding box of an H3 cell and a timestamptz
+ * span
+ * @sqlfn stbox()
+ */
+Datum
+H3index_tstzspan_to_stbox(PG_FUNCTION_ARGS)
+{
+  H3Index cell = PG_GETARG_H3INDEX(0);
+  Span *s = PG_GETARG_SPAN_P(1);
+  PG_RETURN_STBOX_P(h3index_tstzspan_to_stbox(cell, s));
 }

--- a/mobilitydb/src/quadbin/quadbin_ops.c
+++ b/mobilitydb/src/quadbin/quadbin_ops.c
@@ -49,6 +49,7 @@
 #include <postgres.h>
 #include <fmgr.h>
 #include <utils/array.h>
+#include <utils/timestamp.h>
 #include <catalog/pg_type_d.h>
 /* PostGIS */
 #include <liblwgeom.h>
@@ -57,8 +58,10 @@
 #include <meos_geo.h>
 #include <meos_quadbin.h>
 #include <pgtypes.h>
+#include "geo/stbox.h"
 #include "geo/tgeo_spatialfuncs.h"
 #include "temporal/set.h"
+#include "temporal/span.h"
 #include "quadbin/quadbin_meos.h"
 /* MobilityDB */
 #include "pg_geo/postgis.h"
@@ -234,6 +237,56 @@ Quadbin_cell_to_bounding_box(PG_FUNCTION_ARGS)
 {
   Quadbin cell = PG_GETARG_QUADBIN(0);
   PG_RETURN_GSERIALIZED_P(quadbin_cell_to_geom(cell));
+}
+
+/*****************************************************************************
+ * Bounding box
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Quadbin_to_stbox(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Quadbin_to_stbox);
+/**
+ * @ingroup mobilitydb_quadbin_conversion
+ * @brief Return the spatiotemporal bounding box of a quadbin cell
+ * @sqlfn stbox()
+ * @sqlop @p ::
+ */
+Datum
+Quadbin_to_stbox(PG_FUNCTION_ARGS)
+{
+  PG_RETURN_STBOX_P(quadbin_to_stbox(PG_GETARG_QUADBIN(0)));
+}
+
+PGDLLEXPORT Datum Quadbin_timestamptz_to_stbox(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Quadbin_timestamptz_to_stbox);
+/**
+ * @ingroup mobilitydb_quadbin_conversion
+ * @brief Return the spatiotemporal bounding box of a quadbin cell and a
+ * timestamptz
+ * @sqlfn stbox()
+ */
+Datum
+Quadbin_timestamptz_to_stbox(PG_FUNCTION_ARGS)
+{
+  Quadbin cell = PG_GETARG_QUADBIN(0);
+  TimestampTz t = PG_GETARG_TIMESTAMPTZ(1);
+  PG_RETURN_STBOX_P(quadbin_timestamptz_to_stbox(cell, t));
+}
+
+PGDLLEXPORT Datum Quadbin_tstzspan_to_stbox(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Quadbin_tstzspan_to_stbox);
+/**
+ * @ingroup mobilitydb_quadbin_conversion
+ * @brief Return the spatiotemporal bounding box of a quadbin cell and a
+ * timestamptz span
+ * @sqlfn stbox()
+ */
+Datum
+Quadbin_tstzspan_to_stbox(PG_FUNCTION_ARGS)
+{
+  Quadbin cell = PG_GETARG_QUADBIN(0);
+  Span *s = PG_GETARG_SPAN_P(1);
+  PG_RETURN_STBOX_P(quadbin_tstzspan_to_stbox(cell, s));
 }
 
 /*****************************************************************************


### PR DESCRIPTION
The static cell-index base types `h3index` and `quadbin` inherit the `TSpatial<T>` `stbox` cast (STBox bbox + SRID) like every other spatial type; this adds the C exports that back that cast, so the inherited-behaviour generator's `stbox()` cast can be emitted for both cell families (a follow-up flips `scalar_stbox_cast` and regenerates the SQL).

Each family gets the three variants every spatial family exposes — the base cell, and the cell paired with a `timestamptz` or a `tstzspan`:

- MEOS: `quadbin_to_stbox` / `_timestamptz_to_stbox` / `_tstzspan_to_stbox` and the `h3index` equivalents. Each is a thin wrapper that composes the existing `quadbin_set_stbox` / `h3index_set_stbox` spatial helper with the generic `timestamptz_set_stbox` / `tstzspan_set_stbox` time helpers, so the T-stamp is not duplicated per family.
- PG: the matching `Quadbin_*` / `H3index_*` V1 wrappers, tagged `@sqlfn stbox()`.

The generic `timestamptz_set_stbox` helper gains its missing declaration in `meos_internal_geo.h`, beside its `tstzspan_set_stbox` sibling.

The h3 wrappers live in `h3_geo.c` rather than `h3index.c`: `h3index.c` includes `<utils/builtins.h>` (which declares PostgreSQL's `json_object` function), and the `PG_GETARG_SPAN_P` path pulls json-c's `json_object` type — the two collide in the JSON-enabled extension build, so `h3_geo.c` (no `builtins.h`) is the correct home.

This is purely the backing surface — no SQL, tests or docs change. The `stbox()` SQL cast, the retirement of the redundant `quadbinCellToBoundingBox`, and the tests/docs land with the generator manifest change that binds to these symbols.
