### PR TITLE
Add set union, difference, and intersection to quadbinset

### DIFF
--- a/mobilitydb/sql/quadbin/351_quadbinset.in.sql
+++ b/mobilitydb/sql/quadbin/351_quadbinset.in.sql
@@ -267,3 +267,99 @@ CREATE AGGREGATE setUnion(quadbinset) (
 );
 
 /******************************************************************************/
+
+/******************************************************************************
+ * set union +
+ ******************************************************************************/
+
+CREATE FUNCTION setUnion(quadbin, quadbinset)
+  RETURNS quadbinset
+  AS 'MODULE_PATHNAME', 'Union_value_set'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION setUnion(quadbinset, quadbin)
+  RETURNS quadbinset
+  AS 'MODULE_PATHNAME', 'Union_set_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION setUnion(quadbinset, quadbinset)
+  RETURNS quadbinset
+  AS 'MODULE_PATHNAME', 'Union_set_set'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OPERATOR + (
+  PROCEDURE = setUnion,
+  LEFTARG = quadbin, RIGHTARG = quadbinset,
+  COMMUTATOR = +
+);
+CREATE OPERATOR + (
+  PROCEDURE = setUnion,
+  LEFTARG = quadbinset, RIGHTARG = quadbin,
+  COMMUTATOR = +
+);
+CREATE OPERATOR + (
+  PROCEDURE = setUnion,
+  LEFTARG = quadbinset, RIGHTARG = quadbinset,
+  COMMUTATOR = +
+);
+
+/******************************************************************************
+ * set difference -
+ ******************************************************************************/
+
+CREATE FUNCTION setMinus(quadbin, quadbinset)
+  RETURNS quadbinset
+  AS 'MODULE_PATHNAME', 'Minus_value_set'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION setMinus(quadbinset, quadbin)
+  RETURNS quadbinset
+  AS 'MODULE_PATHNAME', 'Minus_set_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION setMinus(quadbinset, quadbinset)
+  RETURNS quadbinset
+  AS 'MODULE_PATHNAME', 'Minus_set_set'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OPERATOR - (
+  PROCEDURE = setMinus,
+  LEFTARG = quadbin, RIGHTARG = quadbinset
+);
+CREATE OPERATOR - (
+  PROCEDURE = setMinus,
+  LEFTARG = quadbinset, RIGHTARG = quadbin
+);
+CREATE OPERATOR - (
+  PROCEDURE = setMinus,
+  LEFTARG = quadbinset, RIGHTARG = quadbinset
+);
+
+/******************************************************************************
+ * set intersection *
+ ******************************************************************************/
+
+CREATE FUNCTION setIntersection(quadbin, quadbinset)
+  RETURNS quadbinset
+  AS 'MODULE_PATHNAME', 'Intersection_value_set'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION setIntersection(quadbinset, quadbin)
+  RETURNS quadbinset
+  AS 'MODULE_PATHNAME', 'Intersection_set_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION setIntersection(quadbinset, quadbinset)
+  RETURNS quadbinset
+  AS 'MODULE_PATHNAME', 'Intersection_set_set'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OPERATOR * (
+  PROCEDURE = setIntersection,
+  LEFTARG = quadbin, RIGHTARG = quadbinset,
+  COMMUTATOR = *
+);
+CREATE OPERATOR * (
+  PROCEDURE = setIntersection,
+  LEFTARG = quadbinset, RIGHTARG = quadbin,
+  COMMUTATOR = *
+);
+CREATE OPERATOR * (
+  PROCEDURE = setIntersection,
+  LEFTARG = quadbinset, RIGHTARG = quadbinset,
+  COMMUTATOR = *
+);

--- a/mobilitydb/test/quadbin/expected/351_quadbinset.test.out
+++ b/mobilitydb/test/quadbin/expected/351_quadbinset.test.out
@@ -165,3 +165,63 @@ SELECT setUnion(s) FROM (VALUES
  {"480fffffffffffff", "48427fffffffffff", "48a6227affffffff"}
 (1 row)
 
+SELECT setUnion(quadbinset '{480fffffffffffff, 48427fffffffffff}', quadbinset '{48427fffffffffff, 48a6227affffffff}');
+                           setunion                           
+--------------------------------------------------------------
+ {"480fffffffffffff", "48427fffffffffff", "48a6227affffffff"}
+(1 row)
+
+SELECT setUnion(quadbinset '{480fffffffffffff}', quadbin '48427fffffffffff');
+                 setunion                 
+------------------------------------------
+ {"480fffffffffffff", "48427fffffffffff"}
+(1 row)
+
+SELECT setUnion(quadbin '480fffffffffffff', quadbinset '{48427fffffffffff}');
+                 setunion                 
+------------------------------------------
+ {"480fffffffffffff", "48427fffffffffff"}
+(1 row)
+
+SELECT quadbinset '{480fffffffffffff, 48427fffffffffff}' + quadbinset '{48a6227affffffff}';
+                           ?column?                           
+--------------------------------------------------------------
+ {"480fffffffffffff", "48427fffffffffff", "48a6227affffffff"}
+(1 row)
+
+SELECT setMinus(quadbinset '{480fffffffffffff, 48427fffffffffff}', quadbinset '{48427fffffffffff}');
+       setminus       
+----------------------
+ {"480fffffffffffff"}
+(1 row)
+
+SELECT setMinus(quadbinset '{480fffffffffffff, 48427fffffffffff}', quadbin '480fffffffffffff');
+       setminus       
+----------------------
+ {"48427fffffffffff"}
+(1 row)
+
+SELECT quadbinset '{480fffffffffffff, 48427fffffffffff}' - quadbinset '{48427fffffffffff}';
+       ?column?       
+----------------------
+ {"480fffffffffffff"}
+(1 row)
+
+SELECT setIntersection(quadbinset '{480fffffffffffff, 48427fffffffffff}', quadbinset '{48427fffffffffff, 48a6227affffffff}');
+   setintersection    
+----------------------
+ {"48427fffffffffff"}
+(1 row)
+
+SELECT setIntersection(quadbinset '{480fffffffffffff, 48427fffffffffff}', quadbin '48427fffffffffff');
+   setintersection    
+----------------------
+ {"48427fffffffffff"}
+(1 row)
+
+SELECT quadbinset '{480fffffffffffff, 48427fffffffffff}' * quadbinset '{48427fffffffffff}';
+       ?column?       
+----------------------
+ {"48427fffffffffff"}
+(1 row)
+

--- a/mobilitydb/test/quadbin/queries/351_quadbinset.test.sql
+++ b/mobilitydb/test/quadbin/queries/351_quadbinset.test.sql
@@ -107,3 +107,20 @@ SELECT setUnion(s) FROM (VALUES
   (quadbinset '{48427fffffffffff, 48a6227affffffff}')) t(s);
 
 -------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- Set operations: union (+), difference (-), intersection (*)
+-------------------------------------------------------------------------------
+
+SELECT setUnion(quadbinset '{480fffffffffffff, 48427fffffffffff}', quadbinset '{48427fffffffffff, 48a6227affffffff}');
+SELECT setUnion(quadbinset '{480fffffffffffff}', quadbin '48427fffffffffff');
+SELECT setUnion(quadbin '480fffffffffffff', quadbinset '{48427fffffffffff}');
+SELECT quadbinset '{480fffffffffffff, 48427fffffffffff}' + quadbinset '{48a6227affffffff}';
+
+SELECT setMinus(quadbinset '{480fffffffffffff, 48427fffffffffff}', quadbinset '{48427fffffffffff}');
+SELECT setMinus(quadbinset '{480fffffffffffff, 48427fffffffffff}', quadbin '480fffffffffffff');
+SELECT quadbinset '{480fffffffffffff, 48427fffffffffff}' - quadbinset '{48427fffffffffff}';
+
+SELECT setIntersection(quadbinset '{480fffffffffffff, 48427fffffffffff}', quadbinset '{48427fffffffffff, 48a6227affffffff}');
+SELECT setIntersection(quadbinset '{480fffffffffffff, 48427fffffffffff}', quadbin '48427fffffffffff');
+SELECT quadbinset '{480fffffffffffff, 48427fffffffffff}' * quadbinset '{48427fffffffffff}';


### PR DESCRIPTION
`quadbinset` registered the comparison operators and the `setUnion` aggregate but not the binary set operations, so unlike every other set type it could not be combined with union, difference, or intersection.

This adds `setUnion`, `setMinus`, and `setIntersection` for `quadbinset` (value/set, set/value, set/set) and their `+` `-` `*` operators, wired to the generic set backing already used by the other set types. No new C. The quadbinset test covers the three operations in function and operator form.