### PR TITLE
Define the count out parameter whichever argument an accessor rejects

### DIFF
--- a/meos/src/geo/stbox.c
+++ b/meos/src/geo/stbox.c
@@ -2389,9 +2389,10 @@ STBox *
 stbox_quad_split(const STBox *box, int *count)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(box, NULL); VALIDATE_NOT_NULL(count, NULL);
+  VALIDATE_NOT_NULL(count, NULL);
   /* The out parameter is defined even when a later check fails */
   *count = 0;
+  VALIDATE_NOT_NULL(box, NULL);
   if (! ensure_has_X(T_STBOX, box->flags))
     return NULL;
 

--- a/meos/src/geo/tgeo_boxops.c
+++ b/meos/src/geo/tgeo_boxops.c
@@ -779,9 +779,10 @@ STBox *
 tgeo_split_n_stboxes(const Temporal *temp, int box_count, int *count)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TSPATIAL(temp, NULL); VALIDATE_NOT_NULL(count, NULL);
+  VALIDATE_NOT_NULL(count, NULL);
   /* The out parameter is defined even when a later check fails */
   *count = 0;
+  VALIDATE_TSPATIAL(temp, NULL);
   if (! ensure_positive(box_count))
     return NULL;
 
@@ -954,9 +955,10 @@ STBox *
 tgeo_split_each_n_stboxes(const Temporal *temp, int elems_per_box, int *count)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TSPATIAL(temp, NULL); VALIDATE_NOT_NULL(count, NULL);
+  VALIDATE_NOT_NULL(count, NULL);
   /* The out parameter is defined even when a later check fails */
   *count = 0;
+  VALIDATE_TSPATIAL(temp, NULL);
   if (! ensure_positive(elems_per_box))
     return NULL;
 
@@ -1175,9 +1177,10 @@ STBox *
 geo_stboxes(const GSERIALIZED *gs, int *count)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(gs, NULL); VALIDATE_NOT_NULL(count, NULL);
+  VALIDATE_NOT_NULL(count, NULL);
   /* The out parameter is defined even when a later check fails */
   *count = 0;
+  VALIDATE_NOT_NULL(gs, NULL);
   if (! ensure_not_empty(gs) || ! ensure_mline_type(gs))
     return NULL;
   
@@ -1425,9 +1428,10 @@ STBox *
 geo_split_n_stboxes(const GSERIALIZED *gs, int box_count, int *count)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(gs, NULL); VALIDATE_NOT_NULL(count, NULL);
+  VALIDATE_NOT_NULL(count, NULL);
   /* The out parameter is defined even when a later check fails */
   *count = 0;
+  VALIDATE_NOT_NULL(gs, NULL);
   if (! ensure_not_empty(gs) || ! ensure_positive(box_count) ||
       ! ensure_mline_type(gs))
     return NULL;
@@ -1613,9 +1617,10 @@ STBox *
 geo_split_each_n_stboxes(const GSERIALIZED *gs, int elems_per_box, int *count)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(gs, NULL); VALIDATE_NOT_NULL(count, NULL);
+  VALIDATE_NOT_NULL(count, NULL);
   /* The out parameter is defined even when a later check fails */
   *count = 0;
+  VALIDATE_NOT_NULL(gs, NULL);
   if (! ensure_not_empty(gs) || ! ensure_positive(elems_per_box) || 
       ! ensure_mline_type(gs))
     return NULL;

--- a/meos/src/geo/tgeo_spatialfuncs.c
+++ b/meos/src/geo/tgeo_spatialfuncs.c
@@ -1695,6 +1695,9 @@ int *
 geo_cluster_kmeans(const GSERIALIZED **geoms, uint32_t n, uint32_t k, int *count)
 {
   /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(count, NULL);
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   VALIDATE_NOT_NULL(geoms, NULL);
   if (! ensure_positive(n) || ! ensure_positive(k))
     return NULL;
@@ -1740,6 +1743,10 @@ geo_cluster_dbscan(const GSERIALIZED **geoms, uint32_t ngeoms,
   double tolerance, int minpoints, int *count)
 {
   /* Ensure validity of arguments */
+  if (! ensure_not_null(count))
+    return NULL;
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   if (! ensure_not_null(geoms))
     return NULL;
   if (tolerance < 0)
@@ -1807,7 +1814,11 @@ geo_cluster_intersecting(const GSERIALIZED **geoms, uint32_t ngeoms,
   bool gotsrid = false;
 
   /* Ensure validity of arguments */
-  if (! ensure_not_null(geoms) || ! ensure_not_null(count) || ngeoms == 0)
+  if (! ensure_not_null(count))
+    return NULL;
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
+  if (! ensure_not_null(geoms) || ngeoms == 0)
     return NULL;
 
   /* TODO short-circuit for one element? */
@@ -1882,8 +1893,11 @@ geo_cluster_within(const GSERIALIZED **geoms, uint32_t ngeoms,
   double tolerance, int *count)
 {
   /* Ensure validity of arguments */
-  /* Ensure validity of arguments */
-  if (! ensure_not_null(geoms) || ! ensure_not_null(count) || ngeoms == 0)
+  if (! ensure_not_null(count))
+    return NULL;
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
+  if (! ensure_not_null(geoms) || ngeoms == 0)
     return NULL;
   if (tolerance < 0)
   {

--- a/meos/src/geo/tgeo_tile.c
+++ b/meos/src/geo/tgeo_tile.c
@@ -666,9 +666,10 @@ stbox_space_time_tiles(const STBox *bounds, double xsize, double ysize,
   /* Ensure the validity of the arguments
    * Since we pass by default Point(0 0 0) as origin independently of the input
    * STBox, we test the same spatial dimensionality only for STBox Z */
-  VALIDATE_NOT_NULL(bounds, NULL); VALIDATE_NOT_NULL(count, NULL);
+  VALIDATE_NOT_NULL(count, NULL);
   /* The out parameter is defined even when a later check fails */
   *count = 0;
+  VALIDATE_NOT_NULL(bounds, NULL);
   if (! ensure_has_X(T_STBOX, bounds->flags) ||
       ! ensure_not_geodetic(bounds->flags) ||
       ! ensure_not_negative_datum(Float8GetDatum(xsize), T_FLOAT8) ||
@@ -956,9 +957,10 @@ tgeo_space_time_boxes(const Temporal *temp, double xsize, double ysize,
   TimestampTz torigin, bool bitmatrix, bool border_inc, int *count)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TGEO(temp, NULL); VALIDATE_NOT_NULL(count, NULL);
+  VALIDATE_NOT_NULL(count, NULL);
   /* The out parameter is defined even when a later check fails */
   *count = 0;
+  VALIDATE_TGEO(temp, NULL);
   if ((xsize > 0 && ! ensure_not_null((void *) sorigin)) ||
       (xsize > 0 && ! ensure_positive_datum(xsize, T_FLOAT8)) ||
       (xsize > 0 && ! ensure_positive_datum(ysize, T_FLOAT8)) ||
@@ -1268,9 +1270,10 @@ tgeo_space_time_tile_init(const Temporal *temp, double xsize, double ysize,
   TimestampTz torigin, bool bitmatrix, bool border_inc, int *ntiles)
 {
   /* Ensure parameter validity */
-  VALIDATE_TGEO(temp, NULL); VALIDATE_NOT_NULL(ntiles, NULL);
+  VALIDATE_NOT_NULL(ntiles, NULL);
   /* The out parameter is defined even when a later check fails */
   *ntiles = 0;
+  VALIDATE_TGEO(temp, NULL);
   if ((xsize && ! ensure_positive_datum(Float8GetDatum(xsize), T_FLOAT8)) ||
       (xsize && ! ensure_positive_datum(Float8GetDatum(ysize), T_FLOAT8)) ||
       (xsize && ! ensure_positive_datum(Float8GetDatum(zsize), T_FLOAT8)) ||

--- a/meos/src/h3/th3index.c
+++ b/meos/src/h3/th3index.c
@@ -333,11 +333,11 @@ th3index_value_n(const Temporal *temp, int n, H3Index *result)
 H3Index *
 th3index_values(const Temporal *temp, int *count)
 {
-  VALIDATE_TH3INDEX(temp, NULL);
   if (! ensure_not_null((void *) count))
     return NULL;
   /* The out parameter is defined even when a later check fails */
   *count = 0;
+  VALIDATE_TH3INDEX(temp, NULL);
   Datum *datums = temporal_values(temp, count);
   if (datums == NULL)
     return NULL;

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -1039,6 +1039,9 @@ double *
 pose_orientation(const Pose *pose, int *count)
 {
   /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(count, NULL);
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   VALIDATE_NOT_NULL(pose, NULL);
   if (! ensure_has_Z(T_POSE, pose->flags))
     return NULL;

--- a/meos/src/quadbin/tquadbin.c
+++ b/meos/src/quadbin/tquadbin.c
@@ -334,11 +334,11 @@ tquadbin_value_n(const Temporal *temp, int n, Quadbin *result)
 Quadbin *
 tquadbin_values(const Temporal *temp, int *count)
 {
-  VALIDATE_TQUADBIN(temp, NULL);
   if (! ensure_not_null((void *) count))
     return NULL;
   /* The out parameter is defined even when a later check fails */
   *count = 0;
+  VALIDATE_TQUADBIN(temp, NULL);
   Datum *datums = temporal_values(temp, count);
   if (datums == NULL)
     return NULL;

--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -816,7 +816,9 @@ TSequence **
 trgeometry_sequences(const Temporal *temp, int *count)
 {
   /* Ensure the validity of the arguments */
-
+  VALIDATE_NOT_NULL(count, NULL);
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   VALIDATE_TRGEOMETRY(temp, NULL);
   if (! ensure_continuous(temp))
     return NULL;
@@ -884,9 +886,10 @@ trgeometry_rotation(const Temporal *temp)
 TSequence **
 trgeometry_segments(const Temporal *temp, int *count)
 {
-  VALIDATE_TRGEOMETRY(temp, NULL); VALIDATE_NOT_NULL(count, NULL);
+  VALIDATE_NOT_NULL(count, NULL);
   /* The out parameter is defined even when a later check fails */
   *count = 0;
+  VALIDATE_TRGEOMETRY(temp, NULL);
   if (! ensure_continuous(temp))
     return NULL;
   const GSERIALIZED *geo = trgeo_geom_p(temp);

--- a/meos/src/rgeo/trgeo_boxops.c
+++ b/meos/src/rgeo/trgeo_boxops.c
@@ -367,6 +367,8 @@ trgeometry_split_n_stboxes(const Temporal *temp, int box_count, int *count)
   assert(temp->temptype == T_TRGEOMETRY);
   if (! ensure_positive(box_count))
     return NULL;
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   const GSERIALIZED *geom = trgeo_geom_p(temp);
   switch (temp->subtype)
   {
@@ -516,6 +518,8 @@ trgeometry_split_each_n_stboxes(const Temporal *temp, int elems_per_box,
   assert(temp->temptype == T_TRGEOMETRY);
   if (! ensure_positive(elems_per_box))
     return NULL;
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   const GSERIALIZED *geom = trgeo_geom_p(temp);
   switch (temp->subtype)
   {

--- a/meos/src/rgeo/trgeo_spatialfuncs.c
+++ b/meos/src/rgeo/trgeo_spatialfuncs.c
@@ -824,6 +824,10 @@ trgeometry_dyntimewarp_distance(const Temporal *temp1, const Temporal *temp2)
 Match *
 trgeometry_frechet_path(const Temporal *temp1, const Temporal *temp2, int *count)
 {
+  if (! ensure_not_null((void *) count))
+    return NULL;
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   if (! ensure_valid_trgeo_trgeo(temp1, temp2))
     return NULL;
   Temporal *tp1 = trgeometry_to_tpoint(temp1);
@@ -844,6 +848,10 @@ trgeometry_frechet_path(const Temporal *temp1, const Temporal *temp2, int *count
 Match *
 trgeometry_dyntimewarp_path(const Temporal *temp1, const Temporal *temp2, int *count)
 {
+  if (! ensure_not_null((void *) count))
+    return NULL;
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   if (! ensure_valid_trgeo_trgeo(temp1, temp2))
     return NULL;
   Temporal *tp1 = trgeometry_to_tpoint(temp1);

--- a/meos/src/temporal/span.c
+++ b/meos/src/temporal/span.c
@@ -1538,9 +1538,10 @@ Span *
 set_split_n_spans(const Set *s, int span_count, int *count)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NUMSET(s, NULL); VALIDATE_NOT_NULL(count, NULL);
+  VALIDATE_NOT_NULL(count, NULL);
   /* The out parameter is defined even when a later check fails */
   *count = 0;
+  VALIDATE_NUMSET(s, NULL);
   if (! ensure_positive(span_count))
     return NULL;
 
@@ -1587,9 +1588,10 @@ Span *
 set_split_each_n_spans(const Set *s, int elems_per_span, int *count)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NUMSET(s, NULL); VALIDATE_NOT_NULL(count, NULL);
+  VALIDATE_NOT_NULL(count, NULL);
   /* The out parameter is defined even when a later check fails */
   *count = 0;
+  VALIDATE_NUMSET(s, NULL);
   if (! ensure_positive(elems_per_span))
     return NULL;
 

--- a/meos/src/temporal/spanset.c
+++ b/meos/src/temporal/spanset.c
@@ -1326,9 +1326,10 @@ Span *
 spanset_split_n_spans(const SpanSet *ss, int span_count, int *count)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(ss, NULL); VALIDATE_NOT_NULL(count, NULL);
+  VALIDATE_NOT_NULL(count, NULL);
   /* The out parameter is defined even when a later check fails */
   *count = 0;
+  VALIDATE_NOT_NULL(ss, NULL);
   if (! ensure_positive(span_count))
     return NULL;
 
@@ -1376,9 +1377,10 @@ Span *
 spanset_split_each_n_spans(const SpanSet *ss, int elems_per_span, int *count)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(ss, NULL); VALIDATE_NOT_NULL(count, NULL);
+  VALIDATE_NOT_NULL(count, NULL);
   /* The out parameter is defined even when a later check fails */
   *count = 0;
+  VALIDATE_NOT_NULL(ss, NULL);
   if (! ensure_positive(elems_per_span))
     return NULL;
 

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -2576,9 +2576,10 @@ TSequence **
 temporal_segments(const Temporal *temp, int *count)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_NOT_NULL(count, NULL);
+  VALIDATE_NOT_NULL(count, NULL);
   /* The out parameter is defined even when a later check fails */
   *count = 0;
+  VALIDATE_NOT_NULL(temp, NULL);
 
   assert(temptype_subtype(temp->subtype));
   switch (temp->subtype)

--- a/meos/src/temporal/temporal_analytics.c
+++ b/meos/src/temporal/temporal_analytics.c
@@ -1681,6 +1681,10 @@ Match *
 temporal_frechet_path(const Temporal *temp1, const Temporal *temp2, int *count)
 {
   /* Ensure the validity of the arguments */
+  if (! ensure_not_null((void *) count))
+    return NULL;
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   if (! ensure_valid_temporal_temporal(temp1, temp2))
     return NULL;
   return temporal_similarity_path(temp1, temp2, count, FRECHET);
@@ -1698,6 +1702,10 @@ temporal_dyntimewarp_path(const Temporal *temp1, const Temporal *temp2,
   int *count)
 {
   /* Ensure the validity of the arguments */
+  if (! ensure_not_null((void *) count))
+    return NULL;
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   if (! ensure_valid_temporal_temporal(temp1, temp2))
     return NULL;
   return temporal_similarity_path(temp1, temp2, count, DYNTIMEWARP);

--- a/meos/src/temporal/temporal_boxops.c
+++ b/meos/src/temporal/temporal_boxops.c
@@ -1011,9 +1011,10 @@ Span *
 temporal_split_n_spans(const Temporal *temp, int span_count, int *count)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_NOT_NULL(count, NULL);
+  VALIDATE_NOT_NULL(count, NULL);
   /* The out parameter is defined even when a later check fails */
   *count = 0;
+  VALIDATE_NOT_NULL(temp, NULL);
   if (! ensure_positive(span_count))
     return NULL;
 
@@ -1183,9 +1184,10 @@ temporal_split_each_n_spans(const Temporal *temp, int elems_per_span,
   int *count)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_NOT_NULL(count, NULL);
+  VALIDATE_NOT_NULL(count, NULL);
   /* The out parameter is defined even when a later check fails */
   *count = 0;
+  VALIDATE_NOT_NULL(temp, NULL);
   if (! ensure_positive(elems_per_span))
     return NULL;
 
@@ -1584,9 +1586,10 @@ TBox *
 tnumber_split_n_tboxes(const Temporal *temp, int box_count, int *count)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TNUMBER(temp, NULL); VALIDATE_NOT_NULL(count, NULL);
+  VALIDATE_NOT_NULL(count, NULL);
   /* The out parameter is defined even when a later check fails */
   *count = 0;
+  VALIDATE_TNUMBER(temp, NULL);
   if (! ensure_positive(box_count))
     return NULL;
 
@@ -1756,9 +1759,10 @@ TBox *
 tnumber_split_each_n_tboxes(const Temporal *temp, int elems_per_box, int *count)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TNUMBER(temp, NULL); VALIDATE_NOT_NULL(count, NULL);
+  VALIDATE_NOT_NULL(count, NULL);
   /* The out parameter is defined even when a later check fails */
   *count = 0;
+  VALIDATE_TNUMBER(temp, NULL);
   if (! ensure_positive(elems_per_box))
     return NULL;
 

--- a/meos/src/temporal/temporal_tile.c
+++ b/meos/src/temporal/temporal_tile.c
@@ -435,6 +435,8 @@ span_bins(const Span *s, Datum size, Datum origin, int *count)
 {
   assert(s); assert(count);
   assert(numspan_type(s->spantype) || timespan_type(s->spantype));
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   if ((numspan_type(s->spantype) && 
         ! ensure_not_negative_datum(size, s->basetype)) ||
       (timespan_type(s->spantype) && 
@@ -482,6 +484,8 @@ spanset_bins(const SpanSet *ss, Datum size, Datum origin, int *count)
 {
   assert(ss); assert(count);
   assert(numspan_type(ss->spantype) || timespan_type(ss->spantype));
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
   if ((numspan_type(ss->spantype) && 
         ! ensure_not_negative_datum(size, ss->basetype)) ||
       (timespan_type(ss->spantype) && 
@@ -544,10 +548,10 @@ temporal_time_bins(const Temporal *temp, const Interval *duration,
   TimestampTz torigin, int *count)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_NOT_NULL(duration, NULL);
   VALIDATE_NOT_NULL(count, NULL);
   /* The out parameter is defined even when a later check fails */
   *count = 0;
+  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_NOT_NULL(duration, NULL);
   if (! ensure_positive_duration(duration))
     return NULL;
 
@@ -872,9 +876,10 @@ tnumber_value_time_tile_init(const Temporal *temp, Datum vsize,
   const Interval *duration, Datum vorigin, TimestampTz torigin, int *ntiles)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TNUMBER(temp, NULL); VALIDATE_NOT_NULL(ntiles, NULL);
+  VALIDATE_NOT_NULL(ntiles, NULL);
   /* The out parameter is defined even when a later check fails */
   *ntiles = 0;
+  VALIDATE_TNUMBER(temp, NULL);
   if (! ensure_not_negative_datum(vsize, temptype_basetype(temp->temptype)) ||
       (duration && ! ensure_positive_duration(duration)))
     return NULL;
@@ -906,7 +911,10 @@ TBox *
 tnumber_value_time_boxes(const Temporal *temp, Datum vsize,
   const Interval *duration, Datum vorigin, TimestampTz torigin, int *count)
 {
-  VALIDATE_TNUMBER(temp, NULL); 
+  VALIDATE_TNUMBER(temp, NULL);
+  assert(count);
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
 
   /* Initialize state */
   int ntiles;

--- a/meos/src/temporal/tsequenceset.c
+++ b/meos/src/temporal/tsequenceset.c
@@ -456,6 +456,9 @@ int *
 ensure_valid_tinstarr_gaps(TInstant **instants, int count, bool merge,
   double maxdist, const Interval *maxt, int *nsplits)
 {
+  assert(instants); assert(nsplits);
+  /* The out parameter is defined even when a later check fails */
+  *nsplits = 0;
   MeosType basetype = temptype_basetype(instants[0]->temptype);
   /* Ensure that zero-fill is done */
   int *result = palloc0(sizeof(int) * count);

--- a/meos/test/error_test.c
+++ b/meos/test/error_test.c
@@ -121,6 +121,33 @@ int main(void)
     meos_errno());
   assert(count == 0);
 
+  /* The count is defined whichever argument the function rejects, not only
+   * when the count itself is the one at fault, so it is checked here on a
+   * rejection of another argument as well */
+  count = -559038737;
+  meos_errno_reset();
+  assert(temporal_segments(NULL, &count) == NULL);
+  printf("temporal_segments(NULL): NULL, count %d, errno %d\n", count,
+    meos_errno());
+  assert(count == 0);
+
+  count = -559038737;
+  Temporal *num = tint_in("{1@2000-01-01}");
+  assert(num != NULL);
+  meos_errno_reset();
+  /* the two values must share a type, so a temporal float is rejected */
+  assert(temporal_frechet_path(num, good, &count) == NULL);
+  printf("temporal_frechet_path(mixed types): NULL, count %d, errno %d\n",
+    count, meos_errno());
+  assert(count == 0);
+
+  /* A NULL count is itself rejected, rather than written through */
+  meos_errno_reset();
+  assert(temporal_frechet_path(num, num, NULL) == NULL);
+  printf("temporal_frechet_path(count NULL): NULL, errno %d\n", meos_errno());
+  assert(meos_errno() == MEOS_ERR_INVALID_ARG);
+
+  free(num);
   free(inst); free(seq);
   free(good); free(good_out);
 


### PR DESCRIPTION
The count out parameter of an accessor returning an array stays undefined when the accessor rejects its arguments, and the caller's variable keeps whatever it holds. The functions writing it after the check on the count itself are already covered; this covers the rest, and closes the case those leave open.

## The case still open

The count is written after the whole validation block, so a rejection by a check standing before the one on the count returns first and the write never happens:

```
temporal_segments(NULL, &count)  ->  NULL, count -559038737   (the caller's own value)
```

The check on the count and the write now stand first, ahead of every other check, so a rejection by any of them leaves the count at zero:

```c
  /* Ensure the validity of the arguments */
+ VALIDATE_NOT_NULL(count, NULL);
+ /* The out parameter is defined even when a later check fails */
+ *count = 0;
- VALIDATE_TNUMBER(temp, NULL); VALIDATE_NOT_NULL(count, NULL);
+ VALIDATE_TNUMBER(temp, NULL);
  if (! ensure_positive_duration(duration))
    return NULL;
```

A count tested inside a disjunction gets its test separated out. A disjunction stops at its first false operand, so it returns before the write for exactly the same reason.

## The functions that never test the count

Those now do, in the form their class calls for. The ones the bindings call test it and return `NULL`; the internal ones assert it, being reached only through a caller that tests it already. `assert` does not return, so the internal ones never carry the ordering problem.

Neither rejects anything a working caller passes: each writes the count on the path where it succeeds, so a caller passing nothing there already fails. `geo_cluster_kmeans` writes `*count = (int) n`, and `temporal_frechet_path` hands the count to `temporal_similarity_path`, which asserts it.

## Result

The contract is the same everywhere the count appears: an accessor that rejects its arguments returns `NULL` and a count of zero.

```
temporal_segments(instant)         ->  NULL, count 0
temporal_segments(NULL)            ->  NULL, count 0
temporal_split_n_spans(seq, 0)     ->  NULL, count 0
temporal_frechet_path(mixed types) ->  NULL, count 0
temporal_frechet_path(count NULL)  ->  NULL, invalid argument
```

`meos/test/error_test.c` takes a rejection of the count, a rejection of a different argument, and a null count. The middle one is the case the earlier round leaves uncovered.

Only the handler installed by `meos_initialize_noexit_error_handler` reaches any of this. The default one ends the process inside the rejected check, which is why the omission stays out of sight.
