### PR TITLE
Define the count out parameter when an accessor rejects its arguments

### DIFF
--- a/meos/src/geo/stbox.c
+++ b/meos/src/geo/stbox.c
@@ -2390,6 +2390,8 @@ stbox_quad_split(const STBox *box, int *count)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(box, NULL); VALIDATE_NOT_NULL(count, NULL);
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   if (! ensure_has_X(T_STBOX, box->flags))
     return NULL;
 

--- a/meos/src/geo/tgeo_boxops.c
+++ b/meos/src/geo/tgeo_boxops.c
@@ -779,6 +779,8 @@ tgeo_split_n_stboxes(const Temporal *temp, int box_count, int *count)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TSPATIAL(temp, NULL); VALIDATE_NOT_NULL(count, NULL);
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   if (! ensure_positive(box_count))
     return NULL;
 
@@ -952,6 +954,8 @@ tgeo_split_each_n_stboxes(const Temporal *temp, int elems_per_box, int *count)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TSPATIAL(temp, NULL); VALIDATE_NOT_NULL(count, NULL);
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   if (! ensure_positive(elems_per_box))
     return NULL;
 
@@ -1171,6 +1175,8 @@ geo_stboxes(const GSERIALIZED *gs, int *count)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(gs, NULL); VALIDATE_NOT_NULL(count, NULL);
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   if (! ensure_not_empty(gs) || ! ensure_mline_type(gs))
     return NULL;
   
@@ -1419,6 +1425,8 @@ geo_split_n_stboxes(const GSERIALIZED *gs, int box_count, int *count)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(gs, NULL); VALIDATE_NOT_NULL(count, NULL);
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   if (! ensure_not_empty(gs) || ! ensure_positive(box_count) ||
       ! ensure_mline_type(gs))
     return NULL;
@@ -1605,6 +1613,8 @@ geo_split_each_n_stboxes(const GSERIALIZED *gs, int elems_per_box, int *count)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(gs, NULL); VALIDATE_NOT_NULL(count, NULL);
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   if (! ensure_not_empty(gs) || ! ensure_positive(elems_per_box) || 
       ! ensure_mline_type(gs))
     return NULL;

--- a/meos/src/geo/tgeo_tile.c
+++ b/meos/src/geo/tgeo_tile.c
@@ -666,6 +666,8 @@ stbox_space_time_tiles(const STBox *bounds, double xsize, double ysize,
    * Since we pass by default Point(0 0 0) as origin independently of the input
    * STBox, we test the same spatial dimensionality only for STBox Z */
   VALIDATE_NOT_NULL(bounds, NULL); VALIDATE_NOT_NULL(count, NULL);
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   if (! ensure_has_X(T_STBOX, bounds->flags) ||
       ! ensure_not_geodetic(bounds->flags) ||
       ! ensure_not_negative_datum(Float8GetDatum(xsize), T_FLOAT8) ||
@@ -954,6 +956,8 @@ tgeo_space_time_boxes(const Temporal *temp, double xsize, double ysize,
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TGEO(temp, NULL); VALIDATE_NOT_NULL(count, NULL);
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   if ((xsize > 0 && ! ensure_not_null((void *) sorigin)) ||
       (xsize > 0 && ! ensure_positive_datum(xsize, T_FLOAT8)) ||
       (xsize > 0 && ! ensure_positive_datum(ysize, T_FLOAT8)) ||
@@ -1264,6 +1268,8 @@ tgeo_space_time_tile_init(const Temporal *temp, double xsize, double ysize,
 {
   /* Ensure parameter validity */
   VALIDATE_TGEO(temp, NULL); VALIDATE_NOT_NULL(ntiles, NULL);
+  /* The out parameter is defined even when a later check fails */
+  *ntiles = 0;
   if ((xsize && ! ensure_positive_datum(Float8GetDatum(xsize), T_FLOAT8)) ||
       (xsize && ! ensure_positive_datum(Float8GetDatum(ysize), T_FLOAT8)) ||
       (xsize && ! ensure_positive_datum(Float8GetDatum(zsize), T_FLOAT8)) ||

--- a/meos/src/h3/th3index.c
+++ b/meos/src/h3/th3index.c
@@ -336,6 +336,8 @@ th3index_values(const Temporal *temp, int *count)
   VALIDATE_TH3INDEX(temp, NULL);
   if (! ensure_not_null((void *) count))
     return NULL;
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   Datum *datums = temporal_values(temp, count);
   if (datums == NULL)
     return NULL;

--- a/meos/src/quadbin/tquadbin.c
+++ b/meos/src/quadbin/tquadbin.c
@@ -337,6 +337,8 @@ tquadbin_values(const Temporal *temp, int *count)
   VALIDATE_TQUADBIN(temp, NULL);
   if (! ensure_not_null((void *) count))
     return NULL;
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   Datum *datums = temporal_values(temp, count);
   if (datums == NULL)
     return NULL;

--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -885,6 +885,8 @@ TSequence **
 trgeometry_segments(const Temporal *temp, int *count)
 {
   VALIDATE_TRGEOMETRY(temp, NULL); VALIDATE_NOT_NULL(count, NULL);
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   if (! ensure_continuous(temp))
     return NULL;
   const GSERIALIZED *geo = trgeo_geom_p(temp);

--- a/meos/src/temporal/span.c
+++ b/meos/src/temporal/span.c
@@ -1539,6 +1539,8 @@ set_split_n_spans(const Set *s, int span_count, int *count)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NUMSET(s, NULL); VALIDATE_NOT_NULL(count, NULL);
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   if (! ensure_positive(span_count))
     return NULL;
 
@@ -1586,6 +1588,8 @@ set_split_each_n_spans(const Set *s, int elems_per_span, int *count)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NUMSET(s, NULL); VALIDATE_NOT_NULL(count, NULL);
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   if (! ensure_positive(elems_per_span))
     return NULL;
 

--- a/meos/src/temporal/spanset.c
+++ b/meos/src/temporal/spanset.c
@@ -1326,6 +1326,8 @@ spanset_split_n_spans(const SpanSet *ss, int span_count, int *count)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(ss, NULL); VALIDATE_NOT_NULL(count, NULL);
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   if (! ensure_positive(span_count))
     return NULL;
 
@@ -1374,6 +1376,8 @@ spanset_split_each_n_spans(const SpanSet *ss, int elems_per_span, int *count)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(ss, NULL); VALIDATE_NOT_NULL(count, NULL);
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   if (! ensure_positive(elems_per_span))
     return NULL;
 

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -2577,6 +2577,8 @@ temporal_segments(const Temporal *temp, int *count)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(temp, NULL); VALIDATE_NOT_NULL(count, NULL);
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
 
   assert(temptype_subtype(temp->subtype));
   switch (temp->subtype)

--- a/meos/src/temporal/temporal_boxops.c
+++ b/meos/src/temporal/temporal_boxops.c
@@ -1011,6 +1011,8 @@ temporal_split_n_spans(const Temporal *temp, int span_count, int *count)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(temp, NULL); VALIDATE_NOT_NULL(count, NULL);
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   if (! ensure_positive(span_count))
     return NULL;
 
@@ -1181,6 +1183,8 @@ temporal_split_each_n_spans(const Temporal *temp, int elems_per_span,
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(temp, NULL); VALIDATE_NOT_NULL(count, NULL);
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   if (! ensure_positive(elems_per_span))
     return NULL;
 
@@ -1580,6 +1584,8 @@ tnumber_split_n_tboxes(const Temporal *temp, int box_count, int *count)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TNUMBER(temp, NULL); VALIDATE_NOT_NULL(count, NULL);
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   if (! ensure_positive(box_count))
     return NULL;
 
@@ -1750,6 +1756,8 @@ tnumber_split_each_n_tboxes(const Temporal *temp, int elems_per_box, int *count)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TNUMBER(temp, NULL); VALIDATE_NOT_NULL(count, NULL);
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   if (! ensure_positive(elems_per_box))
     return NULL;
 

--- a/meos/src/temporal/temporal_tile.c
+++ b/meos/src/temporal/temporal_tile.c
@@ -546,6 +546,8 @@ temporal_time_bins(const Temporal *temp, const Interval *duration,
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(temp, NULL); VALIDATE_NOT_NULL(duration, NULL);
   VALIDATE_NOT_NULL(count, NULL);
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   if (! ensure_positive_duration(duration))
     return NULL;
 
@@ -871,6 +873,8 @@ tnumber_value_time_tile_init(const Temporal *temp, Datum vsize,
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TNUMBER(temp, NULL); VALIDATE_NOT_NULL(ntiles, NULL);
+  /* The out parameter is defined even when a later check fails */
+  *ntiles = 0;
   if (! ensure_not_negative_datum(vsize, temptype_basetype(temp->temptype)) ||
       (duration && ! ensure_positive_duration(duration)))
     return NULL;

--- a/meos/src/temporal/temporal_tile_meos.c
+++ b/meos/src/temporal/temporal_tile_meos.c
@@ -695,6 +695,8 @@ temporal_time_split(const Temporal *temp, const Interval *duration,
   if (! ensure_not_null((void *) temp) || ! ensure_not_null((void *) count) ||
       ! ensure_positive_duration(duration))
     return NULL;
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
 
   Span s;
   temporal_set_tstzspan(temp, &s);
@@ -1345,6 +1347,8 @@ tint_value_split(const Temporal *temp, int size, int origin, int **bins,
   if (! ensure_not_null((void *) temp) || ! ensure_not_null((void *) count) ||
       ! ensure_temporal_isof_type(temp, T_TINT) || ! ensure_positive(size))
     return NULL;
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
 
   Datum *datum_bins;
   Temporal **result = tnumber_value_split(temp, Int32GetDatum(size),
@@ -1379,6 +1383,8 @@ tfloat_value_split(const Temporal *temp, double size, double origin,
       ! ensure_temporal_isof_type(temp, T_TFLOAT) ||
       ! ensure_positive_datum(Float8GetDatum(size), T_FLOAT8))
     return NULL;
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
 
   Datum *datum_bins;
   Temporal **result = tnumber_value_split(temp, Float8GetDatum(size),
@@ -1417,6 +1423,8 @@ tint_value_time_split(const Temporal *temp, int size, const Interval *duration,
       ! ensure_temporal_isof_type(temp, T_TINT) || ! ensure_positive(size) ||
       ! ensure_positive_duration(duration))
     return NULL;
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
 
   Datum *datum_bins;
   Temporal **result = tnumber_value_time_split(temp, Int32GetDatum(size),
@@ -1460,6 +1468,8 @@ tfloat_value_time_split(const Temporal *temp, double size,
       ! ensure_positive_datum(Float8GetDatum(size), T_FLOAT8) ||
       ! ensure_positive_duration(duration))
     return NULL;
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
 
   Datum *datum_bins;
   Temporal **result = tnumber_value_time_split(temp, Float8GetDatum(size),

--- a/meos/test/error_test.c
+++ b/meos/test/error_test.c
@@ -95,6 +95,33 @@ int main(void)
   assert(meos_errno_reset() == failed_errno);
   assert(meos_errno() == 0);
 
+  /* A function returning an array through a count out parameter leaves that
+   * count defined when it rejects its arguments, so a caller reading the count
+   * of a failed call sees no elements rather than whatever the variable held.
+   * Only the noexit handler reaches this: the default one ends the process
+   * inside the rejected check. The count starts at a value the functions never
+   * produce, so that leaving it untouched is distinguishable from setting it. */
+  int count = -559038737;
+  Temporal *inst = tint_in("1@2000-01-01");
+  assert(inst != NULL);
+  meos_errno_reset();
+  /* temporal_segments takes a sequence (set), so an instant is rejected */
+  assert(temporal_segments(inst, &count) == NULL);
+  printf("temporal_segments(instant): NULL, count %d, errno %d\n", count,
+    meos_errno());
+  assert(count == 0);
+
+  count = -559038737;
+  Temporal *seq = tint_in("{1@2000-01-01, 2@2000-01-02}");
+  assert(seq != NULL);
+  meos_errno_reset();
+  /* a span count of zero is rejected */
+  assert(temporal_split_n_spans(seq, 0, &count) == NULL);
+  printf("temporal_split_n_spans(0): NULL, count %d, errno %d\n", count,
+    meos_errno());
+  assert(count == 0);
+
+  free(inst); free(seq);
   free(good); free(good_out);
 
   /* Finalize MEOS */


### PR DESCRIPTION
A function that returns an array through a `count` out parameter and then rejects its arguments returned `NULL` without ever writing that count, so the caller's variable kept whatever it held. Reading it after a failed call gave an arbitrary element count beside a `NULL` array.

Under the default error handler the process ends inside the rejected check, so the caller is never reached and the omission stays out of sight. Under the handler installed by `meos_initialize_noexit_error_handler`, which every language binding uses to raise an exception in its host rather than terminate it, execution continues and the caller sees the undefined count. The Doxygen documents the parameter as an output without qualification, and the catalog carries it to the bindings as such, so a binding is given no signal that the value is meaningless on failure.

```
before:  temporal_segments(instant) -> NULL, count -559038737   (the caller's own value)
after:   temporal_segments(instant) -> NULL, count 0
```

## The change

Each of the 28 functions writes zero to the count immediately after the guard that proves the pointer is non-NULL, so every later rejection inherits a defined value without touching the individual return sites:

```c
  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_NOT_NULL(count, NULL);
+ /* The out parameter is defined even when a later check fails */
+ *count = 0;
```

A failed call now reports `NULL` and a count of zero, the contract already applied to `tinstant_merge_array_iter`.

## What is left alone

Functions whose guards do not establish that the count is non-NULL keep their present behaviour. Defining the parameter there would first require rejecting a NULL count, which changes the arguments those functions accept — `geo_cluster_kmeans`, `geo_cluster_dbscan`, `geo_cluster_intersecting`, `geo_cluster_within`, `temporal_frechet_path`, `temporal_dyntimewarp_path`, `trgeometry_frechet_path`, `trgeometry_dyntimewarp_path`, `span_bins`, `spanset_bins`, `tnumber_value_time_boxes`, `trgeometry_sequences`, `trgeometry_split_n_stboxes`, `trgeometry_split_each_n_stboxes`, `tspatialinst_parse`, `trgeoinst_parse`, `pose_orientation`, `ensure_valid_tinstarr_gaps`.

Parameters declared `const` are inputs, not outputs, and are untouched: `intset_make(const int *values, int count)` and its siblings take an array to read.

## Test

`meos/test/error_test.c` checks the contract on the two rejection paths reachable from the public API — an instant handed to a function taking a sequence, and a span count of zero. The count starts at a value the functions never produce, so leaving it untouched is distinguishable from setting it.
