### PR TITLE
Annotate the output count parameter on the per-base tnumber box functions

### DIFF
--- a/meos/src/temporal/temporal_tile_meos.c
+++ b/meos/src/temporal/temporal_tile_meos.c
@@ -222,6 +222,10 @@ tfloatbox_time_tiles(const TBox *box, const Interval *duration,
  * @ingroup meos_temporal_analytics_tile
  * @brief Return the temporal boxes of a temporal number split with respect to
  * a value grid
+ * @param[in] temp Temporal value
+ * @param[in] vsize Value size of the tiles
+ * @param[in] vorigin Value origin of the tiles
+ * @param[out] count Number of elements in the output array
  */
 TBox *
 tint_value_boxes(const Temporal *temp, int vsize, int vorigin, int *count)
@@ -234,6 +238,10 @@ tint_value_boxes(const Temporal *temp, int vsize, int vorigin, int *count)
  * @ingroup meos_temporal_analytics_tile
  * @brief Return the temporal boxes of a temporal number split with respect to
  * a time grid
+ * @param[in] temp Temporal value
+ * @param[in] duration Interval defining the size of the bins
+ * @param[in] torigin Time origin of the tiles
+ * @param[out] count Number of elements in the output array
  */
 TBox *
 tint_time_boxes(const Temporal *temp, const Interval *duration,
@@ -247,6 +255,12 @@ tint_time_boxes(const Temporal *temp, const Interval *duration,
  * @ingroup meos_temporal_analytics_tile
  * @brief Return the temporal boxes of a temporal number split with respect to
  * a value and possibly a time grid
+ * @param[in] temp Temporal value
+ * @param[in] vsize Value size of the tiles
+ * @param[in] duration Interval defining the size of the bins
+ * @param[in] vorigin Value origin of the tiles
+ * @param[in] torigin Time origin of the tiles
+ * @param[out] count Number of elements in the output array
  */
 TBox *
 tint_value_time_boxes(const Temporal *temp, int vsize,
@@ -262,6 +276,10 @@ tint_value_time_boxes(const Temporal *temp, int vsize,
  * @ingroup meos_temporal_analytics_tile
  * @brief Return the temporal boxes of a temporal number split with respect to
  * a value grid
+ * @param[in] temp Temporal value
+ * @param[in] vsize Value size of the tiles
+ * @param[in] vorigin Value origin of the tiles
+ * @param[out] count Number of elements in the output array
  */
 TBox *
 tfloat_value_boxes(const Temporal *temp, double vsize, double vorigin,
@@ -274,7 +292,11 @@ tfloat_value_boxes(const Temporal *temp, double vsize, double vorigin,
 /**
  * @ingroup meos_temporal_analytics_tile
  * @brief Return the temporal boxes of a temporal number split with respect to
- * a value and possibly a time grid
+ * a time grid
+ * @param[in] temp Temporal value
+ * @param[in] duration Interval defining the size of the bins
+ * @param[in] torigin Time origin of the tiles
+ * @param[out] count Number of elements in the output array
  */
 TBox *
 tfloat_time_boxes(const Temporal *temp, const Interval *duration, 
@@ -288,6 +310,12 @@ tfloat_time_boxes(const Temporal *temp, const Interval *duration,
  * @ingroup meos_temporal_analytics_tile
  * @brief Return the temporal boxes of a temporal number split with respect to
  * a value and possibly a time grid
+ * @param[in] temp Temporal value
+ * @param[in] vsize Value size of the tiles
+ * @param[in] duration Interval defining the size of the bins
+ * @param[in] vorigin Value origin of the tiles
+ * @param[in] torigin Time origin of the tiles
+ * @param[out] count Number of elements in the output array
  */
 TBox *
 tfloat_value_time_boxes(const Temporal *temp, double vsize,


### PR DESCRIPTION
The base-generic `tnumber_value_time_boxes` documents its trailing `int *count` as `@param[out]`, but the six per-base wrappers carry only `@ingroup` and `@brief`. Their `int *count` out-parameter is then indistinguishable from an ordinary input argument to the documentation-driven catalog tooling, so the whole per-base tile-box family (`timeBoxes`/`valueBoxes`/`valueTimeBoxes`) is un-generatable in every binding that derives from the catalog.

This adds the full `@param` list to each, including `@param[out] count`, matching the sibling `tbox_*_tiles` functions:

- `tint_value_boxes`, `tint_time_boxes`, `tint_value_time_boxes`
- `tfloat_value_boxes`, `tfloat_time_boxes`, `tfloat_value_time_boxes`

It also corrects the `@brief` of `tfloat_time_boxes`, which describes a value-and-time grid instead of a time grid.

Comment-only; no code, catalog, or SQL change. Regenerating the catalog marks `outParams: ['count']` for all six.