### PR TITLE
Return from the geography WKT input functions when parsing fails

### DIFF
--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -92,6 +92,8 @@ jobs:
           ./error_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o merge_test merge_test.c -L/usr/local/lib -lmeos
           ./merge_test
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o geo_test geo_test.c -L/usr/local/lib -lmeos
+          ./geo_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o numeric_test numeric_test.c -L/usr/local/lib -lmeos
           ./numeric_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o setspan_test setspan_test.c -L/usr/local/lib -lmeos

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -3424,7 +3424,10 @@ geo_from_text(const char *wkt, int32_t srid)
 
   if (lwgeom_parse_wkt(&lwg_parser_result, (char *) wkt,
       LW_PARSER_CHECK_ALL) == LW_FAILURE )
+  {
     PG_PARSER_ERROR(lwg_parser_result);
+    return NULL;
+  }
 
   lwgeom = lwg_parser_result.geom;
 
@@ -3847,10 +3850,13 @@ geog_in(const char *str, int32 typmod)
   /* WKT then. */
   else
   {
-    if ( lwgeom_parse_wkt(&lwg_parser_result, (char *) str, 
+    if ( lwgeom_parse_wkt(&lwg_parser_result, (char *) str,
         LW_PARSER_CHECK_ALL) == LW_FAILURE )
+    {
       PG_PARSER_ERROR(lwg_parser_result);
-      lwgeom = lwg_parser_result.geom;
+      return NULL;
+    }
+    lwgeom = lwg_parser_result.geom;
   }
 
   GSERIALIZED *result = NULL;

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -1,0 +1,95 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief A program that tests the WKT input functions of the geo API on
+ * malformed input.
+ *
+ * A parse failure is only observable once
+ * #meos_initialize_noexit_error_handler is installed — the handler every
+ * language binding uses, since a binding must return an exception to its host
+ * rather than terminate it. Under it the parse-failure branch of the input
+ * functions is reached, and the program verifies that they return NULL and set
+ * #meos_errno rather than dereferencing the null geometry the parser leaves
+ * behind. The default handler ends the process inside the failing check, so
+ * this path is exercised only here.
+ *
+ * The program can be build as follows
+ * @code
+ * gcc -Wall -g -I/usr/local/include -o geo_test geo_test.c -L/usr/local/lib -lmeos
+ * @endcode
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <meos.h>
+#include <meos_geo.h>
+
+/* Main program */
+int main(void)
+{
+  /* Initialize MEOS and install the error handler that reports through
+   * meos_errno instead of exiting */
+  meos_initialize();
+  meos_initialize_timezone("UTC");
+  meos_initialize_noexit_error_handler();
+
+  /* A malformed WKT geography returns NULL and sets the error status, rather
+   * than dereferencing the null geometry the parser leaves in its result */
+  meos_errno_reset();
+  GSERIALIZED *bad_geog = geog_in("this is not well-known text", -1);
+  printf("geog_in(bad WKT): %s, errno %d\n", bad_geog ? "non-NULL" : "NULL",
+    meos_errno());
+  assert(bad_geog == NULL);
+  assert(meos_errno() != 0);
+
+  /* Same for the geometry/geography from-text constructor */
+  meos_errno_reset();
+  GSERIALIZED *bad_geo = geo_from_text("this is not well-known text", 0);
+  printf("geo_from_text(bad WKT): %s, errno %d\n",
+    bad_geo ? "non-NULL" : "NULL", meos_errno());
+  assert(bad_geo == NULL);
+  assert(meos_errno() != 0);
+
+  /* A valid WKT geography still parses */
+  meos_errno_reset();
+  GSERIALIZED *good = geog_in("Point(1 1)", -1);
+  printf("geog_in(\"Point(1 1)\"): %s, errno %d\n",
+    good ? "non-NULL" : "NULL", meos_errno());
+  assert(good != NULL);
+  assert(meos_errno() == 0);
+  free(good);
+
+  /* Finalize MEOS */
+  meos_finalize();
+
+  return 0;
+}


### PR DESCRIPTION
## Problem

`geog_in` and `geo_from_text` call `PG_PARSER_ERROR` on a WKT parse failure but do not return afterwards. Under the noexit error handler that every language binding installs, `meos_error` records the error and returns rather than terminating the process, so execution reaches the unconditional `lwgeom = lwg_parser_result.geom;` — where the parser left a null geometry — and dereferences it. `geog_in` additionally lacks braces around its failure branch, so that assignment runs even when the guard holds. The default handler ends the process inside the failing check, so this path is reachable only through the bindings.

## Change

- Wraps both parse-failure branches and `return NULL`, matching the sibling WKT/GeoJSON input path already in the same file.
- Adds `meos/test/geo_test.c`: under the noexit handler it feeds malformed WKT to `geog_in` and `geo_from_text` and asserts they return NULL with the error status set, and confirms valid WKT still parses. Wired into the meos workflow.

## Effect

Malformed WKT input yields a NULL return and a set error status. The probe returns exit 0 with the fix; against a build with only this file reverted it segfaults (exit 139).