### PR TITLE
Annotate the output count parameter on the base geo split box functions

### DIFF
--- a/meos/src/geo/tgeo_boxops.c
+++ b/meos/src/geo/tgeo_boxops.c
@@ -1408,6 +1408,9 @@ geo_split_n_gboxes(const GSERIALIZED *gs, int box_count, int *count)
  * @ingroup meos_geo_base_bbox
  * @brief Return an array of N spatial boxes from the segments of a 
  * (multi)linestring
+ * @param[in] gs (Multi)line
+ * @param[in] box_count Number of boxes
+ * @param[out] count Number of elements in the output array
  * @sqlfn splitNStboxes()
  * @csqlfn #Geo_split_n_stboxes()
  */
@@ -1592,6 +1595,9 @@ geo_split_each_n_gboxes(const GSERIALIZED *gs, int elems_per_box, int *count)
  * @ingroup meos_geo_base_bbox
  * @brief Return an array of spatial boxes from the segments of a
  * (multi)linestring
+ * @param[in] gs (Multi)line
+ * @param[in] elems_per_box Number of input segments merged into an output box
+ * @param[out] count Number of elements in the output array
  * @csqlfn Geo_split_each_n_stboxes()
  */
 STBox *


### PR DESCRIPTION
`geo_split_n_stboxes` and `geo_split_each_n_stboxes` return an array of spatial boxes and write its length through a trailing `int *count`, but their doc blocks carry no `@param`, unlike the temporal sibling `Tgeo_split_n_stboxes`. The `count` out-parameter is then indistinguishable from an input argument to the documentation-driven catalog tooling, so these functions are un-generatable in every binding that derives from the catalog.

This adds the `@param` list to both, including `@param[out] count`. Comment-only; regenerating the catalog marks `outParams: ['count']` for both.