### PR TITLE
Regularise the trgeometry dwithin spatial-relationship wrappers

### DIFF
--- a/mobilitydb/src/rgeo/trgeo_spatialrels.c
+++ b/mobilitydb/src/rgeo/trgeo_spatialrels.c
@@ -553,11 +553,11 @@ Adwithin_trgeometry_geo(PG_FUNCTION_ARGS)
 }
 
 /**
- * @brief Return true if two temporal rigid geometries are even/always within a
+ * @brief Return true if two temporal rigid geometries are ever/always within a
  * distance
  * @sqlfn eDwithin(), aDwithin()
  */
-Datum
+static Datum
 EA_dwithin_trgeometry_trgeometry(FunctionCallInfo fcinfo, bool ever)
 {
   Temporal *temp1 = PG_GETARG_TEMPORAL_P(0);
@@ -574,7 +574,7 @@ EA_dwithin_trgeometry_trgeometry(FunctionCallInfo fcinfo, bool ever)
 PGDLLEXPORT Datum Edwithin_trgeometry_trgeometry(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Edwithin_trgeometry_trgeometry);
 /**
- * @ingroup mobilitydb_geo_rel
+ * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if two temporal rigid geometries are ever within a
  * distance
  * @sqlfn eDwithin()
@@ -588,7 +588,7 @@ Edwithin_trgeometry_trgeometry(PG_FUNCTION_ARGS)
 PGDLLEXPORT Datum Adwithin_trgeometry_trgeometry(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Adwithin_trgeometry_trgeometry);
 /**
- * @ingroup mobilitydb_geo_rel
+ * @ingroup mobilitydb_geo_rel_ever
  * @brief Return true if two temporal rigid geometries are always within a
  * distance
  * @sqlfn aDwithin()


### PR DESCRIPTION
Make the ever/always `dwithin` region of `trgeo_spatialrels.c` uniform with its siblings, as a prerequisite for generating it from the inherited-behaviour generator (mirroring the cbuffer dwithin regularisation).

Three fixes, documentation and symbol-table only:

- **`static` linkage** — `EA_dwithin_trgeometry_trgeometry` is file-local, so it gets `static` linkage like every other dispatcher in the file, instead of leaking a symbol.
- **Typo** — the dispatcher brief reads "ever/always" instead of "even/always".
- **Doxygen group** — the two `Edwithin`/`Adwithin_trgeometry_trgeometry` wrappers join the `mobilitydb_geo_rel_ever` group used by every other wrapper in the file, instead of `mobilitydb_geo_rel`.

The public SQL wrappers are unchanged; only the accidental symbol export is dropped.
