### PR TITLE
Restore the tpointseq_make_coords definition

### DIFF
--- a/meos/src/temporal/tsequence.c
+++ b/meos/src/temporal/tsequence.c
@@ -1098,6 +1098,41 @@ tsequence_make_free(TInstant **instants, int count, bool lower_inc,
 }
 
 /**
+ * @ingroup meos_geo_constructor
+ * @brief Return a temporal sequence from arrays of coordinates, one per
+ * dimension, and timestamps
+ * @param[in] xcoords Array of x coordinates
+ * @param[in] ycoords Array of y coordinates
+ * @param[in] zcoords Array of z coordinates
+ * @param[in] times Array of z timestamps
+ * @param[in] count Number of elements in the arrays
+ * @param[in] srid SRID of the spatial coordinates
+ * @param[in] geodetic True for tgeogpoint, false for tgeompoint
+ * @param[in] lower_inc,upper_inc True if the respective bound is inclusive
+ * @param[in] interp Interpolation
+ * @param[in] normalize True if the resulting value should be normalized
+ */
+TSequence *
+tpointseq_make_coords(const double *xcoords, const double *ycoords,
+  const double *zcoords, const TimestampTz *times, int count, int32 srid,
+  bool geodetic, bool lower_inc, bool upper_inc, interpType interp,
+  bool normalize)
+{
+  assert(xcoords); assert(ycoords); assert(times); assert(count > 0);
+  bool hasz = (zcoords != NULL);
+  MeosType temptype = geodetic ? T_TGEOGPOINT : T_TGEOMPOINT;
+  TInstant **instants = palloc(sizeof(TInstant *) * count);
+  for (int i = 0; i < count; i ++)
+  {
+    Datum point = PointerGetDatum(geopoint_make(xcoords[i], ycoords[i],
+      hasz ? zcoords[i] : 0.0, hasz, geodetic, srid));
+    instants[i] = tinstant_make_free(point, temptype, times[i]);
+  }
+  return tsequence_make_free(instants, count, lower_inc, upper_inc, interp,
+    normalize);
+}
+
+/**
  * @ingroup meos_internal_temporal_constructor
  * @brief Return a copy of a temporal sequence
  * @param[in] seq Temporal sequence


### PR DESCRIPTION
Commit d912257be ("Remove #if MEOS gate for MEOS API functions") was meant to un-gate the MEOS-only functions by dropping their `#if MEOS` / `#endif` lines, but for tpointseq_make_coords it deleted the whole guarded block — the function body along with the gate.

The public declaration in meos_geo.h and the meos/examples/tpointseq_make_coords.c example both remain, so the symbol is declared but no longer defined, and it is absent from libmeos. Restore the definition (un-gated, in its original place in tsequence.c) so the declared symbol is exported again.