### PR TITLE
Attribute the public stbox_expand to the geo family and public header

### DIFF
--- a/meos/include/meos_geo.h
+++ b/meos/include/meos_geo.h
@@ -550,6 +550,7 @@ extern bool stbox_zmin(const STBox *box, double *result);
 
 /* Transformation functions */
 
+extern void stbox_expand(const STBox *box1, STBox *box2);
 extern STBox *stbox_expand_space(const STBox *box, double d);
 extern STBox *stbox_expand_time(const STBox *box, const Interval *interv);
 extern STBox *stbox_get_space(const STBox *box);

--- a/meos/include/meos_internal_geo.h
+++ b/meos/include/meos_internal_geo.h
@@ -142,7 +142,6 @@ extern void tstzspanset_set_stbox(const SpanSet *s, STBox *result);
 
 /* Transformation functions for box types */
 
-extern void stbox_expand(const STBox *box1, STBox *box2);
 extern bool stbox_expand_space_set(const STBox *box, double d, STBox *result);
 
 /*****************************************************************************/

--- a/meos/src/geo/stbox.c
+++ b/meos/src/geo/stbox.c
@@ -96,9 +96,10 @@ extern void ll2cart(const POINT2D *g, POINT3D *p);
  *****************************************************************************/
 
 /**
- * @ingroup meos_box_transf
+ * @ingroup meos_geo_box_transf
  * @brief Return the second spatiotemporal box expanded with the first one
- * @param[in] box1,box2 Spatiotemporal boxes
+ * @param[in] box1 Spatiotemporal box
+ * @param[in,out] box2 Spatiotemporal box
  * @pre No tests are made concerning the SRID, dimensionality, etc.
  * This should be ensured by the calling function.
  */


### PR DESCRIPTION
`stbox_expand` is public, and this places it with the rest of the spatiotemporal box surface.

Its Doxygen group is `meos_geo_box_transf`, the group the seven other transformation functions in `meos/src/geo/stbox.c` use, defined in `geo/doxygen_meos_geo.h`. The group `meos_box_transf`, defined in `temporal/doxygen_meos.h`, holds the temporal box functions of `tbox.c`.

Its declaration sits in `meos_geo.h` beside `stbox_expand_space` and `stbox_expand_time`. The `api` classification derives from the Doxygen group, so a function in a public group belongs in the public umbrella header; `meos_internal_geo.h` includes `meos_geo.h`, so the internal callers reach it unchanged.

The `box2` parameter is documented as `in,out`, as in the `tbox_expand` twin, since it is both read and written.
