### PR TITLE
Compile jsonb_path_query_all in the extension build

### DIFF
--- a/pgtypes/utils/jsonpath_exec.c
+++ b/pgtypes/utils/jsonpath_exec.c
@@ -563,14 +563,12 @@ pg_jsonb_path_query_first(const Jsonb *jb, const JsonPath *jp,
  * @note Derived from PostgreSQL function @p jsonb_path_query_first() and
  * @p wrapItemsInArray
  */
-#if MEOS
 Jsonb **
 jsonb_path_query_all(const Jsonb *jb, const JsonPath *jp, const Jsonb *vars,
   bool silent, bool tz, int *count)
 {
   return pg_jsonb_path_query_all(jb, jp, vars, silent, tz, count);
 }
-#endif /* MEOS */
 Jsonb **
 pg_jsonb_path_query_all(const Jsonb *jb, const JsonPath *jp, const Jsonb *vars,
   bool silent, bool tz, int *count)


### PR DESCRIPTION
The base JSON path functions in pgtypes/ wrap their MEOS-build twin in a MEOS-only guard because PostgreSQL exports a symbol of the same name in the extension build: jsonb_path_exists, jsonb_path_match, jsonb_path_query_array and jsonb_path_query_first are each documented as derived from the PostgreSQL function of the same name. jsonb_path_query_all has no such twin — it is constructed from jsonb_path_query_first and wrapItemsInArray — so the guard needlessly drops the public wrapper from the extension build even though its implementation pg_jsonb_path_query_all is always compiled. This removes the guard so the public jsonb_path_query_all is available in both builds.