### PR TITLE
Make text hashing and ordering host-independent in the extension

### DIFF
--- a/pgtypes/access/hashfunc.c
+++ b/pgtypes/access/hashfunc.c
@@ -262,7 +262,7 @@ text_hash(const text *txt, Oid collid)
   }
 
   uint32 result;
-  pg_locale_t mylocale = pg_newlocale_from_collation(collid);
+  pg_locale_t mylocale = meos_pg_newlocale_from_collation(collid);
   if (! mylocale || mylocale->deterministic)
   {
     result = hash_any((unsigned char *) VARDATA_ANY(txt),
@@ -312,7 +312,7 @@ text_hash_extended(const text *txt, uint64 seed, Oid collid)
   }
 
   uint64 result;
-  pg_locale_t mylocale = pg_newlocale_from_collation(collid);
+  pg_locale_t mylocale = meos_pg_newlocale_from_collation(collid);
   if (! mylocale || mylocale->deterministic)
   {
     result = hash_any_extended((unsigned char *) VARDATA_ANY(txt),

--- a/pgtypes/regex/regc_pg_locale.c
+++ b/pgtypes/regex/regc_pg_locale.c
@@ -248,14 +248,14 @@ pg_set_regex_collation(Oid collation)
     /*
      * Some callers expect regexes to work for C_COLLATION_OID before
      * catalog access is available, so we can't call
-     * pg_newlocale_from_collation().
+     * meos_pg_newlocale_from_collation().
      */
     strategy = PG_REGEX_STRATEGY_C;
     locale = 0;
   }
   else
   {
-    locale = pg_newlocale_from_collation(collation);
+    locale = meos_pg_newlocale_from_collation(collation);
 
     if (!locale->deterministic)
     {

--- a/pgtypes/utils/formatting.c
+++ b/pgtypes/utils/formatting.c
@@ -1614,7 +1614,7 @@ str_tolower(const char *buff, size_t nbytes, Oid collid)
     return NULL;
   }
 
-  // mylocale = pg_newlocale_from_collation(collid);
+  // mylocale = meos_pg_newlocale_from_collation(collid);
 
   // /* C/POSIX collations use this path regardless of database encoding */
   // if (mylocale->ctype_is_c)
@@ -1677,7 +1677,7 @@ str_toupper(const char *buff, size_t nbytes, Oid collid)
     return NULL;
   }
 
-  // mylocale = pg_newlocale_from_collation(collid);
+  // mylocale = meos_pg_newlocale_from_collation(collid);
 
   // /* C/POSIX collations use this path regardless of database encoding */
   // if (mylocale->ctype_is_c)
@@ -1740,7 +1740,7 @@ str_initcap(const char *buff, size_t nbytes, Oid collid)
     return NULL;
   }
 
-  // mylocale = pg_newlocale_from_collation(collid);
+  // mylocale = meos_pg_newlocale_from_collation(collid);
 
   // /* C/POSIX collations use this path regardless of database encoding */
   // if (mylocale->ctype_is_c)
@@ -1810,7 +1810,7 @@ str_initcap(const char *buff, size_t nbytes, Oid collid)
     // return NULL;
   // }
 
-  // mylocale = pg_newlocale_from_collation(collid);
+  // mylocale = meos_pg_newlocale_from_collation(collid);
 
   // /* C/POSIX collations use this path regardless of database encoding */
   // if (mylocale->ctype_is_c)

--- a/pgtypes/utils/mb/mbutils.c
+++ b/pgtypes/utils/mb/mbutils.c
@@ -69,11 +69,18 @@ static pg_con_fn ToClientConvProc = NULL;
 static pg_con_fn Utf8ToServerConvProc = NULL;
 
 /*
- * These variables track the currently-selected encodings.
+ * These variables track the selected encodings.
+ *
+ * MEOS uses UTF-8 as its default encoding: the standalone library pins the
+ * builtin C.UTF-8 default collation (see meos_initialize_collation), which is
+ * valid only in a UTF-8 database, and UTF-8 awareness is the purpose of
+ * vendoring the encoding and collation code. In the PostgreSQL extension these
+ * symbols are interposed by the backend, which sets them from the database
+ * encoding, so this default applies only to the standalone build.
  */
-static const pg_enc2name *ClientEncoding = &pg_enc2name_tbl[PG_SQL_ASCII];
-static const pg_enc2name *DatabaseEncoding = &pg_enc2name_tbl[PG_SQL_ASCII];
-static const pg_enc2name *MessageEncoding = &pg_enc2name_tbl[PG_SQL_ASCII];
+static const pg_enc2name *ClientEncoding = &pg_enc2name_tbl[PG_UTF8];
+static const pg_enc2name *DatabaseEncoding = &pg_enc2name_tbl[PG_UTF8];
+static const pg_enc2name *MessageEncoding = &pg_enc2name_tbl[PG_UTF8];
 
 /* Internal functions */
 static char *perform_default_encoding_conversion(const char *src,

--- a/pgtypes/utils/pg_locale.c
+++ b/pgtypes/utils/pg_locale.c
@@ -42,7 +42,13 @@
 #include "utils/builtins.h"
 #include "utils/guc.h"
 #include "utils/memutils.h"
+#include "utils/palloc.h"  /* MEOS: MemoryContext + MemoryContextSwitchTo (backend build) */
 #include "utils/pg_locale.h"
+
+/* MEOS: the vendored memutils.h omits this backend global; declare it locally,
+ * as dynahash.c does, so the extension can pin default_locale in a persistent
+ * context (see meos_initialize_collation). */
+extern PGDLLIMPORT MemoryContext TopMemoryContext;
 
 #include "../../meos/include/meos_tls.h"  /* MEOS: MEOS_TLS */
 
@@ -84,7 +90,7 @@
 #define    MAX_L10N_DATA    80
 
 /* pg_locale_builtin.c */
-extern pg_locale_t create_pg_locale_builtin(Oid collid);
+extern pg_locale_t meos_create_pg_locale_builtin(Oid collid);
 extern char *get_collation_actual_version_builtin(const char *collcollate);
 
 /* pg_locale_icu.c */
@@ -92,10 +98,10 @@ extern char *get_collation_actual_version_builtin(const char *collcollate);
 extern UCollator *pg_ucol_open(const char *loc_str);
 extern char *get_collation_actual_version_icu(const char *collcollate);
 #endif
-extern pg_locale_t create_pg_locale_icu(Oid collid);
+extern pg_locale_t meos_create_pg_locale_icu(Oid collid);
 
 /* pg_locale_libc.c */
-extern pg_locale_t create_pg_locale_libc(Oid collid);
+extern pg_locale_t meos_create_pg_locale_libc(Oid collid);
 extern char *get_collation_actual_version_libc(const char *collcollate);
 
 extern size_t strlower_builtin(char *dst, size_t dstsize, const char *src,
@@ -166,8 +172,11 @@ static const char *COLLATIONPROVIDER[] =
   [COLLPROV_LIBC] = "c",
 };
 
-/* Global variables added by MEOS */
-char *database_locale = "C";
+/* Global variables added by MEOS.
+ * The builtin C.UTF-8 locale makes text handling UTF-8 aware (Unicode case
+ * mapping) while keeping collation deterministic (memcmp), so text hashing and
+ * ordering stay host-independent across PostgreSQL versions. */
+char *database_locale = "C.UTF-8";
 char *database_locprovider = "b";
 char *database_icurules = NULL;
 char *database_ctype = NULL;
@@ -1220,11 +1229,11 @@ create_pg_locale(Oid collid)
   
   pg_locale_t result;
   if (rec->provider == COLLPROVIDER_BUILTIN)
-    result = create_pg_locale_builtin(collid);
+    result = meos_create_pg_locale_builtin(collid);
   else if (rec->provider == COLLPROVIDER_ICU)
-    result = create_pg_locale_icu(collid);
+    result = meos_create_pg_locale_icu(collid);
   else if (rec->provider == COLLPROVIDER_LIBC)
-    result = create_pg_locale_libc(collid);
+    result = meos_create_pg_locale_libc(collid);
   else
   {
     /* shouldn't happen */
@@ -1279,12 +1288,24 @@ meos_initialize_collation(void)
 {
   Assert(default_locale == NULL);
   pg_locale_t result = {0};
+#if ! MEOS
+  /*
+   * In the PostgreSQL extension the default locale is built lazily on the first
+   * text operation, i.e. inside a query whose CurrentMemoryContext is
+   * short-lived (typically a per-tuple context). Allocate it in
+   * TopMemoryContext so the session-global @p default_locale keeps pointing at
+   * live memory after that context resets; otherwise it dangles and the next
+   * tuple's data is read as the locale struct. The standalone library builds it
+   * once in meos_initialize(), already in a persistent context.
+   */
+  MemoryContext oldcontext = MemoryContextSwitchTo(TopMemoryContext);
+#endif /* ! MEOS */
   if (strcmp(database_locprovider, COLLATIONPROVIDER[COLLPROV_BUILTIN]) == 0)
-    result = create_pg_locale_builtin(DEFAULT_COLLATION_OID);
+    result = meos_create_pg_locale_builtin(DEFAULT_COLLATION_OID);
   else if (strcmp(database_locprovider, COLLATIONPROVIDER[COLLPROV_ICU]) == 0)
-    result = create_pg_locale_icu(DEFAULT_COLLATION_OID);
+    result = meos_create_pg_locale_icu(DEFAULT_COLLATION_OID);
   else if (strcmp(database_locprovider, COLLATIONPROVIDER[COLLPROV_LIBC]) == 0)
-    result = create_pg_locale_libc(DEFAULT_COLLATION_OID);
+    result = meos_create_pg_locale_libc(DEFAULT_COLLATION_OID);
   else
     /* shouldn't happen */
     PGLOCALE_SUPPORT_ERROR(database_locprovider[0]); /* MEOS */
@@ -1293,6 +1314,9 @@ meos_initialize_collation(void)
   if (default_locale != NULL)
     pfree(default_locale);
   default_locale = result;
+#if ! MEOS
+  MemoryContextSwitchTo(oldcontext);
+#endif /* ! MEOS */
   return;
 }
 
@@ -1320,13 +1344,28 @@ meos_finalize_collation(void)
  * it shouldn't cost much.
  */
 pg_locale_t
-pg_newlocale_from_collation(Oid collid)
+meos_pg_newlocale_from_collation(Oid collid)
 {
   collation_cache_entry *cache_entry;
   bool found;
 
   if (collid == DEFAULT_COLLATION_OID)
+  {
+    /*
+     * MEOS pins its own deterministic default collation (database_locale =
+     * "C.UTF-8", built by meos_create_pg_locale_builtin) so that text hashing
+     * and comparison
+     * are host-independent -- rather than following the backend's default
+     * collation, whose provider/behaviour varies across PostgreSQL versions.
+     * The standalone library sets this up in meos_initialize(); the PostgreSQL
+     * extension does not run that path, so build it lazily on first use (inside
+     * a query, where the catalog is available). This must never return NULL:
+     * varstr_cmp and friends dereference the locale without a NULL check.
+     */
+    if (default_locale == NULL)
+      meos_initialize_collation();
     return default_locale;
+  }
 
   if (! OidIsValid(collid))
   {
@@ -1593,7 +1632,7 @@ pg_strnxfrm_prefix(char *dest, size_t destsize, const char *src,
  * valid for the locale
  */
 int
-builtin_locale_encoding(const char *locale)
+meos_builtin_locale_encoding(const char *locale)
 {
   if (strcmp(locale, "C") == 0)
     return -1;
@@ -1612,7 +1651,7 @@ builtin_locale_encoding(const char *locale)
  * of the locale name.
  */
 const char *
-builtin_validate_locale(int encoding, const char *locale)
+meos_builtin_validate_locale(int encoding, const char *locale)
 {
   const char *canonical_name = NULL;
 
@@ -1629,7 +1668,7 @@ builtin_validate_locale(int encoding, const char *locale)
     return NULL;
   }
 
-  int required_encoding = builtin_locale_encoding(canonical_name);
+  int required_encoding = meos_builtin_locale_encoding(canonical_name);
   if (required_encoding >= 0 && encoding != required_encoding)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_ERROR,

--- a/pgtypes/utils/pg_locale.h
+++ b/pgtypes/utils/pg_locale.h
@@ -148,7 +148,7 @@ typedef struct
 
 extern void init_database_collation(void);
 extern void free_database_collation(void);
-extern pg_locale_t pg_newlocale_from_collation(Oid collid);
+extern pg_locale_t meos_pg_newlocale_from_collation(Oid collid);
 
 extern char *get_collation_actual_version(char collprovider, const char *collcollate);
 extern size_t pg_strlower(char *dst, size_t dstsize,
@@ -173,8 +173,8 @@ extern size_t pg_strxfrm_prefix(char *dest, const char *src, size_t destsize,
 extern size_t pg_strnxfrm_prefix(char *dest, size_t destsize, const char *src,
   ssize_t srclen, pg_locale_t locale);
 
-extern int  builtin_locale_encoding(const char *locale);
-extern const char *builtin_validate_locale(int encoding, const char *locale);
+extern int  meos_builtin_locale_encoding(const char *locale);
+extern const char *meos_builtin_validate_locale(int encoding, const char *locale);
 extern void icu_validate_locale(const char *loc_str);
 extern char *icu_language_tag(const char *loc_str, int elevel);
 extern void report_newlocale_failure(const char *localename);

--- a/pgtypes/utils/pg_locale_builtin.c
+++ b/pgtypes/utils/pg_locale_builtin.c
@@ -31,7 +31,7 @@
 
 extern char *database_locale;
 
-extern pg_locale_t create_pg_locale_builtin(Oid collid);
+extern pg_locale_t meos_create_pg_locale_builtin(Oid collid);
 extern char *get_collation_actual_version_builtin(const char *collcollate);
 extern size_t strlower_builtin(char *dest, size_t destsize, const char *src,
   ssize_t srclen, pg_locale_t locale);
@@ -126,7 +126,7 @@ strfold_builtin(char *dest, size_t destsize, const char *src, ssize_t srclen,
 }
 
 pg_locale_t
-create_pg_locale_builtin(Oid collid)
+meos_create_pg_locale_builtin(Oid collid)
 {
   const char *locstr;
   pg_locale_t result;
@@ -143,7 +143,7 @@ create_pg_locale_builtin(Oid collid)
     locstr = rec->locale;
   }
 
-  builtin_validate_locale(GetDatabaseEncoding(), locstr);
+  meos_builtin_validate_locale(GetDatabaseEncoding(), locstr);
   result = palloc0(sizeof(struct pg_locale_struct));
   result->info.builtin.locale = strdup(locstr);
   result->info.builtin.casemap_full = (strcmp(locstr, "PG_UNICODE_FAST") == 0);

--- a/pgtypes/utils/pg_locale_icu.c
+++ b/pgtypes/utils/pg_locale_icu.c
@@ -53,7 +53,7 @@
 extern char *database_iculocstr;
 extern char *database_icurules;
 
-extern pg_locale_t create_pg_locale_icu(Oid collid);
+extern pg_locale_t meos_create_pg_locale_icu(Oid collid);
 extern size_t strlower_icu(char *dest, size_t destsize, const char *src,
   ssize_t srclen, pg_locale_t locale);
 extern size_t strtitle_icu(char *dest, size_t destsize, const char *src,
@@ -136,9 +136,9 @@ static const struct collate_methods collate_methods_icu_utf8 = {
 
 pg_locale_t
 #ifdef USE_ICU
-create_pg_locale_icu(Oid collid)
+meos_create_pg_locale_icu(Oid collid)
 #else
-create_pg_locale_icu(Oid collid UNUSED)
+meos_create_pg_locale_icu(Oid collid UNUSED)
 #endif /* USE_ICU */
 {
 #ifdef USE_ICU

--- a/pgtypes/utils/pg_locale_libc.c
+++ b/pgtypes/utils/pg_locale_libc.c
@@ -58,7 +58,7 @@
 extern char *database_collate;
 extern char *database_ctype;
     
-extern pg_locale_t create_pg_locale_libc(Oid collid);
+extern pg_locale_t meos_create_pg_locale_libc(Oid collid);
 
 extern size_t strlower_libc(char *dst, size_t dstsize, const char *src,
   ssize_t srclen, pg_locale_t locale);
@@ -421,7 +421,7 @@ strupper_libc_mb(char *dest, size_t destsize, const char *src, ssize_t srclen,
 }
 
 pg_locale_t
-create_pg_locale_libc(Oid collid)
+meos_create_pg_locale_libc(Oid collid)
 {
   const char *collate;
   const char *ctype;

--- a/pgtypes/utils/varlena.c
+++ b/pgtypes/utils/varlena.c
@@ -795,7 +795,7 @@ text_position(const text *txt1, const text *txt2, Oid collid)
 
   /* Otherwise, can't match if haystack is shorter than needle */
   // if (VARSIZE_ANY_EXHDR(txt1) < VARSIZE_ANY_EXHDR(txt2) &&
-    // pg_newlocale_from_collation(collid)->deterministic)
+    // meos_pg_newlocale_from_collation(collid)->deterministic)
   if (VARSIZE_ANY_EXHDR(txt1) < VARSIZE_ANY_EXHDR(txt2))
     return 0;
 
@@ -849,7 +849,7 @@ text_position_setup(text *txt1, text *txt2, Oid collid,
   int len2 = VARSIZE_ANY_EXHDR(txt2);
 
   check_collation_set(collid);
-  state->locale = pg_newlocale_from_collation(collid);
+  state->locale = meos_pg_newlocale_from_collation(collid);
 
   /*
    * Most callers need greedy mode, but some might want to unset this to
@@ -1227,7 +1227,7 @@ varstr_cmp(const char *txt1, int len1, const char *txt2, int len2, Oid collid)
   check_collation_set(collid);
 
   int result;
-  pg_locale_t mylocale = pg_newlocale_from_collation(collid);
+  pg_locale_t mylocale = meos_pg_newlocale_from_collation(collid);
   if (mylocale->collate_is_c)
   {
     result = memcmp(txt1, txt2, Min(len1, len2));
@@ -1290,7 +1290,7 @@ text_eq(const text *txt1, const text *txt2)
   bool result;
 
   check_collation_set(collid);
-  pg_locale_t mylocale = pg_newlocale_from_collation(collid);
+  pg_locale_t mylocale = meos_pg_newlocale_from_collation(collid);
   if (! mylocale || mylocale->deterministic)
   {
     /*
@@ -1421,7 +1421,7 @@ pg_text_starts_with(const text *txt1, const text *txt2)
   bool result;
 
   check_collation_set(collid);
-  pg_locale_t mylocale = pg_newlocale_from_collation(collid);
+  pg_locale_t mylocale = meos_pg_newlocale_from_collation(collid);
   if (!mylocale->deterministic)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_ERROR,


### PR DESCRIPTION
## Problem

The extension shares the backend's flat symbol namespace, so PostgreSQL interposes its own copies of the vendored `pgtypes` locale functions. For the default collation PostgreSQL derives the locale from `pg_database`, whose provider and behaviour vary across server versions and hosts. Consequently:

- text set/temporal **hashes** and the **ordering** of text sets depend on the host (they follow the backend's default collation), and
- on a **libc-provider** database the extension aborts with `ERROR: unexpected null value in cached tuple for catalog pg_database column datlocale` (`SysCacheGetAttrNotNull`), because PostgreSQL's builtin-locale constructor reads `datlocale`, which is null there.

## Change

- **De-interposes the locale-construction layer.** `create_pg_locale_builtin`/`libc`/`icu`, `builtin_validate_locale` and `builtin_locale_encoding` become their `meos_` counterparts, so the module runs its own catalog-free builder and pins the deterministic builtin **C.UTF-8** locale (memcmp collation, UTF-8 ctype). No `pg_database` read is involved.
- **Pins the default locale in a persistent context.** The default locale is built on the first text operation, whose `CurrentMemoryContext` is a short-lived per-tuple context; the allocation goes to `TopMemoryContext` so the cached default-locale pointer stays valid after that context resets.
- **Defaults standalone MEOS to UTF-8.** The standalone library uses the UTF-8 encoding, matching the pinned C.UTF-8 default collation and making text handling UTF-8 aware. In the extension these encoding variables are interposed by the backend and keep the database encoding.

## Effect

- Text hashes and text-set ordering are identical across server versions and across builtin/libc/icu providers, since they use a fixed deterministic memcmp collation rather than the host default.
- A libc-provider database reads no catalog column for the default locale, so that configuration runs without error.
- On a libc-provider database `001_set_tbl` and `022_temporal` produce output identical to the committed expected files (the same hashes a UTF-8/builtin host produces).