### PR TITLE
Add spatial index support to the temporal quadbin relationships

### DIFF
--- a/mobilitydb/pg_include/pg_quadbin/doxygen_mobilitydb_quadbin.h
+++ b/mobilitydb/pg_include/pg_quadbin/doxygen_mobilitydb_quadbin.h
@@ -69,6 +69,14 @@
  *   @defgroup mobilitydb_quadbin_comp_temp Temporal comparison functions
  *   @ingroup mobilitydb_quadbin_comp
  *   @brief Temporal comparison functions for temporal QUADBIN cell indices
+ *
+ * @defgroup mobilitydb_quadbin_rel Spatial relationship functions
+ * @ingroup mobilitydb_quadbin
+ * @brief Spatial relationship functions for temporal QUADBIN cell indices
+ *
+ *   @defgroup mobilitydb_quadbin_rel_ever Ever and always spatial relationship functions
+ *   @ingroup mobilitydb_quadbin_rel
+ *   @brief Ever and always spatial relationship functions for temporal QUADBIN cell indices
  */
 
 /*****************************************************************************/

--- a/mobilitydb/sql/quadbin/362_tquadbin_spatialrels.in.sql
+++ b/mobilitydb/sql/quadbin/362_tquadbin_spatialrels.in.sql
@@ -160,8 +160,9 @@ CREATE FUNCTION aDisjoint(tquadbin, tquadbin)
 
 CREATE FUNCTION eIntersects(geometry, tquadbin)
   RETURNS boolean
-  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.eIntersects($1, @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
+  AS 'MODULE_PATHNAME', 'Eintersects_geo_tquadbin'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION aIntersects(geometry, tquadbin)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
@@ -169,8 +170,9 @@ CREATE FUNCTION aIntersects(geometry, tquadbin)
 
 CREATE FUNCTION eIntersects(tquadbin, geometry)
   RETURNS boolean
-  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.eIntersects(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry, $2) $$;
+  AS 'MODULE_PATHNAME', 'Eintersects_tquadbin_geo'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION aIntersects(tquadbin, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
@@ -178,9 +180,9 @@ CREATE FUNCTION aIntersects(tquadbin, geometry)
 
 CREATE FUNCTION eIntersects(tquadbin, tquadbin)
   RETURNS boolean
-  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.eIntersects(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry,
-                            @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry) $$;
+  AS 'MODULE_PATHNAME', 'Eintersects_tquadbin_tquadbin'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION aIntersects(tquadbin, tquadbin)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
@@ -226,8 +228,9 @@ CREATE FUNCTION aTouches(tquadbin, tquadbin)
 
 CREATE FUNCTION eDwithin(geometry, tquadbin, dist float)
   RETURNS boolean
-  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.eDwithin($1, @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry, $3) $$;
+  AS 'MODULE_PATHNAME', 'Edwithin_geo_tquadbin'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION aDwithin(geometry, tquadbin, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
@@ -235,8 +238,9 @@ CREATE FUNCTION aDwithin(geometry, tquadbin, dist float)
 
 CREATE FUNCTION eDwithin(tquadbin, geometry, dist float)
   RETURNS boolean
-  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.eDwithin(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry, $2, $3) $$;
+  AS 'MODULE_PATHNAME', 'Edwithin_tquadbin_geo'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION aDwithin(tquadbin, geometry, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
@@ -244,9 +248,9 @@ CREATE FUNCTION aDwithin(tquadbin, geometry, dist float)
 
 CREATE FUNCTION eDwithin(tquadbin, tquadbin, dist float)
   RETURNS boolean
-  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.eDwithin(@extschema@.tquadbinCellToBoundary($1)::@extschema@.tgeometry,
-                         @extschema@.tquadbinCellToBoundary($2)::@extschema@.tgeometry, $3) $$;
+  AS 'MODULE_PATHNAME', 'Edwithin_tquadbin_tquadbin'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION aDwithin(tquadbin, tquadbin, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE

--- a/mobilitydb/src/quadbin/CMakeLists.txt
+++ b/mobilitydb/src/quadbin/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(pg_quadbin OBJECT
   tquadbin.c
   tquadbin_ops.c
   tquadbin_compops.c
+  tquadbin_spatialrels.c
   # The square subset shared with every DGGS family plus the
   # quadbin-unique tile / quadkey conversions; the hexagon-only H3
   # families (directed edges, vertices, pentagon / base-cell /

--- a/mobilitydb/src/quadbin/tquadbin_spatialrels.c
+++ b/mobilitydb/src/quadbin/tquadbin_spatialrels.c
@@ -1,0 +1,197 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2026, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Ever spatial relationships for temporal QUADBIN cell indices
+ *
+ * These functions dispatch to the temporal geometry implementation through the
+ * conversion of a temporal cell index into the temporal geometry of its cell
+ * boundary. They are defined as C functions (rather than SQL wrappers casting
+ * to `tgeometry`) so that the planner support function `tspatial_supportfn`
+ * fires and the spatial index (GiST/SP-GiST) accelerates the predicate.
+ */
+
+/* MEOS */
+#include <meos.h>
+#include <meos_cellindex.h>
+#include "temporal/temporal.h"
+#include "geo/tgeo_spatialrels.h"
+/* MobilityDB */
+#include "pg_temporal/temporal.h"
+#include "pg_geo/postgis.h"
+
+/*****************************************************************************
+ * Ever intersects
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Eintersects_geo_tquadbin(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Eintersects_geo_tquadbin);
+/**
+ * @ingroup mobilitydb_quadbin_rel_ever
+ * @brief Return true if a geometry and a temporal cell index ever intersect
+ * @sqlfn eIntersects()
+ */
+Datum
+Eintersects_geo_tquadbin(PG_FUNCTION_ARGS)
+{
+  GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(0);
+  Temporal *temp = PG_GETARG_TEMPORAL_P(1);
+  Temporal *tgeo = tcellindex_cell_to_boundary(temp);
+  int result = ea_intersects_tgeo_geo(tgeo, gs, EVER);
+  pfree(tgeo);
+  PG_FREE_IF_COPY(gs, 0);
+  PG_FREE_IF_COPY(temp, 1);
+  if (result < 0)
+    PG_RETURN_NULL();
+  PG_RETURN_BOOL(result ? true : false);
+}
+
+PGDLLEXPORT Datum Eintersects_tquadbin_geo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Eintersects_tquadbin_geo);
+/**
+ * @ingroup mobilitydb_quadbin_rel_ever
+ * @brief Return true if a temporal cell index and a geometry ever intersect
+ * @sqlfn eIntersects()
+ */
+Datum
+Eintersects_tquadbin_geo(PG_FUNCTION_ARGS)
+{
+  Temporal *temp = PG_GETARG_TEMPORAL_P(0);
+  GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(1);
+  Temporal *tgeo = tcellindex_cell_to_boundary(temp);
+  int result = ea_intersects_tgeo_geo(tgeo, gs, EVER);
+  pfree(tgeo);
+  PG_FREE_IF_COPY(temp, 0);
+  PG_FREE_IF_COPY(gs, 1);
+  if (result < 0)
+    PG_RETURN_NULL();
+  PG_RETURN_BOOL(result ? true : false);
+}
+
+PGDLLEXPORT Datum Eintersects_tquadbin_tquadbin(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Eintersects_tquadbin_tquadbin);
+/**
+ * @ingroup mobilitydb_quadbin_rel_ever
+ * @brief Return true if two temporal cell indices ever intersect
+ * @sqlfn eIntersects()
+ */
+Datum
+Eintersects_tquadbin_tquadbin(PG_FUNCTION_ARGS)
+{
+  Temporal *temp1 = PG_GETARG_TEMPORAL_P(0);
+  Temporal *temp2 = PG_GETARG_TEMPORAL_P(1);
+  Temporal *tgeo1 = tcellindex_cell_to_boundary(temp1);
+  Temporal *tgeo2 = tcellindex_cell_to_boundary(temp2);
+  int result = ea_intersects_tgeo_tgeo(tgeo1, tgeo2, EVER);
+  pfree(tgeo1); pfree(tgeo2);
+  PG_FREE_IF_COPY(temp1, 0);
+  PG_FREE_IF_COPY(temp2, 1);
+  if (result < 0)
+    PG_RETURN_NULL();
+  PG_RETURN_BOOL(result ? true : false);
+}
+
+/*****************************************************************************
+ * Ever dwithin
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Edwithin_geo_tquadbin(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Edwithin_geo_tquadbin);
+/**
+ * @ingroup mobilitydb_quadbin_rel_ever
+ * @brief Return true if a geometry and a temporal cell index are ever within a
+ * distance
+ * @sqlfn eDwithin()
+ */
+Datum
+Edwithin_geo_tquadbin(PG_FUNCTION_ARGS)
+{
+  GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(0);
+  Temporal *temp = PG_GETARG_TEMPORAL_P(1);
+  double dist = PG_GETARG_FLOAT8(2);
+  Temporal *tgeo = tcellindex_cell_to_boundary(temp);
+  int result = ea_dwithin_tgeo_geo(tgeo, gs, dist, EVER);
+  pfree(tgeo);
+  PG_FREE_IF_COPY(gs, 0);
+  PG_FREE_IF_COPY(temp, 1);
+  if (result < 0)
+    PG_RETURN_NULL();
+  PG_RETURN_BOOL(result ? true : false);
+}
+
+PGDLLEXPORT Datum Edwithin_tquadbin_geo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Edwithin_tquadbin_geo);
+/**
+ * @ingroup mobilitydb_quadbin_rel_ever
+ * @brief Return true if a temporal cell index and a geometry are ever within a
+ * distance
+ * @sqlfn eDwithin()
+ */
+Datum
+Edwithin_tquadbin_geo(PG_FUNCTION_ARGS)
+{
+  Temporal *temp = PG_GETARG_TEMPORAL_P(0);
+  GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(1);
+  double dist = PG_GETARG_FLOAT8(2);
+  Temporal *tgeo = tcellindex_cell_to_boundary(temp);
+  int result = ea_dwithin_tgeo_geo(tgeo, gs, dist, EVER);
+  pfree(tgeo);
+  PG_FREE_IF_COPY(temp, 0);
+  PG_FREE_IF_COPY(gs, 1);
+  if (result < 0)
+    PG_RETURN_NULL();
+  PG_RETURN_BOOL(result ? true : false);
+}
+
+PGDLLEXPORT Datum Edwithin_tquadbin_tquadbin(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Edwithin_tquadbin_tquadbin);
+/**
+ * @ingroup mobilitydb_quadbin_rel_ever
+ * @brief Return true if two temporal cell indices are ever within a distance
+ * @sqlfn eDwithin()
+ */
+Datum
+Edwithin_tquadbin_tquadbin(PG_FUNCTION_ARGS)
+{
+  Temporal *temp1 = PG_GETARG_TEMPORAL_P(0);
+  Temporal *temp2 = PG_GETARG_TEMPORAL_P(1);
+  double dist = PG_GETARG_FLOAT8(2);
+  Temporal *tgeo1 = tcellindex_cell_to_boundary(temp1);
+  Temporal *tgeo2 = tcellindex_cell_to_boundary(temp2);
+  int result = ea_dwithin_tgeo_tgeo(tgeo1, tgeo2, dist, EVER);
+  pfree(tgeo1); pfree(tgeo2);
+  PG_FREE_IF_COPY(temp1, 0);
+  PG_FREE_IF_COPY(temp2, 1);
+  if (result < 0)
+    PG_RETURN_NULL();
+  PG_RETURN_BOOL(result ? true : false);
+}
+
+/*****************************************************************************/

--- a/mobilitydb/src/temporal/temporal_supportfn.c
+++ b/mobilitydb/src/temporal/temporal_supportfn.c
@@ -320,6 +320,9 @@ makeBboxExpr(Node *arg, Oid argoid, Oid retoid, Oid callingfunc)
 #if RGEO
       || argtype == T_TRGEOMETRY
 #endif /* RGEO */
+#if QUADBIN
+      || argtype == T_TQUADBIN
+#endif /* QUADBIN */
       )
     funcname = "stbox";
   else
@@ -536,6 +539,9 @@ Temporal_supportfn(FunctionCallInfo fcinfo, TemporalFamily tempfamily)
 #if RGEO
           || righttype == T_TRGEOMETRY
 #endif /* RGEO */
+#if QUADBIN
+          || righttype == T_TQUADBIN
+#endif /* QUADBIN */
           )
         exproid = meostype_oid(T_STBOX);
       else

--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -36,11 +36,13 @@ BANNER = (
 # so a family opts IN explicitly rather than opting out. front_back guards the Z
 # (front/back) position operators, which only the 3-D-capable spatial families
 # (tpose, trgeometry, and the tgeo reference) have; every other family omits them.
-DEFAULT_FALSE_FLAGS = {"front_back"}
+DEFAULT_FALSE_FLAGS = {"front_back", "index_support"}
 
 
 def apply_conditionals(text: str, sub: dict) -> str:
-    """Strip ``-- @IF <flag>`` / ``-- @ENDIF`` blocks whose flag is false."""
+    """Strip ``-- @IF <flag>`` / ``-- @ENDIF`` blocks whose flag is false (and
+    ``-- @IFNOT <flag>`` blocks whose flag is true — the two forms let one flag
+    select between a pair of mutually exclusive blocks)."""
     # A subtractive flag defaults to true (the reference keeps the block; an
     # exception strips it, e.g. a cell-index sets scalar_stbox_cast: false). An
     # additive flag (DEFAULT_FALSE_FLAGS) defaults to false: the reference omits
@@ -55,6 +57,11 @@ def apply_conditionals(text: str, sub: dict) -> str:
         if s.startswith("-- @IF "):
             flag = s[len("-- @IF "):].strip()
             this_skip = not sub.get(flag, flag not in DEFAULT_FALSE_FLAGS)
+            stack.append(this_skip or (stack[-1] if stack else False))
+            continue
+        if s.startswith("-- @IFNOT "):
+            flag = s[len("-- @IFNOT "):].strip()
+            this_skip = sub.get(flag, flag not in DEFAULT_FALSE_FLAGS)
             stack.append(this_skip or (stack[-1] if stack else False))
             continue
         if s.startswith("-- @ENDIF"):

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -40,6 +40,12 @@ subtypes:
     # exports (meos/src/quadbin/tquadbin_boxops.c).
     scalar_stbox_cast: true
     stboxes: false
+    # quadbin is planar (Web Mercator), so its stbox bounds the whole cell and the
+    # ever intersects/dwithin relationships get spatial index support: they are
+    # emitted as C wrappers with SUPPORT tspatial_supportfn (tquadbin_spatialrels.c)
+    # rather than SQL cast-wrappers. (h3 is geodetic and stays SQL — a geodetic bbox
+    # vs a planar query box would error, so it does not set this flag.)
+    index_support: true
     # compops/posops/topops are generic. spatialrels delegates to the geo spatial
     # relationships via the cell→boundary tgeometry conversion
     # (quadbin_cell_to_boundary), the cell-index

--- a/tools/codegen/inherited/templates/spatialrels.sql.tmpl
+++ b/tools/codegen/inherited/templates/spatialrels.sql.tmpl
@@ -134,29 +134,56 @@ CREATE FUNCTION aDisjoint({TEMP}, {TEMP})
  * Ever/always intersects
  *****************************************************************************/
 
+-- @IF index_support
+CREATE FUNCTION eIntersects(geometry, {TEMP})
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Eintersects_geo_{TEMP}'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+-- @ENDIF
+-- @IFNOT index_support
 CREATE FUNCTION eIntersects(geometry, {TEMP})
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
   AS $$ SELECT @extschema@.eIntersects($1, {CV2}) $$;
+-- @ENDIF
 CREATE FUNCTION aIntersects(geometry, {TEMP})
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
   AS $$ SELECT @extschema@.aIntersects($1, {CV2}) $$;
 
+-- @IF index_support
+CREATE FUNCTION eIntersects({TEMP}, geometry)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Eintersects_{TEMP}_geo'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+-- @ENDIF
+-- @IFNOT index_support
 CREATE FUNCTION eIntersects({TEMP}, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
   AS $$ SELECT @extschema@.eIntersects({CV1}, $2) $$;
+-- @ENDIF
 CREATE FUNCTION aIntersects({TEMP}, geometry)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
   AS $$ SELECT @extschema@.aIntersects({CV1}, $2) $$;
 
+-- @IF index_support
+CREATE FUNCTION eIntersects({TEMP}, {TEMP})
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Eintersects_{TEMP}_{TEMP}'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+-- @ENDIF
+-- @IFNOT index_support
 CREATE FUNCTION eIntersects({TEMP}, {TEMP})
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
   AS $$ SELECT @extschema@.eIntersects({CV1},
                             {CV2}) $$;
+-- @ENDIF
 CREATE FUNCTION aIntersects({TEMP}, {TEMP})
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
@@ -200,29 +227,56 @@ CREATE FUNCTION aTouches({TEMP}, {TEMP})
  * Ever/always dwithin
  *****************************************************************************/
 
+-- @IF index_support
+CREATE FUNCTION eDwithin(geometry, {TEMP}, dist float)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Edwithin_geo_{TEMP}'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+-- @ENDIF
+-- @IFNOT index_support
 CREATE FUNCTION eDwithin(geometry, {TEMP}, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
   AS $$ SELECT @extschema@.eDwithin($1, {CV2}, $3) $$;
+-- @ENDIF
 CREATE FUNCTION aDwithin(geometry, {TEMP}, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
   AS $$ SELECT @extschema@.aDwithin($1, {CV2}, $3) $$;
 
+-- @IF index_support
+CREATE FUNCTION eDwithin({TEMP}, geometry, dist float)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Edwithin_{TEMP}_geo'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+-- @ENDIF
+-- @IFNOT index_support
 CREATE FUNCTION eDwithin({TEMP}, geometry, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
   AS $$ SELECT @extschema@.eDwithin({CV1}, $2, $3) $$;
+-- @ENDIF
 CREATE FUNCTION aDwithin({TEMP}, geometry, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
   AS $$ SELECT @extschema@.aDwithin({CV1}, $2, $3) $$;
 
+-- @IF index_support
+CREATE FUNCTION eDwithin({TEMP}, {TEMP}, dist float)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Edwithin_{TEMP}_{TEMP}'
+  SUPPORT tspatial_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+-- @ENDIF
+-- @IFNOT index_support
 CREATE FUNCTION eDwithin({TEMP}, {TEMP}, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
   AS $$ SELECT @extschema@.eDwithin({CV1},
                          {CV2}, $3) $$;
+-- @ENDIF
 CREATE FUNCTION aDwithin({TEMP}, {TEMP}, dist float)
   RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE


### PR DESCRIPTION
The ever `eIntersects` and `eDwithin` relationships of a temporal quadbin cell index get spatial (GiST/SP-GiST) index acceleration, the same as temporal geometries and temporal rigid geometries. As SQL cast-wrappers with no support function they cannot use the index (the planner runs a full sequential scan / nested loop); as C wrappers with a support function the planner rewrites the predicate into an index condition.

- **Native-C wrappers** — the six ever intersects/dwithin functions are implemented in `tquadbin_spatialrels.c`, dispatching through the cell-boundary `tgeometry` conversion (`tcellindex_cell_to_boundary`, the same boundary the SQL cast uses, so results are identical) and carrying `SUPPORT tspatial_supportfn`. `T_TQUADBIN` joins the support function's two type gates.
- **Soundness** — a quadbin is planar (Web Mercator), so its stored `stbox` bounds the whole cell and the `temp && expandSpace(...)` prefilter is a superset of the predicate (the exact predicate still runs as a recheck).
- **Generation** — a new `index_support` manifest flag drives the shared `spatialrels` template: a family that sets it emits the C+SUPPORT wrappers, otherwise the SQL cast-wrappers (via a new `@IFNOT` conditional). The geodetic h3 family, whose planar predicate must not be rewritten against its geodetic bbox, does not set the flag and keeps its SQL form byte for byte.

The always (`aIntersects`/`aDwithin`) and other predicates are unchanged.
