### PR TITLE
Regularise the tcbuffer dwithin spatial-relationship wrappers

### DIFF
--- a/mobilitydb/src/cbuffer/tcbuffer_spatialrels.c
+++ b/mobilitydb/src/cbuffer/tcbuffer_spatialrels.c
@@ -853,8 +853,7 @@ EA_dwithin_geo_tcbuffer(FunctionCallInfo fcinfo, bool ever)
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(0);
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
   double dist = PG_GETARG_FLOAT8(2);
-  int result = ever ?
-    edwithin_tcbuffer_geo(temp, gs, dist) :
+  int result = ever ? edwithin_tcbuffer_geo(temp, gs, dist) :
     adwithin_tcbuffer_geo(temp, gs, dist);
   PG_FREE_IF_COPY(gs, 0);
   PG_FREE_IF_COPY(temp, 1);
@@ -940,7 +939,7 @@ Adwithin_tcbuffer_geo(PG_FUNCTION_ARGS)
 }
 
 /**
- * @brief Return true if two temporal circular buffers are even/always within a
+ * @brief Return true if two temporal circular buffers are ever/always within a
  * distance
  * @sqlfn eDwithin(), aDwithin()
  */
@@ -972,8 +971,7 @@ EA_dwithin_cbuffer_tcbuffer(FunctionCallInfo fcinfo, bool ever)
   Cbuffer *cb = PG_GETARG_CBUFFER_P(0);
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
   double dist = PG_GETARG_FLOAT8(2);
-  int result = ever ?
-    edwithin_tcbuffer_cbuffer(temp, cb, dist) :
+  int result = ever ? edwithin_tcbuffer_cbuffer(temp, cb, dist) :
     adwithin_tcbuffer_cbuffer(temp, cb, dist);
   PG_FREE_IF_COPY(cb, 0);
   PG_FREE_IF_COPY(temp, 1);
@@ -1015,7 +1013,7 @@ Adwithin_cbuffer_tcbuffer(PG_FUNCTION_ARGS)
  * ever/always within a distance
  * @sqlfn eDwithin()
  */
-Datum
+static Datum
 EA_dwithin_tcbuffer_cbuffer(FunctionCallInfo fcinfo, bool ever)
 {
   Cbuffer *cb = PG_GETARG_CBUFFER_P(1);


### PR DESCRIPTION
Regularises the ever/always **dwithin** region of `mobilitydb/src/cbuffer/tcbuffer_spatialrels.c`, in preparation for bringing it onto the inherited-behaviour generator (the disjoint/intersects region is already generated, #1530). Four irregularities in that region:

- **Leaked symbol:** of the five internal `EA_dwithin_*` dispatchers, only `EA_dwithin_tcbuffer_cbuffer` lacks `static`, so it exports a file-local symbol. It is file-local (no reference anywhere outside the `.c`); this marks it `static` like its four siblings.
- **Typo:** the two-temporal-buffer dispatcher `@brief` reads `even/always`; corrected to `ever/always`.
- **Formatting:** two dispatchers use a three-line ternary while the other three use the two-line form; this normalises the two to the two-line form (all fit within 80 columns).

The five dispatchers keep identical logic and every public `Edwithin_*`/`Adwithin_*` wrapper is untouched, so there is no SQL or catalogue change; the only symbol-table effect is dropping the accidentally-exported `EA_dwithin_tcbuffer_cbuffer`, which is not part of the public API.
