### PR TITLE
Add an exact temporal time-overlap test that respects sequence gaps

### DIFF
--- a/meos/include/meos_internal.h
+++ b/meos/include/meos_internal.h
@@ -1107,6 +1107,7 @@ extern TSequenceSet *tsequenceset_make_free(TSequence **sequences, int count, bo
 /* Conversion functions for temporal types */
 
 extern void temporal_set_tstzspan(const Temporal *temp, Span *s);
+extern bool temporal_time_overlaps(const Temporal *temp1, const Temporal *temp2);
 extern void tinstant_set_tstzspan(const TInstant *inst, Span *s);
 extern void tnumber_set_tbox(const Temporal *temp, TBox *box);
 extern void tnumberinst_set_tbox(const TInstant *inst, TBox *box);

--- a/meos/src/temporal/temporal_boxops.c
+++ b/meos/src/temporal/temporal_boxops.c
@@ -1802,6 +1802,48 @@ boxop_temporal_temporal(const Temporal *temp1, const Temporal *temp2,
   return func(&s1, &s2);
 }
 
+/**
+ * @ingroup meos_temporal_bbox_topo
+ * @brief Return true if the time of two temporal values actually overlaps
+ * @details Unlike @ref overlaps_temporal_temporal, which tests the bounding
+ * spans, this walks the actual periods, so two values whose active parts fall
+ * in each other's gaps do not count as overlapping. The periods are read in
+ * place from the sequences, so there is no allocation.
+ * @param[in] temp1,temp2 Temporal values
+ */
+bool
+temporal_time_overlaps(const Temporal *temp1, const Temporal *temp2)
+{
+  assert(temp1); assert(temp2);
+  /* Cheap bounding-span reject first (no allocation). The bounding span is also
+   * the exact time of an instant or a single sequence, which have no gaps. */
+  Span s1, s2;
+  temporal_set_tstzspan(temp1, &s1);
+  temporal_set_tstzspan(temp2, &s2);
+  if (! overlaps_span_span(&s1, &s2))
+    return false;
+  if (temp1->subtype != TSEQUENCESET && temp2->subtype != TSEQUENCESET)
+    return true;
+  /* Walk the actual periods of the sequence set(s) in place. */
+  int n1 = (temp1->subtype == TSEQUENCESET) ?
+    ((const TSequenceSet *) temp1)->count : 1;
+  int n2 = (temp2->subtype == TSEQUENCESET) ?
+    ((const TSequenceSet *) temp2)->count : 1;
+  for (int i = 0; i < n1; i++)
+  {
+    const Span *p1 = (temp1->subtype == TSEQUENCESET) ?
+      &TSEQUENCESET_SEQ_N((const TSequenceSet *) temp1, i)->period : &s1;
+    for (int j = 0; j < n2; j++)
+    {
+      const Span *p2 = (temp2->subtype == TSEQUENCESET) ?
+        &TSEQUENCESET_SEQ_N((const TSequenceSet *) temp2, j)->period : &s2;
+      if (overlaps_span_span(p1, p2))
+        return true;
+    }
+  }
+  return false;
+}
+
 /*****************************************************************************
  * Generic bounding box functions for temporal number types
  *****************************************************************************/


### PR DESCRIPTION
Add temporal_time_overlaps, an exact test of whether two temporal values share time. It walks the sequence periods in place, so unlike the bounding-span overlaps_temporal_temporal a pair whose active parts fall in each other's gaps does not count as overlapping, and it performs no allocation. It is consumed by the temporal-geo and circular-buffer dwithin predicates.