### PR TITLE
Canonicalize the set topological predicate names to the bare form

### DIFF
--- a/mobilitydb/sql/cbuffer/201_cbufferset.in.sql
+++ b/mobilitydb/sql/cbuffer/201_cbufferset.in.sql
@@ -330,23 +330,23 @@ CREATE OPERATOR CLASS cbufferset_hash_ops
  * Operators
  ******************************************************************************/
 
-CREATE FUNCTION set_contains(cbufferset, cbuffer)
+CREATE FUNCTION contains(cbufferset, cbuffer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_contains(cbufferset, cbufferset)
+CREATE FUNCTION contains(cbufferset, cbufferset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
-  PROCEDURE = set_contains,
+  PROCEDURE = contains,
   LEFTARG = cbufferset, RIGHTARG = cbuffer,
   COMMUTATOR = <@
   -- RESTRICT = span_sel, JOIN = span_joinsel
 );
 CREATE OPERATOR @> (
-  PROCEDURE = set_contains,
+  PROCEDURE = contains,
   LEFTARG = cbufferset, RIGHTARG = cbufferset,
   COMMUTATOR = <@
   -- RESTRICT = span_sel, JOIN = span_joinsel
@@ -354,23 +354,23 @@ CREATE OPERATOR @> (
 
 /******************************************************************************/
 
-CREATE FUNCTION set_contained(cbuffer, cbufferset)
+CREATE FUNCTION contained(cbuffer, cbufferset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_contained(cbufferset, cbufferset)
+CREATE FUNCTION contained(cbufferset, cbufferset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
-  PROCEDURE = set_contained,
+  PROCEDURE = contained,
   LEFTARG = cbuffer, RIGHTARG = cbufferset,
   COMMUTATOR = @>
   -- RESTRICT = span_sel, JOIN = span_joinsel
 );
 CREATE OPERATOR <@ (
-  PROCEDURE = set_contained,
+  PROCEDURE = contained,
   LEFTARG = cbufferset, RIGHTARG = cbufferset,
   COMMUTATOR = @>
   -- RESTRICT = span_sel, JOIN = span_joinsel
@@ -378,13 +378,13 @@ CREATE OPERATOR <@ (
 
 /******************************************************************************/
 
-CREATE FUNCTION set_overlaps(cbufferset, cbufferset)
+CREATE FUNCTION overlaps(cbufferset, cbufferset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (
-  PROCEDURE = set_overlaps,
+  PROCEDURE = overlaps,
   LEFTARG = cbufferset, RIGHTARG = cbufferset,
   COMMUTATOR = &&
   -- RESTRICT = span_sel, JOIN = span_joinsel

--- a/mobilitydb/sql/geo/050_geoset.in.sql
+++ b/mobilitydb/sql/geo/050_geoset.in.sql
@@ -597,43 +597,43 @@ CREATE OPERATOR CLASS geogset_hash_ops
  * Operators
  ******************************************************************************/
 
-CREATE FUNCTION set_contains(geomset, geometry)
+CREATE FUNCTION contains(geomset, geometry)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_contains(geomset, geomset)
+CREATE FUNCTION contains(geomset, geomset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_contains(geogset, geography)
+CREATE FUNCTION contains(geogset, geography)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_contains(geogset, geogset)
+CREATE FUNCTION contains(geogset, geogset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
-  PROCEDURE = set_contains,
+  PROCEDURE = contains,
   LEFTARG = geomset, RIGHTARG = geometry,
   COMMUTATOR = <@
   -- RESTRICT = stbox_sel, JOIN = stbox_joinsel
 );
 CREATE OPERATOR @> (
-  PROCEDURE = set_contains,
+  PROCEDURE = contains,
   LEFTARG = geomset, RIGHTARG = geomset,
   COMMUTATOR = <@
   -- RESTRICT = stbox_sel, JOIN = stbox_joinsel
 );
 CREATE OPERATOR @> (
-  PROCEDURE = set_contains,
+  PROCEDURE = contains,
   LEFTARG = geogset, RIGHTARG = geography,
   COMMUTATOR = <@
   -- RESTRICT = stbox_sel, JOIN = stbox_joinsel
 );
 CREATE OPERATOR @> (
-  PROCEDURE = set_contains,
+  PROCEDURE = contains,
   LEFTARG = geogset, RIGHTARG = geogset,
   COMMUTATOR = <@
   -- RESTRICT = stbox_sel, JOIN = stbox_joinsel
@@ -641,43 +641,43 @@ CREATE OPERATOR @> (
 
 /******************************************************************************/
 
-CREATE FUNCTION set_contained(geometry, geomset)
+CREATE FUNCTION contained(geometry, geomset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_contained(geomset, geomset)
+CREATE FUNCTION contained(geomset, geomset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_contained(geography, geogset)
+CREATE FUNCTION contained(geography, geogset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_contained(geogset, geogset)
+CREATE FUNCTION contained(geogset, geogset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
-  PROCEDURE = set_contained,
+  PROCEDURE = contained,
   LEFTARG = geometry, RIGHTARG = geomset,
   COMMUTATOR = @>
   -- RESTRICT = stbox_sel, JOIN = stbox_joinsel
 );
 CREATE OPERATOR <@ (
-  PROCEDURE = set_contained,
+  PROCEDURE = contained,
   LEFTARG = geomset, RIGHTARG = geomset,
   COMMUTATOR = @>
   -- RESTRICT = stbox_sel, JOIN = stbox_joinsel
 );
 CREATE OPERATOR <@ (
-  PROCEDURE = set_contained,
+  PROCEDURE = contained,
   LEFTARG = geography, RIGHTARG = geogset,
   COMMUTATOR = @>
   -- RESTRICT = stbox_sel, JOIN = stbox_joinsel
 );
 CREATE OPERATOR <@ (
-  PROCEDURE = set_contained,
+  PROCEDURE = contained,
   LEFTARG = geogset, RIGHTARG = geogset,
   COMMUTATOR = @>
   -- RESTRICT = stbox_sel, JOIN = stbox_joinsel
@@ -685,23 +685,23 @@ CREATE OPERATOR <@ (
 
 /******************************************************************************/
 
-CREATE FUNCTION set_overlaps(geomset, geomset)
+CREATE FUNCTION overlaps(geomset, geomset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_overlaps(geogset, geogset)
+CREATE FUNCTION overlaps(geogset, geogset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (
-  PROCEDURE = set_overlaps,
+  PROCEDURE = overlaps,
   LEFTARG = geomset, RIGHTARG = geomset,
   COMMUTATOR = &&
   -- RESTRICT = stbox_sel, JOIN = stbox_joinsel
 );
 CREATE OPERATOR && (
-  PROCEDURE = set_overlaps,
+  PROCEDURE = overlaps,
   LEFTARG = geogset, RIGHTARG = geogset,
   COMMUTATOR = &&
   -- RESTRICT = stbox_sel, JOIN = stbox_joinsel

--- a/mobilitydb/sql/json/450_jsonbset.in.sql
+++ b/mobilitydb/sql/json/450_jsonbset.in.sql
@@ -340,57 +340,57 @@ CREATE OPERATOR CLASS jsonbset_hash_ops
  * Operators
  ******************************************************************************/
 
-CREATE FUNCTION set_contains(jsonbset, jsonb)
+CREATE FUNCTION contains(jsonbset, jsonb)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_contains(jsonbset, jsonbset)
+CREATE FUNCTION contains(jsonbset, jsonbset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
-  PROCEDURE = set_contains,
+  PROCEDURE = contains,
   LEFTARG = jsonbset, RIGHTARG = jsonb,
   COMMUTATOR = <@
 );
 CREATE OPERATOR @> (
-  PROCEDURE = set_contains,
+  PROCEDURE = contains,
   LEFTARG = jsonbset, RIGHTARG = jsonbset,
   COMMUTATOR = <@
 );
 
 /******************************************************************************/
 
-CREATE FUNCTION set_contained(jsonb, jsonbset)
+CREATE FUNCTION contained(jsonb, jsonbset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_contained(jsonbset, jsonbset)
+CREATE FUNCTION contained(jsonbset, jsonbset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
-  PROCEDURE = set_contained,
+  PROCEDURE = contained,
   LEFTARG = jsonb, RIGHTARG = jsonbset,
   COMMUTATOR = @>
 );
 CREATE OPERATOR <@ (
-  PROCEDURE = set_contained,
+  PROCEDURE = contained,
   LEFTARG = jsonbset, RIGHTARG = jsonbset,
   COMMUTATOR = @>
 );
 
 /******************************************************************************/
 
-CREATE FUNCTION set_overlaps(jsonbset, jsonbset)
+CREATE FUNCTION overlaps(jsonbset, jsonbset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (
-  PROCEDURE = set_overlaps,
+  PROCEDURE = overlaps,
   LEFTARG = jsonbset, RIGHTARG = jsonbset,
   COMMUTATOR = &&
 );

--- a/mobilitydb/sql/npoint/301_npointset.in.sql
+++ b/mobilitydb/sql/npoint/301_npointset.in.sql
@@ -323,23 +323,23 @@ CREATE OPERATOR CLASS npointset_hash_ops
  * Operators
  ******************************************************************************/
 
-CREATE FUNCTION set_contains(npointset, npoint)
+CREATE FUNCTION contains(npointset, npoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_contains(npointset, npointset)
+CREATE FUNCTION contains(npointset, npointset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
-  PROCEDURE = set_contains,
+  PROCEDURE = contains,
   LEFTARG = npointset, RIGHTARG = npoint,
   COMMUTATOR = <@
   -- RESTRICT = span_sel, JOIN = span_joinsel
 );
 CREATE OPERATOR @> (
-  PROCEDURE = set_contains,
+  PROCEDURE = contains,
   LEFTARG = npointset, RIGHTARG = npointset,
   COMMUTATOR = <@
   -- RESTRICT = span_sel, JOIN = span_joinsel
@@ -347,23 +347,23 @@ CREATE OPERATOR @> (
 
 /******************************************************************************/
 
-CREATE FUNCTION set_contained(npoint, npointset)
+CREATE FUNCTION contained(npoint, npointset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_contained(npointset, npointset)
+CREATE FUNCTION contained(npointset, npointset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
-  PROCEDURE = set_contained,
+  PROCEDURE = contained,
   LEFTARG = npoint, RIGHTARG = npointset,
   COMMUTATOR = @>
   -- RESTRICT = span_sel, JOIN = span_joinsel
 );
 CREATE OPERATOR <@ (
-  PROCEDURE = set_contained,
+  PROCEDURE = contained,
   LEFTARG = npointset, RIGHTARG = npointset,
   COMMUTATOR = @>
   -- RESTRICT = span_sel, JOIN = span_joinsel
@@ -371,13 +371,13 @@ CREATE OPERATOR <@ (
 
 /******************************************************************************/
 
-CREATE FUNCTION set_overlaps(npointset, npointset)
+CREATE FUNCTION overlaps(npointset, npointset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (
-  PROCEDURE = set_overlaps,
+  PROCEDURE = overlaps,
   LEFTARG = npointset, RIGHTARG = npointset,
   COMMUTATOR = &&
   -- RESTRICT = span_sel, JOIN = span_joinsel

--- a/mobilitydb/sql/pointcloud/400_pcset.in.sql
+++ b/mobilitydb/sql/pointcloud/400_pcset.in.sql
@@ -312,53 +312,53 @@ CREATE OPERATOR CLASS pcpointset_hash_ops
  * pcpointset — Set operations (value ↔ set, set ↔ set)
  ******************************************************************************/
 
-CREATE FUNCTION set_contains(pcpointset, pcpoint)
+CREATE FUNCTION contains(pcpointset, pcpoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_contains(pcpointset, pcpointset)
+CREATE FUNCTION contains(pcpointset, pcpointset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
-  PROCEDURE = set_contains,
+  PROCEDURE = contains,
   LEFTARG = pcpointset, RIGHTARG = pcpoint,
   COMMUTATOR = <@
 );
 CREATE OPERATOR @> (
-  PROCEDURE = set_contains,
+  PROCEDURE = contains,
   LEFTARG = pcpointset, RIGHTARG = pcpointset,
   COMMUTATOR = <@
 );
 
-CREATE FUNCTION set_contained(pcpoint, pcpointset)
+CREATE FUNCTION contained(pcpoint, pcpointset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_contained(pcpointset, pcpointset)
+CREATE FUNCTION contained(pcpointset, pcpointset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
-  PROCEDURE = set_contained,
+  PROCEDURE = contained,
   LEFTARG = pcpoint, RIGHTARG = pcpointset,
   COMMUTATOR = @>
 );
 CREATE OPERATOR <@ (
-  PROCEDURE = set_contained,
+  PROCEDURE = contained,
   LEFTARG = pcpointset, RIGHTARG = pcpointset,
   COMMUTATOR = @>
 );
 
-CREATE FUNCTION set_overlaps(pcpointset, pcpointset)
+CREATE FUNCTION overlaps(pcpointset, pcpointset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (
-  PROCEDURE = set_overlaps,
+  PROCEDURE = overlaps,
   LEFTARG = pcpointset, RIGHTARG = pcpointset,
   COMMUTATOR = &&
 );
@@ -669,53 +669,53 @@ CREATE OPERATOR CLASS pcpatchset_hash_ops
  * pcpatchset — Set operations
  ******************************************************************************/
 
-CREATE FUNCTION set_contains(pcpatchset, pcpatch)
+CREATE FUNCTION contains(pcpatchset, pcpatch)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_contains(pcpatchset, pcpatchset)
+CREATE FUNCTION contains(pcpatchset, pcpatchset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
-  PROCEDURE = set_contains,
+  PROCEDURE = contains,
   LEFTARG = pcpatchset, RIGHTARG = pcpatch,
   COMMUTATOR = <@
 );
 CREATE OPERATOR @> (
-  PROCEDURE = set_contains,
+  PROCEDURE = contains,
   LEFTARG = pcpatchset, RIGHTARG = pcpatchset,
   COMMUTATOR = <@
 );
 
-CREATE FUNCTION set_contained(pcpatch, pcpatchset)
+CREATE FUNCTION contained(pcpatch, pcpatchset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_contained(pcpatchset, pcpatchset)
+CREATE FUNCTION contained(pcpatchset, pcpatchset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
-  PROCEDURE = set_contained,
+  PROCEDURE = contained,
   LEFTARG = pcpatch, RIGHTARG = pcpatchset,
   COMMUTATOR = @>
 );
 CREATE OPERATOR <@ (
-  PROCEDURE = set_contained,
+  PROCEDURE = contained,
   LEFTARG = pcpatchset, RIGHTARG = pcpatchset,
   COMMUTATOR = @>
 );
 
-CREATE FUNCTION set_overlaps(pcpatchset, pcpatchset)
+CREATE FUNCTION overlaps(pcpatchset, pcpatchset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (
-  PROCEDURE = set_overlaps,
+  PROCEDURE = overlaps,
   LEFTARG = pcpatchset, RIGHTARG = pcpatchset,
   COMMUTATOR = &&
 );

--- a/mobilitydb/sql/pose/101_poseset.in.sql
+++ b/mobilitydb/sql/pose/101_poseset.in.sql
@@ -345,23 +345,23 @@ CREATE OPERATOR CLASS poseset_hash_ops
  * Operators
  ******************************************************************************/
 
-CREATE FUNCTION set_contains(poseset, pose)
+CREATE FUNCTION contains(poseset, pose)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_contains(poseset, poseset)
+CREATE FUNCTION contains(poseset, poseset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
-  PROCEDURE = set_contains,
+  PROCEDURE = contains,
   LEFTARG = poseset, RIGHTARG = pose,
   COMMUTATOR = <@
   -- RESTRICT = span_sel, JOIN = span_joinsel
 );
 CREATE OPERATOR @> (
-  PROCEDURE = set_contains,
+  PROCEDURE = contains,
   LEFTARG = poseset, RIGHTARG = poseset,
   COMMUTATOR = <@
   -- RESTRICT = span_sel, JOIN = span_joinsel
@@ -369,23 +369,23 @@ CREATE OPERATOR @> (
 
 /******************************************************************************/
 
-CREATE FUNCTION set_contained(pose, poseset)
+CREATE FUNCTION contained(pose, poseset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_contained(poseset, poseset)
+CREATE FUNCTION contained(poseset, poseset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
-  PROCEDURE = set_contained,
+  PROCEDURE = contained,
   LEFTARG = pose, RIGHTARG = poseset,
   COMMUTATOR = @>
   -- RESTRICT = span_sel, JOIN = span_joinsel
 );
 CREATE OPERATOR <@ (
-  PROCEDURE = set_contained,
+  PROCEDURE = contained,
   LEFTARG = poseset, RIGHTARG = poseset,
   COMMUTATOR = @>
   -- RESTRICT = span_sel, JOIN = span_joinsel
@@ -393,13 +393,13 @@ CREATE OPERATOR <@ (
 
 /******************************************************************************/
 
-CREATE FUNCTION set_overlaps(poseset, poseset)
+CREATE FUNCTION overlaps(poseset, poseset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (
-  PROCEDURE = set_overlaps,
+  PROCEDURE = overlaps,
   LEFTARG = poseset, RIGHTARG = poseset,
   COMMUTATOR = &&
   -- RESTRICT = span_sel, JOIN = span_joinsel


### PR DESCRIPTION
The set-theoretic topological predicates are canonically named by the bare portable name — the catalog tag on the generic backing is `contains()`/`contained()`/`overlaps()`, and the scalar sets (`intset`/`bigintset`/…) and `h3indexset`/`quadbinset` already declare them bare.

The `geomset`, `geogset`, `npointset`, `poseset`, `cbufferset`, `jsonbset`, `pcpointset`, and `pcpatchset` SQL files declared them prefixed, lagging the catalog. This renames the SQL functions and their `@>` `<@` `&&` operator procedures to the canonical bare names. The C backing symbols and the operators are unchanged, so the SQL surface and query results are identical.