### PR TITLE
Clear the error status in meos_errno_reset

### DIFF
--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -88,6 +88,8 @@ jobs:
           python3 ../../tools/codegen/gen_smoketest/gen_smoketest.py tjsonb
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o tjsonb_smoketest tjsonb_smoketest.c -L/usr/local/lib -lmeos -lm
           ./tjsonb_smoketest
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o error_test error_test.c -L/usr/local/lib -lmeos
+          ./error_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o merge_test merge_test.c -L/usr/local/lib -lmeos
           ./merge_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o numeric_test numeric_test.c -L/usr/local/lib -lmeos

--- a/meos/src/temporal/error.c
+++ b/meos/src/temporal/error.c
@@ -134,7 +134,10 @@ meos_errno_restore(int err)
 int meos_errno_reset(void)
 {
   int last_errno = meos_errno();
-  meos_errno_set(0);
+  /* Clear the error status directly: #meos_errno_set ignores a zero argument
+   * so that a caller cannot clear the status through it by accident, and
+   * points here instead */
+  MEOS_ERR_NO = 0;
   errno = 0;
   return last_errno;
 }

--- a/meos/test/error_test.c
+++ b/meos/test/error_test.c
@@ -1,0 +1,104 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief A program that tests the error status functions of the MEOS API.
+ *
+ * The error status is only observable once
+ * #meos_initialize_noexit_error_handler is installed — the handler every
+ * language binding uses, since a binding must return an exception to its host
+ * rather than terminate it. The program verifies that a failing call sets
+ * #meos_errno, that #meos_errno_reset clears it and returns its previous
+ * value, and that #meos_errno_restore puts back a stored value, which is the
+ * sequence documented for monitoring a section of code for new errors.
+ *
+ * The program can be build as follows
+ * @code
+ * gcc -Wall -g -I/usr/local/include -o error_test error_test.c -L/usr/local/lib -lmeos
+ * @endcode
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <meos.h>
+
+/* Main program */
+int main(void)
+{
+  /* Initialize MEOS and install the error handler that reports through
+   * meos_errno instead of exiting */
+  meos_initialize();
+  meos_initialize_timezone("UTC");
+  meos_initialize_noexit_error_handler();
+
+  /* A fresh error status is clear */
+  assert(meos_errno() == 0);
+
+  /* A failing call sets the error status */
+  Temporal *bad = tfloat_in("this is not a temporal float");
+  assert(bad == NULL);
+  int failed_errno = meos_errno();
+  printf("errno after a failed call: %d\n", failed_errno);
+  assert(failed_errno != 0);
+
+  /* Resetting returns the previous value and clears the status */
+  int previous = meos_errno_reset();
+  printf("meos_errno_reset() returned %d, errno is now %d\n", previous,
+    meos_errno());
+  assert(previous == failed_errno);
+  assert(meos_errno() == 0);
+
+  /* A succeeding call leaves the status clear */
+  Temporal *good = tfloat_in("{77@2000-01-01}");
+  assert(good != NULL);
+  char *good_out = tfloat_out(good, 6);
+  printf("tfloat_in(\"{77@2000-01-01}\"): %s, errno %d\n", good_out,
+    meos_errno());
+  assert(meos_errno() == 0);
+
+  /* Restoring puts back a stored value, so that a function which reset the
+   * status to monitor a section of code can hand the caller's error back */
+  meos_errno_restore(failed_errno);
+  printf("meos_errno_restore(%d): errno is now %d\n", failed_errno,
+    meos_errno());
+  assert(meos_errno() == failed_errno);
+
+  /* And the status can be cleared again afterwards */
+  assert(meos_errno_reset() == failed_errno);
+  assert(meos_errno() == 0);
+
+  free(good); free(good_out);
+
+  /* Finalize MEOS */
+  meos_finalize();
+
+  return 0;
+}


### PR DESCRIPTION
`meos_errno_set` ignores a zero argument, so that a caller cannot clear the error status through it by accident, and its comment points at `meos_errno_reset` instead. `meos_errno_reset` in turn clears the status by calling `meos_errno_set` with zero, which that guard refuses. Each function defers to the other and neither clears `MEOS_ERR_NO`; only the C `errno` is cleared.

```
after a failed call : meos_errno()=22
meos_errno_reset() returned 22
after errno_reset   : meos_errno()=22
```

The status is thread-local and is readable only once `meos_initialize_noexit_error_handler` is installed, since the default handler exits the process on an error. That handler is the one every language binding installs, so as to raise an exception in its host rather than terminate it, and `meos_errno` is how such a binding learns that a call failed. A status that never clears leaves every call after the first failure looking like a failure.

`meos_errno_reset` clears `MEOS_ERR_NO` directly. `meos_errno_restore` stays as it is: in the sequence documented under `meos_errno_reset` it is reached only when the monitored section succeeded, where the status is already clear.

`meos/test/error_test.c` walks that sequence — a failing call sets the status, resetting returns the previous value and clears it, a succeeding call leaves it clear, and restoring puts a stored value back. Compiled against the unpatched library the program stops on the assertion that follows the reset; against the patched one it runs to completion.

The three functions are inside `#if MEOS`. PostgreSQL reports errors through `ereport`, which does not return, so the extension never reads a stale status and the change does not reach it.
