### PR TITLE
Add parallel combine to the setUnion aggregates

### DIFF
--- a/mobilitydb/sql/cbuffer/201_cbufferset.in.sql
+++ b/mobilitydb/sql/cbuffer/201_cbufferset.in.sql
@@ -222,11 +222,21 @@ CREATE FUNCTION cbufferset_union_finalfn(internal)
 CREATE AGGREGATE setUnion(cbuffer) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = cbufferset_union_finalfn
 );
 CREATE AGGREGATE setUnion(cbufferset) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = cbufferset_union_finalfn
 );
 

--- a/mobilitydb/sql/geo/050_geoset.in.sql
+++ b/mobilitydb/sql/geo/050_geoset.in.sql
@@ -372,22 +372,42 @@ CREATE FUNCTION geogset_union_finalfn(internal)
 CREATE AGGREGATE setUnion(geometry) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = geomset_union_finalfn
 );
 CREATE AGGREGATE setUnion(geography) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = geogset_union_finalfn
 );
 
 CREATE AGGREGATE setUnion(geomset) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = geomset_union_finalfn
 );
 CREATE AGGREGATE setUnion(geogset) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = geogset_union_finalfn
 );
 

--- a/mobilitydb/sql/h3/251_h3indexset.in.sql
+++ b/mobilitydb/sql/h3/251_h3indexset.in.sql
@@ -255,6 +255,11 @@ CREATE FUNCTION h3indexset_union_finalfn(internal)
 CREATE AGGREGATE setUnion(h3index) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = h3indexset_union_finalfn,
   PARALLEL = safe
 );
@@ -262,6 +267,11 @@ CREATE AGGREGATE setUnion(h3index) (
 CREATE AGGREGATE setUnion(h3indexset) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = h3indexset_union_finalfn,
   PARALLEL = safe
 );

--- a/mobilitydb/sql/json/450_jsonbset.in.sql
+++ b/mobilitydb/sql/json/450_jsonbset.in.sql
@@ -194,11 +194,21 @@ CREATE FUNCTION jsonbset_union_finalfn(internal)
 CREATE AGGREGATE setUnion(jsonb) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = jsonbset_union_finalfn
 );
 CREATE AGGREGATE setUnion(jsonbset) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = jsonbset_union_finalfn
 );
 

--- a/mobilitydb/sql/npoint/301_npointset.in.sql
+++ b/mobilitydb/sql/npoint/301_npointset.in.sql
@@ -215,11 +215,21 @@ CREATE FUNCTION npointset_union_finalfn(internal)
 CREATE AGGREGATE setUnion(npoint) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = npointset_union_finalfn
 );
 CREATE AGGREGATE setUnion(npointset) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = npointset_union_finalfn
 );
 

--- a/mobilitydb/sql/pointcloud/400_pcset.in.sql
+++ b/mobilitydb/sql/pointcloud/400_pcset.in.sql
@@ -210,11 +210,21 @@ CREATE FUNCTION pcpointset_union_finalfn(internal)
 CREATE AGGREGATE setUnion(pcpoint) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = pcpointset_union_finalfn
 );
 CREATE AGGREGATE setUnion(pcpointset) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = pcpointset_union_finalfn
 );
 
@@ -567,11 +577,21 @@ CREATE FUNCTION pcpatchset_union_finalfn(internal)
 CREATE AGGREGATE setUnion(pcpatch) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = pcpatchset_union_finalfn
 );
 CREATE AGGREGATE setUnion(pcpatchset) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = pcpatchset_union_finalfn
 );
 

--- a/mobilitydb/sql/pose/101_poseset.in.sql
+++ b/mobilitydb/sql/pose/101_poseset.in.sql
@@ -237,11 +237,21 @@ CREATE FUNCTION poseset_union_finalfn(internal)
 CREATE AGGREGATE setUnion(pose) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = poseset_union_finalfn
 );
 CREATE AGGREGATE setUnion(poseset) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = poseset_union_finalfn
 );
 

--- a/mobilitydb/sql/quadbin/351_quadbinset.in.sql
+++ b/mobilitydb/sql/quadbin/351_quadbinset.in.sql
@@ -255,6 +255,11 @@ CREATE FUNCTION quadbinset_union_finalfn(internal)
 CREATE AGGREGATE setUnion(quadbin) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = quadbinset_union_finalfn,
   PARALLEL = safe
 );
@@ -262,6 +267,11 @@ CREATE AGGREGATE setUnion(quadbin) (
 CREATE AGGREGATE setUnion(quadbinset) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = quadbinset_union_finalfn,
   PARALLEL = safe
 );

--- a/mobilitydb/sql/temporal/001_set.in.sql
+++ b/mobilitydb/sql/temporal/001_set.in.sql
@@ -824,36 +824,66 @@ CREATE FUNCTION textset_union_finalfn(internal)
 CREATE AGGREGATE setUnion(integer) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = intset_union_finalfn,
   PARALLEL = safe
 );
 CREATE AGGREGATE setUnion(bigint) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = bigintset_union_finalfn,
   PARALLEL = safe
 );
 CREATE AGGREGATE setUnion(float) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = floatset_union_finalfn,
   PARALLEL = safe
 );
 CREATE AGGREGATE setUnion(text) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = textset_union_finalfn,
   PARALLEL = safe
 );
 CREATE AGGREGATE setUnion(date) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = dateset_union_finalfn,
   PARALLEL = safe
 );
 CREATE AGGREGATE setUnion(timestamptz) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = tstzset_union_finalfn,
   PARALLEL = safe
 );
@@ -861,36 +891,66 @@ CREATE AGGREGATE setUnion(timestamptz) (
 CREATE AGGREGATE setUnion(intset) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = intset_union_finalfn,
   PARALLEL = safe
 );
 CREATE AGGREGATE setUnion(bigintset) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = bigintset_union_finalfn,
   PARALLEL = safe
 );
 CREATE AGGREGATE setUnion(floatset) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = floatset_union_finalfn,
   PARALLEL = safe
 );
 CREATE AGGREGATE setUnion(textset) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = textset_union_finalfn,
   PARALLEL = safe
 );
 CREATE AGGREGATE setUnion(dateset) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = dateset_union_finalfn,
   PARALLEL = safe
 );
 CREATE AGGREGATE setUnion(tstzset) (
   SFUNC = set_union_transfn,
   STYPE = internal,
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+#endif //POSTGRESQL_VERSION_NUMBER >= 160000
   FINALFUNC = tstzset_union_finalfn,
   PARALLEL = safe
 );


### PR DESCRIPTION
The `setUnion` aggregates gather their inputs into a PostgreSQL `ArrayBuildState` via `set_union_transfn`, exactly as the `spanUnion` and `spansetUnion` aggregates do. Unlike those, however, they declared no combine function, so they could not perform partial aggregation across parallel workers despite being marked `PARALLEL = safe`.

This wires the built-in `array_agg_combine`, `array_agg_serialize` and `array_agg_deserialize` support functions into every `setUnion` aggregate (32 definitions across the base, geo, cbuffer, npoint, pose, quadbin, h3, pointcloud and jsonb set families), gated on PostgreSQL 16 as for `spanUnion`, so that set union aggregation can run in parallel and be combined across workers.

Because `set_union_transfn` already builds the same generic `ArrayBuildState` that `array_agg` uses, no new C code is required. Results are unchanged: the final function sorts and deduplicates the accumulated values.