### PR TITLE
Prune segments below the running minimum in the nearest-approach kernel

### DIFF
--- a/meos/include/geo/tgeo_distance.h
+++ b/meos/include/geo/tgeo_distance.h
@@ -58,11 +58,20 @@ extern int tgeogpointsegm_distance_turnpt(Datum start1, Datum end1,
 extern double tinstant_distance(const TInstant *inst1, const TInstant *inst2,
   datum_func2 func);
 
+/**
+ * @brief Lower bound on the distance over two synchronized linear segments,
+ * cheap enough to gate the per-segment turning-point computation
+ */
+typedef double (*seglb_func)(Datum start1, Datum end1, Datum start2,
+  Datum end2);
+
 extern bool nad_tcont_tcont_sync_applies(const Temporal *temp1,
   const Temporal *temp2);
 extern double nad_tcont_tcont_sync(const Temporal *temp1,
   const Temporal *temp2, datum_func2 func, tpfunc_temp turnpt,
-  TimestampTz *tmin);
+  seglb_func seglb, TimestampTz *tmin);
+extern double tpointseg_distance_lb(Datum start1, Datum end1, Datum start2,
+  Datum end2);
 
 /*****************************************************************************/
 

--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -1350,6 +1350,34 @@ nad_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 }
 
 /**
+ * @brief Return a lower bound on the distance between two synchronized linear
+ * temporal circular buffer segments
+ * @details A moving disc stays within the bounding box of its two endpoint
+ * centres, so the box-to-box distance of the centre boxes minus the larger
+ * endpoint radius of each disc bounds the signed gap below. The bound is
+ * signed (negative when the discs may overlap), matching #cbuffer_distance
+ */
+static double
+tcbufferseg_distance_lb(Datum start1, Datum end1, Datum start2, Datum end2)
+{
+  const Cbuffer *cs1 = DatumGetCbufferP(start1);
+  const Cbuffer *ce1 = DatumGetCbufferP(end1);
+  const Cbuffer *cs2 = DatumGetCbufferP(start2);
+  const Cbuffer *ce2 = DatumGetCbufferP(end2);
+  const POINT2D *s1 = GSERIALIZED_POINT2D_P(cbuffer_point_p(cs1));
+  const POINT2D *e1 = GSERIALIZED_POINT2D_P(cbuffer_point_p(ce1));
+  const POINT2D *s2 = GSERIALIZED_POINT2D_P(cbuffer_point_p(cs2));
+  const POINT2D *e2 = GSERIALIZED_POINT2D_P(cbuffer_point_p(ce2));
+  double r1 = fmax(cs1->radius, ce1->radius);
+  double r2 = fmax(cs2->radius, ce2->radius);
+  double dx = fmax(fmax(fmin(s1->x, e1->x) - fmax(s2->x, e2->x),
+    fmin(s2->x, e2->x) - fmax(s1->x, e1->x)), 0.0);
+  double dy = fmax(fmax(fmin(s1->y, e1->y) - fmax(s2->y, e2->y),
+    fmin(s2->y, e2->y) - fmax(s1->y, e1->y)), 0.0);
+  return sqrt(dx * dx + dy * dy) - r1 - r2;
+}
+
+/**
  * @ingroup meos_cbuffer_dist
  * @brief Return the nearest approach distance of two temporal circular buffers
  * @param[in] temp1,temp2 Temporal circular buffers
@@ -1370,7 +1398,7 @@ nad_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
   {
     TimestampTz t;
     double d = nad_tcont_tcont_sync(temp1, temp2, &datum_cbuffer_distance,
-      &tcbuffersegm_distance_turnpt, &t);
+      &tcbuffersegm_distance_turnpt, &tcbufferseg_distance_lb, &t);
     if (d != DBL_MAX)
       return d;
   }

--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -1790,20 +1790,42 @@ tdistance_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
  *****************************************************************************/
 
 /**
+ * @brief Return a lower bound on the distance between two synchronized linear
+ * temporal point segments
+ * @details A moving point stays within the bounding box of its two endpoints,
+ * so the box-to-box distance of the endpoint boxes bounds the synchronized
+ * distance below. The radius is zero for a point
+ */
+double
+tpointseg_distance_lb(Datum start1, Datum end1, Datum start2, Datum end2)
+{
+  const POINT2D *s1 = DATUM_POINT2D_P(start1);
+  const POINT2D *e1 = DATUM_POINT2D_P(end1);
+  const POINT2D *s2 = DATUM_POINT2D_P(start2);
+  const POINT2D *e2 = DATUM_POINT2D_P(end2);
+  double dx = fmax(fmax(fmin(s1->x, e1->x) - fmax(s2->x, e2->x),
+    fmin(s2->x, e2->x) - fmax(s1->x, e1->x)), 0.0);
+  double dy = fmax(fmax(fmin(s1->y, e1->y) - fmax(s2->y, e2->y),
+    fmin(s2->y, e2->y) - fmax(s1->y, e1->y)), 0.0);
+  return sqrt(dx * dx + dy * dy);
+}
+
+/**
  * @brief Return the minimum time-synchronous distance over the overlapping
  * period of two linear temporal point sequences, updating the running minimum
  * @param[in] seq1,seq2 Temporal sequences with linear interpolation
  * @param[in] inter Overlapping period of the two sequences
  * @param[in] func Base value distance function
  * @param[in] turnpt Per-segment distance turning-point function
+ * @param[in] seglb Per-segment distance lower-bound function
  * @param[in] curmin Current minimum distance, or infinity at the beginning
  * @param[in,out] tmin Timestamp achieving the running minimum
  * @pre Both sequences are linear and of equal type; @p inter is their overlap
  */
 static double
 nad_tcontseq_tcontseq_sync(const TSequence *seq1, const TSequence *seq2,
-  const Span *inter, datum_func2 func, tpfunc_temp turnpt, double curmin,
-  TimestampTz *tmin)
+  const Span *inter, datum_func2 func, tpfunc_temp turnpt, seglb_func seglb,
+  double curmin, TimestampTz *tmin)
 {
   MeosType temptype = seq1->temptype;
   TInstant *inst1 = (TInstant *) TSEQUENCE_INST_N(seq1, 0);
@@ -1847,17 +1869,26 @@ nad_tcontseq_tcontseq_sync(const TSequence *seq1, const TSequence *seq2,
       inst1 = tcontseq_at_timestamptz(seq1, inst2->t);
       tofree[nfree++] = inst1;
     }
+    /* A cheap segment lower bound gates the whole segment: when it already
+     * exceeds the running minimum, neither the interior turning point(s) nor
+     * the segment endpoint can beat it, so both evaluations are skipped. Sound
+     * because the bound never exceeds the true distance minimum over the
+     * segment. A NULL bound (no cheap sound bound, e.g. a geodetic metric)
+     * always evaluates */
+    double lb = (ninsts > 0 && seglb) ?
+      seglb(tinstant_value_p(prev1), tinstant_value_p(inst1),
+        tinstant_value_p(prev2), tinstant_value_p(inst2)) : -DBL_MAX;
     /* If not the first instant, evaluate the distance at the potential
      * turning point(s) interior to the segment */
-    if (ninsts > 0)
+    if (ninsts > 0 && lb < curmin)
     {
       Datum start1 = tinstant_value_p(prev1);
       Datum end1 = tinstant_value_p(inst1);
       Datum start2 = tinstant_value_p(prev2);
       Datum end2 = tinstant_value_p(inst2);
       TimestampTz tpt1, tpt2;
-      int found = turnpt(start1, end1, start2, end2,
-        (Datum) 0, prev1->t, inst1->t, &tpt1, &tpt2);
+      int found = turnpt(start1, end1, start2, end2, (Datum) 0, prev1->t,
+        inst1->t, &tpt1, &tpt2);
       if (found)
       {
         Datum v1 = tsegment_value_at_timestamptz(start1, end1, temptype,
@@ -1880,10 +1911,14 @@ nad_tcontseq_tcontseq_sync(const TSequence *seq1, const TSequence *seq2,
         }
       }
     }
-    /* Evaluate the distance at the synchronized instant */
-    double d = DatumGetFloat8(func(tinstant_value_p(inst1),
-      tinstant_value_p(inst2)));
-    if (d < curmin) { curmin = d; *tmin = inst1->t; }
+    /* Evaluate the distance at the synchronized instant, unless the segment
+     * leading to it cannot beat the running minimum */
+    if (lb < curmin)
+    {
+      double d = DatumGetFloat8(func(tinstant_value_p(inst1),
+        tinstant_value_p(inst2)));
+      if (d < curmin) { curmin = d; *tmin = inst1->t; }
+    }
     ninsts++;
     if (i == seq1->count || j == seq2->count)
       break;
@@ -1903,6 +1938,7 @@ nad_tcontseq_tcontseq_sync(const TSequence *seq1, const TSequence *seq2,
  * subtype (both #TSEQUENCE or both #TSEQUENCESET)
  * @param[in] func Base value distance function
  * @param[in] turnpt Per-segment distance turning-point function
+ * @param[in] seglb Per-segment distance lower-bound function
  * @param[out] tmin Timestamp achieving the minimum (set only when the result
  * is not infinity)
  * @return The minimum distance, or infinity if the time frames do not
@@ -1911,7 +1947,7 @@ nad_tcontseq_tcontseq_sync(const TSequence *seq1, const TSequence *seq2,
  */
 double
 nad_tcont_tcont_sync(const Temporal *temp1, const Temporal *temp2,
-  datum_func2 func, tpfunc_temp turnpt, TimestampTz *tmin)
+  datum_func2 func, tpfunc_temp turnpt, seglb_func seglb, TimestampTz *tmin)
 {
   if (temp1->subtype == TSEQUENCE)
   {
@@ -1920,7 +1956,7 @@ nad_tcont_tcont_sync(const Temporal *temp1, const Temporal *temp2,
         &((TSequence *) temp2)->period, &inter))
       return DBL_MAX;
     return nad_tcontseq_tcontseq_sync((TSequence *) temp1,
-      (TSequence *) temp2, &inter, func, turnpt, DBL_MAX, tmin);
+      (TSequence *) temp2, &inter, func, turnpt, seglb, DBL_MAX, tmin);
   }
   /* Both TSEQUENCESET: walk the overlapping component sequences */
   const TSequenceSet *ss1 = (const TSequenceSet *) temp1;
@@ -1934,7 +1970,7 @@ nad_tcont_tcont_sync(const Temporal *temp1, const Temporal *temp2,
     Span inter;
     if (inter_span_span(&seq1->period, &seq2->period, &inter))
       result = nad_tcontseq_tcontseq_sync(seq1, seq2, &inter, func, turnpt,
-        result, tmin);
+        seglb, result, tmin);
     int cmp = timestamptz_cmp_internal(
       DatumGetTimestampTz(seq1->period.upper),
       DatumGetTimestampTz(seq2->period.upper));
@@ -2537,8 +2573,10 @@ nai_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
       nad_tcont_tcont_sync_applies(temp1, temp2))
   {
     TimestampTz t;
+    seglb_func lb = MEOS_FLAGS_GET_GEODETIC(temp1->flags) ? NULL :
+      &tpointseg_distance_lb;
     if (nad_tcont_tcont_sync(temp1, temp2, geo_distance_fn(temp1->flags),
-      &tpointsegm_distance_turnpt, &t) != DBL_MAX)
+      &tpointsegm_distance_turnpt, lb, &t) != DBL_MAX)
     {
       /* The closest point may be at an exclusive bound => 3rd arg = false */
       Datum value;
@@ -2732,8 +2770,10 @@ nad_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
       nad_tcont_tcont_sync_applies(temp1, temp2))
   {
     TimestampTz t;
+    seglb_func lb = MEOS_FLAGS_GET_GEODETIC(temp1->flags) ? NULL :
+      &tpointseg_distance_lb;
     double d = nad_tcont_tcont_sync(temp1, temp2,
-      geo_distance_fn(temp1->flags), &tpointsegm_distance_turnpt, &t);
+      geo_distance_fn(temp1->flags), &tpointsegm_distance_turnpt, lb, &t);
     if (d != DBL_MAX)
       return d;
   }
@@ -2854,8 +2894,12 @@ shortestline_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
   bool fast = false;
   if (tpoint_type(temp1->temptype) &&
       nad_tcont_tcont_sync_applies(temp1, temp2))
+  {
+    seglb_func lb = MEOS_FLAGS_GET_GEODETIC(temp1->flags) ? NULL :
+      &tpointseg_distance_lb;
     fast = nad_tcont_tcont_sync(temp1, temp2, geo_distance_fn(temp1->flags),
-      &tpointsegm_distance_turnpt, &tmin) != DBL_MAX;
+      &tpointsegm_distance_turnpt, lb, &tmin) != DBL_MAX;
+  }
 
   Temporal *dist = NULL;
   if (! fast)


### PR DESCRIPTION
The synchronised nearest-approach running minimum takes a per-segment distance lower-bound function. When a segment lower bound already reaches the running minimum, neither its interior turning point nor its endpoint can improve the minimum, so both evaluations are skipped; the bound never exceeds the true distance minimum over the segment, so the result is exact. The lower bound is the box-to-box distance of the two segments endpoint boxes, expanded by the larger endpoint radius of each disc for the circular buffer family and zero for the point family, and is signed for circular buffers to match the signed circular buffer distance. The point family passes no bound for a geodetic metric, where the planar box distance is not a sound lower bound.