### PR TITLE
Tag Temporal_hash with its generic temporal_hash() SQL name

### DIFF
--- a/mobilitydb/src/temporal/temporal.c
+++ b/mobilitydb/src/temporal/temporal.c
@@ -3039,7 +3039,7 @@ PG_FUNCTION_INFO_V1(Temporal_hash);
 /**
  * @ingroup mobilitydb_temporal_accessor
  * @brief Return the hash value of a temporal value
- * @sqlfn tint_hash(), tfloat_hash(), ...
+ * @sqlfn temporal_hash()
  */
 Datum
 Temporal_hash(PG_FUNCTION_ARGS)


### PR DESCRIPTION
The generic hash wrapper `Temporal_hash` backs the single overloaded `temporal_hash(tbool / tint / tbigint / tfloat / ttext)` SQL function — and the spatial temporal families — but its `@sqlfn` tag names the per-subtype functions `tint_hash()`, `tfloat_hash()`, …, which do not exist.

The MEOS-API catalog generator emits the tagged name over every temporal type, so it registers a nonsensical `tint_hash(<every temporal type>)` and never the canonical `temporal_hash`; downstream bindings then generate the wrong surface.

This tags it `temporal_hash()` — the bare generic name every temporal family inherits through `Temporal<T>`, mirroring `Temporal_num_instants` / `numInstants()`. It is a doc-comment change only; the compiled extension and its regression outputs are unchanged.
