### PR TITLE
Correct the raster roadmap for the tile footprint and time restriction

### DIFF
--- a/doc/es/temporal_raster.xml
+++ b/doc/es/temporal_raster.xml
@@ -372,16 +372,14 @@ sudo make install
 
 		<para>Extensiones previstas para la vía <varname>raquet</varname>:</para>
 		<itemizedlist>
-			<listitem><para><emphasis>Huella de la tesela</emphasis> — una conversión a <varname>stbox</varname> y a <varname>geometry</varname> que da la extensión espacial de una tesela, derivada de su celda QUADBIN.</para></listitem>
 			<listitem><para><emphasis>Fusión agregada de teselas</emphasis> — una variante de retorno de conjunto que acepta el arreglo completo de teselas Raquet coincidentes y fusiona los conjuntos de instantes por tesela, eliminando instantes duplicados en los límites de tesela.</para></listitem>
-			<listitem><para><emphasis>Restricción temporal</emphasis> — <varname>atTime(raquet, tstzspan)</varname> restringe una tesela a la extensión espacial visitada por una o más trayectorias durante un intervalo de tiempo.</para></listitem>
 		</itemizedlist>
 
 		<para>Las extensiones siguientes requieren un modelo de datos ráster general, es decir, sistemas de referencia espacial arbitrarios, georreferenciación afín arbitraria y varias bandas por tesela. Un valor <varname>raquet</varname> es una tesela de una sola banda cuya extensión y rejilla de píxeles se derivan de su celda QUADBIN, por lo que quedan fuera de ese modelo y siguen disponibles a través de la vía <varname>raster</varname> de PostGIS:</para>
 		<itemizedlist>
 			<listitem><para><emphasis>Teselas multibanda</emphasis> — un <varname>tfloat</varname> por banda para imágenes multiespectrales como RGB o escenas satelitales multicanal.</para></listitem>
 			<listitem><para><emphasis>Sistemas de referencia espacial arbitrarios</emphasis> — teselas fuera de la rejilla Web-Mercator y reproyección entre sistemas de referencia.</para></listitem>
-			<listitem><para><emphasis>Procesamiento ráster</emphasis> — álgebra de mapas, estadísticas de resumen, remuestreo, recorte y conversión a polígonos.</para></listitem>
+			<listitem><para><emphasis>Procesamiento ráster</emphasis> — álgebra de mapas, estadísticas de resumen, remuestreo y conversión a polígonos, junto con el recorte de una tesela a una región, como la extensión que un conjunto de trayectorias visita durante un intervalo de tiempo.</para></listitem>
 		</itemizedlist>
 	</sect1>
 </chapter>

--- a/doc/temporal_raster.xml
+++ b/doc/temporal_raster.xml
@@ -375,16 +375,14 @@ sudo make install
 
 		<para>Planned extensions to the <varname>raquet</varname> path:</para>
 		<itemizedlist>
-			<listitem><para><emphasis>Tile footprint</emphasis> — an <varname>stbox</varname> cast and a <varname>geometry</varname> conversion giving the spatial extent of a tile, derived from its QUADBIN cell.</para></listitem>
 			<listitem><para><emphasis>Aggregate tile merging</emphasis> — a set-returning variant that accepts the full array of matching Raquet tiles and merges the per-tile instant sets, removing duplicate instants at tile boundaries.</para></listitem>
-			<listitem><para><emphasis>Time restriction</emphasis> — <varname>atTime(raquet, tstzspan)</varname> restricting a tile to the spatial extent visited by one or more trajectories during a time interval.</para></listitem>
 		</itemizedlist>
 
 		<para>The extensions below require a general raster data model, that is, arbitrary spatial reference systems, arbitrary affine georeferencing and several bands per tile. A <varname>raquet</varname> value is a single-band tile whose extent and pixel grid follow from its QUADBIN cell, so these lie outside that model and remain available through the PostGIS <varname>raster</varname> path:</para>
 		<itemizedlist>
 			<listitem><para><emphasis>Multi-band tiles</emphasis> — one <varname>tfloat</varname> per band for multi-spectral imagery such as RGB or multi-channel satellite scenes.</para></listitem>
 			<listitem><para><emphasis>Arbitrary spatial reference systems</emphasis> — tiles outside the Web-Mercator grid, and reprojection between reference systems.</para></listitem>
-			<listitem><para><emphasis>Raster processing</emphasis> — map algebra, summary statistics, resampling, clipping and conversion to polygons.</para></listitem>
+			<listitem><para><emphasis>Raster processing</emphasis> — map algebra, summary statistics, resampling, and conversion to polygons, together with clipping a tile to a region, such as the extent a set of trajectories visits over a time interval.</para></listitem>
 		</itemizedlist>
 	</sect1>
 </chapter>


### PR DESCRIPTION
Two roadmap entries describe work that either exists or belongs elsewhere.

The tile footprint entry listed a `geometry` conversion beside the `stbox` cast. A QUADBIN cell in longitude and latitude is an axis-aligned rectangle, so a footprint polygon carries the same extent as the box, the duplication that retired `quadbinCellToBoundingBox`. The `stbox` cast covers the entry, which is therefore dropped.

The time restriction entry gave `atTime(raquet, tstzspan)` for restricting a tile to the extent trajectories visit over an interval. A `raquet` carries no time dimension, and the operation clips the pixels to a region, which needs a general raster data model. It moves to the raster processing entry, among the extensions the PostGIS path carries.

Documentation only, English and Spanish.
