### PR TITLE
Fix warnings in the Windows build

### DIFF
--- a/meos/src/temporal/temporal_modif.c
+++ b/meos/src/temporal/temporal_modif.c
@@ -878,8 +878,7 @@ tcontseq_delete_tstzset(const TSequence *seq, const Set *s)
   TInstant **instants = palloc0(sizeof(TInstant *) * seq->count);
   int i = 0,    /* current instant of the argument sequence */
     j = 0,      /* current timestamp of the argument timestamp set */
-    ninsts = 0, /* number of instants in the currently constructed sequence */
-    nfree = 0;  /* number of instants removed */
+    ninsts = 0; /* number of instants in the currently constructed sequence */
   bool lower_inc1 = seq->period.lower_inc;
   bool upper_inc1 = seq->period.upper_inc;
   while (i < seq->count && j < s->count)
@@ -899,7 +898,6 @@ tcontseq_delete_tstzset(const TSequence *seq, const Set *s)
         upper_inc1 = true;
       i++; /* advance instants */
       j++; /* advance timestamps */
-      nfree++; /* advance number of instants removed */
       }
     else
     {

--- a/pgtypes/timezone/findtimezone.c
+++ b/pgtypes/timezone/findtimezone.c
@@ -38,7 +38,7 @@ static MEOS_TLS char tzdirpath[MAXPGPATH];
  *
  * In this file, tzdirpath is assumed to be set up by select_default_timezone.
  */
-static const char *
+static const char * pg_attribute_unused() /* MEOS: called only by the non-Windows identify_system_timezone() */
 pg_TZDIR(void)
 {
 #ifndef SYSTEMTZDIR

--- a/pgtypes/utils/numeric.c
+++ b/pgtypes/utils/numeric.c
@@ -4915,8 +4915,7 @@ int64_to_numericvar(int64 val, NumericVar *var)
   if (val < 0)
   {
     var->sign = NUMERIC_NEG;
-    // uval = pg_abs_s64(val);
-    uval = labs(val);
+    uval = i64abs(val); /* MEOS: labs() truncates int64 on LLP64 (Windows) */
   }
   else
   {

--- a/pgtypes/utils/pg_locale.c
+++ b/pgtypes/utils/pg_locale.c
@@ -573,6 +573,8 @@ assign_locale_messages(const char *newval, void *extra UNUSED)
    */
 #ifdef LC_MESSAGES
   (void) pg_perm_setlocale(LC_MESSAGES, newval);
+#else
+  (void) newval; /* MEOS: unused where LC_MESSAGES is absent (Windows) */
 #endif
 }
 

--- a/pgtypes/utils/pg_locale_libc.c
+++ b/pgtypes/utils/pg_locale_libc.c
@@ -669,7 +669,7 @@ get_collation_actual_version_libc(const char *collcollate)
      * given a collation name (earlier versions required a location code
      * that we don't have).
      */
-    NLSVERSIONINFOEX version = {sizeof(NLSVERSIONINFOEX)};
+    NLSVERSIONINFOEX version = { .dwNLSVersionInfoSize = sizeof(NLSVERSIONINFOEX) }; /* MEOS: designated init silences -Wmissing-field-initializers */
     WCHAR    wide_collcollate[LOCALE_NAME_MAX_LENGTH];
 
     MultiByteToWideChar(CP_ACP, 0, collcollate, -1, wide_collcollate,


### PR DESCRIPTION
The `Build for Windows` (MinGW-w64 UCRT) job emits five warnings, none platform-fatal but flagged under the zero-warnings policy. Fixed in place:

**First-party**
- `temporal_modif.c` — `tcontseq_delete_tstzset` declared `nfree` and only ever incremented it; recent GCC flags it with `-Wunused-but-set-variable`. Removed.

**Vendored pgtypes** (fixed in place rather than suppressed, each marked `/* MEOS */`)
- `numeric.c` — `int64_to_numericvar` used `labs()`, whose `long` parameter truncates an `int64` on LLP64 (Windows), `-Wabsolute-value`. Uses the file's own `i64abs()` macro (which selects `llabs`).
- `pg_locale.c` — `assign_locale_messages` left `newval` unused where `LC_MESSAGES` is undefined (Windows), `-Wunused-parameter`. Consumed on that path.
- `pg_locale_libc.c` — `NLSVERSIONINFOEX version = {sizeof(...)}` left later fields unlisted, `-Wmissing-field-initializers`. Uses a designated initializer.
- `findtimezone.c` — `pg_TZDIR()` is called only by the non-Windows `identify_system_timezone()`, so it is unused on Windows, `-Wunused-function`. Marked `pg_attribute_unused()`.
