### PR TITLE
Test every spatial axis in the spatiotemporal box distance

### DIFF
--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -2883,9 +2883,14 @@ stbox_spatial_distance(const STBox *box1, const STBox *box2)
   VALIDATE_NOT_NULL(box1, false); VALIDATE_NOT_NULL(box2, false);
 
   /* Spatial extents overlap → exact minimum is 0 (some pair of points
-   * inside the joined extent has zero distance) */
+   * inside the joined extent has zero distance). Every spatial axis must be
+   * tested: the distance computed below is three-dimensional whenever both
+   * boxes carry Z, so stopping at X and Y would answer 0 for boxes that share
+   * their footprint but are separated in Z. */
+  bool hasz = MEOS_FLAGS_GET_Z(box1->flags) && MEOS_FLAGS_GET_Z(box2->flags);
   if (box1->xmin <= box2->xmax && box2->xmin <= box1->xmax &&
-      box1->ymin <= box2->ymax && box2->ymin <= box1->ymax)
+      box1->ymin <= box2->ymax && box2->ymin <= box1->ymax &&
+      (! hasz || (box1->zmin <= box2->zmax && box2->zmin <= box1->zmax)))
     return 0.0;
 
   /* Spatial extents disjoint → exact bbox-to-bbox euclidean distance.

--- a/mobilitydb/test/geo/expected/064_tgeo_distance.test.out
+++ b/mobilitydb/test/geo/expected/064_tgeo_distance.test.out
@@ -2220,6 +2220,18 @@ SELECT round((stbox 'STBOX ZT(((0,0,0),(1,1,1)),[2000-01-01,2000-01-02])' |=| st
  1.732051
 (1 row)
 
+SELECT round((stbox 'STBOX ZT(((0,0,0),(1,1,1)),[2000-01-01,2000-01-02])' |=| stbox 'STBOX ZT(((0,0,10),(1,1,11)),[2000-01-01,2000-01-02])'), 6);
+ round 
+-------
+     9
+(1 row)
+
+SELECT round((stbox 'STBOX Z((0,0,0),(1,1,1))' |=| stbox 'STBOX Z((0,0,10),(1,1,11))'), 6);
+ round 
+-------
+     9
+(1 row)
+
 SELECT round((stbox 'STBOX XT(((1,1),(1,1)),[2000-01-01,2000-01-02])' |=| geometry 'Point empty'), 6);
  round 
 -------

--- a/mobilitydb/test/geo/queries/064_tgeo_distance.test.sql
+++ b/mobilitydb/test/geo/queries/064_tgeo_distance.test.sql
@@ -473,6 +473,9 @@ SELECT round((stbox 'STBOX XT(((0,0),(1,1)),[2000-01-01,2000-01-02])' |=| stbox 
 SELECT round((stbox 'GEODSTBOX Z((1.0,1.0,1.0),(2.0,2.0,2.0))' |=| stbox 'GEODSTBOX ZT(((2,2,2),(3,3,3)),[2000-01-01,2000-01-02])'), 6);
 -- 3D
 SELECT round((stbox 'STBOX ZT(((0,0,0),(1,1,1)),[2000-01-01,2000-01-02])' |=| stbox 'STBOX ZT(((2,2,2),(3,3,3)),[2000-01-01,2000-01-02])'), 6);
+-- 3D boxes sharing their footprint but separated in Z
+SELECT round((stbox 'STBOX ZT(((0,0,0),(1,1,1)),[2000-01-01,2000-01-02])' |=| stbox 'STBOX ZT(((0,0,10),(1,1,11)),[2000-01-01,2000-01-02])'), 6);
+SELECT round((stbox 'STBOX Z((0,0,0),(1,1,1))' |=| stbox 'STBOX Z((0,0,10),(1,1,11))'), 6);
 
 SELECT round((stbox 'STBOX XT(((1,1),(1,1)),[2000-01-01,2000-01-02])' |=| geometry 'Point empty'), 6);
 SELECT round((stbox 'STBOX XT(((1,1),(1,1)),[2000-01-01,2000-01-02])' |=| geometry 'Point(0 0)'), 6);


### PR DESCRIPTION
The spatial distance between two spatiotemporal boxes returns 0 as soon as the boxes overlap on X and Y, while the distance it computes for disjoint boxes is three-dimensional whenever both boxes carry Z, `geo_distance_fn` selecting `datum_geom_distance3d` on a Z flag. Two boxes that share their footprint and lie far apart in Z therefore report 0 rather than their vertical separation:

```sql
SELECT stbox 'STBOX Z((0,0,0),(1,1,1))' |=| stbox 'STBOX Z((0,0,10),(1,1,11))';
 ?column?
----------
        0     -- the boxes are 9 apart
```

This mirrors the earlier correction that adds the Y test to an overlap check covering X alone. The Z axis stays outside that scope. Adding it lets all three axes decide the overlap, so the test agrees with the distance the function goes on to compute.

The nearest approach distance of two spatiotemporal boxes returns this value directly, so the answer is wrong there rather than merely loose. The outer prunes of the temporal geo and the circular buffer nearest approach read it as a lower bound, which the corrected value only tightens: they keep pruning soundly and prune slightly more.

The distance tests gain the two cases the suite lacks. Every three-dimensional pair already present is either disjoint on all three axes or two-dimensional, so none exercises a shared footprint with a vertical gap. The output is a pure addition, leaving every existing expected value unchanged.
