### PR TITLE
Export the forgotten external trgeometry I/O and restriction functions and align their naming

### DIFF
--- a/meos/include/meos_rgeo.h
+++ b/meos/include/meos_rgeo.h
@@ -74,7 +74,11 @@
  * Input/output functions
  *****************************************************************************/
 
+extern Temporal *trgeometry_in(const char *str);
+extern Temporal *trgeometry_from_mfjson(const char *mfjson);
 extern char *trgeometry_out(const Temporal *temp);
+extern char *trgeometry_as_text(const Temporal *temp, int maxdd);
+extern char *trgeometry_as_ewkt(const Temporal *temp, int maxdd);
 
 /*****************************************************************************
  * Constructor functions
@@ -84,14 +88,14 @@ extern TInstant *trgeometryinst_make(const GSERIALIZED *geom, const Pose *pose, 
 extern TSequence *trgeometryseq_make(const GSERIALIZED *geom, TInstant **instants, int count, bool lower_inc, bool upper_inc, interpType interp, bool normalize);
 extern TSequenceSet *trgeometryseqset_make(const GSERIALIZED *geom, TSequence **sequences, int count, bool normalize);
 extern TSequenceSet *trgeometryseqset_make_gaps(const GSERIALIZED *geom, TInstant **instants, int count, interpType interp, const Interval *maxt, double maxdist);
-extern Temporal *geo_tpose_to_trgeometry(const GSERIALIZED *gs, const Temporal *temp);
+extern Temporal *geometry_tpose_to_trgeometry(const GSERIALIZED *gs, const Temporal *temp);
 
 /*****************************************************************************
  * Conversion functions
  *****************************************************************************/
 
 extern Temporal *trgeometry_to_tpose(const Temporal *temp);
-extern Temporal *trgeometry_to_tpoint(const Temporal *temp);
+extern Temporal *trgeometry_to_tgeompoint(const Temporal *temp);
 extern Temporal *trgeometry_to_tgeometry(const Temporal *temp);
 
 /*****************************************************************************
@@ -168,6 +172,18 @@ extern Temporal *trgeometry_at_geom(const Temporal *temp, const GSERIALIZED *gs)
 extern Temporal *trgeometry_minus_geom(const Temporal *temp, const GSERIALIZED *gs);
 extern Temporal *trgeometry_at_stbox(const Temporal *temp, const STBox *box, bool border_inc);
 extern Temporal *trgeometry_minus_stbox(const Temporal *temp, const STBox *box, bool border_inc);
+extern Temporal *trgeometry_at_value(const Temporal *temp, const GSERIALIZED *gs);
+extern Temporal *trgeometry_minus_value(const Temporal *temp, const GSERIALIZED *gs);
+extern Temporal *trgeometry_at_values(const Temporal *temp, const Set *s);
+extern Temporal *trgeometry_minus_values(const Temporal *temp, const Set *s);
+extern Temporal *trgeometry_at_timestamptz(const Temporal *temp, TimestampTz t);
+extern Temporal *trgeometry_minus_timestamptz(const Temporal *temp, TimestampTz t);
+extern Temporal *trgeometry_at_tstzset(const Temporal *temp, const Set *s);
+extern Temporal *trgeometry_minus_tstzset(const Temporal *temp, const Set *s);
+extern Temporal *trgeometry_at_tstzspan(const Temporal *temp, const Span *s);
+extern Temporal *trgeometry_minus_tstzspan(const Temporal *temp, const Span *s);
+extern Temporal *trgeometry_at_tstzspanset(const Temporal *temp, const SpanSet *ss);
+extern Temporal *trgeometry_minus_tstzspanset(const Temporal *temp, const SpanSet *ss);
 // extern Temporal *trgeometry_at_geo(const Temporal *temp, const GSERIALIZED *gs);
 // extern Temporal *trgeometry_at_elevation(const Temporal *temp, const Span *s);
 // extern Temporal *trgeometry_minus_geo(const Temporal *temp, const GSERIALIZED *gs);

--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -135,9 +135,10 @@ ensure_valid_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2)
  * @brief Return a temporal rigid geometry from its Well-Known Text (WKT)
  * representation
  * @param[in] str String
+ * @csqlfn #Trgeometry_in()
  */
 Temporal *
-trgeo_in(const char *str)
+trgeometry_in(const char *str)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(str, NULL);
@@ -152,7 +153,7 @@ trgeo_in(const char *str)
  * @see #temporal_from_mfjson()
  */
 Temporal *
-trgeo_from_mfjson(const char *mfjson)
+trgeometry_from_mfjson(const char *mfjson)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(mfjson, NULL);
@@ -218,9 +219,10 @@ trgeo_wkt_out(const Temporal *temp, int maxdd, bool extended)
  * geometry
  * @param[in] temp Temporal rigid geometry
  * @param[in] maxdd Maximum number of decimal digits
+ * @csqlfn #Trgeometry_as_text()
  */
 char *
-trgeo_as_text(const Temporal *temp, int maxdd)
+trgeometry_as_text(const Temporal *temp, int maxdd)
 {
   return trgeo_wkt_out(temp, maxdd, false);
 }
@@ -231,9 +233,10 @@ trgeo_as_text(const Temporal *temp, int maxdd)
  * temporal rigid geometry
  * @param[in] temp Temporal rigid geometry
  * @param[in] maxdd Maximum number of decimal digits
+ * @csqlfn #Trgeometry_as_ewkt()
  */
 char *
-trgeo_as_ewkt(const Temporal *temp, int maxdd)
+trgeometry_as_ewkt(const Temporal *temp, int maxdd)
 {
   return trgeo_wkt_out(temp, maxdd, true);
 }
@@ -274,7 +277,7 @@ trgeometry_to_tpose(const Temporal *temp)
  * @csqlfn #Trgeometry_to_tpoint()
  */
 Temporal *
-trgeometry_to_tpoint(const Temporal *temp)
+trgeometry_to_tgeompoint(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
@@ -399,7 +402,7 @@ geo_tposeseqset_to_trgeo(const GSERIALIZED *gs, const TSequenceSet *ss)
  * @param[in] temp Temporal pose
  */
 Temporal *
-geo_tpose_to_trgeometry(const GSERIALIZED *gs, const Temporal *temp)
+geometry_tpose_to_trgeometry(const GSERIALIZED *gs, const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TPOSE(temp, NULL); VALIDATE_NOT_NULL(gs, NULL);
@@ -932,7 +935,7 @@ trgeometry_round(const Temporal *temp, int maxdd)
   Temporal *tpose = trgeometry_to_tpose(temp);
   GSERIALIZED *res_geo = geo_round(trgeo_geom_p(temp), maxdd);
   Temporal *res_tpose = temporal_round(tpose, maxdd);
-  Temporal *result = geo_tpose_to_trgeometry(res_geo, res_tpose);
+  Temporal *result = geometry_tpose_to_trgeometry(res_geo, res_tpose);
   pfree(tpose); pfree(res_geo); pfree(res_tpose);
   return result;
 }
@@ -1044,7 +1047,7 @@ trgeometry_set_interp(const Temporal *temp, interpType interp)
     return NULL;
   /* We need to explicitly set the temporal type to T_TPOSE */
   res->temptype = T_TPOSE;
-  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
+  Temporal *result = geometry_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res); pfree(tpose);
   return result;
 }
@@ -1073,7 +1076,7 @@ trgeometry_restrict_value(const Temporal *temp, Datum value, bool atfunc)
   Temporal *res = temporal_restrict_value(temp, value, atfunc);
   if (! res)
     return NULL;
-  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
+  Temporal *result = geometry_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res);
   return result;
 }
@@ -1086,7 +1089,7 @@ trgeometry_restrict_value(const Temporal *temp, Datum value, bool atfunc)
  * @csqlfn #Temporal_at_value()
  */
 Temporal *
-trgeo_at_value(const Temporal *temp, const GSERIALIZED *gs)
+trgeometry_at_value(const Temporal *temp, const GSERIALIZED *gs)
 {
   return trgeometry_restrict_value(temp, PointerGetDatum(gs), REST_AT);
 }
@@ -1099,7 +1102,7 @@ trgeo_at_value(const Temporal *temp, const GSERIALIZED *gs)
  * @csqlfn #Temporal_minus_value()
  */
 Temporal *
-trgeo_minus_value(const Temporal *temp, const GSERIALIZED *gs)
+trgeometry_minus_value(const Temporal *temp, const GSERIALIZED *gs)
 {
   return trgeometry_restrict_value(temp, PointerGetDatum(gs), REST_MINUS);
 }
@@ -1123,7 +1126,7 @@ trgeometry_restrict_values(const Temporal *temp, const Set *s, bool atfunc)
   Temporal *res = temporal_restrict_values(temp, s, atfunc);
   if (! res)
     return NULL;
-  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
+  Temporal *result = geometry_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res);
   return result;
 }
@@ -1136,7 +1139,7 @@ trgeometry_restrict_values(const Temporal *temp, const Set *s, bool atfunc)
  * @csqlfn #Temporal_at_values()
  */
 Temporal *
-trgeo_at_values(const Temporal *temp, const Set *s)
+trgeometry_at_values(const Temporal *temp, const Set *s)
 {
   return trgeometry_restrict_values(temp, s, REST_AT);
 }
@@ -1150,7 +1153,7 @@ trgeo_at_values(const Temporal *temp, const Set *s)
  * @param[in] s Set of values
  */
 Temporal *
-trgeo_minus_values(const Temporal *temp, const Set *s)
+trgeometry_minus_values(const Temporal *temp, const Set *s)
 {
   return trgeometry_restrict_values(temp, s, REST_MINUS);
 }
@@ -1177,7 +1180,7 @@ trgeometry_restrict_timestamptz(const Temporal *temp, TimestampTz t, bool atfunc
   pfree(tpose); 
   if (! res)
     return NULL;
-  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
+  Temporal *result = geometry_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res);
   return result;
 }
@@ -1190,7 +1193,7 @@ trgeometry_restrict_timestamptz(const Temporal *temp, TimestampTz t, bool atfunc
  * @csqlfn #Temporal_at_timestamptz()
  */
 Temporal *
-trgeo_at_timestamptz(const Temporal *temp, TimestampTz t)
+trgeometry_at_timestamptz(const Temporal *temp, TimestampTz t)
 {
   return trgeometry_restrict_timestamptz(temp, t, REST_AT);
 }
@@ -1204,7 +1207,7 @@ trgeo_at_timestamptz(const Temporal *temp, TimestampTz t)
  * @csqlfn #Temporal_minus_timestamptz()
  */
 Temporal *
-trgeo_minus_timestamptz(const Temporal *temp, TimestampTz t)
+trgeometry_minus_timestamptz(const Temporal *temp, TimestampTz t)
 {
   return trgeometry_restrict_timestamptz(temp, t, REST_MINUS);
 }
@@ -1230,7 +1233,7 @@ trgeometry_restrict_tstzset(const Temporal *temp, const Set *s, bool atfunc)
   pfree(tpose);
   if (! res)
     return NULL;
-  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
+  Temporal *result = geometry_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res);
   return result;
 }
@@ -1243,7 +1246,7 @@ trgeometry_restrict_tstzset(const Temporal *temp, const Set *s, bool atfunc)
  * @csqlfn #Temporal_at_tstzspanset()
  */
 Temporal *
-trgeo_at_tstzset(const Temporal *temp, const Set *s)
+trgeometry_at_tstzset(const Temporal *temp, const Set *s)
 {
   return trgeometry_restrict_tstzset(temp, s, REST_AT);
 }
@@ -1257,7 +1260,7 @@ trgeo_at_tstzset(const Temporal *temp, const Set *s)
  * @csqlfn #Temporal_minus_tstzspanset()
  */
 Temporal *
-trgeo_minus_tstzset(const Temporal *temp, const Set *s)
+trgeometry_minus_tstzset(const Temporal *temp, const Set *s)
 {
   return trgeometry_restrict_tstzset(temp, s, REST_MINUS);
 }
@@ -1283,7 +1286,7 @@ trgeometry_restrict_tstzspan(const Temporal *temp, const Span *s, bool atfunc)
   pfree(tpose);
   if (! res)
     return NULL;
-  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
+  Temporal *result = geometry_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res);
   return result;
 }
@@ -1296,7 +1299,7 @@ trgeometry_restrict_tstzspan(const Temporal *temp, const Span *s, bool atfunc)
  * @csqlfn #Temporal_at_tstzspan()
  */
 Temporal *
-trgeo_at_tstzspan(const Temporal *temp, const Span *s)
+trgeometry_at_tstzspan(const Temporal *temp, const Span *s)
 {
   return trgeometry_restrict_tstzspan(temp, s, REST_AT);
 }
@@ -1310,7 +1313,7 @@ trgeo_at_tstzspan(const Temporal *temp, const Span *s)
  * @csqlfn #Temporal_minus_tstzspan()
  */
 Temporal *
-trgeo_minus_tstzspan(const Temporal *temp, const Span *s)
+trgeometry_minus_tstzspan(const Temporal *temp, const Span *s)
 {
   return trgeometry_restrict_tstzspan(temp, s, REST_MINUS);
 }
@@ -1337,7 +1340,7 @@ trgeometry_restrict_tstzspanset(const Temporal *temp, const SpanSet *ss,
   pfree(tpose);
   if (! res)
     return NULL;
-  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
+  Temporal *result = geometry_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res);
   return result;
 }
@@ -1350,7 +1353,7 @@ trgeometry_restrict_tstzspanset(const Temporal *temp, const SpanSet *ss,
  * @csqlfn #Temporal_at_tstzspanset()
  */
 Temporal *
-trgeo_at_tstzspanset(const Temporal *temp, const SpanSet *ss)
+trgeometry_at_tstzspanset(const Temporal *temp, const SpanSet *ss)
 {
   return trgeometry_restrict_tstzspanset(temp, ss, REST_AT);
 }
@@ -1364,7 +1367,7 @@ trgeo_at_tstzspanset(const Temporal *temp, const SpanSet *ss)
  * @csqlfn #Temporal_minus_tstzspanset()
  */
 Temporal *
-trgeo_minus_tstzspanset(const Temporal *temp, const SpanSet *ss)
+trgeometry_minus_tstzspanset(const Temporal *temp, const SpanSet *ss)
 {
   return trgeometry_restrict_tstzspanset(temp, ss, REST_MINUS);
 }
@@ -1392,7 +1395,7 @@ trgeometry_before_timestamptz(const Temporal *temp, TimestampTz t, bool atfunc)
   pfree(tpose); 
   if (! res)
     return NULL;
-  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
+  Temporal *result = geometry_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res);
   return result;
 }
@@ -1418,7 +1421,7 @@ trgeometry_after_timestamptz(const Temporal *temp, TimestampTz t, bool atfunc)
   pfree(tpose); 
   if (! res)
     return NULL;
-  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
+  Temporal *result = geometry_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res);
   return result;
 }
@@ -1466,7 +1469,7 @@ trgeometry_append_tinstant(Temporal *temp, const TInstant *inst,
     pfree(tpose); pfree(tpose_inst);
     return NULL;
   }
-  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
+  Temporal *result = geometry_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res); pfree(tpose); pfree(tpose_inst);
   return result;
 }
@@ -1500,7 +1503,7 @@ trgeometry_append_tsequence(Temporal *temp, const TSequence *seq, bool expand)
     pfree(tpose); pfree(tpose_seq);
     return NULL;
   }
-  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
+  Temporal *result = geometry_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res); pfree(tpose); pfree(tpose_seq);
   return result;
 }
@@ -1522,7 +1525,7 @@ trgeometry_delete_timestamptz(const Temporal *temp, TimestampTz t, bool connect)
   pfree(tpose);
   if (! res)
     return NULL;
-  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
+  Temporal *result = geometry_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res);
   return result;
 }
@@ -1547,7 +1550,7 @@ trgeometry_delete_tstzset(const Temporal *temp, const Set *s, bool connect)
   pfree(tpose);
   if (! res)
     return NULL;
-  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
+  Temporal *result = geometry_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res);
   return result;
 }
@@ -1571,7 +1574,7 @@ trgeometry_delete_tstzspan(const Temporal *temp, const Span *s, bool connect)
   pfree(tpose);
   if (! res)
     return NULL;
-  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
+  Temporal *result = geometry_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res);
   return result;
 }
@@ -1596,7 +1599,7 @@ trgeometry_delete_tstzspanset(const Temporal *temp, const SpanSet *ss,
   pfree(tpose);
   if (! res)
     return NULL;
-  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
+  Temporal *result = geometry_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res);
   return result;
 }

--- a/meos/src/rgeo/trgeo_spatialfuncs.c
+++ b/meos/src/rgeo/trgeo_spatialfuncs.c
@@ -465,7 +465,7 @@ trgeo_restrict_overlap(const Temporal *temp, const SpanSet *ss, bool atfunc)
   pfree(tpose);
   if (! res)
     return NULL;
-  Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
+  Temporal *result = geometry_tpose_to_trgeometry(trgeo_geom_p(temp), res);
   pfree(res);
   return result;
 }
@@ -768,8 +768,8 @@ trgeometry_hausdorff_distance(const Temporal *temp1, const Temporal *temp2)
 {
   if (! ensure_valid_trgeo_trgeo(temp1, temp2))
     return DBL_MAX;
-  Temporal *tp1 = trgeometry_to_tpoint(temp1);
-  Temporal *tp2 = trgeometry_to_tpoint(temp2);
+  Temporal *tp1 = trgeometry_to_tgeompoint(temp1);
+  Temporal *tp2 = trgeometry_to_tgeompoint(temp2);
   double result = temporal_hausdorff_distance(tp1, tp2);
   pfree(tp1); pfree(tp2);
   return result;
@@ -787,8 +787,8 @@ trgeometry_frechet_distance(const Temporal *temp1, const Temporal *temp2)
 {
   if (! ensure_valid_trgeo_trgeo(temp1, temp2))
     return DBL_MAX;
-  Temporal *tp1 = trgeometry_to_tpoint(temp1);
-  Temporal *tp2 = trgeometry_to_tpoint(temp2);
+  Temporal *tp1 = trgeometry_to_tgeompoint(temp1);
+  Temporal *tp2 = trgeometry_to_tgeompoint(temp2);
   double result = temporal_similarity(tp1, tp2, FRECHET);
   pfree(tp1); pfree(tp2);
   return result;
@@ -806,8 +806,8 @@ trgeometry_dyntimewarp_distance(const Temporal *temp1, const Temporal *temp2)
 {
   if (! ensure_valid_trgeo_trgeo(temp1, temp2))
     return DBL_MAX;
-  Temporal *tp1 = trgeometry_to_tpoint(temp1);
-  Temporal *tp2 = trgeometry_to_tpoint(temp2);
+  Temporal *tp1 = trgeometry_to_tgeompoint(temp1);
+  Temporal *tp2 = trgeometry_to_tgeompoint(temp2);
   double result = temporal_similarity(tp1, tp2, DYNTIMEWARP);
   pfree(tp1); pfree(tp2);
   return result;
@@ -830,8 +830,8 @@ trgeometry_frechet_path(const Temporal *temp1, const Temporal *temp2, int *count
   *count = 0;
   if (! ensure_valid_trgeo_trgeo(temp1, temp2))
     return NULL;
-  Temporal *tp1 = trgeometry_to_tpoint(temp1);
-  Temporal *tp2 = trgeometry_to_tpoint(temp2);
+  Temporal *tp1 = trgeometry_to_tgeompoint(temp1);
+  Temporal *tp2 = trgeometry_to_tgeompoint(temp2);
   Match *result = temporal_similarity_path(tp1, tp2, count, FRECHET);
   pfree(tp1); pfree(tp2);
   return result;
@@ -854,8 +854,8 @@ trgeometry_dyntimewarp_path(const Temporal *temp1, const Temporal *temp2, int *c
   *count = 0;
   if (! ensure_valid_trgeo_trgeo(temp1, temp2))
     return NULL;
-  Temporal *tp1 = trgeometry_to_tpoint(temp1);
-  Temporal *tp2 = trgeometry_to_tpoint(temp2);
+  Temporal *tp1 = trgeometry_to_tgeompoint(temp1);
+  Temporal *tp2 = trgeometry_to_tgeompoint(temp2);
   Match *result = temporal_similarity_path(tp1, tp2, count, DYNTIMEWARP);
   pfree(tp1); pfree(tp2);
   return result;
@@ -878,7 +878,7 @@ trgeometry_length(const Temporal *temp)
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, -1.0);
 
-  Temporal *tpoint = trgeometry_to_tpoint(temp);
+  Temporal *tpoint = trgeometry_to_tgeompoint(temp);
   double result = tpoint_length(tpoint);
   pfree(tpoint);
   return result;
@@ -897,7 +897,7 @@ trgeometry_cumulative_length(const Temporal *temp)
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
 
-  Temporal *tpoint = trgeometry_to_tpoint(temp);
+  Temporal *tpoint = trgeometry_to_tgeompoint(temp);
   Temporal *result = tpoint_cumulative_length(tpoint);
   pfree(tpoint);
   return result;
@@ -915,7 +915,7 @@ trgeometry_speed(const Temporal *temp)
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
 
-  Temporal *tpoint = trgeometry_to_tpoint(temp);
+  Temporal *tpoint = trgeometry_to_tgeompoint(temp);
   Temporal *result = temporal_derivative(tpoint);
   pfree(tpoint);
   return result;
@@ -934,7 +934,7 @@ trgeometry_twcentroid(const Temporal *temp)
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
 
-  Temporal *tpoint = trgeometry_to_tpoint(temp);
+  Temporal *tpoint = trgeometry_to_tgeompoint(temp);
   GSERIALIZED *result = tpoint_twcentroid(tpoint);
   pfree(tpoint);
   return result;
@@ -1118,7 +1118,7 @@ trgeometry_traversed_area(const Temporal *temp, bool unary_union)
  * reference geometry and emits the resulting polygon. The returned
  * `tgeometry` has the same temporal structure as the input and the same
  * SRID as the reference geometry.
- * @note Unlike `trgeometry_to_tpoint` (which gives the antenna point trajectory),
+ * @note Unlike `trgeometry_to_tgeompoint` (which gives the antenna point trajectory),
  * this preserves the body's footprint at each instant — the natural input
  * for compositional spatial-rel queries against `tgeometry`'s full surface.
  * @param[in] temp Temporal rigid geometry

--- a/meos/src/rgeo/trgeo_tile.c
+++ b/meos/src/rgeo/trgeo_tile.c
@@ -32,7 +32,7 @@
  * @brief Spatial and spatiotemporal grid tiling for temporal rigid geometries
  *
  * The boxes are computed on the temporal centroid trajectory
- * (`trgeometry_to_tpoint`) and thus reuse the `tgeo` tiling kernel, keeping the
+ * (`trgeometry_to_tgeompoint`) and thus reuse the `tgeo` tiling kernel, keeping the
  * trgeometry tiling surface aligned with the temporal geometry one.
  */
 
@@ -68,7 +68,7 @@ trgeometry_space_boxes(const Temporal *temp, double xsize, double ysize,
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
 
-  Temporal *tpoint = trgeometry_to_tpoint(temp);
+  Temporal *tpoint = trgeometry_to_tgeompoint(temp);
   STBox *result = tgeo_space_time_boxes(tpoint, xsize, ysize, zsize, NULL,
     sorigin, 0, bitmatrix, border_inc, count);
   pfree(tpoint);
@@ -97,7 +97,7 @@ trgeometry_space_time_boxes(const Temporal *temp, double xsize, double ysize,
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
 
-  Temporal *tpoint = trgeometry_to_tpoint(temp);
+  Temporal *tpoint = trgeometry_to_tgeompoint(temp);
   STBox *result = tgeo_space_time_boxes(tpoint, xsize, ysize, zsize, duration,
     sorigin, torigin, bitmatrix, border_inc, count);
   pfree(tpoint);

--- a/meos/src/temporal/temporal_analytics.c
+++ b/meos/src/temporal/temporal_analytics.c
@@ -998,7 +998,7 @@ temporal_tprecision(const Temporal *temp, const Interval *duration,
     Temporal *tpose = trgeometry_to_tpose(temp);
     Temporal *res = temporal_tprecision(tpose, duration, torigin);
     res->temptype = T_TPOSE;
-    Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
+    Temporal *result = geometry_tpose_to_trgeometry(trgeo_geom_p(temp), res);
     pfree(res); pfree(tpose);
     return result;
   }

--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -1516,7 +1516,7 @@ temporal_from_mfjson(const char *mfjson, MeosType temptype)
   json_object_put(poObj);
 #if RGEO
   if (temptype_orig == T_TRGEOMETRY && temptype == T_TPOSE)
-    return geo_tpose_to_trgeometry(gs, result);
+    return geometry_tpose_to_trgeometry(gs, result);
 #endif /* RGEO */
   return result;
 }
@@ -2586,7 +2586,7 @@ temporal_from_wkb_state(meos_wkb_parse_state *s)
 #if RGEO
   if (s->temptype == T_TPOSE && temptype_orig == T_TRGEOMETRY)
   {
-    Temporal *result = geo_tpose_to_trgeometry(gs, res);
+    Temporal *result = geometry_tpose_to_trgeometry(gs, res);
     pfree(gs); pfree(res);
     return result;
   }

--- a/mobilitydb/sql/rgeo/150_trgeo.in.sql
+++ b/mobilitydb/sql/rgeo/150_trgeo.in.sql
@@ -55,7 +55,7 @@ CREATE FUNCTION trgeometry_send(trgeometry)
   AS 'MODULE_PATHNAME', 'Trgeometry_send'
   LANGUAGE C IMMUTABLE STRICT;
 
-CREATE FUNCTION trgeo_typmod_in(cstring[])
+CREATE FUNCTION trgeometry_typmod_in(cstring[])
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Trgeometry_typmod_in'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -66,7 +66,7 @@ CREATE TYPE trgeometry (
   output = trgeometry_out,
   send = trgeometry_send,
   receive = trgeometry_recv,
-  typmod_in = trgeo_typmod_in,
+  typmod_in = trgeometry_typmod_in,
   typmod_out = tspatial_typmod_out,
   storage = extended,
   alignment = double,

--- a/mobilitydb/src/rgeo/trgeo.c
+++ b/mobilitydb/src/rgeo/trgeo.c
@@ -390,7 +390,7 @@ Trgeometry_constructor(PG_FUNCTION_ARGS)
 {
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(0);
   Temporal *tpose = PG_GETARG_TEMPORAL_P(1);
-  Temporal *result = geo_tpose_to_trgeometry(gs, tpose);
+  Temporal *result = geometry_tpose_to_trgeometry(gs, tpose);
   PG_FREE_IF_COPY(gs, 0);
   if (! result)
     PG_RETURN_NULL();
@@ -428,7 +428,7 @@ Datum
 Trgeometry_to_tpoint(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
-  Temporal *result = trgeometry_to_tpoint(temp);
+  Temporal *result = trgeometry_to_tgeompoint(temp);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_POINTER(result);
 }

--- a/mobilitydb/src/rgeo/trgeo_spatialfuncs.c
+++ b/mobilitydb/src/rgeo/trgeo_spatialfuncs.c
@@ -251,8 +251,8 @@ Trgeo_similarity_distance(FunctionCallInfo fcinfo, SimFunc simfunc)
     PG_FREE_IF_COPY(temp2, 1);
     PG_RETURN_NULL();
   }
-  Temporal *tp1 = trgeometry_to_tpoint(temp1);
-  Temporal *tp2 = trgeometry_to_tpoint(temp2);
+  Temporal *tp1 = trgeometry_to_tgeompoint(temp1);
+  Temporal *tp2 = trgeometry_to_tgeompoint(temp2);
   double result = (simfunc == HAUSDORFF) ?
     temporal_hausdorff_distance(tp1, tp2) :
     temporal_similarity(tp1, tp2, simfunc);
@@ -344,8 +344,8 @@ Trgeo_similarity_path(FunctionCallInfo fcinfo, SimFunc simfunc)
       MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
     Temporal *temp1 = PG_GETARG_TEMPORAL_P(0);
     Temporal *temp2 = PG_GETARG_TEMPORAL_P(1);
-    Temporal *tp1 = trgeometry_to_tpoint(temp1);
-    Temporal *tp2 = trgeometry_to_tpoint(temp2);
+    Temporal *tp1 = trgeometry_to_tgeompoint(temp1);
+    Temporal *tp2 = trgeometry_to_tgeompoint(temp2);
     int count;
     Match *path = temporal_similarity_path(tp1, tp2, &count, simfunc);
     pfree(tp1); pfree(tp2);

--- a/tools/codegen/gen_smoketest/gen_smoketest.py
+++ b/tools/codegen/gen_smoketest/gen_smoketest.py
@@ -383,7 +383,7 @@ TRGEO_CONFIG = dict(
     LINEAR, 0.0, NULL, false);
   TSequence    *trgeo_tseq1    = (TSequence *) trgeo_seq1;
   TSequenceSet *trgeo_tseqset1 = NULL;
-  Temporal *tpoint1 = trgeometry_to_tpoint(trgeo_seq1);
+  Temporal *tpoint1 = trgeometry_to_tgeompoint(trgeo_seq1);
   Temporal *tpose1 = trgeometry_to_tpose(trgeo_seq1);
   int n_out = 0;
 """,


### PR DESCRIPTION
## Change

On the trgeometry surface, public functions use the full `trgeometry_` prefix and internal helpers keep the abbreviated `trgeo_`. Several public-group functions carry the internal `trgeo_` abbreviation and have no declaration in `meos_rgeo.h`, so bindings and the generators cannot reach them.

- **Exports 16 public functions born-canonical.** The I/O functions `trgeometry_in`, `trgeometry_from_mfjson`, `trgeometry_as_text`, `trgeometry_as_ewkt` and the value/time restriction functions `trgeometry_at_`/`trgeometry_minus_` (`value`, `values`, `timestamptz`, `tstzset`, `tstzspan`, `tstzspanset`) take the `trgeometry_` prefix and gain `extern` declarations in `meos_rgeo.h`. These names are not part of the public surface today, so nothing external is renamed.
- **Aligns three already-public names to their canonical type token.** `trgeometry_to_tpoint` becomes `trgeometry_to_tgeompoint` (the conversion result is a temporal geometry point), `geo_tpose_to_trgeometry` becomes `geometry_tpose_to_trgeometry` (the reference base is a geometry), and the SQL type-support function `trgeo_typmod_in` becomes `trgeometry_typmod_in`. Only C symbols and the one SQL support name change; user-facing SQL function names stay the same.

The spatial-relationship and distance grid functions keep the `geo`/`tpoint` superclass tokens, which are the established cross-family convention.

## Effect

The trgeometry I/O and restriction functions are reachable from the header the bindings and smoketest generator consume, and the trgeometry C surface matches the canonical `<temptype>_<op>` / `<basetype>_<timetype>_to_<temptype>` patterns.