### PR TITLE
Add value restrictions to the temporal pgpointcloud types

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3509,6 +3509,9 @@
 				<title>Restricciones</title>
 				<itemizedlist>
 					<listitem>
+						<para><link linkend="tpcpoint_atValues"><varname>atValue</varname>, <varname>minusValue</varname>, <varname>atValues</varname>, <varname>minusValues</varname></link>: Restringir a (al complemento de) un valor o un conjunto de valores</para>
+					</listitem>
+					<listitem>
 						<para><link linkend="tpcpoint_atTime"><varname>atTime</varname>, <varname>minusTime</varname></link>: Restringir a (al complemento de) un selector de tiempo</para>
 					</listitem>
 					<listitem>
@@ -3585,6 +3588,9 @@
 			<sect3>
 				<title>Restricciones</title>
 				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpcpatch_atValues"><varname>atValue</varname>, <varname>minusValue</varname>, <varname>atValues</varname>, <varname>minusValues</varname></link>: Restringir a (al complemento de) un valor o un conjunto de valores</para>
+					</listitem>
 					<listitem>
 						<para><link linkend="tpcpatch_atTpcbox"><varname>atTpcbox</varname>, <varname>minusTpcbox</varname></link>: Restringir a los instantes cuyo parche se solapa con un tpcbox (nivel de parche)</para>
 					</listitem>

--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -705,6 +705,18 @@ SELECT ST_AsText(startValue(tpcpoint(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),
 		<sect2 xml:id="tpcpoint_restrictions">
 			<title>Restricciones</title>
 			<itemizedlist>
+				<listitem xml:id="tpcpoint_atValues">
+					<indexterm significance="normal"><primary><varname>atValue</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>minusValue</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>atValues</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>minusValues</varname></primary></indexterm>
+					<para>Restringir un tpcpoint a (al complemento de) un valor pcpoint o un conjunto de valores pcpoint</para>
+					<para><varname>atValue(tpcpoint,pcpoint) → tpcpoint</varname></para>
+					<para><varname>minusValue(tpcpoint,pcpoint) → tpcpoint</varname></para>
+					<para><varname>atValues(tpcpoint,pcpointset) → tpcpoint</varname></para>
+					<para><varname>minusValues(tpcpoint,pcpointset) → tpcpoint</varname></para>
+				</listitem>
+
 				<listitem xml:id="tpcpoint_atTime">
 					<indexterm significance="normal"><primary><varname>atTime</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>minusTime</varname></primary></indexterm>
@@ -892,6 +904,18 @@ SELECT t, point FROM points(tpcpatch(
 		<sect2 xml:id="tpcpatch_restrictions">
 			<title>Restricciones</title>
 			<itemizedlist>
+				<listitem xml:id="tpcpatch_atValues">
+					<indexterm significance="normal"><primary><varname>atValue</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>minusValue</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>atValues</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>minusValues</varname></primary></indexterm>
+					<para>Restringir un tpcpatch a (al complemento de) un valor pcpatch o un conjunto de valores pcpatch</para>
+					<para><varname>atValue(tpcpatch,pcpatch) → tpcpatch</varname></para>
+					<para><varname>minusValue(tpcpatch,pcpatch) → tpcpatch</varname></para>
+					<para><varname>atValues(tpcpatch,pcpatchset) → tpcpatch</varname></para>
+					<para><varname>minusValues(tpcpatch,pcpatchset) → tpcpatch</varname></para>
+				</listitem>
+
 				<listitem xml:id="tpcpatch_atTpcbox">
 					<indexterm significance="normal"><primary><varname>atTpcbox</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>minusTpcbox</varname></primary></indexterm>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3487,6 +3487,9 @@
 				<title>Restrictions</title>
 				<itemizedlist>
 					<listitem>
+						<para><link linkend="tpcpoint_atValues"><varname>atValue</varname>, <varname>minusValue</varname>, <varname>atValues</varname>, <varname>minusValues</varname></link>: Restrict to (the complement of) a value or a set of values</para>
+					</listitem>
+					<listitem>
 						<para><link linkend="tpcpoint_atTime"><varname>atTime</varname>, <varname>minusTime</varname></link>: Restrict to (the complement of) a time selector</para>
 					</listitem>
 					<listitem>
@@ -3563,6 +3566,9 @@
 			<sect3>
 				<title>Restrictions</title>
 				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpcpatch_atValues"><varname>atValue</varname>, <varname>minusValue</varname>, <varname>atValues</varname>, <varname>minusValues</varname></link>: Restrict to (the complement of) a value or a set of values</para>
+					</listitem>
 					<listitem>
 						<para><link linkend="tpcpatch_atTpcbox"><varname>atTpcbox</varname>, <varname>minusTpcbox</varname></link>: Restrict to the instants whose patch overlaps a tpcbox (patch-level)</para>
 					</listitem>

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -710,6 +710,18 @@ SELECT ST_AsText(startValue(tpcpoint(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),
 		<sect2 xml:id="tpcpoint_restrictions">
 			<title>Restrictions</title>
 			<itemizedlist>
+				<listitem xml:id="tpcpoint_atValues">
+					<indexterm significance="normal"><primary><varname>atValue</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>minusValue</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>atValues</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>minusValues</varname></primary></indexterm>
+					<para>Restrict a tpcpoint to (the complement of) a pcpoint value or a set of pcpoint values</para>
+					<para><varname>atValue(tpcpoint,pcpoint) → tpcpoint</varname></para>
+					<para><varname>minusValue(tpcpoint,pcpoint) → tpcpoint</varname></para>
+					<para><varname>atValues(tpcpoint,pcpointset) → tpcpoint</varname></para>
+					<para><varname>minusValues(tpcpoint,pcpointset) → tpcpoint</varname></para>
+				</listitem>
+
 				<listitem xml:id="tpcpoint_atTime">
 					<indexterm significance="normal"><primary><varname>atTime</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>minusTime</varname></primary></indexterm>
@@ -898,6 +910,18 @@ SELECT t, point FROM points(tpcpatch(
 		<sect2 xml:id="tpcpatch_restrictions">
 			<title>Restrictions</title>
 			<itemizedlist>
+				<listitem xml:id="tpcpatch_atValues">
+					<indexterm significance="normal"><primary><varname>atValue</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>minusValue</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>atValues</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>minusValues</varname></primary></indexterm>
+					<para>Restrict a tpcpatch to (the complement of) a pcpatch value or a set of pcpatch values</para>
+					<para><varname>atValue(tpcpatch,pcpatch) → tpcpatch</varname></para>
+					<para><varname>minusValue(tpcpatch,pcpatch) → tpcpatch</varname></para>
+					<para><varname>atValues(tpcpatch,pcpatchset) → tpcpatch</varname></para>
+					<para><varname>minusValues(tpcpatch,pcpatchset) → tpcpatch</varname></para>
+				</listitem>
+
 				<listitem xml:id="tpcpatch_atTpcbox">
 					<indexterm significance="normal"><primary><varname>atTpcbox</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>minusTpcbox</varname></primary></indexterm>

--- a/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
+++ b/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
@@ -406,6 +406,26 @@ CREATE CAST (tpcpoint AS tgeompoint) WITH FUNCTION tgeompoint(tpcpoint);
  * Restrictions
  ******************************************************************************/
 
+CREATE FUNCTION atValue(tpcpoint, pcpoint)
+  RETURNS tpcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_at_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION minusValue(tpcpoint, pcpoint)
+  RETURNS tpcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_minus_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION atValues(tpcpoint, pcpointset)
+  RETURNS tpcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_at_values'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION minusValues(tpcpoint, pcpointset)
+  RETURNS tpcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_minus_values'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE FUNCTION atTime(tpcpoint, timestamptz)
   RETURNS tpcpoint
   AS 'MODULE_PATHNAME', 'Temporal_at_timestamptz'

--- a/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
+++ b/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
@@ -372,6 +372,26 @@ CREATE FUNCTION numPoints(tpcpatch)
  * Restrictions
  ******************************************************************************/
 
+CREATE FUNCTION atValue(tpcpatch, pcpatch)
+  RETURNS tpcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_at_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION minusValue(tpcpatch, pcpatch)
+  RETURNS tpcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_minus_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION atValues(tpcpatch, pcpatchset)
+  RETURNS tpcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_at_values'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION minusValues(tpcpatch, pcpatchset)
+  RETURNS tpcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_minus_values'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE FUNCTION atTime(tpcpatch, timestamptz)
   RETURNS tpcpatch
   AS 'MODULE_PATHNAME', 'Temporal_at_timestamptz'

--- a/mobilitydb/test/pointcloud/expected/420_tpcpoint.test.out
+++ b/mobilitydb/test/pointcloud/expected/420_tpcpoint.test.out
@@ -180,6 +180,42 @@ SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::t
  t
 (1 row)
 
+SELECT atValue(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]),
+  PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[])) IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT minusValue(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]),
+  PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[])) IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT atValues(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]),
+  set(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]),
+    PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])])) IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT minusValues(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]),
+  set(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[])])) IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT atValue(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]),
+  PC_MakePoint(1, ARRAY[9.0, 9.0, 9.0]::float[])) IS NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
 SELECT atTime(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]),
   tstzspan '[2024-01-02, 2024-01-03]') IS NOT NULL;
  ?column? 

--- a/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
+++ b/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
@@ -205,6 +205,41 @@ SELECT (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), 
  t
 (1 row)
 
+SELECT atValue(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-04'::timestamptz)]), PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]))
+  IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT minusValue(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-04'::timestamptz)]), PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]))
+  IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT atValues(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-04'::timestamptz)]),
+  set(ARRAY[PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])])])) IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT minusValues(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-04'::timestamptz)]),
+  set(ARRAY[PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])])])) IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT atValue(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-04'::timestamptz)]),
+  PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[9.0, 9.0, 9.0]::float[])])) IS NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
 SELECT atTime(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz)]),
   tstzspan '[2024-01-02, 2024-01-03]') IS NOT NULL;
  ?column? 

--- a/mobilitydb/test/pointcloud/queries/420_tpcpoint.test.sql
+++ b/mobilitydb/test/pointcloud/queries/420_tpcpoint.test.sql
@@ -105,6 +105,20 @@ SELECT (:inst1) < (:inst2);
 -- Restrictions
 -------------------------------------------------------------------------------
 
+-- Value restrictions: present value → at non-null / minus non-null;
+-- value set → at / minus non-null; absent value → at NULL.
+SELECT atValue(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
+  PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[])) IS NOT NULL;
+SELECT minusValue(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
+  PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[])) IS NOT NULL;
+SELECT atValues(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
+  set(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]),
+    PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])])) IS NOT NULL;
+SELECT minusValues(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
+  set(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[])])) IS NOT NULL;
+SELECT atValue(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
+  PC_MakePoint(1, ARRAY[9.0, 9.0, 9.0]::float[])) IS NULL;
+
 SELECT atTime(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
   tstzspan '[2024-01-02, 2024-01-03]') IS NOT NULL;
 SELECT atTpcbox(:inst2, tpcbox_zt(0, 0, 0, 10, 10, 10,

--- a/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
+++ b/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
@@ -110,8 +110,21 @@ SELECT (:inst1) <> (:inst2);
 SELECT (:inst1) < (:inst2);
 
 -------------------------------------------------------------------------------
--- Restrictions — at/minusTime, at/minusTpcbox.
+-- Restrictions — at/minusValue(s), at/minusTime, at/minusTpcbox.
 -------------------------------------------------------------------------------
+
+-- Value restrictions: present value → at / minus non-null; value set →
+-- at / minus non-null; absent value → at NULL.
+SELECT atValue(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3, :inst4]), :patch1)
+  IS NOT NULL;
+SELECT minusValue(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3, :inst4]), :patch1)
+  IS NOT NULL;
+SELECT atValues(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3, :inst4]),
+  set(ARRAY[:patch1, :patch2])) IS NOT NULL;
+SELECT minusValues(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3, :inst4]),
+  set(ARRAY[:patch1])) IS NOT NULL;
+SELECT atValue(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3, :inst4]),
+  PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[9.0, 9.0, 9.0]::float[])])) IS NULL;
 
 SELECT atTime(tpcpatchSeq(ARRAY[:inst1, :inst2]),
   tstzspan '[2024-01-02, 2024-01-03]') IS NOT NULL;


### PR DESCRIPTION
The temporal pgpointcloud types `tpcpoint` and `tpcpatch` carry time and
bounding-box restrictions but not the value restrictions the other base-type
families provide. This adds them, mirroring the `tjsonb` sibling and completing
the restriction surface.

## What this adds

For `tpcpoint` and `tpcpatch`, restriction to (the complement of) a base value or
a set of base values:

- `atValue(tpcpoint, pcpoint)` / `minusValue(tpcpoint, pcpoint)`
- `atValues(tpcpoint, pcpointset)` / `minusValues(tpcpoint, pcpointset)`
- the same four for `tpcpatch` with `pcpatch` / `pcpatchset`

Each binds the generic `Temporal_at_value` / `Temporal_minus_value` /
`Temporal_at_values` / `Temporal_minus_values` wrapper — the same wrapper the
other families use — over the base-type equality that `pcpoint` and `pcpatch`
provide through `eEq`, so no type-specific C is required.

Regression tests exercise the four functions per type, and the reference and
pointcloud chapters in English and Spanish document them.
