### PR TITLE
Generate the tcbuffer dwithin spatial relationships

### DIFF
--- a/mobilitydb/src/cbuffer/tcbuffer_spatialrels.c
+++ b/mobilitydb/src/cbuffer/tcbuffer_spatialrels.c
@@ -837,6 +837,9 @@ Atouches_tcbuffer_tcbuffer(PG_FUNCTION_ARGS)
   return EA_spatialrel_tspatial_tspatial(fcinfo, &ea_touches_tcbuffer_tcbuffer,
     ALWAYS);
 }
+
+/* GENERATED-SPATIALRELS-BEGIN cbuffer_ea_dwithin — tools/codegen/inherited/generate.py from templates/spatialrels.c.tmpl;
+ * DO NOT EDIT BY HAND; edit the template + manifest.yaml (spatialrel_families) and re-run. */
 /*****************************************************************************
  * Ever/always dwithin
  * The function only accepts points and not arbitrary geometries
@@ -845,7 +848,7 @@ Atouches_tcbuffer_tcbuffer(PG_FUNCTION_ARGS)
 /**
  * @brief Return true if a geometry and a temporal circular buffer are
  * ever/always within a distance
- * @sqlfn eDwithin()
+ * @sqlfn eDwithin(), aDwithin()
  */
 static Datum
 EA_dwithin_geo_tcbuffer(FunctionCallInfo fcinfo, bool ever)
@@ -893,13 +896,13 @@ Adwithin_geo_tcbuffer(PG_FUNCTION_ARGS)
 /**
  * @brief Return true if a temporal circular buffer and a geometry are
  * ever/always within a distance
- * @sqlfn eDwithin()
+ * @sqlfn eDwithin(), aDwithin()
  */
 static Datum
 EA_dwithin_tcbuffer_geo(FunctionCallInfo fcinfo, bool ever)
 {
-  GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(1);
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
+  GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(1);
   double dist = PG_GETARG_FLOAT8(2);
   int result = ever ? edwithin_tcbuffer_geo(temp, gs, dist) :
     adwithin_tcbuffer_geo(temp, gs, dist);
@@ -939,31 +942,9 @@ Adwithin_tcbuffer_geo(PG_FUNCTION_ARGS)
 }
 
 /**
- * @brief Return true if two temporal circular buffers are ever/always within a
- * distance
- * @sqlfn eDwithin(), aDwithin()
- */
-static Datum
-EA_dwithin_tcbuffer_tcbuffer(FunctionCallInfo fcinfo, bool ever)
-{
-  Temporal *temp1 = PG_GETARG_TEMPORAL_P(0);
-  Temporal *temp2 = PG_GETARG_TEMPORAL_P(1);
-  double dist = PG_GETARG_FLOAT8(2);
-  int result = ever ? edwithin_tcbuffer_tcbuffer(temp1, temp2, dist) :
-    adwithin_tcbuffer_tcbuffer(temp1, temp2, dist);
-  PG_FREE_IF_COPY(temp1, 0);
-  PG_FREE_IF_COPY(temp2, 1);
-  if (result < 0)
-    PG_RETURN_NULL();
-  PG_RETURN_BOOL(result);
-}
-
-/*****************************************************************************/
-
-/**
  * @brief Return true if a circular buffer and a temporal circular buffer are
  * ever/always within a distance
- * @sqlfn eDwithin()
+ * @sqlfn eDwithin(), aDwithin()
  */
 static Datum
 EA_dwithin_cbuffer_tcbuffer(FunctionCallInfo fcinfo, bool ever)
@@ -1011,13 +992,13 @@ Adwithin_cbuffer_tcbuffer(PG_FUNCTION_ARGS)
 /**
  * @brief Return true if a temporal circular buffer and a circular buffer are
  * ever/always within a distance
- * @sqlfn eDwithin()
+ * @sqlfn eDwithin(), aDwithin()
  */
 static Datum
 EA_dwithin_tcbuffer_cbuffer(FunctionCallInfo fcinfo, bool ever)
 {
-  Cbuffer *cb = PG_GETARG_CBUFFER_P(1);
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
+  Cbuffer *cb = PG_GETARG_CBUFFER_P(1);
   double dist = PG_GETARG_FLOAT8(2);
   int result = ever ? edwithin_tcbuffer_cbuffer(temp, cb, dist) :
     adwithin_tcbuffer_cbuffer(temp, cb, dist);
@@ -1056,13 +1037,32 @@ Adwithin_tcbuffer_cbuffer(PG_FUNCTION_ARGS)
   return EA_dwithin_tcbuffer_cbuffer(fcinfo, ALWAYS);
 }
 
-/*****************************************************************************/
+/**
+ * @brief Return true if two temporal circular buffers are ever/always within a
+ * distance
+ * @sqlfn eDwithin(), aDwithin()
+ */
+static Datum
+EA_dwithin_tcbuffer_tcbuffer(FunctionCallInfo fcinfo, bool ever)
+{
+  Temporal *temp1 = PG_GETARG_TEMPORAL_P(0);
+  Temporal *temp2 = PG_GETARG_TEMPORAL_P(1);
+  double dist = PG_GETARG_FLOAT8(2);
+  int result = ever ? edwithin_tcbuffer_tcbuffer(temp1, temp2, dist) :
+    adwithin_tcbuffer_tcbuffer(temp1, temp2, dist);
+  PG_FREE_IF_COPY(temp1, 0);
+  PG_FREE_IF_COPY(temp2, 1);
+  if (result < 0)
+    PG_RETURN_NULL();
+  PG_RETURN_BOOL(result);
+}
 
 PGDLLEXPORT Datum Edwithin_tcbuffer_tcbuffer(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Edwithin_tcbuffer_tcbuffer);
 /**
  * @ingroup mobilitydb_cbuffer_rel_ever
- * @brief Return true if two temporal circular buffers are ever within a distance
+ * @brief Return true if two temporal circular buffers are ever within a
+ * distance
  * @sqlfn eDwithin()
  */
 inline Datum
@@ -1075,7 +1075,8 @@ PGDLLEXPORT Datum Adwithin_tcbuffer_tcbuffer(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Adwithin_tcbuffer_tcbuffer);
 /**
  * @ingroup mobilitydb_cbuffer_rel_ever
- * @brief Return true if two temporal circular buffers are always within a distance
+ * @brief Return true if two temporal circular buffers are always within a
+ * distance
  * @sqlfn aDwithin()
  */
 inline Datum
@@ -1083,5 +1084,6 @@ Adwithin_tcbuffer_tcbuffer(PG_FUNCTION_ARGS)
 {
   return EA_dwithin_tcbuffer_tcbuffer(fcinfo, ALWAYS);
 }
+/* GENERATED-SPATIALRELS-END cbuffer_ea_dwithin */
 
 /*****************************************************************************/

--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -290,6 +290,55 @@ def extract_spatialrels(filetext: str, family: str) -> str:
     return filetext[b:e]
 
 
+# --- dwithin (SQL spatialrels PG wrappers, distinct shape) ---------------
+# dwithin does not fit the shared spatialrels dispatch: each direction has a
+# static helper EA_dwithin_<dir>(fcinfo, ever) that reads the two operands and
+# the distance and calls the e/a MEOS kernel directly (no &meos dispatcher arg),
+# with two thin public wrappers on top. The static helper uses its own template;
+# the public wrappers reuse the shared spatialrels block (only {RETURN} differs).
+_DW_GET = {
+    "GSERIALIZED *": "PG_GETARG_GSERIALIZED_P",
+    "Temporal *":    "PG_GETARG_TEMPORAL_P",
+    "Cbuffer *":     "PG_GETARG_CBUFFER_P",
+}
+
+
+def render_dwithin(fam: dict) -> str:
+    """Render the ever/always dwithin region: per direction a static dispatcher
+    (rendered from dwithin_dispatcher.c.tmpl) followed by its ever and always
+    public wrappers. Arguments are declared and freed in position order."""
+    banner_t, block_t = (TEMPLATES / "spatialrels.c.tmpl").read_text().split("\n\n")
+    block_t = block_t.rstrip("\n")
+    disp_t = (TEMPLATES / "dwithin_dispatcher.c.tmpl").read_text().rstrip("\n")
+    ingroup = fam.get("ingroup", "mobilitydb_geo_rel_ever")
+    out = [banner_t.replace("{BANNER}", fam["banner"])]
+    for direc in fam["order"]:
+        d = fam["directions"][direc]
+        args = sorted(d["args"], key=lambda a: a["pos"])
+        decls = "\n".join(
+            f"  {a['type']}{a['var']} = {_DW_GET[a['type']]}({a['pos']});" for a in args)
+        frees = "\n".join(
+            f"  PG_FREE_IF_COPY({a['var']}, {a['pos']});" for a in args)
+        out.append(
+            disp_t.replace("{BRIEF}", _wrap_brief(
+                        f"Return true if {d['noun']} are ever/always within a distance"))
+                  .replace("{DIR}", direc)
+                  .replace("{DECLS}", decls)
+                  .replace("{KERNEL}", d["kernel"])
+                  .replace("{KARGS}", d["kargs"])
+                  .replace("{FREES}", frees))
+        for ea, word in (("E", "ever"), ("A", "always")):
+            out.append(
+                block_t.replace("{FN}", f"{ea}dwithin_{direc}")
+                       .replace("{INGROUP}", ingroup)
+                       .replace("{BRIEF}", _wrap_brief(
+                            f"Return true if {d['noun']} are {word} within a distance"))
+                       .replace("{SQLFN}", f"{'e' if ea == 'E' else 'a'}Dwithin")
+                       .replace("{RETURN}", f"  return EA_dwithin_{direc}(fcinfo, "
+                                            f"{'EVER' if ea == 'E' else 'ALWAYS'});"))
+    return "\n\n".join(out) + "\n"
+
+
 # --- SQL accessors (per-family, region-in-file) --------------------------
 # The Temporal<T> accessor surface (tempSubtype..segments) is declared INLINE in
 # each family's type file (052_tgeo, 202_tcbuffer, ...), not a separate numbered
@@ -578,7 +627,7 @@ def main() -> int:
             if not fam.get("reference"):
                 continue
             p = ROOT / fam["file"]
-            gen = render_spatialrels(fam)
+            gen = render_dwithin(fam) if fam.get("dwithin") else render_spatialrels(fam)
             cur = extract_spatialrels(p.read_text(), fam["family"]) if p.exists() else ""
             same = gen == cur
             ok = ok and same

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -342,6 +342,55 @@ spatialrel_families:
           tcbuffer_cbuffer:  "a temporal circular buffer and a circular buffer {word} intersect"
           tcbuffer_tcbuffer: "two temporal circular buffers {word} intersect"
 
+  # dwithin uses a distinct shape (a per-direction static dispatcher that reads
+  # the operands + the distance and calls the e/a kernel directly, with two thin
+  # public wrappers), so `dwithin: true` selects render_dwithin. Each direction
+  # lists its two arguments (declared/freed in position order), the MEOS kernel
+  # suffix and the kernel call arguments (temporal operand first).
+  - family:    cbuffer_ea_dwithin
+    file:      mobilitydb/src/cbuffer/tcbuffer_spatialrels.c
+    reference: true
+    dwithin:   true
+    ingroup:   mobilitydb_cbuffer_rel_ever
+    banner:    "Ever/always dwithin\n * The function only accepts points and not arbitrary geometries"
+    order:     [geo_tcbuffer, tcbuffer_geo, cbuffer_tcbuffer, tcbuffer_cbuffer, tcbuffer_tcbuffer]
+    directions:
+      geo_tcbuffer:
+        noun:   "a geometry and a temporal circular buffer"
+        kernel: tcbuffer_geo
+        kargs:  "temp, gs, dist"
+        args:
+          - {type: "GSERIALIZED *", var: gs,   pos: 0}
+          - {type: "Temporal *",    var: temp, pos: 1}
+      tcbuffer_geo:
+        noun:   "a temporal circular buffer and a geometry"
+        kernel: tcbuffer_geo
+        kargs:  "temp, gs, dist"
+        args:
+          - {type: "Temporal *",    var: temp, pos: 0}
+          - {type: "GSERIALIZED *", var: gs,   pos: 1}
+      cbuffer_tcbuffer:
+        noun:   "a circular buffer and a temporal circular buffer"
+        kernel: tcbuffer_cbuffer
+        kargs:  "temp, cb, dist"
+        args:
+          - {type: "Cbuffer *",  var: cb,   pos: 0}
+          - {type: "Temporal *", var: temp, pos: 1}
+      tcbuffer_cbuffer:
+        noun:   "a temporal circular buffer and a circular buffer"
+        kernel: tcbuffer_cbuffer
+        kargs:  "temp, cb, dist"
+        args:
+          - {type: "Temporal *", var: temp, pos: 0}
+          - {type: "Cbuffer *",  var: cb,   pos: 1}
+      tcbuffer_tcbuffer:
+        noun:   "two temporal circular buffers"
+        kernel: tcbuffer_tcbuffer
+        kargs:  "temp1, temp2, dist"
+        args:
+          - {type: "Temporal *", var: temp1, pos: 0}
+          - {type: "Temporal *", var: temp2, pos: 1}
+
 # ---------------------------------------------------------------------------
 # Accessor axis (SQL, per-family, region-in-file). The whole Temporal<T> accessor
 # surface (tempSubtype..segments) lives INLINE in each family's type file and

--- a/tools/codegen/inherited/templates/dwithin_dispatcher.c.tmpl
+++ b/tools/codegen/inherited/templates/dwithin_dispatcher.c.tmpl
@@ -1,0 +1,16 @@
+/**
+ * @brief {BRIEF}
+ * @sqlfn eDwithin(), aDwithin()
+ */
+static Datum
+EA_dwithin_{DIR}(FunctionCallInfo fcinfo, bool ever)
+{
+{DECLS}
+  double dist = PG_GETARG_FLOAT8(2);
+  int result = ever ? edwithin_{KERNEL}({KARGS}) :
+    adwithin_{KERNEL}({KARGS});
+{FREES}
+  if (result < 0)
+    PG_RETURN_NULL();
+  PG_RETURN_BOOL(result);
+}


### PR DESCRIPTION
Brings the ever/always **dwithin** PG wrappers in `mobilitydb/src/cbuffer/tcbuffer_spatialrels.c` onto the inherited-behaviour generator, completing the cbuffer spatial-relationship surface (contains/covers and disjoint/intersects (#1530) are already generated).

dwithin has a distinct shape from the other predicates: each direction has a static helper `EA_dwithin_<dir>(fcinfo, ever)` that reads the two operands and the distance and calls the e/a MEOS kernel directly (no `&meos` dispatcher argument), with two thin public wrappers on top. So it gets:
- a dedicated dispatcher template `dwithin_dispatcher.c.tmpl`;
- a `render_dwithin` path in `generate.py`, selected by `dwithin: true` on the `cbuffer_ea_dwithin` manifest entry (the public wrappers reuse the shared spatialrels block, differing only in `{RETURN}`).

`generate.py --validate` self-regenerates the region byte-for-byte.

Behaviour- and catalogue-neutral: the region keeps the identical set of five dispatchers and ten wrappers, the same MEOS kernels, dispatch and argument reads (an identical call/getarg multiset vs. master). Generation additionally regularises two remaining irregularities — the canonical five-direction order (the `tcbuffer`/`tcbuffer` helper is grouped with its wrappers rather than split across the region) and position-order argument declarations — both behaviour-neutral. No SQL or MEOS symbol changes.

Next in the wave: the rgeo and pose spatial-relationship families.
