### PR TITLE
Sample a trajectory from an array of Raquet tiles

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3732,6 +3732,10 @@
 				<listitem>
 					<para><link linkend="raster_tile_value"><varname>raster_tile_value</varname></link>: Muestrear una tesela ráster raquet a lo largo de una trayectoria</para>
 				</listitem>
+
+				<listitem>
+					<para><link linkend="raster_tile_value_array"><varname>raster_tile_value</varname></link>: Muestrear un arreglo de teselas ráster raquet a lo largo de una trayectoria, conservando la resolución más fina donde se solapan</para>
+				</listitem>
 			</itemizedlist>
 		</sect2>
 

--- a/doc/es/temporal_raster.xml
+++ b/doc/es/temporal_raster.xml
@@ -178,6 +178,21 @@ JOIN elevation_tiles r
   ON r.quadbin = ANY(trajectory_quadbins(t.trip4326, 8));
 </programlisting>
 			</listitem>
+
+			<listitem xml:id="raster_tile_value_array">
+				<indexterm significance="normal"><primary><varname>raster_tile_value</varname></primary></indexterm>
+				<para>Muestrear un arreglo de teselas ráster <varname>raquet</varname> a lo largo de una trayectoria</para>
+				<para><varname>raster_tile_value(raquet[],tgeompoint) → tfloat</varname></para>
+				<para>Evalúa cada tesela de <varname>rast</varname> en cada instante de <varname>traj</varname> (SRID 4326) y devuelve los valores de píxel muestreados como un único <varname>tfloat</varname>. Una trayectoria que sale de una tesela queda cubierta por varias, y cada una aporta los instantes que caen dentro de ella. Las teselas de un mismo nivel de zoom particionan el plano, de modo que aportan instantes disjuntos. Las teselas de niveles de zoom distintos se solapan, y cuando dos de ellas muestrean el mismo instante se conserva el valor de la tesela de mayor zoom, que es la que tiene la resolución más fina. Devuelve <varname>NULL</varname> cuando ningún instante cae dentro de una tesela o sobrevive al filtrado de nodata.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Muestrear una trayectoria en todas las teselas que cruza, en un solo valor
+SELECT t.tripid, raster_tile_value(array_agg(r.tile), t.trip4326)
+FROM trips t
+JOIN elevation_tiles r
+  ON r.quadbin = ANY(trajectory_quadbins(t.trip4326, 8))
+GROUP BY t.tripid, t.trip4326;
+</programlisting>
+			</listitem>
 		</itemizedlist>
 	</sect1>
 
@@ -369,11 +384,6 @@ sudo make install
 		<para>Las dos vías descritas en este capítulo sirven propósitos distintos y ambas se mantienen. La vía <varname>raquet</varname> es un tipo de valor MEOS autocontenido: transporta sus píxeles y su georreferenciación QUADBIN en un único valor y no necesita PostgreSQL para evaluarse, por lo que está disponible en todos los enlaces de lenguaje derivados de MEOS. La vía <varname>raster</varname> de PostGIS ofrece el procesamiento ráster mucho más rico de la extensión <varname>postgis_raster</varname> — álgebra de mapas, estadísticas, remuestreo, recorte, conversión a polígonos — únicamente dentro de PostgreSQL.</para>
 
 		<para>Ninguna vía reemplaza a la otra. El trabajo sobre la vía <varname>raquet</varname> amplía lo que una tesela nativa de la nube puede hacer a lo largo de una trayectoria; no pretende reimplementar el procesamiento ráster.</para>
-
-		<para>Extensiones previstas para la vía <varname>raquet</varname>:</para>
-		<itemizedlist>
-			<listitem><para><emphasis>Fusión agregada de teselas</emphasis> — una variante de retorno de conjunto que acepta el arreglo completo de teselas Raquet coincidentes y fusiona los conjuntos de instantes por tesela, eliminando instantes duplicados en los límites de tesela.</para></listitem>
-		</itemizedlist>
 
 		<para>Las extensiones siguientes requieren un modelo de datos ráster general, es decir, sistemas de referencia espacial arbitrarios, georreferenciación afín arbitraria y varias bandas por tesela. Un valor <varname>raquet</varname> es una tesela de una sola banda cuya extensión y rejilla de píxeles se derivan de su celda QUADBIN, por lo que quedan fuera de ese modelo y siguen disponibles a través de la vía <varname>raster</varname> de PostGIS:</para>
 		<itemizedlist>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3710,6 +3710,10 @@
 				<listitem>
 					<para><link linkend="raster_tile_value"><varname>raster_tile_value</varname></link>: Sample a Raquet raster tile along a trajectory</para>
 				</listitem>
+
+				<listitem>
+					<para><link linkend="raster_tile_value_array"><varname>raster_tile_value</varname></link>: Sample an array of Raquet raster tiles along a trajectory, keeping the finer resolution where tiles overlap</para>
+				</listitem>
 			</itemizedlist>
 		</sect2>
 

--- a/doc/temporal_raster.xml
+++ b/doc/temporal_raster.xml
@@ -180,6 +180,21 @@ JOIN elevation_tiles r
   ON r.quadbin = ANY(trajectory_quadbins(t.trip4326, 8));
 </programlisting>
 			</listitem>
+
+			<listitem xml:id="raster_tile_value_array">
+				<indexterm significance="normal"><primary><varname>raster_tile_value</varname></primary></indexterm>
+				<para>Sample an array of <varname>raquet</varname> raster tiles along a trajectory</para>
+				<para><varname>raster_tile_value(raquet[],tgeompoint) → tfloat</varname></para>
+				<para>Evaluates every tile of <varname>rast</varname> at each instant of <varname>traj</varname> (SRID 4326) and returns the sampled pixel values as a single <varname>tfloat</varname>. A trajectory that leaves one tile is covered by several of them, each contributing the instants that fall inside it. Tiles of one zoom level partition the plane, so they contribute disjoint instants. Tiles of different zoom levels overlap, and where two of them sample the same instant the value of the tile of higher zoom is kept, that being the one carrying the finer resolution. Returns <varname>NULL</varname> when no instant falls inside a tile or survives nodata filtering.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Sample a trajectory across every tile it crosses, in one value
+SELECT t.tripid, raster_tile_value(array_agg(r.tile), t.trip4326)
+FROM trips t
+JOIN elevation_tiles r
+  ON r.quadbin = ANY(trajectory_quadbins(t.trip4326, 8))
+GROUP BY t.tripid, t.trip4326;
+</programlisting>
+			</listitem>
 		</itemizedlist>
 	</sect1>
 
@@ -372,11 +387,6 @@ sudo make install
 		<para>The two paths described in this chapter serve different purposes and are both maintained. The <varname>raquet</varname> path is a self-contained MEOS value type: it carries its pixels and its QUADBIN georeferencing in a single value and needs no PostgreSQL to evaluate, so it is available to every language binding derived from MEOS. The PostGIS <varname>raster</varname> path offers the far richer raster processing of the <varname>postgis_raster</varname> extension — map algebra, statistics, resampling, clipping, conversion to polygons — inside PostgreSQL only.</para>
 
 		<para>Neither path replaces the other. Work on the <varname>raquet</varname> path extends what a cloud-native tile can do along a trajectory; it is not an attempt to reimplement raster processing.</para>
-
-		<para>Planned extensions to the <varname>raquet</varname> path:</para>
-		<itemizedlist>
-			<listitem><para><emphasis>Aggregate tile merging</emphasis> — a set-returning variant that accepts the full array of matching Raquet tiles and merges the per-tile instant sets, removing duplicate instants at tile boundaries.</para></listitem>
-		</itemizedlist>
 
 		<para>The extensions below require a general raster data model, that is, arbitrary spatial reference systems, arbitrary affine georeferencing and several bands per tile. A <varname>raquet</varname> value is a single-band tile whose extent and pixel grid follow from its QUADBIN cell, so these lie outside that model and remain available through the PostGIS <varname>raster</varname> path:</para>
 		<itemizedlist>

--- a/meos/include/meos_raster.h
+++ b/meos/include/meos_raster.h
@@ -116,6 +116,8 @@ extern Temporal *raster_tile_value_quadbin(const uint8_t *pixels,
   double nodata, bool has_nodata, const Temporal *traj);
 
 extern Temporal *raster_tile_value(const Raquet *rq, const Temporal *traj);
+extern Temporal *raster_tile_value_array(const Raquet **rqarr, int count,
+  const Temporal *traj);
 
 extern uint64 *trajectory_quadbins(const Temporal *traj, uint32_t zoom,
   int *count);

--- a/meos/include/raster/raster_quadbin.h
+++ b/meos/include/raster/raster_quadbin.h
@@ -52,4 +52,6 @@ extern bool raster_quadbin_from_bounds(double origin_x, double origin_y,
 extern void raster_quadbin_bounds(uint64 cell, double *xmin, double *ymin,
   double *xmax, double *ymax);
 
+extern uint32_t raster_quadbin_zoom(uint64 cell);
+
 #endif /* __RASTER_QUADBIN_H__ */

--- a/meos/src/raster/raquet.c
+++ b/meos/src/raster/raquet.c
@@ -520,4 +520,82 @@ raster_tile_value(const Raquet *rq, const Temporal *traj)
     rq->quadbin, (MeosPixType) rq->pixtype, rq->nodata, rq->has_nodata, traj);
 }
 
+/**
+ * @ingroup meos_raster
+ * @brief Return the values of an array of Raquet tiles sampled at the instants
+ * of a trajectory
+ * @details A trajectory that leaves a single tile is sampled from the whole set
+ * of tiles covering it, each tile contributing the instants that fall inside
+ * it. Tiles of one zoom level partition the plane, so they contribute disjoint
+ * instants. Tiles of different zoom levels overlap, and where two of them
+ * sample the same instant the value of the tile of higher zoom is kept, that
+ * being the one carrying the finer resolution.
+ * @param[in] rqarr Array of Raquet tiles
+ * @param[in] count Number of tiles in the array
+ * @param[in] traj Trajectory (temporal geometry point)
+ * @return A temporal float, or @p NULL when no instant of @p traj falls inside
+ * a tile or survives nodata filtering
+ * @csqlfn #Raster_tile_value_array()
+ */
+Temporal *
+raster_tile_value_array(const Raquet **rqarr, int count, const Temporal *traj)
+{
+  VALIDATE_NOT_NULL(rqarr, NULL); VALIDATE_NOT_NULL(traj, NULL);
+  if (! ensure_positive(count))
+    return NULL;
+
+  /* The instants of the trajectory are the slots the tiles compete for, since a
+   * sampled instant carries the timestamp of the instant it was sampled at */
+  int ninsts;
+  const TInstant **insts = temporal_insts_p(traj, &ninsts);
+  double *values = palloc(sizeof(double) * ninsts);
+  int *zooms = palloc(sizeof(int) * ninsts);
+  for (int i = 0; i < ninsts; i++)
+    zooms[i] = -1;                  /* no tile has covered this instant yet */
+
+  for (int i = 0; i < count; i++)
+  {
+    if (rqarr[i] == NULL)
+      continue;
+    Temporal *sampled = raster_tile_value(rqarr[i], traj);
+    if (sampled == NULL)
+      continue;
+    int zoom = (int) raster_quadbin_zoom(rqarr[i]->quadbin);
+    int nsampled;
+    const TInstant **sinsts = temporal_insts_p(sampled, &nsampled);
+    /* Both arrays are ordered by timestamp, so one walk places every sampled
+     * value in its slot */
+    int k = 0;
+    for (int j = 0; j < nsampled; j++)
+    {
+      while (k < ninsts && insts[k]->t < sinsts[j]->t)
+        k++;
+      if (k == ninsts)
+        break;
+      if (insts[k]->t == sinsts[j]->t && zoom > zooms[k])
+      {
+        zooms[k] = zoom;
+        values[k] = DatumGetFloat8(tinstant_value(sinsts[j]));
+      }
+    }
+    pfree(sinsts); pfree(sampled);
+  }
+
+  TInstant **result_insts = palloc(sizeof(TInstant *) * ninsts);
+  int nresult = 0;
+  for (int i = 0; i < ninsts; i++)
+    if (zooms[i] >= 0)
+      result_insts[nresult++] =
+        tinstant_make(Float8GetDatum(values[i]), T_TFLOAT, insts[i]->t);
+  pfree(insts); pfree(values); pfree(zooms);
+
+  if (nresult == 0)
+  {
+    pfree(result_insts);
+    return NULL;
+  }
+  return (Temporal *) tsequence_make_free(result_insts, nresult, true, true,
+    DISCRETE, NORMALIZE);
+}
+
 /*****************************************************************************/

--- a/meos/src/raster/raster_quadbin.c
+++ b/meos/src/raster/raster_quadbin.c
@@ -179,6 +179,21 @@ raster_quadbin_bounds(uint64 cell, double *xmin, double *ymin, double *xmax,
 }
 
 /**
+ * @brief Return the zoom level of the tile identified by a QUADBIN cell
+ * @param[in] cell QUADBIN cell
+ * @details A higher zoom covers less ground with the same pixel grid, so of two
+ * tiles covering a point the one with the higher zoom carries the finer
+ * resolution
+ */
+uint32_t
+raster_quadbin_zoom(uint64 cell)
+{
+  uint32_t tx, ty, tz;
+  qb_to_xyz(cell, &tx, &ty, &tz);
+  return tz;
+}
+
+/**
  * @brief Derive the QUADBIN cell of a Web-Mercator raster tile from its
  * EPSG:3857 georeferencing.
  * @details A Raquet tile is a single QUADBIN cell of the Web-Mercator tile 

--- a/mobilitydb/pg_include/pg_temporal/type_util.h
+++ b/mobilitydb/pg_include/pg_temporal/type_util.h
@@ -54,6 +54,9 @@
 #if RGEO
   #include "rgeo/trgeo.h"
 #endif
+#if RASTER
+  #include <meos_raster.h>
+#endif
 
 /*****************************************************************************/
 
@@ -96,6 +99,9 @@ extern ArrayType *cbufferarr_to_array(const Cbuffer **cbarr, int count);
 #if POSE || RGEO
 extern Pose **posearr_extract(ArrayType *array, int *count);
 extern ArrayType *posearr_to_array(const Pose **posearr, int count);
+#endif
+#if RASTER
+extern Raquet **raquetarr_extract(ArrayType *array, int *count);
 #endif
 extern Span *spanarr_extract(ArrayType *array, int *count);
 extern STBox *stboxarr_extract(ArrayType *array, int *count);

--- a/mobilitydb/sql/raster/500_raster.in.sql
+++ b/mobilitydb/sql/raster/500_raster.in.sql
@@ -190,6 +190,21 @@ CREATE FUNCTION raster_tile_value(
   AS 'MODULE_PATHNAME', 'Raster_tile_value'
   LANGUAGE C STRICT;
 
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Sample an array of raquet raster tiles at the instants of a
+ * trajectory, keeping the value of the tile of highest zoom where tiles overlap
+ * @param[in] rast Array of raquet tiles
+ * @param[in] traj Trajectory
+ * @csqlfn #Raster_tile_value_array()
+ */
+CREATE FUNCTION raster_tile_value(
+    rast raquet[],
+    traj tgeompoint
+) RETURNS tfloat
+  AS 'MODULE_PATHNAME', 'Raster_tile_value_array'
+  LANGUAGE C STRICT;
+
 /******************************************************************************
  * trajectory_quadbins
  *****************************************************************************/

--- a/mobilitydb/src/raster/temporal_raster.c
+++ b/mobilitydb/src/raster/temporal_raster.c
@@ -75,6 +75,7 @@ extern text *cstring_to_text(const char *s);
 #include "raster/raster_quadbin.h"
 /* MobilityDB */
 #include "pg_temporal/temporal.h"
+#include "pg_temporal/type_util.h" /* raquetarr_extract */
 #include "pg_raster/temporal_raster.h"
 
 /*****************************************************************************
@@ -440,6 +441,33 @@ Raster_tile_value(PG_FUNCTION_ARGS)
   Temporal *traj = PG_GETARG_TEMPORAL_P(1);
   Temporal *result = raster_tile_value(rq, traj);
   PG_FREE_IF_COPY(rq, 0);
+  PG_FREE_IF_COPY(traj, 1);
+  if (result == NULL)
+    PG_RETURN_NULL();
+  PG_RETURN_POINTER(result);
+}
+
+PGDLLEXPORT Datum Raster_tile_value_array(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_tile_value_array);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Sample an array of Raquet tiles along a tgeompoint trajectory
+ * @param[in] rqarr Array of Raquet tiles
+ * @param[in] traj  Trajectory (tgeompoint)
+ * @sqlfn raster_tile_value()
+ */
+Datum
+Raster_tile_value_array(PG_FUNCTION_ARGS)
+{
+  ArrayType *array = PG_GETARG_ARRAYTYPE_P(0);
+  ensure_not_empty_array(array);
+  Temporal *traj = PG_GETARG_TEMPORAL_P(1);
+  int count;
+  Raquet **rqarr = raquetarr_extract(array, &count);
+  Temporal *result = raster_tile_value_array((const Raquet **) rqarr, count,
+    traj);
+  pfree(rqarr);
+  PG_FREE_IF_COPY(array, 0);
   PG_FREE_IF_COPY(traj, 1);
   if (result == NULL)
     PG_RETURN_NULL();

--- a/mobilitydb/src/temporal/type_util.c
+++ b/mobilitydb/src/temporal/type_util.c
@@ -59,6 +59,9 @@
 #if RGEO
   #include "rgeo/trgeo.h"
 #endif
+#if RASTER
+  #include "raster/raquet.h"
+#endif
 /* MobilityDB */
 #include "pg_temporal/meos_catalog.h"
 #include "pg_temporal/doublen.h"
@@ -255,6 +258,20 @@ rgeomarr_extract(ArrayType *array, int *count)
   return result;
 }
 #endif /* RGEO */
+
+#if RASTER
+/**
+ * @brief Extract a C array from a PostgreSQL array containing Raquet tiles
+ */
+Raquet **
+raquetarr_extract(ArrayType *array, int *count)
+{
+  Raquet **result;
+  deconstruct_array(array, array->elemtype, -1, false, 'd', (Datum **) &result,
+    NULL, count);
+  return result;
+}
+#endif /* RASTER */
 
 /**
  * @brief Extract a C array from a PostgreSQL array containing spans

--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -233,6 +233,51 @@ FROM t;
  t
 (1 row)
 
+WITH t AS (
+  SELECT tgeompointFromText('SRID=4326;{Point(-45.0 75.0)@2024-01-01 00:00:00+00, Point(45.0 75.0)@2024-01-02 00:00:00+00, Point(135.0 75.0)@2024-01-03 00:00:00+00}') AS traj,
+    raquet('\x01020304'::bytea, 2, 2, 5192650370358181888::bigint, 'UINT8') AS west,
+    raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8') AS east
+)
+SELECT raster_tile_value(west, traj)::text AS west_alone,
+       raster_tile_value(east, traj)::text AS east_alone,
+       raster_tile_value(ARRAY[west, east], traj)::text AS merged
+FROM t;
+         west_alone         |                      east_alone                      |                                     merged                                     
+----------------------------+------------------------------------------------------+--------------------------------------------------------------------------------
+ {2@2024-01-01 00:00:00+00} | {1@2024-01-02 00:00:00+00, 2@2024-01-03 00:00:00+00} | {2@2024-01-01 00:00:00+00, 1@2024-01-02 00:00:00+00, 2@2024-01-03 00:00:00+00}
+(1 row)
+
+WITH t AS (
+  SELECT tgeompointFromText('SRID=4326;{Point(-45.0 75.0)@2024-01-01 00:00:00+00, Point(45.0 75.0)@2024-01-02 00:00:00+00, Point(135.0 75.0)@2024-01-03 00:00:00+00}') AS traj,
+    raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8') AS east,
+    raquet('\x01020304'::bytea, 2, 2, 5198279869892395008::bigint, 'UINT8') AS fine
+)
+SELECT raster_tile_value(fine, traj)::text AS fine_alone,
+       raster_tile_value(ARRAY[east, fine], traj)::text AS east_then_fine,
+       raster_tile_value(ARRAY[fine, east], traj)::text AS fine_then_east
+FROM t;
+         fine_alone         |                    east_then_fine                    |                    fine_then_east                    
+----------------------------+------------------------------------------------------+------------------------------------------------------
+ {4@2024-01-02 00:00:00+00} | {4@2024-01-02 00:00:00+00, 2@2024-01-03 00:00:00+00} | {4@2024-01-02 00:00:00+00, 2@2024-01-03 00:00:00+00}
+(1 row)
+
+WITH t AS (
+  SELECT tgeompointFromText('SRID=4326;{Point(45.0 75.0)@2024-01-02 00:00:00+00}') AS traj,
+    raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8') AS east,
+    raquet('\x01020304'::bytea, 2, 2, 5192650370358181888::bigint, 'UINT8') AS west
+)
+SELECT raster_tile_value(ARRAY[east], traj)::text = raster_tile_value(east, traj)::text
+         AS singleton_equals_scalar,
+       raster_tile_value(ARRAY[west], traj) IS NULL AS uncovered_is_null
+FROM t;
+ singleton_equals_scalar | uncovered_is_null 
+-------------------------+-------------------
+ t                       | t
+(1 row)
+
+SELECT raster_tile_value(ARRAY[]::raquet[],
+  tgeompoint 'SRID=4326;{Point(45.0 75.0)@2024-01-02 00:00:00+00}');
+ERROR:  The input array cannot be empty
 SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8')::text::raquet::text
      = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8')::text
        AS hexwkb_roundtrip_ok;

--- a/mobilitydb/test/raster/queries/500_raster.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster.test.sql
@@ -273,6 +273,58 @@ SELECT raster_tile_value(
        AS typed_equals_untyped
 FROM t;
 
+-- raster_tile_value(raquet[], tgeompoint) samples a trajectory from every tile
+-- covering it. The three tiles below carry the same 2x2 pixel array; what
+-- distinguishes them is the ground they cover:
+--   west  = zoom 1 tile (0,0), lon [-180, 0)
+--   east  = zoom 1 tile (1,0), lon [0, 180)
+--   fine  = zoom 2 tile (2,0), lon [0, 90), lat (66.51, 85.05]
+-- The trajectory visits Point(-45 75) in west only, Point(45 75) in east and
+-- in fine, which overlap there, and Point(135 75) in east only.
+
+-- Two tiles of the same zoom partition the plane, so a trajectory crossing
+-- from one into the other is sampled from both, with no instant contributed
+-- twice. The merged result therefore covers every instant that either tile
+-- covers alone.
+WITH t AS (
+  SELECT tgeompointFromText('SRID=4326;{Point(-45.0 75.0)@2024-01-01 00:00:00+00, Point(45.0 75.0)@2024-01-02 00:00:00+00, Point(135.0 75.0)@2024-01-03 00:00:00+00}') AS traj,
+    raquet('\x01020304'::bytea, 2, 2, 5192650370358181888::bigint, 'UINT8') AS west,
+    raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8') AS east
+)
+SELECT raster_tile_value(west, traj)::text AS west_alone,
+       raster_tile_value(east, traj)::text AS east_alone,
+       raster_tile_value(ARRAY[west, east], traj)::text AS merged
+FROM t;
+
+-- Tiles of different zoom levels overlap. Where both sample the same instant
+-- the value of the tile of higher zoom is kept, that being the one carrying
+-- the finer resolution, and the outcome does not depend on the array order.
+WITH t AS (
+  SELECT tgeompointFromText('SRID=4326;{Point(-45.0 75.0)@2024-01-01 00:00:00+00, Point(45.0 75.0)@2024-01-02 00:00:00+00, Point(135.0 75.0)@2024-01-03 00:00:00+00}') AS traj,
+    raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8') AS east,
+    raquet('\x01020304'::bytea, 2, 2, 5198279869892395008::bigint, 'UINT8') AS fine
+)
+SELECT raster_tile_value(fine, traj)::text AS fine_alone,
+       raster_tile_value(ARRAY[east, fine], traj)::text AS east_then_fine,
+       raster_tile_value(ARRAY[fine, east], traj)::text AS fine_then_east
+FROM t;
+
+-- A one-element array agrees with the scalar form, and an array of tiles that
+-- the trajectory never enters returns NULL.
+WITH t AS (
+  SELECT tgeompointFromText('SRID=4326;{Point(45.0 75.0)@2024-01-02 00:00:00+00}') AS traj,
+    raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8') AS east,
+    raquet('\x01020304'::bytea, 2, 2, 5192650370358181888::bigint, 'UINT8') AS west
+)
+SELECT raster_tile_value(ARRAY[east], traj)::text = raster_tile_value(east, traj)::text
+         AS singleton_equals_scalar,
+       raster_tile_value(ARRAY[west], traj) IS NULL AS uncovered_is_null
+FROM t;
+
+-- An empty array is rejected.
+SELECT raster_tile_value(ARRAY[]::raquet[],
+  tgeompoint 'SRID=4326;{Point(45.0 75.0)@2024-01-02 00:00:00+00}');
+
 -- The HexWKB text representation round-trips through the raquet type's input
 -- and output functions (raquet::text uses raquet_out, text::raquet uses
 -- raquet_in).


### PR DESCRIPTION
A trajectory long enough to leave one tile has to be sampled from every tile it crosses, and the tiles that cover it are what a join against a Raquet table returns. `raster_tile_value` gains an array form that takes them together and returns one temporal float, closing the last entry of the roadmap for the `raquet` path.

```sql
SELECT t.tripid, raster_tile_value(array_agg(r.tile), t.trip4326)
FROM trips t
JOIN elevation_tiles r
  ON r.quadbin = ANY(trajectory_quadbins(t.trip4326, 8))
GROUP BY t.tripid, t.trip4326;
```

## Which tile wins

Tiles of one zoom level partition the plane, so each contributes the instants that fall inside it and none is contributed twice. The sampling window is half-open: a point on a tile's western or northern edge belongs to that tile, and one on its eastern or southern edge belongs to the neighbour. Tiles of different zoom levels do overlap, and there the value of the tile of higher zoom is kept, that being the one carrying the finer resolution, so the result does not depend on the order of the array.

The three tiles of the test carry the same 2×2 pixel array and differ only in the ground they cover: `west` is zoom 1 over lon [-180, 0), `east` is zoom 1 over lon [0, 180), and `fine` is the zoom 2 tile over lon [0, 90), lat (66.51, 85.05] inside `east`. The trajectory visits `Point(-45 75)` in `west` alone, `Point(45 75)` where `east` and `fine` overlap, and `Point(135 75)` in `east` alone:

```
     west_alone: {2@01-01}
     east_alone: {1@01-02, 2@01-03}
         merged: {2@01-01, 1@01-02, 2@01-03}

     fine_alone: {4@01-02}
 east_then_fine: {4@01-02, 2@01-03}
 fine_then_east: {4@01-02, 2@01-03}
```

At `01-02` the zoom 1 tile alone gives `1`; merged with its zoom 2 child it gives `4`, and swapping the array order does not change that.

## Reach

The zoom of a tile comes from `raster_quadbin_zoom`, which decodes it from the QUADBIN cell the way the raster family decodes the tile bounds, so the raster path still stands on its own arithmetic rather than on the QUADBIN family.

The merge is one ordered walk. Both the instants of the trajectory and the instants each tile samples are ordered by timestamp, so a single pass per tile places every sampled value in its slot; there is no sort and no timestamp map.

The array reaches SQL through `raquetarr_extract`, beside the extractors of the other families carrying a value type, and the empty array is rejected as it is for the other functions taking one.

Documented in the raster chapter in English and Spanish, and in both reference summaries.
