### PR TITLE
Answer the ever covers of a temporal point over its whole definition time

### DIFF
--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -809,6 +809,19 @@ ea_covers_tgeo_geo_common(const Temporal *temp, const GSERIALIZED *gs, bool ever
       ! ensure_not_geodetic_geo(gs) || ! ensure_has_not_Z_geo(gs) ||
       ! ensure_has_not_Z(temp->temptype, temp->flags))
     return -1;
+  /* A geometry covers a point exactly when it intersects it, both placing the
+   * point in the closure of the geometry; only contains differs, by excluding
+   * the boundary. The ever semantics of a temporal point are therefore the
+   * ever intersects, which the trajectory settles in a single call, in place
+   * of the iteration below that tests every distinct value of the temporal
+   * point against the geometry one at a time. The equivalence belongs to the
+   * point: a temporal geometry intersects a geometry without being covered by
+   * it, and a point covers a geometry only where the geometry is that same
+   * point, so the reduction stays with the geometry-covers-temporal-point
+   * direction of a temporal point. */
+  if (ever && invert && tpoint_type(temp->temptype))
+    return ea_intersects_tgeo_geo(temp, gs, EVER);
+
   int result = ever ?
     /* Iterate for each composing geometry */
     ea_spatialrel_tspatial_geo(temp, gs, &datum_geo_covers2d, EVER, invert) :

--- a/mobilitydb/test/geo/expected/070_tpoint_spatialrels.test.out
+++ b/mobilitydb/test/geo/expected/070_tpoint_spatialrels.test.out
@@ -77,6 +77,81 @@ SELECT eContains(geometry 'Point(1 1 1)', tgeompoint 'Point(1 1)@2000-01-01');
 ERROR:  The geometry cannot have Z dimension
 SELECT eContains(geometry 'Point(1 1)', tgeompoint 'Point(1 1 1)@2000-01-01');
 ERROR:  The tgeompoint cannot have Z dimension
+SELECT eCovers(geometry 'Point(1 1)', tgeompoint 'Point(1 1)@2000-01-01');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT eCovers(geometry 'Point(1 1)', tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03}');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT eCovers(geometry 'Point(1 1)', tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03]');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT eCovers(geometry 'Point(1 1)', tgeompoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03],[Point(3 3)@2000-01-04, Point(3 3)@2000-01-05]}');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT eCovers(geometry 'Linestring(1 1,3 3)', tgeompoint '[Point(4 2)@2000-01-01, Point(2 4)@2000-01-02]');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT eCovers(geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))', tgeompoint '[Point(1 4)@2000-01-01, Point(4 1)@2000-01-02]');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT eCovers(geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))', tgeompoint '[Point(-5 0)@2000-01-01, Point(5 0)@2000-01-02]');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT eIntersects(geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))', tgeompoint '[Point(-5 0)@2000-01-01, Point(5 0)@2000-01-02]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eCovers(geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))', tgeompoint 'Interp=Step;[Point(-5 0)@2000-01-01, Point(5 0)@2000-01-02]');
+ ecovers 
+---------
+ f
+(1 row)
+
+SELECT aCovers(geometry 'Polygon((-5 -5,-5 5,5 5,5 3,-3 3,-3 -3,5 -3,5 -5,-5 -5))', tgeompoint '[Point(4 4)@2000-01-01, Point(4 -4)@2000-01-02]');
+ acovers 
+---------
+ f
+(1 row)
+
+SELECT aCovers(geometry 'Polygon((-9 -9,-9 9,9 9,9 -9,-9 -9))', tgeompoint '[Point(-5 0)@2000-01-01, Point(5 0)@2000-01-02]');
+ acovers 
+---------
+ t
+(1 row)
+
+SELECT eCovers(geometry 'Point empty', tgeompoint 'Point(1 1)@2000-01-01');
+ ecovers 
+---------
+ 
+(1 row)
+
+/* Errors */
+SELECT eCovers(geometry 'SRID=5676;Point(1 1)', tgeompoint 'Point(1 1)@2000-01-01');
+ERROR:  Operation on mixed SRID
 SELECT eDisjoint(geometry 'Point(1 1)', tgeompoint 'Point(1 1)@2000-01-01');
  edisjoint 
 -----------

--- a/mobilitydb/test/geo/queries/070_tpoint_spatialrels.test.sql
+++ b/mobilitydb/test/geo/queries/070_tpoint_spatialrels.test.sql
@@ -52,6 +52,38 @@ SELECT eContains(geometry 'Point(1 1 1)', tgeompoint 'Point(1 1)@2000-01-01');
 SELECT eContains(geometry 'Point(1 1)', tgeompoint 'Point(1 1 1)@2000-01-01');
 
 -------------------------------------------------------------------------------
+-- eCovers, aCovers
+-------------------------------------------------------------------------------
+
+SELECT eCovers(geometry 'Point(1 1)', tgeompoint 'Point(1 1)@2000-01-01');
+SELECT eCovers(geometry 'Point(1 1)', tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03}');
+SELECT eCovers(geometry 'Point(1 1)', tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03]');
+SELECT eCovers(geometry 'Point(1 1)', tgeompoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03],[Point(3 3)@2000-01-04, Point(3 3)@2000-01-05]}');
+
+SELECT eCovers(geometry 'Linestring(1 1,3 3)', tgeompoint '[Point(4 2)@2000-01-01, Point(2 4)@2000-01-02]');
+SELECT eCovers(geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))', tgeompoint '[Point(1 4)@2000-01-01, Point(4 1)@2000-01-02]');
+
+-- The point crosses the polygon between two instants and neither of them is
+-- inside it, so the relationship holds over the segment although it holds at
+-- no instant. It agrees with the ever intersects, a geometry covering a point
+-- exactly when it intersects it
+SELECT eCovers(geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))', tgeompoint '[Point(-5 0)@2000-01-01, Point(5 0)@2000-01-02]');
+SELECT eIntersects(geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))', tgeompoint '[Point(-5 0)@2000-01-01, Point(5 0)@2000-01-02]');
+-- The same crossing under step interpolation, where the point holds the value
+-- of the first instant over the segment and so never enters the polygon
+SELECT eCovers(geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))', tgeompoint 'Interp=Step;[Point(-5 0)@2000-01-01, Point(5 0)@2000-01-02]');
+
+-- The always semantics over a geometry that is not convex: both instants are
+-- covered and the segment between them leaves through the mouth
+SELECT aCovers(geometry 'Polygon((-5 -5,-5 5,5 5,5 3,-3 3,-3 -3,5 -3,5 -5,-5 -5))', tgeompoint '[Point(4 4)@2000-01-01, Point(4 -4)@2000-01-02]');
+SELECT aCovers(geometry 'Polygon((-9 -9,-9 9,9 9,9 -9,-9 -9))', tgeompoint '[Point(-5 0)@2000-01-01, Point(5 0)@2000-01-02]');
+
+SELECT eCovers(geometry 'Point empty', tgeompoint 'Point(1 1)@2000-01-01');
+
+/* Errors */
+SELECT eCovers(geometry 'SRID=5676;Point(1 1)', tgeompoint 'Point(1 1)@2000-01-01');
+
+-------------------------------------------------------------------------------
 -- eDisjoint
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
The ever semantics of the covers relationship walk the distinct values of the temporal geo and test each one against the geometry. For a temporal point those values are the positions the point holds at its instants, and the segments between them are never looked at, so a point that enters the geometry between two instants and leaves before the next one counts as never covered:

```
eCovers(geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))',
        tgeompoint '[Point(-5 0)@2000-01-01, Point(5 0)@2000-01-02]')  -> f
eIntersects(<the same operands>)                                       -> t
ST_Covers(<the same polygon>, ST_MakeLine(ST_Point(-5,0), ST_Point(5,0))) -> t
```

The point travels straight through the square and holds no instant inside it.

A geometry covers a point exactly when it intersects it, both placing the point in the closure of the geometry; only contains differs, by excluding the boundary. The ever quantifier of a temporal point therefore routes to the ever intersects, which reads the trajectory and so covers the whole definition time, in one call rather than one per value.

The equivalence belongs to the point: a temporal geometry intersects a geometry without being covered by it, and a point covers a geometry only where the geometry is that same point. The reduction accordingly stays with the geometry-covers-temporal-point direction of a temporal point. The always quantifier reads the traversed area and keeps it, as do both contains relationships, which read the trajectory.

The trajectory carries the interpolation: the same crossing under step interpolation stays false, the point holding the value of its first instant over the segment and never entering the square.

## Tests

The temporal point relationship file carried no covers case at all, which is how the gap survived. It gains the crossing above, its agreement with the ever intersects, the step-interpolation variant, and an always case over a geometry that is not convex, where both instants are covered and the segment between them leaves through the mouth. No expected output already in the corpus changes.

## Measurements

Answering from the trajectory also settles the relationship in a single call where the walk made one per value. Over a hundred vessel trips against a hundred protected areas the ever covers of the trips ran to 46.8 s, against 5.9 s for the ever intersects of the same operands.
