### PR TITLE
Represent the circular buffer with the centre-point coordinates

### DIFF
--- a/meos/include/cbuffer/cbuffer.h
+++ b/meos/include/cbuffer/cbuffer.h
@@ -36,6 +36,8 @@
 
 /* PostgreSQL */
 #include <postgres.h>
+/* PostGIS */
+#include <liblwgeom.h>
 /* MEOS */
 #include <meos.h>
 #include <meos_cbuffer.h>
@@ -49,11 +51,10 @@
 struct Cbuffer
 {
   int32 vl_len_;        /**< Varlena header (do not touch directly!) */
-  double radius;        /**< radius */
-  Datum point;          /**< First 8 bytes of the point which is passed by 
-                             reference. The extra bytes needed are added upon 
-                             creation. */
-  /* variable-length data follows */
+  int32 srid;           /**< Spatial reference identifier */
+  double radius;        /**< Radius */
+  double x;             /**< X coordinate of the centre point */
+  double y;             /**< Y coordinate of the centre point */
 };
 
 /*****************************************************************************
@@ -92,7 +93,9 @@ extern char *cbuffer_wkt_out(Datum value, int maxdd, bool extended);
 
 /* Accessor functions */
 
-extern const GSERIALIZED *cbuffer_point_p(const Cbuffer *cb);
+extern const POINT2D *cbuffer_point2d_p(const Cbuffer *cb);
+extern Cbuffer *cbuffer_make_coords(int32_t srid, double x, double y,
+  double radius);
 
 extern Datum datum_cbuffer_round(Datum buffer, Datum size);
 

--- a/meos/src/cbuffer/cbuffer.c
+++ b/meos/src/cbuffer/cbuffer.c
@@ -47,6 +47,7 @@
 #endif
 #include "common/hashfn.h"
 #include "port/pg_bitutils.h"
+#include <utils/float.h>
 /* PostGIS */
 #include <liblwgeom.h>
 /* MEOS */
@@ -81,10 +82,11 @@ bool
 cbuffer_collinear(const Cbuffer *cb1, const Cbuffer *cb2, const Cbuffer *cb3,
   double ratio)
 {
-  Datum value1 = PointerGetDatum(&cb1->point);
-  Datum value2 = PointerGetDatum(&cb2->point);
-  Datum value3 = PointerGetDatum(&cb3->point);
-  if (! geopoint_collinear(value1, value2, value3, ratio, false, false))
+  /* Circular buffers are 2D and non-geodetic: replicate the point
+   * collinearity test of #geopoint_collinear on the raw coordinates */
+  double px = cb1->x + (cb3->x - cb1->x) * ratio;
+  double py = cb1->y + (cb3->y - cb1->y) * ratio;
+  if (fabs(cb2->x - px) > MEOS_EPSILON || fabs(cb2->y - py) > MEOS_EPSILON)
     return false;
   return float_collinear(cb1->radius, cb2->radius, cb3->radius, ratio);
 }
@@ -100,22 +102,23 @@ long double
 cbuffersegm_locate(const Cbuffer *start, const Cbuffer *end,
   const Cbuffer *value)
 {
-  const GSERIALIZED *gs1 = cbuffer_point_p(start);
-  const GSERIALIZED *gs2 = cbuffer_point_p(end);
-  const GSERIALIZED *gs = cbuffer_point_p(value);
   long double result1 = -1.0;
   long double result2 = -1.0;
-  if (! geopoint_eq(gs1, gs2))
+  if (! (float8_eq(start->x, end->x) && float8_eq(start->y, end->y)))
   {
+    GSERIALIZED *gs1 = cbuffer_point(start);
+    GSERIALIZED *gs2 = cbuffer_point(end);
+    GSERIALIZED *gs = cbuffer_point(value);
     result1 = pointsegm_locate(PointerGetDatum(gs1), PointerGetDatum(gs2),
       PointerGetDatum(gs), NULL);
+    pfree(gs1); pfree(gs2); pfree(gs);
     if (result1 < 0.0)
       return -1.0;
   }
   else
   {
     /* If constant segment and the point of the value is different */
-    if (! geopoint_eq(gs1, gs))
+    if (! (float8_eq(start->x, value->x) && float8_eq(start->y, value->y)))
       return -1.0;
   }
   if (start->radius != end->radius)
@@ -153,13 +156,12 @@ cbuffersegm_interpolate(const Cbuffer *start, const Cbuffer *end,
   long double ratio)
 {
   assert(ratio >= 0.0 && ratio <= 1.0);
-  Datum value1 = PointerGetDatum(&start->point);
-  Datum value2 = PointerGetDatum(&end->point);
-  Datum value = pointsegm_interpolate(value1, value2, ratio);
+  /* Circular buffers are 2D and non-geodetic: replicate the linear
+   * interpolation of #pointsegm_interpolate on the raw coordinates */
+  double x = start->x + (double) ((long double) (end->x - start->x) * ratio);
+  double y = start->y + (double) ((long double) (end->y - start->y) * ratio);
   double radius = floatsegm_interpolate(start->radius, end->radius, ratio);
-  Cbuffer *result = cbuffer_make(DatumGetGserializedP(value), radius);
-  pfree(DatumGetPointer(value));
-  return result;
+  return cbuffer_make_coords(start->srid, x, y, radius);
 }
 
 /*****************************************************************************
@@ -318,13 +320,13 @@ cbuffer_out(const Cbuffer *cb, int maxdd)
   if (! ensure_not_negative(maxdd))
     return NULL;
 
-  Datum d = PointerGetDatum(&cb->point);
-  char *point = basetype_out(d, T_GEOMETRY, maxdd);
+  GSERIALIZED *gs = cbuffer_point(cb);
+  char *point = basetype_out(PointerGetDatum(gs), T_GEOMETRY, maxdd);
   char *radius = float8_out(cb->radius, maxdd);
   size_t size = strlen(point) + strlen(radius) + 11; // Cbuffer(,) + end NULL
   char *result = palloc(size);
   snprintf(result, size, "Cbuffer(%s,%s)", point, radius);
-  pfree(point); pfree(radius);
+  pfree(point); pfree(radius); pfree(gs);
   return result;
 }
 
@@ -339,8 +341,7 @@ char *
 cbuffer_wkt_out(Datum value, int maxdd, bool extended)
 {
   Cbuffer *cb = DatumGetCbufferP(value);
-  Datum d = PointerGetDatum(&cb->point);
-  GSERIALIZED *gs = DatumGetGserializedP(d);
+  GSERIALIZED *gs = cbuffer_point(cb);
   LWGEOM *geom = lwgeom_from_gserialized(gs);
   size_t len;
   char *wkt = lwgeom_to_wkt(geom, extended ? WKT_EXTENDED : WKT_ISO, maxdd,
@@ -349,7 +350,7 @@ cbuffer_wkt_out(Datum value, int maxdd, bool extended)
   len += strlen(radius) + 11; // Cbuffer(,) + end NULL
   char *result = palloc(len);
   snprintf(result, len, "Cbuffer(%s,%s)", wkt, radius);
-  lwgeom_free(geom); pfree(wkt); pfree(radius);
+  lwgeom_free(geom); pfree(wkt); pfree(radius); pfree(gs);
   return result;
 }
 
@@ -483,18 +484,26 @@ cbuffer_make(const GSERIALIZED *point, double radius)
       ! ensure_not_negative_datum(Float8GetDatum(radius), T_FLOAT8))
     return NULL;
 
-  size_t value_offset = sizeof(Cbuffer) - sizeof(Datum);
-  size_t size = value_offset;
-  /* Create the circular buffer */
-  void *value_from = (void *) point;
-  size_t value_size = DOUBLE_PAD(VARSIZE(value_from));
-  size += value_size;
-  Cbuffer *result = palloc0(size);
-  void *value_to = ((char *) result) + value_offset;
-  memcpy(value_to, value_from, value_size);
-  /* Initialize the radius and the size of the variable-length structure */
+  const POINT2D *p = GSERIALIZED_POINT2D_P(point);
+  return cbuffer_make_coords(gserialized_get_srid(point), p->x, p->y, radius);
+}
+
+/**
+ * @ingroup meos_internal_cbuffer_base_constructor
+ * @brief Return a circular buffer from a 2D centre point and a radius
+ * @param[in] srid Spatial reference identifier
+ * @param[in] x,y Coordinates of the centre point
+ * @param[in] radius Radius
+ */
+Cbuffer *
+cbuffer_make_coords(int32_t srid, double x, double y, double radius)
+{
+  Cbuffer *result = palloc0(sizeof(Cbuffer));
+  SET_VARSIZE(result, sizeof(Cbuffer));
+  result->srid = srid;
   result->radius = radius;
-  SET_VARSIZE(result, size);
+  result->x = x;
+  result->y = y;
   return result;
 }
 
@@ -528,15 +537,12 @@ cbuffer_to_geom(const Cbuffer *cb)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(cb, NULL);
-  const GSERIALIZED *gs = DatumGetGserializedP(PointerGetDatum(&cb->point));
   /* A zero-radius circular buffer is geometrically its centre point: return
    * the point itself rather than a degenerate circle (lwcircle_make requires
    * a positive radius), matching the documented first-class zero-radius case */
   if (cb->radius == 0)
-    return geo_copy(gs);
-  const POINT2D *p = (POINT2D *) GS_POINT_PTR(gs);
-  int32_t srid = gserialized_get_srid(gs);
-  return geocircle_make(p->x, p->y, cb->radius, srid);
+    return cbuffer_point(cb);
+  return geocircle_make(cb->x, cb->y, cb->radius, cb->srid);
 }
 
 /**
@@ -650,14 +656,19 @@ bool
 cbuffer_set_stbox(const Cbuffer *cb, STBox *box)
 {
   assert(cb); assert(box);
-  const GSERIALIZED *point = cbuffer_point_p(cb);
-  bool result = geo_set_stbox(point, box);
+  /* Circular buffers are 2D and non-geodetic */
+  memset(box, 0, sizeof(STBox));
+  box->srid = cb->srid;
+  MEOS_FLAGS_SET_X(box->flags, true);
+  MEOS_FLAGS_SET_Z(box->flags, false);
+  MEOS_FLAGS_SET_T(box->flags, false);
+  MEOS_FLAGS_SET_GEODETIC(box->flags, false);
   /* Expand spatial coordinates with respect to radius */
-  box->xmin -= cb->radius;
-  box->ymin -= cb->radius;
-  box->xmax += cb->radius;
-  box->ymax += cb->radius;
-  return result;
+  box->xmin = cb->x - cb->radius;
+  box->ymin = cb->y - cb->radius;
+  box->xmax = cb->x + cb->radius;
+  box->ymax = cb->y + cb->radius;
+  return true;
 }
 
 /**
@@ -704,15 +715,14 @@ cbuffer_to_stbox(const Cbuffer *cb)
 
 /**
  * @ingroup meos_internal_cbuffer_base_accessor
- * @brief Return a pointer to the point of a circular buffer
+ * @brief Return a pointer to the centre point of a circular buffer
  * @param[in] cb Circular buffer
- * @csqlfn #Cbuffer_point()
  */
-inline const GSERIALIZED *
-cbuffer_point_p(const Cbuffer *cb)
+inline const POINT2D *
+cbuffer_point2d_p(const Cbuffer *cb)
 {
   assert(cb);
-  return (const GSERIALIZED *) (&cb->point);
+  return (const POINT2D *) (&cb->x);
 }
 
 /**
@@ -726,8 +736,7 @@ cbuffer_point(const Cbuffer *cb)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(cb, NULL);
-  const GSERIALIZED *gs = (const GSERIALIZED *) (&cb->point);
-  return geo_copy(gs);
+  return geopoint_make(cb->x, cb->y, 0.0, false, false, cb->srid);
 }
 
 /**
@@ -763,11 +772,10 @@ cbuffer_round(const Cbuffer *cb, int maxdd)
     return NULL;
 
   /* Set precision of the point and the radius */
-  GSERIALIZED *point = point_round((GSERIALIZED *) (&cb->point), maxdd);
+  double x = float8_round(cb->x, maxdd);
+  double y = float8_round(cb->y, maxdd);
   double radius = float8_round(cb->radius, maxdd);
-  Cbuffer *result = cbuffer_make(point, radius);
-  pfree(point);
-  return result;
+  return cbuffer_make_coords(cb->srid, x, y, radius);
 }
 
 /**
@@ -821,8 +829,7 @@ cbuffer_srid(const Cbuffer *cb)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(cb, SRID_INVALID);
-  return gserialized_get_srid(
-    DatumGetGserializedP(PointerGetDatum(&cb->point)));
+  return cb->srid;
 }
 
 /**
@@ -837,8 +844,7 @@ cbuffer_set_srid(Cbuffer *cb, int32_t srid)
 {
   /* Ensure the validity of the arguments */
   assert(cb);
-  GSERIALIZED *gs = DatumGetGserializedP(PointerGetDatum(&cb->point));
-  gserialized_set_srid(gs, srid);
+  cb->srid = srid;
   return;
 }
 
@@ -856,14 +862,17 @@ Cbuffer *
 cbuffer_transf_pj(const Cbuffer *cb, int32_t srid_to, const LWPROJ *pj)
 {
   VALIDATE_NOT_NULL(cb, NULL); assert(pj);
-  /* Copy the circular buffer to transform its point in place */
-  Cbuffer *result = cbuffer_copy(cb);
-  GSERIALIZED *gs = DatumGetGserializedP(PointerGetDatum(&result->point));
+  /* Reproject the centre point through a temporary geometry */
+  GSERIALIZED *gs = cbuffer_point(cb);
   if (! point_transf_pj(gs, srid_to, pj))
   {
-    pfree(result);
+    pfree(gs);
     return NULL;
   }
+  const POINT2D *p = GSERIALIZED_POINT2D_P(gs);
+  Cbuffer *result = cbuffer_make_coords(gserialized_get_srid(gs), p->x, p->y,
+    cb->radius);
+  pfree(gs);
   return result;
 }
 
@@ -941,9 +950,7 @@ cbuffer_transform_pipeline(const Cbuffer *cb, const char *pipeline,
 double
 cbuffer_distance(const Cbuffer *cb1, const Cbuffer *cb2)
 {
-  const POINT2D *p1 = GSERIALIZED_POINT2D_P(cbuffer_point_p(cb1));
-  const POINT2D *p2 = GSERIALIZED_POINT2D_P(cbuffer_point_p(cb2));
-  double result = Max(hypot(p2->x - p1->x, p2->y - p1->y) -
+  double result = Max(hypot(cb2->x - cb1->x, cb2->y - cb1->y) -
     cb1->radius - cb2->radius, 0);
   return result;
 }
@@ -1081,10 +1088,8 @@ point_inside_circle(const POINT2D *center, double radius, double x, double y)
 int
 cbuffer_contains(const Cbuffer *cb1, const Cbuffer *cb2)
 {
-  const GSERIALIZED *point1 = cbuffer_point_p(cb1);
-  const GSERIALIZED *point2 = cbuffer_point_p(cb2);
-  const POINT2D *pt1 = (POINT2D *) GS_POINT_PTR(point1);
-  const POINT2D *pt2 = (POINT2D *) GS_POINT_PTR(point2);
+  const POINT2D *pt1 = cbuffer_point2d_p(cb1);
+  const POINT2D *pt2 = cbuffer_point2d_p(cb2);
   if (! point_inside_circle(pt1, cb1->radius, pt2->x - cb2->radius, pt2->y) ||
       ! point_inside_circle(pt1, cb1->radius, pt2->x + cb2->radius, pt2->y) ||
       ! point_inside_circle(pt1, cb1->radius, pt2->x, pt2->y - cb2->radius) ||
@@ -1103,10 +1108,8 @@ cbuffer_contains(const Cbuffer *cb1, const Cbuffer *cb2)
 int
 cbuffer_covers(const Cbuffer *cb1, const Cbuffer *cb2)
 {
-  const GSERIALIZED *point1 = cbuffer_point_p(cb1);
-  const GSERIALIZED *point2 = cbuffer_point_p(cb2);
-  const POINT2D *pt1 = (POINT2D *) GS_POINT_PTR(point1);
-  const POINT2D *pt2 = (POINT2D *) GS_POINT_PTR(point2);
+  const POINT2D *pt1 = cbuffer_point2d_p(cb1);
+  const POINT2D *pt2 = cbuffer_point2d_p(cb2);
   if (! point_in_circle(pt1, cb1->radius, pt2->x - cb2->radius, pt2->y) ||
       ! point_in_circle(pt1, cb1->radius, pt2->x + cb2->radius, pt2->y) ||
       ! point_in_circle(pt1, cb1->radius, pt2->x, pt2->y - cb2->radius) ||
@@ -1152,9 +1155,7 @@ cbuffer_intersects(const Cbuffer *cb1, const Cbuffer *cb2)
 int
 cbuffer_touches(const Cbuffer *cb1, const Cbuffer *cb2)
 {
-  Datum d1 = PointerGetDatum(&cb1->point);
-  Datum d2 = PointerGetDatum(&cb2->point);
-  double dist1 = DatumGetFloat8(datum_pt_distance2d(d1, d2));
+  double dist1 = hypot(cb2->x - cb1->x, cb2->y - cb1->y);
   return (dist1 == cb1->radius + cb2->radius) ? 1 : 0;
 }
 
@@ -1360,9 +1361,8 @@ cbuffer_eq(const Cbuffer *cb1, const Cbuffer *cb2)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(cb1, false); VALIDATE_NOT_NULL(cb2, false);
-  Datum d1 = PointerGetDatum(&cb1->point);
-  Datum d2 = PointerGetDatum(&cb2->point);
-  return datum_point_eq(d1, d2) &&
+  return cb1->srid == cb2->srid &&
+    float8_eq(cb1->x, cb2->x) && float8_eq(cb1->y, cb2->y) &&
     fabs(cb1->radius - cb2->radius) < MEOS_EPSILON;
 }
 
@@ -1394,8 +1394,8 @@ cbuffer_same(const Cbuffer *cb1, const Cbuffer *cb2)
   if (fabs(cb1->radius - cb2->radius) > MEOS_EPSILON)
     return false;
   /* Same points */
-  return datum_point_same(PointerGetDatum(&cb1->point),
-    PointerGetDatum(&cb2->point));
+  return cb1->srid == cb2->srid &&
+    MEOS_FP_EQ(cb1->x, cb2->x) && MEOS_FP_EQ(cb1->y, cb2->y);
 }
 
 /**
@@ -1422,18 +1422,14 @@ cbuffer_cmp(const Cbuffer *cb1, const Cbuffer *cb2)
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(cb1, false); VALIDATE_NOT_NULL(cb2, false);
 
-  const GSERIALIZED *gs1 = (GSERIALIZED *) (&cb1->point);
-  const GSERIALIZED *gs2 = (GSERIALIZED *) (&cb2->point);
-  int32_t srid1 = gserialized_get_srid(gs1);
-  int32_t srid2 = gserialized_get_srid(gs2);
   /* Compare SRID */
-  if (srid1 < srid2)
+  if (cb1->srid < cb2->srid)
     return -1;
-  if (srid1 > srid2)
+  if (cb1->srid > cb2->srid)
     return 1;
   /* Compare coordinates */
-  const POINT2D *pt1 = (POINT2D *) GS_POINT_PTR(gs1);
-  const POINT2D *pt2 = (POINT2D *) GS_POINT_PTR(gs2);
+  const POINT2D *pt1 = cbuffer_point2d_p(cb1);
+  const POINT2D *pt2 = cbuffer_point2d_p(cb2);
   if (pt1->x < pt2->x)
     return -1;
   if (pt1->x > pt2->x)
@@ -1518,16 +1514,20 @@ cbuffer_hash(const Cbuffer *cb)
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(cb, INT_MAX);
 
-  /* Compute hashes of value and radius */
-  Datum d = PointerGetDatum(&cb->point);
-  uint32 point_hash = gserialized_hash(DatumGetGserializedP(d));
+  /* Compute hashes of the coordinates and the radius */
+  uint32 x_hash = float8_hash(cb->x);
+  uint32 y_hash = float8_hash(cb->y);
   uint32 radius_hash = float8_hash(cb->radius);
 
-  /* Merge hashes of value and radius */
-  uint32 result = point_hash;
+  /* Merge the hashes of the coordinates and the radius */
+  uint32 result = x_hash;
 #if POSTGRESQL_VERSION_NUMBER >= 150000
   result = pg_rotate_left32(result, 1);
+  result ^= y_hash;
+  result = pg_rotate_left32(result, 1);
 #else
+  result =  (result << 1) | (result >> 31);
+  result ^= y_hash;
   result =  (result << 1) | (result >> 31);
 #endif
   result ^= radius_hash;

--- a/meos/src/cbuffer/tcbuffer.c
+++ b/meos/src/cbuffer/tcbuffer.c
@@ -171,10 +171,10 @@ tcbuffersegm_dwithin_turnpt(Datum start1, Datum end1, Datum start2, Datum end2,
   double d = DatumGetFloat8(dist);
 
   /* Extract the points */
-  const POINT2D *spt1 = GSERIALIZED_POINT2D_P(cbuffer_point_p(sv1));
-  const POINT2D *ept1 = GSERIALIZED_POINT2D_P(cbuffer_point_p(ev1));
-  const POINT2D *spt2 = GSERIALIZED_POINT2D_P(cbuffer_point_p(sv2));
-  const POINT2D *ept2 = GSERIALIZED_POINT2D_P(cbuffer_point_p(ev2));
+  const POINT2D *spt1 = cbuffer_point2d_p(sv1);
+  const POINT2D *ept1 = cbuffer_point2d_p(ev1);
+  const POINT2D *spt2 = cbuffer_point2d_p(sv2);
+  const POINT2D *ept2 = cbuffer_point2d_p(ev2);
 
   double duration = (double)(upper - lower);
 
@@ -299,10 +299,10 @@ tcbuffersegm_tdwithin_turnpt(Datum start1, Datum end1, Datum start2,
   Cbuffer *sv2 = DatumGetCbufferP(start2);
   Cbuffer *ev2 = DatumGetCbufferP(end2);
   double d = DatumGetFloat8(dist);
-  const POINT2D *spt1 = GSERIALIZED_POINT2D_P(cbuffer_point_p(sv1));
-  const POINT2D *ept1 = GSERIALIZED_POINT2D_P(cbuffer_point_p(ev1));
-  const POINT2D *spt2 = GSERIALIZED_POINT2D_P(cbuffer_point_p(sv2));
-  const POINT2D *ept2 = GSERIALIZED_POINT2D_P(cbuffer_point_p(ev2));
+  const POINT2D *spt1 = cbuffer_point2d_p(sv1);
+  const POINT2D *ept1 = cbuffer_point2d_p(ev1);
+  const POINT2D *spt2 = cbuffer_point2d_p(sv2);
+  const POINT2D *ept2 = cbuffer_point2d_p(ev2);
   double duration = (double) (upper - lower);
   if (duration <= FP_TOLERANCE)
   {
@@ -740,9 +740,11 @@ TInstant *
 tcbufferinst_tgeompointinst(const TInstant *inst)
 {
   assert(inst); assert(inst->temptype == T_TCBUFFER);
-  const GSERIALIZED *point = cbuffer_point_p(
-    DatumGetCbufferP(tinstant_value_p(inst)));
-  return tinstant_make(PointerGetDatum(point), T_TGEOMPOINT, inst->t);
+  GSERIALIZED *point = cbuffer_point(DatumGetCbufferP(tinstant_value_p(inst)));
+  TInstant *result = tinstant_make(PointerGetDatum(point), T_TGEOMPOINT,
+    inst->t);
+  pfree(point);
+  return result;
 }
 
 /**
@@ -1043,9 +1045,16 @@ static Set *
 tcbufferinst_members(const TInstant *inst, bool point)
 {
   Cbuffer *cb = DatumGetCbufferP(tinstant_value_p(inst));
-  Datum value = point ?
-    PointerGetDatum(&cb->point) : Float8GetDatum(cb->radius);
-  return set_make_exp(&value, 1, 1, point ? T_GEOMETRY : T_TFLOAT, ORDER_NO);
+  if (point)
+  {
+    GSERIALIZED *gs = cbuffer_point(cb);
+    Datum value = PointerGetDatum(gs);
+    Set *result = set_make_exp(&value, 1, 1, T_GEOMETRY, ORDER_NO);
+    pfree(gs);
+    return result;
+  }
+  Datum value = Float8GetDatum(cb->radius);
+  return set_make_exp(&value, 1, 1, T_FLOAT8, ORDER_NO);
 }
 
 /**
@@ -1060,18 +1069,19 @@ tcbufferseq_members(const TSequence *seq, bool point)
     const Cbuffer *cb = DatumGetCbufferP(
       tinstant_value_p(TSEQUENCE_INST_N(seq, i)));
     values[i] = point ?
-      PointerGetDatum(&cb->point) : Float8GetDatum(cb->radius);
+      PointerGetDatum(cbuffer_point(cb)) : Float8GetDatum(cb->radius);
   }
   MeosType basetype = point ? T_GEOMETRY : T_FLOAT8;
   datumarr_sort(values, seq->count, basetype);
   int count = datumarr_remove_duplicates(values, seq->count, basetype);
+  Set *result = set_make_exp(values, count, count, basetype, ORDER_NO);
   if (point)
   {
-    /* Free the duplicate values that have been found */
-    for (int i = count; i < seq->count; i++)
+    for (int i = 0; i < seq->count; i++)
       pfree(DatumGetPointer(values[i]));
   }
-  return set_make_free(values, count, basetype, ORDER_NO);
+  pfree(values);
+  return result;
 }
 
 /**
@@ -1080,24 +1090,30 @@ tcbufferseq_members(const TSequence *seq, bool point)
 static Set *
 tcbufferseqset_members(const TSequenceSet *ss, bool point)
 {
-  Datum *values = palloc(sizeof(Datum) * ss->count);
+  Datum *values = palloc(sizeof(Datum) * ss->totalcount);
+  int nvalues = 0;
   for (int i = 0; i < ss->count; i++)
   {
     const TSequence *seq = TSEQUENCESET_SEQ_N(ss, i);
     for (int j = 0; j < seq->count; j++)
     {
-      Cbuffer *cb = DatumGetCbufferP(tinstant_value_p(TSEQUENCE_INST_N(seq, j)));
-      values[i] = point ?
-        PointerGetDatum(&cb->point) : Float8GetDatum(cb->radius);
+      const Cbuffer *cb = DatumGetCbufferP(
+        tinstant_value_p(TSEQUENCE_INST_N(seq, j)));
+      values[nvalues++] = point ?
+        PointerGetDatum(cbuffer_point(cb)) : Float8GetDatum(cb->radius);
     }
   }
-  MeosType basetype = point ? T_GEOMETRY : T_TFLOAT;
-  datumarr_sort(values, ss->count, basetype);
-  int count = datumarr_remove_duplicates(values, ss->count, basetype);
-  /* Free the duplicate values that have been found */
-  for (int i = count; i < ss->count; i++)
-    pfree(DatumGetPointer(values[i]));
-  return set_make_free(values, count, basetype, ORDER_NO);
+  MeosType basetype = point ? T_GEOMETRY : T_FLOAT8;
+  datumarr_sort(values, ss->totalcount, basetype);
+  int count = datumarr_remove_duplicates(values, ss->totalcount, basetype);
+  Set *result = set_make_exp(values, count, count, basetype, ORDER_NO);
+  if (point)
+  {
+    for (int i = 0; i < ss->totalcount; i++)
+      pfree(DatumGetPointer(values[i]));
+  }
+  pfree(values);
+  return result;
 }
 
 /**
@@ -1182,7 +1198,9 @@ tcbufferinst_expand(const TInstant *inst, double dist)
 {
   assert(inst); assert(inst->temptype == T_TCBUFFER);
   const Cbuffer *cb = DatumGetCbufferP(tinstant_value_p(inst));
-  Cbuffer *result = cbuffer_make(cbuffer_point_p(cb), cbuffer_radius(cb) + dist);
+  const POINT2D *p = cbuffer_point2d_p(cb);
+  Cbuffer *result = cbuffer_make_coords(cbuffer_srid(cb), p->x, p->y,
+    cbuffer_radius(cb) + dist);
   return tinstant_make_free(PointerGetDatum(result), T_TCBUFFER, inst->t);
 }
 

--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -71,16 +71,13 @@ tcbuffer_cbuffer_distance_turnpt(Datum start, Datum end, Datum value,
 {
   /* Extract the two CBUFFER values */
   Cbuffer *ca1 = DatumGetCbufferP(start);
-  const GSERIALIZED *gs1 = cbuffer_point_p(ca1);
-  const POINT2D *p1 = GSERIALIZED_POINT2D_P(gs1);
+  const POINT2D *p1 = cbuffer_point2d_p(ca1);
   Cbuffer *ca2 = DatumGetCbufferP(end);
-  const GSERIALIZED *gs2 = cbuffer_point_p(ca2);
-  const POINT2D *p2 = GSERIALIZED_POINT2D_P(gs2);
+  const POINT2D *p2 = cbuffer_point2d_p(ca2);
 
   /* Extract the circular buffer value */
   Cbuffer *cb = DatumGetCbufferP(value);
-  const GSERIALIZED *gs = cbuffer_point_p(cb);
-  const POINT2D *p = GSERIALIZED_POINT2D_P(gs);
+  const POINT2D *p = cbuffer_point2d_p(cb);
 
   /* Extract coordinates and radius at the two instants */
   double xa1 = p1->x;
@@ -325,7 +322,7 @@ nai_tcbufferseq(const TSequence *seq, const GeoDistGeom *g, GeoDistNai *w)
     {
       const TInstant *inst = TSEQUENCE_INST_N(seq, i);
       const Cbuffer *c = DatumGetCbufferP(tinstant_value_p(inst));
-      const POINT2D *p = GSERIALIZED_POINT2D_P(cbuffer_point_p(c));
+      const POINT2D *p = cbuffer_point2d_p(c);
       geodist_segm_nai(p->x, p->y, c->radius, inst->t, p->x, p->y, c->radius,
         inst->t, g, w);
     }
@@ -337,8 +334,8 @@ nai_tcbufferseq(const TSequence *seq, const GeoDistGeom *g, GeoDistNai *w)
     const TInstant *i2 = TSEQUENCE_INST_N(seq, i);
     const Cbuffer *c1 = DatumGetCbufferP(tinstant_value_p(i1));
     const Cbuffer *c2 = DatumGetCbufferP(tinstant_value_p(i2));
-    const POINT2D *p1 = GSERIALIZED_POINT2D_P(cbuffer_point_p(c1));
-    const POINT2D *p2 = GSERIALIZED_POINT2D_P(cbuffer_point_p(c2));
+    const POINT2D *p1 = cbuffer_point2d_p(c1);
+    const POINT2D *p2 = cbuffer_point2d_p(c2);
     geodist_segm_nai(p1->x, p1->y, c1->radius, i1->t, p2->x, p2->y, c2->radius,
       i2->t, g, w);
     i1 = i2;
@@ -368,7 +365,7 @@ nai_tcbuffer_geo_analytic(const Temporal *temp, const GSERIALIZED *gs,
   {
     const TInstant *inst = (TInstant *) temp;
     const Cbuffer *c = DatumGetCbufferP(tinstant_value_p(inst));
-    const POINT2D *p = GSERIALIZED_POINT2D_P(cbuffer_point_p(c));
+    const POINT2D *p = cbuffer_point2d_p(c);
     geodist_segm_nai(p->x, p->y, c->radius, inst->t, p->x, p->y, c->radius,
       inst->t, &g, &w);
   }
@@ -565,7 +562,7 @@ tcbufferseq_nad(const TSequence *seq, const GeoDistGeom *g, double *best)
     {
       const Cbuffer *c = DatumGetCbufferP(
         tinstant_value_p(TSEQUENCE_INST_N(seq, i)));
-      const POINT2D *p = GSERIALIZED_POINT2D_P(cbuffer_point_p(c));
+      const POINT2D *p = cbuffer_point2d_p(c);
       geodist_segm_nad(p->x, p->y, c->radius, p->x, p->y, c->radius, g, best);
     }
     return;
@@ -576,8 +573,8 @@ tcbufferseq_nad(const TSequence *seq, const GeoDistGeom *g, double *best)
     const TInstant *i2 = TSEQUENCE_INST_N(seq, i);
     const Cbuffer *c1 = DatumGetCbufferP(tinstant_value_p(i1));
     const Cbuffer *c2 = DatumGetCbufferP(tinstant_value_p(i2));
-    const POINT2D *p1 = GSERIALIZED_POINT2D_P(cbuffer_point_p(c1));
-    const POINT2D *p2 = GSERIALIZED_POINT2D_P(cbuffer_point_p(c2));
+    const POINT2D *p1 = cbuffer_point2d_p(c1);
+    const POINT2D *p2 = cbuffer_point2d_p(c2);
     geodist_segm_nad(p1->x, p1->y, c1->radius, p2->x, p2->y, c2->radius, g, best);
     i1 = i2;
   }
@@ -606,7 +603,7 @@ nad_tcbuffer_geo_analytic(const Temporal *temp, const GSERIALIZED *gs)
   if (temp->subtype == TINSTANT)
   {
     const Cbuffer *c = DatumGetCbufferP(tinstant_value_p((TInstant *) temp));
-    const POINT2D *p = GSERIALIZED_POINT2D_P(cbuffer_point_p(c));
+    const POINT2D *p = cbuffer_point2d_p(c);
     geodist_segm_nad(p->x, p->y, c->radius, p->x, p->y, c->radius, &g, &best);
   }
   else if (temp->subtype == TSEQUENCE)
@@ -636,7 +633,7 @@ tcbufferseq_shortestline(const TSequence *seq, const GeoDistGeom *g,
     {
       const Cbuffer *c = DatumGetCbufferP(
         tinstant_value_p(TSEQUENCE_INST_N(seq, i)));
-      const POINT2D *p = GSERIALIZED_POINT2D_P(cbuffer_point_p(c));
+      const POINT2D *p = cbuffer_point2d_p(c);
       geodist_segm_shortestline(p->x, p->y, c->radius, p->x, p->y, c->radius,
         g, w);
     }
@@ -648,8 +645,8 @@ tcbufferseq_shortestline(const TSequence *seq, const GeoDistGeom *g,
     const TInstant *i2 = TSEQUENCE_INST_N(seq, i);
     const Cbuffer *c1 = DatumGetCbufferP(tinstant_value_p(i1));
     const Cbuffer *c2 = DatumGetCbufferP(tinstant_value_p(i2));
-    const POINT2D *p1 = GSERIALIZED_POINT2D_P(cbuffer_point_p(c1));
-    const POINT2D *p2 = GSERIALIZED_POINT2D_P(cbuffer_point_p(c2));
+    const POINT2D *p1 = cbuffer_point2d_p(c1);
+    const POINT2D *p2 = cbuffer_point2d_p(c2);
     geodist_segm_shortestline(p1->x, p1->y, c1->radius, p2->x, p2->y,
       c2->radius, g, w);
     i1 = i2;
@@ -676,7 +673,7 @@ shortestline_tcbuffer_geo_analytic(const Temporal *temp, const GSERIALIZED *gs)
   if (temp->subtype == TINSTANT)
   {
     const Cbuffer *c = DatumGetCbufferP(tinstant_value_p((TInstant *) temp));
-    const POINT2D *p = GSERIALIZED_POINT2D_P(cbuffer_point_p(c));
+    const POINT2D *p = cbuffer_point2d_p(c);
     geodist_segm_shortestline(p->x, p->y, c->radius, p->x, p->y, c->radius,
       &g, &w);
   }
@@ -804,7 +801,7 @@ bool
 tcbuffer_disc_within_ctx(const Cbuffer *cb, double dist, const void *ctxv)
 {
   const TcbufferGeoCtx *ctx = (const TcbufferGeoCtx *) ctxv;
-  const POINT2D *p = GSERIALIZED_POINT2D_P(cbuffer_point_p(cb));
+  const POINT2D *p = cbuffer_point2d_p(cb);
   return tcbuffer_disc_within_dist(p->x, p->y, cb->radius, dist, &ctx->g);
 }
 
@@ -967,8 +964,8 @@ tcbufferseg_within_ctx(const Cbuffer *cb1, const Cbuffer *cb2, double dist,
   const void *ctxv, double *outlo, double *outhi, int maxout)
 {
   const TcbufferGeoCtx *ctx = (const TcbufferGeoCtx *) ctxv;
-  const POINT2D *p1 = GSERIALIZED_POINT2D_P(cbuffer_point_p(cb1));
-  const POINT2D *p2 = GSERIALIZED_POINT2D_P(cbuffer_point_p(cb2));
+  const POINT2D *p1 = cbuffer_point2d_p(cb1);
+  const POINT2D *p2 = cbuffer_point2d_p(cb2);
   double cx1 = p1->x, cy1 = p1->y, r1 = cb1->radius;
   double cx2 = p2->x, cy2 = p2->y, r2 = cb2->radius;
   int ncap = 2 + 8 * ctx->g.n;
@@ -1113,7 +1110,7 @@ bool
 tcbuffer_disc_touch_ctx(const Cbuffer *cb, const void *ctxv)
 {
   const TcbufferGeoCtx *ctx = (const TcbufferGeoCtx *) ctxv;
-  const POINT2D *p = GSERIALIZED_POINT2D_P(cbuffer_point_p(cb));
+  const POINT2D *p = cbuffer_point2d_p(cb);
   bool inside;
   double sg = tcbuffer_disc_signed_boundary(p->x, p->y, cb->radius, &ctx->g,
     &inside);
@@ -1140,7 +1137,7 @@ bool
 tcbuffer_disc_contains_ctx(const Cbuffer *cb, const void *ctxv, bool strict)
 {
   const TcbufferGeoCtx *ctx = (const TcbufferGeoCtx *) ctxv;
-  const POINT2D *p = GSERIALIZED_POINT2D_P(cbuffer_point_p(cb));
+  const POINT2D *p = cbuffer_point2d_p(cb);
   bool inside;
   double sg = tcbuffer_disc_signed_boundary(p->x, p->y, cb->radius, &ctx->g,
     &inside);
@@ -1165,8 +1162,8 @@ tcbufferseg_sg_roots(const Cbuffer *cb1, const Cbuffer *cb2,
   const void *ctxv, double *outt, int maxout, bool outside_only)
 {
   const TcbufferGeoCtx *ctx = (const TcbufferGeoCtx *) ctxv;
-  const POINT2D *p1 = GSERIALIZED_POINT2D_P(cbuffer_point_p(cb1));
-  const POINT2D *p2 = GSERIALIZED_POINT2D_P(cbuffer_point_p(cb2));
+  const POINT2D *p1 = cbuffer_point2d_p(cb1);
+  const POINT2D *p2 = cbuffer_point2d_p(cb2);
   double cx1 = p1->x, cy1 = p1->y, r1 = cb1->radius;
   double cx2 = p2->x, cy2 = p2->y, r2 = cb2->radius;
   int ncap = 8 * ctx->g.n + 2;
@@ -1364,10 +1361,10 @@ tcbufferseg_distance_lb(Datum start1, Datum end1, Datum start2, Datum end2)
   const Cbuffer *ce1 = DatumGetCbufferP(end1);
   const Cbuffer *cs2 = DatumGetCbufferP(start2);
   const Cbuffer *ce2 = DatumGetCbufferP(end2);
-  const POINT2D *s1 = GSERIALIZED_POINT2D_P(cbuffer_point_p(cs1));
-  const POINT2D *e1 = GSERIALIZED_POINT2D_P(cbuffer_point_p(ce1));
-  const POINT2D *s2 = GSERIALIZED_POINT2D_P(cbuffer_point_p(cs2));
-  const POINT2D *e2 = GSERIALIZED_POINT2D_P(cbuffer_point_p(ce2));
+  const POINT2D *s1 = cbuffer_point2d_p(cs1);
+  const POINT2D *e1 = cbuffer_point2d_p(ce1);
+  const POINT2D *s2 = cbuffer_point2d_p(cs2);
+  const POINT2D *e2 = cbuffer_point2d_p(ce2);
   double r1 = fmax(cs1->radius, ce1->radius);
   double r2 = fmax(cs2->radius, ce2->radius);
   double dx = fmax(fmax(fmin(s1->x, e1->x) - fmax(s2->x, e2->x),
@@ -1686,8 +1683,8 @@ mindist_tcbufferseq_tcbufferseq_threshold(const TSequence *seq1,
     const Cbuffer *cb_b = (seq2->count > 1) ?
       DatumGetCbufferP(tinstant_value_p(TSEQUENCE_INST_N(seq2, j + 1))) :
       cb_a;
-    const POINT2D *pa = GSERIALIZED_POINT2D_P(cbuffer_point_p(cb_a));
-    const POINT2D *pb = GSERIALIZED_POINT2D_P(cbuffer_point_p(cb_b));
+    const POINT2D *pa = cbuffer_point2d_p(cb_a);
+    const POINT2D *pb = cbuffer_point2d_p(cb_b);
     double r_max = fmax(cb_a->radius, cb_b->radius);
     boxes2[j].idx = j;
     boxes2[j].minx = (float) (fmin(pa->x, pb->x) - r_max);
@@ -1705,8 +1702,8 @@ mindist_tcbufferseq_tcbufferseq_threshold(const TSequence *seq1,
     const Cbuffer *cb_b1 = (seq1->count > 1) ?
       DatumGetCbufferP(tinstant_value_p(TSEQUENCE_INST_N(seq1, i + 1))) :
       cb_a1;
-    const POINT2D *pa1 = GSERIALIZED_POINT2D_P(cbuffer_point_p(cb_a1));
-    const POINT2D *pb1 = GSERIALIZED_POINT2D_P(cbuffer_point_p(cb_b1));
+    const POINT2D *pa1 = cbuffer_point2d_p(cb_a1);
+    const POINT2D *pb1 = cbuffer_point2d_p(cb_b1);
     double r_max1 = fmax(cb_a1->radius, cb_b1->radius);
     double s1_minx = fmin(pa1->x, pb1->x) - r_max1;
     double s1_maxx = fmax(pa1->x, pb1->x) + r_max1;
@@ -1740,8 +1737,8 @@ mindist_tcbufferseq_tcbufferseq_threshold(const TSequence *seq1,
       const Cbuffer *cb_b2 = (seq2->count > 1) ?
         DatumGetCbufferP(tinstant_value_p(TSEQUENCE_INST_N(seq2, j + 1))) :
         cb_a2;
-      const POINT2D *pa2 = GSERIALIZED_POINT2D_P(cbuffer_point_p(cb_a2));
-      const POINT2D *pb2 = GSERIALIZED_POINT2D_P(cbuffer_point_p(cb_b2));
+      const POINT2D *pa2 = cbuffer_point2d_p(cb_a2);
+      const POINT2D *pb2 = cbuffer_point2d_p(cb_b2);
       double d = cbuffersegm_segm_mindist(pa1, cb_a1->radius, pb1, cb_b1->radius,
         pa2, cb_a2->radius, pb2, cb_b2->radius, best);
       if (d < best) best = d;

--- a/meos/src/cbuffer/tcbuffer_spatialfuncs.c
+++ b/meos/src/cbuffer/tcbuffer_spatialfuncs.c
@@ -174,10 +174,8 @@ LWGEOM *
 trapezoid_make(const Cbuffer *c1, const Cbuffer *c2)
 {
   assert(c1); assert(c2); assert(cbuffer_srid(c1) == cbuffer_srid(c2));
-  const GSERIALIZED *gs1 = cbuffer_point_p(c1);
-  const GSERIALIZED *gs2 = cbuffer_point_p(c2);
-  const POINT2D *p1 = GSERIALIZED_POINT2D_P(gs1);
-  const POINT2D *p2 = GSERIALIZED_POINT2D_P(gs2);
+  const POINT2D *p1 = cbuffer_point2d_p(c1);
+  const POINT2D *p2 = cbuffer_point2d_p(c2);
   int32_t srid = cbuffer_srid(c1);
 
   /* Compute the Euclidean distance between the centers of the circles */
@@ -348,9 +346,8 @@ GSERIALIZED *
 cbuffer_traversed_area(const Cbuffer *cb)
 {
   assert(cb);
-  const GSERIALIZED *gs = cbuffer_point_p(cb);
-  const POINT2D *p = GSERIALIZED_POINT2D_P(gs);
-  int32_t srid = gserialized_get_srid(gs);
+  const POINT2D *p = cbuffer_point2d_p(cb);
+  int32_t srid = cbuffer_srid(cb);
   LWGEOM *lwgeom;
   GSERIALIZED *result;
   /* If radius is 0 construct a point */
@@ -457,11 +454,9 @@ tcbuffersegm_traversed_area(const TInstant *inst1, const TInstant *inst2)
     cb_min = cb2;
     cb_max = cb1;
   }
-  const GSERIALIZED *gs1 = cbuffer_point_p(cb_min);
-  const GSERIALIZED *gs2 = cbuffer_point_p(cb_max);
-  const POINT2D *p1 = GSERIALIZED_POINT2D_P(gs1);
-  const POINT2D *p2 = GSERIALIZED_POINT2D_P(gs2);
-  int32_t srid = gserialized_get_srid(gs1);
+  const POINT2D *p1 = cbuffer_point2d_p(cb_min);
+  const POINT2D *p2 = cbuffer_point2d_p(cb_max);
+  int32_t srid = cbuffer_srid(cb_min);
 
   /* If the two points are equal compute the traversed area of the circular
    * buffer with the bigger radius */
@@ -476,9 +471,11 @@ tcbuffersegm_traversed_area(const TInstant *inst1, const TInstant *inst2)
   GSERIALIZED *result;
   if (cb_min->radius == 0.0 && cb_max->radius == 0.0)
   {
+    GSERIALIZED *gs1 = cbuffer_point(cb_min);
+    GSERIALIZED *gs2 = cbuffer_point(cb_max);
     res = (LWGEOM *) lwline_make(PointerGetDatum(gs1), PointerGetDatum(gs2));
     result = geo_serialize(res);
-    lwgeom_free(res);
+    lwgeom_free(res); pfree(gs1); pfree(gs2);
     return result;
   }
 

--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -182,7 +182,7 @@ tcbufferinst_xybox(const TInstant *inst, double *xmin, double *ymin,
   double *xmax, double *ymax)
 {
   const Cbuffer *cb = DatumGetCbufferP(tinstant_value_p(inst));
-  const POINT2D *p = GSERIALIZED_POINT2D_P(cbuffer_point_p(cb));
+  const POINT2D *p = cbuffer_point2d_p(cb);
   double r = cb->radius;
   *xmin = p->x - r; *xmax = p->x + r;
   *ymin = p->y - r; *ymax = p->y + r;

--- a/meos/src/geo/tpoint_spatialfuncs.c
+++ b/meos/src/geo/tpoint_spatialfuncs.c
@@ -3319,22 +3319,22 @@ static GEOSGeometry *
 multipoint_make(const TSequence *seq, int start, int end)
 {
   GEOSContextHandle_t ctx = geos_get_context();
-  GSERIALIZED *gs = NULL; /* make compiler quiet */
   GEOSGeometry **geoms = palloc(sizeof(GEOSGeometry *) * (end - start + 1));
   for (int i = 0; i < end - start + 1; ++i)
   {
+    const POINT2D *pt = NULL; /* make compiler quiet */
     if (tpoint_type(seq->temptype))
-      gs = DatumGetGserializedP(
-        tinstant_value_p(TSEQUENCE_INST_N(seq, start + i)));
+      pt = GSERIALIZED_POINT2D_P(DatumGetGserializedP(
+        tinstant_value_p(TSEQUENCE_INST_N(seq, start + i))));
 #if CBUFFER
     else if (seq->temptype == T_TCBUFFER)
-      gs = (GSERIALIZED *) cbuffer_point_p(DatumGetCbufferP(
+      pt = cbuffer_point2d_p(DatumGetCbufferP(
         tinstant_value_p(TSEQUENCE_INST_N(seq, start + i))));
 #endif
 #if NPOINT
     else if (seq->temptype == T_TNPOINT)
-      gs = npoint_to_geompoint(DatumGetNpointP(
-        tinstant_value_p(TSEQUENCE_INST_N(seq, start + i))));
+      pt = GSERIALIZED_POINT2D_P(npoint_to_geompoint(DatumGetNpointP(
+        tinstant_value_p(TSEQUENCE_INST_N(seq, start + i)))));
 #endif
     else
     {
@@ -3342,7 +3342,6 @@ multipoint_make(const TSequence *seq, int start, int end)
         "Sequence must have a spatial point base type");
       return NULL;
     }
-    const POINT2D *pt = GSERIALIZED_POINT2D_P(gs);
     geoms[i] = GEOSGeom_createPointFromXY_r(ctx, pt->x, pt->y);
   }
   GEOSGeometry *result = GEOSGeom_createCollection_r(ctx, GEOS_MULTIPOINT, geoms, end - start + 1);
@@ -3358,17 +3357,20 @@ static GEOSGeometry *
 multipoint_add_inst_free(GEOSGeometry *geom, const TInstant *inst)
 {
   GEOSContextHandle_t ctx = geos_get_context();
-  GSERIALIZED *gs = NULL; /* make compiler quiet */
+  GSERIALIZED *gs = NULL; /* only set (and freed) for the npoint case */
+  const POINT2D *pt = NULL; /* make compiler quiet */
   if (tpoint_type(inst->temptype))
-    gs = DatumGetGserializedP(tinstant_value_p(inst));
+    pt = GSERIALIZED_POINT2D_P(DatumGetGserializedP(tinstant_value_p(inst)));
 #if CBUFFER
   else if (inst->temptype == T_TCBUFFER)
-    gs = (GSERIALIZED *) cbuffer_point_p(DatumGetCbufferP(
-      tinstant_value_p(inst)));
+    pt = cbuffer_point2d_p(DatumGetCbufferP(tinstant_value_p(inst)));
 #endif
 #if NPOINT
   else if (inst->temptype == T_TNPOINT)
+  {
     gs = npoint_to_geompoint(DatumGetNpointP(tinstant_value_p(inst)));
+    pt = GSERIALIZED_POINT2D_P(gs);
+  }
 #endif
   else
   {
@@ -3376,11 +3378,10 @@ multipoint_add_inst_free(GEOSGeometry *geom, const TInstant *inst)
       "Instant must have a spatial point base type");
     return NULL;
   }
-  const POINT2D *pt = GSERIALIZED_POINT2D_P(gs);
   GEOSGeometry *geom1 = GEOSGeom_createPointFromXY_r(ctx, pt->x, pt->y);
   GEOSGeometry *result = GEOSUnion_r(ctx, geom, geom1);
   GEOSGeom_destroy_r(ctx, geom1); GEOSGeom_destroy_r(ctx, geom);
-  if (inst->temptype == T_TNPOINT)
+  if (gs != NULL)
     pfree(gs);
   return result;
 }

--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -1789,10 +1789,7 @@ cbuffer_from_wkb_state(meos_wkb_parse_state *s, bool component)
   double x = double_from_wkb_state(s);
   double y = double_from_wkb_state(s);
   double radius = double_from_wkb_state(s);
-  GSERIALIZED *gs = geopoint_make(x, y, 0.0, false, false, srid);
-  Cbuffer *result = cbuffer_make(gs, radius);
-  pfree(gs);
-  return result;
+  return cbuffer_make_coords(srid, x, y, radius);
 }
 #endif /* CBUFFER */
 

--- a/meos/src/temporal/type_out.c
+++ b/meos/src/temporal/type_out.c
@@ -1975,7 +1975,6 @@ static uint8_t *
 cbuffer_to_wkb_buf(const Cbuffer *cb, uint8_t *buf, uint8_t variant,
   bool component)
 {
-  Datum d = PointerGetDatum(&cb->point);
   if (! component)
   {
     /* Write the endian flag (byte) */
@@ -1984,14 +1983,12 @@ cbuffer_to_wkb_buf(const Cbuffer *cb, uint8_t *buf, uint8_t variant,
     uint8_t wkb_flags = (uint8_t) MEOS_WKB_SRIDFLAG;
     buf = bytes_to_wkb_buf(&wkb_flags, MEOS_WKB_BYTE_SIZE, buf, variant);
     /* Write the SRID */
-    int32_t srid = gserialized_get_srid(DatumGetGserializedP(d));
-    if (spatial_wkb_needs_srid(srid, variant))
-      buf = int32_to_wkb_buf(srid, buf, variant);
+    if (spatial_wkb_needs_srid(cb->srid, variant))
+      buf = int32_to_wkb_buf(cb->srid, buf, variant);
   }
   /* Write the circular buffer */
-  const POINT2D *point = DATUM_POINT2D_P(d);
-  buf = double_to_wkb_buf(point->x, buf, variant);
-  buf = double_to_wkb_buf(point->y, buf, variant);
+  buf = double_to_wkb_buf(cb->x, buf, variant);
+  buf = double_to_wkb_buf(cb->y, buf, variant);
   buf = double_to_wkb_buf(cb->radius, buf, variant);
   return buf;
 }

--- a/mobilitydb/src/cbuffer/cbuffer.c
+++ b/mobilitydb/src/cbuffer/cbuffer.c
@@ -379,8 +379,7 @@ Datum
 Cbuffer_point(PG_FUNCTION_ARGS)
 {
   Cbuffer *cb = PG_GETARG_CBUFFER_P(0);
-  Datum d = PointerGetDatum(&cb->point);
-  PG_RETURN_DATUM(datum_copy(d, T_GEOMETRY));
+  PG_RETURN_POINTER(cbuffer_point(cb));
 }
 
 PGDLLEXPORT Datum Cbuffer_radius(PG_FUNCTION_ARGS);

--- a/mobilitydb/test/cbuffer/expected/201_cbufferset_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/201_cbufferset_tbl.test.out
@@ -48,7 +48,7 @@ SELECT MIN(radius(startValue(round(s, 3)))) FROM tbl_cbufferset;
 SELECT MAX(memSize(s)) FROM tbl_cbufferset;
  max 
 -----
- 664
+ 504
 (1 row)
 
 SELECT MIN(numValues(s)) FROM tbl_cbufferset;
@@ -142,13 +142,13 @@ SELECT COUNT(*) FROM tbl_cbufferset t1, tbl_cbufferset t2 WHERE t1.s >= t2.s;
 SELECT MAX(set_hash(s)) FROM tbl_cbufferset;
     max     
 ------------
- 2108338657
+ 2092598553
 (1 row)
 
 SELECT MAX(set_hash_extended(s, 1)) FROM tbl_cbufferset;
          max         
 ---------------------
- 8841573282622179135
+ 8663420753996198537
 (1 row)
 
 SELECT numValues(setUnion(cb)) FROM tbl_cbuffer;

--- a/mobilitydb/test/cbuffer/expected/202_tcbuffer.test.out
+++ b/mobilitydb/test/cbuffer/expected/202_tcbuffer.test.out
@@ -713,25 +713,25 @@ SELECT tempSubtype(tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Poin
 SELECT memSize(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01');
  memsize 
 ---------
-      64
+      48
 (1 row)
 
 SELECT memSize(tcbuffer '{Cbuffer(Point(1 1), 0.3)@2000-01-01, Cbuffer(Point(1 1), 0.5)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03}');
  memsize 
 ---------
-     320
+     272
 (1 row)
 
 SELECT memSize(tcbuffer '[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03]');
  memsize 
 ---------
-     320
+     272
 (1 row)
 
 SELECT memSize(tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03], [Cbuffer(Point(2 2), 0.6)@2000-01-04, Cbuffer(Point(2 2), 0.6)@2000-01-05]}');
  memsize 
 ---------
-     688
+     608
 (1 row)
 
 SELECT asText(getValue(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01'));


### PR DESCRIPTION
A circular buffer stores its centre as the two coordinates of the 2D point together with the SRID and the radius, rather than an embedded variable-length geometry. The type is a fixed-length structure, its accessors read the coordinates directly, and its Well-Known Binary form (the SRID and three doubles) is unchanged.