### PR TITLE
Retire the SQL wrapper of the temporal geo eDisjoint functions

### DIFF
--- a/mobilitydb/sql/geo/070_tgeo_spatialrels.in.sql
+++ b/mobilitydb/sql/geo/070_tgeo_spatialrels.in.sql
@@ -111,96 +111,31 @@ CREATE FUNCTION aCovers(tgeometry, tgeometry)
  * eDisjoint, aDisjoint
  *****************************************************************************/
 
--- TODO implement the index support in the tspatial_supportfn
-
-CREATE FUNCTION _edisjoint(geometry, tgeometry)
-  RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Edisjoint_geo_tgeo'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION eDisjoint(geometry, tgeometry)
   RETURNS boolean
-  AS 'SELECT NOT(stbox($1) OPERATOR(@extschema@.&&) $2) OR @extschema@._edisjoint($1,$2)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
-
-CREATE FUNCTION _edisjoint(tgeometry, geometry)
-  RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Edisjoint_tgeo_geo'
+  AS 'MODULE_PATHNAME', 'Edisjoint_geo_tgeo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION eDisjoint(tgeometry, geometry)
   RETURNS boolean
-  AS 'SELECT NOT($1 OPERATOR(@extschema@.&&) stbox($2)) OR @extschema@._edisjoint($1,$2)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
-
-CREATE FUNCTION _edisjoint(tgeometry, tgeometry)
-  RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Edisjoint_tgeo_tgeo'
+  AS 'MODULE_PATHNAME', 'Edisjoint_tgeo_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION eDisjoint(tgeometry, tgeometry)
   RETURNS boolean
-  AS 'SELECT NOT($1 OPERATOR(@extschema@.&&) $2) OR @extschema@._edisjoint($1,$2)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
+  AS 'MODULE_PATHNAME', 'Edisjoint_tgeo_tgeo'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
--- CREATE FUNCTION eDisjoint(geometry, tgeometry)
-  -- RETURNS boolean
-  -- AS 'MODULE_PATHNAME', 'Edisjoint_geo_tgeo'
-  -- SUPPORT tspatial_supportfn
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
--- CREATE FUNCTION eDisjoint(tgeometry, geometry)
-  -- RETURNS boolean
-  -- AS 'MODULE_PATHNAME', 'Edisjoint_tgeo_geo'
-  -- SUPPORT tspatial_supportfn
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
--- CREATE FUNCTION eDisjoint(tgeometry, tgeometry)
-  -- RETURNS boolean
-  -- AS 'MODULE_PATHNAME', 'Edisjoint_tgeo_tgeo'
-  -- SUPPORT tspatial_supportfn
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-/*****************************************************************************/
-
--- TODO implement the index support in the tspatial_supportfn
-
-CREATE FUNCTION _edisjoint(geography, tgeography)
+CREATE FUNCTION eDisjoint(geography, tgeography)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Edisjoint_geo_tgeo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION eDisjoint(geography, tgeography)
-  RETURNS boolean
-  AS 'SELECT NOT(stbox($1) OPERATOR(@extschema@.&&) $2) OR @extschema@._edisjoint($1,$2)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
-
-CREATE FUNCTION _edisjoint(tgeography, geography)
+CREATE FUNCTION eDisjoint(tgeography, geography)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Edisjoint_tgeo_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION eDisjoint(tgeography, geography)
-  RETURNS boolean
-  AS 'SELECT NOT($1 OPERATOR(@extschema@.&&) stbox($2)) OR @extschema@._edisjoint($1,$2)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
-
-CREATE FUNCTION _edisjoint(tgeography, tgeography)
+CREATE FUNCTION eDisjoint(tgeography, tgeography)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Edisjoint_tgeo_tgeo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION eDisjoint(tgeography, tgeography)
-  RETURNS boolean
-  AS 'SELECT NOT($1 OPERATOR(@extschema@.&&) $2) OR @extschema@._edisjoint($1,$2)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
-
--- CREATE FUNCTION eDisjoint(geography, tgeography)
-  -- RETURNS boolean
-  -- AS 'MODULE_PATHNAME', 'Edisjoint_geo_tgeo'
-  -- SUPPORT tspatial_supportfn
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
--- CREATE FUNCTION eDisjoint(tgeography, geography)
-  -- RETURNS boolean
-  -- AS 'MODULE_PATHNAME', 'Edisjoint_tgeo_geo'
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
--- CREATE FUNCTION eDisjoint(tgeography, tgeography)
-  -- RETURNS boolean
-  -- AS 'MODULE_PATHNAME', 'Edisjoint_tgeo_tgeo'
-  -- SUPPORT tspatial_supportfn
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************/
 

--- a/mobilitydb/sql/geo/070_tpoint_spatialrels.in.sql
+++ b/mobilitydb/sql/geo/070_tpoint_spatialrels.in.sql
@@ -73,92 +73,31 @@ CREATE FUNCTION aCovers(geometry, tgeompoint)
  * eDisjoint, aDisjoint
  *****************************************************************************/
 
--- TODO implement the index support in the tspatial_supportfn
-
-CREATE FUNCTION _edisjoint(geometry, tgeompoint)
-  RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Edisjoint_geo_tgeo'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION eDisjoint(geometry, tgeompoint)
   RETURNS boolean
-  AS 'SELECT NOT(stbox($1) OPERATOR(@extschema@.&&) $2) OR @extschema@._edisjoint($1,$2)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
-
-CREATE FUNCTION _edisjoint(tgeompoint, geometry)
-  RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Edisjoint_tgeo_geo'
+  AS 'MODULE_PATHNAME', 'Edisjoint_geo_tgeo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION eDisjoint(tgeompoint, geometry)
   RETURNS boolean
-  AS 'SELECT NOT($1 OPERATOR(@extschema@.&&) stbox($2)) OR @extschema@._edisjoint($1,$2)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
-
-CREATE FUNCTION _edisjoint(tgeompoint, tgeompoint)
-  RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Edisjoint_tgeo_tgeo'
+  AS 'MODULE_PATHNAME', 'Edisjoint_tgeo_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION eDisjoint(tgeompoint, tgeompoint)
   RETURNS boolean
-  AS 'SELECT NOT($1 OPERATOR(@extschema@.&&) $2) OR @extschema@._edisjoint($1,$2)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
+  AS 'MODULE_PATHNAME', 'Edisjoint_tgeo_tgeo'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
--- CREATE FUNCTION eDisjoint(geometry, tgeompoint)
-  -- RETURNS boolean
-  -- AS 'MODULE_PATHNAME', 'Edisjoint_geo_tgeo'
-  -- SUPPORT tspatial_supportfn
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
--- CREATE FUNCTION eDisjoint(tgeompoint, geometry)
-  -- RETURNS boolean
-  -- AS 'MODULE_PATHNAME', 'Edisjoint_tgeo_geo'
-  -- SUPPORT tspatial_supportfn
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
--- CREATE FUNCTION eDisjoint(tgeompoint, tgeompoint)
-  -- RETURNS boolean
-  -- AS 'MODULE_PATHNAME', 'Edisjoint_tgeo_tgeo'
-  -- SUPPORT tspatial_supportfn
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-CREATE FUNCTION _edisjoint(geography, tgeogpoint)
+CREATE FUNCTION eDisjoint(geography, tgeogpoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Edisjoint_geo_tgeo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION eDisjoint(geography, tgeogpoint)
-  RETURNS boolean
-  AS 'SELECT NOT(stbox($1) OPERATOR(@extschema@.&&) $2) OR @extschema@._edisjoint($1,$2)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
-
-CREATE FUNCTION _edisjoint(tgeogpoint, geography)
+CREATE FUNCTION eDisjoint(tgeogpoint, geography)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Edisjoint_tgeo_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION eDisjoint(tgeogpoint, geography)
-  RETURNS boolean
-  AS 'SELECT NOT($1 OPERATOR(@extschema@.&&) stbox($2)) OR @extschema@._edisjoint($1,$2)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
-
-CREATE FUNCTION _edisjoint(tgeogpoint, tgeogpoint)
+CREATE FUNCTION eDisjoint(tgeogpoint, tgeogpoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Edisjoint_tgeo_tgeo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION eDisjoint(tgeogpoint, tgeogpoint)
-  RETURNS boolean
-  AS 'SELECT NOT($1 OPERATOR(@extschema@.&&) $2) OR @extschema@._edisjoint($1,$2)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
-
--- CREATE FUNCTION eDisjoint(geography, tgeogpoint)
-  -- RETURNS boolean
-  -- AS 'MODULE_PATHNAME', 'Edisjoint_geo_tgeo'
-  -- SUPPORT tspatial_supportfn
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
--- CREATE FUNCTION eDisjoint(tgeogpoint, geography)
-  -- RETURNS boolean
-  -- AS 'MODULE_PATHNAME', 'Edisjoint_tgeo_geo'
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
--- CREATE FUNCTION eDisjoint(tgeogpoint, tgeogpoint)
-  -- RETURNS boolean
-  -- AS 'MODULE_PATHNAME', 'Edisjoint_tgeo_tgeo'
-  -- SUPPORT tspatial_supportfn
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************/
 

--- a/mobilitydb/test/geo/expected/070_tgeo_spatialrels.test.out
+++ b/mobilitydb/test/geo/expected/070_tgeo_spatialrels.test.out
@@ -411,10 +411,8 @@ SELECT eDisjoint(geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))', tgeometry '{Point(3 
 /* Errors */
 SELECT eDisjoint(geometry 'SRID=3812;Point(1 1)', tgeometry 'Point(1 1)@2000-01-01');
 ERROR:  Operation on mixed SRID
-CONTEXT:  SQL function "edisjoint" statement 1
 SELECT eDisjoint(tgeometry 'Point(1 1)@2000-01-01', geometry 'SRID=3812;Point(1 1)');
 ERROR:  Operation on mixed SRID
-CONTEXT:  SQL function "edisjoint" statement 1
 SELECT eIntersects(geometry 'Point(1 1)', tgeometry 'Point(1 1)@2000-01-01');
  eintersects 
 -------------

--- a/mobilitydb/test/geo/expected/070_tgeo_spatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/070_tgeo_spatialrels_tbl.test.out
@@ -85,7 +85,7 @@ SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE eDisjoint(temp, g);
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE eDisjoint(t1.temp, t2.temp);
  count 
 -------
-  9900
+     4
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry3D, tbl_tgeometry3D WHERE eDisjoint(g, temp);
@@ -103,19 +103,19 @@ SELECT COUNT(*) FROM tbl_tgeometry3D, tbl_geometry3D WHERE eDisjoint(temp, g);
 SELECT COUNT(*) FROM tbl_tgeometry3D t1, tbl_tgeometry3D t2 WHERE eDisjoint(t1.temp, t2.temp);
  count 
 -------
-  9898
+     2
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeography t1, tbl_tgeography t2 WHERE eDisjoint(t1.temp, t2.temp);
  count 
 -------
-  9900
+     4
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeography3D t1, tbl_tgeography3D t2 WHERE eDisjoint(t1.temp, t2.temp);
  count 
 -------
-  9900
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry t1, tbl_tgeometry t2 WHERE t1.k % 3 = 0 AND aDisjoint(g, temp);

--- a/mobilitydb/test/geo/expected/070_tpoint_spatialrels.test.out
+++ b/mobilitydb/test/geo/expected/070_tpoint_spatialrels.test.out
@@ -338,10 +338,8 @@ SELECT eDisjoint(tgeompoint 'Interp=Step;[Point(1 1)@2000-01-01, Point(2 2)@2000
 /* Errors */
 SELECT eDisjoint(geometry 'SRID=5676;Point(1 1)', tgeompoint 'Point(1 1)@2000-01-01');
 ERROR:  Operation on mixed SRID
-CONTEXT:  SQL function "edisjoint" statement 1
 SELECT eDisjoint(tgeompoint 'Point(1 1)@2000-01-01', geometry 'SRID=5676;Point(1 1)');
 ERROR:  Operation on mixed SRID
-CONTEXT:  SQL function "edisjoint" statement 1
 SELECT eIntersects(geometry 'Point(1 1)', tgeompoint 'Point(1 1)@2000-01-01');
  eintersects 
 -------------

--- a/mobilitydb/test/geo/expected/070_tpoint_spatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/070_tpoint_spatialrels_tbl.test.out
@@ -25,31 +25,31 @@ SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom WHERE eDisjoint(temp, g);
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE eDisjoint(t1.temp, t2.temp);
  count 
 -------
-  9878
+    34
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geom3D, tbl_tgeompoint3D WHERE eDisjoint(g, temp);
  count 
 -------
-  9226
+  9195
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint3D, tbl_geom3D WHERE eDisjoint(temp, g);
  count 
 -------
-  9226
+  9195
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2 WHERE eDisjoint(t1.temp, t2.temp);
  count 
 -------
-  9876
+    32
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_tgeogpoint t2 WHERE eDisjoint(t1.temp, t2.temp);
  count 
 -------
-  9874
+    30
 (1 row)
 
 SELECT COUNT(*) > 0 FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2 WHERE eDisjoint(t1.temp, t2.temp);

--- a/mobilitydb/test/h3/expected/290_th3index_spatialrels_tbl.test.out
+++ b/mobilitydb/test/h3/expected/290_th3index_spatialrels_tbl.test.out
@@ -25,7 +25,7 @@ SELECT COUNT(*) FROM tbl_th3index t1, tbl_th3index t2 WHERE tCovers(t1.temp, t2.
 SELECT COUNT(*) FROM tbl_th3index t1, tbl_th3index t2 WHERE eDisjoint(t1.temp, t2.temp);
  count 
 -------
-  9900
+     2
 (1 row)
 
 SELECT COUNT(*) FROM tbl_th3index t1, tbl_th3index t2 WHERE aDisjoint(t1.temp, t2.temp);

--- a/mobilitydb/test/quadbin/expected/362_tquadbin_spatialrels_tbl.test.out
+++ b/mobilitydb/test/quadbin/expected/362_tquadbin_spatialrels_tbl.test.out
@@ -25,7 +25,7 @@ SELECT COUNT(*) FROM tbl_tquadbin t1, tbl_tquadbin t2 WHERE tCovers(t1.temp, t2.
 SELECT COUNT(*) FROM tbl_tquadbin t1, tbl_tquadbin t2 WHERE eDisjoint(t1.temp, t2.temp);
  count 
 -------
-  9900
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tquadbin t1, tbl_tquadbin t2 WHERE aDisjoint(t1.temp, t2.temp);


### PR DESCRIPTION
The temporal `eDisjoint` functions are SQL wrappers `NOT(stbox($1) OPERATOR(&&) $2) OR _edisjoint($1, $2)` over an internal C primitive. The bounding-box short-circuit produces results that disagree with the `eDisjoint` predicate itself:

- **No common time frame.** Two temporal geometries whose time periods do not overlap have no instant at which they can be compared. A temporal `stbox` `&&` tests space *and* time, so the wrapper treats them as ever-disjoint. On `tbl_tgeometry` squared this yields `eDisjoint = 9900`, while the direct predicate, `aDisjoint`, and the `ever(tDisjoint)` oracle all yield `4`.
- **Dimensionality.** The short-circuit uses the full spatiotemporal bounding box, while the predicate is two-dimensional. A geometry coinciding with a temporal point in x/y but separated in z is reported as disjoint by the bounding box, whereas the predicate reports them as intersecting.

This change defines `eDisjoint` directly in C from the `Edisjoint_*` symbols, mirroring `aDisjoint`, so the result follows the predicate: `NULL` when the operands share no time, and the two-dimensional relationship otherwise. It removes the internal `_edisjoint` functions and the commented-out `eDisjoint` definitions carrying `SUPPORT tspatial_supportfn`: disjointness cannot use the `&&` bounding-box index prefilter, since a bounding-box miss is exactly the case where disjointness holds.

The expected results reflect the pairs that now return `NULL` or the two-dimensional value, including the h3 and quadbin cell tests that reach `eDisjoint` through the geometry cast.