### PR TITLE
Add PostgreSQL 19 to the CI matrix and make type-mismatch error tests version-robust

### DIFF
--- a/.github/workflows/pgversion.yml
+++ b/.github/workflows/pgversion.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          psql: [16, 17, 18]
+          psql: [16, 17, 18, 19]
           postgis: [3]
           os: ["ubuntu-24.04"]
           coverage: [0]
@@ -68,7 +68,7 @@ jobs:
           sudo apt-get install curl ca-certificates gnupg
           curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ \
-            $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+            $(lsb_release -cs)-pgdg main ${{ matrix.psql }}" > /etc/apt/sources.list.d/pgdg.list'
 
       - name: Install dependencies
         run: |

--- a/mobilitydb/test/cbuffer/expected/200_cbuffer.test.out
+++ b/mobilitydb/test/cbuffer/expected/200_cbuffer.test.out
@@ -54,10 +54,7 @@ SELECT asText(cbuffer(ST_Point(1,1), 0.5));
 
 /* Errors */
 SELECT cbuffer(1000,0.5);
-ERROR:  function cbuffer(integer, numeric) does not exist
-LINE 2: SELECT cbuffer(1000,0.5);
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ERROR:  function cbuffer(integer, numeric) does not exist at character 21
 SELECT cbuffer('Linestring(1 1,2 2)',1.5);
 ERROR:  Only point geometries accepted
 SELECT cbuffer('Point Z(1 1 1)',1.5);
@@ -65,10 +62,7 @@ ERROR:  The geometry cannot have Z dimension
 SELECT cbuffer('Point M(1 1 1)',1.5);
 ERROR:  The geometry cannot have M dimension
 SELECT cbuffer(geography 'Point(1 1)',1.5);
-ERROR:  function cbuffer(geography, numeric) does not exist
-LINE 1: SELECT cbuffer(geography 'Point(1 1)',1.5);
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ERROR:  function cbuffer(geography, numeric) does not exist at character 8
 SELECT cbuffer('Point(1 1)',-1.5);
 ERROR:  The value cannot be negative: -1.500000
 SELECT ST_AsText(point(cbuffer 'Cbuffer(Point(1 1),0.5)'));

--- a/mobilitydb/test/cbuffer/queries/200_cbuffer.test.sql
+++ b/mobilitydb/test/cbuffer/queries/200_cbuffer.test.sql
@@ -49,11 +49,15 @@ SELECT cbuffer 'Cbuffer(Point(1 1),0.5)xxx';
 SELECT asText(cbuffer('Point(1 1)', 0.5));
 SELECT asText(cbuffer(ST_Point(1,1), 0.5));
 /* Errors */
+\set VERBOSITY terse
 SELECT cbuffer(1000,0.5);
+\set VERBOSITY default
 SELECT cbuffer('Linestring(1 1,2 2)',1.5);
 SELECT cbuffer('Point Z(1 1 1)',1.5);
 SELECT cbuffer('Point M(1 1 1)',1.5);
+\set VERBOSITY terse
 SELECT cbuffer(geography 'Point(1 1)',1.5);
+\set VERBOSITY default
 SELECT cbuffer('Point(1 1)',-1.5);
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/h3/expected/250_h3index.test.out
+++ b/mobilitydb/test/h3/expected/250_h3index.test.out
@@ -105,10 +105,7 @@ SELECT (h3index '8a2a1072b59ffff')::bigint;
 
 /* Errors */
 SELECT 622236750694711295::bigint = h3index '8a2a1072b59ffff';
-ERROR:  operator does not exist: bigint = h3index
-LINE 2: SELECT 622236750694711295::bigint = h3index '8a2a1072b59ffff...
-                                          ^
-HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
+ERROR:  operator does not exist: bigint = h3index at character 48
 DROP TABLE IF EXISTS tbl_h3index_test;
 NOTICE:  table "tbl_h3index_test" does not exist, skipping
 DROP TABLE

--- a/mobilitydb/test/h3/expected/270_th3index.test.out
+++ b/mobilitydb/test/h3/expected/270_th3index.test.out
@@ -257,10 +257,7 @@ DROP TABLE tbl_th3index_assign;
 DROP TABLE
 /* Errors */
 SELECT tbigint '622236723497533439@2012-01-01 08:00:00' = th3index '622236723497533439@2012-01-01 08:00:00';
-ERROR:  operator does not exist: tbigint = th3index
-LINE 2: ... tbigint '622236723497533439@2012-01-01 08:00:00' = th3index...
-                                                             ^
-HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
+ERROR:  operator does not exist: tbigint = th3index at character 70
 DROP TABLE IF EXISTS tbl_th3index_binio;
 NOTICE:  table "tbl_th3index_binio" does not exist, skipping
 DROP TABLE

--- a/mobilitydb/test/h3/expected/281_th3index_hierarchy.test.out
+++ b/mobilitydb/test/h3/expected/281_th3index_hierarchy.test.out
@@ -80,10 +80,7 @@ SELECT th3CellToChildPos(th3index '622236750694711295@2001-01-01', 9);
 (1 row)
 
 SELECT th3CellToChildPos(th3index '622236750694711295@2001-01-01', 3) >= 0;
-ERROR:  operator does not exist: tbigint >= integer
-LINE 1: ...oChildPos(th3index '622236750694711295@2001-01-01', 3) >= 0;
-                                                                  ^
-HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
+ERROR:  operator does not exist: tbigint >= integer at character 71
 SELECT th3CellToChildPos(th3index
   '[622236750694711295@2001-01-01, 622236750694711295@2001-01-02]', 9);
                         th3celltochildpos                         

--- a/mobilitydb/test/h3/queries/250_h3index.test.sql
+++ b/mobilitydb/test/h3/queries/250_h3index.test.sql
@@ -67,7 +67,9 @@ SELECT (h3index '8a2a1072b59ffff')::bigint;
 
 -- The cast is NOT implicit — direct comparison without `::` must error
 /* Errors */
+\set VERBOSITY terse
 SELECT 622236750694711295::bigint = h3index '8a2a1072b59ffff';
+\set VERBOSITY default
 
 -------------------------------------------------------------------------------
 -- btree opclass: ORDER BY, DISTINCT, GROUP BY

--- a/mobilitydb/test/h3/queries/270_th3index.test.sql
+++ b/mobilitydb/test/h3/queries/270_th3index.test.sql
@@ -132,7 +132,9 @@ DROP TABLE tbl_th3index_assign;
 -- without an explicit cast must error (binder reports that no operator
 -- exists for the mixed types).
 /* Errors */
+\set VERBOSITY terse
 SELECT tbigint '622236723497533439@2012-01-01 08:00:00' = th3index '622236723497533439@2012-01-01 08:00:00';
+\set VERBOSITY default
 
 -------------------------------------------------------------------------------
 -- Send/receive (binary IO round-trip)

--- a/mobilitydb/test/h3/queries/281_th3index_hierarchy.test.sql
+++ b/mobilitydb/test/h3/queries/281_th3index_hierarchy.test.sql
@@ -81,7 +81,9 @@ SELECT th3GetResolution(
 SELECT th3CellToChildPos(th3index '622236750694711295@2001-01-01', 9);
 
 -- Position relative to res-3 ancestor (0x83 prefix) is in [0, 7^7 - 1].
+\set VERBOSITY terse
 SELECT th3CellToChildPos(th3index '622236750694711295@2001-01-01', 3) >= 0;
+\set VERBOSITY default
 
 SELECT th3CellToChildPos(th3index
   '[622236750694711295@2001-01-01, 622236750694711295@2001-01-02]', 9);

--- a/mobilitydb/test/pose/expected/100_pose.test.out
+++ b/mobilitydb/test/pose/expected/100_pose.test.out
@@ -67,10 +67,7 @@ ERROR:  The geometry cannot have Z dimension
 SELECT pose('Point M(1 1 1)',1.5);
 ERROR:  The geometry cannot have M dimension
 SELECT pose(geography 'Point(1 1)',1.5);
-ERROR:  function pose(geography, numeric) does not exist
-LINE 1: SELECT pose(geography 'Point(1 1)',1.5);
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ERROR:  function pose(geography, numeric) does not exist at character 8
 SELECT pose('Point(1 1)',-1.5);
                           pose                           
 ---------------------------------------------------------

--- a/mobilitydb/test/pose/queries/100_pose.test.sql
+++ b/mobilitydb/test/pose/queries/100_pose.test.sql
@@ -52,7 +52,9 @@ SELECT asText(pose(ST_Point(1,1), 0.5));
 SELECT pose('Linestring(1 1,2 2)',1.5);
 SELECT pose('Point Z(1 1 1)',1.5);
 SELECT pose('Point M(1 1 1)',1.5);
+\set VERBOSITY terse
 SELECT pose(geography 'Point(1 1)',1.5);
+\set VERBOSITY default
 SELECT pose('Point(1 1)',-1.5);
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/quadbin/expected/350_quadbin.test.out
+++ b/mobilitydb/test/quadbin/expected/350_quadbin.test.out
@@ -85,10 +85,7 @@ SELECT (quadbin '480fffffffffffff')::bigint;
 
 /* Errors */
 SELECT 5192650370358181887::bigint = quadbin '480fffffffffffff';
-ERROR:  operator does not exist: bigint = quadbin
-LINE 2: SELECT 5192650370358181887::bigint = quadbin '480fffffffffff...
-                                           ^
-HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
+ERROR:  operator does not exist: bigint = quadbin at character 49
 SELECT isValidIndex(quadbin '480fffffffffffff');
  isvalidindex 
 --------------

--- a/mobilitydb/test/quadbin/expected/352_tquadbin.test.out
+++ b/mobilitydb/test/quadbin/expected/352_tquadbin.test.out
@@ -109,10 +109,7 @@ DROP TABLE tbl_tquadbin_assign;
 DROP TABLE
 /* Errors */
 SELECT tbigint '5192650370358181887@2012-01-01 08:00:00' = tquadbin '480fffffffffffff@2012-01-01 08:00:00';
-ERROR:  operator does not exist: tbigint = tquadbin
-LINE 2: ...tbigint '5192650370358181887@2012-01-01 08:00:00' = tquadbin...
-                                                             ^
-HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
+ERROR:  operator does not exist: tbigint = tquadbin at character 71
 SELECT tquadbin '480fffffffffffff@2012-01-01' = tquadbin '480fffffffffffff@2012-01-01';
  ?column? 
 ----------

--- a/mobilitydb/test/quadbin/queries/350_quadbin.test.sql
+++ b/mobilitydb/test/quadbin/queries/350_quadbin.test.sql
@@ -73,7 +73,9 @@ SELECT (quadbin '480fffffffffffff')::bigint;
 
 -- The cast is NOT implicit — direct comparison without `::` must error
 /* Errors */
+\set VERBOSITY terse
 SELECT 5192650370358181887::bigint = quadbin '480fffffffffffff';
+\set VERBOSITY default
 
 -------------------------------------------------------------------------------
 -- Validity predicates

--- a/mobilitydb/test/quadbin/queries/352_tquadbin.test.sql
+++ b/mobilitydb/test/quadbin/queries/352_tquadbin.test.sql
@@ -88,7 +88,9 @@ DROP TABLE tbl_tquadbin_assign;
 
 -- The cast is NOT implicit
 /* Errors */
+\set VERBOSITY terse
 SELECT tbigint '5192650370358181887@2012-01-01 08:00:00' = tquadbin '480fffffffffffff@2012-01-01 08:00:00';
+\set VERBOSITY default
 
 -------------------------------------------------------------------------------
 -- Comparison operators + btree/hash

--- a/mobilitydb/test/temporal/expected/022_temporal.test.out
+++ b/mobilitydb/test/temporal/expected/022_temporal.test.out
@@ -8060,10 +8060,7 @@ SELECT segmentMaxDuration(tfloat '{[1.5@2000-01-01, 2.5@2000-01-02, 1.5@2000-01-
 (1 row)
 
 SELECT segmentMaxDuration(tfloat 'Interp=Step;[1.5@2000-01-01, 2.5@2000-01-02, 1.5@2000-01-03]', 2);
-ERROR:  function segmentmaxduration(tfloat, integer) does not exist
-LINE 1: SELECT segmentMaxDuration(tfloat 'Interp=Step;[1.5@2000-01-0...
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ERROR:  function segmentmaxduration(tfloat, integer) does not exist at character 8
 SELECT segmentMaxDuration(tfloat 'Interp=Step;{[1.5@2000-01-01, 2.5@2000-01-02, 1.5@2000-01-03],[3.5@2000-01-04, 3.5@2000-01-05]}', '1 day');
                                                           segmentmaxduration                                                          
 --------------------------------------------------------------------------------------------------------------------------------------

--- a/mobilitydb/test/temporal/queries/022_temporal.test.sql
+++ b/mobilitydb/test/temporal/queries/022_temporal.test.sql
@@ -1914,7 +1914,9 @@ SELECT segmentMinDuration(tfloat '{1.5@2000-01-01, 2.5@2000-01-02, 1.5@2000-01-0
 
 SELECT segmentMaxDuration(tfloat '[1.5@2000-01-01, 2.5@2000-01-02, 1.5@2000-01-03]', '1 day');
 SELECT segmentMaxDuration(tfloat '{[1.5@2000-01-01, 2.5@2000-01-02, 1.5@2000-01-03],[3.5@2000-01-04, 3.5@2000-01-05]}', '1 day');
+\set VERBOSITY terse
 SELECT segmentMaxDuration(tfloat 'Interp=Step;[1.5@2000-01-01, 2.5@2000-01-02, 1.5@2000-01-03]', 2);
+\set VERBOSITY default
 SELECT segmentMaxDuration(tfloat 'Interp=Step;{[1.5@2000-01-01, 2.5@2000-01-02, 1.5@2000-01-03],[3.5@2000-01-04, 3.5@2000-01-05]}', '1 day');
 /* NULL */
 SELECT segmentMaxDuration(tfloat '[1.5@2000-01-01]', '1 day');

--- a/pgtypes/access/hashfunc.c
+++ b/pgtypes/access/hashfunc.c
@@ -262,7 +262,7 @@ text_hash(const text *txt, Oid collid)
   }
 
   uint32 result;
-  pg_locale_t mylocale = pg_newlocale_from_collation(collid);
+  pg_locale_t mylocale = meos_pg_newlocale_from_collation(collid);
   if (! mylocale || mylocale->deterministic)
   {
     result = hash_any((unsigned char *) VARDATA_ANY(txt),
@@ -312,7 +312,7 @@ text_hash_extended(const text *txt, uint64 seed, Oid collid)
   }
 
   uint64 result;
-  pg_locale_t mylocale = pg_newlocale_from_collation(collid);
+  pg_locale_t mylocale = meos_pg_newlocale_from_collation(collid);
   if (! mylocale || mylocale->deterministic)
   {
     result = hash_any_extended((unsigned char *) VARDATA_ANY(txt),

--- a/pgtypes/regex/regc_pg_locale.c
+++ b/pgtypes/regex/regc_pg_locale.c
@@ -248,14 +248,14 @@ pg_set_regex_collation(Oid collation)
     /*
      * Some callers expect regexes to work for C_COLLATION_OID before
      * catalog access is available, so we can't call
-     * pg_newlocale_from_collation().
+     * meos_pg_newlocale_from_collation().
      */
     strategy = PG_REGEX_STRATEGY_C;
     locale = 0;
   }
   else
   {
-    locale = pg_newlocale_from_collation(collation);
+    locale = meos_pg_newlocale_from_collation(collation);
 
     if (!locale->deterministic)
     {

--- a/pgtypes/utils/formatting.c
+++ b/pgtypes/utils/formatting.c
@@ -1614,7 +1614,7 @@ str_tolower(const char *buff, size_t nbytes, Oid collid)
     return NULL;
   }
 
-  // mylocale = pg_newlocale_from_collation(collid);
+  // mylocale = meos_pg_newlocale_from_collation(collid);
 
   // /* C/POSIX collations use this path regardless of database encoding */
   // if (mylocale->ctype_is_c)
@@ -1677,7 +1677,7 @@ str_toupper(const char *buff, size_t nbytes, Oid collid)
     return NULL;
   }
 
-  // mylocale = pg_newlocale_from_collation(collid);
+  // mylocale = meos_pg_newlocale_from_collation(collid);
 
   // /* C/POSIX collations use this path regardless of database encoding */
   // if (mylocale->ctype_is_c)
@@ -1740,7 +1740,7 @@ str_initcap(const char *buff, size_t nbytes, Oid collid)
     return NULL;
   }
 
-  // mylocale = pg_newlocale_from_collation(collid);
+  // mylocale = meos_pg_newlocale_from_collation(collid);
 
   // /* C/POSIX collations use this path regardless of database encoding */
   // if (mylocale->ctype_is_c)
@@ -1810,7 +1810,7 @@ str_initcap(const char *buff, size_t nbytes, Oid collid)
     // return NULL;
   // }
 
-  // mylocale = pg_newlocale_from_collation(collid);
+  // mylocale = meos_pg_newlocale_from_collation(collid);
 
   // /* C/POSIX collations use this path regardless of database encoding */
   // if (mylocale->ctype_is_c)

--- a/pgtypes/utils/mb/mbutils.c
+++ b/pgtypes/utils/mb/mbutils.c
@@ -69,11 +69,18 @@ static pg_con_fn ToClientConvProc = NULL;
 static pg_con_fn Utf8ToServerConvProc = NULL;
 
 /*
- * These variables track the currently-selected encodings.
+ * These variables track the selected encodings.
+ *
+ * MEOS uses UTF-8 as its default encoding: the standalone library pins the
+ * builtin C.UTF-8 default collation (see meos_initialize_collation), which is
+ * valid only in a UTF-8 database, and UTF-8 awareness is the purpose of
+ * vendoring the encoding and collation code. In the PostgreSQL extension these
+ * symbols are interposed by the backend, which sets them from the database
+ * encoding, so this default applies only to the standalone build.
  */
-static const pg_enc2name *ClientEncoding = &pg_enc2name_tbl[PG_SQL_ASCII];
-static const pg_enc2name *DatabaseEncoding = &pg_enc2name_tbl[PG_SQL_ASCII];
-static const pg_enc2name *MessageEncoding = &pg_enc2name_tbl[PG_SQL_ASCII];
+static const pg_enc2name *ClientEncoding = &pg_enc2name_tbl[PG_UTF8];
+static const pg_enc2name *DatabaseEncoding = &pg_enc2name_tbl[PG_UTF8];
+static const pg_enc2name *MessageEncoding = &pg_enc2name_tbl[PG_UTF8];
 
 /* Internal functions */
 static char *perform_default_encoding_conversion(const char *src,

--- a/pgtypes/utils/pg_locale.c
+++ b/pgtypes/utils/pg_locale.c
@@ -42,7 +42,13 @@
 #include "utils/builtins.h"
 #include "utils/guc.h"
 #include "utils/memutils.h"
+#include "utils/palloc.h"  /* MEOS: MemoryContext + MemoryContextSwitchTo (backend build) */
 #include "utils/pg_locale.h"
+
+/* MEOS: the vendored memutils.h omits this backend global; declare it locally,
+ * as dynahash.c does, so the extension can pin default_locale in a persistent
+ * context (see meos_initialize_collation). */
+extern PGDLLIMPORT MemoryContext TopMemoryContext;
 
 #include "../../meos/include/meos_tls.h"  /* MEOS: MEOS_TLS */
 
@@ -84,7 +90,7 @@
 #define    MAX_L10N_DATA    80
 
 /* pg_locale_builtin.c */
-extern pg_locale_t create_pg_locale_builtin(Oid collid);
+extern pg_locale_t meos_create_pg_locale_builtin(Oid collid);
 extern char *get_collation_actual_version_builtin(const char *collcollate);
 
 /* pg_locale_icu.c */
@@ -92,10 +98,10 @@ extern char *get_collation_actual_version_builtin(const char *collcollate);
 extern UCollator *pg_ucol_open(const char *loc_str);
 extern char *get_collation_actual_version_icu(const char *collcollate);
 #endif
-extern pg_locale_t create_pg_locale_icu(Oid collid);
+extern pg_locale_t meos_create_pg_locale_icu(Oid collid);
 
 /* pg_locale_libc.c */
-extern pg_locale_t create_pg_locale_libc(Oid collid);
+extern pg_locale_t meos_create_pg_locale_libc(Oid collid);
 extern char *get_collation_actual_version_libc(const char *collcollate);
 
 extern size_t strlower_builtin(char *dst, size_t dstsize, const char *src,
@@ -166,8 +172,11 @@ static const char *COLLATIONPROVIDER[] =
   [COLLPROV_LIBC] = "c",
 };
 
-/* Global variables added by MEOS */
-char *database_locale = "C";
+/* Global variables added by MEOS.
+ * The builtin C.UTF-8 locale makes text handling UTF-8 aware (Unicode case
+ * mapping) while keeping collation deterministic (memcmp), so text hashing and
+ * ordering stay host-independent across PostgreSQL versions. */
+char *database_locale = "C.UTF-8";
 char *database_locprovider = "b";
 char *database_icurules = NULL;
 char *database_ctype = NULL;
@@ -1220,11 +1229,11 @@ create_pg_locale(Oid collid)
   
   pg_locale_t result;
   if (rec->provider == COLLPROVIDER_BUILTIN)
-    result = create_pg_locale_builtin(collid);
+    result = meos_create_pg_locale_builtin(collid);
   else if (rec->provider == COLLPROVIDER_ICU)
-    result = create_pg_locale_icu(collid);
+    result = meos_create_pg_locale_icu(collid);
   else if (rec->provider == COLLPROVIDER_LIBC)
-    result = create_pg_locale_libc(collid);
+    result = meos_create_pg_locale_libc(collid);
   else
   {
     /* shouldn't happen */
@@ -1279,12 +1288,24 @@ meos_initialize_collation(void)
 {
   Assert(default_locale == NULL);
   pg_locale_t result = {0};
+#if ! MEOS
+  /*
+   * In the PostgreSQL extension the default locale is built lazily on the first
+   * text operation, i.e. inside a query whose CurrentMemoryContext is
+   * short-lived (typically a per-tuple context). Allocate it in
+   * TopMemoryContext so the session-global @p default_locale keeps pointing at
+   * live memory after that context resets; otherwise it dangles and the next
+   * tuple's data is read as the locale struct. The standalone library builds it
+   * once in meos_initialize(), already in a persistent context.
+   */
+  MemoryContext oldcontext = MemoryContextSwitchTo(TopMemoryContext);
+#endif /* ! MEOS */
   if (strcmp(database_locprovider, COLLATIONPROVIDER[COLLPROV_BUILTIN]) == 0)
-    result = create_pg_locale_builtin(DEFAULT_COLLATION_OID);
+    result = meos_create_pg_locale_builtin(DEFAULT_COLLATION_OID);
   else if (strcmp(database_locprovider, COLLATIONPROVIDER[COLLPROV_ICU]) == 0)
-    result = create_pg_locale_icu(DEFAULT_COLLATION_OID);
+    result = meos_create_pg_locale_icu(DEFAULT_COLLATION_OID);
   else if (strcmp(database_locprovider, COLLATIONPROVIDER[COLLPROV_LIBC]) == 0)
-    result = create_pg_locale_libc(DEFAULT_COLLATION_OID);
+    result = meos_create_pg_locale_libc(DEFAULT_COLLATION_OID);
   else
     /* shouldn't happen */
     PGLOCALE_SUPPORT_ERROR(database_locprovider[0]); /* MEOS */
@@ -1293,6 +1314,9 @@ meos_initialize_collation(void)
   if (default_locale != NULL)
     pfree(default_locale);
   default_locale = result;
+#if ! MEOS
+  MemoryContextSwitchTo(oldcontext);
+#endif /* ! MEOS */
   return;
 }
 
@@ -1320,13 +1344,28 @@ meos_finalize_collation(void)
  * it shouldn't cost much.
  */
 pg_locale_t
-pg_newlocale_from_collation(Oid collid)
+meos_pg_newlocale_from_collation(Oid collid)
 {
   collation_cache_entry *cache_entry;
   bool found;
 
   if (collid == DEFAULT_COLLATION_OID)
+  {
+    /*
+     * MEOS pins its own deterministic default collation (database_locale =
+     * "C.UTF-8", built by meos_create_pg_locale_builtin) so that text hashing
+     * and comparison
+     * are host-independent -- rather than following the backend's default
+     * collation, whose provider/behaviour varies across PostgreSQL versions.
+     * The standalone library sets this up in meos_initialize(); the PostgreSQL
+     * extension does not run that path, so build it lazily on first use (inside
+     * a query, where the catalog is available). This must never return NULL:
+     * varstr_cmp and friends dereference the locale without a NULL check.
+     */
+    if (default_locale == NULL)
+      meos_initialize_collation();
     return default_locale;
+  }
 
   if (! OidIsValid(collid))
   {
@@ -1593,7 +1632,7 @@ pg_strnxfrm_prefix(char *dest, size_t destsize, const char *src,
  * valid for the locale
  */
 int
-builtin_locale_encoding(const char *locale)
+meos_builtin_locale_encoding(const char *locale)
 {
   if (strcmp(locale, "C") == 0)
     return -1;
@@ -1612,7 +1651,7 @@ builtin_locale_encoding(const char *locale)
  * of the locale name.
  */
 const char *
-builtin_validate_locale(int encoding, const char *locale)
+meos_builtin_validate_locale(int encoding, const char *locale)
 {
   const char *canonical_name = NULL;
 
@@ -1629,7 +1668,7 @@ builtin_validate_locale(int encoding, const char *locale)
     return NULL;
   }
 
-  int required_encoding = builtin_locale_encoding(canonical_name);
+  int required_encoding = meos_builtin_locale_encoding(canonical_name);
   if (required_encoding >= 0 && encoding != required_encoding)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_ERROR,

--- a/pgtypes/utils/pg_locale.h
+++ b/pgtypes/utils/pg_locale.h
@@ -148,7 +148,7 @@ typedef struct
 
 extern void init_database_collation(void);
 extern void free_database_collation(void);
-extern pg_locale_t pg_newlocale_from_collation(Oid collid);
+extern pg_locale_t meos_pg_newlocale_from_collation(Oid collid);
 
 extern char *get_collation_actual_version(char collprovider, const char *collcollate);
 extern size_t pg_strlower(char *dst, size_t dstsize,
@@ -173,8 +173,8 @@ extern size_t pg_strxfrm_prefix(char *dest, const char *src, size_t destsize,
 extern size_t pg_strnxfrm_prefix(char *dest, size_t destsize, const char *src,
   ssize_t srclen, pg_locale_t locale);
 
-extern int  builtin_locale_encoding(const char *locale);
-extern const char *builtin_validate_locale(int encoding, const char *locale);
+extern int  meos_builtin_locale_encoding(const char *locale);
+extern const char *meos_builtin_validate_locale(int encoding, const char *locale);
 extern void icu_validate_locale(const char *loc_str);
 extern char *icu_language_tag(const char *loc_str, int elevel);
 extern void report_newlocale_failure(const char *localename);

--- a/pgtypes/utils/pg_locale_builtin.c
+++ b/pgtypes/utils/pg_locale_builtin.c
@@ -31,7 +31,7 @@
 
 extern char *database_locale;
 
-extern pg_locale_t create_pg_locale_builtin(Oid collid);
+extern pg_locale_t meos_create_pg_locale_builtin(Oid collid);
 extern char *get_collation_actual_version_builtin(const char *collcollate);
 extern size_t strlower_builtin(char *dest, size_t destsize, const char *src,
   ssize_t srclen, pg_locale_t locale);
@@ -126,7 +126,7 @@ strfold_builtin(char *dest, size_t destsize, const char *src, ssize_t srclen,
 }
 
 pg_locale_t
-create_pg_locale_builtin(Oid collid)
+meos_create_pg_locale_builtin(Oid collid)
 {
   const char *locstr;
   pg_locale_t result;
@@ -143,7 +143,7 @@ create_pg_locale_builtin(Oid collid)
     locstr = rec->locale;
   }
 
-  builtin_validate_locale(GetDatabaseEncoding(), locstr);
+  meos_builtin_validate_locale(GetDatabaseEncoding(), locstr);
   result = palloc0(sizeof(struct pg_locale_struct));
   result->info.builtin.locale = strdup(locstr);
   result->info.builtin.casemap_full = (strcmp(locstr, "PG_UNICODE_FAST") == 0);

--- a/pgtypes/utils/pg_locale_icu.c
+++ b/pgtypes/utils/pg_locale_icu.c
@@ -53,7 +53,7 @@
 extern char *database_iculocstr;
 extern char *database_icurules;
 
-extern pg_locale_t create_pg_locale_icu(Oid collid);
+extern pg_locale_t meos_create_pg_locale_icu(Oid collid);
 extern size_t strlower_icu(char *dest, size_t destsize, const char *src,
   ssize_t srclen, pg_locale_t locale);
 extern size_t strtitle_icu(char *dest, size_t destsize, const char *src,
@@ -136,9 +136,9 @@ static const struct collate_methods collate_methods_icu_utf8 = {
 
 pg_locale_t
 #ifdef USE_ICU
-create_pg_locale_icu(Oid collid)
+meos_create_pg_locale_icu(Oid collid)
 #else
-create_pg_locale_icu(Oid collid UNUSED)
+meos_create_pg_locale_icu(Oid collid UNUSED)
 #endif /* USE_ICU */
 {
 #ifdef USE_ICU

--- a/pgtypes/utils/pg_locale_libc.c
+++ b/pgtypes/utils/pg_locale_libc.c
@@ -58,7 +58,7 @@
 extern char *database_collate;
 extern char *database_ctype;
     
-extern pg_locale_t create_pg_locale_libc(Oid collid);
+extern pg_locale_t meos_create_pg_locale_libc(Oid collid);
 
 extern size_t strlower_libc(char *dst, size_t dstsize, const char *src,
   ssize_t srclen, pg_locale_t locale);
@@ -421,7 +421,7 @@ strupper_libc_mb(char *dest, size_t destsize, const char *src, ssize_t srclen,
 }
 
 pg_locale_t
-create_pg_locale_libc(Oid collid)
+meos_create_pg_locale_libc(Oid collid)
 {
   const char *collate;
   const char *ctype;

--- a/pgtypes/utils/varlena.c
+++ b/pgtypes/utils/varlena.c
@@ -795,7 +795,7 @@ text_position(const text *txt1, const text *txt2, Oid collid)
 
   /* Otherwise, can't match if haystack is shorter than needle */
   // if (VARSIZE_ANY_EXHDR(txt1) < VARSIZE_ANY_EXHDR(txt2) &&
-    // pg_newlocale_from_collation(collid)->deterministic)
+    // meos_pg_newlocale_from_collation(collid)->deterministic)
   if (VARSIZE_ANY_EXHDR(txt1) < VARSIZE_ANY_EXHDR(txt2))
     return 0;
 
@@ -849,7 +849,7 @@ text_position_setup(text *txt1, text *txt2, Oid collid,
   int len2 = VARSIZE_ANY_EXHDR(txt2);
 
   check_collation_set(collid);
-  state->locale = pg_newlocale_from_collation(collid);
+  state->locale = meos_pg_newlocale_from_collation(collid);
 
   /*
    * Most callers need greedy mode, but some might want to unset this to
@@ -1227,7 +1227,7 @@ varstr_cmp(const char *txt1, int len1, const char *txt2, int len2, Oid collid)
   check_collation_set(collid);
 
   int result;
-  pg_locale_t mylocale = pg_newlocale_from_collation(collid);
+  pg_locale_t mylocale = meos_pg_newlocale_from_collation(collid);
   if (mylocale->collate_is_c)
   {
     result = memcmp(txt1, txt2, Min(len1, len2));
@@ -1290,7 +1290,7 @@ text_eq(const text *txt1, const text *txt2)
   bool result;
 
   check_collation_set(collid);
-  pg_locale_t mylocale = pg_newlocale_from_collation(collid);
+  pg_locale_t mylocale = meos_pg_newlocale_from_collation(collid);
   if (! mylocale || mylocale->deterministic)
   {
     /*
@@ -1421,7 +1421,7 @@ pg_text_starts_with(const text *txt1, const text *txt2)
   bool result;
 
   check_collation_set(collid);
-  pg_locale_t mylocale = pg_newlocale_from_collation(collid);
+  pg_locale_t mylocale = meos_pg_newlocale_from_collation(collid);
   if (!mylocale->deterministic)
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_ERROR,


### PR DESCRIPTION
## Change

- Adds PostgreSQL 19 to the `pgversion` workflow matrix, so the supported-version test covers 16, 17, 18 and 19 (PostgreSQL 19 and its PostGIS package come from the same `apt.postgresql.org` repository the workflow already uses).
- Runs the type-mismatch error queries under terse verbosity. PostgreSQL 19 restructures the `HINT`/`DETAIL` text of "function/operator does not exist" errors; terse verbosity emits only the primary `ERROR` message with its character position, which is identical across the supported server versions.

Affected tests: `022_temporal`, `100_pose`, `200_cbuffer`, `250_h3index`, `270_th3index`, `281_th3index_hierarchy`, `350_quadbin`, `352_tquadbin`.