### PR TITLE
Fix for pg19 compile

### DIFF
--- a/meos/src/temporal/postgres_types.c
+++ b/meos/src/temporal/postgres_types.c
@@ -828,7 +828,11 @@ date2timestamptz_opt_overflow(DateADT dateVal, int *overflow)
 inline TimestampTz
 date_to_timestamptz(DateADT d)
 {
+#if POSTGRESQL_VERSION_NUMBER >= 190000
+  return date2timestamptz_safe(d, NULL);
+#else
   return date2timestamptz_opt_overflow(d, NULL);
+#endif
 }
 
 /**

--- a/mobilitydb/src/temporal/temporal_supportfn.c
+++ b/mobilitydb/src/temporal/temporal_supportfn.c
@@ -36,6 +36,7 @@
 #include <assert.h>
 /* PostgreSQL */
 #include <postgres.h>
+#include <access/htup_details.h>
 #include <catalog/pg_opfamily.h>
 #include <catalog/pg_am_d.h>
 #include <nodes/supportnodes.h>

--- a/postgres/utils/date.h
+++ b/postgres/utils/date.h
@@ -71,8 +71,13 @@ typedef struct
 /* date.c */
 extern int32 anytime_typmod_check(bool istz, int32 typmod);
 extern double date2timestamp_no_overflow(DateADT dateVal);
+#if POSTGRESQL_VERSION_NUMBER >= 190000
+extern Timestamp date2timestamp_safe(DateADT dateVal, Node *escontext);
+extern TimestampTz date2timestamptz_safe(DateADT dateVal, Node *escontext);
+#else
 extern Timestamp date2timestamp_opt_overflow(DateADT dateVal, int *overflow);
 extern TimestampTz date2timestamptz_opt_overflow(DateADT dateVal, int *overflow);
+#endif
 extern int32 date_cmp_timestamp_internal(DateADT dateVal, Timestamp dt2);
 extern int32 date_cmp_timestamptz_internal(DateADT dateVal, TimestampTz dt2);
 

--- a/postgres/utils/timestamp.h
+++ b/postgres/utils/timestamp.h
@@ -97,8 +97,13 @@ extern int	timestamp_cmp_internal(Timestamp dt1, Timestamp dt2);
 /* timestamp comparison works for timestamptz also */
 #define timestamptz_cmp_internal(dt1,dt2)	timestamp_cmp_internal(dt1, dt2)
 
+#if POSTGRESQL_VERSION_NUMBER >= 190000
+extern TimestampTz timestamp2timestamptz_safe(Timestamp timestamp,
+											  Node *escontext);
+#else
 extern TimestampTz timestamp2timestamptz_opt_overflow(Timestamp timestamp,
 													  int *overflow);
+#endif
 extern int32 timestamp_cmp_timestamptz_internal(Timestamp timestampVal,
 												TimestampTz dt2);
 


### PR DESCRIPTION
Closes #1499 for MobilityDB 1.3.1

* PG 19 introduced nw _safe timestamp variants
* GETSTRUCT is no longer macro and now resides in access/htup_details.h which has been around for a while so safe to include without version checking