### PR TITLE
Return NULL from the tcbuffer dwithin, intersects and disjoint predicates when the buffers share no time

### DIFF
--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -513,6 +513,13 @@ ea_spatialrel_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
   if (! ensure_valid_tcbuffer_tcbuffer(temp1, temp2))
     return -1;
 
+  /* Common-time gate: return -1 (SQL NULL) when the two temporal circular
+   * buffers share no time, respecting the gaps of a sequence set so a pair
+   * whose active periods fall in each other's gaps stays NULL rather than
+   * becoming a spurious 0 in the bounding-box test below. */
+  if (! temporal_time_overlaps(temp1, temp2))
+    return -1;
+
   /* Bounding box test */
   if (bbox_test)
   {
@@ -1195,12 +1202,10 @@ ea_disjoint_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
   if (! ensure_valid_tcbuffer_tcbuffer(temp1, temp2))
     return -1;
 
-  /* Time-overlap test: mirror the generic function's contract of returning -1
-   * when the two temporal circular buffers do not share time. */
-  Span s1, s2;
-  temporal_set_tstzspan(temp1, &s1);
-  temporal_set_tstzspan(temp2, &s2);
-  if (! overlaps_span_span(&s1, &s2))
+  /* Common-time gate: return -1 (SQL NULL) when the two temporal circular
+   * buffers share no time, respecting the gaps of a sequence set so a pair
+   * whose active periods fall in each other's gaps stays NULL. */
+  if (! temporal_time_overlaps(temp1, temp2))
     return -1;
   /* Disjoint is the boolean complement of intersects with the ever/always
    * quantifier swapped: aDisjoint = not eIntersects, eDisjoint = not
@@ -1824,12 +1829,10 @@ ea_dwithin_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
       ! ensure_not_negative_datum(Float8GetDatum(dist), T_FLOAT8))
     return -1;
 
-  /* Time-overlap test: mirror the generic function's contract of returning -1
-   * when the two temporal circular buffers do not share time. */
-  Span s1, s2;
-  temporal_set_tstzspan(temp1, &s1);
-  temporal_set_tstzspan(temp2, &s2);
-  if (! overlaps_span_span(&s1, &s2))
+  /* Common-time gate: return -1 (SQL NULL) when the two temporal circular
+   * buffers share no time, respecting the gaps of a sequence set so a pair
+   * whose active periods fall in each other's gaps stays NULL. */
+  if (! temporal_time_overlaps(temp1, temp2))
     return -1;
 
   /* Bounding box test with distance expansion: the buffers share time, so if

--- a/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels.test.out
@@ -735,6 +735,24 @@ SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(0 0
  t
 (1 row)
 
+SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02],[Cbuffer(Point(1 1),0.5)@2000-01-05, Cbuffer(Point(2 2),0.5)@2000-01-06]}', tcbuffer '[Cbuffer(Point(100 100),0.5)@2000-01-03, Cbuffer(Point(101 101),0.5)@2000-01-04]', 10);
+ edwithin 
+----------
+ 
+(1 row)
+
+SELECT eIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02],[Cbuffer(Point(1 1),0.5)@2000-01-05, Cbuffer(Point(2 2),0.5)@2000-01-06]}', tcbuffer '[Cbuffer(Point(100 100),0.5)@2000-01-03, Cbuffer(Point(101 101),0.5)@2000-01-04]');
+ eintersects 
+-------------
+ 
+(1 row)
+
+SELECT eDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02],[Cbuffer(Point(1 1),0.5)@2000-01-05, Cbuffer(Point(2 2),0.5)@2000-01-06]}', tcbuffer '[Cbuffer(Point(100 100),0.5)@2000-01-03, Cbuffer(Point(101 101),0.5)@2000-01-04]');
+ edisjoint 
+-----------
+ 
+(1 row)
+
 SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-02, Cbuffer(Point(2 2),0.5)@2000-01-03],[Cbuffer(Point(1 1),0.5)@2000-01-05]}', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-04}', 10);
  edwithin 
 ----------

--- a/mobilitydb/test/cbuffer/queries/212_tcbuffer_spatialrels.test.sql
+++ b/mobilitydb/test/cbuffer/queries/212_tcbuffer_spatialrels.test.sql
@@ -260,6 +260,12 @@ SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-02]', tcbuffer '{Cbuf
 SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-02, Cbuffer(Point(2 2),0.5)@2000-01-03, Cbuffer(Point(1 1),0.5)@2000-01-05]', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-04, Cbuffer(Point(2 2),0.5)@2000-01-06}', 10);
 SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(2 2),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02]', 2);
 SELECT eDwithin(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(0 0),0.5)@2000-01-02]', tcbuffer '[Cbuffer(Point(0 2),0.5)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]', 2);
+
+-- No shared time (active periods fall in the other's gap) is NULL for every
+-- box-short-circuited predicate, not a spurious value.
+SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02],[Cbuffer(Point(1 1),0.5)@2000-01-05, Cbuffer(Point(2 2),0.5)@2000-01-06]}', tcbuffer '[Cbuffer(Point(100 100),0.5)@2000-01-03, Cbuffer(Point(101 101),0.5)@2000-01-04]', 10);
+SELECT eIntersects(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02],[Cbuffer(Point(1 1),0.5)@2000-01-05, Cbuffer(Point(2 2),0.5)@2000-01-06]}', tcbuffer '[Cbuffer(Point(100 100),0.5)@2000-01-03, Cbuffer(Point(101 101),0.5)@2000-01-04]');
+SELECT eDisjoint(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02],[Cbuffer(Point(1 1),0.5)@2000-01-05, Cbuffer(Point(2 2),0.5)@2000-01-06]}', tcbuffer '[Cbuffer(Point(100 100),0.5)@2000-01-03, Cbuffer(Point(101 101),0.5)@2000-01-04]');
 SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-02, Cbuffer(Point(2 2),0.5)@2000-01-03],[Cbuffer(Point(1 1),0.5)@2000-01-05]}', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-04}', 10);
 SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-02, Cbuffer(Point(2 2),0.5)@2000-01-03],[Cbuffer(Point(1 1),0.5)@2000-01-06]}', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-04, Cbuffer(Point(2 2),0.5)@2000-01-05]', 10);
 SELECT eDwithin(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-02, Cbuffer(Point(2 2),0.5)@2000-01-03],[Cbuffer(Point(1 1),0.5)@2000-01-06]}', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01],[Cbuffer(Point(1 1),0.5)@2000-01-04, Cbuffer(Point(2 2),0.5)@2000-01-05]}', 10);


### PR DESCRIPTION
The tcbuffer ever and always dwithin, intersects and disjoint predicates gated their bounding-box short circuit on the bounding spans, so two temporal circular buffers whose active periods fall in each other's gaps returned a spurious false or true instead of the undefined NULL. Gate on the exact temporal_time_overlaps so those pairs report NULL.