### PR TITLE
Generate the tcbuffer disjoint and intersects spatial relationships

### DIFF
--- a/mobilitydb/src/cbuffer/tcbuffer_spatialrels.c
+++ b/mobilitydb/src/cbuffer/tcbuffer_spatialrels.c
@@ -386,6 +386,9 @@ Acovers_tcbuffer_tcbuffer(PG_FUNCTION_ARGS)
     ALWAYS);
 }
 /* GENERATED-SPATIALRELS-END cbuffer_ea_contains_covers */
+
+/* GENERATED-SPATIALRELS-BEGIN cbuffer_ea_disjoint_intersects — tools/codegen/inherited/generate.py from templates/spatialrels.c.tmpl;
+ * DO NOT EDIT BY HAND; edit the template + manifest.yaml (spatialrel_families) and re-run. */
 /*****************************************************************************
  * Ever/always disjoint
  *****************************************************************************/
@@ -446,14 +449,12 @@ Adisjoint_tcbuffer_geo(PG_FUNCTION_ARGS)
   return EA_spatialrel_tspatial_geo(fcinfo, &ea_disjoint_tcbuffer_geo, ALWAYS);
 }
 
-/*****************************************************************************/
-
 PGDLLEXPORT Datum Edisjoint_cbuffer_tcbuffer(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Edisjoint_cbuffer_tcbuffer);
 /**
  * @ingroup mobilitydb_cbuffer_rel_ever
- * @brief Return true if a circular buffer and a temporal circular buffer are ever
- * disjoint
+ * @brief Return true if a circular buffer and a temporal circular buffer are
+ * ever disjoint
  * @sqlfn eDisjoint()
  */
 inline Datum
@@ -508,8 +509,6 @@ Adisjoint_tcbuffer_cbuffer(PG_FUNCTION_ARGS)
     ALWAYS);
 }
 
-/*****************************************************************************/
-
 PGDLLEXPORT Datum Edisjoint_tcbuffer_tcbuffer(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Edisjoint_tcbuffer_tcbuffer);
 /**
@@ -520,22 +519,22 @@ PG_FUNCTION_INFO_V1(Edisjoint_tcbuffer_tcbuffer);
 inline Datum
 Edisjoint_tcbuffer_tcbuffer(PG_FUNCTION_ARGS)
 {
-  return EA_spatialrel_tspatial_tspatial(fcinfo,
-    &ea_disjoint_tcbuffer_tcbuffer, EVER);
+  return EA_spatialrel_tspatial_tspatial(fcinfo, &ea_disjoint_tcbuffer_tcbuffer,
+    EVER);
 }
 
 PGDLLEXPORT Datum Adisjoint_tcbuffer_tcbuffer(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Adisjoint_tcbuffer_tcbuffer);
 /**
  * @ingroup mobilitydb_cbuffer_rel_ever
- * @brief Return true if two temporal circular buffers are ever disjoint
+ * @brief Return true if two temporal circular buffers are always disjoint
  * @sqlfn aDisjoint()
  */
 inline Datum
 Adisjoint_tcbuffer_tcbuffer(PG_FUNCTION_ARGS)
 {
-  return EA_spatialrel_tspatial_tspatial(fcinfo,
-    &ea_disjoint_tcbuffer_tcbuffer, ALWAYS);
+  return EA_spatialrel_tspatial_tspatial(fcinfo, &ea_disjoint_tcbuffer_tcbuffer,
+    ALWAYS);
 }
 
 /*****************************************************************************
@@ -553,15 +552,14 @@ PG_FUNCTION_INFO_V1(Eintersects_geo_tcbuffer);
 inline Datum
 Eintersects_geo_tcbuffer(PG_FUNCTION_ARGS)
 {
-  return EA_spatialrel_geo_tspatial(fcinfo, &ea_intersects_geo_tcbuffer,
-    EVER);
+  return EA_spatialrel_geo_tspatial(fcinfo, &ea_intersects_geo_tcbuffer, EVER);
 }
 
 PGDLLEXPORT Datum Aintersects_geo_tcbuffer(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Aintersects_geo_tcbuffer);
 /**
  * @ingroup mobilitydb_cbuffer_rel_ever
- * @brief Return true if a geometry and a temporal circular buffer ever
+ * @brief Return true if a geometry and a temporal circular buffer always
  * intersect
  * @sqlfn aIntersects()
  */
@@ -583,8 +581,7 @@ PG_FUNCTION_INFO_V1(Eintersects_tcbuffer_geo);
 inline Datum
 Eintersects_tcbuffer_geo(PG_FUNCTION_ARGS)
 {
-  return EA_spatialrel_tspatial_geo(fcinfo, &ea_intersects_tcbuffer_geo,
-    EVER);
+  return EA_spatialrel_tspatial_geo(fcinfo, &ea_intersects_tcbuffer_geo, EVER);
 }
 
 PGDLLEXPORT Datum Aintersects_tcbuffer_geo(PG_FUNCTION_ARGS);
@@ -606,63 +603,61 @@ PGDLLEXPORT Datum Eintersects_cbuffer_tcbuffer(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Eintersects_cbuffer_tcbuffer);
 /**
  * @ingroup mobilitydb_cbuffer_rel_ever
- * @brief Return true if a circular buffer and a temporal
- * circular buffer ever intersect
+ * @brief Return true if a circular buffer and a temporal circular buffer ever
+ * intersect
  * @sqlfn eIntersects()
  */
 inline Datum
 Eintersects_cbuffer_tcbuffer(PG_FUNCTION_ARGS)
 {
-  return EA_spatialrel_cbuffer_tcbuffer(fcinfo,
-    &ea_intersects_cbuffer_tcbuffer, EVER);
+  return EA_spatialrel_cbuffer_tcbuffer(fcinfo, &ea_intersects_cbuffer_tcbuffer,
+    EVER);
 }
 
 PGDLLEXPORT Datum Aintersects_cbuffer_tcbuffer(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Aintersects_cbuffer_tcbuffer);
 /**
  * @ingroup mobilitydb_cbuffer_rel_ever
- * @brief Return true if a circular buffer and a temporal
- * circular buffer always intersect
+ * @brief Return true if a circular buffer and a temporal circular buffer always
+ * intersect
  * @sqlfn aIntersects()
  */
 inline Datum
 Aintersects_cbuffer_tcbuffer(PG_FUNCTION_ARGS)
 {
-  return EA_spatialrel_cbuffer_tcbuffer(fcinfo,
-    &ea_intersects_cbuffer_tcbuffer, ALWAYS);
+  return EA_spatialrel_cbuffer_tcbuffer(fcinfo, &ea_intersects_cbuffer_tcbuffer,
+    ALWAYS);
 }
 
 PGDLLEXPORT Datum Eintersects_tcbuffer_cbuffer(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Eintersects_tcbuffer_cbuffer);
 /**
  * @ingroup mobilitydb_cbuffer_rel_ever
- * @brief Return true if a temporal circular buffer and a circular buffer 
- * ever intersect
+ * @brief Return true if a temporal circular buffer and a circular buffer ever
+ * intersect
  * @sqlfn eIntersects()
  */
 inline Datum
 Eintersects_tcbuffer_cbuffer(PG_FUNCTION_ARGS)
 {
-  return EA_spatialrel_tcbuffer_cbuffer(fcinfo,
-    &ea_intersects_tcbuffer_cbuffer, EVER);
+  return EA_spatialrel_tcbuffer_cbuffer(fcinfo, &ea_intersects_tcbuffer_cbuffer,
+    EVER);
 }
 
 PGDLLEXPORT Datum Aintersects_tcbuffer_cbuffer(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Aintersects_tcbuffer_cbuffer);
 /**
  * @ingroup mobilitydb_cbuffer_rel_ever
- * @brief Return true if a temporal circular buffer and a circular buffer 
- * always intersect
+ * @brief Return true if a temporal circular buffer and a circular buffer always
+ * intersect
  * @sqlfn aIntersects()
  */
 inline Datum
 Aintersects_tcbuffer_cbuffer(PG_FUNCTION_ARGS)
 {
-  return EA_spatialrel_tcbuffer_cbuffer(fcinfo,
-    &ea_intersects_tcbuffer_cbuffer, ALWAYS);
+  return EA_spatialrel_tcbuffer_cbuffer(fcinfo, &ea_intersects_tcbuffer_cbuffer,
+    ALWAYS);
 }
-
-/*****************************************************************************/
 
 PGDLLEXPORT Datum Eintersects_tcbuffer_tcbuffer(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Eintersects_tcbuffer_tcbuffer);
@@ -674,23 +669,24 @@ PG_FUNCTION_INFO_V1(Eintersects_tcbuffer_tcbuffer);
 inline Datum
 Eintersects_tcbuffer_tcbuffer(PG_FUNCTION_ARGS)
 {
-  return EA_spatialrel_tspatial_tspatial(fcinfo,
-    &ea_intersects_tcbuffer_tcbuffer, EVER);
+  return EA_spatialrel_tspatial_tspatial(fcinfo, &ea_intersects_tcbuffer_tcbuffer,
+    EVER);
 }
 
 PGDLLEXPORT Datum Aintersects_tcbuffer_tcbuffer(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Aintersects_tcbuffer_tcbuffer);
 /**
  * @ingroup mobilitydb_cbuffer_rel_ever
- * @brief Return true if two temporal circular buffers ever intersect
+ * @brief Return true if two temporal circular buffers always intersect
  * @sqlfn aIntersects()
  */
 inline Datum
 Aintersects_tcbuffer_tcbuffer(PG_FUNCTION_ARGS)
 {
-  return EA_spatialrel_tspatial_tspatial(fcinfo, 
-    &ea_intersects_tcbuffer_tcbuffer, ALWAYS);
+  return EA_spatialrel_tspatial_tspatial(fcinfo, &ea_intersects_tcbuffer_tcbuffer,
+    ALWAYS);
 }
+/* GENERATED-SPATIALRELS-END cbuffer_ea_disjoint_intersects */
 
 /*****************************************************************************
  * Ever/always touches

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -311,6 +311,37 @@ spatialrel_families:
           tcbuffer_cbuffer:  "a temporal circular buffer {word} covers a circular buffer"
           tcbuffer_tcbuffer: "a temporal circular buffer {word} covers another one"
 
+  - family:    cbuffer_ea_disjoint_intersects
+    file:      mobilitydb/src/cbuffer/tcbuffer_spatialrels.c
+    reference: true
+    ingroup:   mobilitydb_cbuffer_rel_ever
+    order:     [geo_tcbuffer, tcbuffer_geo, cbuffer_tcbuffer, tcbuffer_cbuffer, tcbuffer_tcbuffer]
+    disp:
+      geo_tcbuffer:      EA_spatialrel_geo_tspatial
+      tcbuffer_geo:      EA_spatialrel_tspatial_geo
+      cbuffer_tcbuffer:  EA_spatialrel_cbuffer_tcbuffer
+      tcbuffer_cbuffer:  EA_spatialrel_tcbuffer_cbuffer
+      tcbuffer_tcbuffer: EA_spatialrel_tspatial_tspatial
+    predicates:
+      - rel: disjoint
+        Rel: Disjoint
+        banner: "Ever/always disjoint"
+        briefs:
+          geo_tcbuffer:      "a geometry and a temporal circular buffer are {word} disjoint"
+          tcbuffer_geo:      "a temporal circular buffer and a geometry are {word} disjoint"
+          cbuffer_tcbuffer:  "a circular buffer and a temporal circular buffer are {word} disjoint"
+          tcbuffer_cbuffer:  "a temporal circular buffer and a circular buffer are {word} disjoint"
+          tcbuffer_tcbuffer: "two temporal circular buffers are {word} disjoint"
+      - rel: intersects
+        Rel: Intersects
+        banner: "Ever/always intersects"
+        briefs:
+          geo_tcbuffer:      "a geometry and a temporal circular buffer {word} intersect"
+          tcbuffer_geo:      "a temporal circular buffer and a geometry {word} intersect"
+          cbuffer_tcbuffer:  "a circular buffer and a temporal circular buffer {word} intersect"
+          tcbuffer_cbuffer:  "a temporal circular buffer and a circular buffer {word} intersect"
+          tcbuffer_tcbuffer: "two temporal circular buffers {word} intersect"
+
 # ---------------------------------------------------------------------------
 # Accessor axis (SQL, per-family, region-in-file). The whole Temporal<T> accessor
 # surface (tempSubtype..segments) lives INLINE in each family's type file and


### PR DESCRIPTION
The ever/always **disjoint** and **intersects** PG wrappers in `mobilitydb/src/cbuffer/tcbuffer_spatialrels.c` come from the inherited-behaviour generator (`tools/codegen/inherited/`), mirroring the already-generated tcbuffer **contains**/**covers** region.

- Adds a `cbuffer_ea_disjoint_intersects` entry to the `spatialrel_families` manifest, reusing the cbuffer `ingroup`, five-direction `order` (geo⊗T, T⊗geo, cbuffer⊗T, T⊗cbuffer, T⊗T) and dispatcher map that the contains/covers family already defines.
- Wraps the disjoint + intersects region in `GENERATED-SPATIALRELS` markers; `generate.py --validate` self-regenerates all four families byte-for-byte.

The change is behaviour- and catalogue-neutral: with comments and whitespace stripped the region's code tokens are identical to master (same 20 `Edisjoint/Adisjoint/Eintersects/Aintersects` wrappers, same `PG_FUNCTION_INFO_V1` set, same dispatchers and MEOS kernels). Only the banner separators and the return-statement line wrapping are normalised to the generator's 80-column house style. No SQL, `@sqlfn`, or MEOS symbols change.

Next in this wave: `dwithin` (different wrapper shape — carries a distance, no `&meos` arg), then the rgeo and pose families.
