### PR TITLE
Align the raster production roadmap with the two documented paths

### DIFF
--- a/doc/es/temporal_raster.xml
+++ b/doc/es/temporal_raster.xml
@@ -335,11 +335,23 @@ sudo make install
 	<sect1 xml:id="raster_roadmap">
 		<title>Hoja de Ruta de Producción</title>
 
-		<para>Extensiones futuras de este capítulo:</para>
+		<para>Las dos vías descritas en este capítulo sirven propósitos distintos y ambas se mantienen. La vía <varname>raquet</varname> es un tipo de valor MEOS autocontenido: transporta sus píxeles y su georreferenciación QUADBIN en un único valor y no necesita PostgreSQL para evaluarse, por lo que está disponible en todos los enlaces de lenguaje derivados de MEOS. La vía <varname>raster</varname> de PostGIS ofrece el procesamiento ráster mucho más rico de la extensión <varname>postgis_raster</varname> — álgebra de mapas, estadísticas, remuestreo, recorte, conversión a polígonos — únicamente dentro de PostgreSQL.</para>
+
+		<para>Ninguna vía reemplaza a la otra. El trabajo sobre la vía <varname>raquet</varname> amplía lo que una tesela nativa de la nube puede hacer a lo largo de una trayectoria; no pretende reimplementar el procesamiento ráster.</para>
+
+		<para>Extensiones previstas para la vía <varname>raquet</varname>:</para>
 		<itemizedlist>
-			<listitem><para><emphasis>Soporte multibanda</emphasis> — devolver un <varname>tfloat</varname> por banda para teselas Raquet multiespectrales (p. ej. RGB o imágenes satelitales multicanal).</para></listitem>
+			<listitem><para><emphasis>Huella de la tesela</emphasis> — una conversión a <varname>stbox</varname> y a <varname>geometry</varname> que da la extensión espacial de una tesela, derivada de su celda QUADBIN.</para></listitem>
+			<listitem><para><emphasis>Indexación espacial</emphasis> — un agregado <varname>extent</varname> y clases de operadores GiST y SP-GiST sobre la huella de la tesela, de modo que una trayectoria se una a una tabla de teselas por solapamiento espacial en lugar de por una prueba de igualdad sobre la celda QUADBIN en un único nivel de zoom fijo.</para></listitem>
 			<listitem><para><emphasis>Fusión agregada de teselas</emphasis> — una variante de retorno de conjunto que acepta el arreglo completo de teselas Raquet coincidentes y fusiona los conjuntos de instantes por tesela, eliminando instantes duplicados en los límites de tesela.</para></listitem>
-			<listitem><para><emphasis>Operador inverso</emphasis> — <varname>raster_atTime(raster, tstzspan)</varname> restringe un ráster a la extensión espacial visitada por una o más trayectorias durante un intervalo de tiempo.</para></listitem>
+			<listitem><para><emphasis>Restricción temporal</emphasis> — <varname>atTime(raquet, tstzspan)</varname> restringe una tesela a la extensión espacial visitada por una o más trayectorias durante un intervalo de tiempo.</para></listitem>
+		</itemizedlist>
+
+		<para>Las extensiones siguientes requieren un modelo de datos ráster general, es decir, sistemas de referencia espacial arbitrarios, georreferenciación afín arbitraria y varias bandas por tesela. Un valor <varname>raquet</varname> es una tesela de una sola banda cuya extensión y rejilla de píxeles se derivan de su celda QUADBIN, por lo que quedan fuera de ese modelo y siguen disponibles a través de la vía <varname>raster</varname> de PostGIS:</para>
+		<itemizedlist>
+			<listitem><para><emphasis>Teselas multibanda</emphasis> — un <varname>tfloat</varname> por banda para imágenes multiespectrales como RGB o escenas satelitales multicanal.</para></listitem>
+			<listitem><para><emphasis>Sistemas de referencia espacial arbitrarios</emphasis> — teselas fuera de la rejilla Web-Mercator y reproyección entre sistemas de referencia.</para></listitem>
+			<listitem><para><emphasis>Procesamiento ráster</emphasis> — álgebra de mapas, estadísticas de resumen, remuestreo, recorte y conversión a polígonos.</para></listitem>
 		</itemizedlist>
 	</sect1>
 </chapter>

--- a/doc/temporal_raster.xml
+++ b/doc/temporal_raster.xml
@@ -338,11 +338,23 @@ sudo make install
 	<sect1 xml:id="raster_roadmap">
 		<title>Production Roadmap</title>
 
-		<para>Future extensions to this chapter:</para>
+		<para>The two paths described in this chapter serve different purposes and are both maintained. The <varname>raquet</varname> path is a self-contained MEOS value type: it carries its pixels and its QUADBIN georeferencing in a single value and needs no PostgreSQL to evaluate, so it is available to every language binding derived from MEOS. The PostGIS <varname>raster</varname> path offers the far richer raster processing of the <varname>postgis_raster</varname> extension — map algebra, statistics, resampling, clipping, conversion to polygons — inside PostgreSQL only.</para>
+
+		<para>Neither path replaces the other. Work on the <varname>raquet</varname> path extends what a cloud-native tile can do along a trajectory; it is not an attempt to reimplement raster processing.</para>
+
+		<para>Planned extensions to the <varname>raquet</varname> path:</para>
 		<itemizedlist>
-			<listitem><para><emphasis>Multi-band support</emphasis> — return one <varname>tfloat</varname> per band for multi-spectral Raquet tiles (e.g. RGB or multi-channel satellite imagery).</para></listitem>
+			<listitem><para><emphasis>Tile footprint</emphasis> — an <varname>stbox</varname> cast and a <varname>geometry</varname> conversion giving the spatial extent of a tile, derived from its QUADBIN cell.</para></listitem>
+			<listitem><para><emphasis>Spatial indexing</emphasis> — an <varname>extent</varname> aggregate and GiST and SP-GiST operator classes over the tile footprint, so that a trajectory is joined against a tile table by spatial overlap instead of by an equality test on the QUADBIN cell at a single fixed zoom level.</para></listitem>
 			<listitem><para><emphasis>Aggregate tile merging</emphasis> — a set-returning variant that accepts the full array of matching Raquet tiles and merges the per-tile instant sets, removing duplicate instants at tile boundaries.</para></listitem>
-			<listitem><para><emphasis>Inverse operator</emphasis> — <varname>raster_atTime(raster, tstzspan)</varname> restricts a raster to the spatial extent visited by one or more trajectories during a time interval.</para></listitem>
+			<listitem><para><emphasis>Time restriction</emphasis> — <varname>atTime(raquet, tstzspan)</varname> restricting a tile to the spatial extent visited by one or more trajectories during a time interval.</para></listitem>
+		</itemizedlist>
+
+		<para>The extensions below require a general raster data model, that is, arbitrary spatial reference systems, arbitrary affine georeferencing and several bands per tile. A <varname>raquet</varname> value is a single-band tile whose extent and pixel grid follow from its QUADBIN cell, so these lie outside that model and remain available through the PostGIS <varname>raster</varname> path:</para>
+		<itemizedlist>
+			<listitem><para><emphasis>Multi-band tiles</emphasis> — one <varname>tfloat</varname> per band for multi-spectral imagery such as RGB or multi-channel satellite scenes.</para></listitem>
+			<listitem><para><emphasis>Arbitrary spatial reference systems</emphasis> — tiles outside the Web-Mercator grid, and reprojection between reference systems.</para></listitem>
+			<listitem><para><emphasis>Raster processing</emphasis> — map algebra, summary statistics, resampling, clipping and conversion to polygons.</para></listitem>
 		</itemizedlist>
 	</sect1>
 </chapter>


### PR DESCRIPTION
The production roadmap states how the two paths documented in this chapter relate, and splits the pending work along that line.

Both paths are maintained and serve different purposes. The `raquet` path is a self-contained MEOS value type: it carries its pixels and its QUADBIN georeferencing in a single value and needs no PostgreSQL to evaluate, so it is available to every language binding derived from MEOS. The PostGIS `raster` path carries the richer raster processing of the `postgis_raster` extension inside PostgreSQL. Neither path replaces the other.

Extensions listed for the `raquet` path are those that fit a QUADBIN-tiled single-band value: the tile footprint as `stbox` and `geometry`, spatial indexing over that footprint so a trajectory joins a tile table by spatial overlap rather than by an equality test on the QUADBIN cell at one fixed zoom level, aggregate tile merging, and `atTime` time restriction.

Extensions requiring a general raster data model are listed separately as available through the PostGIS path: multi-band tiles, arbitrary spatial reference systems, and raster processing such as map algebra, statistics, resampling and clipping. A `raquet` value is a single-band tile whose extent and pixel grid follow from its QUADBIN cell, which places these outside that model.

Documentation only, English and Spanish, with no new anchors or cross-references.
