### PR TITLE
Fix remaining warnings in the MEOS Windows build

### DIFF
--- a/meos/src/npoint/ways_meos.c
+++ b/meos/src/npoint/ways_meos.c
@@ -271,7 +271,9 @@ get_ways_record(int64 rid, ways_record *rec)
   do
   {
     char geo_buffer[MAX_LEN_GEOM];
-    int read = fscanf(file, "%ld,%100000s\n", &rec->gid, geo_buffer);
+    long long gidbuf; /* MEOS: %ld mismatches int64 on LLP64 (Windows) */
+    int read = fscanf(file, "%lld,%100000s\n", &gidbuf, geo_buffer);
+    rec->gid = (int64) gidbuf; /* MEOS */
     if (ferror(file))
     {
       meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
@@ -439,7 +441,9 @@ geompoint_to_npoint(const GSERIALIZED *gs)
      */
     /* Buffer for reading the geometry string */
     char geo_buffer[MAX_LEN_GEOM];
-    int read = fscanf(file, "%ld,%100000s\n", &rec.gid, geo_buffer);
+    long long gidbuf; /* MEOS: %ld mismatches int64 on LLP64 (Windows) */
+    int read = fscanf(file, "%lld,%100000s\n", &gidbuf, geo_buffer);
+    rec.gid = (int64) gidbuf; /* MEOS */
     if (ferror(file))
     {
       meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,

--- a/pgtypes/c.h
+++ b/pgtypes/c.h
@@ -255,6 +255,14 @@
 #define pg_attribute_printf(f,a)
 #endif
 
+/* Mark a char array that is deliberately not a NUL-terminated string, so
+ * -Wunterminated-string-initialization / -Wstringop-* stay quiet (GCC 15+). */
+#if defined(__has_attribute) && __has_attribute (nonstring)
+#define pg_attribute_nonstring __attribute__((nonstring))
+#else
+#define pg_attribute_nonstring
+#endif
+
 /* GCC and Sunpro support aligned and packed */
 #if defined(__GNUC__) || defined(__SUNPRO_C)
 #define pg_attribute_aligned(a) __attribute__((aligned(a)))

--- a/pgtypes/timezone/findtimezone.c
+++ b/pgtypes/timezone/findtimezone.c
@@ -38,7 +38,10 @@ static MEOS_TLS char tzdirpath[MAXPGPATH];
  *
  * In this file, tzdirpath is assumed to be set up by select_default_timezone.
  */
-static const char * pg_attribute_unused() /* MEOS: called only by the non-Windows identify_system_timezone() */
+/* MEOS: pg_TZDIR() is called only by the non-Windows identify_system_timezone(),
+ * so it is unused on Windows; mark it to silence -Wunused-function. */
+static const char *pg_TZDIR(void) pg_attribute_unused();
+static const char *
 pg_TZDIR(void)
 {
 #ifndef SYSTEMTZDIR

--- a/pgtypes/utils/numutils.c
+++ b/pgtypes/utils/numutils.c
@@ -28,7 +28,7 @@
  * A table of all two-digit numbers. This is used to speed up decimal digit
  * generation by copying pairs of digits into the final output.
  */
-static const char DIGIT_TABLE[200] =
+static const char DIGIT_TABLE[200] pg_attribute_nonstring = /* MEOS: packed digit-pair table, deliberately not NUL-terminated */
 "00" "01" "02" "03" "04" "05" "06" "07" "08" "09"
 "10" "11" "12" "13" "14" "15" "16" "17" "18" "19"
 "20" "21" "22" "23" "24" "25" "26" "27" "28" "29"


### PR DESCRIPTION
The `Build MEOS on Windows (MSYS2/UCRT64)` standalone build surfaces warnings the extension build does not (it compiles `numutils.c` and `ways_meos.c`). Fixed in place, each marked `/* MEOS */`.

**pgtypes**
- `findtimezone.c` — `pg_TZDIR()` is used only by the non-Windows `identify_system_timezone()`, so it is unused on Windows (`-Wunused-function`). The `pg_attribute_unused()` added earlier sat between the return type and the declarator, so it bound to the *type* and the warning persisted; moved to a forward declaration where it applies to the function.
- `numutils.c` — `DIGIT_TABLE[200]` is a packed digit-pair array, deliberately not NUL-terminated (`-Wunterminated-string-initialization`, GCC 15). Marked with a new `pg_attribute_nonstring` (added to `c.h`, mirroring upstream PostgreSQL).

**MEOS (first-party)**
- `ways_meos.c` — the ways CSV loader read the route `gid` with `"%ld"`, whose `long` argument mismatches `int64` on LLP64 (Windows), `-Wformat`. Reads into a `long long` and assigns to the `int64` field (portable across LP64/LLP64/macOS, unlike `SCNd64`).
