### PR TITLE
Use the vendored JSONB builder in the extension and scope its free-list to the memory context

### DIFF
--- a/pgtypes/utils/jsonb.c
+++ b/pgtypes/utils/jsonb.c
@@ -312,7 +312,7 @@ static JsonParseErrorType
 jsonb_in_object_start(void *pstate)
 {
   JsonbInState *_state = (JsonbInState *) pstate;
-  _state->res = pushJsonbValue(&_state->parseState, WJB_BEGIN_OBJECT, NULL);
+  _state->res = meos_pushJsonbValue(&_state->parseState, WJB_BEGIN_OBJECT, NULL);
   _state->parseState->unique_keys = _state->unique_keys;
   return JSON_SUCCESS;
 }
@@ -321,7 +321,7 @@ static JsonParseErrorType
 jsonb_in_object_end(void *pstate)
 {
   JsonbInState *_state = (JsonbInState *) pstate;
-  _state->res = pushJsonbValue(&_state->parseState, WJB_END_OBJECT, NULL);
+  _state->res = meos_pushJsonbValue(&_state->parseState, WJB_END_OBJECT, NULL);
   return JSON_SUCCESS;
 }
 
@@ -329,7 +329,7 @@ static JsonParseErrorType
 jsonb_in_array_start(void *pstate)
 {
   JsonbInState *_state = (JsonbInState *) pstate;
-  _state->res = pushJsonbValue(&_state->parseState, WJB_BEGIN_ARRAY, NULL);
+  _state->res = meos_pushJsonbValue(&_state->parseState, WJB_BEGIN_ARRAY, NULL);
   return JSON_SUCCESS;
 }
 
@@ -337,7 +337,7 @@ static JsonParseErrorType
 jsonb_in_array_end(void *pstate)
 {
   JsonbInState *_state = (JsonbInState *) pstate;
-  _state->res = pushJsonbValue(&_state->parseState, WJB_END_ARRAY, NULL);
+  _state->res = meos_pushJsonbValue(&_state->parseState, WJB_END_ARRAY, NULL);
   return JSON_SUCCESS;
 }
 
@@ -352,7 +352,7 @@ jsonb_in_object_field_start(void *pstate, char *fname, bool isnull UNUSED)
   if (!checkStringLen(v.val.string.len, _state->escontext))
     return JSON_SEM_ACTION_FAILED;
   v.val.string.val = fname;
-  _state->res = pushJsonbValue(&_state->parseState, WJB_KEY, &v);
+  _state->res = meos_pushJsonbValue(&_state->parseState, WJB_KEY, &v);
   return JSON_SUCCESS;
 }
 
@@ -447,9 +447,9 @@ jsonb_in_scalar(void *pstate, char *token, JsonTokenType tokentype)
     va.val.array.rawScalar = true;
     va.val.array.nElems = 1;
 
-    _state->res = pushJsonbValue(&_state->parseState, WJB_BEGIN_ARRAY, &va);
-    _state->res = pushJsonbValue(&_state->parseState, WJB_ELEM, &v);
-    _state->res = pushJsonbValue(&_state->parseState, WJB_END_ARRAY, NULL);
+    _state->res = meos_pushJsonbValue(&_state->parseState, WJB_BEGIN_ARRAY, &va);
+    _state->res = meos_pushJsonbValue(&_state->parseState, WJB_ELEM, &v);
+    _state->res = meos_pushJsonbValue(&_state->parseState, WJB_END_ARRAY, NULL);
   }
   else
   {
@@ -457,10 +457,10 @@ jsonb_in_scalar(void *pstate, char *token, JsonTokenType tokentype)
     switch (o->type)
     {
       case jbvArray:
-        _state->res = pushJsonbValue(&_state->parseState, WJB_ELEM, &v);
+        _state->res = meos_pushJsonbValue(&_state->parseState, WJB_ELEM, &v);
         break;
       case jbvObject:
-        _state->res = pushJsonbValue(&_state->parseState, WJB_VALUE, &v);
+        _state->res = meos_pushJsonbValue(&_state->parseState, WJB_VALUE, &v);
         break;
       default:
         meos_error(ERROR, MEOS_ERR_INTERNAL_ERROR,
@@ -677,7 +677,7 @@ pg_jsonb_make(text **keys_vals, int count)
 
   JsonbInState state;
   memset(&state, 0, sizeof(JsonbInState));
-  (void) pushJsonbValue(&state.parseState, WJB_BEGIN_OBJECT, NULL);
+  (void) meos_pushJsonbValue(&state.parseState, WJB_BEGIN_OBJECT, NULL);
 
   /* Transform the keys and values into strings */
   char **keys_vals_str = palloc0(sizeof(char *) * count);
@@ -703,7 +703,7 @@ pg_jsonb_make(text **keys_vals, int count)
     v.type = jbvString;
     v.val.string.len = len;
     v.val.string.val = str;
-    (void) pushJsonbValue(&state.parseState, WJB_KEY, &v);
+    (void) meos_pushJsonbValue(&state.parseState, WJB_KEY, &v);
 
     if (! keys_vals_str[i * 2 + 1])
     {
@@ -717,10 +717,10 @@ pg_jsonb_make(text **keys_vals, int count)
       v.val.string.len = len;
       v.val.string.val = str;
     }
-    (void) pushJsonbValue(&state.parseState, WJB_VALUE, &v);
+    (void) meos_pushJsonbValue(&state.parseState, WJB_VALUE, &v);
   }
 
-  state.res = pushJsonbValue(&state.parseState, WJB_END_OBJECT, NULL);
+  state.res = meos_pushJsonbValue(&state.parseState, WJB_END_OBJECT, NULL);
   Jsonb *result = JsonbValueToJsonb(state.res);
 
   /* Clean up and return */
@@ -754,7 +754,7 @@ pg_jsonb_make_two_arg(text **keys, text **values, int count)
 {
   JsonbInState state;
   memset(&state, 0, sizeof(JsonbInState));
-  (void) pushJsonbValue(&state.parseState, WJB_BEGIN_OBJECT, NULL);
+  (void) meos_pushJsonbValue(&state.parseState, WJB_BEGIN_OBJECT, NULL);
   char **keys_str = palloc(sizeof(char *) * count);
   /* Initialized to 0 since some values may be null */
   char **values_str = palloc0(sizeof(char *) * count);
@@ -780,7 +780,7 @@ pg_jsonb_make_two_arg(text **keys, text **values, int count)
     v.type = jbvString;
     v.val.string.len = len;
     v.val.string.val = str;
-    (void) pushJsonbValue(&state.parseState, WJB_KEY, &v);
+    (void) meos_pushJsonbValue(&state.parseState, WJB_KEY, &v);
     if (! values[i])
     {
       v.type = jbvNull;
@@ -793,10 +793,10 @@ pg_jsonb_make_two_arg(text **keys, text **values, int count)
       v.val.string.len = len;
       v.val.string.val = str;
     }
-    (void) pushJsonbValue(&state.parseState, WJB_VALUE, &v);
+    (void) meos_pushJsonbValue(&state.parseState, WJB_VALUE, &v);
   }
 
-  state.res = pushJsonbValue(&state.parseState, WJB_END_OBJECT, NULL);
+  state.res = meos_pushJsonbValue(&state.parseState, WJB_END_OBJECT, NULL);
   Jsonb *result = JsonbValueToJsonb(state.res);
   for (int i = 0; i < count; ++i)
     pfree(keys_str[i]);

--- a/pgtypes/utils/jsonb.h
+++ b/pgtypes/utils/jsonb.h
@@ -412,7 +412,7 @@ extern JsonbValue *getKeyJsonValueFromContainer(JsonbContainer *container,
   const char *keyVal, int keyLen, JsonbValue *res);
 extern JsonbValue *getIthJsonbValueFromContainer(JsonbContainer *container,
   uint32 i);
-extern JsonbValue *pushJsonbValue(JsonbParseState **pstate,
+extern JsonbValue *meos_pushJsonbValue(JsonbParseState **pstate,
   JsonbIteratorToken seq, JsonbValue *jbval);
 extern JsonbIterator *JsonbIteratorInit(JsonbContainer *container);
 extern JsonbIteratorToken JsonbIteratorNext(JsonbIterator **it, JsonbValue *val,

--- a/pgtypes/utils/jsonb_util.c
+++ b/pgtypes/utils/jsonb_util.c
@@ -19,6 +19,7 @@
 #include "common/hashfn.h"
 #include "lib/stringinfo.h"
 #include "port/pg_bitutils.h"
+#include "utils/palloc.h"  /* MEOS: MemoryContext + reset-callback API (backend build) */
 #include "utils/date.h"
 #include "utils/datetime.h"
 #include "utils/json.h"
@@ -29,6 +30,7 @@
 
 #include "pgtypes.h"
 #include "../../meos/include/meos_error.h"
+#include "../../meos/include/meos_tls.h"  /* MEOS: MEOS_TLS */
 
 /*****************************************************************************/
 
@@ -36,7 +38,31 @@
  * @brief Global variable that keeps the elements to free after a JSON parsing
  */
 
-static json_to_free *JSON_TO_FREE = NULL;
+static MEOS_TLS json_to_free *JSON_TO_FREE = NULL;
+
+#if ! MEOS
+/*
+ * In the PostgreSQL backend the scratch tracked by the free-list is palloc'd in
+ * the current memory context, which PostgreSQL resets or deletes between
+ * queries. The global handle must not outlive that memory: otherwise the next
+ * parse repalloc()s/pfree()s a dangling pointer. Historically every operation
+ * had to call json_reset_tofree() to avoid this (see json_reset_tofree), which
+ * is easy to miss on a build path. Instead, bind the handle's lifetime to the
+ * context that backs it -- when that context is reset or deleted, drop the
+ * handle so the next parse rebuilds it in a live context. In the standalone
+ * MEOS build there is no host memory manager, so the manual free-list stands on
+ * its own and this callback is compiled out.
+ */
+static MEOS_TLS MemoryContext JSON_TO_FREE_CONTEXT = NULL;
+
+static void
+json_tofree_context_reset(void *arg)
+{
+  (void) arg;
+  JSON_TO_FREE = NULL;
+  JSON_TO_FREE_CONTEXT = NULL;
+}
+#endif /* ! MEOS */
 
 /**
  * @brief Get the global variable that keeps the elements to free after
@@ -52,8 +78,20 @@ json_get_tofree(void)
     JSON_TO_FREE = (json_to_free *) palloc0(sizeof(json_to_free));
     JSON_TO_FREE->tofree_size = JSON_TO_FREE_INITIAL_SIZE;
     JSON_TO_FREE->tofree_count = 0;
-    JSON_TO_FREE->tofree = (void **) palloc0(JSON_TO_FREE_INITIAL_SIZE * 
+    JSON_TO_FREE->tofree = (void **) palloc0(JSON_TO_FREE_INITIAL_SIZE *
       sizeof(void *));
+#if ! MEOS
+    /* Register one reset callback on the context that backs the handle, so it
+     * is dropped when that context is reset or deleted (see the note above). */
+    if (JSON_TO_FREE_CONTEXT != CurrentMemoryContext)
+    {
+      MemoryContextCallback *cb = (MemoryContextCallback *)
+        palloc0(sizeof(MemoryContextCallback));
+      cb->func = json_tofree_context_reset;
+      MemoryContextRegisterResetCallback(CurrentMemoryContext, cb);
+      JSON_TO_FREE_CONTEXT = CurrentMemoryContext;
+    }
+#endif /* ! MEOS */
   }
  return JSON_TO_FREE;
 }
@@ -204,9 +242,9 @@ JsonbValueToJsonb(const JsonbValue *val)
     scalarArray.val.array.rawScalar = true;
     scalarArray.val.array.nElems = 1;
 
-    pushJsonbValue(&pstate, WJB_BEGIN_ARRAY, &scalarArray);
-    pushJsonbValue(&pstate, WJB_ELEM, (JsonbValue *) val);
-    res = pushJsonbValue(&pstate, WJB_END_ARRAY, NULL);
+    meos_pushJsonbValue(&pstate, WJB_BEGIN_ARRAY, &scalarArray);
+    meos_pushJsonbValue(&pstate, WJB_ELEM, (JsonbValue *) val);
+    res = meos_pushJsonbValue(&pstate, WJB_END_ARRAY, NULL);
 
     out = convertToJsonb(res);
   }
@@ -620,7 +658,7 @@ fillJsonbValue(JsonbContainer *container, int index, char *base_addr,
  * are unpacked before being added to the result.
  */
 JsonbValue *
-pushJsonbValue(JsonbParseState **pstate, JsonbIteratorToken seq,
+meos_pushJsonbValue(JsonbParseState **pstate, JsonbIteratorToken seq,
   JsonbValue *jbval)
 {
   JsonbValue *res = NULL;
@@ -628,23 +666,23 @@ pushJsonbValue(JsonbParseState **pstate, JsonbIteratorToken seq,
 
   if (jbval && (seq == WJB_ELEM || seq == WJB_VALUE) && jbval->type == jbvObject)
   {
-    pushJsonbValue(pstate, WJB_BEGIN_OBJECT, NULL);
+    meos_pushJsonbValue(pstate, WJB_BEGIN_OBJECT, NULL);
     for (i = 0; i < jbval->val.object.nPairs; i++)
     {
-      pushJsonbValue(pstate, WJB_KEY, &jbval->val.object.pairs[i].key);
-      pushJsonbValue(pstate, WJB_VALUE, &jbval->val.object.pairs[i].value);
+      meos_pushJsonbValue(pstate, WJB_KEY, &jbval->val.object.pairs[i].key);
+      meos_pushJsonbValue(pstate, WJB_VALUE, &jbval->val.object.pairs[i].value);
     }
-    return pushJsonbValue(pstate, WJB_END_OBJECT, NULL);
+    return meos_pushJsonbValue(pstate, WJB_END_OBJECT, NULL);
   }
 
   if (jbval && (seq == WJB_ELEM || seq == WJB_VALUE) && jbval->type == jbvArray)
   {
-    pushJsonbValue(pstate, WJB_BEGIN_ARRAY, NULL);
+    meos_pushJsonbValue(pstate, WJB_BEGIN_ARRAY, NULL);
     for (i = 0; i < jbval->val.array.nElems; i++)
     {
-      pushJsonbValue(pstate, WJB_ELEM, &jbval->val.array.elems[i]);
+      meos_pushJsonbValue(pstate, WJB_ELEM, &jbval->val.array.elems[i]);
     }
-    return pushJsonbValue(pstate, WJB_END_ARRAY, NULL);
+    return meos_pushJsonbValue(pstate, WJB_END_ARRAY, NULL);
   }
 
   if (!jbval || (seq != WJB_ELEM && seq != WJB_VALUE) ||
@@ -783,7 +821,7 @@ pushJsonbValueScalar(JsonbParseState **pstate, JsonbIteratorToken seq,
 }
 
 /*
- * pushJsonbValue() worker:  Iteration-like forming of Jsonb
+ * meos_pushJsonbValue() worker:  Iteration-like forming of Jsonb
  */
 static JsonbParseState *
 pushState(JsonbParseState **pstate)
@@ -798,7 +836,7 @@ pushState(JsonbParseState **pstate)
 }
 
 /*
- * pushJsonbValue() worker:  Append a pair key to state when generating a Jsonb
+ * meos_pushJsonbValue() worker:  Append a pair key to state when generating a Jsonb
  */
 static void
 appendKey(JsonbParseState *pstate, JsonbValue *string)
@@ -826,7 +864,7 @@ appendKey(JsonbParseState *pstate, JsonbValue *string)
 }
 
 /*
- * pushJsonbValue() worker:  Append a pair value to state when generating a
+ * meos_pushJsonbValue() worker:  Append a pair value to state when generating a
  * Jsonb
  */
 static void
@@ -838,7 +876,7 @@ appendValue(JsonbParseState *pstate, JsonbValue *scalarVal)
 }
 
 /*
- * pushJsonbValue() worker:  Append an element to state when generating a Jsonb
+ * meos_pushJsonbValue() worker:  Append an element to state when generating a Jsonb
  */
 static void
 appendElement(JsonbParseState *pstate, JsonbValue *scalarVal)

--- a/pgtypes/utils/jsonfuncs.c
+++ b/pgtypes/utils/jsonfuncs.c
@@ -1479,7 +1479,7 @@ push_null_elements(JsonbParseState **ps, int num)
   JsonbValue null;
   null.type = jbvNull;
   while (num-- > 0)
-    pushJsonbValue(ps, WJB_ELEM, &null);
+    meos_pushJsonbValue(ps, WJB_ELEM, &null);
 }
 
 /*
@@ -1529,14 +1529,14 @@ push_path(JsonbParseState **st, int level, Datum *path_elems, bool *path_nulls,
       newkey.type = jbvString;
       newkey.val.string.val = c;
       newkey.val.string.len = strlen(c);
-      (void) pushJsonbValue(st, WJB_BEGIN_OBJECT, NULL);
-      (void) pushJsonbValue(st, WJB_KEY, &newkey);
+      (void) meos_pushJsonbValue(st, WJB_BEGIN_OBJECT, NULL);
+      (void) meos_pushJsonbValue(st, WJB_KEY, &newkey);
       tpath[i - level] = jbvObject;
     }
     else
     {
       /* integer, an array is expected */
-      (void) pushJsonbValue(st, WJB_BEGIN_ARRAY, NULL);
+      (void) meos_pushJsonbValue(st, WJB_BEGIN_ARRAY, NULL);
       push_null_elements(st, lindex);
       tpath[i - level] = jbvArray;
     }
@@ -1545,10 +1545,10 @@ push_path(JsonbParseState **st, int level, Datum *path_elems, bool *path_nulls,
   /* Insert an actual value for either an object or array */
   if (tpath[(path_len - level) - 1] == jbvArray)
   {
-    (void) pushJsonbValue(st, WJB_ELEM, newval);
+    (void) meos_pushJsonbValue(st, WJB_ELEM, newval);
   }
   else
-    (void) pushJsonbValue(st, WJB_VALUE, newval);
+    (void) meos_pushJsonbValue(st, WJB_VALUE, newval);
 
   /*
    * Close everything up to the last but one level. The last one will be
@@ -1560,9 +1560,9 @@ push_path(JsonbParseState **st, int level, Datum *path_elems, bool *path_nulls,
       break;
 
     if (tpath[i - level] == jbvObject)
-      (void) pushJsonbValue(st, WJB_END_OBJECT, NULL);
+      (void) meos_pushJsonbValue(st, WJB_END_OBJECT, NULL);
     else
-      (void) pushJsonbValue(st, WJB_END_ARRAY, NULL);
+      (void) meos_pushJsonbValue(st, WJB_END_ARRAY, NULL);
   }
   return;
 }
@@ -2443,7 +2443,7 @@ pg_jsonb_strip_nulls(const Jsonb *jb, bool strip_in_arrays)
         continue;
 
       /* otherwise, do a delayed push of the key */
-      (void) pushJsonbValue(&parseState, WJB_KEY, &k);
+      (void) meos_pushJsonbValue(&parseState, WJB_KEY, &k);
     }
 
     /* if strip_in_arrays is set, also skip null array elements */
@@ -2452,9 +2452,9 @@ pg_jsonb_strip_nulls(const Jsonb *jb, bool strip_in_arrays)
         continue;
 
     if (type == WJB_VALUE || type == WJB_ELEM)
-      res = pushJsonbValue(&parseState, type, &v);
+      res = meos_pushJsonbValue(&parseState, type, &v);
     else
-      res = pushJsonbValue(&parseState, type, NULL);
+      res = meos_pushJsonbValue(&parseState, type, NULL);
   }
 
   Assert(res != NULL);
@@ -2575,7 +2575,7 @@ pg_jsonb_delete(const Jsonb *jb, const text *key)
         (void) JsonbIteratorNext(&it, &v, true);
       continue;
     }
-    res = pushJsonbValue(&state, r, r < WJB_BEGIN_ARRAY ? &v : NULL);
+    res = meos_pushJsonbValue(&state, r, r < WJB_BEGIN_ARRAY ? &v : NULL);
   }
 
   Assert(res != NULL);
@@ -2649,7 +2649,7 @@ pg_jsonb_delete_array(const Jsonb *jb, text **keys_elems, int keys_len)
         continue;
       }
     }
-    res = pushJsonbValue(&state, r, r < WJB_BEGIN_ARRAY ? &v : NULL);
+    res = meos_pushJsonbValue(&state, r, r < WJB_BEGIN_ARRAY ? &v : NULL);
   }
 
   assert(res != NULL);
@@ -2710,7 +2710,7 @@ pg_jsonb_delete_index(const Jsonb *jb, int idx)
   if (idx >= (int) n)
     return pg_jsonb_copy(jb);
 
-  pushJsonbValue(&state, r, NULL);
+  meos_pushJsonbValue(&state, r, NULL);
   while ((r = JsonbIteratorNext(&it, &v, true)) != WJB_DONE)
   {
     if (r == WJB_ELEM)
@@ -2718,7 +2718,7 @@ pg_jsonb_delete_index(const Jsonb *jb, int idx)
       if ((int) i++ == idx)
         continue;
     }
-    res = pushJsonbValue(&state, r, r < WJB_BEGIN_ARRAY ? &v : NULL);
+    res = meos_pushJsonbValue(&state, r, r < WJB_BEGIN_ARRAY ? &v : NULL);
   }
 
   assert(res != NULL);
@@ -2952,9 +2952,9 @@ IteratorConcat(JsonbIterator **it1, JsonbIterator **it2,
      * Append all the tokens from v1 to res, except last WJB_END_OBJECT
      * (because res will not be finished yet).
      */
-    pushJsonbValue(state, rk1, NULL);
+    meos_pushJsonbValue(state, rk1, NULL);
     while ((r1 = JsonbIteratorNext(it1, &v1, true)) != WJB_END_OBJECT)
-      pushJsonbValue(state, r1, &v1);
+      meos_pushJsonbValue(state, r1, &v1);
 
     /*
      * Append all the tokens from v2 to res, including last WJB_END_OBJECT
@@ -2962,28 +2962,28 @@ IteratorConcat(JsonbIterator **it1, JsonbIterator **it2,
      * automatically override the value from the first object.
      */
     while ((r2 = JsonbIteratorNext(it2, &v2, true)) != WJB_DONE)
-      res = pushJsonbValue(state, r2, r2 != WJB_END_OBJECT ? &v2 : NULL);
+      res = meos_pushJsonbValue(state, r2, r2 != WJB_END_OBJECT ? &v2 : NULL);
   }
   else if (rk1 == WJB_BEGIN_ARRAY && rk2 == WJB_BEGIN_ARRAY)
   {
     /*
      * Both inputs are arrays.
      */
-    pushJsonbValue(state, rk1, NULL);
+    meos_pushJsonbValue(state, rk1, NULL);
 
     while ((r1 = JsonbIteratorNext(it1, &v1, true)) != WJB_END_ARRAY)
     {
       Assert(r1 == WJB_ELEM);
-      pushJsonbValue(state, r1, &v1);
+      meos_pushJsonbValue(state, r1, &v1);
     }
 
     while ((r2 = JsonbIteratorNext(it2, &v2, true)) != WJB_END_ARRAY)
     {
       Assert(r2 == WJB_ELEM);
-      pushJsonbValue(state, WJB_ELEM, &v2);
+      meos_pushJsonbValue(state, WJB_ELEM, &v2);
     }
 
-    res = pushJsonbValue(state, WJB_END_ARRAY, NULL /* signal to sort */ );
+    res = meos_pushJsonbValue(state, WJB_END_ARRAY, NULL /* signal to sort */ );
   }
   else if (rk1 == WJB_BEGIN_OBJECT)
   {
@@ -2992,13 +2992,13 @@ IteratorConcat(JsonbIterator **it1, JsonbIterator **it2,
      */
     Assert(rk2 == WJB_BEGIN_ARRAY);
 
-    pushJsonbValue(state, WJB_BEGIN_ARRAY, NULL);
-    pushJsonbValue(state, WJB_BEGIN_OBJECT, NULL);
+    meos_pushJsonbValue(state, WJB_BEGIN_ARRAY, NULL);
+    meos_pushJsonbValue(state, WJB_BEGIN_OBJECT, NULL);
     while ((r1 = JsonbIteratorNext(it1, &v1, true)) != WJB_DONE)
-      pushJsonbValue(state, r1, r1 != WJB_END_OBJECT ? &v1 : NULL);
+      meos_pushJsonbValue(state, r1, r1 != WJB_END_OBJECT ? &v1 : NULL);
 
     while ((r2 = JsonbIteratorNext(it2, &v2, true)) != WJB_DONE)
-      res = pushJsonbValue(state, r2, r2 != WJB_END_ARRAY ? &v2 : NULL);
+      res = meos_pushJsonbValue(state, r2, r2 != WJB_END_ARRAY ? &v2 : NULL);
   }
   else
   {
@@ -3008,15 +3008,15 @@ IteratorConcat(JsonbIterator **it1, JsonbIterator **it2,
     Assert(rk1 == WJB_BEGIN_ARRAY);
     Assert(rk2 == WJB_BEGIN_OBJECT);
 
-    pushJsonbValue(state, WJB_BEGIN_ARRAY, NULL);
+    meos_pushJsonbValue(state, WJB_BEGIN_ARRAY, NULL);
     while ((r1 = JsonbIteratorNext(it1, &v1, true)) != WJB_END_ARRAY)
-      pushJsonbValue(state, r1, &v1);
+      meos_pushJsonbValue(state, r1, &v1);
 
-    pushJsonbValue(state, WJB_BEGIN_OBJECT, NULL);
+    meos_pushJsonbValue(state, WJB_BEGIN_OBJECT, NULL);
     while ((r2 = JsonbIteratorNext(it2, &v2, true)) != WJB_DONE)
-      pushJsonbValue(state, r2, r2 != WJB_END_OBJECT ? &v2 : NULL);
+      meos_pushJsonbValue(state, r2, r2 != WJB_END_OBJECT ? &v2 : NULL);
 
-    res = pushJsonbValue(state, WJB_END_ARRAY, NULL);
+    res = meos_pushJsonbValue(state, WJB_END_ARRAY, NULL);
   }
   return res;
 }
@@ -3082,20 +3082,20 @@ setPath(JsonbIterator **it, Datum *path_elems, bool *path_nulls, int path_len,
         return NULL;
       }
 
-      (void) pushJsonbValue(st, r, NULL);
+      (void) meos_pushJsonbValue(st, r, NULL);
       setPathArray(it, path_elems, path_nulls, path_len, st, level, newval,
         v.val.array.nElems, op_type);
       r = JsonbIteratorNext(it, &v, false);
       Assert(r == WJB_END_ARRAY);
-      res = pushJsonbValue(st, r, NULL);
+      res = meos_pushJsonbValue(st, r, NULL);
       break;
     case WJB_BEGIN_OBJECT:
-      (void) pushJsonbValue(st, r, NULL);
+      (void) meos_pushJsonbValue(st, r, NULL);
       setPathObject(it, path_elems, path_nulls, path_len, st, level, newval,
         v.val.object.nPairs, op_type);
       r = JsonbIteratorNext(it, &v, true);
       Assert(r == WJB_END_OBJECT);
-      res = pushJsonbValue(st, r, NULL);
+      res = meos_pushJsonbValue(st, r, NULL);
       break;
     case WJB_ELEM:
     case WJB_VALUE:
@@ -3113,7 +3113,7 @@ setPath(JsonbIterator **it, Datum *path_elems, bool *path_nulls, int path_len,
         return NULL;
       }
 
-      res = pushJsonbValue(st, r, &v);
+      res = meos_pushJsonbValue(st, r, &v);
       break;
     default:
       meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
@@ -3152,8 +3152,8 @@ setPathObject(JsonbIterator **it, Datum *path_elems, bool *path_nulls,
     newkey.type = jbvString;
     newkey.val.string.val = VARDATA_ANY(pathelem);
     newkey.val.string.len = VARSIZE_ANY_EXHDR(pathelem);
-    (void) pushJsonbValue(st, WJB_KEY, &newkey);
-    (void) pushJsonbValue(st, WJB_VALUE, newval);
+    (void) meos_pushJsonbValue(st, WJB_KEY, &newkey);
+    (void) meos_pushJsonbValue(st, WJB_VALUE, newval);
   }
 
   for (i = 0; i < (int) npairs; i++)
@@ -3181,13 +3181,13 @@ setPathObject(JsonbIterator **it, Datum *path_elems, bool *path_nulls,
         r = JsonbIteratorNext(it, &v, true);  /* skip value */
         if (!(op_type & JB_PATH_DELETE))
         {
-          (void) pushJsonbValue(st, WJB_KEY, &k);
-          (void) pushJsonbValue(st, WJB_VALUE, newval);
+          (void) meos_pushJsonbValue(st, WJB_KEY, &k);
+          (void) meos_pushJsonbValue(st, WJB_VALUE, newval);
         }
       }
       else
       {
-        (void) pushJsonbValue(st, r, &k);
+        (void) meos_pushJsonbValue(st, r, &k);
         setPath(it, path_elems, path_nulls, path_len, st, level + 1, newval,
           op_type);
       }
@@ -3201,13 +3201,13 @@ setPathObject(JsonbIterator **it, Datum *path_elems, bool *path_nulls,
         newkey.type = jbvString;
         newkey.val.string.val = VARDATA_ANY(pathelem);
         newkey.val.string.len = VARSIZE_ANY_EXHDR(pathelem);
-        (void) pushJsonbValue(st, WJB_KEY, &newkey);
-        (void) pushJsonbValue(st, WJB_VALUE, newval);
+        (void) meos_pushJsonbValue(st, WJB_KEY, &newkey);
+        (void) meos_pushJsonbValue(st, WJB_VALUE, newval);
       }
 
-      (void) pushJsonbValue(st, r, &k);
+      (void) meos_pushJsonbValue(st, r, &k);
       r = JsonbIteratorNext(it, &v, false);
-      (void) pushJsonbValue(st, r, r < WJB_BEGIN_ARRAY ? &v : NULL);
+      (void) meos_pushJsonbValue(st, r, r < WJB_BEGIN_ARRAY ? &v : NULL);
       if (r == WJB_BEGIN_ARRAY || r == WJB_BEGIN_OBJECT)
       {
         int walking_level = 1;
@@ -3218,7 +3218,7 @@ setPathObject(JsonbIterator **it, Datum *path_elems, bool *path_nulls,
             ++walking_level;
           if (r == WJB_END_ARRAY || r == WJB_END_OBJECT)
             --walking_level;
-          (void) pushJsonbValue(st, r, r < WJB_BEGIN_ARRAY ? &v : NULL);
+          (void) meos_pushJsonbValue(st, r, r < WJB_BEGIN_ARRAY ? &v : NULL);
         }
       }
     }
@@ -3240,7 +3240,7 @@ setPathObject(JsonbIterator **it, Datum *path_elems, bool *path_nulls,
     newkey.type = jbvString;
     newkey.val.string.val = VARDATA_ANY(pathelem);
     newkey.val.string.len = VARSIZE_ANY_EXHDR(pathelem);
-    (void) pushJsonbValue(st, WJB_KEY, &newkey);
+    (void) meos_pushJsonbValue(st, WJB_KEY, &newkey);
     (void) push_path(st, level, path_elems, path_nulls, path_len, newval);
     /* Result is closed with WJB_END_OBJECT outside of this function */
   }
@@ -3318,7 +3318,7 @@ setPathArray(JsonbIterator **it, Datum *path_elems, bool *path_nulls,
     Assert(newval != NULL);
     if (op_type & JB_PATH_FILL_GAPS && nelems == 0 && idx > 0)
       push_null_elements(st, idx);
-    (void) pushJsonbValue(st, WJB_ELEM, newval);
+    (void) meos_pushJsonbValue(st, WJB_ELEM, newval);
     done = true;
   }
 
@@ -3334,7 +3334,7 @@ setPathArray(JsonbIterator **it, Datum *path_elems, bool *path_nulls,
       {
         r = JsonbIteratorNext(it, &v, true);  /* skip */
         if (op_type & (JB_PATH_INSERT_BEFORE | JB_PATH_CREATE))
-          (void) pushJsonbValue(st, WJB_ELEM, newval);
+          (void) meos_pushJsonbValue(st, WJB_ELEM, newval);
 
         /*
          * We should keep current value only in case of
@@ -3342,10 +3342,10 @@ setPathArray(JsonbIterator **it, Datum *path_elems, bool *path_nulls,
          * otherwise it should be deleted or replaced
          */
         if (op_type & (JB_PATH_INSERT_AFTER | JB_PATH_INSERT_BEFORE))
-          (void) pushJsonbValue(st, r, &v);
+          (void) meos_pushJsonbValue(st, r, &v);
 
         if (op_type & (JB_PATH_INSERT_AFTER | JB_PATH_REPLACE))
-          (void) pushJsonbValue(st, WJB_ELEM, newval);
+          (void) meos_pushJsonbValue(st, WJB_ELEM, newval);
       }
       else
         (void) setPath(it, path_elems, path_nulls, path_len, st, level + 1,
@@ -3354,7 +3354,7 @@ setPathArray(JsonbIterator **it, Datum *path_elems, bool *path_nulls,
     else
     {
       r = JsonbIteratorNext(it, &v, false);
-      (void) pushJsonbValue(st, r, r < WJB_BEGIN_ARRAY ? &v : NULL);
+      (void) meos_pushJsonbValue(st, r, r < WJB_BEGIN_ARRAY ? &v : NULL);
       if (r == WJB_BEGIN_ARRAY || r == WJB_BEGIN_OBJECT)
       {
         int walking_level = 1;
@@ -3365,7 +3365,7 @@ setPathArray(JsonbIterator **it, Datum *path_elems, bool *path_nulls,
             ++walking_level;
           if (r == WJB_END_ARRAY || r == WJB_END_OBJECT)
             --walking_level;
-          (void) pushJsonbValue(st, r, r < WJB_BEGIN_ARRAY ? &v : NULL);
+          (void) meos_pushJsonbValue(st, r, r < WJB_BEGIN_ARRAY ? &v : NULL);
         }
       }
     }
@@ -3379,7 +3379,7 @@ setPathArray(JsonbIterator **it, Datum *path_elems, bool *path_nulls,
      */
     if (op_type & JB_PATH_FILL_GAPS && idx > (int) nelems)
       push_null_elements(st, idx - nelems);
-    (void) pushJsonbValue(st, WJB_ELEM, newval);
+    (void) meos_pushJsonbValue(st, WJB_ELEM, newval);
     done = true;
   }
 
@@ -3635,11 +3635,11 @@ transform_jsonb_string_values(Jsonb *jsonb, void *action_state,
         v.val.string.len);
       v.val.string.val = VARDATA_ANY(out);
       v.val.string.len = VARSIZE_ANY_EXHDR(out);
-      res = pushJsonbValue(&st, type, type < WJB_BEGIN_ARRAY ? &v : NULL);
+      res = meos_pushJsonbValue(&st, type, type < WJB_BEGIN_ARRAY ? &v : NULL);
     }
     else
     {
-      res = pushJsonbValue(&st, type, (type == WJB_KEY || type == WJB_VALUE ||
+      res = meos_pushJsonbValue(&st, type, (type == WJB_KEY || type == WJB_VALUE ||
         type == WJB_ELEM) ? &v : NULL);
     }
   }

--- a/pgtypes/utils/jsonpath_exec.c
+++ b/pgtypes/utils/jsonpath_exec.c
@@ -2578,14 +2578,14 @@ executeKeyValueMethod(JsonPathExecContext *cxt, JsonPathItem *jsp,
     tok = JsonbIteratorNext(&it, &val, true);
     Assert(tok == WJB_VALUE);
     ps = NULL;
-    pushJsonbValue(&ps, WJB_BEGIN_OBJECT, NULL);
-    pushJsonbValue(&ps, WJB_KEY, &keystr);
-    pushJsonbValue(&ps, WJB_VALUE, &key);
-    pushJsonbValue(&ps, WJB_KEY, &valstr);
-    pushJsonbValue(&ps, WJB_VALUE, &val);
-    pushJsonbValue(&ps, WJB_KEY, &idstr);
-    pushJsonbValue(&ps, WJB_VALUE, &idval);
-    keyval = pushJsonbValue(&ps, WJB_END_OBJECT, NULL);
+    meos_pushJsonbValue(&ps, WJB_BEGIN_OBJECT, NULL);
+    meos_pushJsonbValue(&ps, WJB_KEY, &keystr);
+    meos_pushJsonbValue(&ps, WJB_VALUE, &key);
+    meos_pushJsonbValue(&ps, WJB_KEY, &valstr);
+    meos_pushJsonbValue(&ps, WJB_VALUE, &val);
+    meos_pushJsonbValue(&ps, WJB_KEY, &idstr);
+    meos_pushJsonbValue(&ps, WJB_VALUE, &idval);
+    keyval = meos_pushJsonbValue(&ps, WJB_END_OBJECT, NULL);
     jsonb = JsonbValueToJsonb(keyval);
     JsonbInitBinary(&obj, jsonb);
     baseObject = setBaseObject(cxt, &obj, cxt->lastGeneratedObjectId++);
@@ -3270,11 +3270,11 @@ wrapItemsInArray(const JsonValueList *items)
   JsonbParseState *ps = NULL;
   JsonValueListIterator it;
   JsonbValue *jbv;
-  pushJsonbValue(&ps, WJB_BEGIN_ARRAY, NULL);
+  meos_pushJsonbValue(&ps, WJB_BEGIN_ARRAY, NULL);
   JsonValueListInitIterator(items, &it);
   while ((jbv = JsonValueListNext(items, &it)))
-    pushJsonbValue(&ps, WJB_ELEM, jbv);
-  return pushJsonbValue(&ps, WJB_END_ARRAY, NULL);
+    meos_pushJsonbValue(&ps, WJB_ELEM, jbv);
+  return meos_pushJsonbValue(&ps, WJB_END_ARRAY, NULL);
 }
 
 /* Check if the timezone required for casting from type1 to type2 is used */


### PR DESCRIPTION
The vendored JSONB code duplicates PostgreSQL symbols such as `pushJsonbValue`. On Linux the extension shares the backend's flat symbol namespace, so PostgreSQL interposes its own `pushJsonbValue` over the vendored copy. PostgreSQL 19 changes that function's signature (from `JsonbValue *(JsonbParseState **)` to `void (JsonbInState *)`), so the interposed call receives the wrong arguments and the backend crashes on any JSONB build path (for example `s || jb` over a `jsonbset`).

This prefixes the vendored `pushJsonbValue` to `meos_pushJsonbValue` so the module always calls its own definition, matching the two-level namespace macOS and Windows already provide.

Running the vendored builder also exposes a memory bug: the scratch free-list handle (`JSON_TO_FREE`) is a process global whose buffer is `palloc`'d in the current memory context. Once that context is reset between queries the global points at freed memory, and the next parse `repalloc`'s or `pfree`'s a dangling pointer. This binds the handle's lifetime to the context with a reset callback, so it is dropped when its backing memory is freed. In the standalone build there is no host memory manager, so the manual free-list stands on its own and the callback is compiled out.
