### PR TITLE
Synchronize the nearest-approach running minimum by a merge walk

### DIFF
--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -1859,14 +1859,23 @@ nad_tcontseq_tcontseq_sync(const TSequence *seq1, const TSequence *seq2,
     }
     else if (cmp < 0)
     {
+      /* Interpolate seq2 at inst1->t on its current segment, known from the
+       * merge position [j-1, j], avoiding a per-instant binary search */
       i++;
-      inst2 = tcontseq_at_timestamptz(seq2, inst1->t);
+      const TInstant *b1 = TSEQUENCE_INST_N(seq2, j - 1);
+      Datum v = tsegment_value_at_timestamptz(tinstant_value_p(b1),
+        tinstant_value_p(inst2), temptype, b1->t, inst2->t, inst1->t);
+      inst2 = tinstant_make_free(v, temptype, inst1->t);
       tofree[nfree++] = inst2;
     }
     else
     {
+      /* Interpolate seq1 at inst2->t on its current segment [i-1, i] */
       j++;
-      inst1 = tcontseq_at_timestamptz(seq1, inst2->t);
+      const TInstant *a1 = TSEQUENCE_INST_N(seq1, i - 1);
+      Datum v = tsegment_value_at_timestamptz(tinstant_value_p(a1),
+        tinstant_value_p(inst1), temptype, a1->t, inst1->t, inst2->t);
+      inst1 = tinstant_make_free(v, temptype, inst2->t);
       tofree[nfree++] = inst1;
     }
     /* A cheap segment lower bound gates the whole segment: when it already


### PR DESCRIPTION
The time-synchronous nearest-approach running minimum interpolates each sequence at the other sequence timestamps. The bracketing segment is known from the merge position, so the value is interpolated on that segment directly instead of being located by a per-instant binary search over the whole sequence.