### PR TITLE
Add the explicit htup_details.h and math.h includes PostgreSQL 19 requires

### DIFF
--- a/meos/src/cbuffer/cbuffer.c
+++ b/meos/src/cbuffer/cbuffer.c
@@ -38,6 +38,7 @@
 #include <assert.h>
 #include <float.h>
 #include <limits.h>
+#include <math.h>
 /* PostgreSQL */
 #include <postgres.h>
 #include <pgtypes.h>

--- a/meos/src/geo/tgeo_boxops.c
+++ b/meos/src/geo/tgeo_boxops.c
@@ -45,6 +45,7 @@
 
 /* C */
 #include <assert.h>
+#include <math.h>
 /* PostgreSQL */
 #include <utils/timestamp.h>
 /* PostGIS */

--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -48,6 +48,7 @@
 
 /* C */
 #include <assert.h>
+#include <math.h>
 /* MEOS */
 #include <liblwgeom.h>
 #include <meos.h>

--- a/meos/src/geo/tgeo_tile.c
+++ b/meos/src/geo/tgeo_tile.c
@@ -39,6 +39,7 @@
 /* PostgreSQL */
 #include <postgres.h>
 #include <float.h>
+#include <math.h>
 #include <utils/timestamp.h>
 /* PostGIS */
 #include <liblwgeom.h>

--- a/meos/src/npoint/npoint.c
+++ b/meos/src/npoint/npoint.c
@@ -38,6 +38,7 @@
 #include <assert.h>
 #include <float.h>
 #include <limits.h>
+#include <math.h>
 /* PostgreSQL */
 #include <postgres.h>
 #include <common/hashfn.h>

--- a/meos/src/npoint/tnpoint_spatialfuncs.c
+++ b/meos/src/npoint/tnpoint_spatialfuncs.c
@@ -36,6 +36,7 @@
 
 /* C */
 #include <assert.h>
+#include <math.h>
 /* MEOS */
 #include <meos.h>
 #include <meos_internal_geo.h>

--- a/meos/src/rgeo/trgeo_spatialfuncs.c
+++ b/meos/src/rgeo/trgeo_spatialfuncs.c
@@ -47,6 +47,7 @@
 /* PostgreSQL */
 #include <postgres.h>
 #include <float.h>
+#include <math.h>
 #include <utils/timestamp.h>
 /* MEOS */
 #include <meos.h>

--- a/meos/src/temporal/doublen.c
+++ b/meos/src/temporal/doublen.c
@@ -45,6 +45,7 @@
 
 /* C */
 #include <assert.h>
+#include <math.h>
 /* PostgreSQL */
 #include <postgres.h>
 /* MEOS */

--- a/meos/src/temporal/lifting.c
+++ b/meos/src/temporal/lifting.c
@@ -176,6 +176,7 @@
 
 /* C */
 #include <assert.h>
+#include <math.h>
 /* PostgreSQL */
 #include <postgres.h>
 #include <utils/timestamp.h>

--- a/meos/src/temporal/spanset.c
+++ b/meos/src/temporal/spanset.c
@@ -38,6 +38,7 @@
 #include <assert.h>
 #include <float.h>
 #include <limits.h>
+#include <math.h>
 /* PostgreSQL */
 #include <postgres.h>
 #include "utils/timestamp.h"

--- a/meos/src/temporal/tbox.c
+++ b/meos/src/temporal/tbox.c
@@ -37,6 +37,7 @@
 /* C */
 #include <assert.h>
 #include <limits.h>
+#include <math.h>
 #include <assert.h>
 /* PostgreSQL */
 #include "common/hashfn.h"

--- a/meos/src/temporal/temporal_boxops.c
+++ b/meos/src/temporal/temporal_boxops.c
@@ -48,6 +48,7 @@
 /* C */
 #include <assert.h>
 #include <limits.h>
+#include <math.h>
 /* PostgreSQL */
 #include <utils/timestamp.h>
 /* MEOS */

--- a/mobilitydb/src/geo/tgeo_spatialfuncs.c
+++ b/mobilitydb/src/geo/tgeo_spatialfuncs.c
@@ -37,6 +37,7 @@
 /* PostgreSQL */
 #include <postgres.h>
 #include <funcapi.h>
+#include <access/htup_details.h>
 /* PostGIS */
 #include <liblwgeom.h>
 #include <lwgeom_pg.h>

--- a/mobilitydb/src/geo/tgeo_spatialrels.c
+++ b/mobilitydb/src/geo/tgeo_spatialrels.c
@@ -50,6 +50,7 @@
 
 /* PostgreSQL */
 #include <funcapi.h>
+#include <access/htup_details.h>
 #include <utils/array.h>
 /* MEOS */
 #include <meos.h>

--- a/mobilitydb/src/geo/tgeo_tile.c
+++ b/mobilitydb/src/geo/tgeo_tile.c
@@ -37,6 +37,7 @@
 /* PostgreSQL */
 #include <postgres.h>
 #include <funcapi.h>
+#include <access/htup_details.h>
 #include <utils/array.h>
 #include <utils/timestamp.h>
 /* PostGIS */

--- a/mobilitydb/src/rgeo/trgeo_spatialfuncs.c
+++ b/mobilitydb/src/rgeo/trgeo_spatialfuncs.c
@@ -36,6 +36,7 @@
 #include <postgres.h>
 #include <float.h>
 #include <funcapi.h>
+#include <access/htup_details.h>
 /* MEOS */
 #include <meos.h>
 #include <meos_internal.h>

--- a/mobilitydb/src/temporal/span_selfuncs.c
+++ b/mobilitydb/src/temporal/span_selfuncs.c
@@ -39,6 +39,7 @@
 
 /* C */
 #include <assert.h>
+#include <math.h>
 /* PostgreSQL */
 #include <postgres.h>
 #include <pgtypes.h>

--- a/mobilitydb/src/temporal/temporal_supportfn.c
+++ b/mobilitydb/src/temporal/temporal_supportfn.c
@@ -36,6 +36,7 @@
 #include <assert.h>
 /* PostgreSQL */
 #include <postgres.h>
+#include <access/htup_details.h>
 #include <catalog/pg_opfamily.h>
 #include <catalog/pg_am_d.h>
 #include <nodes/supportnodes.h>

--- a/mobilitydb/src/temporal/temporal_tile.c
+++ b/mobilitydb/src/temporal/temporal_tile.c
@@ -44,6 +44,7 @@
 #include <pgtypes.h>
 #include <utils/array.h>
 #include <funcapi.h>
+#include <access/htup_details.h>
 /* MEOS */
 #include <meos.h>
 #include <meos_internal.h>


### PR DESCRIPTION
On PostgreSQL 19 `<funcapi.h>` does not pull in `<access/htup_details.h>`, so files that call `heap_form_tuple` or `GETSTRUCT` without including it directly fail to compile: the function is implicitly declared and its implicit `int` return truncates the returned pointer on 64-bit platforms. Several files also call math functions (`fabs`, `ceil`, `sqrt`, `llround`, `isinf`) without `<math.h>`, whose implicit `int` return likewise corrupts the `double` result. Modern compilers (GCC 14+, mingw64) treat an implicit declaration as an error rather than a warning, so the build fails outright.

This adds `<access/htup_details.h>` to the files that use `heap_form_tuple`/`GETSTRUCT` and `<math.h>` to the files that use math functions. The includes are idempotent on PostgreSQL 16–18, so behaviour on the supported versions is unchanged.
