### PR TITLE
Register the h3indexset and quadbinset types as spatial set types

### DIFF
--- a/meos/src/temporal/meos_catalog.c
+++ b/meos/src/temporal/meos_catalog.c
@@ -909,7 +909,8 @@ bool
 spatialset_type(MeosType type)
 {
   return (type == T_GEOMSET || type == T_GEOGSET || type == T_NPOINTSET ||
-    type == T_POSESET || type == T_CBUFFERSET);
+    type == T_POSESET || type == T_CBUFFERSET || type == T_H3INDEXSET ||
+    type == T_QUADBINSET);
 }
 
 #if MEOS


### PR DESCRIPTION
The `h3index` and `quadbin` base types are spatial: `spatial_basetype`, `spatial_srid` and `spatialarr_set_bbox` all dispatch them, and their sets already carry an `STBox` bounding box. But `spatialset_type()` omits `h3indexset` and `quadbinset`, so in an assert-enabled build `set_bbox_size` in `meos/src/temporal/set.c` aborts on any `h3indexset` or `quadbinset` operation — for instance building the set returned by `quadbinCellToChildren`.

This adds `T_H3INDEXSET` and `T_QUADBINSET` to `spatialset_type()`, completing the base-to-set symmetry. The bounding box, SRID and WKB paths are already wired for the cell base types, so the change is purely the missing classification and leaves the output unchanged.