### PR TITLE
Generate the trgeometry dwithin spatial relationships

### DIFF
--- a/mobilitydb/src/rgeo/trgeo_spatialrels.c
+++ b/mobilitydb/src/rgeo/trgeo_spatialrels.c
@@ -491,6 +491,8 @@ Atouches_trgeometry_trgeometry(PG_FUNCTION_ARGS)
     ALWAYS);
 }
 
+/* GENERATED-SPATIALRELS-BEGIN rgeo_ea_dwithin — tools/codegen/inherited/generate.py from templates/spatialrels.c.tmpl;
+ * DO NOT EDIT BY HAND; edit the template + manifest.yaml (spatialrel_families) and re-run. */
 /*****************************************************************************
  * Ever/always dwithin (for both geometry and geography)
  * The function only accepts points and not arbitrary geometries/geographies
@@ -598,5 +600,6 @@ Adwithin_trgeometry_trgeometry(PG_FUNCTION_ARGS)
 {
   return EA_dwithin_trgeometry_trgeometry(fcinfo, ALWAYS);
 }
+/* GENERATED-SPATIALRELS-END rgeo_ea_dwithin */
 
 /*****************************************************************************/

--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -308,10 +308,32 @@ _DW_GET = {
 }
 
 
+def _dwithin_wrappers(block_t, ingroup, direc, noun, ret_fn):
+    """The two (ever/always) public wrappers for one dwithin direction. `ret_fn`
+    maps the EVER/ALWAYS token to the wrapper's return statement (a call to either
+    a local static dispatcher or a shared family-wide one)."""
+    out = []
+    for ea, word in (("E", "ever"), ("A", "always")):
+        eaq = "EVER" if ea == "E" else "ALWAYS"
+        out.append(
+            block_t.replace("{FN}", f"{ea}dwithin_{direc}")
+                   .replace("{INGROUP}", ingroup)
+                   .replace("{BRIEF}", _wrap_brief(
+                        f"Return true if {noun} are {word} within a distance"))
+                   .replace("{SQLFN}", f"{'e' if ea == 'E' else 'a'}Dwithin")
+                   .replace("{RETURN}", ret_fn(eaq)))
+    return out
+
+
 def render_dwithin(fam: dict) -> str:
-    """Render the ever/always dwithin region: per direction a static dispatcher
-    (rendered from dwithin_dispatcher.c.tmpl) followed by its ever and always
-    public wrappers. Arguments are declared and freed in position order."""
+    """Render the ever/always dwithin region. Each direction is either `local`
+    (its own static dispatcher reading the operands and calling the kernel, plus
+    two public wrappers — the cbuffer shape) or `shape: shared` (it reuses a
+    family-wide EA_dwithin_* dispatcher with a fixed kernel and emits only the two
+    wrappers — the geo/tgeo mixed directions of rgeo). A local dispatcher calls
+    its kernel either as a single `ea_` function taking `ever` as its last
+    argument (`ever_arg: true`, rgeo) or as an `ever ? e... : a...` ternary over
+    separate kernels (cbuffer)."""
     banner_t, block_t = (TEMPLATES / "spatialrels.c.tmpl").read_text().split("\n\n")
     block_t = block_t.rstrip("\n")
     disp_t = (TEMPLATES / "dwithin_dispatcher.c.tmpl").read_text().rstrip("\n")
@@ -319,28 +341,31 @@ def render_dwithin(fam: dict) -> str:
     out = [banner_t.replace("{BANNER}", fam["banner"])]
     for direc in fam["order"]:
         d = fam["directions"][direc]
+        if d.get("shape") == "shared":
+            out += _dwithin_wrappers(
+                block_t, ingroup, direc, d["noun"],
+                lambda eaq: f"  return {d['disp']}(fcinfo, &{d['kernel']}, {eaq});")
+            continue
         args = sorted(d["args"], key=lambda a: a["pos"])
         decls = "\n".join(
             f"  {a['type']}{a['var']} = {_DW_GET[a['type']]}({a['pos']});" for a in args)
         frees = "\n".join(
             f"  PG_FREE_IF_COPY({a['var']}, {a['pos']});" for a in args)
+        if d.get("ever_arg"):
+            result = f"  int result = ea_dwithin_{d['kernel']}({d['kargs']});"
+        else:
+            result = (f"  int result = ever ? edwithin_{d['kernel']}({d['kargs']}) :\n"
+                      f"    adwithin_{d['kernel']}({d['kargs']});")
         out.append(
             disp_t.replace("{BRIEF}", _wrap_brief(
                         f"Return true if {d['noun']} are ever/always within a distance"))
                   .replace("{DIR}", direc)
                   .replace("{DECLS}", decls)
-                  .replace("{KERNEL}", d["kernel"])
-                  .replace("{KARGS}", d["kargs"])
+                  .replace("{RESULT}", result)
                   .replace("{FREES}", frees))
-        for ea, word in (("E", "ever"), ("A", "always")):
-            out.append(
-                block_t.replace("{FN}", f"{ea}dwithin_{direc}")
-                       .replace("{INGROUP}", ingroup)
-                       .replace("{BRIEF}", _wrap_brief(
-                            f"Return true if {d['noun']} are {word} within a distance"))
-                       .replace("{SQLFN}", f"{'e' if ea == 'E' else 'a'}Dwithin")
-                       .replace("{RETURN}", f"  return EA_dwithin_{direc}(fcinfo, "
-                                            f"{'EVER' if ea == 'E' else 'ALWAYS'});"))
+        out += _dwithin_wrappers(
+            block_t, ingroup, direc, d["noun"],
+            lambda eaq: f"  return EA_dwithin_{direc}(fcinfo, {eaq});")
     return "\n\n".join(out) + "\n"
 
 

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -453,6 +453,39 @@ spatialrel_families:
           trgeometry_geo:        "a temporal rigid geometry and a geometry {word} intersect"
           trgeometry_trgeometry: "two temporal rigid geometries {word} intersect"
 
+  # rgeo dwithin is a HYBRID (dwithin: true selects render_dwithin): the two mixed
+  # directions reuse the family-wide EA_dwithin_* dispatchers with the single fixed
+  # kernel ea_dwithin_trgeo_geo (the dispatcher fixes the argument order), so they
+  # are `shape: shared` and emit only the two wrappers; the T⊗T direction keeps a
+  # local static dispatcher that calls ea_dwithin_trgeo_trgeo(temp1, temp2, dist,
+  # ever) — a single kernel taking `ever` as its last argument (ever_arg: true).
+  - family:    rgeo_ea_dwithin
+    file:      mobilitydb/src/rgeo/trgeo_spatialrels.c
+    reference: true
+    dwithin:   true
+    ingroup:   mobilitydb_geo_rel_ever
+    banner:    "Ever/always dwithin (for both geometry and geography)\n * The function only accepts points and not arbitrary geometries/geographies"
+    order:     [geo_trgeometry, trgeometry_geo, trgeometry_trgeometry]
+    directions:
+      geo_trgeometry:
+        shape:  shared
+        noun:   "a geometry and a temporal rigid geometry"
+        disp:   EA_dwithin_geo_tspatial
+        kernel: ea_dwithin_trgeo_geo
+      trgeometry_geo:
+        shape:  shared
+        noun:   "a temporal rigid geometry and a geometry"
+        disp:   EA_dwithin_tspatial_geo
+        kernel: ea_dwithin_trgeo_geo
+      trgeometry_trgeometry:
+        noun:     "two temporal rigid geometries"
+        ever_arg: true
+        kernel:   trgeo_trgeo
+        kargs:    "temp1, temp2, dist, ever"
+        args:
+          - {type: "Temporal *", var: temp1, pos: 0}
+          - {type: "Temporal *", var: temp2, pos: 1}
+
 # ---------------------------------------------------------------------------
 # Accessor axis (SQL, per-family, region-in-file). The whole Temporal<T> accessor
 # surface (tempSubtype..segments) lives INLINE in each family's type file and

--- a/tools/codegen/inherited/templates/dwithin_dispatcher.c.tmpl
+++ b/tools/codegen/inherited/templates/dwithin_dispatcher.c.tmpl
@@ -7,8 +7,7 @@ EA_dwithin_{DIR}(FunctionCallInfo fcinfo, bool ever)
 {
 {DECLS}
   double dist = PG_GETARG_FLOAT8(2);
-  int result = ever ? edwithin_{KERNEL}({KARGS}) :
-    adwithin_{KERNEL}({KARGS});
+{RESULT}
 {FREES}
   if (result < 0)
     PG_RETURN_NULL();


### PR DESCRIPTION
Bring the ever/always `dwithin` wrappers of `trgeo_spatialrels.c` onto the inherited-behaviour generator, alongside the already-generated contains, covers, disjoint and intersects regions. The emitted region reproduces the committed wrappers byte for byte — only the generation markers are added.

rgeo `dwithin` is a hybrid shape, so the generator gains two small knobs:

- **Per-direction shared/local switch** — the two mixed directions (`geo,trgeometry` and `trgeometry,geo`) reuse the family-wide `EA_dwithin_*` dispatchers with the fixed kernel `ea_dwithin_trgeo_geo`, so they emit only their two public wrappers; the `trgeometry,trgeometry` direction keeps a local static dispatcher.
- **Ever-argument kernel-call form** — the local dispatcher calls the single `ea_dwithin_trgeo_trgeo` kernel that takes `ever` as its last argument. The dispatcher template now takes the result line as a token, so both this form and the cbuffer ternary (`ever ? edwithin_… : adwithin_…`) render from the same template.

`cbuffer` and `geo` dwithin still self-regenerate unchanged (`generate.py --validate` reproduces all nine spatial-relationship regions byte for byte).
