### PR TITLE
Answer the planar spatiotemporal box distance in closed form

### DIFF
--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -2893,7 +2893,23 @@ stbox_spatial_distance(const STBox *box1, const STBox *box2)
       (! hasz || (box1->zmin <= box2->zmax && box2->zmin <= box1->zmax)))
     return 0.0;
 
-  /* Spatial extents disjoint → exact bbox-to-bbox euclidean distance.
+  /* Spatial extents disjoint, planar input → exact bbox-to-bbox euclidean
+   * distance in closed form on the box coordinates. Each axis contributes the
+   * gap between the two extents, zero when they overlap on it, and the boxes
+   * are axis-aligned, so a nearest pair of points differs by exactly that gap
+   * on every axis. This is the form the geometry distance prune already uses
+   * per edge, and it answers without building the two box geometries that the
+   * general path below serialises for every pair it is given. */
+  if (! MEOS_FLAGS_GET_GEODETIC(box1->flags))
+  {
+    double dx = Max(Max(box1->xmin - box2->xmax, box2->xmin - box1->xmax), 0.0);
+    double dy = Max(Max(box1->ymin - box2->ymax, box2->ymin - box1->ymax), 0.0);
+    double dz = hasz ?
+      Max(Max(box1->zmin - box2->zmax, box2->zmin - box1->zmax), 0.0) : 0.0;
+    return sqrt(dx * dx + dy * dy + dz * dz);
+  }
+
+  /* Spatial extents disjoint, geodetic input → distance on the spheroid.
    * Drop the time component of each box before serialising to geometry. */
   datum_func2 func = geo_distance_fn(box1->flags);
   STBox b1 = *box1, b2 = *box2;

--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -2883,9 +2883,14 @@ stbox_spatial_distance(const STBox *box1, const STBox *box2)
   VALIDATE_NOT_NULL(box1, false); VALIDATE_NOT_NULL(box2, false);
 
   /* Spatial extents overlap → exact minimum is 0 (some pair of points
-   * inside the joined extent has zero distance) */
+   * inside the joined extent has zero distance). Every spatial axis must be
+   * tested: the distance computed below is three-dimensional whenever both
+   * boxes carry Z, so stopping at X and Y would answer 0 for boxes that share
+   * their footprint but are separated in Z. */
+  bool hasz = MEOS_FLAGS_GET_Z(box1->flags) && MEOS_FLAGS_GET_Z(box2->flags);
   if (box1->xmin <= box2->xmax && box2->xmin <= box1->xmax &&
-      box1->ymin <= box2->ymax && box2->ymin <= box1->ymax)
+      box1->ymin <= box2->ymax && box2->ymin <= box1->ymax &&
+      (! hasz || (box1->zmin <= box2->zmax && box2->zmin <= box1->zmax)))
     return 0.0;
 
   /* Spatial extents disjoint → exact bbox-to-bbox euclidean distance.

--- a/mobilitydb/test/geo/expected/064_tgeo_distance.test.out
+++ b/mobilitydb/test/geo/expected/064_tgeo_distance.test.out
@@ -2220,6 +2220,18 @@ SELECT round((stbox 'STBOX ZT(((0,0,0),(1,1,1)),[2000-01-01,2000-01-02])' |=| st
  1.732051
 (1 row)
 
+SELECT round((stbox 'STBOX ZT(((0,0,0),(1,1,1)),[2000-01-01,2000-01-02])' |=| stbox 'STBOX ZT(((0,0,10),(1,1,11)),[2000-01-01,2000-01-02])'), 6);
+ round 
+-------
+     9
+(1 row)
+
+SELECT round((stbox 'STBOX Z((0,0,0),(1,1,1))' |=| stbox 'STBOX Z((0,0,10),(1,1,11))'), 6);
+ round 
+-------
+     9
+(1 row)
+
 SELECT round((stbox 'STBOX XT(((1,1),(1,1)),[2000-01-01,2000-01-02])' |=| geometry 'Point empty'), 6);
  round 
 -------

--- a/mobilitydb/test/geo/queries/064_tgeo_distance.test.sql
+++ b/mobilitydb/test/geo/queries/064_tgeo_distance.test.sql
@@ -473,6 +473,9 @@ SELECT round((stbox 'STBOX XT(((0,0),(1,1)),[2000-01-01,2000-01-02])' |=| stbox 
 SELECT round((stbox 'GEODSTBOX Z((1.0,1.0,1.0),(2.0,2.0,2.0))' |=| stbox 'GEODSTBOX ZT(((2,2,2),(3,3,3)),[2000-01-01,2000-01-02])'), 6);
 -- 3D
 SELECT round((stbox 'STBOX ZT(((0,0,0),(1,1,1)),[2000-01-01,2000-01-02])' |=| stbox 'STBOX ZT(((2,2,2),(3,3,3)),[2000-01-01,2000-01-02])'), 6);
+-- 3D boxes sharing their footprint but separated in Z
+SELECT round((stbox 'STBOX ZT(((0,0,0),(1,1,1)),[2000-01-01,2000-01-02])' |=| stbox 'STBOX ZT(((0,0,10),(1,1,11)),[2000-01-01,2000-01-02])'), 6);
+SELECT round((stbox 'STBOX Z((0,0,0),(1,1,1))' |=| stbox 'STBOX Z((0,0,10),(1,1,11))'), 6);
 
 SELECT round((stbox 'STBOX XT(((1,1),(1,1)),[2000-01-01,2000-01-02])' |=| geometry 'Point empty'), 6);
 SELECT round((stbox 'STBOX XT(((1,1),(1,1)),[2000-01-01,2000-01-02])' |=| geometry 'Point(0 0)'), 6);


### PR DESCRIPTION
This branch carries the commit of `fix/stbox-spatial-distance-z`, which corrects the overlap test to consider the Z axis. That one merges first; the closed form here is behaviour-neutral only once it is in, since the two branches of the function otherwise disagree about Z.

The spatial distance between two disjoint spatiotemporal boxes serialises both boxes to geometries, calls the geometry distance and frees them again. For planar input the answer is a closed form on the box coordinates: the boxes are axis-aligned, so a nearest pair of points differs on each axis by the gap between the two extents, zero where they overlap. Geodetic input keeps the geometry path, where the distance is measured on the spheroid rather than in the plane.

Readers of this value are the nearest approach distance of two spatiotemporal boxes, the outer prunes of the temporal geo and circular buffer nearest approach, and the pair loop of the temporal geo array nearest approach, which reads it once per pair to order the pairs before walking them.

Equivalence against the geometry distance it replaces, 20 000 random box pairs per dimensionality:

| check | pairs | max abs difference |
| --- | --- | --- |
| planar 2D against `ST_Distance` | 20000 | 2.8e-14 |
| planar 3D against `ST_3DDistance` | 20000 | 2.8e-14 |

The 3D set contains 131 overlapping pairs, exercising the zero branch.

Not measured: this removes two geometry allocations and one geometry distance call per box pair, with no benchmark attached. An earlier reduction of box-distance cost on the `minDistance` aggregate showed no gain, the running threshold there rarely firing the prune. The pair loop of the array nearest approach is a different site, computing the value unconditionally for every pair, and stays unmeasured either way.
