### PR TITLE
Report a merge conflict instead of crashing under the noexit error handler

### DIFF
--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -88,6 +88,8 @@ jobs:
           python3 ../../tools/codegen/gen_smoketest/gen_smoketest.py tjsonb
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o tjsonb_smoketest tjsonb_smoketest.c -L/usr/local/lib -lmeos -lm
           ./tjsonb_smoketest
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o merge_test merge_test.c -L/usr/local/lib -lmeos
+          ./merge_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o numeric_test numeric_test.c -L/usr/local/lib -lmeos
           ./numeric_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o setspan_test setspan_test.c -L/usr/local/lib -lmeos

--- a/meos/src/temporal/temporal_modif.c
+++ b/meos/src/temporal/temporal_modif.c
@@ -205,6 +205,8 @@ tgeoinst_merge_array_iter(TInstant **instants, int count, int *newcount)
  * @param[out] newcount Number of values in the output array
  * @pre The number of elements in the array is greater than 1 and the elemets
  * are sorted
+ * @note Returns @p NULL and sets @p newcount to 0 when the instants cannot be
+ * merged, for example when two of them share a timestamp with different values
  */
 TInstant **
 tinstant_merge_array_iter(TInstant **instants, int count, int *newcount)
@@ -225,7 +227,10 @@ tinstant_merge_array_iter(TInstant **instants, int count, int *newcount)
 
   /* Ensure the validity of the arguments and compute the bounding box */
   if (! ensure_valid_tinstarr(instants1, count1, MERGE, DISCRETE))
+  {
+    *newcount = 0;
     return NULL;
+  }
 
   TInstant **newinstants = palloc(sizeof(TInstant *) * count1);
   memcpy(newinstants, instants1, sizeof(TInstant *) * count1);
@@ -250,13 +255,10 @@ tinstant_merge_array(TInstant **instants, int count)
   tinstarr_sort((TInstant **) instants, count);
   int count1;
   TInstant **instants1 = tinstant_merge_array_iter(instants, count, &count1);
-
-  /* Ensure the validity of the arguments and TODO compute the bounding box */
-  if (! ensure_valid_tinstarr(instants1, count1, MERGE, DISCRETE))
-  {
-    pfree_array((void **) instants1, count1);
+  /* The iterator has already ensured the validity of the instants; it returns
+   * NULL when they cannot be merged */
+  if (instants1 == NULL)
     return NULL;
-  }
 
   TInstant **newinstants = palloc(sizeof(TInstant *) * count1);
   memcpy(newinstants, instants1, sizeof(TInstant *) * count1);

--- a/meos/test/merge_test.c
+++ b/meos/test/merge_test.c
@@ -1,0 +1,134 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief A program that tests how the merge functions of the MEOS API report a
+ * conflict under the noexit error handler.
+ *
+ * Merging temporal values that share a timestamp with different values is an
+ * error. Under the default error handler the process exits, so the error path
+ * is only observable once #meos_initialize_noexit_error_handler is installed —
+ * the handler every language binding uses, since a binding must return an
+ * exception to its host rather than terminate it. The program verifies that
+ * each merge function reports the conflict by returning NULL and setting
+ * #MEOS_ERR_INVALID_ARG_VALUE, and that merging compatible values still
+ * succeeds afterwards.
+ *
+ * The program can be build as follows
+ * @code
+ * gcc -Wall -g -I/usr/local/include -o merge_test merge_test.c -L/usr/local/lib -lmeos
+ * @endcode
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <meos.h>
+#include <meos_geo.h>
+
+/* Main program */
+int main(void)
+{
+  /* Initialize MEOS and install the error handler that reports through
+   * meos_errno instead of exiting */
+  meos_initialize();
+  meos_initialize_timezone("UTC");
+  meos_initialize_noexit_error_handler();
+
+  /* Two instant sets sharing a timestamp with different values */
+  Temporal *conflict1 = tfloat_in("{77@2000-01-01}");
+  Temporal *conflict2 = tfloat_in("{88@2000-01-01}");
+  assert(conflict1); assert(conflict2);
+
+  /* temporal_merge_array reports the conflict */
+  Temporal *conflictarr[2] = {conflict1, conflict2};
+  meos_errno_reset();
+  Temporal *merged = temporal_merge_array(conflictarr, 2);
+  printf("temporal_merge_array({%s, %s}, 2): NULL, errno %d\n",
+    "{77@2000-01-01}", "{88@2000-01-01}", meos_errno());
+  assert(merged == NULL);
+  assert(meos_errno() == MEOS_ERR_INVALID_ARG_VALUE);
+
+  /* temporal_merge reports the same conflict */
+  meos_errno_reset();
+  merged = temporal_merge(conflict1, conflict2);
+  printf("temporal_merge(%s, %s): NULL, errno %d\n",
+    "{77@2000-01-01}", "{88@2000-01-01}", meos_errno());
+  assert(merged == NULL);
+  assert(meos_errno() == MEOS_ERR_INVALID_ARG_VALUE);
+
+  /* A conflict on a shared timestamp of temporal points is reported alike */
+  Temporal *point1 = tgeompoint_in("SRID=4326;{POINT(1 1)@2000-01-01}");
+  Temporal *point2 = tgeompoint_in("SRID=4326;{POINT(2 2)@2000-01-01}");
+  assert(point1); assert(point2);
+  Temporal *pointarr[2] = {point1, point2};
+  meos_errno_reset();
+  merged = temporal_merge_array(pointarr, 2);
+  printf("temporal_merge_array({POINT(1 1)@…, POINT(2 2)@…}, 2): NULL, "
+    "errno %d\n", meos_errno());
+  assert(merged == NULL);
+  assert(meos_errno() == MEOS_ERR_INVALID_ARG_VALUE);
+
+  /* Merging compatible values still succeeds after the reported conflicts */
+  Temporal *ok1 = tfloat_in("{77@2000-01-01}");
+  Temporal *ok2 = tfloat_in("{88@2000-01-02}");
+  assert(ok1); assert(ok2);
+  Temporal *okarr[2] = {ok1, ok2};
+  merged = temporal_merge_array(okarr, 2);
+  assert(merged);
+  char *merged_out = tfloat_out(merged, 6);
+  printf("temporal_merge_array({%s, %s}, 2): %s\n",
+    "{77@2000-01-01}", "{88@2000-01-02}", merged_out);
+  assert(strcmp(merged_out,
+    "{77@2000-01-01 00:00:00+00, 88@2000-01-02 00:00:00+00}") == 0);
+
+  /* Values sharing a timestamp with the SAME value merge into one instant */
+  Temporal *same1 = tfloat_in("{77@2000-01-01}");
+  Temporal *same2 = tfloat_in("{77@2000-01-01}");
+  assert(same1); assert(same2);
+  Temporal *samearr[2] = {same1, same2};
+  Temporal *sameres = temporal_merge_array(samearr, 2);
+  assert(sameres);
+  char *sameres_out = tfloat_out(sameres, 6);
+  printf("temporal_merge_array({%s, %s}, 2): %s\n",
+    "{77@2000-01-01}", "{77@2000-01-01}", sameres_out);
+  assert(strcmp(sameres_out, "77@2000-01-01 00:00:00+00") == 0);
+
+  free(conflict1); free(conflict2);
+  free(point1); free(point2);
+  free(ok1); free(ok2); free(merged); free(merged_out);
+  free(same1); free(same2); free(sameres); free(sameres_out);
+
+  /* Finalize MEOS */
+  meos_finalize();
+
+  return 0;
+}


### PR DESCRIPTION
Merging temporal values that share a timestamp with different values is an error, raised by `tinstant_merge_array_iter` through `ensure_valid_tinstarr` before it returns `NULL`. Its only caller, `tinstant_merge_array`, does not examine that `NULL`: it hands the array to a second `ensure_valid_tinstarr` together with a count the iterator leaves unassigned on that path, and then indexes it.

Under the default error handler the process exits inside the first check, so the caller is out of reach. Under the handler installed by `meos_initialize_noexit_error_handler`, which reports through `meos_errno` so a language binding can raise an exception rather than terminate its host, execution continues, and reaching the caller is a segmentation fault. Two temporal float instant sets sharing a timestamp are enough:

```c
meos_initialize();
meos_initialize_noexit_error_handler();
Temporal *arr[2] = {tfloat_in("{77@2000-01-01}"),
                    tfloat_in("{88@2000-01-01}")};
temporal_merge_array(arr, 2);   /* SIGSEGV */
```

The caller returns `NULL` as soon as the iterator does, and the iterator sets the count to zero on that path, so it is never read uninitialised. `temporal_merge_array` then reports the conflict the way the rest of the API does, returning `NULL` with `meos_errno` set to `MEOS_ERR_INVALID_ARG_VALUE`.

The second validity check goes with it. It repeats the check the iterator already makes, and its `pfree_array` releases the caller's own instants, because for types other than temporal geos the iterator hands back the array it is given rather than a copy.

`meos/test/merge_test.c` covers the conflict for temporal floats through both `temporal_merge_array` and `temporal_merge`, and for temporal points through the temporal geo branch of the iterator, and checks that compatible values still merge and that values repeating a timestamp with the same value collapse to a single instant. Compiled against the unpatched library the program stops on `SIGSEGV`; against the patched one it runs to completion.

`tinstant_merge_array` is the single caller of the iterator, and no symbol changes, so the reach of the change is those two functions.
