### PR TITLE
Reduce the ever dwithin of a temporal geo and a geometry to the nearest approach

### DIFF
--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -1666,17 +1666,38 @@ ea_dwithin_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist,
       return 0;
   }
 
+  /* The ever quantifier is the running minimum of the distance: a temporal geo
+   * is ever within @p dist of the geometry exactly when the smallest distance
+   * it ever attains is at most @p dist, which is the nearest approach distance.
+   * Reducing to it keeps the ever semantics off the temporal Boolean of the
+   * native path below, which resolves every within-distance sub-period of every
+   * segment only for the projection to discard all but their existence. The
+   * nearest approach is a single running minimum, and
+   * #nad_tpoint_geo_analytic computes it with the same GEOS-free analytic
+   * engine, so the reduction is cheaper without giving up the native path. A
+   * zero distance is left on the paths below, where the ever/always intersects
+   * and disjoint relationships are defined in terms of ea_dwithin(., ., 0.0),
+   * and geodetic input keeps the trajectory path of its own EVER branch. The
+   * reduction is restricted to planar 2D input on both sides, the same
+   * condition the native path below carries: the nearest approach requires the
+   * two operands to have the same dimensionality, whereas this relationship
+   * accepts a 2D operand against a 3D one and answers on their common
+   * dimensions. */
+  if (ever && dist > 0.0 && ! MEOS_FLAGS_GET_GEODETIC(temp->flags) &&
+      ! MEOS_FLAGS_GET_Z(temp->flags) && ! FLAGS_GET_Z(gs->gflags))
+    return (nad_tgeo_geo(temp, gs) <= dist) ? 1 : 0;
+
   /* Native fast path for a temporal geometry point with linear interpolation
    * against a non-point geometry the clip engine supports (planar, 2D,
    * strictly positive distance). Compute the native temporal within Boolean
-   * once and project it to the ever/always quantifier. Using the same
-   * #tpoint_linear_dwithin_geom as #tdwithin_tgeo_geo makes the ever/always
-   * projections consistent with the temporal result by construction. This kills
-   * both the EVER GEOS trajectory dwithin and the ALWAYS geom_buffer + covers
-   * approximation. A zero distance is left on the existing paths because the
-   * ever/always intersects and disjoint relationships are defined in terms of
-   * ea_dwithin(., ., 0.0); the POINT-vs-POINT and unsupported cases also fall
-   * through to the paths below. */
+   * once and project it to the always quantifier. Using the same
+   * #tpoint_linear_dwithin_geom as #tdwithin_tgeo_geo makes the always
+   * projection consistent with the temporal result by construction. This kills
+   * the ALWAYS geom_buffer + covers approximation. A zero distance is left on
+   * the existing paths because the ever/always intersects and disjoint
+   * relationships are defined in terms of ea_dwithin(., ., 0.0); the
+   * POINT-vs-POINT and unsupported cases also fall through to the paths
+   * below. */
   if (dist > 0.0 && temp->temptype == T_TGEOMPOINT &&
       temp->subtype != TINSTANT &&
       MEOS_FLAGS_GET_INTERP(temp->flags) == LINEAR &&


### PR DESCRIPTION
The ever quantifier of the within-distance relationship is the running minimum of the distance: a temporal geo is ever within a distance of a geometry exactly when the smallest distance it ever attains is at most that distance, which is the nearest approach distance.

`ea_dwithin_tgeo_geo` instead built the temporal within Boolean of the whole temporal geo and projected it, so it resolved every within-distance sub-period of every segment against every edge only for the projection to discard all of them but their existence.

The ever quantifier now reduces to the nearest approach, which the same analytic engine computes as a single running minimum, `nad_tgeo_geo` routing planar two-dimensional temporal points through `nad_tpoint_geo_analytic`. The always quantifier keeps the temporal path, where the projection is what the relationship needs.

The reduction is restricted to planar two-dimensional input on both sides, which is the condition the native path already carries: the nearest approach requires the operands to have the same dimensionality, whereas this relationship accepts a two-dimensional operand against a three-dimensional one and answers on their common dimensions. A zero distance stays on the existing paths, which the ever and always intersects and disjoint relationships are defined in terms of.

## Measurements

A hundred vessel trips against a hundred protected areas, both operands measured in the same database so that only the ratio between the temporal point and the temporal circular buffer is read:

| `eDwithin(geom, ., 100)` | temporal point | temporal circular buffer | ratio |
| --- | --- | --- | --- |
| before | 68.4 s | 12.4 s | 0.18 |
| after | 3.4 s | 13.1 s | 3.83 |

The temporal circular buffer column is the control, since this change cannot reach it, and it reads 12.4 s against 13.1 s across the two runs. The ratio moves from the temporal point being the slower of the two, which the shapes do not justify, to the temporal circular buffer costing more than the temporal point, which is what a moving disk against a moving point should cost.

## Tests

`070_tgeo_spatialrels`, `070_tpoint_spatialrels`, `072_tgeo_tempspatialrels`, `072_tpoint_tempspatialrels` and their table variants pass with no change to any expected output, so the reduction is equivalent over the whole corpus.
