### PR TITLE
Take the synchronized value with tsegment_at_timestamptz in the merge walks

### DIFF
--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -1862,20 +1862,16 @@ nad_tcontseq_tcontseq_sync(const TSequence *seq1, const TSequence *seq2,
       /* Interpolate seq2 at inst1->t on its current segment, known from the
        * merge position [j-1, j], avoiding a per-instant binary search */
       i++;
-      const TInstant *b1 = TSEQUENCE_INST_N(seq2, j - 1);
-      Datum v = tsegment_value_at_timestamptz(tinstant_value_p(b1),
-        tinstant_value_p(inst2), temptype, b1->t, inst2->t, inst1->t);
-      inst2 = tinstant_make_free(v, temptype, inst1->t);
+      inst2 = tsegment_at_timestamptz(TSEQUENCE_INST_N(seq2, j - 1), inst2,
+        LINEAR, inst1->t);
       tofree[nfree++] = inst2;
     }
     else
     {
       /* Interpolate seq1 at inst2->t on its current segment [i-1, i] */
       j++;
-      const TInstant *a1 = TSEQUENCE_INST_N(seq1, i - 1);
-      Datum v = tsegment_value_at_timestamptz(tinstant_value_p(a1),
-        tinstant_value_p(inst1), temptype, a1->t, inst1->t, inst2->t);
-      inst1 = tinstant_make_free(v, temptype, inst2->t);
+      inst1 = tsegment_at_timestamptz(TSEQUENCE_INST_N(seq1, i - 1), inst1,
+        LINEAR, inst2->t);
       tofree[nfree++] = inst1;
     }
     /* A cheap segment lower bound gates the whole segment: when it already

--- a/meos/src/temporal/tsequence.c
+++ b/meos/src/temporal/tsequence.c
@@ -59,6 +59,7 @@
 #include "temporal/temporal.h"
 #include "temporal/tinstant.h"
 #include "temporal/temporal_boxops.h"
+#include "temporal/temporal_restrict.h"
 #include "temporal/type_util.h"
 #include "temporal/type_parser.h"
 #include "geo/tgeo_spatialfuncs.h"
@@ -2312,14 +2313,19 @@ synchronize_tsequence_tsequence(const TSequence *seq1, const TSequence *seq2,
     }
     else if (cmp < 0)
     {
+      /* Interpolate seq2 at inst1->t on its current segment [j-1, j], known
+       * from the merge position, avoiding a per-instant binary search */
       i++;
-      inst2 = tsequence_at_timestamptz(seq2, inst1->t);
+      inst2 = tsegment_at_timestamptz(TSEQUENCE_INST_N(seq2, j - 1), inst2,
+        interp2, inst1->t);
       tofree[nfree++] = inst2;
     }
     else
     {
+      /* Interpolate seq1 at inst2->t on its current segment [i-1, i] */
       j++;
-      inst1 = tsequence_at_timestamptz(seq1, inst2->t);
+      inst1 = tsegment_at_timestamptz(TSEQUENCE_INST_N(seq1, i - 1), inst1,
+        interp1, inst2->t);
       tofree[nfree++] = inst1;
     }
     /* If not the first instant add potential crossing before adding the new


### PR DESCRIPTION
The nearest-approach running minimum and the two-sequence synchronization interpolate each sequence at the other sequence timestamps. The bracketing segment is known from the merge position, so the value is taken on that segment directly through tsegment_at_timestamptz, honoring the sequence interpolation, instead of being located by a per-instant binary search over the whole sequence.