### PR TITLE
Add transformation functions to the temporal pgpointcloud types

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3494,6 +3494,18 @@
 			</sect3>
 
 			<sect3>
+				<title>Transformaciones</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpcpoint_subtype"><varname>tpcpointInst</varname>, <varname>tpcpointSeq</varname>, <varname>tpcpointSeqSet</varname></link>: Transformar un tpcpoint en otro subtipo</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tpcpoint_setInterp"><varname>setInterp</varname></link>: Transformar un tpcpoint a otra interpolación</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
 				<title>Comparaciones</title>
 				<itemizedlist>
 					<listitem>
@@ -3580,6 +3592,19 @@
 					</listitem>
 					<listitem>
 						<para><link linkend="tpcpatch_points"><varname>points</varname></link>: Función que devuelve conjuntos, emitiendo una fila por (marca de tiempo, pcpoint)</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+
+			<sect3>
+				<title>Transformaciones</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpcpatch_subtype"><varname>tpcpatchInst</varname>, <varname>tpcpatchSeq</varname>, <varname>tpcpatchSeqSet</varname></link>: Transformar un tpcpatch en otro subtipo</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tpcpatch_setInterp"><varname>setInterp</varname></link>: Transformar un tpcpatch a otra interpolación</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -673,6 +673,26 @@ SELECT ST_AsText(startValue(tpcpoint(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),
 			</itemizedlist>
 		</sect2>
 
+		<sect2 xml:id="tpcpoint_transformations">
+			<title>Transformaciones</title>
+			<itemizedlist>
+				<listitem xml:id="tpcpoint_subtype">
+					<indexterm significance="normal"><primary><varname>tpcpointInst</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>tpcpointSeq</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>tpcpointSeqSet</varname></primary></indexterm>
+					<para>Transformar un tpcpoint en otro subtipo</para>
+					<para><varname>tpcpointInst(tpcpoint) → tpcpoint</varname></para>
+					<para><varname>tpcpointSeq(tpcpoint,interp='step') → tpcpoint</varname></para>
+					<para><varname>tpcpointSeqSet(tpcpoint) → tpcpoint</varname></para>
+				</listitem>
+				<listitem xml:id="tpcpoint_setInterp">
+					<indexterm significance="normal"><primary><varname>setInterp</varname></primary></indexterm>
+					<para>Transformar un tpcpoint a otra interpolación</para>
+					<para><varname>setInterp(tpcpoint,interp) → tpcpoint</varname></para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
 		<sect2 xml:id="tpcpoint_compops">
 			<title>Comparaciones</title>
 			<itemizedlist>
@@ -900,6 +920,26 @@ SELECT t, point FROM points(tpcpatch(
 			<para>Véase <xref linkend="tpcpatch_perpoint_roadmap" /> para conocer los límites de estos accesores y qué está y qué no está disponible a nivel de granularidad por punto.</para>
 		</sect2>
 
+
+		<sect2 xml:id="tpcpatch_transformations">
+			<title>Transformaciones</title>
+			<itemizedlist>
+				<listitem xml:id="tpcpatch_subtype">
+					<indexterm significance="normal"><primary><varname>tpcpatchInst</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>tpcpatchSeq</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>tpcpatchSeqSet</varname></primary></indexterm>
+					<para>Transformar un tpcpatch en otro subtipo</para>
+					<para><varname>tpcpatchInst(tpcpatch) → tpcpatch</varname></para>
+					<para><varname>tpcpatchSeq(tpcpatch,interp='step') → tpcpatch</varname></para>
+					<para><varname>tpcpatchSeqSet(tpcpatch) → tpcpatch</varname></para>
+				</listitem>
+				<listitem xml:id="tpcpatch_setInterp">
+					<indexterm significance="normal"><primary><varname>setInterp</varname></primary></indexterm>
+					<para>Transformar un tpcpatch a otra interpolación</para>
+					<para><varname>setInterp(tpcpatch,interp) → tpcpatch</varname></para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
 
 		<sect2 xml:id="tpcpatch_restrictions">
 			<title>Restricciones</title>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3472,6 +3472,18 @@
 			</sect3>
 
 			<sect3>
+				<title>Transformations</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpcpoint_subtype"><varname>tpcpointInst</varname>, <varname>tpcpointSeq</varname>, <varname>tpcpointSeqSet</varname></link>: Transform a tpcpoint to another subtype</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tpcpoint_setInterp"><varname>setInterp</varname></link>: Transform a tpcpoint to another interpolation</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
 				<title>Comparisons</title>
 				<itemizedlist>
 					<listitem>
@@ -3558,6 +3570,19 @@
 					</listitem>
 					<listitem>
 						<para><link linkend="tpcpatch_points"><varname>points</varname></link>: Set-returning function emitting one row per (timestamp, pcpoint)</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+
+			<sect3>
+				<title>Transformations</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpcpatch_subtype"><varname>tpcpatchInst</varname>, <varname>tpcpatchSeq</varname>, <varname>tpcpatchSeqSet</varname></link>: Transform a tpcpatch to another subtype</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tpcpatch_setInterp"><varname>setInterp</varname></link>: Transform a tpcpatch to another interpolation</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -678,6 +678,26 @@ SELECT ST_AsText(startValue(tpcpoint(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),
 			</itemizedlist>
 		</sect2>
 
+		<sect2 xml:id="tpcpoint_transformations">
+			<title>Transformations</title>
+			<itemizedlist>
+				<listitem xml:id="tpcpoint_subtype">
+					<indexterm significance="normal"><primary><varname>tpcpointInst</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>tpcpointSeq</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>tpcpointSeqSet</varname></primary></indexterm>
+					<para>Transform a tpcpoint to another subtype</para>
+					<para><varname>tpcpointInst(tpcpoint) → tpcpoint</varname></para>
+					<para><varname>tpcpointSeq(tpcpoint,interp='step') → tpcpoint</varname></para>
+					<para><varname>tpcpointSeqSet(tpcpoint) → tpcpoint</varname></para>
+				</listitem>
+				<listitem xml:id="tpcpoint_setInterp">
+					<indexterm significance="normal"><primary><varname>setInterp</varname></primary></indexterm>
+					<para>Transform a tpcpoint to another interpolation</para>
+					<para><varname>setInterp(tpcpoint,interp) → tpcpoint</varname></para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
 		<sect2 xml:id="tpcpoint_compops">
 			<title>Comparisons</title>
 			<itemizedlist>
@@ -906,6 +926,26 @@ SELECT t, point FROM points(tpcpatch(
 			<para>See <xref linkend="tpcpatch_perpoint_roadmap" /> for the limits of these accessors and what is and is not available at per-point granularity.</para>
 		</sect2>
 
+
+		<sect2 xml:id="tpcpatch_transformations">
+			<title>Transformations</title>
+			<itemizedlist>
+				<listitem xml:id="tpcpatch_subtype">
+					<indexterm significance="normal"><primary><varname>tpcpatchInst</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>tpcpatchSeq</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>tpcpatchSeqSet</varname></primary></indexterm>
+					<para>Transform a tpcpatch to another subtype</para>
+					<para><varname>tpcpatchInst(tpcpatch) → tpcpatch</varname></para>
+					<para><varname>tpcpatchSeq(tpcpatch,interp='step') → tpcpatch</varname></para>
+					<para><varname>tpcpatchSeqSet(tpcpatch) → tpcpatch</varname></para>
+				</listitem>
+				<listitem xml:id="tpcpatch_setInterp">
+					<indexterm significance="normal"><primary><varname>setInterp</varname></primary></indexterm>
+					<para>Transform a tpcpatch to another interpolation</para>
+					<para><varname>setInterp(tpcpatch,interp) → tpcpatch</varname></para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
 
 		<sect2 xml:id="tpcpatch_restrictions">
 			<title>Restrictions</title>

--- a/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
+++ b/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
@@ -403,6 +403,51 @@ CREATE FUNCTION tgeompoint(tpcpoint)
 CREATE CAST (tpcpoint AS tgeompoint) WITH FUNCTION tgeompoint(tpcpoint);
 
 /******************************************************************************
+ * Transformation functions
+ ******************************************************************************/
+
+CREATE FUNCTION tpcpointInst(tpcpoint)
+  RETURNS tpcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_as_tinstant'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+-- The function is not strict
+CREATE FUNCTION tpcpointSeq(tpcpoint, text DEFAULT NULL)
+  RETURNS tpcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequence'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+-- The function is not strict
+CREATE FUNCTION tpcpointSeqSet(tpcpoint)
+  RETURNS tpcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequenceset'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE FUNCTION setInterp(tpcpoint, text)
+  RETURNS tpcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_set_interp'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION shiftTime(tpcpoint, interval)
+  RETURNS tpcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_shift_time'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION scaleTime(tpcpoint, interval)
+  RETURNS tpcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_scale_time'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION shiftScaleTime(tpcpoint, interval, interval)
+  RETURNS tpcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_shift_scale_time'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION tsample(tpcpoint, duration interval,
+  origin timestamptz DEFAULT '2000-01-03', interp text DEFAULT 'discrete')
+  RETURNS tpcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_tsample'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/******************************************************************************
  * Restrictions
  ******************************************************************************/
 

--- a/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
+++ b/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
@@ -369,6 +369,51 @@ CREATE FUNCTION numPoints(tpcpatch)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /******************************************************************************
+ * Transformation functions
+ ******************************************************************************/
+
+CREATE FUNCTION tpcpatchInst(tpcpatch)
+  RETURNS tpcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_as_tinstant'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+-- The function is not strict
+CREATE FUNCTION tpcpatchSeq(tpcpatch, text DEFAULT NULL)
+  RETURNS tpcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequence'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+-- The function is not strict
+CREATE FUNCTION tpcpatchSeqSet(tpcpatch)
+  RETURNS tpcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequenceset'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE FUNCTION setInterp(tpcpatch, text)
+  RETURNS tpcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_set_interp'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION shiftTime(tpcpatch, interval)
+  RETURNS tpcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_shift_time'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION scaleTime(tpcpatch, interval)
+  RETURNS tpcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_scale_time'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION shiftScaleTime(tpcpatch, interval, interval)
+  RETURNS tpcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_shift_scale_time'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION tsample(tpcpatch, duration interval,
+  origin timestamptz DEFAULT '2000-01-03', interp text DEFAULT 'discrete')
+  RETURNS tpcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_tsample'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/******************************************************************************
  * Restrictions
  ******************************************************************************/
 

--- a/mobilitydb/test/pointcloud/expected/420_tpcpoint.test.out
+++ b/mobilitydb/test/pointcloud/expected/420_tpcpoint.test.out
@@ -180,6 +180,57 @@ SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::t
  t
 (1 row)
 
+SELECT tpcpointInst(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT tpcpointSeq(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT tpcpointSeqSet(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT setInterp(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]), 'step') IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT shiftTime(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), interval '1 day') IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT scaleTime(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]), interval '2 days')
+  IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT shiftScaleTime(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]),
+  interval '1 day', interval '2 days') IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT tsample(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]), interval '1 day')
+  IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
 SELECT atValue(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]),
   PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[])) IS NOT NULL;
  ?column? 

--- a/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
+++ b/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
@@ -205,6 +205,58 @@ SELECT (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), 
  t
 (1 row)
 
+SELECT tpcpatchInst(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz)) IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT tpcpatchSeq(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz)) IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT tpcpatchSeqSet(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz)) IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT setInterp(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-04'::timestamptz)]), 'step')
+  IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT shiftTime(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), interval '1 day') IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT scaleTime(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-04'::timestamptz)]),
+  interval '2 days') IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT shiftScaleTime(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-04'::timestamptz)]),
+  interval '1 day', interval '2 days') IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT tsample(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-04'::timestamptz)]),
+  interval '1 day') IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
 SELECT atValue(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-04'::timestamptz)]), PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]))
   IS NOT NULL;
  ?column? 

--- a/mobilitydb/test/pointcloud/queries/420_tpcpoint.test.sql
+++ b/mobilitydb/test/pointcloud/queries/420_tpcpoint.test.sql
@@ -102,6 +102,22 @@ SELECT (:inst1) <> (:inst2);
 SELECT (:inst1) < (:inst2);
 
 -------------------------------------------------------------------------------
+-- Transformations
+-------------------------------------------------------------------------------
+
+SELECT tpcpointInst(:inst1) IS NOT NULL;
+SELECT tpcpointSeq(:inst1) IS NOT NULL;
+SELECT tpcpointSeqSet(:inst1) IS NOT NULL;
+SELECT setInterp(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]), 'step') IS NOT NULL;
+SELECT shiftTime(:inst1, interval '1 day') IS NOT NULL;
+SELECT scaleTime(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]), interval '2 days')
+  IS NOT NULL;
+SELECT shiftScaleTime(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
+  interval '1 day', interval '2 days') IS NOT NULL;
+SELECT tsample(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]), interval '1 day')
+  IS NOT NULL;
+
+-------------------------------------------------------------------------------
 -- Restrictions
 -------------------------------------------------------------------------------
 

--- a/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
+++ b/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
@@ -110,6 +110,23 @@ SELECT (:inst1) <> (:inst2);
 SELECT (:inst1) < (:inst2);
 
 -------------------------------------------------------------------------------
+-- Transformations
+-------------------------------------------------------------------------------
+
+SELECT tpcpatchInst(:inst1) IS NOT NULL;
+SELECT tpcpatchSeq(:inst1) IS NOT NULL;
+SELECT tpcpatchSeqSet(:inst1) IS NOT NULL;
+SELECT setInterp(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3, :inst4]), 'step')
+  IS NOT NULL;
+SELECT shiftTime(:inst1, interval '1 day') IS NOT NULL;
+SELECT scaleTime(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3, :inst4]),
+  interval '2 days') IS NOT NULL;
+SELECT shiftScaleTime(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3, :inst4]),
+  interval '1 day', interval '2 days') IS NOT NULL;
+SELECT tsample(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3, :inst4]),
+  interval '1 day') IS NOT NULL;
+
+-------------------------------------------------------------------------------
 -- Restrictions — at/minusValue(s), at/minusTime, at/minusTpcbox.
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
The temporal pgpointcloud types `tpcpoint` and `tpcpatch` expose constructors,
accessors, and restrictions but not the transformation functions the other
base-type families provide. This adds them, mirroring the `tjsonb` sibling.

## What this adds

For `tpcpoint` and `tpcpatch`, the transformation surface into the generic
temporal machinery:

- **Subtype transforms** — `tpcpointInst(tpcpoint)`, `tpcpointSeq(tpcpoint, text)`,
  `tpcpointSeqSet(tpcpoint)` (and the `tpcpatch` equivalents).
- **Interpolation** — `setInterp(tpcpoint, text)`.
- **Time shift and scale** — `shiftTime(tpcpoint, interval)`,
  `scaleTime(tpcpoint, interval)`,
  `shiftScaleTime(tpcpoint, interval, interval)`.
- **Sampling** — `tsample(tpcpoint, interval, timestamptz, text)`.

Each binds the generic `Temporal_as_tinstant` / `Temporal_as_tsequence` /
`Temporal_as_tsequenceset` / `Temporal_set_interp` / `Temporal_shift_time` /
`Temporal_scale_time` / `Temporal_shift_scale_time` / `Temporal_tsample`
wrapper — the same wrapper the other families use — so no type-specific C is
required.

Regression tests exercise the functions per type, and the reference and
pointcloud chapters in English and Spanish document them.
