### PR TITLE
Copy the GeoJSON output of geo_as_geojson with its exact length

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -3724,7 +3724,10 @@ geo_as_geojson(const GSERIALIZED *gs, int option, int precision,
 
   LWGEOM *geom = lwgeom_from_gserialized(gs);
   lwvarlena_t *txt = lwgeom_to_geojson(geom, srs, precision, output_bbox);
-  char *result = pstrdup(VARDATA(txt));
+  /* The result of lwgeom_to_geojson is a length-prefixed lwvarlena_t whose data
+   * is not null-terminated; copy exactly its length so the string does not read
+   * past the end into adjacent memory */
+  char *result = pnstrdup(VARDATA(txt), LWSIZE_GET(txt->size) - LWVARHDRSZ);
   lwgeom_free(geom); pfree(txt);
   return result;
 }


### PR DESCRIPTION
## Problem

`lwgeom_to_geojson` returns a length-prefixed `lwvarlena_t` whose data is not null-terminated. `geo_as_geojson` duplicates it with `pstrdup`, which reads from the data start until it meets a null byte — past the end of the GeoJSON, into adjacent memory. When a temporal geometry or temporal rigid geometry has a reference geometry whose GeoJSON ends next to non-null bytes, that trailing memory is appended to the output and `asMFJSON` produces invalid JSON. This is allocator-sensitive, and is reported for `asMFJSON` on a `trgeometry` in the extension.

## Change

Copies exactly `LWSIZE_GET(txt->size) - LWVARHDRSZ` bytes with `pnstrdup`, so the string ends where the GeoJSON ends.

## Effect

`asMFJSON` on temporal geometry and temporal rigid geometry values is valid JSON. On the reported sample, the current code makes the `::jsonb` cast raise `invalid input syntax for type json`, while this change casts cleanly. `geo_as_geojson` is shared, so the fix covers `tgeometry` and `trgeometry` alike.