### PR TITLE
Annotate the parameters of th3index_value_n

### DIFF
--- a/meos/src/h3/th3index.c
+++ b/meos/src/h3/th3index.c
@@ -302,6 +302,9 @@ th3index_end_value(const Temporal *temp)
  * @ingroup meos_h3_accessor
  * @brief Return the H3 cell value at the `n`-th distinct value of `temp`.
  * 1-indexed, following the cbuffer convention.
+ * @param[in] temp Temporal value
+ * @param[in] n Number
+ * @param[out] result Value
  * @return `true` on success, `false` if `n` is out of range.
  * @csqlfn #Temporal_value_n()
  */


### PR DESCRIPTION
`th3index_value_n` returns the n-th distinct H3 cell value through an `H3Index *result` argument, but its doc block documents only `@return` and `@csqlfn`, with no `@param`. The written-through argument is then indistinguishable from an input argument to the documentation-driven catalog tooling.

This adds the `@param` list, including `@param[out] result`, matching the sibling `value_n` accessors. Comment-only; regenerating the catalog marks `outParams: ['result']`.