### PR TITLE
Generate the trgeometry contains and covers spatial relationships

### DIFF
--- a/mobilitydb/src/rgeo/trgeo_spatialrels.c
+++ b/mobilitydb/src/rgeo/trgeo_spatialrels.c
@@ -56,6 +56,8 @@
 #include "pg_geo/postgis.h"
 #include "pg_geo/tspatial.h"
 
+/* GENERATED-SPATIALRELS-BEGIN rgeo_ea_contains_covers — tools/codegen/inherited/generate.py from templates/spatialrels.c.tmpl;
+ * DO NOT EDIT BY HAND; edit the template + manifest.yaml (spatialrel_families) and re-run. */
 /*****************************************************************************
  * Ever/always contains
  *****************************************************************************/
@@ -85,66 +87,6 @@ Acontains_geo_trgeometry(PG_FUNCTION_ARGS)
 {
   return EA_spatialrel_geo_tspatial(fcinfo, &ea_contains_geo_trgeo, ALWAYS);
 }
-
-/*****************************************************************************
- * Ever/always covers
- *****************************************************************************/
-
-PGDLLEXPORT Datum Ecovers_geo_trgeometry(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Ecovers_geo_trgeometry);
-/**
- * @ingroup mobilitydb_geo_rel_ever
- * @brief Return true if a geometry ever covers a temporal rigid geometry
- * @sqlfn eCovers()
- */
-inline Datum
-Ecovers_geo_trgeometry(PG_FUNCTION_ARGS)
-{
-  return EA_spatialrel_geo_tspatial(fcinfo, &ea_covers_geo_trgeo, EVER);
-}
-
-PGDLLEXPORT Datum Acovers_geo_trgeometry(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Acovers_geo_trgeometry);
-/**
- * @ingroup mobilitydb_geo_rel_ever
- * @brief Return true if a geometry always covers a temporal rigid geometry
- * @sqlfn aCovers()
- */
-inline Datum
-Acovers_geo_trgeometry(PG_FUNCTION_ARGS)
-{
-  return EA_spatialrel_geo_tspatial(fcinfo, &ea_covers_geo_trgeo, ALWAYS);
-}
-
-/*****************************************************************************/
-
-PGDLLEXPORT Datum Ecovers_trgeometry_geo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Ecovers_trgeometry_geo);
-/**
- * @ingroup mobilitydb_geo_rel_ever
- * @brief Return true if a geometry ever covers a temporal rigid geometry
- * @sqlfn eCovers()
- */
-inline Datum
-Ecovers_trgeometry_geo(PG_FUNCTION_ARGS)
-{
-  return EA_spatialrel_tspatial_geo(fcinfo, &ea_covers_trgeo_geo, EVER);
-}
-
-PGDLLEXPORT Datum Acovers_trgeometry_geo(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Acovers_trgeometry_geo);
-/**
- * @ingroup mobilitydb_geo_rel_ever
- * @brief Return true if a geometry always covers a temporal rigid geometry
- * @sqlfn aCovers()
- */
-inline Datum
-Acovers_trgeometry_geo(PG_FUNCTION_ARGS)
-{
-  return EA_spatialrel_tspatial_geo(fcinfo, &ea_covers_trgeo_geo, ALWAYS);
-}
-
-/*****************************************************************************/
 
 PGDLLEXPORT Datum Econtains_trgeometry_geo(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Econtains_trgeometry_geo);
@@ -200,6 +142,62 @@ Acontains_trgeometry_trgeometry(PG_FUNCTION_ARGS)
     ALWAYS);
 }
 
+/*****************************************************************************
+ * Ever/always covers
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Ecovers_geo_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Ecovers_geo_trgeometry);
+/**
+ * @ingroup mobilitydb_geo_rel_ever
+ * @brief Return true if a geometry ever covers a temporal rigid geometry
+ * @sqlfn eCovers()
+ */
+inline Datum
+Ecovers_geo_trgeometry(PG_FUNCTION_ARGS)
+{
+  return EA_spatialrel_geo_tspatial(fcinfo, &ea_covers_geo_trgeo, EVER);
+}
+
+PGDLLEXPORT Datum Acovers_geo_trgeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Acovers_geo_trgeometry);
+/**
+ * @ingroup mobilitydb_geo_rel_ever
+ * @brief Return true if a geometry always covers a temporal rigid geometry
+ * @sqlfn aCovers()
+ */
+inline Datum
+Acovers_geo_trgeometry(PG_FUNCTION_ARGS)
+{
+  return EA_spatialrel_geo_tspatial(fcinfo, &ea_covers_geo_trgeo, ALWAYS);
+}
+
+PGDLLEXPORT Datum Ecovers_trgeometry_geo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Ecovers_trgeometry_geo);
+/**
+ * @ingroup mobilitydb_geo_rel_ever
+ * @brief Return true if a temporal rigid geometry ever covers a geometry
+ * @sqlfn eCovers()
+ */
+inline Datum
+Ecovers_trgeometry_geo(PG_FUNCTION_ARGS)
+{
+  return EA_spatialrel_tspatial_geo(fcinfo, &ea_covers_trgeo_geo, EVER);
+}
+
+PGDLLEXPORT Datum Acovers_trgeometry_geo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Acovers_trgeometry_geo);
+/**
+ * @ingroup mobilitydb_geo_rel_ever
+ * @brief Return true if a temporal rigid geometry always covers a geometry
+ * @sqlfn aCovers()
+ */
+inline Datum
+Acovers_trgeometry_geo(PG_FUNCTION_ARGS)
+{
+  return EA_spatialrel_tspatial_geo(fcinfo, &ea_covers_trgeo_geo, ALWAYS);
+}
+
 PGDLLEXPORT Datum Ecovers_trgeometry_trgeometry(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Ecovers_trgeometry_trgeometry);
 /**
@@ -226,6 +224,7 @@ Acovers_trgeometry_trgeometry(PG_FUNCTION_ARGS)
   return EA_spatialrel_tspatial_tspatial(fcinfo, &ea_covers_trgeo_trgeo,
     ALWAYS);
 }
+/* GENERATED-SPATIALRELS-END rgeo_ea_contains_covers */
 
 /*****************************************************************************
  * Ever disjoint (for both geometry and geography)

--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -242,6 +242,11 @@ def render_spatialrels(fam: dict) -> str:
     ingroup = fam.get("ingroup", "mobilitydb_geo_rel_ever")
     order = fam.get("order", _SR_ORDER)
     disp_map = fam.get("disp", _SR_DISP)
+    # Some families name the MEOS kernel with an abbreviated type token that
+    # differs from the public-function direction token (e.g. rgeo functions are
+    # `..._trgeometry` but their kernels are `ea_..._trgeo`). kernel_dir maps a
+    # direction to its kernel token; absent, the direction is used unchanged.
+    kernel_dir = fam.get("kernel_dir", {})
     out = []
     for pred in fam["predicates"]:
         out.append(banner_t.replace("{BANNER}", pred["banner"]))
@@ -249,7 +254,7 @@ def render_spatialrels(fam: dict) -> str:
         meos_fixed = pred.get("meos_fixed")
         for direc in pred.get("directions", order):
             disp = disp_over.get(direc, disp_map[direc])
-            meos = meos_fixed or f"ea_{pred['rel']}_{direc}"
+            meos = meos_fixed or f"ea_{pred['rel']}_{kernel_dir.get(direc, direc)}"
             for ea, word, low in (("E", "ever", "e"), ("A", "always", "a")):
                 brief = _wrap_brief(
                     "Return true if " + pred["briefs"][direc].replace("{word}", word))

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -391,6 +391,39 @@ spatialrel_families:
           - {type: "Temporal *", var: temp1, pos: 0}
           - {type: "Temporal *", var: temp2, pos: 1}
 
+  # rgeo (temporal rigid geometry) has the reduced three-direction shape (geo⊗T,
+  # T⊗geo, T⊗T; no base-value directions) and abbreviates its kernel type token
+  # trgeometry -> trgeo, so it uses kernel_dir. It shares the geo ever/always doc
+  # group.
+  - family:    rgeo_ea_contains_covers
+    file:      mobilitydb/src/rgeo/trgeo_spatialrels.c
+    reference: true
+    ingroup:   mobilitydb_geo_rel_ever
+    order:     [geo_trgeometry, trgeometry_geo, trgeometry_trgeometry]
+    disp:
+      geo_trgeometry:        EA_spatialrel_geo_tspatial
+      trgeometry_geo:        EA_spatialrel_tspatial_geo
+      trgeometry_trgeometry: EA_spatialrel_tspatial_tspatial
+    kernel_dir:
+      geo_trgeometry:        geo_trgeo
+      trgeometry_geo:        trgeo_geo
+      trgeometry_trgeometry: trgeo_trgeo
+    predicates:
+      - rel: contains
+        Rel: Contains
+        banner: "Ever/always contains"
+        briefs:
+          geo_trgeometry:        "a geometry {word} contains a temporal rigid geometry"
+          trgeometry_geo:        "a temporal rigid geometry {word} contains a geometry"
+          trgeometry_trgeometry: "a temporal rigid geometry {word} contains another one"
+      - rel: covers
+        Rel: Covers
+        banner: "Ever/always covers"
+        briefs:
+          geo_trgeometry:        "a geometry {word} covers a temporal rigid geometry"
+          trgeometry_geo:        "a temporal rigid geometry {word} covers a geometry"
+          trgeometry_trgeometry: "a temporal rigid geometry {word} covers another one"
+
 # ---------------------------------------------------------------------------
 # Accessor axis (SQL, per-family, region-in-file). The whole Temporal<T> accessor
 # surface (tempSubtype..segments) lives INLINE in each family's type file and


### PR DESCRIPTION
Brings the ever/always **contains** and **covers** PG wrappers in `mobilitydb/src/rgeo/trgeo_spatialrels.c` onto the inherited-behaviour generator, extending the spatial-relationship wave from geo and cbuffer to rgeo (temporal rigid geometry).

rgeo has the reduced three-direction shape (geo/T, T/geo, T/T; no base-value directions) and names its MEOS kernels with an abbreviated type token — `trgeometry` in the public function, `trgeo` in the kernel (`ea_contains_geo_trgeo`). A small optional `kernel_dir` map on the family decouples the function-direction token from the kernel token; it defaults to the direction unchanged, so geo and cbuffer regenerate byte-for-byte (`--validate` stays green for every family).

Behaviour- and catalogue-neutral: the region keeps the identical set of twelve wrappers and the same MEOS kernels and dispatchers (an identical call multiset vs. master). Generation additionally regularises the function order — master interleaves the contains and covers directions (contains-geo, covers-geo, covers-T/geo, contains-T/geo, …); the generated region groups each predicate's three directions together. No SQL or MEOS symbol changes.

Future in the rgeo wave: disjoint/intersects, then dwithin (whose region also carries a leaked static helper, an `even/always` typo, and two `@ingroup` values missing `_ever`, to regularise as in the cbuffer counterpart).
