### PR TITLE
Make the temporal pose disjoint and dwithin relationships strict

### DIFF
--- a/mobilitydb/sql/pose/112_tpose_spatialrels.in.sql
+++ b/mobilitydb/sql/pose/112_tpose_spatialrels.in.sql
@@ -102,15 +102,15 @@ CREATE FUNCTION aCovers(tpose, tpose)
 
 CREATE FUNCTION eDisjoint(geometry, tpose)
   RETURNS boolean
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
   $$ SELECT @extschema@.eDisjoint($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
 CREATE FUNCTION eDisjoint(tpose, geometry)
   RETURNS boolean
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
   $$ SELECT @extschema@.eDisjoint($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
 CREATE FUNCTION eDisjoint(tpose, tpose)
   RETURNS boolean
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
   $$ SELECT @extschema@.eDisjoint($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
 
 /*****************************************************************************/

--- a/mobilitydb/sql/pose/114_tpose_tempspatialrels.in.sql
+++ b/mobilitydb/sql/pose/114_tpose_tempspatialrels.in.sql
@@ -129,7 +129,7 @@ CREATE FUNCTION tDwithin(geometry, tpose, dist float)
   $$ SELECT @extschema@.tDwithin($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry, $3) $$;
 CREATE FUNCTION tDwithin(tpose, geometry, dist float)
   RETURNS tbool
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
   $$ SELECT @extschema@.tDwithin($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2, $3) $$;
 CREATE FUNCTION tDwithin(tpose, tpose, dist float)
   RETURNS tbool


### PR DESCRIPTION
Four temporal pose spatial-relationship functions are missing the `STRICT` qualifier that every one of their siblings carries:

- the three `eDisjoint` directions — while all three `aDisjoint` directions are `STRICT`;
- `tDwithin(tpose, geometry)` — while the `geometry, tpose` and `tpose, tpose` directions are `STRICT`.

The `tgeometry` relationships these functions delegate to are `STRICT` as well, so this marks the four functions `STRICT` for consistency. A null argument now returns null without evaluating the body (same observable result as before, since the delegated call is itself `STRICT`).
