### PR TITLE
Document indexing a raquet tile table through the tile footprint

### DIFF
--- a/doc/es/temporal_raster.xml
+++ b/doc/es/temporal_raster.xml
@@ -241,6 +241,20 @@ SELECT round(stbox(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
 SELECT * FROM elevation_tiles
 WHERE tile::stbox &amp;&amp; stbox 'SRID=4326;STBOX X((0,0),(30,30))';
 </programlisting>
+				<para>La huella admite los operadores, agregados y clases de operadores de <varname>stbox</varname>, por lo que una tabla de teselas se consulta por solapamiento espacial en cualquier nivel de zoom en lugar de por una prueba de igualdad sobre la celda QUADBIN en uno fijo. Indexar la conversión dota a la tabla de teselas de un índice espacial, y la extensión de un conjunto de teselas es la extensión de sus huellas.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- A spatial index over the tile footprints
+CREATE INDEX elevation_tiles_gist ON elevation_tiles USING gist (stbox(tile));
+CREATE INDEX elevation_tiles_spgist ON elevation_tiles USING spgist (stbox(tile));
+
+-- The extent covered by a set of tiles
+SELECT extent(stbox(tile)) FROM elevation_tiles;
+
+-- Tiles a trajectory passes through, at whatever zoom levels the table holds
+SELECT t.tripid, r.tile
+FROM trips t, elevation_tiles r
+WHERE stbox(r.tile) &amp;&amp; stbox(t.trip4326);
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="raquet_comparison">
@@ -359,7 +373,6 @@ sudo make install
 		<para>Extensiones previstas para la vía <varname>raquet</varname>:</para>
 		<itemizedlist>
 			<listitem><para><emphasis>Huella de la tesela</emphasis> — una conversión a <varname>stbox</varname> y a <varname>geometry</varname> que da la extensión espacial de una tesela, derivada de su celda QUADBIN.</para></listitem>
-			<listitem><para><emphasis>Indexación espacial</emphasis> — un agregado <varname>extent</varname> y clases de operadores GiST y SP-GiST sobre la huella de la tesela, de modo que una trayectoria se una a una tabla de teselas por solapamiento espacial en lugar de por una prueba de igualdad sobre la celda QUADBIN en un único nivel de zoom fijo.</para></listitem>
 			<listitem><para><emphasis>Fusión agregada de teselas</emphasis> — una variante de retorno de conjunto que acepta el arreglo completo de teselas Raquet coincidentes y fusiona los conjuntos de instantes por tesela, eliminando instantes duplicados en los límites de tesela.</para></listitem>
 			<listitem><para><emphasis>Restricción temporal</emphasis> — <varname>atTime(raquet, tstzspan)</varname> restringe una tesela a la extensión espacial visitada por una o más trayectorias durante un intervalo de tiempo.</para></listitem>
 		</itemizedlist>

--- a/doc/temporal_raster.xml
+++ b/doc/temporal_raster.xml
@@ -243,6 +243,20 @@ SELECT round(stbox(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
 SELECT * FROM elevation_tiles
 WHERE tile::stbox &amp;&amp; stbox 'SRID=4326;STBOX X((0,0),(30,30))';
 </programlisting>
+				<para>The footprint carries the <varname>stbox</varname> operators, aggregates and operator classes, so a tile table is searched by spatial overlap at any zoom level rather than by an equality test on the QUADBIN cell at a single fixed one. Indexing the conversion gives the tile table a spatial index, and the extent of a set of tiles is the extent of their footprints.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- A spatial index over the tile footprints
+CREATE INDEX elevation_tiles_gist ON elevation_tiles USING gist (stbox(tile));
+CREATE INDEX elevation_tiles_spgist ON elevation_tiles USING spgist (stbox(tile));
+
+-- The extent covered by a set of tiles
+SELECT extent(stbox(tile)) FROM elevation_tiles;
+
+-- Tiles a trajectory passes through, at whatever zoom levels the table holds
+SELECT t.tripid, r.tile
+FROM trips t, elevation_tiles r
+WHERE stbox(r.tile) &amp;&amp; stbox(t.trip4326);
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="raquet_comparison">
@@ -362,7 +376,6 @@ sudo make install
 		<para>Planned extensions to the <varname>raquet</varname> path:</para>
 		<itemizedlist>
 			<listitem><para><emphasis>Tile footprint</emphasis> — an <varname>stbox</varname> cast and a <varname>geometry</varname> conversion giving the spatial extent of a tile, derived from its QUADBIN cell.</para></listitem>
-			<listitem><para><emphasis>Spatial indexing</emphasis> — an <varname>extent</varname> aggregate and GiST and SP-GiST operator classes over the tile footprint, so that a trajectory is joined against a tile table by spatial overlap instead of by an equality test on the QUADBIN cell at a single fixed zoom level.</para></listitem>
 			<listitem><para><emphasis>Aggregate tile merging</emphasis> — a set-returning variant that accepts the full array of matching Raquet tiles and merges the per-tile instant sets, removing duplicate instants at tile boundaries.</para></listitem>
 			<listitem><para><emphasis>Time restriction</emphasis> — <varname>atTime(raquet, tstzspan)</varname> restricting a tile to the spatial extent visited by one or more trajectories during a time interval.</para></listitem>
 		</itemizedlist>

--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -405,3 +405,31 @@ FROM t;
  t                                  | t
 (1 row)
 
+CREATE TABLE test_raquet_tiles (id integer, tile raquet);
+CREATE TABLE
+INSERT INTO test_raquet_tiles
+SELECT g, raquet('\x01020304'::bytea, 2, 2, c, 'UINT8')
+FROM (VALUES (1, 5193776270265024512::bigint), (2, 5202501994543054848::bigint),
+             (3, 5203346419473186816::bigint), (4, 5203416788217364480::bigint))
+     v(g, c);
+INSERT 0 4
+CREATE INDEX test_raquet_tiles_gist ON test_raquet_tiles USING gist (stbox(tile));
+CREATE INDEX
+CREATE INDEX test_raquet_tiles_spgist ON test_raquet_tiles
+  USING spgist (stbox(tile));
+CREATE INDEX
+SELECT round(extent(stbox(tile)), 6) FROM test_raquet_tiles;
+                   round                    
+--------------------------------------------
+ SRID=4326;STBOX X((-90,0),(180,85.051129))
+(1 row)
+
+SELECT count(*) FROM test_raquet_tiles
+WHERE stbox(tile) && stbox 'SRID=4326;STBOX X((0,0),(30,30))';
+ count 
+-------
+     1
+(1 row)
+
+DROP TABLE test_raquet_tiles;
+DROP TABLE

--- a/mobilitydb/test/raster/queries/500_raster.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster.test.sql
@@ -434,3 +434,29 @@ WITH t(a, b) AS (VALUES (
 SELECT stbox(a) <> stbox(b) AS distinct_cells_distinct_footprints,
        stbox(a) && stbox(a) AS overlaps_itself
 FROM t;
+
+-------------------------------------------------------------------------------
+-- raquet spatial indexing through the tile footprint
+-------------------------------------------------------------------------------
+
+CREATE TABLE test_raquet_tiles (id integer, tile raquet);
+INSERT INTO test_raquet_tiles
+SELECT g, raquet('\x01020304'::bytea, 2, 2, c, 'UINT8')
+FROM (VALUES (1, 5193776270265024512::bigint), (2, 5202501994543054848::bigint),
+             (3, 5203346419473186816::bigint), (4, 5203416788217364480::bigint))
+     v(g, c);
+
+-- The footprint is indexable with the stbox operator classes, so a tile table
+-- is searched by spatial overlap rather than by an equality test on the cell.
+CREATE INDEX test_raquet_tiles_gist ON test_raquet_tiles USING gist (stbox(tile));
+CREATE INDEX test_raquet_tiles_spgist ON test_raquet_tiles
+  USING spgist (stbox(tile));
+
+-- The extent of a set of tiles composes the footprint with the stbox extent.
+SELECT round(extent(stbox(tile)), 6) FROM test_raquet_tiles;
+
+-- Tiles are selected by overlap with a region of interest.
+SELECT count(*) FROM test_raquet_tiles
+WHERE stbox(tile) && stbox 'SRID=4326;STBOX X((0,0),(30,30))';
+
+DROP TABLE test_raquet_tiles;


### PR DESCRIPTION
The tile footprint carries the `stbox` operators, aggregates and operator classes, so a `raquet` table is indexed and searched spatially by indexing the conversion:

```sql
CREATE INDEX elevation_tiles_gist ON elevation_tiles USING gist (stbox(tile));
SELECT extent(stbox(tile)) FROM elevation_tiles;
```

A tile table is therefore joined against a trajectory by spatial overlap at whatever zoom levels the table holds, rather than by an equality test on the QUADBIN cell at one fixed level.

No `raquet` operator class and no `raquet` extent aggregate are needed. This matches the other base spatial types: `cbuffer`, `npoint`, `nsegment`, `pose`, `quadbin`, `h3index` and `pcpatch` each expose an `stbox` conversion and none carries an operator class or an extent aggregate of its own; `stbox` carries `stbox_rtree_ops`, `stbox_quadtree_ops` and `stbox_kdtree_ops`, and the rest composes.

The chapter documents the pattern, and the tests build the GiST and SP-GiST indexes over a tile table, take its extent, and select tiles by overlap. The roadmap entry describing spatial indexing as pending operator classes is dropped, since the capability follows from the footprint conversion.

Documentation and tests only.
