### PR TITLE
Generate the inherited stbox cast for the h3index and quadbin cell types

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3231,10 +3231,6 @@
 				<listitem>
 					<para><link linkend="tquadbin_quadbin_cell_to_boundary"><varname>quadbinCellToBoundary</varname>, <varname>tquadbinCellToBoundary</varname></link>: Devuelve el polígono de frontera de una celda</para>
 				</listitem>
-
-				<listitem>
-					<para><link linkend="tquadbin_quadbin_cell_to_bounding_box"><varname>quadbinCellToBoundingBox</varname></link>: Devuelve la caja delimitadora de una celda</para>
-				</listitem>
 			</itemizedlist>
 		</sect2>
 

--- a/doc/es/temporal_quadbin_index.xml
+++ b/doc/es/temporal_quadbin_index.xml
@@ -261,12 +261,6 @@ SELECT geoToQuadbinCell(geometry 'SRID=4326;POINT(4.35 50.85)', 10)
 				<para><varname>quadbinCellToBoundary(quadbin) → geometry</varname></para>
 				<para><varname>tquadbinCellToBoundary(tquadbin) → tgeometry</varname></para>
 			</listitem>
-
-			<listitem xml:id="tquadbin_quadbin_cell_to_bounding_box">
-				<indexterm significance="normal"><primary><varname>quadbinCellToBoundingBox</varname></primary></indexterm>
-				<para>Devuelve el rectángulo delimitador alineado con los ejes de una celda como una geometría SRID 4326. Para una celda QUADBIN el rectángulo delimitador y el contorno coinciden, ya que las celdas son cuadrados web-mercator alineados con los ejes.</para>
-				<para><varname>quadbinCellToBoundingBox(quadbin) → geometry</varname></para>
-			</listitem>
 		</itemizedlist>
 	</sect1>
 

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3209,10 +3209,6 @@
 				<listitem>
 					<para><link linkend="tquadbin_quadbin_cell_to_boundary"><varname>quadbinCellToBoundary</varname>, <varname>tquadbinCellToBoundary</varname></link>: Return the boundary polygon of a cell</para>
 				</listitem>
-
-				<listitem>
-					<para><link linkend="tquadbin_quadbin_cell_to_bounding_box"><varname>quadbinCellToBoundingBox</varname></link>: Return the bounding box of a cell</para>
-				</listitem>
 			</itemizedlist>
 		</sect2>
 

--- a/doc/temporal_quadbin_index.xml
+++ b/doc/temporal_quadbin_index.xml
@@ -261,12 +261,6 @@ SELECT geoToQuadbinCell(geometry 'SRID=4326;POINT(4.35 50.85)', 10)
 				<para><varname>quadbinCellToBoundary(quadbin) → geometry</varname></para>
 				<para><varname>tquadbinCellToBoundary(tquadbin) → tgeometry</varname></para>
 			</listitem>
-
-			<listitem xml:id="tquadbin_quadbin_cell_to_bounding_box">
-				<indexterm significance="normal"><primary><varname>quadbinCellToBoundingBox</varname></primary></indexterm>
-				<para>Return the axis-aligned bounding box of a cell as an SRID-4326 geometry. For a QUADBIN cell the bounding box and the boundary coincide, since cells are axis-aligned web-mercator squares.</para>
-				<para><varname>quadbinCellToBoundingBox(quadbin) → geometry</varname></para>
-			</listitem>
 		</itemizedlist>
 	</sect1>
 

--- a/meos/src/quadbin/quadbin.c
+++ b/meos/src/quadbin/quadbin.c
@@ -380,9 +380,9 @@ quadbin_cell_to_point(Quadbin cell, double *longitude, double *latitude)
 /**
  * @ingroup meos_quadbin
  * @brief Return the lon/lat bounding box (xmin, ymin, xmax, ymax) of a cell
- * @details Out-parameter helper; the geometry projections quadbinCellToBoundary
- * and quadbinCellToBoundingBox are backed by quadbin_cell_to_geom in
- * quadbin_geo.c.
+ * @details Out-parameter helper shared by the geometry boundary projection
+ * quadbinCellToBoundary (via quadbin_cell_to_geom in quadbin_geo.c) and the
+ * stbox(quadbin) cast (via quadbin_set_stbox).
  */
 void
 quadbin_cell_to_bounding_box(Quadbin cell, double *xmin, double *ymin,

--- a/meos/src/quadbin/quadbin_geo.c
+++ b/meos/src/quadbin/quadbin_geo.c
@@ -96,7 +96,7 @@ quadbin_cell_to_geompoint(Quadbin cell)
  * reference system its boundary polygon coincides with its envelope; it is
  * built from the cell extent as a closed 5-point ring.
  * @param[in] cell Quadbin cell
- * @csqlfn #Quadbin_cell_to_boundary(), #Quadbin_cell_to_bounding_box()
+ * @csqlfn #Quadbin_cell_to_boundary()
  */
 GSERIALIZED *
 quadbin_cell_to_geom(Quadbin cell)

--- a/mobilitydb/sql/h3/258_th3index_topops.in.sql
+++ b/mobilitydb/sql/h3/258_th3index_topops.in.sql
@@ -38,12 +38,27 @@
  * Temporal h3index to stbox
  *****************************************************************************/
 
+CREATE FUNCTION stbox(h3index)
+  RETURNS stbox
+  AS 'MODULE_PATHNAME', 'H3index_to_stbox'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION stbox(h3index, timestamptz)
+  RETURNS stbox
+  AS 'MODULE_PATHNAME', 'H3index_timestamptz_to_stbox'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION stbox(h3index, tstzspan)
+  RETURNS stbox
+  AS 'MODULE_PATHNAME', 'H3index_tstzspan_to_stbox'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION stbox(th3index)
   RETURNS stbox
   AS 'MODULE_PATHNAME', 'Tspatial_to_stbox'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE CAST (h3index AS stbox) WITH FUNCTION stbox(h3index);
 CREATE CAST (th3index AS stbox) WITH FUNCTION stbox(th3index);
 
 /*****************************************************************************/

--- a/mobilitydb/sql/quadbin/352_quadbin_ops.in.sql
+++ b/mobilitydb/sql/quadbin/352_quadbin_ops.in.sql
@@ -111,21 +111,17 @@ CREATE FUNCTION quadbinCellToPoint(quadbin)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /******************************************************************************
- * Boundary / bounding box
+ * Boundary
  *
  * `quadbinCellToBoundary` returns the cell as a polygon (the four
- * corners of the square tile); `quadbinCellToBoundingBox` returns
- * the axis-aligned envelope geometry. Both emit lon/lat in SRID 4326.
+ * corners of the square tile) in lon/lat SRID 4326. The axis-aligned
+ * envelope of a cell is obtained through the inherited `stbox(quadbin)`
+ * cast (see the topological-operators file).
  ******************************************************************************/
 
 CREATE FUNCTION quadbinCellToBoundary(quadbin)
   RETURNS geometry
   AS 'MODULE_PATHNAME', 'Quadbin_cell_to_boundary'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-CREATE FUNCTION quadbinCellToBoundingBox(quadbin)
-  RETURNS geometry
-  AS 'MODULE_PATHNAME', 'Quadbin_cell_to_bounding_box'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /******************************************************************************

--- a/mobilitydb/sql/quadbin/358_tquadbin_topops.in.sql
+++ b/mobilitydb/sql/quadbin/358_tquadbin_topops.in.sql
@@ -38,12 +38,27 @@
  * Temporal quadbin to stbox
  *****************************************************************************/
 
+CREATE FUNCTION stbox(quadbin)
+  RETURNS stbox
+  AS 'MODULE_PATHNAME', 'Quadbin_to_stbox'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION stbox(quadbin, timestamptz)
+  RETURNS stbox
+  AS 'MODULE_PATHNAME', 'Quadbin_timestamptz_to_stbox'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION stbox(quadbin, tstzspan)
+  RETURNS stbox
+  AS 'MODULE_PATHNAME', 'Quadbin_tstzspan_to_stbox'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION stbox(tquadbin)
   RETURNS stbox
   AS 'MODULE_PATHNAME', 'Tspatial_to_stbox'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE CAST (quadbin AS stbox) WITH FUNCTION stbox(quadbin);
 CREATE CAST (tquadbin AS stbox) WITH FUNCTION stbox(tquadbin);
 
 /*****************************************************************************/

--- a/mobilitydb/src/quadbin/quadbin_ops.c
+++ b/mobilitydb/src/quadbin/quadbin_ops.c
@@ -225,20 +225,6 @@ Quadbin_cell_to_boundary(PG_FUNCTION_ARGS)
   PG_RETURN_GSERIALIZED_P(quadbin_cell_to_geom(cell));
 }
 
-PGDLLEXPORT Datum Quadbin_cell_to_bounding_box(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Quadbin_cell_to_bounding_box);
-/**
- * @ingroup mobilitydb_quadbin_conversion
- * @brief Return the cell axis-aligned envelope as a polygon (SRID 4326)
- * @sqlfn quadbinCellToBoundingBox()
- */
-Datum
-Quadbin_cell_to_bounding_box(PG_FUNCTION_ARGS)
-{
-  Quadbin cell = PG_GETARG_QUADBIN(0);
-  PG_RETURN_GSERIALIZED_P(quadbin_cell_to_geom(cell));
-}
-
 /*****************************************************************************
  * Bounding box
  *****************************************************************************/

--- a/mobilitydb/test/quadbin/expected/355_quadbin_golden.test.out
+++ b/mobilitydb/test/quadbin/expected/355_quadbin_golden.test.out
@@ -73,25 +73,25 @@ SELECT round(ST_Y(quadbinCellToPoint(quadbin '48a6227affffffff'))::numeric, 6) =
  t
 (1 row)
 
-SELECT round(ST_XMin(quadbinCellToBoundingBox(quadbin '48a6227affffffff'))::numeric, 6) = 4.218750;
+SELECT round(xMin(stbox(quadbin '48a6227affffffff'))::numeric, 6) = 4.218750;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT round(ST_YMin(quadbinCellToBoundingBox(quadbin '48a6227affffffff'))::numeric, 6) = 50.736455;
+SELECT round(yMin(stbox(quadbin '48a6227affffffff'))::numeric, 6) = 50.736455;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT round(ST_XMax(quadbinCellToBoundingBox(quadbin '48a6227affffffff'))::numeric, 6) = 4.570312;
+SELECT round(xMax(stbox(quadbin '48a6227affffffff'))::numeric, 6) = 4.570312;
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT round(ST_YMax(quadbinCellToBoundingBox(quadbin '48a6227affffffff'))::numeric, 6) = 50.958427;
+SELECT round(yMax(stbox(quadbin '48a6227affffffff'))::numeric, 6) = 50.958427;
  ?column? 
 ----------
  t

--- a/mobilitydb/test/quadbin/expected/356_quadbin_ops.test.out
+++ b/mobilitydb/test/quadbin/expected/356_quadbin_ops.test.out
@@ -123,10 +123,10 @@ SELECT ST_GeometryType(quadbinCellToBoundary(quadbin '48a6227affffffff'));
  ST_Polygon
 (1 row)
 
-SELECT ST_GeometryType(quadbinCellToBoundingBox(quadbin '48a6227affffffff'));
- st_geometrytype 
------------------
- ST_Polygon
+SELECT round(xMax(stbox(quadbin '48a6227affffffff'))::numeric, 6);
+  round   
+----------
+ 4.570313
 (1 row)
 
 SELECT ST_SRID(quadbinCellToBoundary(quadbin '48a6227affffffff'));

--- a/mobilitydb/test/quadbin/queries/355_quadbin_golden.test.sql
+++ b/mobilitydb/test/quadbin/queries/355_quadbin_golden.test.sql
@@ -83,10 +83,10 @@ SELECT round(ST_Y(quadbinCellToPoint(quadbin '48a6227affffffff'))::numeric, 6) =
 -- quadbin-py bbox(48a6227affffffff) = (4.218750, 50.736455, 4.570312, 50.958427)
 -------------------------------------------------------------------------------
 
-SELECT round(ST_XMin(quadbinCellToBoundingBox(quadbin '48a6227affffffff'))::numeric, 6) = 4.218750;
-SELECT round(ST_YMin(quadbinCellToBoundingBox(quadbin '48a6227affffffff'))::numeric, 6) = 50.736455;
-SELECT round(ST_XMax(quadbinCellToBoundingBox(quadbin '48a6227affffffff'))::numeric, 6) = 4.570312;
-SELECT round(ST_YMax(quadbinCellToBoundingBox(quadbin '48a6227affffffff'))::numeric, 6) = 50.958427;
+SELECT round(xMin(stbox(quadbin '48a6227affffffff'))::numeric, 6) = 4.218750;
+SELECT round(yMin(stbox(quadbin '48a6227affffffff'))::numeric, 6) = 50.736455;
+SELECT round(xMax(stbox(quadbin '48a6227affffffff'))::numeric, 6) = 4.570312;
+SELECT round(yMax(stbox(quadbin '48a6227affffffff'))::numeric, 6) = 50.958427;
 
 -------------------------------------------------------------------------------
 -- cell_to_parent / cell_to_children golden vectors (quadbin-py hierarchy)

--- a/mobilitydb/test/quadbin/queries/356_quadbin_ops.test.sql
+++ b/mobilitydb/test/quadbin/queries/356_quadbin_ops.test.sql
@@ -86,11 +86,11 @@ SELECT round(ST_Y(quadbinCellToPoint(quadbin '48a6227affffffff'))::numeric, 6);
 SELECT ST_SRID(quadbinCellToPoint(quadbin '48a6227affffffff'));
 
 -------------------------------------------------------------------------------
--- Boundary / bounding box
+-- Boundary
 -------------------------------------------------------------------------------
 
 SELECT ST_GeometryType(quadbinCellToBoundary(quadbin '48a6227affffffff'));
-SELECT ST_GeometryType(quadbinCellToBoundingBox(quadbin '48a6227affffffff'));
+SELECT round(xMax(stbox(quadbin '48a6227affffffff'))::numeric, 6);
 SELECT ST_SRID(quadbinCellToBoundary(quadbin '48a6227affffffff'));
 
 -- The centroid point lies inside the cell boundary polygon

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -35,12 +35,14 @@ subtypes:
     brief: "temporal QUADBIN cells"
     bin:   350
     category: tspatial
-    # A cell-index (like h3) has NO scalar base::stbox cast — drop that block.
-    scalar_stbox_cast: false
+    # A cell-index inherits the scalar base::stbox cast like every spatial type,
+    # backed by the quadbin_to_stbox / quadbin_{timestamptz,tstzspan}_to_stbox
+    # exports (meos/src/quadbin/tquadbin_boxops.c).
+    scalar_stbox_cast: true
     stboxes: false
-    # compops/posops/topops are generic (topops' scalar cast stripped via the flag
-    # above). spatialrels delegates to the geo spatial relationships via the
-    # cell→boundary tgeometry conversion (quadbin_cell_to_boundary), the cell-index
+    # compops/posops/topops are generic. spatialrels delegates to the geo spatial
+    # relationships via the cell→boundary tgeometry conversion
+    # (quadbin_cell_to_boundary), the cell-index
     # analogue of th3index 290. GiST/SP-GiST are split (322/323), the canonical
     # cell-index layout (th3index 272/273), not the combined cbuffer `indexes` form.
     files: [compops, posops, topops, spatialrels, gist, spgist]
@@ -55,8 +57,10 @@ subtypes:
     boundary_fn: th3CellToBoundary
     bin:   250
     category: tspatial
-    # A cell-index has NO scalar base::stbox cast — same as tquadbin.
-    scalar_stbox_cast: false
+    # A cell-index inherits the scalar base::stbox cast — same as tquadbin —
+    # backed by the h3index_to_stbox / h3index_{timestamptz,tstzspan}_to_stbox
+    # exports (meos/src/h3/th3index_boxops.c).
+    scalar_stbox_cast: true
     stboxes: false
     files: [compops, posops, topops, spatialrels, gist, spgist]
 


### PR DESCRIPTION
The `th3index` and `quadbin` cell-index types both inherit from `Spatial<T>`, so the scalar value-to-`stbox` cast is inherited behaviour that belongs to the inherited-operator generator rather than a hand-written function.

The inherited manifest sets `scalar_stbox_cast` to `true` for `th3index` and `quadbin`, so their generated topological-operator files carry `stbox(<cell>)`, `stbox(<cell>, timestamptz)`, `stbox(<cell>, tstzspan)` and `CREATE CAST (<cell> AS stbox)`, backed by the `h3index_to_stbox` and `quadbin_to_stbox` exports.

The redundant `quadbinCellToBoundingBox` is dropped in favour of the inherited `stbox(quadbin)` cast: for an axis-aligned QUADBIN cell the envelope geometry coincides with the boundary polygon. Its SQL function, PG wrapper and EN/ES documentation entries are removed, and the golden and operator tests use the `stbox` coordinate accessors.