### PR TITLE
Compare squared distances in the circular buffer box prune

### DIFF
--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -158,16 +158,19 @@ spatialrel_geo_geo(const GSERIALIZED *gs1, const GSERIALIZED *gs2,
  *****************************************************************************/
 
 /**
- * @brief Return the 2D distance between two axis-aligned bounding boxes,
- * 0 when they overlap
+ * @brief Return the squared 2D distance between two axis-aligned bounding
+ * boxes, 0 when they overlap
+ * @note The square is returned so that the callers compare it with a squared
+ * distance, as the geometry distance prune does, the square root being
+ * monotonic and both compared values non-negative
  */
 static double
-box2d_distance(double axmin, double aymin, double axmax, double aymax,
+box2d_distance_sqr(double axmin, double aymin, double axmax, double aymax,
   double bxmin, double bymin, double bxmax, double bymax)
 {
   double dx = fmax(fmax(axmin - bxmax, bxmin - axmax), 0.0);
   double dy = fmax(fmax(aymin - bymax, bymin - aymax), 0.0);
-  return sqrt(dx * dx + dy * dy);
+  return dx * dx + dy * dy;
 }
 
 /**
@@ -199,11 +202,15 @@ tcbuffer_geo_box_decided(varfunc func, Datum param, int numparam,
   double sxmin, double symin, double sxmax, double symax,
   double gxmin, double gymin, double gxmax, double gymax, int *result)
 {
-  double bd = box2d_distance(sxmin, symin, sxmax, symax, gxmin, gymin,
+  double bd = box2d_distance_sqr(sxmin, symin, sxmax, symax, gxmin, gymin,
     gxmax, gymax);
   if (func == (varfunc) (&datum_geom_dwithin2d) && numparam == 3)
   {
-    if (bd > DatumGetFloat8(param))
+    /* The distance is validated as non-negative by the ever/always dwithin
+     * functions, so comparing the squares decides the same way as comparing
+     * the distances themselves */
+    double d = DatumGetFloat8(param);
+    if (bd > d * d)
     {
       *result = 0;
       return true;


### PR DESCRIPTION
The bounding-box prune of the ever/always circular buffer spatial relationships takes a square root per segment to obtain the distance between the swept box and the geometry, and then only compares it with the dwithin distance or with zero. Returning the square instead, and comparing it with the squared distance, decides both branches identically and drops a square root from the prune that every tcbuffer-geometry ever, always and temporal relationship passes through.

The square root is monotonic on the non-negative reals, so the ordering it induces is the one the comparison needs. The dwithin distance is non-negative: `ea_dwithin_tcbuffer_geo` validates it through `ensure_not_negative_datum` before dispatching, and that function holds the only call site reaching the prune with `datum_geom_dwithin2d`. Squaring both sides is therefore order-preserving on the values that arrive.

The overlap branch is unchanged in meaning: both axis gaps are clamped at zero, so the sum of their squares is zero exactly when the distance is.

This is the form the geometry distance prune already uses, which compares squared distances rather than taking a root per edge.
