### PR TITLE
Use the printf format archetype for meos_error under Clang

### DIFF
--- a/meos/include/meos_error.h
+++ b/meos/include/meos_error.h
@@ -65,8 +65,10 @@ extern void meos_error(int errlevel, int errcode, const char *format, ...)
  */
 #if defined(pg_attribute_printf)
   pg_attribute_printf(3, 4);
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) && !defined(__clang__)
   __attribute__((format(gnu_printf, 3, 4)));
+#elif defined(__GNUC__)
+  __attribute__((format(printf, 3, 4)));
 #else
   ;
 #endif

--- a/pgtypes/CMakeLists.txt
+++ b/pgtypes/CMakeLists.txt
@@ -82,9 +82,12 @@ set(NAMEDATALEN 64)
 set(MEMSET_LOOP_LIMIT 1024)
 set(PG_MAJORVERSION 18)
 
-# `gnu_printf` on GCC/Clang gives format-string warnings for the %z, %lld
-# extensions PG uses; everywhere else fall back to plain `printf`.
-if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+# `gnu_printf` gives GCC format-string checking for the %z, %lld extensions PG
+# uses (needed on MinGW, where the default `printf` archetype has MS semantics).
+# Clang does not support the `gnu_printf` archetype (it warns
+# `-Wignored-attributes`) and its plain `printf` archetype already understands
+# these C99 modifiers, so use `printf` everywhere except real GCC.
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
   set(PG_PRINTF_ATTRIBUTE gnu_printf)
 else()
   set(PG_PRINTF_ATTRIBUTE printf)


### PR DESCRIPTION
The `Build for Ubuntu with clang` workflow emits, at every translation unit that includes `meos_error.h`:

```
meos/include/meos_error.h:67:3: warning: 'format' attribute argument not supported: gnu_printf [-Wignored-attributes]
```

Clang does not support the `gnu_printf` format archetype. The attribute reaches Clang two ways: `pgtypes/CMakeLists.txt` set `PG_PRINTF_ATTRIBUTE=gnu_printf` for `GNU|Clang`, and the self-contained fallback in `meos_error.h` used `gnu_printf` under any `__GNUC__` compiler (Clang defines `__GNUC__`).

`gnu_printf` is only needed for real GCC (MinGW, where the default `printf` archetype has MS semantics for `%lld`); Clang's plain `printf` archetype already understands the `%z`/`%lld` modifiers. This restricts `gnu_printf` to `CMAKE_C_COMPILER_ID STREQUAL "GNU"` and adds a `!defined(__clang__)` guard in the header fallback, so Clang uses `printf` and the warning is gone while GCC keeps full format checking.
