### PR TITLE
Segment the tcbuffer contains and covers on the tangencies from both sides

### DIFF
--- a/meos/include/cbuffer/tcbuffer.h
+++ b/meos/include/cbuffer/tcbuffer.h
@@ -86,6 +86,8 @@ extern int tcbufferseg_touch_roots(const Cbuffer *cb1, const Cbuffer *cb2,
   const void *ctx, double *outt, int maxout);
 extern bool tcbuffer_disc_contains_ctx(const Cbuffer *cb, const void *ctx,
   bool strict);
+extern int tcbufferseg_boundary_roots(const Cbuffer *cb1, const Cbuffer *cb2,
+  const void *ctx, double *outt, int maxout);
 
 /*****************************************************************************/
 

--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -1281,20 +1281,20 @@ tcbuffer_disc_contains_ctx(const Cbuffer *cb, const void *ctxv, bool strict)
 }
 
 /**
- * @brief Append to @p outt the normalized times in (0,1) at which a linearly
- * moving disk touches the geometry
+ * @brief Append to @p outt the normalized times in (0,1) at which the signed
+ * boundary distance of a linearly moving disk vanishes, keeping only the
+ * contacts made from outside the geometry when @p outside_only is true
  * @details The candidate crossing times are the same region roots the within
  * kernel uses (#tcbuffersegm_edge_within_roots / #tcbuffersegm_arc_within_roots
  * at distance 0, where dist(centre, edge) == radius). Each is kept only when the
- * exact signed boundary distance vanishes there — a genuine tangential contact,
- * not an interior penetration where a nearer edge makes the signed minimum
- * negative, nor a spurious root of the squared equation where it stays
- * positive — and the centre is not inside a polygon. Returns the number of
- * contact times written (at most @p maxout)
+ * exact signed boundary distance vanishes there — not an interior penetration
+ * where a nearer edge makes the signed minimum negative, nor a spurious root of
+ * the squared equation where it stays positive. Returns the number of times
+ * written (at most @p maxout)
  */
-int
-tcbufferseg_touch_roots(const Cbuffer *cb1, const Cbuffer *cb2,
-  const void *ctxv, double *outt, int maxout)
+static int
+tcbufferseg_sg_roots(const Cbuffer *cb1, const Cbuffer *cb2,
+  const void *ctxv, double *outt, int maxout, bool outside_only)
 {
   const TcbufferGeoCtx *ctx = (const TcbufferGeoCtx *) ctxv;
   const POINT2D *p1 = GSERIALIZED_POINT2D_P(cbuffer_point_p(cb1));
@@ -1345,7 +1345,7 @@ tcbufferseg_touch_roots(const Cbuffer *cb1, const Cbuffer *cb2,
     double r = r1 + (r2 - r1) * t;
     bool inside;
     double sg = tcbuffer_disc_signed_boundary(cx, cy, r, &ctx->g, &inside);
-    if (! inside && fabs(sg) <= TCBUFFER_TOUCH_EPS)
+    if ((! outside_only || ! inside) && fabs(sg) <= TCBUFFER_TOUCH_EPS)
     {
       outt[nout++] = t;
       last = t;
@@ -1353,6 +1353,39 @@ tcbufferseg_touch_roots(const Cbuffer *cb1, const Cbuffer *cb2,
   }
   pfree(cand);
   return nout;
+}
+
+/**
+ * @brief Append to @p outt the normalized times in (0,1) at which a linearly
+ * moving disk touches the geometry
+ * @details A touch requires the interiors to be disjoint, so a vanishing signed
+ * boundary distance reached with the centre inside a polygon — the disk grazing
+ * the boundary from within — is not a contact and is left out. Returns the
+ * number of contact times written (at most @p maxout)
+ */
+int
+tcbufferseg_touch_roots(const Cbuffer *cb1, const Cbuffer *cb2,
+  const void *ctxv, double *outt, int maxout)
+{
+  return tcbufferseg_sg_roots(cb1, cb2, ctxv, outt, maxout, true);
+}
+
+/**
+ * @brief Append to @p outt the normalized times in (0,1) at which the disk
+ * boundary and the geometry boundary of a linearly moving disk are tangent,
+ * from either side
+ * @details These are the instants at which the geometry can start or stop
+ * containing or covering the disk, so they are the sub-interval breakpoints of
+ * the contains/covers kernels. Unlike #tcbufferseg_touch_roots this keeps the
+ * internal tangency, where the disk grazes the boundary from within and
+ * containment changes but no touch occurs. Returns the number of times written
+ * (at most @p maxout)
+ */
+int
+tcbufferseg_boundary_roots(const Cbuffer *cb1, const Cbuffer *cb2,
+  const void *ctxv, double *outt, int maxout)
+{
+  return tcbufferseg_sg_roots(cb1, cb2, ctxv, outt, maxout, false);
 }
 
 /*****************************************************************************

--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -548,7 +548,7 @@ nai_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
     return tinstant_make_free(value, temp->temptype, t);
   }
 
-  /* Curved or otherwise unsupported geometry: fall back to the centreline */
+  /* A geometry that has no edge decomposition: fall back to the centreline */
   Temporal *tpoint = tcbuffer_to_tgeompoint(temp);
   TInstant *resultgeom = nai_tgeo_geo(tpoint, gs);
   Datum value;
@@ -722,8 +722,8 @@ tcbufferseq_nad(const TSequence *seq, const GeoDistGeom *g, double *best)
 static double
 nad_tcbuffer_geo_analytic(const Temporal *temp, const GSERIALIZED *gs)
 {
-  /* Curved / unsupported geometry, or no segments: fall back to the exact
-   * traversed-area distance so the result is never wrong */
+  /* A geometry that has no edge decomposition, or no segments: fall back to
+   * the exact traversed-area distance so the result is never wrong */
   GeoDistGeom g;
   if (! geodist_geom_build(gs, &g))
   {
@@ -842,7 +842,7 @@ shortestline_tcbuffer_geo_analytic(const Temporal *temp, const GSERIALIZED *gs)
  * Temporal within relationship
  *
  * The sub-periods during which a temporal circular buffer stays within a
- * distance of a non-curved geometry, from the same swept-capsule distance
+ * distance of a geometry, from the same swept-capsule distance
  * kernel as the nearest-approach value. The candidate crossing instants are
  * the roots of dist(centre(t), edge) = radius(t) + dist per boundary edge;
  * each candidate sub-interval is classified with the exact interior-aware unit
@@ -862,9 +862,10 @@ typedef struct
 } TcbufferGeoCtx;
 
 /**
- * @brief Build the reusable geometry context for the native within kernel, or
- * return NULL for curved or unsupported geometry (the caller then uses the
- * exact traversed-area path)
+ * @brief Build the reusable geometry context for the native within kernel from
+ * the straight and circular-arc edges of the boundary, or return NULL for a
+ * geometry that has no edge decomposition, that is, a TIN or a polyhedral
+ * surface (the caller then uses the traversed-area path)
  */
 void *
 tcbuffer_geo_ctx_make(const GSERIALIZED *gs)
@@ -1936,7 +1937,8 @@ shortestline_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
   GSERIALIZED *result = shortestline_tcbuffer_geo_analytic(temp, gs);
   if (result)
     return result;
-  /* Curved or unsupported geometry: exact traversed-area shortest line */
+  /* A geometry that has no edge decomposition: exact traversed-area
+   * shortest line */
   GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
   result = geom_shortestline2d(trav, gs);
   pfree(trav);

--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -536,7 +536,8 @@ ea_contains_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp,
   bool ever)
 {
   /* Native running ever/always contains, exactly consistent with the temporal
-   * contains; curved or unsupported geometry keeps the traversed-area path. */
+   * contains; a geometry that has no edge decomposition keeps the
+   * traversed-area path. */
   int native = eacontains_tcbuffer_geo_native(temp, gs, ever, true);
   if (native >= 0)
     return native;
@@ -773,8 +774,8 @@ int
 ea_covers_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp, bool ever)
 {
   /* Native running ever/always covers (contains up to boundary tangency),
-   * exactly consistent with the temporal covers; curved or unsupported
-   * geometry keeps the traversed-area path. */
+   * exactly consistent with the temporal covers; a geometry that has no edge
+   * decomposition keeps the traversed-area path. */
   int native = eacontains_tcbuffer_geo_native(temp, gs, ever, false);
   if (native >= 0)
     return native;
@@ -1011,8 +1012,8 @@ acovers_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
  * distance: aDisjoint(temp, gs) ⟺ ¬eIntersects(temp, gs) ⟺
  * min_t dist(disk(t), gs) > 0. The ever semantics are computed from the
  * native coverage of the intersecting sub-periods: eDisjoint(temp, gs) ⟺
- * ∃t disk(t) ∩ gs = ∅. Curved or unsupported geometry falls back to the
- * exact traversed-area path.
+ * ∃t disk(t) ∩ gs = ∅. A geometry that has no edge decomposition falls back
+ * to the exact traversed-area path.
  * @param[in] temp Temporal circular buffer
  * @param[in] gs Geometry
  * @param[in] ever True for the ever semantics, false for the always semantics
@@ -1246,8 +1247,9 @@ adisjoint_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
  * distance: eIntersects(temp, gs) ⟺ min_t dist(disk(t), gs) ≤ 0. The always
  * semantics are the complement of ever disjoint: aIntersects(temp, gs) ⟺
  * ¬eDisjoint(temp, gs), computed from the native coverage of the intersecting
- * sub-periods. Both avoid linearizing the round buffer through GEOS; curved
- * or unsupported geometry falls back to the exact traversed-area path.
+ * sub-periods. Both avoid linearizing the round buffer through GEOS; a
+ * geometry that has no edge decomposition falls back to the exact
+ * traversed-area path.
  * @param[in] temp Temporal circular buffer
  * @param[in] gs Geometry
  * @param[in] ever True for the ever semantics, false for the always semantics
@@ -1488,9 +1490,9 @@ ea_touches_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
    * many-vertex disk for which the analytic distance is not a win. */
   if (nad_tcbuffer_geo(temp, gs) > 1e-6)
     return 0;
-  /* Native path for non-curved geometry: eTouches/aTouches derive from the
-   * exact boundary-contact instants, consistent with ever/always(tTouches).
-   * Curved or unsupported geometry keeps the traversed-area path. */
+  /* Native path: eTouches/aTouches derive from the exact boundary-contact
+   * instants, consistent with ever/always(tTouches). A geometry that has no
+   * edge decomposition keeps the traversed-area path. */
   int native = eatouches_tcbuffer_geo_native(temp, gs, ever);
   if (native >= 0)
     return native;
@@ -1696,8 +1698,8 @@ ea_dwithin_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs,
    * (dist(disk, gs) ≤ d ⟺ dist(disk⊕d, gs) ≤ 0), so aDwithin(temp, gs, d) ⟺
    * the buffer expanded by d always intersects the geometry ⟺ it is never
    * disjoint from it. Reuse the ever-disjoint coverage kernel on the expanded
-   * buffer; curved or unsupported geometry returns -1 and keeps the
-   * traversed-area path below. */
+   * buffer; a geometry that has no edge decomposition returns -1 and keeps
+   * the traversed-area path below. */
   Temporal *temp_exp = tcbuffer_expand(temp, dist);
   int native = edisjoint_tcbuffer_geo_native(temp_exp, gs);
   pfree(temp_exp);

--- a/meos/src/cbuffer/tcbuffer_tempspatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_tempspatialrels.c
@@ -555,9 +555,12 @@ tinterrel_tcbufferseqset_geom(const TSequenceSet *ss, const GSERIALIZED *gs,
  *
  * These mirror the traversed-area functions above but discover the
  * intersecting sub-periods from the exact swept-capsule distance kernel
- * instead of linearizing the circular buffer through GEOS. They are used for
- * every non-curved geometry; the traversed-area functions remain the fallback
- * for curved input.
+ * instead of linearizing the circular buffer through GEOS. The boundary is
+ * decomposed into straight and circular-arc edges, so they are used for curved
+ * input (circular strings, compound curves, curve polygons, and the multi
+ * types grouping them) as well; the traversed-area functions remain the
+ * fallback for a geometry that has no edge decomposition, that is, a TIN or a
+ * polyhedral surface.
  *****************************************************************************/
 
 /**
@@ -856,8 +859,8 @@ tinterrel_tcbufferseqset_geo_native(const TSequenceSet *ss, bool tinter,
  *   eDisjoint(temp, gs) ⟺ ∃t disk(t) ∩ gs = ∅ ⟺ the intersecting 
  *     sub-periods do not cover the definition time;
  *   aIntersects(temp, gs) ⟺ ¬eDisjoint(temp, gs).
- * Curved or unsupported geometry (no context) returns -1 so the caller keeps
- * the exact traversed-area path.
+ * A geometry that has no edge decomposition (no context) returns -1 so the
+ * caller keeps the exact traversed-area path.
  *****************************************************************************/
 
 /**
@@ -905,8 +908,8 @@ tcbufferseq_ever_disjoint_native(const TSequence *seq, const void *ctx)
 /**
  * @ingroup meos_internal_cbuffer_rel_ever
  * @brief Return 1 if a temporal circular buffer is ever disjoint from a
- * geometry, 0 if it always intersects, and -1 for curved or unsupported
- * geometry (the caller then uses the traversed-area path)
+ * geometry, 0 if it always intersects, and -1 for a geometry that has no edge
+ * decomposition (the caller then uses the traversed-area path)
  * @param[in] temp Temporal circular buffer
  * @param[in] gs Geometry
  */
@@ -946,8 +949,8 @@ edisjoint_tcbuffer_geo_native(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] dist Distance by which the circular buffer is expanded, used to
  * back `tdwithin`; zero for `tintersects` and `tdisjoint`
  * @details The distance is threaded to the native within kernels, which fold
- * it into the disc radius, avoiding a separate radius-expansion pass. For
- * curved geometry, which has no native kernel, the radius is expanded and the
+ * it into the disc radius, avoiding a separate radius-expansion pass. For a
+ * geometry that has no native kernel, the radius is expanded and the
  * traversed-area path is used
  */
 static Temporal *
@@ -975,8 +978,8 @@ tinterrel_tcbuffer_geo_dist(const Temporal *temp, const GSERIALIZED *gs,
       /* Computing disjoint */
       temporal_from_base_temp(BoolGetDatum(true), T_TBOOL, temp);
 
-  /* Native path for non-curved geometry; the traversed-area path
-   * remains the fallback for curved input */
+  /* Native path, straight and circular-arc edges alike; the traversed-area
+   * path remains the fallback for a geometry that has no edge decomposition */
   void *ctx = tcbuffer_geo_ctx_make(gs);
   Temporal *result = NULL;
   assert(temptype_subtype(temp->subtype));
@@ -999,8 +1002,9 @@ tinterrel_tcbuffer_geo_dist(const Temporal *temp, const GSERIALIZED *gs,
     tcbuffer_geo_ctx_free(ctx);
     return result;
   }
-  /* Curved or unsupported geometry: expand the radius by the distance (a no-op
-   * for a zero distance) and fall back to the traversed-area path */
+  /* A geometry that has no edge decomposition: expand the radius by the
+   * distance (a no-op for a zero distance) and fall back to the traversed-area
+   * path */
   const Temporal *tw = (dist > 0.0) ? tcbuffer_expand(temp, dist) : temp;
   switch (temp->subtype)
   {
@@ -1115,8 +1119,8 @@ tspatialrel_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb,
 
 /* Native temporal contains (@p strict true) / covers (@p strict false) of a
  * moving disk by a geometry, defined with the touch machinery below; returns
- * NULL for curved or unsupported geometry so the caller keeps the per-instant
- * lifting path */
+ * NULL for a geometry that has no edge decomposition so the caller keeps the
+ * per-instant lifting path */
 static Temporal *tcontains_geo_tcbuffer_native(const Temporal *temp,
   const GSERIALIZED *gs, bool strict);
 
@@ -1446,8 +1450,8 @@ tintersects_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
  * sub-period. The temporal touches Boolean is thus true exactly on the contact
  * set and false elsewhere, the moving-disk analogue of the temporal-point
  * boundary approach ttouches(tpoint, geo) = tintersects(tpoint, boundary(geo)).
- * Curved or unsupported geometry (no context) keeps the traversed-area GEOS
- * path.
+ * A geometry that has no edge decomposition (no context) keeps the
+ * traversed-area GEOS path.
  *****************************************************************************/
 
 /**
@@ -1671,7 +1675,8 @@ ttouches_tcbufferseqset_geo_native(const TSequenceSet *ss, const void *ctx)
  * stays clear of the boundary so the relation is constant and decided by the
  * interior test at a sample point. A geometry with no polygonal component
  * cannot contain a positive-radius disk, which the point-in-polygon guard makes
- * false. Curved or unsupported geometry (no context) keeps the lifting path.
+ * false. A geometry that has no edge decomposition (no context) keeps the
+ * lifting path.
  *****************************************************************************/
 
 /**
@@ -1925,7 +1930,7 @@ tcontains_tcbufferseqset_geo_native(const TSequenceSet *ss, const void *ctx,
 
 /**
  * @brief Native temporal contains/covers of a moving disk by a geometry (NULL
- * for curved or unsupported geometry so the caller falls back)
+ * for a geometry that has no edge decomposition so the caller falls back)
  */
 static Temporal *
 tcontains_geo_tcbuffer_native(const Temporal *temp, const GSERIALIZED *gs,
@@ -1976,8 +1981,8 @@ tcontains_geo_tcbuffer_native(const Temporal *temp, const GSERIALIZED *gs,
  * eTouches scans the instants and segment contact roots with early exit on the
  * first contact; aTouches tests whether the contact sub-periods cover the whole
  * definition time (true only in degenerate always-tangent configurations).
- * Curved or unsupported geometry (no context) returns -1 so the caller keeps
- * the traversed-area path.
+ * A geometry that has no edge decomposition (no context) returns -1 so the
+ * caller keeps the traversed-area path.
  *****************************************************************************/
 
 /**
@@ -2037,8 +2042,8 @@ tcbufferseq_always_touches_native(const TSequence *seq, const void *ctx)
 /**
  * @ingroup meos_internal_cbuffer_rel_ever
  * @brief Return 1 if a temporal circular buffer ever/always touches a geometry,
- * 0 if not, and -1 for curved or unsupported geometry (the caller then uses the
- * traversed-area path)
+ * 0 if not, and -1 for a geometry that has no edge decomposition (the caller
+ * then uses the traversed-area path)
  * @param[in] temp Temporal circular buffer
  * @param[in] gs Geometry
  * @param[in] ever True for the ever semantics, false for the always semantics
@@ -2189,8 +2194,8 @@ tcbufferseq_always_contains_native(const TSequence *seq, const void *ctx,
 /**
  * @ingroup meos_internal_cbuffer_rel_ever
  * @brief Return 1 if a geometry ever/always contains (@p strict) or covers a
- * temporal circular buffer, 0 if not, and -1 for curved or unsupported geometry
- * (the caller then uses the traversed-area path)
+ * temporal circular buffer, 0 if not, and -1 for a geometry that has no edge
+ * decomposition (the caller then uses the traversed-area path)
  * @param[in] temp Temporal circular buffer
  * @param[in] gs Geometry
  * @param[in] ever True for the ever semantics, false for the always semantics
@@ -2270,8 +2275,9 @@ ttouches_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
   if (! overlaps_stbox_stbox(&box1, &box2))
     return temporal_from_base_temp(BoolGetDatum(false), T_TBOOL, temp);
 
-  /* Native path for non-curved geometry: the moving-disk boundary contact 
-   * instants. Curved or unsupported geometry keeps the traversed-area path. */
+  /* Native path: the moving-disk boundary contact instants, for straight and
+   * circular-arc edges alike. A geometry that has no edge decomposition keeps
+   * the traversed-area path. */
   void *ctx = tcbuffer_geo_ctx_make(gs);
   if (! ctx)
     return tspatialrel_tcbuffer_geo(temp, gs, INVERT_NO, &datum_cbuffer_touches);

--- a/meos/src/cbuffer/tcbuffer_tempspatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_tempspatialrels.c
@@ -1787,9 +1787,12 @@ tcbufferseq_contains_spanset(const TSequence *seq, const void *ctx, bool strict)
     }
     return ss;
   }
-  /* Linear: the relation is constant between consecutive sg = 0 (touch) roots.
-   * Union each vertex/root instant where it holds and each open sub-interval
-   * whose interpolated midpoint satisfies it; the spanset union normalizes the
+  /* Linear: the relation is constant between consecutive sg = 0 roots, taken
+   * from either side of the boundary — containment changes at the internal
+   * tangency just as it does at the external one, so the touch roots alone
+   * would miss the instant the disk starts poking out of the geometry. Union
+   * each vertex/root instant where it holds and each open sub-interval whose
+   * interpolated midpoint satisfies it; the spanset union normalizes the
    * endpoint inclusivity, preserving an isolated tangency (covers) or a grazing
    * hole (contains). */
   int maxo = tcbuffer_geo_ctx_nsegs(ctx) + 2;
@@ -1804,7 +1807,7 @@ tcbufferseq_contains_spanset(const TSequence *seq, const void *ctx, bool strict)
     const Cbuffer *cb1 = DatumGetCbufferP(tinstant_value_p(inst1));
     const Cbuffer *cb2 = DatumGetCbufferP(tinstant_value_p(inst2));
     double dur = (double) (inst2->t - inst1->t);
-    int nr = tcbufferseg_touch_roots(cb1, cb2, ctx, rt, maxo);
+    int nr = tcbufferseg_boundary_roots(cb1, cb2, ctx, rt, maxo);
     /* Sort the roots ascending (insertion sort; nr is small) */
     for (int a = 1; a < nr; a++)
     {
@@ -2127,7 +2130,7 @@ tcbufferseq_ever_contains_native(const TSequence *seq, const void *ctx,
     const TInstant *inst2 = TSEQUENCE_INST_N(seq, i);
     const Cbuffer *cb1 = DatumGetCbufferP(tinstant_value_p(inst1));
     const Cbuffer *cb2 = DatumGetCbufferP(tinstant_value_p(inst2));
-    int nr = tcbufferseg_touch_roots(cb1, cb2, ctx, rt, maxo);
+    int nr = tcbufferseg_boundary_roots(cb1, cb2, ctx, rt, maxo);
     for (int a = 1; a < nr; a++)
     {
       double v = rt[a];

--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -312,9 +312,11 @@ geodist_segs_add_curvepoly_ring(const LWGEOM *ring, bool allow_arc,
 }
 
 /**
- * @brief Recursively collect the boundary segments of a geometry. Returns
- * false for a curved type that cannot be decomposed exactly (the caller
- * then falls back to the exact traversed-area path).
+ * @brief Recursively collect the boundary segments of a geometry, as straight
+ * edges and, when @p allow_arc is true, as circular-arc edges. Returns false
+ * for a type that has no exact edge decomposition, that is, a TIN or a
+ * polyhedral surface, and for a circular-arc type when @p allow_arc is false
+ * (the caller then falls back to the exact traversed-area path).
  */
 bool
 geodist_geom_edges(const LWGEOM *lw, bool allow_arc, GeoDistEdge **arr, int *cap,
@@ -388,7 +390,8 @@ geodist_geom_edges(const LWGEOM *lw, bool allow_arc, GeoDistEdge **arr, int *cap
       return true;
     }
     default:
-      /* Curved or unsupported type: let the caller use the exact path */
+      /* A type with no edge decomposition, that is, a TIN or a polyhedral
+       * surface: let the caller use the exact path */
       return false;
   }
 }

--- a/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels.test.out
@@ -70,6 +70,30 @@ SELECT eContains(tcbuffer '[Cbuffer(Point(1 4),0.5)@2000-01-01, Cbuffer(Point(4 
  t
 (1 row)
 
+SELECT eContains(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT aContains(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
+ acontains 
+-----------
+ f
+(1 row)
+
+SELECT aContains(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]');
+ acontains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer 'Cbuffer(Point(4.5 0),0.5)@2000-01-01');
+ econtains 
+-----------
+ f
+(1 row)
+
 SELECT eContains(tcbuffer 'Cbuffer(Point(1 1),1)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
  econtains 
 -----------
@@ -145,6 +169,24 @@ SELECT eCovers(tcbuffer '[Cbuffer(Point(1 1),1)@2000-01-01, Cbuffer(Point(2 2),1
  t
 (1 row)
 
+SELECT eCovers(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer 'Cbuffer(Point(4.5 0),0.5)@2000-01-01');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT eCovers(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT aCovers(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]');
+ acovers 
+---------
+ t
+(1 row)
+
 /* Errors */
 SELECT eCovers(tcbuffer 'Cbuffer(Point(1 1),1)@2000-01-01', geometry 'SRID=3812;Point(1 1)');
 ERROR:  Operation on mixed SRID
@@ -192,6 +234,30 @@ SELECT eDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 
 
 SELECT eDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}',  cbuffer 'Cbuffer(Point(1 1),0.5)');
  edisjoint 
+-----------
+ t
+(1 row)
+
+SELECT eDisjoint(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
+ edisjoint 
+-----------
+ t
+(1 row)
+
+SELECT eDisjoint(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]');
+ edisjoint 
+-----------
+ f
+(1 row)
+
+SELECT aDisjoint(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(8 0),0.5)@2000-01-01, Cbuffer(Point(8 8),0.5)@2000-01-03]');
+ adisjoint 
+-----------
+ t
+(1 row)
+
+SELECT aDisjoint(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Point(5 -3),0.5)@2000-01-01, Cbuffer(Point(5 -1),0.5)@2000-01-03]');
+ adisjoint 
 -----------
  t
 (1 row)
@@ -345,6 +411,48 @@ SELECT eIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point
  t
 (1 row)
 
+SELECT eIntersects(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Point(8 6),2.5)@2000-01-01, Cbuffer(Point(4 3),2.5)@2000-01-03]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Point(5 -3),0.5)@2000-01-01, Cbuffer(Point(5 -1),0.5)@2000-01-03]');
+ eintersects 
+-------------
+ f
+(1 row)
+
+SELECT eIntersects(geometry 'CompoundCurve(CircularString(5 0, 4 3, 0 5),(0 5, -4 5))', tcbuffer '[Cbuffer(Point(-2 8),0.5)@2000-01-01, Cbuffer(Point(-2 4),0.5)@2000-01-03]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(geometry 'MultiCurve(CircularString(5 0, 4 3, 0 5),(0 5, -4 5))', tcbuffer '[Cbuffer(Point(8 6),2.5)@2000-01-01, Cbuffer(Point(4 3),2.5)@2000-01-03]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(geometry 'MultiSurface(CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0)))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT aIntersects(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]');
+ aintersects 
+-------------
+ t
+(1 row)
+
+SELECT aIntersects(tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]', geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))');
+ aintersects 
+-------------
+ f
+(1 row)
+
 /* Errors */
 SELECT eIntersects(geometry 'SRID=3812;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
 ERROR:  Operation on mixed SRID
@@ -428,6 +536,30 @@ SELECT eTouches(tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(1 0
  etouches 
 ----------
  t
+(1 row)
+
+SELECT eTouches(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer 'Cbuffer(Point(6 0),1)@2000-01-01');
+ etouches 
+----------
+ t
+(1 row)
+
+SELECT eTouches(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(10 0),1)@2000-01-01, Cbuffer(Point(0 0),1)@2000-01-03]');
+ etouches 
+----------
+ t
+(1 row)
+
+SELECT aTouches(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer 'Cbuffer(Point(6 0),1)@2000-01-01');
+ atouches 
+----------
+ t
+(1 row)
+
+SELECT eTouches(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(10 0),1)@2000-01-01, Cbuffer(Point(10 10),1)@2000-01-03]');
+ etouches 
+----------
+ f
 (1 row)
 
 /* Errors */
@@ -607,6 +739,30 @@ SELECT eDwithin(tcbuffer 'Interp=Step;{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuf
  edwithin 
 ----------
  t
+(1 row)
+
+SELECT eDwithin(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Point(8 6),0.5)@2000-01-01, Cbuffer(Point(4 3),0.5)@2000-01-03]', 2);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Point(5 -3),0.5)@2000-01-01, Cbuffer(Point(5 -1),0.5)@2000-01-03]', 0.3);
+ edwithin 
+----------
+ f
+(1 row)
+
+SELECT aDwithin(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]', 1);
+ adwithin 
+----------
+ t
+(1 row)
+
+SELECT aDwithin(tcbuffer '[Cbuffer(Point(8 0),0.5)@2000-01-01, Cbuffer(Point(8 8),0.5)@2000-01-03]', geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', 1);
+ adwithin 
+----------
+ f
 (1 row)
 
 /* Errors */

--- a/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels.test.out
@@ -70,6 +70,24 @@ SELECT eContains(tcbuffer '[Cbuffer(Point(1 4),0.5)@2000-01-01, Cbuffer(Point(4 
  t
 (1 row)
 
+SELECT eContains(geometry 'Polygon((-5 -5,-5 5,5 5,5 -5,-5 -5),(-1 -1,-1 1,1 1,1 -1,-1 -1))', tcbuffer '[Cbuffer(Point(-3 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT aContains(geometry 'Polygon((-5 -5,-5 5,5 5,5 -5,-5 -5),(-1 -1,-1 1,1 1,1 -1,-1 -1))', tcbuffer '[Cbuffer(Point(-3 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]');
+ acontains 
+-----------
+ f
+(1 row)
+
+SELECT eContains(geometry 'Polygon((-5 -5,-5 5,5 5,5 -5,-5 -5))', tcbuffer '[Cbuffer(Point(-8 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
+ econtains 
+-----------
+ t
+(1 row)
+
 SELECT eContains(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
  econtains 
 -----------

--- a/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels.test.out
@@ -64,6 +64,24 @@ SELECT tContains(geometry 'Linestring(1 1,2 2)', tcbuffer '[Cbuffer(Point(1 1),0
  [f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]
 (1 row)
 
+SELECT tContains(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]');
+                             tcontains                              
+--------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tContains(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer 'Cbuffer(Point(4.5 0),0.5)@2000-01-01');
+           tcontains            
+--------------------------------
+ f@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tContains(geometry 'MultiSurface(CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0)))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]');
+                             tcontains                              
+--------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 /* Errors */
 SELECT tContains(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
 ERROR:  Operation on mixed SRID
@@ -223,6 +241,36 @@ SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2
  tdisjoint 
 -----------
  
+(1 row)
+
+SELECT tDisjoint(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Point(8 6),2.5)@2000-01-01, Cbuffer(Point(4 3),2.5)@2000-01-03]');
+                                             tdisjoint                                              
+----------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tDisjoint(tcbuffer '[Cbuffer(Point(4 3),2.5)@2000-01-01, Cbuffer(Point(8 6),2.5)@2000-01-03]', geometry 'CircularString(5 0, 4 3, 0 5)');
+                                                              tdisjoint                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST], (t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tDisjoint(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Point(5 -3),0.5)@2000-01-01, Cbuffer(Point(5 -1),0.5)@2000-01-03]');
+                            tdisjoint                             
+------------------------------------------------------------------
+ [t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
+SELECT tDisjoint(geometry 'CompoundCurve(CircularString(5 0, 4 3, 0 5),(0 5, -4 5))', tcbuffer '[Cbuffer(Point(-2 8),0.5)@2000-01-01, Cbuffer(Point(-2 4),0.5)@2000-01-03]');
+                                                                              tdisjoint                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 06:00:00 2000 PST, f@Sun Jan 02 18:00:00 2000 PST], (t@Sun Jan 02 18:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tDisjoint(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
+                                                              tdisjoint                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 09:00:00 2000 PST], (t@Sun Jan 02 09:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
 (1 row)
 
 /* Errors */
@@ -444,6 +492,18 @@ SELECT tIntersects(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5
  {[t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 09:00:00 2000 PST], (f@Sun Jan 02 09:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
 (1 row)
 
+SELECT tIntersects(geometry 'MultiCurve(CircularString(5 0, 4 3, 0 5),(0 5, -4 5))', tcbuffer '[Cbuffer(Point(8 6),2.5)@2000-01-01, Cbuffer(Point(4 3),2.5)@2000-01-03]');
+                                            tintersects                                             
+----------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tIntersects(geometry 'MultiSurface(CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0)))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
+                                                             tintersects                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 09:00:00 2000 PST], (f@Sun Jan 02 09:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer 'Cbuffer(Point(2 2),0.5)@2000-01-02');
  tintersects 
 -------------
@@ -601,6 +661,24 @@ SELECT tTouches(geometry 'Linestring(1 1,2 2)', tcbuffer '[Cbuffer(Point(1 1),0.
                              ttouches                             
 ------------------------------------------------------------------
  [f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]
+(1 row)
+
+SELECT tTouches(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(10 0),1)@2000-01-01, Cbuffer(Point(0 0),1)@2000-01-03]');
+                                                               ttouches                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 19:12:00 2000 PST], (f@Sat Jan 01 19:12:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tTouches(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(10 0),1)@2000-01-01, Cbuffer(Point(10 10),1)@2000-01-03]');
+                             ttouches                             
+------------------------------------------------------------------
+ [f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
+SELECT tTouches(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Point(10 0),1)@2000-01-01, Cbuffer(Point(0 0),1)@2000-01-03]');
+                                                                                                ttouches                                                                                                
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 19:12:00 2000 PST], (f@Sat Jan 01 19:12:00 2000 PST, t@Sun Jan 02 04:48:00 2000 PST], (f@Sun Jan 02 04:48:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
 (1 row)
 
 /* Errors */

--- a/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels.test.out
@@ -64,10 +64,40 @@ SELECT tContains(geometry 'Linestring(1 1,2 2)', tcbuffer '[Cbuffer(Point(1 1),0
  [f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]
 (1 row)
 
+SELECT tContains(geometry 'Polygon((-5 -5,-5 5,5 5,5 -5,-5 -5))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
+                                             tcontains                                              
+----------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 03:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tContains(geometry 'Polygon((-5 -5,-5 5,5 5,5 -5,-5 -5))', tcbuffer '[Cbuffer(Point(8 0),0.5)@2000-01-01, Cbuffer(Point(0 0),0.5)@2000-01-03]');
+                                                              tcontains                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 21:00:00 2000 PST], (t@Sat Jan 01 21:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tContains(geometry 'Polygon((-5 -5,-5 5,5 5,5 -5,-5 -5),(-1 -1,-1 1,1 1,1 -1,-1 -1))', tcbuffer '[Cbuffer(Point(-3 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]');
+                                                                              tcontains                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 12:00:00 2000 PST, f@Sun Jan 02 12:00:00 2000 PST], (t@Sun Jan 02 12:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tCovers(geometry 'Polygon((-5 -5,-5 5,5 5,5 -5,-5 -5),(-1 -1,-1 1,1 1,1 -1,-1 -1))', tcbuffer '[Cbuffer(Point(-3 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]');
+                                                                               tcovers                                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 12:00:00 2000 PST], (f@Sat Jan 01 12:00:00 2000 PST, t@Sun Jan 02 12:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tContains(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]');
                              tcontains                              
 --------------------------------------------------------------------
  {[t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tContains(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
+                                             tcontains                                              
+----------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 03:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
 (1 row)
 
 SELECT tContains(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer 'Cbuffer(Point(4.5 0),0.5)@2000-01-01');
@@ -80,6 +110,12 @@ SELECT tContains(geometry 'MultiSurface(CurvePolygon(CircularString(5 0, 0 5, -5
                              tcontains                              
 --------------------------------------------------------------------
  {[t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tContains(geometry 'MultiSurface(CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0)))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
+                                             tcontains                                              
+----------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 03:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
 (1 row)
 
 /* Errors */

--- a/mobilitydb/test/cbuffer/queries/212_tcbuffer_spatialrels.test.sql
+++ b/mobilitydb/test/cbuffer/queries/212_tcbuffer_spatialrels.test.sql
@@ -46,6 +46,15 @@ SELECT eContains(tcbuffer '[Cbuffer(Point(4 2),0.5)@2000-01-01, Cbuffer(Point(2 
 SELECT eContains(tcbuffer '[Cbuffer(Point(0 1),0.5)@2000-01-01, Cbuffer(Point(4 1),0.5)@2000-01-02]', geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))');
 SELECT eContains(tcbuffer '[Cbuffer(Point(1 4),0.5)@2000-01-01, Cbuffer(Point(4 1),0.5)@2000-01-02]', geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))');
 
+-- Curve polygon (arc ring) input, native arc-exact; the ring is the circle of
+-- centre (0,0) and radius 5. The disc starts strictly inside and leaves it
+SELECT eContains(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
+SELECT aContains(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
+-- The disc stays strictly inside the ring
+SELECT aContains(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]');
+-- Internally tangent disc: covered by the ring but not strictly contained
+SELECT eContains(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer 'Cbuffer(Point(4.5 0),0.5)@2000-01-01');
+
 SELECT eContains(tcbuffer 'Cbuffer(Point(1 1),1)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
 SELECT eContains(tcbuffer '[Cbuffer(Point(1 1),1)@2000-01-01, Cbuffer(Point(2 2),1)@2000-01-02]', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02]');
 
@@ -69,6 +78,13 @@ SELECT eCovers(tcbuffer '{[Cbuffer(Point(1 1),1)@2000-01-01, Cbuffer(Point(2 2),
 SELECT eCovers(tcbuffer 'Cbuffer(Point(1 1),1)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
 SELECT eCovers(tcbuffer '[Cbuffer(Point(1 1),1)@2000-01-01, Cbuffer(Point(2 2),1)@2000-01-02]', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02]');
 
+-- Curve polygon (arc ring) input, native arc-exact; the ring is the circle of
+-- centre (0,0) and radius 5. The internally tangent disc is covered but not
+-- strictly contained, unlike the eContains case above
+SELECT eCovers(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer 'Cbuffer(Point(4.5 0),0.5)@2000-01-01');
+SELECT eCovers(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
+SELECT aCovers(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]');
+
 /* Errors */
 SELECT eCovers(tcbuffer 'Cbuffer(Point(1 1),1)@2000-01-01', geometry 'SRID=3812;Point(1 1)');
 
@@ -85,6 +101,16 @@ SELECT eDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01',  cbuffer 'Cbuffe
 SELECT eDisjoint(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}',  cbuffer 'Cbuffer(Point(1 1),0.5)');
 SELECT eDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]',  cbuffer 'Cbuffer(Point(1 1),0.5)');
 SELECT eDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}',  cbuffer 'Cbuffer(Point(1 1),0.5)');
+
+-- Curved input, native arc-exact; the curve polygon ring is the circle of
+-- centre (0,0) and radius 5. The disc starts inside the ring and exits it
+SELECT eDisjoint(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
+-- The disc stays inside the ring
+SELECT eDisjoint(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]');
+-- The disc stays outside the ring
+SELECT aDisjoint(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(8 0),0.5)@2000-01-01, Cbuffer(Point(8 8),0.5)@2000-01-03]');
+-- Circular arc, off-span: the disc meets the full circle but not the arc
+SELECT aDisjoint(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Point(5 -3),0.5)@2000-01-01, Cbuffer(Point(5 -1),0.5)@2000-01-03]');
 
 /* Errors */
 SELECT eDisjoint(geometry 'SRID=3812;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
@@ -135,6 +161,21 @@ SELECT eIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(
 SELECT eIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
 SELECT eIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
 
+------------------------
+-- Curved geometry input (native arc-exact)
+------------------------
+-- Arc centre (0,0) radius 5, upper-right quadrant
+SELECT eIntersects(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Point(8 6),2.5)@2000-01-01, Cbuffer(Point(4 3),2.5)@2000-01-03]');
+-- Off-span: the disc meets the full circle but not the arc (angular gating)
+SELECT eIntersects(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Point(5 -3),0.5)@2000-01-01, Cbuffer(Point(5 -1),0.5)@2000-01-03]');
+-- Compound curve (arc chained to a line) and the multi types grouping them
+SELECT eIntersects(geometry 'CompoundCurve(CircularString(5 0, 4 3, 0 5),(0 5, -4 5))', tcbuffer '[Cbuffer(Point(-2 8),0.5)@2000-01-01, Cbuffer(Point(-2 4),0.5)@2000-01-03]');
+SELECT eIntersects(geometry 'MultiCurve(CircularString(5 0, 4 3, 0 5),(0 5, -4 5))', tcbuffer '[Cbuffer(Point(8 6),2.5)@2000-01-01, Cbuffer(Point(4 3),2.5)@2000-01-03]');
+SELECT eIntersects(geometry 'MultiSurface(CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0)))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
+-- The disc stays inside the curve polygon ring
+SELECT aIntersects(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]');
+SELECT aIntersects(tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]', geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))');
+
 /* Errors */
 SELECT eIntersects(geometry 'SRID=3812;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
 SELECT eIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=3812;Point(1 1)');
@@ -161,6 +202,15 @@ SELECT eTouches(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 
 -- tcbuffer x tcbuffer (circles touch when distance between centers = sum of radii)
 SELECT eTouches(tcbuffer 'Cbuffer(Point(0 0),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 0),0.5)@2000-01-01');
 SELECT eTouches(tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(1 0),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(1 0),0.5)@2000-01-01, Cbuffer(Point(2 0),0.5)@2000-01-02]');
+
+-- Curve polygon (arc ring) input, native arc-exact; the ring is the circle of
+-- centre (0,0) and radius 5. The disc of radius 1 is externally tangent to the
+-- ring when its centre is at distance 6
+SELECT eTouches(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer 'Cbuffer(Point(6 0),1)@2000-01-01');
+SELECT eTouches(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(10 0),1)@2000-01-01, Cbuffer(Point(0 0),1)@2000-01-03]');
+SELECT aTouches(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer 'Cbuffer(Point(6 0),1)@2000-01-01');
+-- The disc stays away from the ring
+SELECT eTouches(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(10 0),1)@2000-01-01, Cbuffer(Point(10 10),1)@2000-01-03]');
 
 /* Errors */
 SELECT eTouches(geometry 'SRID=3812;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
@@ -208,6 +258,15 @@ SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-02, Cbuffer(Point(2 
 
 -- Step interpolation
 SELECT eDwithin(tcbuffer 'Interp=Step;{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', tcbuffer 'Interp=Step;{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', 2);
+
+-- Curved input (native arc-exact); arc centre (0,0) radius 5, upper-right
+-- quadrant. The distance is folded into the disc radius by the same kernel
+SELECT eDwithin(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Point(8 6),0.5)@2000-01-01, Cbuffer(Point(4 3),0.5)@2000-01-03]', 2);
+-- Off-span: within the full circle but not the arc (angular gating)
+SELECT eDwithin(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Point(5 -3),0.5)@2000-01-01, Cbuffer(Point(5 -1),0.5)@2000-01-03]', 0.3);
+-- The disc stays inside the curve polygon ring, hence within any distance
+SELECT aDwithin(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]', 1);
+SELECT aDwithin(tcbuffer '[Cbuffer(Point(8 0),0.5)@2000-01-01, Cbuffer(Point(8 8),0.5)@2000-01-03]', geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', 1);
 
 /* Errors */
 SELECT eDwithin(geometry 'SRID=3812;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);

--- a/mobilitydb/test/cbuffer/queries/212_tcbuffer_spatialrels.test.sql
+++ b/mobilitydb/test/cbuffer/queries/212_tcbuffer_spatialrels.test.sql
@@ -46,6 +46,14 @@ SELECT eContains(tcbuffer '[Cbuffer(Point(4 2),0.5)@2000-01-01, Cbuffer(Point(2 
 SELECT eContains(tcbuffer '[Cbuffer(Point(0 1),0.5)@2000-01-01, Cbuffer(Point(4 1),0.5)@2000-01-02]', geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))');
 SELECT eContains(tcbuffer '[Cbuffer(Point(1 4),0.5)@2000-01-01, Cbuffer(Point(4 1),0.5)@2000-01-02]', geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))');
 
+-- A hole the disc passes over: it is contained on both sides of the hole, so
+-- the ever semantics hold and the always semantics do not, both decided at
+-- internal tangencies where the disc starts and stops overlapping the hole
+SELECT eContains(geometry 'Polygon((-5 -5,-5 5,5 5,5 -5,-5 -5),(-1 -1,-1 1,1 1,1 -1,-1 -1))', tcbuffer '[Cbuffer(Point(-3 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]');
+SELECT aContains(geometry 'Polygon((-5 -5,-5 5,5 5,5 -5,-5 -5),(-1 -1,-1 1,1 1,1 -1,-1 -1))', tcbuffer '[Cbuffer(Point(-3 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]');
+-- The disc is contained only strictly inside the segment, at no vertex
+SELECT eContains(geometry 'Polygon((-5 -5,-5 5,5 5,5 -5,-5 -5))', tcbuffer '[Cbuffer(Point(-8 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
+
 -- Curve polygon (arc ring) input, native arc-exact; the ring is the circle of
 -- centre (0,0) and radius 5. The disc starts strictly inside and leaves it
 SELECT eContains(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');

--- a/mobilitydb/test/cbuffer/queries/214_tcbuffer_tempspatialrels.test.sql
+++ b/mobilitydb/test/cbuffer/queries/214_tcbuffer_tempspatialrels.test.sql
@@ -47,6 +47,14 @@ SELECT tContains(geometry 'Point empty', tcbuffer '{[Cbuffer(Point(1 1),0.5)@200
 
 SELECT tContains(geometry 'Linestring(1 1,2 2)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02]');
 
+-- Curve polygon (arc ring) input, native arc-exact; the ring is the circle of
+-- centre (0,0) and radius 5. The disc stays strictly inside the ring
+SELECT tContains(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]');
+-- Internally tangent disc: covered by the ring but not strictly contained
+SELECT tContains(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer 'Cbuffer(Point(4.5 0),0.5)@2000-01-01');
+-- Multi surface grouping the same curve polygon
+SELECT tContains(geometry 'MultiSurface(CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0)))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]');
+
 /* Errors */
 SELECT tContains(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
 SELECT tContains(geometry 'Point(1 1)', tcbuffer 'SRID=5676;Cbuffer(Point(1 1),0.5)@2000-01-01');
@@ -88,6 +96,17 @@ SELECT tDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'Point 
 SELECT tDisjoint(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', geometry 'Point empty');
 SELECT tDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', geometry 'Point empty');
 SELECT tDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point empty');
+
+-- Circular arc input (native arc-exact); arc centre (0,0) radius 5, upper-right
+-- quadrant. Complement of the corresponding tIntersects cases below
+SELECT tDisjoint(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Point(8 6),2.5)@2000-01-01, Cbuffer(Point(4 3),2.5)@2000-01-03]');
+SELECT tDisjoint(tcbuffer '[Cbuffer(Point(4 3),2.5)@2000-01-01, Cbuffer(Point(8 6),2.5)@2000-01-03]', geometry 'CircularString(5 0, 4 3, 0 5)');
+-- Off-span: the disc meets the full circle but not the arc (angular gating)
+SELECT tDisjoint(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Point(5 -3),0.5)@2000-01-01, Cbuffer(Point(5 -1),0.5)@2000-01-03]');
+-- Compound curve (arc chained to a line)
+SELECT tDisjoint(geometry 'CompoundCurve(CircularString(5 0, 4 3, 0 5),(0 5, -4 5))', tcbuffer '[Cbuffer(Point(-2 8),0.5)@2000-01-01, Cbuffer(Point(-2 4),0.5)@2000-01-03]');
+-- Curve polygon (arc ring): the disc starts inside the ring and exits it
+SELECT tDisjoint(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
 
 /* Errors */
 SELECT tDisjoint(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
@@ -148,6 +167,9 @@ SELECT tIntersects(geometry 'CompoundCurve(CircularString(5 0, 4 3, 0 5),(0 5, -
 SELECT tIntersects(geometry 'CompoundCurve(CircularString(5 0, 4 3, 0 5),(0 5, -4 5))', tcbuffer '[Cbuffer(Point(-2 8),0.5)@2000-01-01, Cbuffer(Point(-2 4),0.5)@2000-01-03]');
 -- Curve polygon (arc ring): the disc starts inside the ring and exits it
 SELECT tIntersects(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
+-- Multi curve and multi surface grouping the same arc components
+SELECT tIntersects(geometry 'MultiCurve(CircularString(5 0, 4 3, 0 5),(0 5, -4 5))', tcbuffer '[Cbuffer(Point(8 6),2.5)@2000-01-01, Cbuffer(Point(4 3),2.5)@2000-01-03]');
+SELECT tIntersects(geometry 'MultiSurface(CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0)))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
 
 -- Coverage
 SELECT tIntersects(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-03}', tcbuffer 'Cbuffer(Point(2 2),0.5)@2000-01-02');
@@ -196,6 +218,15 @@ SELECT tTouches(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2
 SELECT tTouches(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03], [Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', geometry 'Point empty');
 
 SELECT tTouches(geometry 'Linestring(1 1,2 2)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02]');
+
+-- Curve polygon (arc ring) input, native arc-exact; the ring is the circle of
+-- centre (0,0) and radius 5. The disc of radius 1 comes from outside and is
+-- externally tangent to the ring at the instant its centre is at distance 6
+SELECT tTouches(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(10 0),1)@2000-01-01, Cbuffer(Point(0 0),1)@2000-01-03]');
+-- The disc stays outside the ring and never reaches it
+SELECT tTouches(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(10 0),1)@2000-01-01, Cbuffer(Point(10 10),1)@2000-01-03]');
+-- Circular arc (a curve, not a region): the disc grazes the arc
+SELECT tTouches(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Point(10 0),1)@2000-01-01, Cbuffer(Point(0 0),1)@2000-01-03]');
 
 /* Errors */
 SELECT tTouches(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');

--- a/mobilitydb/test/cbuffer/queries/214_tcbuffer_tempspatialrels.test.sql
+++ b/mobilitydb/test/cbuffer/queries/214_tcbuffer_tempspatialrels.test.sql
@@ -47,13 +47,26 @@ SELECT tContains(geometry 'Point empty', tcbuffer '{[Cbuffer(Point(1 1),0.5)@200
 
 SELECT tContains(geometry 'Linestring(1 1,2 2)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02]');
 
+-- The disc leaves the geometry: containment stops at the internal tangency,
+-- when the disc starts poking out, not at the later external tangency where it
+-- stops intersecting
+SELECT tContains(geometry 'Polygon((-5 -5,-5 5,5 5,5 -5,-5 -5))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
+SELECT tContains(geometry 'Polygon((-5 -5,-5 5,5 5,5 -5,-5 -5))', tcbuffer '[Cbuffer(Point(8 0),0.5)@2000-01-01, Cbuffer(Point(0 0),0.5)@2000-01-03]');
+-- A hole the disc passes over: contained on both sides, not while it overlaps
+-- the hole, so containment starts and stops at internal tangencies only
+SELECT tContains(geometry 'Polygon((-5 -5,-5 5,5 5,5 -5,-5 -5),(-1 -1,-1 1,1 1,1 -1,-1 -1))', tcbuffer '[Cbuffer(Point(-3 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]');
+SELECT tCovers(geometry 'Polygon((-5 -5,-5 5,5 5,5 -5,-5 -5),(-1 -1,-1 1,1 1,1 -1,-1 -1))', tcbuffer '[Cbuffer(Point(-3 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]');
+
 -- Curve polygon (arc ring) input, native arc-exact; the ring is the circle of
 -- centre (0,0) and radius 5. The disc stays strictly inside the ring
 SELECT tContains(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]');
+-- The disc leaves the arc ring at the internal tangency
+SELECT tContains(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
 -- Internally tangent disc: covered by the ring but not strictly contained
 SELECT tContains(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer 'Cbuffer(Point(4.5 0),0.5)@2000-01-01');
 -- Multi surface grouping the same curve polygon
 SELECT tContains(geometry 'MultiSurface(CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0)))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]');
+SELECT tContains(geometry 'MultiSurface(CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0)))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
 
 /* Errors */
 SELECT tContains(geometry 'SRID=5676;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');


### PR DESCRIPTION
The native contains and covers kernels partition each segment at the instants where the signed boundary distance of the moving disk vanishes, and classify every sub-interval by its midpoint. They take those instants from `tcbufferseg_touch_roots`, which by definition excludes a tangency reached with the centre inside the geometry, since a touch requires the interiors to be disjoint.

That excluded instant is exactly the one at which the disk starts poking out of the geometry, so it never becomes a breakpoint: the sub-interval spanning it is classified by a midpoint still deep inside, and the relationship therefore holds until the disk has left the geometry altogether.

A disk of radius 0.5 leaving a square of side 10 through an edge counts as contained until its centre reaches distance 5.5 from the centre of the square, the instant it stops intersecting, rather than distance 4.5, the instant it stops being contained:

```
valueAtTimestamp(tContains(Polygon((-5 -5,-5 5,5 5,5 -5,-5 -5)),
  [Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]),
  '2000-01-02 06:00')                                      -> t
valueAtTimestamp(<the same tcbuffer>, '2000-01-02 06:00')  -> Cbuffer(Point(5 0),0.5)
eContains(<the same polygon>, Cbuffer(Point(5 0),0.5)@..)  -> f
ST_Contains(<the same polygon>, ST_Buffer(Point(5 0),0.5)) -> f
```

This splits the root search into a general one, which keeps every vanishing signed boundary distance, and the touch one, which keeps those reached from outside, and gives the contains and covers kernels the general roots. The temporal contains and covers and their ever and always variants change value at the internal tangency as well.

Candidate generation and its pruning stay as they are, since the signed boundary distance already gets computed for every candidate and the filter only decides whether to keep it. The added cost sits downstream, in up to twice as many sub-intervals to classify per segment.

## Tests

The reversed trajectory is the discriminating case, since the two readings predict different instants: containment stops at distance 4.5 rather than 5.5, and starts at 4.5 rather than 5.5 on the way in. A polygon with a hole the disk passes over is contained on both sides of the hole rather than throughout, and covers includes the two tangency instants that contains excludes.

No existing expected output changes, on either the literal or the table tests.
