### PR TITLE
Generate the Temporal value surface for the temporal pgpointcloud types

### DIFF
--- a/meos/include/meos_pointcloud.h
+++ b/meos/include/meos_pointcloud.h
@@ -393,10 +393,61 @@ extern bool overafter_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2);
 extern bool ensure_same_pcid_tpcbox(const TPCBox *box1, const TPCBox *box2);
 
 /*****************************************************************************
- * tpcpoint constructor and spatial predicates
+ * Temporal pgpointcloud types (tpcpoint / tpcpatch) — value surface
  *****************************************************************************/
 
-extern TInstant *tpointcloudinst_make(const Pcpoint *pt, TimestampTz t);
+#if MEOS
+  #define VALIDATE_TPCPOINT(temp, ret) \
+    do { \
+          if (! ensure_not_null((void *) (temp)) || \
+              ! ensure_temporal_isof_type((Temporal *) (temp), T_TPCPOINT) ) \
+           return (ret); \
+    } while (0)
+  #define VALIDATE_TPCPATCH(temp, ret) \
+    do { \
+          if (! ensure_not_null((void *) (temp)) || \
+              ! ensure_temporal_isof_type((Temporal *) (temp), T_TPCPATCH) ) \
+           return (ret); \
+    } while (0)
+#else
+  #define VALIDATE_TPCPOINT(temp, ret) \
+    do { assert(temp); \
+      assert(((Temporal *) (temp))->temptype == T_TPCPOINT); } while (0)
+  #define VALIDATE_TPCPATCH(temp, ret) \
+    do { assert(temp); \
+      assert(((Temporal *) (temp))->temptype == T_TPCPATCH); } while (0)
+#endif
+
+extern TInstant *tpcpointinst_make(const Pcpoint *pt, TimestampTz t);
+extern TSequence *tpcpointseq_from_base_tstzset(const Pcpoint *pt, const Set *s);
+extern TSequence *tpcpointseq_from_base_tstzspan(const Pcpoint *pt, const Span *sp);
+extern TSequenceSet *tpcpointseqset_from_base_tstzspanset(const Pcpoint *pt, const SpanSet *ss);
+extern Temporal *tpcpoint_from_base_temp(const Pcpoint *pt, const Temporal *temp);
+extern Pcpoint *tpcpoint_start_value(const Temporal *temp);
+extern Pcpoint *tpcpoint_end_value(const Temporal *temp);
+extern bool tpcpoint_value_n(const Temporal *temp, int n, Pcpoint **result);
+extern Pcpoint **tpcpoint_values(const Temporal *temp, int *count);
+extern bool tpcpoint_value_at_timestamptz(const Temporal *temp, TimestampTz t, bool strict, Pcpoint **value);
+extern Temporal *tpcpoint_at_value(const Temporal *temp, const Pcpoint *pt);
+extern Temporal *tpcpoint_minus_value(const Temporal *temp, const Pcpoint *pt);
+
+extern TInstant *tpcpatchinst_make(const Pcpatch *pa, TimestampTz t);
+extern TSequence *tpcpatchseq_from_base_tstzset(const Pcpatch *pa, const Set *s);
+extern TSequence *tpcpatchseq_from_base_tstzspan(const Pcpatch *pa, const Span *sp);
+extern TSequenceSet *tpcpatchseqset_from_base_tstzspanset(const Pcpatch *pa, const SpanSet *ss);
+extern Temporal *tpcpatch_from_base_temp(const Pcpatch *pa, const Temporal *temp);
+extern Pcpatch *tpcpatch_start_value(const Temporal *temp);
+extern Pcpatch *tpcpatch_end_value(const Temporal *temp);
+extern bool tpcpatch_value_n(const Temporal *temp, int n, Pcpatch **result);
+extern Pcpatch **tpcpatch_values(const Temporal *temp, int *count);
+extern bool tpcpatch_value_at_timestamptz(const Temporal *temp, TimestampTz t, bool strict, Pcpatch **value);
+extern Temporal *tpcpatch_at_value(const Temporal *temp, const Pcpatch *pa);
+extern Temporal *tpcpatch_minus_value(const Temporal *temp, const Pcpatch *pa);
+
+/*****************************************************************************
+ * tpcpoint spatial predicates
+ *****************************************************************************/
+
 extern bool eintersects_tpcpoint_geo(const Temporal *temp,
   const GSERIALIZED *gs);
 extern double nad_tpcpoint_geo(const Temporal *temp, const GSERIALIZED *gs);

--- a/meos/include/pointcloud/doxygen_meos_pointcloud.h
+++ b/meos/include/pointcloud/doxygen_meos_pointcloud.h
@@ -65,15 +65,15 @@
  *****************************************************************************/
 
 /**
- * @defgroup meos_pointcloud_inout Input and output functions
+ * @defgroup meos_pointcloud_base_inout Input and output functions
  * @ingroup meos_pointcloud_base
  * @brief Hex-WKB input / output functions for pcpoint and pcpatch
  *
- * @defgroup meos_pointcloud_accessor Accessor functions
+ * @defgroup meos_pointcloud_base_accessor Accessor functions
  * @ingroup meos_pointcloud_base
  * @brief Schema-aware coordinate accessors and metadata for pcpoint / pcpatch
  *
- * @defgroup meos_pointcloud_comp Comparison functions
+ * @defgroup meos_pointcloud_base_comp Comparison functions
  * @ingroup meos_pointcloud_base
  * @brief Equality, ordering, and hashing for pcpoint and pcpatch
  */
@@ -157,6 +157,14 @@
  * @defgroup meos_pointcloud_constructor Constructor functions
  * @ingroup meos_pointcloud
  * @brief Constructor functions for temporal pgpointcloud types
+ *
+ * @defgroup meos_pointcloud_accessor Accessor functions
+ * @ingroup meos_pointcloud
+ * @brief Accessor functions for temporal pgpointcloud types
+ *
+ * @defgroup meos_pointcloud_restrict Restriction functions
+ * @ingroup meos_pointcloud
+ * @brief Restriction functions for temporal pgpointcloud types
  *
  * @defgroup meos_pointcloud_dist Distance functions
  * @ingroup meos_pointcloud

--- a/meos/src/pointcloud/CMakeLists.txt
+++ b/meos/src/pointcloud/CMakeLists.txt
@@ -43,9 +43,15 @@ if(POINTCLOUD)
     # fast points(tpcpatch) SRF) delegate into.
     pcpatch_decompose.c
 
-    # Instant constructor and per-point geo-spatial predicates for tpcpoint:
-    # tpointcloudinst_make, eintersects_tpcpoint_geo, nad_tpcpoint_geo.
+    # Per-point geo-spatial predicates for tpcpoint: eintersects_tpcpoint_geo,
+    # nad_tpcpoint_geo.
     tpcpoint_spatialfuncs.c
+
+    # Temporal<T> value surface (constructors, accessors, restrictions) for the
+    # temporal pgpointcloud types, generated from the tjsonb reference by
+    # tools/codegen/temporal_basetype/generate.py.
+    tpcpoint.c
+    tpcpatch.c
   )
 
   # Probe whether the linked libpc.a already declares pc_patch_deserialize

--- a/meos/src/pointcloud/pcpatch.c
+++ b/meos/src/pointcloud/pcpatch.c
@@ -159,7 +159,7 @@ pcpatch_parse(const char **str, bool end)
 }
 
 /**
- * @ingroup meos_pointcloud_inout
+ * @ingroup meos_pointcloud_base_inout
  * @brief Return a pcpatch from its textual (hex-WKB) representation
  * @param[in] str String
  * @note PG-side input is provided by pgpointcloud's own
@@ -177,7 +177,7 @@ pcpatch_hex_in(const char *str)
 }
 
 /**
- * @ingroup meos_pointcloud_inout
+ * @ingroup meos_pointcloud_base_inout
  * @brief Return the textual (hex-WKB) representation of a pcpatch
  * @param[in] pa Patch
  * @param[in] maxdd Unused (kept for API uniformity with set_out)
@@ -197,7 +197,7 @@ pcpatch_hex_out(const Pcpatch *pa, int maxdd)
 }
 
 /**
- * @ingroup meos_pointcloud_inout
+ * @ingroup meos_pointcloud_base_inout
  * @brief Return a pcpatch from its hex-WKB representation
  */
 Pcpatch *
@@ -207,7 +207,7 @@ pcpatch_from_hexwkb(const char *hexwkb)
 }
 
 /**
- * @ingroup meos_pointcloud_inout
+ * @ingroup meos_pointcloud_base_inout
  * @brief Return the hex-WKB representation of a pcpatch
  */
 char *
@@ -235,7 +235,7 @@ pcpatch_copy(const Pcpatch *pa)
 }
 
 /**
- * @ingroup meos_pointcloud_accessor
+ * @ingroup meos_pointcloud_base_accessor
  * @brief Return the pcid (schema id) of a pcpatch
  * @csqlfn #Pcpatch_pcid()
  */
@@ -245,7 +245,7 @@ uint32_t pcpatch_get_pcid(const Pcpatch *pa)
 }
 
 /**
- * @ingroup meos_pointcloud_accessor
+ * @ingroup meos_pointcloud_base_accessor
  * @brief Return the number of points stored in a pcpatch
  */
 uint32_t pcpatch_npoints(const Pcpatch *pa)
@@ -254,7 +254,7 @@ uint32_t pcpatch_npoints(const Pcpatch *pa)
 }
 
 /**
- * @ingroup meos_pointcloud_accessor
+ * @ingroup meos_pointcloud_base_accessor
  * @brief Return the 32-bit hash of a pcpatch
  */
 uint32
@@ -266,7 +266,7 @@ pcpatch_hash(const Pcpatch *pa)
 }
 
 /**
- * @ingroup meos_pointcloud_accessor
+ * @ingroup meos_pointcloud_base_accessor
  * @brief Return the 64-bit hash of a pcpatch with a seed
  */
 uint64
@@ -282,7 +282,7 @@ pcpatch_hash_extended(const Pcpatch *pa, uint64 seed)
  *****************************************************************************/
 
 /**
- * @ingroup meos_pointcloud_comp
+ * @ingroup meos_pointcloud_base_comp
  * @brief Compare two pcpatch values byte-wise
  * @return -1 / 0 / 1
  * @note Compares only the meaningful-prefix bytes — pgpointcloud's
@@ -303,28 +303,28 @@ pcpatch_cmp(const Pcpatch *pa1, const Pcpatch *pa2)
 }
 
 /**
- * @ingroup meos_pointcloud_comp
+ * @ingroup meos_pointcloud_base_comp
  * @brief Return true if two pcpatch values are equal
  */
 bool pcpatch_eq(const Pcpatch *pa1, const Pcpatch *pa2)
 { return pcpatch_cmp(pa1, pa2) == 0; }
 
 /**
- * @ingroup meos_pointcloud_comp
+ * @ingroup meos_pointcloud_base_comp
  * @brief Return true if two pcpatch values differ
  */
 bool pcpatch_ne(const Pcpatch *pa1, const Pcpatch *pa2)
 { return pcpatch_cmp(pa1, pa2) != 0; }
 
 /**
- * @ingroup meos_pointcloud_comp
+ * @ingroup meos_pointcloud_base_comp
  * @brief Return true if the first pcpatch precedes the second in total order
  */
 bool pcpatch_lt(const Pcpatch *pa1, const Pcpatch *pa2)
 { return pcpatch_cmp(pa1, pa2) <  0; }
 
 /**
- * @ingroup meos_pointcloud_comp
+ * @ingroup meos_pointcloud_base_comp
  * @brief Return true if the first pcpatch precedes or equals the second
  *   in total order
  */
@@ -332,14 +332,14 @@ bool pcpatch_le(const Pcpatch *pa1, const Pcpatch *pa2)
 { return pcpatch_cmp(pa1, pa2) <= 0; }
 
 /**
- * @ingroup meos_pointcloud_comp
+ * @ingroup meos_pointcloud_base_comp
  * @brief Return true if the first pcpatch follows the second in total order
  */
 bool pcpatch_gt(const Pcpatch *pa1, const Pcpatch *pa2)
 { return pcpatch_cmp(pa1, pa2) >  0; }
 
 /**
- * @ingroup meos_pointcloud_comp
+ * @ingroup meos_pointcloud_base_comp
  * @brief Return true if the first pcpatch follows or equals the second
  *   in total order
  */

--- a/meos/src/pointcloud/pcpoint.c
+++ b/meos/src/pointcloud/pcpoint.c
@@ -204,7 +204,7 @@ pcpoint_parse(const char **str, bool end)
 }
 
 /**
- * @ingroup meos_pointcloud_inout
+ * @ingroup meos_pointcloud_base_inout
  * @brief Return a pcpoint from its textual (hex-WKB) representation
  * @param[in] str String
  * @note PG-side input is provided by pgpointcloud's own @c pcpoint_in,
@@ -222,7 +222,7 @@ pcpoint_hex_in(const char *str)
 }
 
 /**
- * @ingroup meos_pointcloud_inout
+ * @ingroup meos_pointcloud_base_inout
  * @brief Return the textual (hex-WKB) representation of a pcpoint
  * @param[in] pt Point
  * @param[in] maxdd Unused (kept for API uniformity with set_out)
@@ -242,7 +242,7 @@ pcpoint_hex_out(const Pcpoint *pt, int maxdd)
 }
 
 /**
- * @ingroup meos_pointcloud_inout
+ * @ingroup meos_pointcloud_base_inout
  * @brief Return a pcpoint from its hex-WKB representation
  */
 Pcpoint *
@@ -252,7 +252,7 @@ pcpoint_from_hexwkb(const char *hexwkb)
 }
 
 /**
- * @ingroup meos_pointcloud_inout
+ * @ingroup meos_pointcloud_base_inout
  * @brief Return the hex-WKB representation of a pcpoint
  */
 char *
@@ -284,7 +284,7 @@ pcpoint_copy(const Pcpoint *pt)
  *****************************************************************************/
 
 /**
- * @ingroup meos_pointcloud_accessor
+ * @ingroup meos_pointcloud_base_accessor
  * @brief Return the pcid (schema id) of a pcpoint
  * @csqlfn #Pcpoint_pcid()
  */
@@ -296,7 +296,7 @@ pcpoint_get_pcid(const Pcpoint *pt)
 }
 
 /**
- * @ingroup meos_pointcloud_accessor
+ * @ingroup meos_pointcloud_base_accessor
  * @brief Return the 32-bit hash of a pcpoint
  * @note Hashes only the meaningful-prefix bytes — pgpointcloud's
  *   struct-tail padding is skipped because it holds uninitialized heap
@@ -311,7 +311,7 @@ pcpoint_hash(const Pcpoint *pt)
 }
 
 /**
- * @ingroup meos_pointcloud_accessor
+ * @ingroup meos_pointcloud_base_accessor
  * @brief Return the 64-bit seeded hash of a pcpoint
  */
 uint64
@@ -331,7 +331,7 @@ pcpoint_hash_extended(const Pcpoint *pt, uint64 seed)
  *****************************************************************************/
 
 /**
- * @ingroup meos_pointcloud_comp
+ * @ingroup meos_pointcloud_base_comp
  * @brief Compare two pcpoints byte-wise
  * @return -1 / 0 / 1
  * @note Compares only the meaningful-prefix bytes — pgpointcloud's
@@ -353,28 +353,28 @@ pcpoint_cmp(const Pcpoint *pt1, const Pcpoint *pt2)
 }
 
 /**
- * @ingroup meos_pointcloud_comp
+ * @ingroup meos_pointcloud_base_comp
  * @brief Return true if two pcpoints are equal
  */
 bool pcpoint_eq(const Pcpoint *pt1, const Pcpoint *pt2)
 { return pcpoint_cmp(pt1, pt2) == 0; }
 
 /**
- * @ingroup meos_pointcloud_comp
+ * @ingroup meos_pointcloud_base_comp
  * @brief Return true if two pcpoints differ
  */
 bool pcpoint_ne(const Pcpoint *pt1, const Pcpoint *pt2)
 { return pcpoint_cmp(pt1, pt2) != 0; }
 
 /**
- * @ingroup meos_pointcloud_comp
+ * @ingroup meos_pointcloud_base_comp
  * @brief Return true if the first pcpoint precedes the second in total order
  */
 bool pcpoint_lt(const Pcpoint *pt1, const Pcpoint *pt2)
 { return pcpoint_cmp(pt1, pt2) <  0; }
 
 /**
- * @ingroup meos_pointcloud_comp
+ * @ingroup meos_pointcloud_base_comp
  * @brief Return true if the first pcpoint precedes or equals the second
  *   in total order
  */
@@ -382,14 +382,14 @@ bool pcpoint_le(const Pcpoint *pt1, const Pcpoint *pt2)
 { return pcpoint_cmp(pt1, pt2) <= 0; }
 
 /**
- * @ingroup meos_pointcloud_comp
+ * @ingroup meos_pointcloud_base_comp
  * @brief Return true if the first pcpoint follows the second in total order
  */
 bool pcpoint_gt(const Pcpoint *pt1, const Pcpoint *pt2)
 { return pcpoint_cmp(pt1, pt2) >  0; }
 
 /**
- * @ingroup meos_pointcloud_comp
+ * @ingroup meos_pointcloud_base_comp
  * @brief Return true if the first pcpoint follows or equals the second
  *   in total order
  */
@@ -421,7 +421,7 @@ pcpoint_as_pcpt(const Pcpoint *pt, PCSCHEMA *schema, PCPOINT *out)
 }
 
 /**
- * @ingroup meos_pointcloud_accessor
+ * @ingroup meos_pointcloud_base_accessor
  * @brief Return the X coordinate of a pcpoint via the given schema
  * @param[in] pt Point
  * @param[in] schema Point cloud schema
@@ -442,7 +442,7 @@ pcpoint_get_x(const Pcpoint *pt, PCSCHEMA *schema, double *out)
 }
 
 /**
- * @ingroup meos_pointcloud_accessor
+ * @ingroup meos_pointcloud_base_accessor
  * @brief Return the Y coordinate of a pcpoint via the given schema
  * @param[in] pt Point
  * @param[in] schema Point cloud schema
@@ -461,7 +461,7 @@ pcpoint_get_y(const Pcpoint *pt, PCSCHEMA *schema, double *out)
 }
 
 /**
- * @ingroup meos_pointcloud_accessor
+ * @ingroup meos_pointcloud_base_accessor
  * @brief Return the Z coordinate of a pcpoint via the given schema
  * @param[in] pt Point
  * @param[in] schema Point cloud schema
@@ -480,7 +480,7 @@ pcpoint_get_z(const Pcpoint *pt, PCSCHEMA *schema, double *out)
 }
 
 /**
- * @ingroup meos_pointcloud_accessor
+ * @ingroup meos_pointcloud_base_accessor
  * @brief Return any named dimension of a pcpoint via the given schema
  * @param[in] pt Point
  * @param[in] schema Point cloud schema

--- a/meos/src/pointcloud/tpcpatch.c
+++ b/meos/src/pointcloud/tpcpatch.c
@@ -1,0 +1,278 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Temporal pgpointcloud patch value surface — the Temporal<T> value bridge
+ *   (constructors, accessors, restrictions), generated from the tjsonb reference
+ *   by tools/codegen/temporal_basetype/generate.py; DO NOT EDIT BY HAND.
+ */
+
+/* C */
+#include <assert.h>
+#include <float.h>
+/* PostgreSQL */
+#include <postgres.h>
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  #include "varatt.h"
+#endif
+/* MEOS */
+#include <meos.h>
+#include <meos_internal.h>
+#include <meos_pointcloud.h>
+#include "temporal/meos_catalog.h"
+#include "temporal/set.h"
+#include "temporal/span.h"
+#include "temporal/spanset.h"
+#include "temporal/temporal.h"
+#include "temporal/type_util.h"
+#include "pointcloud/pcpatch.h"
+/*****************************************************************************
+ * Constructor functions
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_pointcloud_constructor
+ * @brief Return a temporal pgpointcloud patch instant from a pgpointcloud patch and a timestamptz
+ * @param[in] pa Value
+ * @param[in] t Timestamp
+ * @csqlfn #Tinstant_constructor()
+ */
+TInstant *
+tpcpatchinst_make(const Pcpatch *pa, TimestampTz t)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pa, NULL);
+  return tinstant_make(PointerGetDatum(pa), T_TPCPATCH, t);
+}
+
+/**
+ * @ingroup meos_pointcloud_constructor
+ * @brief Return a temporal pgpointcloud patch discrete sequence from a pgpointcloud patch value and a
+ * timestamptz set
+ * @param[in] pa Value
+ * @param[in] s Set
+ * @csqlfn #Tsequence_from_base_tstzset()
+ */
+TSequence *
+tpcpatchseq_from_base_tstzset(const Pcpatch *pa, const Set *s)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pa, NULL); VALIDATE_TSTZSET(s, NULL);
+  return tsequence_from_base_tstzset(PointerGetDatum(pa), T_TPCPATCH, s);
+}
+
+/**
+ * @ingroup meos_pointcloud_constructor
+ * @brief Return a temporal pgpointcloud patch sequence from a pgpointcloud patch value and a timestamptz
+ * span
+ * @param[in] pa Value
+ * @param[in] sp Span
+ * @csqlfn #Tsequence_from_base_tstzspan()
+ */
+TSequence *
+tpcpatchseq_from_base_tstzspan(const Pcpatch *pa, const Span *sp)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pa, NULL); VALIDATE_TSTZSPAN(sp, NULL);
+  return tsequence_from_base_tstzspan(PointerGetDatum(pa), T_TPCPATCH, sp, STEP);
+}
+
+/**
+ * @ingroup meos_pointcloud_constructor
+ * @brief Return a temporal pgpointcloud patch sequence set from a pgpointcloud patch value and a
+ * timestamptz span set
+ * @param[in] pa Value
+ * @param[in] ss Span set
+ * @csqlfn #Tsequenceset_from_base_tstzspanset()
+ */
+TSequenceSet *
+tpcpatchseqset_from_base_tstzspanset(const Pcpatch *pa, const SpanSet *ss)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pa, NULL);
+  VALIDATE_TSTZSPANSET(ss, NULL);
+  /* Delegate to the generic tsequenceset constructor, with STEP interpolation */
+  return tsequenceset_from_base_tstzspanset(PointerGetDatum(pa),T_TPCPATCH, ss,
+    STEP);
+}
+
+/**
+ * @ingroup meos_pointcloud_constructor
+ * @brief Return a temporal pgpointcloud patch from a pgpointcloud patch and the time frame of
+ * another temporal value
+ * @param[in] pa Value
+ * @param[in] temp Temporal value
+ */
+Temporal *
+tpcpatch_from_base_temp(const Pcpatch *pa, const Temporal *temp)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pa, NULL); VALIDATE_NOT_NULL(temp, NULL);
+  return temporal_from_base_temp(PointerGetDatum(pa), T_TPCPATCH, temp);
+}
+
+/*****************************************************************************
+ * Accessor functions
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_pointcloud_accessor
+ * @brief Return the start value of a temporal pgpointcloud patch
+ * @param[in] temp Temporal value
+ * @return On error return @p NULL
+ * @csqlfn #Temporal_start_value()
+ */
+Pcpatch *
+tpcpatch_start_value(const Temporal *temp)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TPCPATCH(temp, NULL);
+  return DatumGetPcpatchP(temporal_start_value(temp));
+}
+
+/**
+ * @ingroup meos_pointcloud_accessor
+ * @brief Return the end value of a temporal pgpointcloud patch
+ * @param[in] temp Temporal value
+ * @return On error return @p NULL
+ * @csqlfn #Temporal_end_value()
+ */
+Pcpatch *
+tpcpatch_end_value(const Temporal *temp)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TPCPATCH(temp, NULL);
+  return DatumGetPcpatchP(temporal_end_value(temp));
+}
+
+/**
+ * @ingroup meos_pointcloud_accessor
+ * @brief Return the n-th value of a temporal pgpointcloud patch
+ * @param[in] temp Temporal value
+ * @param[in] n Number
+ * @param[out] result Value
+ * @csqlfn #Temporal_value_n()
+ */
+bool
+tpcpatch_value_n(const Temporal *temp, int n, Pcpatch **result)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TPCPATCH(temp, false); VALIDATE_NOT_NULL(result, false);
+  Datum dresult;
+  if (! temporal_value_n(temp, n, &dresult))
+    return false;
+  *result = DatumGetPcpatchP(dresult);
+  return true;
+}
+
+/**
+ * @ingroup meos_pointcloud_accessor
+ * @brief Return an array of copies of base values of a temporal pgpointcloud patch
+ * @param[in] temp Temporal value
+ * @param[out] count Number of values in the output array
+ * @csqlfn #Temporal_valueset()
+ */
+Pcpatch **
+tpcpatch_values(const Temporal *temp, int *count)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TPCPATCH(temp, NULL); VALIDATE_NOT_NULL(count, NULL);
+  Datum *datumarr = temporal_values_p(temp, count);
+  Pcpatch **result = palloc(sizeof(Pcpatch *) * *count);
+  for (int i = 0; i < *count; i++)
+    result[i] = pcpatch_copy(DatumGetPcpatchP(datumarr[i]));
+  pfree(datumarr);
+  return result;
+}
+
+/*****************************************************************************/
+
+/**
+ * @ingroup meos_pointcloud_accessor
+ * @brief Return the value of a temporal pgpointcloud patch at a timestamptz
+ * @param[in] temp Temporal value
+ * @param[in] t Timestamp
+ * @param[in] strict True if the timestamp must belong to the temporal value,
+ * false when it may be at an exclusive bound
+ * @param[out] value Resulting value
+ * @csqlfn #Temporal_value_at_timestamptz()
+ */
+bool
+tpcpatch_value_at_timestamptz(const Temporal *temp, TimestampTz t, bool strict,
+  Pcpatch **value)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TPCPATCH(temp, false); VALIDATE_NOT_NULL(value, false);
+  Datum res;
+  bool result = temporal_value_at_timestamptz(temp, t, strict, &res);
+  *value = DatumGetPcpatchP(res);
+  return result;
+}
+
+/*****************************************************************************
+ * Restriction functions
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_pointcloud_restrict
+ * @brief Return a temporal pgpointcloud patch restricted to a specific pgpointcloud patch value
+ * @param[in] temp Temporal value
+ * @param[in] pa pgpointcloud patch value
+ * @csqlfn #Temporal_at_value()
+ */
+Temporal *
+tpcpatch_at_value(const Temporal *temp, const Pcpatch *pa)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TPCPATCH(temp, NULL); VALIDATE_NOT_NULL(pa, NULL);
+  /* Restrict the temporal pgpointcloud patch to the instants where it equals the given pa */
+  return temporal_restrict_value(temp, PointerGetDatum(pa), REST_AT);
+}
+
+/**
+ * @ingroup meos_pointcloud_restrict
+ * @brief Return a temporal pgpointcloud patch restricted to the complement of a specific
+ * pgpointcloud patch value
+ * @param[in] temp Temporal value
+ * @param[in] pa pgpointcloud patch value
+ * @csqlfn #Temporal_minus_value()
+ */
+Temporal *
+tpcpatch_minus_value(const Temporal *temp, const Pcpatch *pa)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TPCPATCH(temp, NULL); VALIDATE_NOT_NULL(pa, NULL);
+  /* Restrict the temporal pgpointcloud patch to the instants where it does not equal the
+   * given pa */
+  return temporal_restrict_value(temp, PointerGetDatum(pa), REST_MINUS);
+}
+
+/*****************************************************************************/
+

--- a/meos/src/pointcloud/tpcpoint.c
+++ b/meos/src/pointcloud/tpcpoint.c
@@ -1,0 +1,278 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Temporal pgpointcloud point value surface — the Temporal<T> value bridge
+ *   (constructors, accessors, restrictions), generated from the tjsonb reference
+ *   by tools/codegen/temporal_basetype/generate.py; DO NOT EDIT BY HAND.
+ */
+
+/* C */
+#include <assert.h>
+#include <float.h>
+/* PostgreSQL */
+#include <postgres.h>
+#if POSTGRESQL_VERSION_NUMBER >= 160000
+  #include "varatt.h"
+#endif
+/* MEOS */
+#include <meos.h>
+#include <meos_internal.h>
+#include <meos_pointcloud.h>
+#include "temporal/meos_catalog.h"
+#include "temporal/set.h"
+#include "temporal/span.h"
+#include "temporal/spanset.h"
+#include "temporal/temporal.h"
+#include "temporal/type_util.h"
+#include "pointcloud/pcpoint.h"
+/*****************************************************************************
+ * Constructor functions
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_pointcloud_constructor
+ * @brief Return a temporal pgpointcloud point instant from a pgpointcloud point and a timestamptz
+ * @param[in] pt Value
+ * @param[in] t Timestamp
+ * @csqlfn #Tinstant_constructor()
+ */
+TInstant *
+tpcpointinst_make(const Pcpoint *pt, TimestampTz t)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pt, NULL);
+  return tinstant_make(PointerGetDatum(pt), T_TPCPOINT, t);
+}
+
+/**
+ * @ingroup meos_pointcloud_constructor
+ * @brief Return a temporal pgpointcloud point discrete sequence from a pgpointcloud point value and a
+ * timestamptz set
+ * @param[in] pt Value
+ * @param[in] s Set
+ * @csqlfn #Tsequence_from_base_tstzset()
+ */
+TSequence *
+tpcpointseq_from_base_tstzset(const Pcpoint *pt, const Set *s)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pt, NULL); VALIDATE_TSTZSET(s, NULL);
+  return tsequence_from_base_tstzset(PointerGetDatum(pt), T_TPCPOINT, s);
+}
+
+/**
+ * @ingroup meos_pointcloud_constructor
+ * @brief Return a temporal pgpointcloud point sequence from a pgpointcloud point value and a timestamptz
+ * span
+ * @param[in] pt Value
+ * @param[in] sp Span
+ * @csqlfn #Tsequence_from_base_tstzspan()
+ */
+TSequence *
+tpcpointseq_from_base_tstzspan(const Pcpoint *pt, const Span *sp)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pt, NULL); VALIDATE_TSTZSPAN(sp, NULL);
+  return tsequence_from_base_tstzspan(PointerGetDatum(pt), T_TPCPOINT, sp, STEP);
+}
+
+/**
+ * @ingroup meos_pointcloud_constructor
+ * @brief Return a temporal pgpointcloud point sequence set from a pgpointcloud point value and a
+ * timestamptz span set
+ * @param[in] pt Value
+ * @param[in] ss Span set
+ * @csqlfn #Tsequenceset_from_base_tstzspanset()
+ */
+TSequenceSet *
+tpcpointseqset_from_base_tstzspanset(const Pcpoint *pt, const SpanSet *ss)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pt, NULL);
+  VALIDATE_TSTZSPANSET(ss, NULL);
+  /* Delegate to the generic tsequenceset constructor, with STEP interpolation */
+  return tsequenceset_from_base_tstzspanset(PointerGetDatum(pt),T_TPCPOINT, ss,
+    STEP);
+}
+
+/**
+ * @ingroup meos_pointcloud_constructor
+ * @brief Return a temporal pgpointcloud point from a pgpointcloud point and the time frame of
+ * another temporal value
+ * @param[in] pt Value
+ * @param[in] temp Temporal value
+ */
+Temporal *
+tpcpoint_from_base_temp(const Pcpoint *pt, const Temporal *temp)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pt, NULL); VALIDATE_NOT_NULL(temp, NULL);
+  return temporal_from_base_temp(PointerGetDatum(pt), T_TPCPOINT, temp);
+}
+
+/*****************************************************************************
+ * Accessor functions
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_pointcloud_accessor
+ * @brief Return the start value of a temporal pgpointcloud point
+ * @param[in] temp Temporal value
+ * @return On error return @p NULL
+ * @csqlfn #Temporal_start_value()
+ */
+Pcpoint *
+tpcpoint_start_value(const Temporal *temp)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TPCPOINT(temp, NULL);
+  return DatumGetPcpointP(temporal_start_value(temp));
+}
+
+/**
+ * @ingroup meos_pointcloud_accessor
+ * @brief Return the end value of a temporal pgpointcloud point
+ * @param[in] temp Temporal value
+ * @return On error return @p NULL
+ * @csqlfn #Temporal_end_value()
+ */
+Pcpoint *
+tpcpoint_end_value(const Temporal *temp)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TPCPOINT(temp, NULL);
+  return DatumGetPcpointP(temporal_end_value(temp));
+}
+
+/**
+ * @ingroup meos_pointcloud_accessor
+ * @brief Return the n-th value of a temporal pgpointcloud point
+ * @param[in] temp Temporal value
+ * @param[in] n Number
+ * @param[out] result Value
+ * @csqlfn #Temporal_value_n()
+ */
+bool
+tpcpoint_value_n(const Temporal *temp, int n, Pcpoint **result)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TPCPOINT(temp, false); VALIDATE_NOT_NULL(result, false);
+  Datum dresult;
+  if (! temporal_value_n(temp, n, &dresult))
+    return false;
+  *result = DatumGetPcpointP(dresult);
+  return true;
+}
+
+/**
+ * @ingroup meos_pointcloud_accessor
+ * @brief Return an array of copies of base values of a temporal pgpointcloud point
+ * @param[in] temp Temporal value
+ * @param[out] count Number of values in the output array
+ * @csqlfn #Temporal_valueset()
+ */
+Pcpoint **
+tpcpoint_values(const Temporal *temp, int *count)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TPCPOINT(temp, NULL); VALIDATE_NOT_NULL(count, NULL);
+  Datum *datumarr = temporal_values_p(temp, count);
+  Pcpoint **result = palloc(sizeof(Pcpoint *) * *count);
+  for (int i = 0; i < *count; i++)
+    result[i] = pcpoint_copy(DatumGetPcpointP(datumarr[i]));
+  pfree(datumarr);
+  return result;
+}
+
+/*****************************************************************************/
+
+/**
+ * @ingroup meos_pointcloud_accessor
+ * @brief Return the value of a temporal pgpointcloud point at a timestamptz
+ * @param[in] temp Temporal value
+ * @param[in] t Timestamp
+ * @param[in] strict True if the timestamp must belong to the temporal value,
+ * false when it may be at an exclusive bound
+ * @param[out] value Resulting value
+ * @csqlfn #Temporal_value_at_timestamptz()
+ */
+bool
+tpcpoint_value_at_timestamptz(const Temporal *temp, TimestampTz t, bool strict,
+  Pcpoint **value)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TPCPOINT(temp, false); VALIDATE_NOT_NULL(value, false);
+  Datum res;
+  bool result = temporal_value_at_timestamptz(temp, t, strict, &res);
+  *value = DatumGetPcpointP(res);
+  return result;
+}
+
+/*****************************************************************************
+ * Restriction functions
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_pointcloud_restrict
+ * @brief Return a temporal pgpointcloud point restricted to a specific pgpointcloud point value
+ * @param[in] temp Temporal value
+ * @param[in] pt pgpointcloud point value
+ * @csqlfn #Temporal_at_value()
+ */
+Temporal *
+tpcpoint_at_value(const Temporal *temp, const Pcpoint *pt)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TPCPOINT(temp, NULL); VALIDATE_NOT_NULL(pt, NULL);
+  /* Restrict the temporal pgpointcloud point to the instants where it equals the given pt */
+  return temporal_restrict_value(temp, PointerGetDatum(pt), REST_AT);
+}
+
+/**
+ * @ingroup meos_pointcloud_restrict
+ * @brief Return a temporal pgpointcloud point restricted to the complement of a specific
+ * pgpointcloud point value
+ * @param[in] temp Temporal value
+ * @param[in] pt pgpointcloud point value
+ * @csqlfn #Temporal_minus_value()
+ */
+Temporal *
+tpcpoint_minus_value(const Temporal *temp, const Pcpoint *pt)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TPCPOINT(temp, NULL); VALIDATE_NOT_NULL(pt, NULL);
+  /* Restrict the temporal pgpointcloud point to the instants where it does not equal the
+   * given pt */
+  return temporal_restrict_value(temp, PointerGetDatum(pt), REST_MINUS);
+}
+
+/*****************************************************************************/
+

--- a/meos/src/pointcloud/tpcpoint_spatialfuncs.c
+++ b/meos/src/pointcloud/tpcpoint_spatialfuncs.c
@@ -8,12 +8,12 @@
 
 /**
  * @file
- * @brief Instant constructor and per-point spatial predicates for the
- *   tpcpoint temporal type.
+ * @brief Per-point spatial predicates for the tpcpoint temporal type.
  *
- * Provides the three entry-points needed for per-event streaming (e.g.
- * MobilityNebula NES operators): @ref tpointcloudinst_make,
- * @ref nad_tpcpoint_geo, and @ref eintersects_tpcpoint_geo.
+ * Provides the two per-event streaming entry-points (e.g. MobilityNebula NES
+ * operators): @ref nad_tpcpoint_geo and @ref eintersects_tpcpoint_geo. The
+ * instant constructor @ref tpcpointinst_make lives with the rest of the
+ * Temporal<T> value surface in @ref tpcpoint.c.
  */
 
 #include <assert.h>
@@ -34,24 +34,6 @@
 #include "temporal/temporal.h"  /* Temporal, TInstant */
 #include "temporal/meos_catalog.h"  /* T_TPCPOINT */
 #include "pointcloud/pcpoint.h" /* struct Pcpoint body (.pcid field) */
-
-/*****************************************************************************
- * Instant constructor
- *****************************************************************************/
-
-/**
- * @ingroup meos_pointcloud_constructor
- * @brief Return a tpcpoint instant from a pcpoint value and a timestamp
- * @param[in] pt Pcpoint value
- * @param[in] t Timestamp
- * @csqlfn #Tpointcloudinst_make()
- */
-TInstant *
-tpointcloudinst_make(const Pcpoint *pt, TimestampTz t)
-{
-  VALIDATE_NOT_NULL(pt, NULL);
-  return tinstant_make(PointerGetDatum(pt), T_TPCPOINT, t);
-}
 
 /*****************************************************************************
  * Internal helpers

--- a/tools/codegen/temporal_basetype/generate.py
+++ b/tools/codegen/temporal_basetype/generate.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Generate the MEOS-C Temporal<T> value surface for value-opaque base types.
+
+A value-opaque base type (jsonb, pcpoint, pcpatch, ...) stores its base value as an
+opaque varlena Datum, so the whole Temporal<T> value bridge — Constructors
+(inst_make / seq_from_base_* / from_base_temp), Accessors (start/end value, value_n,
+values, value_at_timestamptz) and Restrictions (at_value / minus_value) — is a pure
+Datum-move that differs only by a small token set. This generator takes the value
+sections of `meos/src/json/tjsonb.c` as the byte-for-byte REFERENCE, reverse-tokenizes
+them into a template, and re-renders the same sections for every other value-opaque
+type. `--validate` proves that re-rendering the jsonb row reproduces the live reference
+byte for byte (drift guard) and that no `json` token leaks into a target rendering.
+
+Modes:  --validate   reference self-reproduces + targets leak-free (exit 1 on mismatch)
+        --check      list the files that would be written
+        (default)    write the target .c files
+"""
+import argparse, pathlib, re, sys
+
+HERE = pathlib.Path(__file__).resolve().parent
+ROOT = HERE.parents[2]
+REFERENCE = ROOT / "meos/src/json/tjsonb.c"
+
+# Ordered reverse-token map: reference (jsonb) string -> {PLACEHOLDER}. Longest/most
+# specific first so no reference string is a substring of an earlier replacement.
+TOKENS = [
+    ("{COPY}",     "pg_jsonb_copy"),
+    ("{VALIDATE}", "VALIDATE_TJSONB"),
+    ("{TYPEENUM}", "T_TJSONB"),
+    ("{GROUP}",    "meos_json_"),
+    ("{DOCNOUN}",  "JSONB"),
+    ("{TEMP}",     "tjsonb"),
+    ("{VALTYPE}",  "Jsonb"),
+    ("{ARG}",      "jb"),   # word-bounded
+]
+
+# One row per value-opaque type. `reference: True` is the jsonb identity row used only
+# for --validate. Targets carry their token values, the output .c file and its includes.
+FAMILIES = [
+    {"name": "jsonb", "reference": True,
+     "{COPY}": "pg_jsonb_copy", "{VALIDATE}": "VALIDATE_TJSONB", "{TYPEENUM}": "T_TJSONB",
+     "{GROUP}": "meos_json_", "{DOCNOUN}": "JSONB", "{TEMP}": "tjsonb",
+     "{VALTYPE}": "Jsonb", "{ARG}": "jb"},
+    {"name": "pcpoint",
+     "{COPY}": "pcpoint_copy", "{VALIDATE}": "VALIDATE_TPCPOINT", "{TYPEENUM}": "T_TPCPOINT",
+     "{GROUP}": "meos_pointcloud_", "{DOCNOUN}": "pgpointcloud point", "{TEMP}": "tpcpoint",
+     "{VALTYPE}": "Pcpoint", "{ARG}": "pt",
+     "file": "meos/src/pointcloud/tpcpoint.c",
+     "valheader": "pointcloud/pcpoint.h"},
+    {"name": "pcpatch",
+     "{COPY}": "pcpatch_copy", "{VALIDATE}": "VALIDATE_TPCPATCH", "{TYPEENUM}": "T_TPCPATCH",
+     "{GROUP}": "meos_pointcloud_", "{DOCNOUN}": "pgpointcloud patch", "{TEMP}": "tpcpatch",
+     "{VALTYPE}": "Pcpatch", "{ARG}": "pa",
+     "file": "meos/src/pointcloud/tpcpatch.c",
+     "valheader": "pointcloud/pcpatch.h"},
+]
+
+COPYRIGHT = REFERENCE.read_text().split("*/\n", 1)[0] + "*/\n"
+
+def _section(src, name, endname):
+    beg = re.compile(r"/\*{5,}\n \* " + re.escape(name) + r"\n \*{5,}/\n").search(src)
+    end = re.compile(r"/\*{5,}\n \* " + re.escape(endname) + r"\n \*{5,}/\n").search(src, beg.end())
+    return src[beg.start(): end.start() if end else len(src)]
+
+def value_sections():
+    """The three generic value-bridge sections of the reference, concatenated."""
+    src = REFERENCE.read_text()
+    return (_section(src, "Constructor functions", "Conversion functions")
+          + _section(src, "Accessor functions", "Transformation functions")
+          + _section(src, "Restriction functions", "\x00none\x00"))
+
+def template():
+    tmpl = value_sections()
+    for ph, ref in TOKENS:
+        tmpl = re.sub(r"\b" + re.escape(ref) + r"\b", ph, tmpl) if ph == "{ARG}" \
+               else tmpl.replace(ref, ph)
+    return tmpl
+
+def render_sections(fam, tmpl):
+    out = tmpl
+    for ph, _ in TOKENS:
+        out = out.replace(ph, fam[ph])
+    return out
+
+def render_file(fam, tmpl):
+    inc = "\n".join([
+        "/* C */", "#include <assert.h>", "#include <float.h>",
+        "/* PostgreSQL */", "#include <postgres.h>",
+        "#if POSTGRESQL_VERSION_NUMBER >= 160000", '  #include "varatt.h"', "#endif",
+        "/* MEOS */", "#include <meos.h>", "#include <meos_internal.h>",
+        "#include <meos_pointcloud.h>",
+        '#include "temporal/meos_catalog.h"', '#include "temporal/set.h"',
+        '#include "temporal/span.h"', '#include "temporal/spanset.h"',
+        '#include "temporal/temporal.h"', '#include "temporal/type_util.h"',
+        f'#include "{fam["valheader"]}"',
+    ])
+    brief = (f"/**\n * @file\n * @brief Temporal {fam['{DOCNOUN}']} value surface — the "
+             f"Temporal<T> value bridge\n *   (constructors, accessors, restrictions), "
+             f"generated from the tjsonb reference\n *   by tools/codegen/temporal_basetype/"
+             f"generate.py; DO NOT EDIT BY HAND.\n */\n")
+    return COPYRIGHT + "\n" + brief + "\n" + inc + "\n" + render_sections(fam, tmpl)
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--validate", action="store_true")
+    ap.add_argument("--check", action="store_true")
+    args = ap.parse_args()
+    tmpl = template()
+    if args.validate:
+        ok = True
+        ref = value_sections()
+        for fam in FAMILIES:
+            if fam.get("reference"):
+                got = render_sections(fam, tmpl)
+                same = got == ref
+                ok = ok and same
+                print(f"[{'OK ' if same else 'DIFF'}] reference self-regen {fam['name']} "
+                      f"(byte-for-byte vs {REFERENCE.relative_to(ROOT)})")
+                if not same:
+                    for n,(a,b) in enumerate(zip(got.splitlines(), ref.splitlines()),1):
+                        if a!=b: print(f"     first diff line {n}: {a!r} vs {b!r}"); break
+            else:
+                leaks = re.findall(r"(?i)json", render_sections(fam, tmpl))
+                clean = not leaks
+                ok = ok and clean
+                print(f"[{'OK ' if clean else 'LEAK'}] target leak-free {fam['name']} "
+                      f"({len(leaks)} residual 'json')")
+        return 0 if ok else 1
+    for fam in FAMILIES:
+        if fam.get("reference"):
+            continue
+        p = ROOT / fam["file"]
+        if args.check:
+            print(f"would write {fam['file']}"); continue
+        p.write_text(render_file(fam, tmpl))
+        print(f"wrote {fam['file']}")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The temporal pgpointcloud types `tpcpoint` and `tpcpatch` lack the Temporal value
bridge that the other base-type families expose, so their base values cannot be
constructed or read back through the MEOS API. This adds that surface, mirroring
the `tjsonb` sibling.

## What this adds

For each of `tpcpoint` and `tpcpatch`, the value bridge into the generic temporal
machinery:

- **Constructors** — instant; discrete sequence from a timestamptz set; sequence
  from a timestamptz span; sequence set from a timestamptz span set; and from-base
  over the time frame of another temporal value.
- **Accessors** — start / end / n-th base value; the base value array; and the
  value at a timestamptz.
- **Restrictions** — restrict to, and restrict to the complement of, a base value.

Each function validates its arguments and performs a pure `Datum` move into the
generic `temporal_*` machinery, so it carries no type-specific logic.

## Generation

A new `tools/codegen/temporal_basetype` generator produces the two source files
from the `tjsonb` reference: it extracts the value sections of
`meos/src/json/tjsonb.c` and reverse-tokenizes them per family. Its `--validate`
mode re-renders the `jsonb` reference byte-for-byte and checks that the pointcloud
targets carry no residual `json` tokens.

## Naming and grouping

- The instant constructor is named `tpcpointinst_make` / `tpcpatchinst_make`,
  matching the `<type>inst_make` convention of the other families.
- The static `pcpoint` / `pcpatch` Doxygen groups move to `meos_pointcloud_base_*`,
  so the bare `meos_pointcloud_constructor`, `meos_pointcloud_accessor`, and
  `meos_pointcloud_restrict` groups name the temporal value surface, consistent
  with every other family.
