### PR TITLE
Add contains, contained, and overlaps operators to quadbinset

### DIFF
--- a/mobilitydb/sql/quadbin/351_quadbinset.in.sql
+++ b/mobilitydb/sql/quadbin/351_quadbinset.in.sql
@@ -269,6 +269,90 @@ CREATE AGGREGATE setUnion(quadbinset) (
 /******************************************************************************/
 
 /******************************************************************************
+ * Set-theoretic operators
+ *
+ * The value-dim ordering operators (`<<`, `&<`, `>>`, `&>`) that other
+ * `*set` types ship are intentionally NOT declared: QUADBIN cell ids have
+ * no meaningful total order — the int64 comparison that the framework would
+ * use for "strictly-left" queries has no spatial or hierarchical meaning
+ * (same rationale as the bbox-operator pruning for `tquadbin`).
+ *
+ * All C implementations behind these operators (`Contains_set_*`,
+ * `Overlaps_set_set`, `Union_*`, `Minus_*`, `Intersection_*`) are
+ * type-generic — they dispatch on the operand's MeosType and route through
+ * `datum_cmp` / `datum_eq` from `type_util.c`, where `T_QUADBIN` is already
+ * wired.
+ ******************************************************************************/
+
+/******************************************************************************
+ * contains @>
+ ******************************************************************************/
+
+CREATE FUNCTION contains(quadbinset, quadbin)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Contains_set_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION contains(quadbinset, quadbinset)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Contains_set_set'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OPERATOR @> (
+  PROCEDURE = contains,
+  LEFTARG = quadbinset, RIGHTARG = quadbin,
+  COMMUTATOR = <@,
+  RESTRICT = span_sel, JOIN = span_joinsel
+);
+CREATE OPERATOR @> (
+  PROCEDURE = contains,
+  LEFTARG = quadbinset, RIGHTARG = quadbinset,
+  COMMUTATOR = <@,
+  RESTRICT = span_sel, JOIN = span_joinsel
+);
+
+/******************************************************************************
+ * contained by <@
+ ******************************************************************************/
+
+CREATE FUNCTION contained(quadbin, quadbinset)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Contained_value_set'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION contained(quadbinset, quadbinset)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Contained_set_set'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OPERATOR <@ (
+  PROCEDURE = contained,
+  LEFTARG = quadbin, RIGHTARG = quadbinset,
+  COMMUTATOR = @>,
+  RESTRICT = span_sel, JOIN = span_joinsel
+);
+CREATE OPERATOR <@ (
+  PROCEDURE = contained,
+  LEFTARG = quadbinset, RIGHTARG = quadbinset,
+  COMMUTATOR = @>,
+  RESTRICT = span_sel, JOIN = span_joinsel
+);
+
+/******************************************************************************
+ * overlaps &&
+ ******************************************************************************/
+
+CREATE FUNCTION overlaps(quadbinset, quadbinset)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Overlaps_set_set'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OPERATOR && (
+  PROCEDURE = overlaps,
+  LEFTARG = quadbinset, RIGHTARG = quadbinset,
+  COMMUTATOR = &&,
+  RESTRICT = span_sel, JOIN = span_joinsel
+);
+
+/******************************************************************************
  * set union +
  ******************************************************************************/
 

--- a/mobilitydb/test/quadbin/expected/351_quadbinset.test.out
+++ b/mobilitydb/test/quadbin/expected/351_quadbinset.test.out
@@ -225,3 +225,51 @@ SELECT quadbinset '{480fffffffffffff, 48427fffffffffff}' * quadbinset '{48427fff
  {"48427fffffffffff"}
 (1 row)
 
+SELECT contains(quadbinset '{480fffffffffffff, 48427fffffffffff}', quadbin '480fffffffffffff');
+ contains 
+----------
+ t
+(1 row)
+
+SELECT contains(quadbinset '{480fffffffffffff, 48427fffffffffff}', quadbinset '{480fffffffffffff}');
+ contains 
+----------
+ t
+(1 row)
+
+SELECT quadbinset '{480fffffffffffff, 48427fffffffffff}' @> quadbin '48a6227affffffff';
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT contained(quadbin '480fffffffffffff', quadbinset '{480fffffffffffff, 48427fffffffffff}');
+ contained 
+-----------
+ t
+(1 row)
+
+SELECT contained(quadbinset '{480fffffffffffff}', quadbinset '{480fffffffffffff, 48427fffffffffff}');
+ contained 
+-----------
+ t
+(1 row)
+
+SELECT quadbin '48a6227affffffff' <@ quadbinset '{480fffffffffffff}';
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT overlaps(quadbinset '{480fffffffffffff, 48427fffffffffff}', quadbinset '{48427fffffffffff, 48a6227affffffff}');
+ overlaps 
+----------
+ t
+(1 row)
+
+SELECT quadbinset '{480fffffffffffff}' && quadbinset '{48427fffffffffff}';
+ ?column? 
+----------
+ f
+(1 row)
+

--- a/mobilitydb/test/quadbin/queries/351_quadbinset.test.sql
+++ b/mobilitydb/test/quadbin/queries/351_quadbinset.test.sql
@@ -124,3 +124,18 @@ SELECT quadbinset '{480fffffffffffff, 48427fffffffffff}' - quadbinset '{48427fff
 SELECT setIntersection(quadbinset '{480fffffffffffff, 48427fffffffffff}', quadbinset '{48427fffffffffff, 48a6227affffffff}');
 SELECT setIntersection(quadbinset '{480fffffffffffff, 48427fffffffffff}', quadbin '48427fffffffffff');
 SELECT quadbinset '{480fffffffffffff, 48427fffffffffff}' * quadbinset '{48427fffffffffff}';
+
+-------------------------------------------------------------------------------
+-- Set topological operators: contains (@>), contained (<@), overlaps (&&)
+-------------------------------------------------------------------------------
+
+SELECT contains(quadbinset '{480fffffffffffff, 48427fffffffffff}', quadbin '480fffffffffffff');
+SELECT contains(quadbinset '{480fffffffffffff, 48427fffffffffff}', quadbinset '{480fffffffffffff}');
+SELECT quadbinset '{480fffffffffffff, 48427fffffffffff}' @> quadbin '48a6227affffffff';
+
+SELECT contained(quadbin '480fffffffffffff', quadbinset '{480fffffffffffff, 48427fffffffffff}');
+SELECT contained(quadbinset '{480fffffffffffff}', quadbinset '{480fffffffffffff, 48427fffffffffff}');
+SELECT quadbin '48a6227affffffff' <@ quadbinset '{480fffffffffffff}';
+
+SELECT overlaps(quadbinset '{480fffffffffffff, 48427fffffffffff}', quadbinset '{48427fffffffffff, 48a6227affffffff}');
+SELECT quadbinset '{480fffffffffffff}' && quadbinset '{48427fffffffffff}';


### PR DESCRIPTION
`quadbinset` shipped the comparison operators but not the set-theoretic topological operators that `h3indexset` and the other set types provide.

This adds `contains` (`@>`), `contained` (`<@`), and `overlaps` (`&&`) for `quadbinset`, wired to the generic `Contains`/`Contained`/`Overlaps_set` backing (no new C). As for `h3indexset`, the value-ordering operators (`<<`, `&<`, `>>`, `&>`) are not declared because QUADBIN cell ids have no meaningful total order. The quadbinset test covers the three operators.