### PR TITLE
Prune the ever and always dwithin of two temporal geos by bounding box

### DIFF
--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -1991,6 +1991,31 @@ ea_dwithin_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2, double dist,
       ! ensure_not_negative_datum(Float8GetDatum(dist), T_FLOAT8))
     return -1;
 
+  /* Common-time gate: return -1 (SQL NULL) when the two temporal geos share
+   * no time, matching the lifted evaluation below rather than the 0 of a box
+   * that does not meet the other. */
+  if (! temporal_time_overlaps(temp1, temp2))
+    return -1;
+
+  /* Bounding box test with distance expansion: the two share time, so if the
+   * box of the first does not meet the box of the second expanded by the
+   * distance, every common instant holds them farther apart than the distance
+   * and they are neither ever nor always within it. The reject is exact because
+   * a temporal geo never leaves its box, and the expansion grows the second box
+   * by the distance along each axis. This mirrors the constant-time reject the
+   * circular buffers carry in #ea_dwithin_tcbuffer_tcbuffer. Geodetic input
+   * keeps the lifted path, its box being in degrees where the distance is in
+   * metres, as #ea_dwithin_tgeo_geo also leaves it. */
+  if (! MEOS_FLAGS_GET_GEODETIC(temp1->flags))
+  {
+    STBox box1, box2, box2_exp;
+    tspatial_set_stbox(temp1, &box1);
+    tspatial_set_stbox(temp2, &box2);
+    stbox_expand_space_set(&box2, dist, &box2_exp);
+    if (! overlaps_stbox_stbox(&box1, &box2_exp))
+      return 0;
+  }
+
   datum_func3 func = geo_dwithin_fn(temp1->flags, temp2->flags);
   /* Fill the lifted structure */
   LiftedFunctionInfo lfinfo;

--- a/mobilitydb/test/geo/expected/070_tgeo_spatialrels.test.out
+++ b/mobilitydb/test/geo/expected/070_tgeo_spatialrels.test.out
@@ -1604,6 +1604,24 @@ SELECT eDwithin(tgeometry '[Point(1 1)@2000-01-02, Point(2 2)@2000-01-03, Point(
  t
 (1 row)
 
+SELECT eDwithin(tgeometry '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02],[Point(1 1)@2000-01-05, Point(2 2)@2000-01-06]}', tgeometry '[Point(100 100)@2000-01-03, Point(101 101)@2000-01-04]', 10);
+ edwithin 
+----------
+ 
+(1 row)
+
+SELECT eDwithin(tgeometry '[Point(1 1)@2000-01-03, Point(2 2)@2000-01-04]', tgeometry '[Point(100 100)@2000-01-03, Point(101 101)@2000-01-04]', 10);
+ edwithin 
+----------
+ f
+(1 row)
+
+SELECT eDwithin(tgeometry '[Point(1 1)@2000-01-03, Point(2 2)@2000-01-04]', tgeometry '[Point(1 4)@2000-01-03, Point(2 5)@2000-01-04]', 10);
+ edwithin 
+----------
+ t
+(1 row)
+
 SELECT eDwithin(tgeometry '[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02]', tgeometry '[Point(2 2)@2000-01-01, Point(2 2)@2000-01-02]', 2);
  edwithin 
 ----------

--- a/mobilitydb/test/geo/queries/070_tgeo_spatialrels.test.sql
+++ b/mobilitydb/test/geo/queries/070_tgeo_spatialrels.test.sql
@@ -426,6 +426,12 @@ SELECT eDwithin(tgeometry '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point
 
 SELECT eDwithin(tgeometry '[Point(1 1)@2000-01-02]', tgeometry '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-03}', 10);
 SELECT eDwithin(tgeometry '[Point(1 1)@2000-01-02, Point(2 2)@2000-01-03, Point(1 1)@2000-01-05]', tgeometry '{Point(1 1)@2000-01-04, Point(2 2)@2000-01-06}', 10);
+
+-- Box prune keeps the exact three-valued result. Far apart in space but sharing
+-- no time (active periods fall in the other's gap) stays NULL, not a spurious 0.
+SELECT eDwithin(tgeometry '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02],[Point(1 1)@2000-01-05, Point(2 2)@2000-01-06]}', tgeometry '[Point(100 100)@2000-01-03, Point(101 101)@2000-01-04]', 10);
+SELECT eDwithin(tgeometry '[Point(1 1)@2000-01-03, Point(2 2)@2000-01-04]', tgeometry '[Point(100 100)@2000-01-03, Point(101 101)@2000-01-04]', 10);
+SELECT eDwithin(tgeometry '[Point(1 1)@2000-01-03, Point(2 2)@2000-01-04]', tgeometry '[Point(1 4)@2000-01-03, Point(2 5)@2000-01-04]', 10);
 SELECT eDwithin(tgeometry '[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02]', tgeometry '[Point(2 2)@2000-01-01, Point(2 2)@2000-01-02]', 2);
 SELECT eDwithin(tgeometry '[Point(1 1)@2000-01-01, Point(0 0)@2000-01-02]', tgeometry '[Point(0 2)@2000-01-01, Point(1 1)@2000-01-02]', 2);
 SELECT eDwithin(tgeometry '{[Point(1 1)@2000-01-02, Point(2 2)@2000-01-03],[Point(1 1)@2000-01-05]}', tgeometry '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-04}', 10);


### PR DESCRIPTION
Give the two-temporal ever and always dwithin of temporal geos the constant-time bounding-box reject the circular buffers already carry, so a spatial self-join skips the far-apart pairs before the per-segment turning-point distance. The reject is gated on temporal_time_overlaps, so a pair that shares no time stays NULL, and geodetic input keeps the lifted path. Stacks on the foundation branch.