### PR TITLE
Make raquet a first-class value type

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3736,6 +3736,35 @@
 		</sect2>
 
 		<sect2>
+			<title>Accesores y Comparación de Raquet</title>
+			<itemizedlist>
+				<listitem>
+					<para><link linkend="raquet_quadbin_accessor"><varname>quadbin</varname></link>: Devolver la celda QUADBIN de una tesela Raquet</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="raquet_width"><varname>width</varname></link>: Devolver el ancho en píxeles de una tesela Raquet</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="raquet_height"><varname>height</varname></link>: Devolver el alto en píxeles de una tesela Raquet</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="raquet_nodata"><varname>nodata</varname></link>: Devolver el valor centinela nodata de una tesela Raquet</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="raquet_pixtype"><varname>pixtype</varname></link>: Devolver el nombre del tipo de dato de píxel de una tesela Raquet</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="raquet_comparison"><varname>comparación de raquet</varname></link>: Comparar dos teselas Raquet</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2>
 			<title>Operadores de Restricción y Predicado</title>
 			<itemizedlist>
 				<listitem>

--- a/doc/es/temporal_raster.xml
+++ b/doc/es/temporal_raster.xml
@@ -181,6 +181,74 @@ JOIN elevation_tiles r
 		</itemizedlist>
 	</sect1>
 
+	<sect1 xml:id="raquet_accessors">
+		<title>Accesores y Comparación de Raquet</title>
+
+		<para>Un valor <varname>raquet</varname> es autodescriptivo: los accesores siguientes leen la georreferenciación y la disposición que transporta, de modo que una tesela empaquetada con el constructor <link linkend="raquet"><varname>raquet</varname></link> o decodificada con <link linkend="raquet_read"><varname>raquet_read</varname></link> puede inspeccionarse sin conservar las columnas sueltas a partir de las cuales se construyó.</para>
+
+		<para>Las teselas también admiten el conjunto completo de operadores de comparación. El orden es total y se define primero por la celda QUADBIN, luego por el tipo de píxel, el ancho, el alto y finalmente los bytes de píxeles; está pensado para indexación y deduplicación, no para una interpretación espacial. Una clase de operadores btree por defecto hace que <varname>ORDER BY</varname>, <varname>DISTINCT</varname> y las uniones por mezcla funcionen sobre columnas <varname>raquet</varname>, y una clase de operadores hash por defecto habilita las uniones y agregaciones hash.</para>
+
+		<itemizedlist>
+			<listitem xml:id="raquet_quadbin_accessor">
+				<indexterm significance="normal"><primary><varname>quadbin</varname></primary></indexterm>
+				<para>Devolver la celda QUADBIN de una tesela Raquet</para>
+				<para><varname>quadbin(raquet) → bigint</varname></para>
+			</listitem>
+
+			<listitem xml:id="raquet_width">
+				<indexterm significance="normal"><primary><varname>width</varname></primary></indexterm>
+				<para>Devolver el ancho en píxeles de una tesela Raquet</para>
+				<para><varname>width(raquet) → integer</varname></para>
+			</listitem>
+
+			<listitem xml:id="raquet_height">
+				<indexterm significance="normal"><primary><varname>height</varname></primary></indexterm>
+				<para>Devolver el alto en píxeles de una tesela Raquet</para>
+				<para><varname>height(raquet) → integer</varname></para>
+			</listitem>
+
+			<listitem xml:id="raquet_nodata">
+				<indexterm significance="normal"><primary><varname>nodata</varname></primary></indexterm>
+				<para>Devolver el valor centinela nodata de una tesela Raquet</para>
+				<para><varname>nodata(raquet) → float8</varname></para>
+			</listitem>
+
+			<listitem xml:id="raquet_pixtype">
+				<indexterm significance="normal"><primary><varname>pixtype</varname></primary></indexterm>
+				<para>Devolver el nombre del tipo de dato de píxel de una tesela Raquet</para>
+				<para><varname>pixtype(raquet) → text</varname></para>
+				<para>El nombre devuelto es el que aceptan los constructores, es decir, uno de <varname>UINT8</varname>, <varname>INT16</varname>, <varname>INT32</varname>, <varname>FLOAT32</varname> o <varname>FLOAT64</varname>.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Leer la disposición de una tesela empaquetada
+SELECT quadbin(tile), width(tile), height(tile), pixtype(tile), nodata(tile)
+FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8') AS tile) t;
+-- 5193776270265024512 | 2 | 2 | UINT8 | 0
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="raquet_comparison">
+				<indexterm significance="normal"><primary><varname>comparación de raquet</varname></primary></indexterm>
+				<para>Comparar dos teselas Raquet</para>
+				<para><varname>raquet = raquet → boolean</varname></para>
+				<para><varname>raquet &lt;&gt; raquet → boolean</varname></para>
+				<para><varname>raquet &lt; raquet → boolean</varname></para>
+				<para><varname>raquet &lt;= raquet → boolean</varname></para>
+				<para><varname>raquet &gt;= raquet → boolean</varname></para>
+				<para><varname>raquet &gt; raquet → boolean</varname></para>
+				<para>Las funciones que respaldan estos operadores son <varname>eq</varname>, <varname>ne</varname>, <varname>lt</varname>, <varname>le</varname>, <varname>ge</varname> y <varname>gt</varname>, junto con <varname>cmp(raquet,raquet) → integer</varname>, que devuelve -1, 0 o 1.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Dos teselas con la misma celda, disposición y píxeles son iguales
+SELECT raquet('\x0102'::bytea, 2, 1, 5193776270265024512, 'UINT8') =
+       raquet('\x0102'::bytea, 2, 1, 5193776270265024512, 'UINT8');
+-- true
+
+-- Deduplicar teselas, lo que permiten las clases de operadores btree y hash
+SELECT DISTINCT tile FROM elevation_tiles;
+</programlisting>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
 	<sect1 xml:id="raster_restriction">
 		<title>Operadores de Restricción y Predicado</title>
 

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3714,6 +3714,35 @@
 		</sect2>
 
 		<sect2>
+			<title>Raquet Accessors and Comparison</title>
+			<itemizedlist>
+				<listitem>
+					<para><link linkend="raquet_quadbin_accessor"><varname>quadbin</varname></link>: Return the QUADBIN cell of a Raquet tile</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="raquet_width"><varname>width</varname></link>: Return the width in pixels of a Raquet tile</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="raquet_height"><varname>height</varname></link>: Return the height in pixels of a Raquet tile</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="raquet_nodata"><varname>nodata</varname></link>: Return the nodata sentinel value of a Raquet tile</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="raquet_pixtype"><varname>pixtype</varname></link>: Return the name of the pixel data type of a Raquet tile</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="raquet_comparison"><varname>raquet comparison</varname></link>: Compare two Raquet tiles</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2>
 			<title>Restriction and Predicate Operators</title>
 			<itemizedlist>
 				<listitem>

--- a/doc/temporal_raster.xml
+++ b/doc/temporal_raster.xml
@@ -183,6 +183,74 @@ JOIN elevation_tiles r
 		</itemizedlist>
 	</sect1>
 
+	<sect1 xml:id="raquet_accessors">
+		<title>Raquet Accessors and Comparison</title>
+
+		<para>A <varname>raquet</varname> value is self-describing: the accessors below read back the georeferencing and layout it carries, so a tile packaged with the <link linkend="raquet"><varname>raquet</varname></link> constructor or decoded with <link linkend="raquet_read"><varname>raquet_read</varname></link> can be inspected without keeping the loose columns it was built from.</para>
+
+		<para>Tiles also support the full set of comparison operators. The ordering is total and is defined on the QUADBIN cell first, then the pixel type, the width, the height, and finally the pixel bytes; it is meant for indexing and deduplication rather than for a spatial interpretation. A default btree operator class makes <varname>ORDER BY</varname>, <varname>DISTINCT</varname> and merge joins work on <varname>raquet</varname> columns, and a default hash operator class enables hash joins and hash aggregation.</para>
+
+		<itemizedlist>
+			<listitem xml:id="raquet_quadbin_accessor">
+				<indexterm significance="normal"><primary><varname>quadbin</varname></primary></indexterm>
+				<para>Return the QUADBIN cell of a Raquet tile</para>
+				<para><varname>quadbin(raquet) → bigint</varname></para>
+			</listitem>
+
+			<listitem xml:id="raquet_width">
+				<indexterm significance="normal"><primary><varname>width</varname></primary></indexterm>
+				<para>Return the width in pixels of a Raquet tile</para>
+				<para><varname>width(raquet) → integer</varname></para>
+			</listitem>
+
+			<listitem xml:id="raquet_height">
+				<indexterm significance="normal"><primary><varname>height</varname></primary></indexterm>
+				<para>Return the height in pixels of a Raquet tile</para>
+				<para><varname>height(raquet) → integer</varname></para>
+			</listitem>
+
+			<listitem xml:id="raquet_nodata">
+				<indexterm significance="normal"><primary><varname>nodata</varname></primary></indexterm>
+				<para>Return the nodata sentinel value of a Raquet tile</para>
+				<para><varname>nodata(raquet) → float8</varname></para>
+			</listitem>
+
+			<listitem xml:id="raquet_pixtype">
+				<indexterm significance="normal"><primary><varname>pixtype</varname></primary></indexterm>
+				<para>Return the name of the pixel data type of a Raquet tile</para>
+				<para><varname>pixtype(raquet) → text</varname></para>
+				<para>The returned name is the one the constructors accept, that is, one of <varname>UINT8</varname>, <varname>INT16</varname>, <varname>INT32</varname>, <varname>FLOAT32</varname>, or <varname>FLOAT64</varname>.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Read back the layout of a packaged tile
+SELECT quadbin(tile), width(tile), height(tile), pixtype(tile), nodata(tile)
+FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8') AS tile) t;
+-- 5193776270265024512 | 2 | 2 | UINT8 | 0
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="raquet_comparison">
+				<indexterm significance="normal"><primary><varname>raquet comparison</varname></primary></indexterm>
+				<para>Compare two Raquet tiles</para>
+				<para><varname>raquet = raquet → boolean</varname></para>
+				<para><varname>raquet &lt;&gt; raquet → boolean</varname></para>
+				<para><varname>raquet &lt; raquet → boolean</varname></para>
+				<para><varname>raquet &lt;= raquet → boolean</varname></para>
+				<para><varname>raquet &gt;= raquet → boolean</varname></para>
+				<para><varname>raquet &gt; raquet → boolean</varname></para>
+				<para>The functions backing these operators are <varname>eq</varname>, <varname>ne</varname>, <varname>lt</varname>, <varname>le</varname>, <varname>ge</varname> and <varname>gt</varname>, together with <varname>cmp(raquet,raquet) → integer</varname>, which returns -1, 0, or 1.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Two tiles with the same cell, layout and pixels are equal
+SELECT raquet('\x0102'::bytea, 2, 1, 5193776270265024512, 'UINT8') =
+       raquet('\x0102'::bytea, 2, 1, 5193776270265024512, 'UINT8');
+-- true
+
+-- Deduplicate tiles, which the btree and hash operator classes support
+SELECT DISTINCT tile FROM elevation_tiles;
+</programlisting>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
 	<sect1 xml:id="raster_restriction">
 		<title>Restriction and Predicate Operators</title>
 

--- a/meos/include/meos_raster.h
+++ b/meos/include/meos_raster.h
@@ -91,11 +91,19 @@ extern uint64 raquet_quadbin(const Raquet *rq);
 extern int raquet_width(const Raquet *rq);
 extern int raquet_height(const Raquet *rq);
 extern double raquet_nodata(const Raquet *rq);
+extern char *raquet_pixtype(const Raquet *rq);
+extern uint32 raquet_hash(const Raquet *rq);
+extern uint64 raquet_hash_extended(const Raquet *rq, uint64 seed);
 
 /* Comparison functions for Raquet tiles */
 
 extern int raquet_cmp(const Raquet *rq1, const Raquet *rq2);
 extern bool raquet_eq(const Raquet *rq1, const Raquet *rq2);
+extern bool raquet_ne(const Raquet *rq1, const Raquet *rq2);
+extern bool raquet_lt(const Raquet *rq1, const Raquet *rq2);
+extern bool raquet_le(const Raquet *rq1, const Raquet *rq2);
+extern bool raquet_ge(const Raquet *rq1, const Raquet *rq2);
+extern bool raquet_gt(const Raquet *rq1, const Raquet *rq2);
 
 /* Sampling functions */
 

--- a/meos/include/raster/raquet.h
+++ b/meos/include/raster/raquet.h
@@ -114,4 +114,17 @@ raquet_pixels_size(const Raquet *rq)
     raquet_pixtype_size((MeosPixType) rq->pixtype);
 }
 
+/**
+ * @brief Return the number of hashable bytes of a Raquet tile, that is, the
+ * whole value but the varlena header
+ * @note The header is excluded since its representation depends on whether the
+ * value has been detoasted, while the bytes that follow are deterministic: the
+ * constructor zeroes the allocation, so any padding hashes reproducibly
+ */
+static inline size_t
+raquet_meaningful_size(const Raquet *rq)
+{
+  return offsetof(struct Raquet, pixels) - VARHDRSZ + raquet_pixels_size(rq);
+}
+
 #endif /* __RAQUET_H__ */

--- a/meos/src/raster/raquet.c
+++ b/meos/src/raster/raquet.c
@@ -42,10 +42,12 @@
 
 /* C */
 #include <assert.h>
+#include <limits.h>
 #include <string.h>
 /* PostgreSQL */
 #include <postgres.h>
 #include <pgtypes.h>
+#include "common/hashfn.h"
 #if POSTGRESQL_VERSION_NUMBER >= 160000
   #include "varatt.h"
 #endif
@@ -282,6 +284,33 @@ raquet_nodata(const Raquet *rq)
   return rq->nodata;
 }
 
+/**
+ * @ingroup meos_raster_base_accessor
+ * @brief Return the name of the pixel data type of a Raquet tile
+ * @param[in] rq Raquet tile
+ * @return On error return @p NULL
+ * @note The returned name is the one accepted by the tile constructors, that
+ * is, one of UINT8, INT16, INT32, FLOAT32, or FLOAT64
+ * @csqlfn #Raquet_pixtype()
+ */
+char *
+raquet_pixtype(const Raquet *rq)
+{
+  VALIDATE_NOT_NULL(rq, NULL);
+  switch ((MeosPixType) rq->pixtype)
+  {
+    case MEOS_PT_UINT8:   return pstrdup("UINT8");
+    case MEOS_PT_INT16:   return pstrdup("INT16");
+    case MEOS_PT_INT32:   return pstrdup("INT32");
+    case MEOS_PT_FLOAT32: return pstrdup("FLOAT32");
+    case MEOS_PT_FLOAT64: return pstrdup("FLOAT64");
+    default:
+      meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+        "Unknown raquet pixel type code: %u", rq->pixtype);
+      return NULL;
+  }
+}
+
 /*****************************************************************************
  * Comparison functions
  *****************************************************************************/
@@ -321,6 +350,106 @@ raquet_eq(const Raquet *rq1, const Raquet *rq2)
 {
   assert(rq1); assert(rq2);
   return raquet_cmp(rq1, rq2) == 0;
+}
+
+/**
+ * @ingroup meos_raster_base_comp
+ * @brief Return true if two Raquet tiles are different
+ * @param[in] rq1,rq2 Raquet tiles
+ * @csqlfn #Raquet_ne()
+ */
+bool
+raquet_ne(const Raquet *rq1, const Raquet *rq2)
+{
+  assert(rq1); assert(rq2);
+  return raquet_cmp(rq1, rq2) != 0;
+}
+
+/**
+ * @ingroup meos_raster_base_comp
+ * @brief Return true if the first Raquet tile is less than the second one
+ * @param[in] rq1,rq2 Raquet tiles
+ * @csqlfn #Raquet_lt()
+ */
+bool
+raquet_lt(const Raquet *rq1, const Raquet *rq2)
+{
+  assert(rq1); assert(rq2);
+  return raquet_cmp(rq1, rq2) < 0;
+}
+
+/**
+ * @ingroup meos_raster_base_comp
+ * @brief Return true if the first Raquet tile is less than or equal to the
+ * second one
+ * @param[in] rq1,rq2 Raquet tiles
+ * @csqlfn #Raquet_le()
+ */
+bool
+raquet_le(const Raquet *rq1, const Raquet *rq2)
+{
+  assert(rq1); assert(rq2);
+  return raquet_cmp(rq1, rq2) <= 0;
+}
+
+/**
+ * @ingroup meos_raster_base_comp
+ * @brief Return true if the first Raquet tile is greater than or equal to the
+ * second one
+ * @param[in] rq1,rq2 Raquet tiles
+ * @csqlfn #Raquet_ge()
+ */
+bool
+raquet_ge(const Raquet *rq1, const Raquet *rq2)
+{
+  assert(rq1); assert(rq2);
+  return raquet_cmp(rq1, rq2) >= 0;
+}
+
+/**
+ * @ingroup meos_raster_base_comp
+ * @brief Return true if the first Raquet tile is greater than the second one
+ * @param[in] rq1,rq2 Raquet tiles
+ * @csqlfn #Raquet_gt()
+ */
+bool
+raquet_gt(const Raquet *rq1, const Raquet *rq2)
+{
+  assert(rq1); assert(rq2);
+  return raquet_cmp(rq1, rq2) > 0;
+}
+
+/*****************************************************************************
+ * Hash functions
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_raster_base_accessor
+ * @brief Return the 32-bit hash of a Raquet tile
+ * @param[in] rq Raquet tile
+ * @csqlfn #Raquet_hash()
+ */
+uint32
+raquet_hash(const Raquet *rq)
+{
+  VALIDATE_NOT_NULL(rq, INT_MAX);
+  return hash_any(((const unsigned char *) rq) + VARHDRSZ,
+    (int) raquet_meaningful_size(rq));
+}
+
+/**
+ * @ingroup meos_raster_base_accessor
+ * @brief Return the 64-bit hash of a Raquet tile using a seed
+ * @param[in] rq Raquet tile
+ * @param[in] seed Seed
+ * @csqlfn #Raquet_hash_extended()
+ */
+uint64
+raquet_hash_extended(const Raquet *rq, uint64 seed)
+{
+  VALIDATE_NOT_NULL(rq, LONG_MAX);
+  return hash_any_extended(((const unsigned char *) rq) + VARHDRSZ,
+    (int) raquet_meaningful_size(rq), seed);
 }
 
 /*****************************************************************************

--- a/mobilitydb/sql/raster/500_raster.in.sql
+++ b/mobilitydb/sql/raster/500_raster.in.sql
@@ -303,3 +303,127 @@ CREATE OR REPLACE FUNCTION aRasterValue(
   SELECT v IS NOT NULL AND minusSpan(v, $3) IS NULL
   FROM (SELECT raster_value($1, $2, $4) AS v) t
 $$ LANGUAGE SQL STRICT;
+
+/******************************************************************************
+ * Accessors for raquet tiles
+ *****************************************************************************/
+
+CREATE FUNCTION quadbin(raquet)
+  RETURNS bigint
+  AS 'MODULE_PATHNAME', 'Raquet_quadbin'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION width(raquet)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Raquet_width'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION height(raquet)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Raquet_height'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION nodata(raquet)
+  RETURNS float8
+  AS 'MODULE_PATHNAME', 'Raquet_nodata'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION pixtype(raquet)
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Raquet_pixtype'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/******************************************************************************
+ * Comparison of raquet tiles
+ *****************************************************************************/
+
+CREATE FUNCTION eq(raquet, raquet)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Raquet_eq'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION ne(raquet, raquet)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Raquet_ne'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION lt(raquet, raquet)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Raquet_lt'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION le(raquet, raquet)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Raquet_le'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION ge(raquet, raquet)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Raquet_ge'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION gt(raquet, raquet)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Raquet_gt'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION cmp(raquet, raquet)
+  RETURNS int4
+  AS 'MODULE_PATHNAME', 'Raquet_cmp'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OPERATOR = (
+  LEFTARG = raquet, RIGHTARG = raquet,
+  PROCEDURE = eq,
+  COMMUTATOR = =, NEGATOR = <>,
+  RESTRICT = eqsel, JOIN = eqjoinsel
+);
+CREATE OPERATOR <> (
+  LEFTARG = raquet, RIGHTARG = raquet,
+  PROCEDURE = ne,
+  COMMUTATOR = <>, NEGATOR = =,
+  RESTRICT = neqsel, JOIN = neqjoinsel
+);
+CREATE OPERATOR < (
+  PROCEDURE = lt,
+  LEFTARG = raquet, RIGHTARG = raquet,
+  COMMUTATOR = >, NEGATOR = >=,
+  RESTRICT = areasel, JOIN = areajoinsel
+);
+CREATE OPERATOR <= (
+  PROCEDURE = le,
+  LEFTARG = raquet, RIGHTARG = raquet,
+  COMMUTATOR = >=, NEGATOR = >,
+  RESTRICT = areasel, JOIN = areajoinsel
+);
+CREATE OPERATOR >= (
+  PROCEDURE = ge,
+  LEFTARG = raquet, RIGHTARG = raquet,
+  COMMUTATOR = <=, NEGATOR = <,
+  RESTRICT = areasel, JOIN = areajoinsel
+);
+CREATE OPERATOR > (
+  PROCEDURE = gt,
+  LEFTARG = raquet, RIGHTARG = raquet,
+  COMMUTATOR = <, NEGATOR = <=,
+  RESTRICT = areasel, JOIN = areajoinsel
+);
+
+CREATE OPERATOR CLASS raquet_btree_ops
+  DEFAULT FOR TYPE raquet USING btree AS
+  OPERATOR  1  < ,
+  OPERATOR  2  <= ,
+  OPERATOR  3  = ,
+  OPERATOR  4  >= ,
+  OPERATOR  5  > ,
+  FUNCTION  1  cmp(raquet, raquet);
+
+/*****************************************************************************/
+
+CREATE FUNCTION raquet_hash(raquet)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Raquet_hash'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION raquet_hash_extended(raquet, bigint)
+  RETURNS bigint
+  AS 'MODULE_PATHNAME', 'Raquet_hash_extended'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OPERATOR CLASS raquet_hash_ops
+  DEFAULT FOR TYPE raquet USING hash AS
+    OPERATOR    1   = ,
+    FUNCTION    1   raquet_hash(raquet),
+    FUNCTION    2   raquet_hash_extended(raquet, bigint);
+
+/*****************************************************************************/

--- a/mobilitydb/src/raster/temporal_raster.c
+++ b/mobilitydb/src/raster/temporal_raster.c
@@ -486,3 +486,260 @@ Trajectory_quadbins(PG_FUNCTION_ARGS)
 
   PG_RETURN_ARRAYTYPE_P(arr);
 }
+
+/*****************************************************************************
+ * Raquet type: accessors
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Raquet_quadbin(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_quadbin);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the QUADBIN cell of a Raquet tile
+ * @sqlfn quadbin()
+ */
+Datum
+Raquet_quadbin(PG_FUNCTION_ARGS)
+{
+  Raquet *rq = PG_GETARG_RAQUET_P(0);
+  uint64 result = raquet_quadbin(rq);
+  PG_FREE_IF_COPY(rq, 0);
+  PG_RETURN_INT64((int64) result);
+}
+
+PGDLLEXPORT Datum Raquet_width(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_width);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the width in pixels of a Raquet tile
+ * @sqlfn width()
+ */
+Datum
+Raquet_width(PG_FUNCTION_ARGS)
+{
+  Raquet *rq = PG_GETARG_RAQUET_P(0);
+  int result = raquet_width(rq);
+  PG_FREE_IF_COPY(rq, 0);
+  PG_RETURN_INT32(result);
+}
+
+PGDLLEXPORT Datum Raquet_height(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_height);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the height in pixels of a Raquet tile
+ * @sqlfn height()
+ */
+Datum
+Raquet_height(PG_FUNCTION_ARGS)
+{
+  Raquet *rq = PG_GETARG_RAQUET_P(0);
+  int result = raquet_height(rq);
+  PG_FREE_IF_COPY(rq, 0);
+  PG_RETURN_INT32(result);
+}
+
+PGDLLEXPORT Datum Raquet_nodata(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_nodata);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the nodata sentinel value of a Raquet tile
+ * @sqlfn nodata()
+ */
+Datum
+Raquet_nodata(PG_FUNCTION_ARGS)
+{
+  Raquet *rq = PG_GETARG_RAQUET_P(0);
+  double result = raquet_nodata(rq);
+  PG_FREE_IF_COPY(rq, 0);
+  PG_RETURN_FLOAT8(result);
+}
+
+PGDLLEXPORT Datum Raquet_pixtype(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_pixtype);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the name of the pixel data type of a Raquet tile
+ * @sqlfn pixtype()
+ */
+Datum
+Raquet_pixtype(PG_FUNCTION_ARGS)
+{
+  Raquet *rq = PG_GETARG_RAQUET_P(0);
+  char *str = raquet_pixtype(rq);
+  text *result = cstring_to_text(str);
+  pfree(str);
+  PG_FREE_IF_COPY(rq, 0);
+  PG_RETURN_TEXT_P(result);
+}
+
+/*****************************************************************************
+ * Raquet type: comparison
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Raquet_eq(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_eq);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return true if the Raquet tiles are equal
+ * @sqlfn eq()
+ * @sqlop @p =
+ */
+Datum
+Raquet_eq(PG_FUNCTION_ARGS)
+{
+  Raquet *rq1 = PG_GETARG_RAQUET_P(0);
+  Raquet *rq2 = PG_GETARG_RAQUET_P(1);
+  bool result = raquet_eq(rq1, rq2);
+  PG_FREE_IF_COPY(rq1, 0); PG_FREE_IF_COPY(rq2, 1);
+  PG_RETURN_BOOL(result);
+}
+
+PGDLLEXPORT Datum Raquet_ne(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_ne);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return true if the Raquet tiles are different
+ * @sqlfn ne()
+ * @sqlop @p <>
+ */
+Datum
+Raquet_ne(PG_FUNCTION_ARGS)
+{
+  Raquet *rq1 = PG_GETARG_RAQUET_P(0);
+  Raquet *rq2 = PG_GETARG_RAQUET_P(1);
+  bool result = raquet_ne(rq1, rq2);
+  PG_FREE_IF_COPY(rq1, 0); PG_FREE_IF_COPY(rq2, 1);
+  PG_RETURN_BOOL(result);
+}
+
+PGDLLEXPORT Datum Raquet_lt(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_lt);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return true if the first Raquet tile is less than the second one
+ * @sqlfn lt()
+ * @sqlop @p <
+ */
+Datum
+Raquet_lt(PG_FUNCTION_ARGS)
+{
+  Raquet *rq1 = PG_GETARG_RAQUET_P(0);
+  Raquet *rq2 = PG_GETARG_RAQUET_P(1);
+  bool result = raquet_lt(rq1, rq2);
+  PG_FREE_IF_COPY(rq1, 0); PG_FREE_IF_COPY(rq2, 1);
+  PG_RETURN_BOOL(result);
+}
+
+PGDLLEXPORT Datum Raquet_le(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_le);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return true if the first Raquet tile is less than or equal to the
+ * second one
+ * @sqlfn le()
+ * @sqlop @p <=
+ */
+Datum
+Raquet_le(PG_FUNCTION_ARGS)
+{
+  Raquet *rq1 = PG_GETARG_RAQUET_P(0);
+  Raquet *rq2 = PG_GETARG_RAQUET_P(1);
+  bool result = raquet_le(rq1, rq2);
+  PG_FREE_IF_COPY(rq1, 0); PG_FREE_IF_COPY(rq2, 1);
+  PG_RETURN_BOOL(result);
+}
+
+PGDLLEXPORT Datum Raquet_ge(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_ge);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return true if the first Raquet tile is greater than or equal to the
+ * second one
+ * @sqlfn ge()
+ * @sqlop @p >=
+ */
+Datum
+Raquet_ge(PG_FUNCTION_ARGS)
+{
+  Raquet *rq1 = PG_GETARG_RAQUET_P(0);
+  Raquet *rq2 = PG_GETARG_RAQUET_P(1);
+  bool result = raquet_ge(rq1, rq2);
+  PG_FREE_IF_COPY(rq1, 0); PG_FREE_IF_COPY(rq2, 1);
+  PG_RETURN_BOOL(result);
+}
+
+PGDLLEXPORT Datum Raquet_gt(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_gt);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return true if the first Raquet tile is greater than the second one
+ * @sqlfn gt()
+ * @sqlop @p >
+ */
+Datum
+Raquet_gt(PG_FUNCTION_ARGS)
+{
+  Raquet *rq1 = PG_GETARG_RAQUET_P(0);
+  Raquet *rq2 = PG_GETARG_RAQUET_P(1);
+  bool result = raquet_gt(rq1, rq2);
+  PG_FREE_IF_COPY(rq1, 0); PG_FREE_IF_COPY(rq2, 1);
+  PG_RETURN_BOOL(result);
+}
+
+PGDLLEXPORT Datum Raquet_cmp(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_cmp);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return -1, 0, or 1 depending on whether the first Raquet tile is
+ * less than, equal to, or greater than the second one
+ * @sqlfn cmp()
+ */
+Datum
+Raquet_cmp(PG_FUNCTION_ARGS)
+{
+  Raquet *rq1 = PG_GETARG_RAQUET_P(0);
+  Raquet *rq2 = PG_GETARG_RAQUET_P(1);
+  int result = raquet_cmp(rq1, rq2);
+  PG_FREE_IF_COPY(rq1, 0); PG_FREE_IF_COPY(rq2, 1);
+  PG_RETURN_INT32(result);
+}
+
+/*****************************************************************************
+ * Raquet type: hash
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Raquet_hash(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_hash);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the 32-bit hash of a Raquet tile
+ * @sqlfn raquet_hash()
+ */
+Datum
+Raquet_hash(PG_FUNCTION_ARGS)
+{
+  Raquet *rq = PG_GETARG_RAQUET_P(0);
+  uint32 result = raquet_hash(rq);
+  PG_FREE_IF_COPY(rq, 0);
+  PG_RETURN_UINT32(result);
+}
+
+PGDLLEXPORT Datum Raquet_hash_extended(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_hash_extended);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the 64-bit hash of a Raquet tile using a seed
+ * @sqlfn raquet_hash_extended()
+ */
+Datum
+Raquet_hash_extended(PG_FUNCTION_ARGS)
+{
+  Raquet *rq = PG_GETARG_RAQUET_P(0);
+  uint64 seed = PG_GETARG_INT64(1);
+  uint64 result = raquet_hash_extended(rq, seed);
+  PG_FREE_IF_COPY(rq, 0);
+  PG_RETURN_UINT64(result);
+}
+
+/*****************************************************************************/

--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -283,3 +283,89 @@ FROM t;
 SELECT raquet_read(
   decode('49492a00080000000b000001030001000000020000000101030001000000020000000201030001000000080000000301030001000000010000000601030001000000010000001101040001000000920000001501030001000000010000001601030001000000020000001701040001000000040000001c01030001000000010000005301030001000000010000000000000001020304', 'hex'));
 ERROR:  Raster has no geotransform; cannot derive its QUADBIN cell: in-memory raster
+SELECT quadbin(tile), width(tile), height(tile), pixtype(tile), nodata(tile)
+FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint,
+        'UINT8') AS tile) t;
+       quadbin       | width | height | pixtype | nodata 
+---------------------+-------+--------+---------+--------
+ 5193776270265024512 |     2 |      2 | UINT8   |      0
+(1 row)
+
+SELECT pixtype(raquet('\x01'::bytea, 1, 1, 5193776270265024512::bigint, 'UINT8')),
+       pixtype(raquet('\x0102'::bytea, 1, 1, 5193776270265024512::bigint, 'INT16')),
+       pixtype(raquet('\x01020304'::bytea, 1, 1, 5193776270265024512::bigint, 'INT32')),
+       pixtype(raquet('\x01020304'::bytea, 1, 1, 5193776270265024512::bigint, 'FLOAT32')),
+       pixtype(raquet('\x0102030405060708'::bytea, 1, 1, 5193776270265024512::bigint,
+         'FLOAT64'));
+ pixtype | pixtype | pixtype | pixtype | pixtype 
+---------+---------+---------+---------+---------
+ UINT8   | INT16   | INT32   | FLOAT32 | FLOAT64
+(1 row)
+
+SELECT nodata(raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8',
+  -9999.0));
+ nodata 
+--------
+  -9999
+(1 row)
+
+SELECT raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') =
+       raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') AS eq,
+       raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') <>
+       raquet('\x0103'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') AS ne;
+ eq | ne 
+----+----
+ t  | t
+(1 row)
+
+SELECT raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') <
+       raquet('\x0103'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') AS lt_pixels,
+       raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') <=
+       raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') AS le_equal,
+       raquet('\x0103'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') >
+       raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') AS gt_pixels,
+       raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') >=
+       raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') AS ge_equal;
+ lt_pixels | le_equal | gt_pixels | ge_equal 
+-----------+----------+-----------+----------
+ t         | t        | t         | t
+(1 row)
+
+SELECT cmp(raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8'),
+           raquet('\x0103'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8')) AS lt,
+       cmp(raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8'),
+           raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8')) AS eq,
+       cmp(raquet('\x0103'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8'),
+           raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8')) AS gt;
+ lt | eq | gt 
+----+----+----
+ -1 |  0 |  1
+(1 row)
+
+WITH tiles(tile) AS (VALUES
+  (raquet('\x0103'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8')),
+  (raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8')),
+  (raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8')))
+SELECT count(*) AS total, count(DISTINCT tile) AS distinct_tiles,
+       (SELECT tile::text FROM tiles ORDER BY tile LIMIT 1) =
+         raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint,
+           'UINT8')::text AS smallest_sorts_first
+FROM tiles;
+ total | distinct_tiles | smallest_sorts_first 
+-------+----------------+----------------------
+     3 |              2 | t
+(1 row)
+
+SELECT raquet_hash(raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint,
+         'UINT8')) =
+       raquet_hash(raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint,
+         'UINT8')) AS equal_tiles_hash_equally,
+       raquet_hash_extended(raquet('\x0102'::bytea, 2, 1,
+         5193776270265024512::bigint, 'UINT8'), 0) <>
+       raquet_hash_extended(raquet('\x0102'::bytea, 2, 1,
+         5193776270265024512::bigint, 'UINT8'), 1) AS seed_changes_hash;
+ equal_tiles_hash_equally | seed_changes_hash 
+--------------------------+-------------------
+ t                        | t
+(1 row)
+

--- a/mobilitydb/test/raster/queries/500_raster.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster.test.sql
@@ -330,3 +330,75 @@ FROM t;
 -- 2 x 2 GeoTIFF carries no geotransform, so omitting the quadbin is an error.
 SELECT raquet_read(
   decode('49492a00080000000b000001030001000000020000000101030001000000020000000201030001000000080000000301030001000000010000000601030001000000010000001101040001000000920000001501030001000000010000001601030001000000020000001701040001000000040000001c01030001000000010000005301030001000000010000000000000001020304', 'hex'));
+
+-------------------------------------------------------------------------------
+-- raquet accessors
+-------------------------------------------------------------------------------
+
+-- The accessors read back the georeferencing and layout the tile carries, so a
+-- packaged tile needs none of the loose columns it was built from.
+SELECT quadbin(tile), width(tile), height(tile), pixtype(tile), nodata(tile)
+FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint,
+        'UINT8') AS tile) t;
+
+-- Every pixel type name round-trips through the constructor and pixtype.
+SELECT pixtype(raquet('\x01'::bytea, 1, 1, 5193776270265024512::bigint, 'UINT8')),
+       pixtype(raquet('\x0102'::bytea, 1, 1, 5193776270265024512::bigint, 'INT16')),
+       pixtype(raquet('\x01020304'::bytea, 1, 1, 5193776270265024512::bigint, 'INT32')),
+       pixtype(raquet('\x01020304'::bytea, 1, 1, 5193776270265024512::bigint, 'FLOAT32')),
+       pixtype(raquet('\x0102030405060708'::bytea, 1, 1, 5193776270265024512::bigint,
+         'FLOAT64'));
+
+-- The nodata sentinel supplied to the constructor is the one reported back.
+SELECT nodata(raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8',
+  -9999.0));
+
+-------------------------------------------------------------------------------
+-- raquet comparison
+-------------------------------------------------------------------------------
+
+-- Tiles agreeing on cell, layout and pixels are equal; any difference orders.
+SELECT raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') =
+       raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') AS eq,
+       raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') <>
+       raquet('\x0103'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') AS ne;
+
+-- The ordering is on the QUADBIN cell first, then pixel type, width, height and
+-- finally the pixel bytes.
+SELECT raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') <
+       raquet('\x0103'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') AS lt_pixels,
+       raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') <=
+       raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') AS le_equal,
+       raquet('\x0103'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') >
+       raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') AS gt_pixels,
+       raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') >=
+       raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') AS ge_equal;
+
+-- cmp returns the three-way comparison the btree operator class uses.
+SELECT cmp(raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8'),
+           raquet('\x0103'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8')) AS lt,
+       cmp(raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8'),
+           raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8')) AS eq,
+       cmp(raquet('\x0103'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8'),
+           raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8')) AS gt;
+
+-- Sorting and deduplication go through the btree and hash operator classes.
+WITH tiles(tile) AS (VALUES
+  (raquet('\x0103'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8')),
+  (raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8')),
+  (raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8')))
+SELECT count(*) AS total, count(DISTINCT tile) AS distinct_tiles,
+       (SELECT tile::text FROM tiles ORDER BY tile LIMIT 1) =
+         raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint,
+           'UINT8')::text AS smallest_sorts_first
+FROM tiles;
+
+-- Equal tiles hash equally, and the seeded hash varies with the seed.
+SELECT raquet_hash(raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint,
+         'UINT8')) =
+       raquet_hash(raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint,
+         'UINT8')) AS equal_tiles_hash_equally,
+       raquet_hash_extended(raquet('\x0102'::bytea, 2, 1,
+         5193776270265024512::bigint, 'UINT8'), 0) <>
+       raquet_hash_extended(raquet('\x0102'::bytea, 2, 1,
+         5193776270265024512::bigint, 'UINT8'), 1) AS seed_changes_hash;


### PR DESCRIPTION
A `raquet` tile is self-describing, but SQL exposes none of what it carries and it has no comparison surface, so tiles cannot be read back, ordered, deduplicated, indexed or joined.

**Accessors** — `quadbin`, `width`, `height`, `nodata` and `pixtype` read back the georeferencing and layout, so a tile packaged by the constructor or decoded by `raquet_read` stands on its own without the loose columns feeding it. `pixtype` is backed by a new MEOS `raquet_pixtype` returning the name the constructors accept. `quadbin` returns `bigint`, matching how the chapter spells QUADBIN cells throughout, since `RASTER` and `QUADBIN` are independent build options.

**Comparison** — `eq`, `ne`, `lt`, `le`, `ge`, `gt` and `cmp` with their six operators and a default btree operator class. MEOS carries only `raquet_cmp` and `raquet_eq`; the five added comparisons are thin over `raquet_cmp`, as in the `pcpatch` sibling. The ordering is the one `raquet_cmp` defines: QUADBIN cell, pixel type, width, height, then pixel bytes.

**Hash** — `raquet_hash` and `raquet_hash_extended` over `hash_any`/`hash_any_extended`, with a default hash operator class, enabling hash joins and hash aggregation.

Function names follow the canonical bare form used by `eq(stbox, stbox)` and the 46 other types that carry a comparison surface. The opclass support functions keep the `raquet_hash` spelling used by every type.

Tests cover the accessors, every pixel-type name, the six operators, `cmp`, sorting and deduplication through the two operator classes, and hash equality with seed sensitivity. Documented in the EN and ES chapters and both reference chapters.
