### PR TITLE
Schema-qualify the generated cell-index spatial relationships

### DIFF
--- a/mobilitydb/sql/h3/262_th3index_spatialrels.in.sql
+++ b/mobilitydb/sql/h3/262_th3index_spatialrels.in.sql
@@ -62,31 +62,31 @@
 CREATE FUNCTION eContains(geometry, th3index)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eContains($1, th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eContains($1, @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aContains(geometry, th3index)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aContains($1, th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aContains($1, @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION eContains(th3index, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eContains(th3CellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.eContains(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION aContains(th3index, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aContains(th3CellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.aContains(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 
 CREATE FUNCTION eContains(th3index, th3index)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eContains(th3CellToBoundary($1)::tgeometry,
-                          th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eContains(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry,
+                          @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aContains(th3index, th3index)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aContains(th3CellToBoundary($1)::tgeometry,
-                          th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aContains(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry,
+                          @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 
 /*****************************************************************************
  * Ever/always covers
@@ -95,31 +95,31 @@ CREATE FUNCTION aContains(th3index, th3index)
 CREATE FUNCTION eCovers(geometry, th3index)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eCovers($1, th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eCovers($1, @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aCovers(geometry, th3index)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aCovers($1, th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aCovers($1, @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION eCovers(th3index, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eCovers(th3CellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.eCovers(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION aCovers(th3index, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aCovers(th3CellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.aCovers(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 
 CREATE FUNCTION eCovers(th3index, th3index)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eCovers(th3CellToBoundary($1)::tgeometry,
-                        th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eCovers(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry,
+                        @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aCovers(th3index, th3index)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aCovers(th3CellToBoundary($1)::tgeometry,
-                        th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aCovers(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry,
+                        @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 
 /*****************************************************************************
  * Ever/always disjoint
@@ -128,31 +128,31 @@ CREATE FUNCTION aCovers(th3index, th3index)
 CREATE FUNCTION eDisjoint(geometry, th3index)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eDisjoint($1, th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eDisjoint($1, @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aDisjoint(geometry, th3index)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aDisjoint($1, th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aDisjoint($1, @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION eDisjoint(th3index, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eDisjoint(th3CellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.eDisjoint(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION aDisjoint(th3index, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aDisjoint(th3CellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.aDisjoint(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 
 CREATE FUNCTION eDisjoint(th3index, th3index)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eDisjoint(th3CellToBoundary($1)::tgeometry,
-                          th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eDisjoint(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry,
+                          @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aDisjoint(th3index, th3index)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aDisjoint(th3CellToBoundary($1)::tgeometry,
-                          th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aDisjoint(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry,
+                          @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 
 /*****************************************************************************
  * Ever/always intersects
@@ -161,31 +161,31 @@ CREATE FUNCTION aDisjoint(th3index, th3index)
 CREATE FUNCTION eIntersects(geometry, th3index)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eIntersects($1, th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eIntersects($1, @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aIntersects(geometry, th3index)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aIntersects($1, th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aIntersects($1, @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION eIntersects(th3index, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eIntersects(th3CellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.eIntersects(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION aIntersects(th3index, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aIntersects(th3CellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.aIntersects(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 
 CREATE FUNCTION eIntersects(th3index, th3index)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eIntersects(th3CellToBoundary($1)::tgeometry,
-                            th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eIntersects(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry,
+                            @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aIntersects(th3index, th3index)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aIntersects(th3CellToBoundary($1)::tgeometry,
-                            th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aIntersects(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry,
+                            @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 
 /*****************************************************************************
  * Ever/always touches
@@ -194,31 +194,31 @@ CREATE FUNCTION aIntersects(th3index, th3index)
 CREATE FUNCTION eTouches(geometry, th3index)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eTouches($1, th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eTouches($1, @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aTouches(geometry, th3index)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aTouches($1, th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aTouches($1, @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION eTouches(th3index, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eTouches(th3CellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.eTouches(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION aTouches(th3index, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aTouches(th3CellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.aTouches(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 
 CREATE FUNCTION eTouches(th3index, th3index)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eTouches(th3CellToBoundary($1)::tgeometry,
-                         th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eTouches(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry,
+                         @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aTouches(th3index, th3index)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aTouches(th3CellToBoundary($1)::tgeometry,
-                         th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aTouches(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry,
+                         @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 
 /*****************************************************************************
  * Ever/always dwithin
@@ -227,31 +227,31 @@ CREATE FUNCTION aTouches(th3index, th3index)
 CREATE FUNCTION eDwithin(geometry, th3index, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eDwithin($1, th3CellToBoundary($2)::tgeometry, $3) $$;
+  AS $$ SELECT @extschema@.eDwithin($1, @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry, $3) $$;
 CREATE FUNCTION aDwithin(geometry, th3index, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aDwithin($1, th3CellToBoundary($2)::tgeometry, $3) $$;
+  AS $$ SELECT @extschema@.aDwithin($1, @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry, $3) $$;
 
 CREATE FUNCTION eDwithin(th3index, geometry, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eDwithin(th3CellToBoundary($1)::tgeometry, $2, $3) $$;
+  AS $$ SELECT @extschema@.eDwithin(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry, $2, $3) $$;
 CREATE FUNCTION aDwithin(th3index, geometry, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aDwithin(th3CellToBoundary($1)::tgeometry, $2, $3) $$;
+  AS $$ SELECT @extschema@.aDwithin(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry, $2, $3) $$;
 
 CREATE FUNCTION eDwithin(th3index, th3index, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eDwithin(th3CellToBoundary($1)::tgeometry,
-                         th3CellToBoundary($2)::tgeometry, $3) $$;
+  AS $$ SELECT @extschema@.eDwithin(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry,
+                         @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry, $3) $$;
 CREATE FUNCTION aDwithin(th3index, th3index, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aDwithin(th3CellToBoundary($1)::tgeometry,
-                         th3CellToBoundary($2)::tgeometry, $3) $$;
+  AS $$ SELECT @extschema@.aDwithin(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry,
+                         @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry, $3) $$;
 
 /*****************************************************************************
  * Temporal spatial relationships
@@ -265,85 +265,85 @@ CREATE FUNCTION aDwithin(th3index, th3index, dist float)
 CREATE FUNCTION tContains(geometry, th3index)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tContains($1, th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tContains($1, @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION tContains(th3index, geometry)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tContains(th3CellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.tContains(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION tContains(th3index, th3index)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tContains(th3CellToBoundary($1)::tgeometry,
-                          th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tContains(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry,
+                          @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION tCovers(geometry, th3index)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tCovers($1, th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tCovers($1, @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION tCovers(th3index, geometry)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tCovers(th3CellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.tCovers(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION tCovers(th3index, th3index)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tCovers(th3CellToBoundary($1)::tgeometry,
-                        th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tCovers(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry,
+                        @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION tDisjoint(geometry, th3index)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tDisjoint($1, th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tDisjoint($1, @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION tDisjoint(th3index, geometry)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tDisjoint(th3CellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.tDisjoint(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION tDisjoint(th3index, th3index)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tDisjoint(th3CellToBoundary($1)::tgeometry,
-                          th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tDisjoint(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry,
+                          @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION tIntersects(geometry, th3index)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tIntersects($1, th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tIntersects($1, @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION tIntersects(th3index, geometry)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tIntersects(th3CellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.tIntersects(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION tIntersects(th3index, th3index)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tIntersects(th3CellToBoundary($1)::tgeometry,
-                            th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tIntersects(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry,
+                            @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION tTouches(geometry, th3index)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tTouches($1, th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tTouches($1, @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION tTouches(th3index, geometry)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tTouches(th3CellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.tTouches(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION tTouches(th3index, th3index)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tTouches(th3CellToBoundary($1)::tgeometry,
-                         th3CellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tTouches(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry,
+                         @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION tDwithin(geometry, th3index, dist float)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tDwithin($1, th3CellToBoundary($2)::tgeometry, $3) $$;
+  AS $$ SELECT @extschema@.tDwithin($1, @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry, $3) $$;
 CREATE FUNCTION tDwithin(th3index, geometry, dist float)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tDwithin(th3CellToBoundary($1)::tgeometry, $2, $3) $$;
+  AS $$ SELECT @extschema@.tDwithin(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry, $2, $3) $$;
 CREATE FUNCTION tDwithin(th3index, th3index, dist float)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tDwithin(th3CellToBoundary($1)::tgeometry,
-                         th3CellToBoundary($2)::tgeometry, $3) $$;
+  AS $$ SELECT @extschema@.tDwithin(@extschema@.th3CellToBoundary($1)::@extschema@.tgeometry,
+                         @extschema@.th3CellToBoundary($2)::@extschema@.tgeometry, $3) $$;
 
 /*****************************************************************************/

--- a/mobilitydb/sql/quadbin/362_tquadbin_spatialrels.in.sql
+++ b/mobilitydb/sql/quadbin/362_tquadbin_spatialrels.in.sql
@@ -62,31 +62,31 @@
 CREATE FUNCTION eContains(geometry, tquadbin)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eContains($1, tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eContains($1, @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aContains(geometry, tquadbin)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aContains($1, tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aContains($1, @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION eContains(tquadbin, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eContains(tquadbinCellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.eContains(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION aContains(tquadbin, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aContains(tquadbinCellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.aContains(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 
 CREATE FUNCTION eContains(tquadbin, tquadbin)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eContains(tquadbinCellToBoundary($1)::tgeometry,
-                          tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eContains(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry,
+                          @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aContains(tquadbin, tquadbin)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aContains(tquadbinCellToBoundary($1)::tgeometry,
-                          tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aContains(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry,
+                          @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 
 /*****************************************************************************
  * Ever/always covers
@@ -95,31 +95,31 @@ CREATE FUNCTION aContains(tquadbin, tquadbin)
 CREATE FUNCTION eCovers(geometry, tquadbin)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eCovers($1, tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eCovers($1, @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aCovers(geometry, tquadbin)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aCovers($1, tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aCovers($1, @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION eCovers(tquadbin, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eCovers(tquadbinCellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.eCovers(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION aCovers(tquadbin, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aCovers(tquadbinCellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.aCovers(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 
 CREATE FUNCTION eCovers(tquadbin, tquadbin)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eCovers(tquadbinCellToBoundary($1)::tgeometry,
-                        tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eCovers(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry,
+                        @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aCovers(tquadbin, tquadbin)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aCovers(tquadbinCellToBoundary($1)::tgeometry,
-                        tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aCovers(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry,
+                        @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 
 /*****************************************************************************
  * Ever/always disjoint
@@ -128,31 +128,31 @@ CREATE FUNCTION aCovers(tquadbin, tquadbin)
 CREATE FUNCTION eDisjoint(geometry, tquadbin)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eDisjoint($1, tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eDisjoint($1, @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aDisjoint(geometry, tquadbin)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aDisjoint($1, tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aDisjoint($1, @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION eDisjoint(tquadbin, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eDisjoint(tquadbinCellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.eDisjoint(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION aDisjoint(tquadbin, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aDisjoint(tquadbinCellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.aDisjoint(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 
 CREATE FUNCTION eDisjoint(tquadbin, tquadbin)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eDisjoint(tquadbinCellToBoundary($1)::tgeometry,
-                          tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eDisjoint(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry,
+                          @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aDisjoint(tquadbin, tquadbin)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aDisjoint(tquadbinCellToBoundary($1)::tgeometry,
-                          tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aDisjoint(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry,
+                          @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 
 /*****************************************************************************
  * Ever/always intersects
@@ -161,31 +161,31 @@ CREATE FUNCTION aDisjoint(tquadbin, tquadbin)
 CREATE FUNCTION eIntersects(geometry, tquadbin)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eIntersects($1, tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eIntersects($1, @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aIntersects(geometry, tquadbin)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aIntersects($1, tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aIntersects($1, @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION eIntersects(tquadbin, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eIntersects(tquadbinCellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.eIntersects(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION aIntersects(tquadbin, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aIntersects(tquadbinCellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.aIntersects(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 
 CREATE FUNCTION eIntersects(tquadbin, tquadbin)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eIntersects(tquadbinCellToBoundary($1)::tgeometry,
-                            tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eIntersects(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry,
+                            @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aIntersects(tquadbin, tquadbin)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aIntersects(tquadbinCellToBoundary($1)::tgeometry,
-                            tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aIntersects(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry,
+                            @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 
 /*****************************************************************************
  * Ever/always touches
@@ -194,31 +194,31 @@ CREATE FUNCTION aIntersects(tquadbin, tquadbin)
 CREATE FUNCTION eTouches(geometry, tquadbin)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eTouches($1, tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eTouches($1, @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aTouches(geometry, tquadbin)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aTouches($1, tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aTouches($1, @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION eTouches(tquadbin, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eTouches(tquadbinCellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.eTouches(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION aTouches(tquadbin, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aTouches(tquadbinCellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.aTouches(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 
 CREATE FUNCTION eTouches(tquadbin, tquadbin)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eTouches(tquadbinCellToBoundary($1)::tgeometry,
-                         tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eTouches(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry,
+                         @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aTouches(tquadbin, tquadbin)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aTouches(tquadbinCellToBoundary($1)::tgeometry,
-                         tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aTouches(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry,
+                         @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 
 /*****************************************************************************
  * Ever/always dwithin
@@ -227,31 +227,31 @@ CREATE FUNCTION aTouches(tquadbin, tquadbin)
 CREATE FUNCTION eDwithin(geometry, tquadbin, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eDwithin($1, tquadbinCellToBoundary($2)::tgeometry, $3) $$;
+  AS $$ SELECT @extschema@.eDwithin($1, @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry, $3) $$;
 CREATE FUNCTION aDwithin(geometry, tquadbin, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aDwithin($1, tquadbinCellToBoundary($2)::tgeometry, $3) $$;
+  AS $$ SELECT @extschema@.aDwithin($1, @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry, $3) $$;
 
 CREATE FUNCTION eDwithin(tquadbin, geometry, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eDwithin(tquadbinCellToBoundary($1)::tgeometry, $2, $3) $$;
+  AS $$ SELECT @extschema@.eDwithin(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry, $2, $3) $$;
 CREATE FUNCTION aDwithin(tquadbin, geometry, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aDwithin(tquadbinCellToBoundary($1)::tgeometry, $2, $3) $$;
+  AS $$ SELECT @extschema@.aDwithin(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry, $2, $3) $$;
 
 CREATE FUNCTION eDwithin(tquadbin, tquadbin, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eDwithin(tquadbinCellToBoundary($1)::tgeometry,
-                         tquadbinCellToBoundary($2)::tgeometry, $3) $$;
+  AS $$ SELECT @extschema@.eDwithin(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry,
+                         @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry, $3) $$;
 CREATE FUNCTION aDwithin(tquadbin, tquadbin, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aDwithin(tquadbinCellToBoundary($1)::tgeometry,
-                         tquadbinCellToBoundary($2)::tgeometry, $3) $$;
+  AS $$ SELECT @extschema@.aDwithin(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry,
+                         @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry, $3) $$;
 
 /*****************************************************************************
  * Temporal spatial relationships
@@ -265,85 +265,85 @@ CREATE FUNCTION aDwithin(tquadbin, tquadbin, dist float)
 CREATE FUNCTION tContains(geometry, tquadbin)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tContains($1, tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tContains($1, @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION tContains(tquadbin, geometry)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tContains(tquadbinCellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.tContains(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION tContains(tquadbin, tquadbin)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tContains(tquadbinCellToBoundary($1)::tgeometry,
-                          tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tContains(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry,
+                          @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION tCovers(geometry, tquadbin)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tCovers($1, tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tCovers($1, @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION tCovers(tquadbin, geometry)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tCovers(tquadbinCellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.tCovers(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION tCovers(tquadbin, tquadbin)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tCovers(tquadbinCellToBoundary($1)::tgeometry,
-                        tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tCovers(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry,
+                        @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION tDisjoint(geometry, tquadbin)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tDisjoint($1, tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tDisjoint($1, @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION tDisjoint(tquadbin, geometry)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tDisjoint(tquadbinCellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.tDisjoint(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION tDisjoint(tquadbin, tquadbin)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tDisjoint(tquadbinCellToBoundary($1)::tgeometry,
-                          tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tDisjoint(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry,
+                          @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION tIntersects(geometry, tquadbin)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tIntersects($1, tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tIntersects($1, @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION tIntersects(tquadbin, geometry)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tIntersects(tquadbinCellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.tIntersects(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION tIntersects(tquadbin, tquadbin)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tIntersects(tquadbinCellToBoundary($1)::tgeometry,
-                            tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tIntersects(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry,
+                            @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION tTouches(geometry, tquadbin)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tTouches($1, tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tTouches($1, @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION tTouches(tquadbin, geometry)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tTouches(tquadbinCellToBoundary($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.tTouches(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION tTouches(tquadbin, tquadbin)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tTouches(tquadbinCellToBoundary($1)::tgeometry,
-                         tquadbinCellToBoundary($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tTouches(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry,
+                         @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION tDwithin(geometry, tquadbin, dist float)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tDwithin($1, tquadbinCellToBoundary($2)::tgeometry, $3) $$;
+  AS $$ SELECT @extschema@.tDwithin($1, @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry, $3) $$;
 CREATE FUNCTION tDwithin(tquadbin, geometry, dist float)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tDwithin(tquadbinCellToBoundary($1)::tgeometry, $2, $3) $$;
+  AS $$ SELECT @extschema@.tDwithin(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry, $2, $3) $$;
 CREATE FUNCTION tDwithin(tquadbin, tquadbin, dist float)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tDwithin(tquadbinCellToBoundary($1)::tgeometry,
-                         tquadbinCellToBoundary($2)::tgeometry, $3) $$;
+  AS $$ SELECT @extschema@.tDwithin(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry,
+                         @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry, $3) $$;
 
 /*****************************************************************************/

--- a/tools/codegen/inherited/templates/spatialrels.sql.tmpl
+++ b/tools/codegen/inherited/templates/spatialrels.sql.tmpl
@@ -60,31 +60,31 @@
 CREATE FUNCTION eContains(geometry, {TEMP})
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eContains($1, {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eContains($1, @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aContains(geometry, {TEMP})
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aContains($1, {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aContains($1, @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION eContains({TEMP}, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eContains({BOUNDARY}($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.eContains(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION aContains({TEMP}, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aContains({BOUNDARY}($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.aContains(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry, $2) $$;
 
 CREATE FUNCTION eContains({TEMP}, {TEMP})
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eContains({BOUNDARY}($1)::tgeometry,
-                          {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eContains(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry,
+                          @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aContains({TEMP}, {TEMP})
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aContains({BOUNDARY}($1)::tgeometry,
-                          {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aContains(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry,
+                          @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 
 /*****************************************************************************
  * Ever/always covers
@@ -93,31 +93,31 @@ CREATE FUNCTION aContains({TEMP}, {TEMP})
 CREATE FUNCTION eCovers(geometry, {TEMP})
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eCovers($1, {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eCovers($1, @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aCovers(geometry, {TEMP})
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aCovers($1, {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aCovers($1, @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION eCovers({TEMP}, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eCovers({BOUNDARY}($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.eCovers(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION aCovers({TEMP}, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aCovers({BOUNDARY}($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.aCovers(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry, $2) $$;
 
 CREATE FUNCTION eCovers({TEMP}, {TEMP})
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eCovers({BOUNDARY}($1)::tgeometry,
-                        {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eCovers(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry,
+                        @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aCovers({TEMP}, {TEMP})
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aCovers({BOUNDARY}($1)::tgeometry,
-                        {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aCovers(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry,
+                        @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 
 /*****************************************************************************
  * Ever/always disjoint
@@ -126,31 +126,31 @@ CREATE FUNCTION aCovers({TEMP}, {TEMP})
 CREATE FUNCTION eDisjoint(geometry, {TEMP})
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eDisjoint($1, {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eDisjoint($1, @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aDisjoint(geometry, {TEMP})
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aDisjoint($1, {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aDisjoint($1, @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION eDisjoint({TEMP}, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eDisjoint({BOUNDARY}($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.eDisjoint(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION aDisjoint({TEMP}, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aDisjoint({BOUNDARY}($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.aDisjoint(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry, $2) $$;
 
 CREATE FUNCTION eDisjoint({TEMP}, {TEMP})
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eDisjoint({BOUNDARY}($1)::tgeometry,
-                          {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eDisjoint(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry,
+                          @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aDisjoint({TEMP}, {TEMP})
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aDisjoint({BOUNDARY}($1)::tgeometry,
-                          {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aDisjoint(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry,
+                          @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 
 /*****************************************************************************
  * Ever/always intersects
@@ -159,31 +159,31 @@ CREATE FUNCTION aDisjoint({TEMP}, {TEMP})
 CREATE FUNCTION eIntersects(geometry, {TEMP})
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eIntersects($1, {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eIntersects($1, @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aIntersects(geometry, {TEMP})
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aIntersects($1, {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aIntersects($1, @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION eIntersects({TEMP}, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eIntersects({BOUNDARY}($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.eIntersects(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION aIntersects({TEMP}, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aIntersects({BOUNDARY}($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.aIntersects(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry, $2) $$;
 
 CREATE FUNCTION eIntersects({TEMP}, {TEMP})
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eIntersects({BOUNDARY}($1)::tgeometry,
-                            {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eIntersects(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry,
+                            @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aIntersects({TEMP}, {TEMP})
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aIntersects({BOUNDARY}($1)::tgeometry,
-                            {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aIntersects(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry,
+                            @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 
 /*****************************************************************************
  * Ever/always touches
@@ -192,31 +192,31 @@ CREATE FUNCTION aIntersects({TEMP}, {TEMP})
 CREATE FUNCTION eTouches(geometry, {TEMP})
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eTouches($1, {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eTouches($1, @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aTouches(geometry, {TEMP})
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aTouches($1, {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aTouches($1, @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION eTouches({TEMP}, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eTouches({BOUNDARY}($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.eTouches(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION aTouches({TEMP}, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aTouches({BOUNDARY}($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.aTouches(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry, $2) $$;
 
 CREATE FUNCTION eTouches({TEMP}, {TEMP})
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eTouches({BOUNDARY}($1)::tgeometry,
-                         {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.eTouches(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry,
+                         @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION aTouches({TEMP}, {TEMP})
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aTouches({BOUNDARY}($1)::tgeometry,
-                         {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.aTouches(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry,
+                         @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 
 /*****************************************************************************
  * Ever/always dwithin
@@ -225,31 +225,31 @@ CREATE FUNCTION aTouches({TEMP}, {TEMP})
 CREATE FUNCTION eDwithin(geometry, {TEMP}, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eDwithin($1, {BOUNDARY}($2)::tgeometry, $3) $$;
+  AS $$ SELECT @extschema@.eDwithin($1, @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry, $3) $$;
 CREATE FUNCTION aDwithin(geometry, {TEMP}, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aDwithin($1, {BOUNDARY}($2)::tgeometry, $3) $$;
+  AS $$ SELECT @extschema@.aDwithin($1, @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry, $3) $$;
 
 CREATE FUNCTION eDwithin({TEMP}, geometry, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eDwithin({BOUNDARY}($1)::tgeometry, $2, $3) $$;
+  AS $$ SELECT @extschema@.eDwithin(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry, $2, $3) $$;
 CREATE FUNCTION aDwithin({TEMP}, geometry, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aDwithin({BOUNDARY}($1)::tgeometry, $2, $3) $$;
+  AS $$ SELECT @extschema@.aDwithin(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry, $2, $3) $$;
 
 CREATE FUNCTION eDwithin({TEMP}, {TEMP}, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT eDwithin({BOUNDARY}($1)::tgeometry,
-                         {BOUNDARY}($2)::tgeometry, $3) $$;
+  AS $$ SELECT @extschema@.eDwithin(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry,
+                         @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry, $3) $$;
 CREATE FUNCTION aDwithin({TEMP}, {TEMP}, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT aDwithin({BOUNDARY}($1)::tgeometry,
-                         {BOUNDARY}($2)::tgeometry, $3) $$;
+  AS $$ SELECT @extschema@.aDwithin(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry,
+                         @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry, $3) $$;
 
 /*****************************************************************************
  * Temporal spatial relationships
@@ -263,85 +263,85 @@ CREATE FUNCTION aDwithin({TEMP}, {TEMP}, dist float)
 CREATE FUNCTION tContains(geometry, {TEMP})
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tContains($1, {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tContains($1, @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION tContains({TEMP}, geometry)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tContains({BOUNDARY}($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.tContains(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION tContains({TEMP}, {TEMP})
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tContains({BOUNDARY}($1)::tgeometry,
-                          {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tContains(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry,
+                          @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION tCovers(geometry, {TEMP})
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tCovers($1, {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tCovers($1, @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION tCovers({TEMP}, geometry)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tCovers({BOUNDARY}($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.tCovers(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION tCovers({TEMP}, {TEMP})
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tCovers({BOUNDARY}($1)::tgeometry,
-                        {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tCovers(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry,
+                        @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION tDisjoint(geometry, {TEMP})
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tDisjoint($1, {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tDisjoint($1, @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION tDisjoint({TEMP}, geometry)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tDisjoint({BOUNDARY}($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.tDisjoint(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION tDisjoint({TEMP}, {TEMP})
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tDisjoint({BOUNDARY}($1)::tgeometry,
-                          {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tDisjoint(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry,
+                          @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION tIntersects(geometry, {TEMP})
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tIntersects($1, {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tIntersects($1, @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION tIntersects({TEMP}, geometry)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tIntersects({BOUNDARY}($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.tIntersects(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION tIntersects({TEMP}, {TEMP})
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tIntersects({BOUNDARY}($1)::tgeometry,
-                            {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tIntersects(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry,
+                            @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION tTouches(geometry, {TEMP})
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tTouches($1, {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tTouches($1, @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 CREATE FUNCTION tTouches({TEMP}, geometry)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tTouches({BOUNDARY}($1)::tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.tTouches(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION tTouches({TEMP}, {TEMP})
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tTouches({BOUNDARY}($1)::tgeometry,
-                         {BOUNDARY}($2)::tgeometry) $$;
+  AS $$ SELECT @extschema@.tTouches(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry,
+                         @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry) $$;
 
 CREATE FUNCTION tDwithin(geometry, {TEMP}, dist float)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tDwithin($1, {BOUNDARY}($2)::tgeometry, $3) $$;
+  AS $$ SELECT @extschema@.tDwithin($1, @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry, $3) $$;
 CREATE FUNCTION tDwithin({TEMP}, geometry, dist float)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tDwithin({BOUNDARY}($1)::tgeometry, $2, $3) $$;
+  AS $$ SELECT @extschema@.tDwithin(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry, $2, $3) $$;
 CREATE FUNCTION tDwithin({TEMP}, {TEMP}, dist float)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT tDwithin({BOUNDARY}($1)::tgeometry,
-                         {BOUNDARY}($2)::tgeometry, $3) $$;
+  AS $$ SELECT @extschema@.tDwithin(@extschema@.{BOUNDARY}($1)::@extschema@.tgeometry,
+                         @extschema@.{BOUNDARY}($2)::@extschema@.tgeometry, $3) $$;
 
 /*****************************************************************************/


### PR DESCRIPTION
The temporal cell-index spatial relationships (`th3index`, `tquadbin`) are `LANGUAGE SQL` functions whose bodies reference other extension objects by name — the delegated predicate (`eContains`, …), the cell-boundary function (`th3CellToBoundary` / `tquadbinCellToBoundary`) and the `tgeometry` cast target. For a SQL-body function those names resolve against the **caller's `search_path`**, so without qualification a caller with a narrowed or hostile `search_path` can resolve them to the wrong object or fail.

This qualifies every such reference with `@extschema@`, so the functions always resolve to the extension's own objects — matching what the temporal pose spatial relationships already do. The `spatialrels.sql.tmpl` template emits the qualification, so it is applied uniformly wherever the template is used.

- Qualification is applied to the **SQL bodies only**; the `CREATE FUNCTION` signatures stay unqualified (resolved once at install time).
- Behaviour is unchanged under a `search_path` that includes the extension schema — the diff is pure qualification (every changed line is identical after stripping `@extschema@`).
