### PR TITLE
Annotate the parameters of tnpoint_positions

### DIFF
--- a/meos/src/npoint/tnpoint.c
+++ b/meos/src/npoint/tnpoint.c
@@ -794,6 +794,8 @@ tnpointseqset_positions(const TSequenceSet *ss, int *count)
 /**
  * @ingroup meos_npoint_accessor
  * @brief Return the network segments covered by the temporal network point
+ * @param[in] temp Temporal value
+ * @param[out] count Number of elements in the output array
  * @csqlfn #Tnpoint_positions()
  */
 Nsegment **


### PR DESCRIPTION
`tnpoint_positions` returns the network segments covered by a temporal network point as an array whose length is written through a trailing `int *count`, but its doc block documents only `@brief` and `@csqlfn`. The written-through length argument is then indistinguishable from an input argument to the documentation-driven catalog tooling.

This adds the `@param` list, including `@param[out] count`. Comment-only; regenerating the catalog marks `outParams: ['count']`.