### PR TITLE
Generate the trgeometry disjoint and intersects spatial relationships

### DIFF
--- a/mobilitydb/src/rgeo/trgeo_spatialrels.c
+++ b/mobilitydb/src/rgeo/trgeo_spatialrels.c
@@ -226,6 +226,8 @@ Acovers_trgeometry_trgeometry(PG_FUNCTION_ARGS)
 }
 /* GENERATED-SPATIALRELS-END rgeo_ea_contains_covers */
 
+/* GENERATED-SPATIALRELS-BEGIN rgeo_ea_disjoint_intersects — tools/codegen/inherited/generate.py from templates/spatialrels.c.tmpl;
+ * DO NOT EDIT BY HAND; edit the template + manifest.yaml (spatialrel_families) and re-run. */
 /*****************************************************************************
  * Ever disjoint (for both geometry and geography)
  *****************************************************************************/
@@ -304,7 +306,7 @@ PGDLLEXPORT Datum Adisjoint_trgeometry_trgeometry(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Adisjoint_trgeometry_trgeometry);
 /**
  * @ingroup mobilitydb_geo_rel_ever
- * @brief Return true if two temporal rigid geometries are ever disjoint
+ * @brief Return true if two temporal rigid geometries are always disjoint
  * @sqlfn aDisjoint()
  */
 inline Datum
@@ -322,8 +324,7 @@ PGDLLEXPORT Datum Eintersects_geo_trgeometry(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Eintersects_geo_trgeometry);
 /**
  * @ingroup mobilitydb_geo_rel_ever
- * @brief Return true if a geometry and a temporal rigid geometry ever
- * intersect
+ * @brief Return true if a geometry and a temporal rigid geometry ever intersect
  * @sqlfn eIntersects()
  */
 inline Datum
@@ -336,7 +337,7 @@ PGDLLEXPORT Datum Aintersects_geo_trgeometry(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Aintersects_geo_trgeometry);
 /**
  * @ingroup mobilitydb_geo_rel_ever
- * @brief Return true if a geometry and a temporal rigid geometry ever
+ * @brief Return true if a geometry and a temporal rigid geometry always
  * intersect
  * @sqlfn aIntersects()
  */
@@ -350,8 +351,7 @@ PGDLLEXPORT Datum Eintersects_trgeometry_geo(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Eintersects_trgeometry_geo);
 /**
  * @ingroup mobilitydb_geo_rel_ever
- * @brief Return true if a temporal rigid geometry and a geometry ever
- * intersect
+ * @brief Return true if a temporal rigid geometry and a geometry ever intersect
  * @sqlfn eIntersects()
  */
 inline Datum
@@ -392,7 +392,7 @@ PGDLLEXPORT Datum Aintersects_trgeometry_trgeometry(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Aintersects_trgeometry_trgeometry);
 /**
  * @ingroup mobilitydb_geo_rel_ever
- * @brief Return true if two temporal rigid geometries ever intersect
+ * @brief Return true if two temporal rigid geometries always intersect
  * @sqlfn aIntersects()
  */
 inline Datum
@@ -401,6 +401,7 @@ Aintersects_trgeometry_trgeometry(PG_FUNCTION_ARGS)
   return EA_spatialrel_tspatial_tspatial(fcinfo, &ea_intersects_trgeo_trgeo,
     ALWAYS);
 }
+/* GENERATED-SPATIALRELS-END rgeo_ea_disjoint_intersects */
 
 /*****************************************************************************
  * Ever/always touches

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -424,6 +424,35 @@ spatialrel_families:
           trgeometry_geo:        "a temporal rigid geometry {word} covers a geometry"
           trgeometry_trgeometry: "a temporal rigid geometry {word} covers another one"
 
+  - family:    rgeo_ea_disjoint_intersects
+    file:      mobilitydb/src/rgeo/trgeo_spatialrels.c
+    reference: true
+    ingroup:   mobilitydb_geo_rel_ever
+    order:     [geo_trgeometry, trgeometry_geo, trgeometry_trgeometry]
+    disp:
+      geo_trgeometry:        EA_spatialrel_geo_tspatial
+      trgeometry_geo:        EA_spatialrel_tspatial_geo
+      trgeometry_trgeometry: EA_spatialrel_tspatial_tspatial
+    kernel_dir:
+      geo_trgeometry:        geo_trgeo
+      trgeometry_geo:        trgeo_geo
+      trgeometry_trgeometry: trgeo_trgeo
+    predicates:
+      - rel: disjoint
+        Rel: Disjoint
+        banner: "Ever disjoint (for both geometry and geography)"
+        briefs:
+          geo_trgeometry:        "a geometry and a temporal rigid geometry are {word} disjoint"
+          trgeometry_geo:        "a temporal rigid geometry and a geometry are {word} disjoint"
+          trgeometry_trgeometry: "two temporal rigid geometries are {word} disjoint"
+      - rel: intersects
+        Rel: Intersects
+        banner: "Ever intersects (for both geometry and geography)"
+        briefs:
+          geo_trgeometry:        "a geometry and a temporal rigid geometry {word} intersect"
+          trgeometry_geo:        "a temporal rigid geometry and a geometry {word} intersect"
+          trgeometry_trgeometry: "two temporal rigid geometries {word} intersect"
+
 # ---------------------------------------------------------------------------
 # Accessor axis (SQL, per-family, region-in-file). The whole Temporal<T> accessor
 # surface (tempSubtype..segments) lives INLINE in each family's type file and


### PR DESCRIPTION
Brings the ever/always **disjoint** and **intersects** PG wrappers in `mobilitydb/src/rgeo/trgeo_spatialrels.c` onto the inherited-behaviour generator, mirroring the already-generated rgeo contains/covers region (#1540) — reusing its ingroup, three-direction order, dispatcher map and the `trgeometry -> trgeo` `kernel_dir`.

`generate.py --validate` self-regenerates both rgeo regions byte-for-byte.

Behaviour- and catalogue-neutral: the region keeps the identical set of twelve wrappers and the same MEOS kernels and dispatchers (an identical call multiset vs. master). Generation additionally corrects the always-direction `@brief` comments, which reuse the "ever" wording copied from their ever siblings (e.g. `Adisjoint_trgeometry_trgeometry` reads "ever disjoint") — the same copy-paste class the geo disjoint/intersects generation fixed. No SQL or MEOS symbol changes.

Future in the rgeo wave: dwithin (whose region also carries a leaked static helper, an `even/always` typo, and two `@ingroup` values missing `_ever`, to regularise first).
