### PR TITLE
Annotate the output parameters of the quadbin cell functions

### DIFF
--- a/meos/src/quadbin/quadbin.c
+++ b/meos/src/quadbin/quadbin.c
@@ -365,6 +365,9 @@ quadbin_point_to_cell(double longitude, double latitude, uint32_t resolution)
  * @brief Return the lon/lat centroid of a quadbin cell
  * @details Out-parameter helper; the geometry projection quadbinCellToPoint
  * is backed by quadbin_cell_to_geompoint in quadbin_geo.c.
+ * @param[in] cell Quadbin cell
+ * @param[out] longitude Longitude of the centroid
+ * @param[out] latitude Latitude of the centroid
  */
 void
 quadbin_cell_to_point(Quadbin cell, double *longitude, double *latitude)
@@ -383,6 +386,11 @@ quadbin_cell_to_point(Quadbin cell, double *longitude, double *latitude)
  * @details Out-parameter helper shared by the geometry boundary projection
  * quadbinCellToBoundary (via quadbin_cell_to_geom in quadbin_geo.c) and the
  * stbox(quadbin) cast (via quadbin_set_stbox).
+ * @param[in] cell Quadbin cell
+ * @param[out] xmin Minimum X coordinate
+ * @param[out] ymin Minimum Y coordinate
+ * @param[out] xmax Maximum X coordinate
+ * @param[out] ymax Maximum Y coordinate
  */
 void
 quadbin_cell_to_bounding_box(Quadbin cell, double *xmin, double *ymin,

--- a/meos/src/quadbin/tquadbin.c
+++ b/meos/src/quadbin/tquadbin.c
@@ -303,6 +303,9 @@ tquadbin_end_value(const Temporal *temp)
  * @ingroup meos_quadbin_accessor
  * @brief Return the quadbin cell value at the `n`-th distinct value of `temp`.
  * 1-indexed.
+ * @param[in] temp Temporal value
+ * @param[in] n Number
+ * @param[out] result Value
  * @return `true` on success, `false` if `n` is out of range.
  * @csqlfn #Temporal_value_n()
  */


### PR DESCRIPTION
The value_n accessor and the two cell-geometry helpers each write their result through a non-const pointer argument that carries no parameter documentation, so the catalog tooling cannot tell it apart from an input. This adds the parameter lists marking each result as an output, matching the sibling accessors. Comment-only.