### PR TITLE
Canonicalize the set distance function name to setDistance

### DIFF
--- a/mobilitydb/sql/cbuffer/201_cbufferset.in.sql
+++ b/mobilitydb/sql/cbuffer/201_cbufferset.in.sql
@@ -482,31 +482,31 @@ CREATE OPERATOR * (
 
 /*****************************************************************************/
 
-CREATE FUNCTION set_distance(cbuffer, cbufferset)
+CREATE FUNCTION setDistance(cbuffer, cbufferset)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_distance(cbufferset, cbuffer)
+CREATE FUNCTION setDistance(cbufferset, cbuffer)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_distance(cbufferset, cbufferset)
+CREATE FUNCTION setDistance(cbufferset, cbufferset)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = cbuffer, RIGHTARG = cbufferset,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = cbufferset, RIGHTARG = cbuffer,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = cbufferset, RIGHTARG = cbufferset,
   COMMUTATOR = <->
 );

--- a/mobilitydb/sql/geo/050_geoset.in.sql
+++ b/mobilitydb/sql/geo/050_geoset.in.sql
@@ -883,60 +883,60 @@ CREATE OPERATOR * (
 
 /*****************************************************************************/
 
-CREATE FUNCTION set_distance(geometry, geomset)
+CREATE FUNCTION setDistance(geometry, geomset)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_distance(geomset, geometry)
+CREATE FUNCTION setDistance(geomset, geometry)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_distance(geomset, geomset)
+CREATE FUNCTION setDistance(geomset, geomset)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION set_distance(geography, geogset)
+CREATE FUNCTION setDistance(geography, geogset)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_distance(geogset, geography)
+CREATE FUNCTION setDistance(geogset, geography)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_distance(geogset, geogset)
+CREATE FUNCTION setDistance(geogset, geogset)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = geometry, RIGHTARG = geomset,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = geomset, RIGHTARG = geometry,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = geomset, RIGHTARG = geomset,
   COMMUTATOR = <->
 );
 
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = geography, RIGHTARG = geogset,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = geogset, RIGHTARG = geography,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = geogset, RIGHTARG = geogset,
   COMMUTATOR = <->
 );

--- a/mobilitydb/sql/npoint/301_npointset.in.sql
+++ b/mobilitydb/sql/npoint/301_npointset.in.sql
@@ -475,31 +475,31 @@ CREATE OPERATOR * (
 
 /*****************************************************************************/
 
-CREATE FUNCTION set_distance(npoint, npointset)
+CREATE FUNCTION setDistance(npoint, npointset)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_distance(npointset, npoint)
+CREATE FUNCTION setDistance(npointset, npoint)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_distance(npointset, npointset)
+CREATE FUNCTION setDistance(npointset, npointset)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = npoint, RIGHTARG = npointset,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = npointset, RIGHTARG = npoint,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = npointset, RIGHTARG = npointset,
   COMMUTATOR = <->
 );

--- a/mobilitydb/sql/pose/101_poseset.in.sql
+++ b/mobilitydb/sql/pose/101_poseset.in.sql
@@ -497,31 +497,31 @@ CREATE OPERATOR * (
 
 /*****************************************************************************/
 
-CREATE FUNCTION set_distance(pose, poseset)
+CREATE FUNCTION setDistance(pose, poseset)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_distance(poseset, pose)
+CREATE FUNCTION setDistance(poseset, pose)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_distance(poseset, poseset)
+CREATE FUNCTION setDistance(poseset, poseset)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = pose, RIGHTARG = poseset,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = poseset, RIGHTARG = pose,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = poseset, RIGHTARG = poseset,
   COMMUTATOR = <->
 );

--- a/mobilitydb/sql/temporal/002_set_ops.in.sql
+++ b/mobilitydb/sql/temporal/002_set_ops.in.sql
@@ -1527,192 +1527,192 @@ CREATE OPERATOR * (
 
 /*****************************************************************************/
 
-CREATE FUNCTION set_distance(integer, integer)
+CREATE FUNCTION setDistance(integer, integer)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Distance_value_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_distance(integer, intset)
+CREATE FUNCTION setDistance(integer, intset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Distance_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_distance(intset, integer)
+CREATE FUNCTION setDistance(intset, integer)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Distance_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_distance(intset, intset)
+CREATE FUNCTION setDistance(intset, intset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Distance_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION set_distance(bigint, bigint)
+CREATE FUNCTION setDistance(bigint, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Distance_value_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_distance(bigint, bigintset)
+CREATE FUNCTION setDistance(bigint, bigintset)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Distance_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_distance(bigintset, bigint)
+CREATE FUNCTION setDistance(bigintset, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Distance_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_distance(bigintset, bigintset)
+CREATE FUNCTION setDistance(bigintset, bigintset)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION set_distance(float, float)
+CREATE FUNCTION setDistance(float, float)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_value_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_distance(float, floatset)
+CREATE FUNCTION setDistance(float, floatset)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_distance(floatset, float)
+CREATE FUNCTION setDistance(floatset, float)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_distance(floatset, floatset)
+CREATE FUNCTION setDistance(floatset, floatset)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION set_distance(date, date)
+CREATE FUNCTION setDistance(date, date)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Distance_value_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_distance(date, dateset)
+CREATE FUNCTION setDistance(date, dateset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Distance_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_distance(dateset, date)
+CREATE FUNCTION setDistance(dateset, date)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Distance_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_distance(dateset, dateset)
+CREATE FUNCTION setDistance(dateset, dateset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Distance_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION set_distance(timestamptz, timestamptz)
+CREATE FUNCTION setDistance(timestamptz, timestamptz)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_value_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_distance(timestamptz, tstzset)
+CREATE FUNCTION setDistance(timestamptz, tstzset)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_distance(tstzset, timestamptz)
+CREATE FUNCTION setDistance(tstzset, timestamptz)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_distance(tstzset, tstzset)
+CREATE FUNCTION setDistance(tstzset, tstzset)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_set_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = integer, RIGHTARG = integer,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = integer, RIGHTARG = intset,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = intset, RIGHTARG = integer,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = intset, RIGHTARG = intset,
   COMMUTATOR = <->
 );
 
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = bigint, RIGHTARG = bigint,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = bigint, RIGHTARG = bigintset,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = bigintset, RIGHTARG = bigint,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = bigintset, RIGHTARG = bigintset,
   COMMUTATOR = <->
 );
 
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = float, RIGHTARG = float,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = float, RIGHTARG = floatset,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = floatset, RIGHTARG = float,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = floatset, RIGHTARG = floatset,
   COMMUTATOR = <->
 );
 
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = date, RIGHTARG = date,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = date, RIGHTARG = dateset,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = dateset, RIGHTARG = date,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = dateset, RIGHTARG = dateset,
   COMMUTATOR = <->
 );
 
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = timestamptz, RIGHTARG = timestamptz,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = timestamptz, RIGHTARG = tstzset,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = tstzset, RIGHTARG = timestamptz,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = set_distance,
+  PROCEDURE = setDistance,
   LEFTARG = tstzset, RIGHTARG = tstzset,
   COMMUTATOR = <->
 );

--- a/mobilitydb/src/temporal/set_ops.c
+++ b/mobilitydb/src/temporal/set_ops.c
@@ -568,7 +568,7 @@ PG_FUNCTION_INFO_V1(Distance_value_set);
 /**
  * @ingroup mobilitydb_setspan_dist
  * @brief Return the distance between a value and a set
- * @sqlfn set_distance()
+ * @sqlfn setDistance()
  * @sqlop @p <->
  */
 inline Datum
@@ -586,7 +586,7 @@ PG_FUNCTION_INFO_V1(Distance_set_value);
 /**
  * @ingroup mobilitydb_setspan_dist
  * @brief Return the distance between a set and a value
- * @sqlfn set_distance()
+ * @sqlfn setDistance()
  * @sqlop @p <->
  */
 Datum
@@ -604,7 +604,7 @@ PG_FUNCTION_INFO_V1(Distance_set_set);
 /**
  * @ingroup mobilitydb_setspan_dist
  * @brief Return the distance between two sets
- * @sqlfn set_distance()
+ * @sqlfn setDistance()
  * @sqlop @p <->
  */
 Datum


### PR DESCRIPTION
The set operations use camelCase compound names (`setUnion`, `setMinus`, `setIntersection`). This renames the set distance function from the snake_case `set_distance` to the matching `setDistance`.

`set_distance` is a MobilityDB-only PG function (no MEOS API function), so its canonical name is governed by its `@sqlfn` tag in `mobilitydb/src/temporal/set_ops.c`. This recases the tag to `setDistance()` and renames the SQL functions in the set files (`002_set_ops`, `geoset`, `npointset`, `poseset`, `cbufferset`) to match. The C backing symbols are unchanged and PostgreSQL folds the identifier, so query results are identical.