### PR TITLE
Test the arguments of the base type comparisons as their siblings do

### DIFF
--- a/meos/src/pointcloud/tpcbox.c
+++ b/meos/src/pointcloud/tpcbox.c
@@ -994,7 +994,8 @@ adjacent_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
 int
 tpcbox_cmp(const TPCBox *box1, const TPCBox *box2)
 {
-  assert(box1); assert(box2);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(box1, false); VALIDATE_NOT_NULL(box2, false);
   if (box1->pcid != box2->pcid)
     return (box1->pcid < box2->pcid) ? -1 : 1;
   if (box1->srid != box2->srid)

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -1916,7 +1916,7 @@ int
 pose_cmp(const Pose *pose1, const Pose *pose2)
 {
   /* Ensure the validity of the arguments */
-  assert(pose1); assert(pose2);
+  VALIDATE_NOT_NULL(pose1, false); VALIDATE_NOT_NULL(pose2, false);
 
   /* Compare first the dimension, then the SRID,
      then the position, then the orientation */

--- a/meos/src/raster/raquet.c
+++ b/meos/src/raster/raquet.c
@@ -373,7 +373,8 @@ raquet_to_stbox(const Raquet *rq)
 int
 raquet_cmp(const Raquet *rq1, const Raquet *rq2)
 {
-  assert(rq1); assert(rq2);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(rq1, false); VALIDATE_NOT_NULL(rq2, false);
   if (rq1->quadbin != rq2->quadbin)
     return (rq1->quadbin < rq2->quadbin) ? -1 : 1;
   if (rq1->pixtype != rq2->pixtype)
@@ -396,7 +397,8 @@ raquet_cmp(const Raquet *rq1, const Raquet *rq2)
 bool
 raquet_eq(const Raquet *rq1, const Raquet *rq2)
 {
-  assert(rq1); assert(rq2);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(rq1, false); VALIDATE_NOT_NULL(rq2, false);
   return raquet_cmp(rq1, rq2) == 0;
 }
 
@@ -409,7 +411,6 @@ raquet_eq(const Raquet *rq1, const Raquet *rq2)
 bool
 raquet_ne(const Raquet *rq1, const Raquet *rq2)
 {
-  assert(rq1); assert(rq2);
   return raquet_cmp(rq1, rq2) != 0;
 }
 
@@ -422,7 +423,6 @@ raquet_ne(const Raquet *rq1, const Raquet *rq2)
 bool
 raquet_lt(const Raquet *rq1, const Raquet *rq2)
 {
-  assert(rq1); assert(rq2);
   return raquet_cmp(rq1, rq2) < 0;
 }
 
@@ -436,7 +436,6 @@ raquet_lt(const Raquet *rq1, const Raquet *rq2)
 bool
 raquet_le(const Raquet *rq1, const Raquet *rq2)
 {
-  assert(rq1); assert(rq2);
   return raquet_cmp(rq1, rq2) <= 0;
 }
 
@@ -450,7 +449,6 @@ raquet_le(const Raquet *rq1, const Raquet *rq2)
 bool
 raquet_ge(const Raquet *rq1, const Raquet *rq2)
 {
-  assert(rq1); assert(rq2);
   return raquet_cmp(rq1, rq2) >= 0;
 }
 
@@ -463,7 +461,6 @@ raquet_ge(const Raquet *rq1, const Raquet *rq2)
 bool
 raquet_gt(const Raquet *rq1, const Raquet *rq2)
 {
-  assert(rq1); assert(rq2);
   return raquet_cmp(rq1, rq2) > 0;
 }
 


### PR DESCRIPTION
A public function tests its arguments and returns an error; an internal one asserts and trusts its caller. The comparisons of three base types assert instead, and `assert` compiles to nothing once asserts are excluded, so a release build carries no test at all and reads through the pointer:

```
raquet_cmp(NULL, rq)   ->  SIGSEGV
```

## What the neighbours do

`cbuffer_cmp`, `npoint_cmp` and `nsegment_cmp` open with `VALIDATE_NOT_NULL` on both operands, as do `stbox_cmp` and `tbox_cmp` among the boxes. `raquet_cmp`, `pose_cmp` and `tpcbox_cmp` are the ones that do not, and `raquet_cmp` took `cbuffer_cmp` for its model.

| | guard |
|---|---|
| `cbuffer_cmp`, `npoint_cmp`, `nsegment_cmp`, `stbox_cmp`, `tbox_cmp` | `VALIDATE_NOT_NULL` |
| `raquet_cmp`, `pose_cmp`, `tpcbox_cmp` | `assert` |

Those three now open the same way, and return on a rejection what their models return:

```c
 raquet_cmp(const Raquet *rq1, const Raquet *rq2)
 {
-  assert(rq1); assert(rq2);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(rq1, false); VALIDATE_NOT_NULL(rq2, false);
```

`raquet_eq` keeps a test of its own, as `cbuffer_eq` has one. The comparisons reached through it drop theirs, as `cbuffer_ne` and its neighbours carry none, which is what makes this a shorter file rather than a longer one.

## Left alone

`pose_set_srid` sits beside `cbuffer_set_srid`, and `tpcbox_expand` beside `stbox_expand` and `tbox_expand`. Those neighbours assert too, so the three agree with their own kind and stay as they are.

## On the evidence

The three types are built only when their family is asked for, and the workflow that runs `meos/test` asks for circular buffers and JSON alone, so no test there reaches them. The SQL functions are `STRICT`, so PostgreSQL passes no null through either. What stands behind this is the behaviour above, taken by hand against a release build before and after:

```
before:  raquet_cmp(NULL, rq)  ->  SIGSEGV
after:   raquet_cmp(NULL, rq)  ->  0, invalid argument
```

The callers this reaches are the ones that hold a MEOS value directly, which is what a language binding does.
