### PR TITLE
Collect statistics for the temporal pointcloud types

### DIFF
--- a/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
+++ b/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
@@ -88,7 +88,8 @@ CREATE TYPE tpcpoint (
   typmod_in = tpc_typmod_in,
   typmod_out = tpc_typmod_out,
   storage = extended,
-  alignment = double
+  alignment = double,
+  analyze = tspatial_analyze
 );
 
 -- Special cast for enforcing the typmod restriction on INSERT / cast.

--- a/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
+++ b/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
@@ -78,7 +78,8 @@ CREATE TYPE tpcpatch (
   typmod_in = tpc_typmod_in,
   typmod_out = tpc_typmod_out,
   storage = extended,
-  alignment = double
+  alignment = double,
+  analyze = tspatial_analyze
 );
 
 -- Special cast for enforcing the typmod restriction on INSERT / cast.

--- a/mobilitydb/src/geo/tspatial_analyze.c
+++ b/mobilitydb/src/geo/tspatial_analyze.c
@@ -73,6 +73,9 @@
 #include "pg_temporal/meos_catalog.h"
 #include "pg_temporal/span_analyze.h"
 #include "pg_temporal/temporal_analyze.h"
+#if POINTCLOUD
+  #include "pointcloud/tpc_boxops.h"
+#endif
 
 /*****************************************************************************
  * Functions copied from PostGIS file gserialized_estimate.c
@@ -604,7 +607,11 @@ gserialized_compute_stats(VacAttrStats *stats, AnalyzeAttrFetchFunc fetchfunc,
      * a temporal point while the original function gets a geometry.
      */
     MeosType type = oid_meostype(stats->attrtypid);
-    assert(spatialset_type(type) || tspatial_type(type));
+    assert(spatialset_type(type) || tspatial_type(type)
+#if POINTCLOUD
+      || tpointcloud_temptype(type)
+#endif
+      );
     if (spatialset_type(type))
     {
       /* Get bounding box from spatial set */
@@ -614,6 +621,20 @@ gserialized_compute_stats(VacAttrStats *stats, AnalyzeAttrFetchFunc fetchfunc,
       if (VARATT_IS_EXTENDED(set))
         pfree(set);
     }
+#if POINTCLOUD
+    else if (tpointcloud_temptype(type))
+    {
+      /* Get the bounding box from a temporal pointcloud value, projecting its
+       * TPCBox to an STBox (dropping the schema-specific pcid) */
+      Temporal *temp = DatumGetTemporalP(datum);
+      TPCBox tpcbox;
+      temporal_set_bbox(temp, &tpcbox);
+      tpcbox_set_stbox(&tpcbox, &box);
+      /* Free up memory if our temporal value was copied */
+      if (VARATT_IS_EXTENDED(temp))
+        pfree(temp);
+    }
+#endif
     else /* tspatial_type(type) */
     {
       /* Get bounding box from temporal point */

--- a/mobilitydb/test/pointcloud/expected/437_tpc_gist_tbl.test.out
+++ b/mobilitydb/test/pointcloud/expected/437_tpc_gist_tbl.test.out
@@ -168,3 +168,7 @@ RESET enable_indexscan;
 RESET
 RESET enable_bitmapscan;
 RESET
+ANALYZE tbl_tpcpoint;
+ANALYZE
+ANALYZE tbl_tpcpatch;
+ANALYZE

--- a/mobilitydb/test/pointcloud/queries/437_tpc_gist_tbl.test.sql
+++ b/mobilitydb/test/pointcloud/queries/437_tpc_gist_tbl.test.sql
@@ -125,4 +125,9 @@ RESET enable_seqscan;
 RESET enable_indexscan;
 RESET enable_bitmapscan;
 
+-- typanalyze: ANALYZE must succeed on the temporal pointcloud columns; tspatial_analyze
+-- projects each TPCBox bounding box to an STBox for the spatial statistics
+ANALYZE tbl_tpcpoint;
+ANALYZE tbl_tpcpatch;
+
 -------------------------------------------------------------------------------


### PR DESCRIPTION
The temporal pointcloud types `tpcpoint` and `tpcpatch` carry a `tpcbox` spatial
bounding box and GiST indexes, but their `CREATE TYPE` registers no analyze function, so
the planner has no column statistics for them.

Register `analyze = tspatial_analyze` for both types and teach the shared spatial
statistics collector to accept a temporal pointcloud column: it projects each value's
`TPCBox` to an `STBox` — dropping the schema-specific `pcid` — through the existing
`tpcbox_set_stbox`, then reuses the same 2D/ND and time statistics path as the other
spatial temporal types. The projection is required rather than a raw reinterpretation
because a `TPCBox` shares its leading layout with an `STBox` only up to the SRID: the
`pcid` sits before the flags, so reading the box directly would misread the flags.

An `ANALYZE` test on the temporal pointcloud tables exercises the new path.
