### PR TITLE
Add the canonical Agg-suffixed aggregate names to the remaining families

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -2227,7 +2227,7 @@
 					<title>Modificaciones</title>
 					<itemizedlist>
 						<listitem>
-							<para><link linkend="tcbuffer_appendInstant"><varname>appendInstant</varname>, <varname>appendSequence</varname></link>: Añade un instante temporal o una secuencia temporal</para>
+							<para><link linkend="tcbuffer_appendInstant"><varname>appendInstant</varname>, <varname>appendInstantAgg</varname>, <varname>appendSequence</varname>, <varname>appendSequenceAgg</varname></link>: Añade un instante temporal o una secuencia temporal</para>
 						</listitem>
 
 						<listitem>
@@ -2385,11 +2385,11 @@
 				</listitem>
 
 				<listitem>
-					<para><link linkend="trgeometry_appendInstant"><varname>appendInstant</varname></link>: Añade un único instante a una trgeometry existente</para>
+					<para><link linkend="trgeometry_appendInstant"><varname>appendInstant</varname>, <varname>appendInstantAgg</varname></link>: Añade un único instante a una trgeometry existente</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="trgeometry_appendSequence"><varname>appendSequence</varname></link>: Añade una secuencia completa a una trgeometry existente</para>
+					<para><link linkend="trgeometry_appendSequence"><varname>appendSequence</varname>, <varname>appendSequenceAgg</varname></link>: Añade una secuencia completa a una trgeometry existente</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -2607,7 +2607,7 @@
 				</listitem>
 
 				<listitem>
-					<para><link linkend="trgeometry_merge"><varname>merge</varname></link>: Combina dos trgeometries con la misma geometría de referencia en un conjunto de secuencias</para>
+					<para><link linkend="trgeometry_merge"><varname>merge</varname>, <varname>mergeAgg</varname></link>: Combina dos trgeometries con la misma geometría de referencia en un conjunto de secuencias</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3638,10 +3638,10 @@
 					<para><link linkend="tpcpatch_tdensity"><varname>tdensity</varname></link>: Densidad de puntos por instante sumada entre filas</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tpcpoint_merge"><varname>merge</varname></link>: Combinar múltiples valores temporales en uno solo</para>
+					<para><link linkend="tpcpoint_merge"><varname>merge</varname>, <varname>mergeAgg</varname></link>: Combinar múltiples valores temporales en uno solo</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tpcpoint_append"><varname>appendInstant</varname>, <varname>appendSequence</varname></link>: Agregaciones de construcción en flujo</para>
+					<para><link linkend="tpcpoint_append"><varname>appendInstant</varname>, <varname>appendInstantAgg</varname>, <varname>appendSequence</varname>, <varname>appendSequenceAgg</varname></link>: Agregaciones de construcción en flujo</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -1041,6 +1041,7 @@ CREATE INDEX ON my_table USING spgist(my_tpcpoint_column tpcpoint_kdtree_ops);
 				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
 				<para>Combina múltiples valores temporales en uno solo con todos los instantes de entrada fusionados en orden temporal. Todas las entradas deben compartir el mismo pcid y subtipo.</para>
 				<para><varname>merge(tpcpoint) → tpcpoint</varname>, <varname>merge(tpcpatch) → tpcpatch</varname></para>
+				<para><varname>mergeAgg(tpcpoint) → tpcpoint</varname>, <varname>mergeAgg(tpcpatch) → tpcpatch</varname></para>
 			</listitem>
 
 			<listitem xml:id="tpcpoint_append">
@@ -1048,7 +1049,9 @@ CREATE INDEX ON my_table USING spgist(my_tpcpoint_column tpcpoint_kdtree_ops);
 				<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
 				<para>Agregados de construcción en flujo: <varname>appendInstant</varname> ensambla instantes en una secuencia; <varname>appendSequence</varname> ensambla secuencias en un conjunto de secuencias. Útil para cargadores de trayectorias que consumen filas en orden temporal.</para>
 				<para><varname>appendInstant(tpcpoint[,interp,maxt]) → tpcpoint</varname>, <varname>appendInstant(tpcpatch) → tpcpatch</varname></para>
+				<para><varname>appendInstantAgg(tpcpoint[,interp,maxt]) → tpcpoint</varname>, <varname>appendInstantAgg(tpcpatch) → tpcpatch</varname></para>
 				<para><varname>appendSequence(tpcpoint) → tpcpoint</varname>, <varname>appendSequence(tpcpatch) → tpcpatch</varname></para>
+				<para><varname>appendSequenceAgg(tpcpoint) → tpcpoint</varname>, <varname>appendSequenceAgg(tpcpatch) → tpcpatch</varname></para>
 			</listitem>
 		</itemizedlist>
 	</sect1>

--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -978,6 +978,7 @@ SELECT asText(appendSequence(tpose '[Pose(Point(1 1), 0.5)@2001-01-01]', '[Pose(
 				<para>Fusionar las poses temporales</para>
 				<para><varname>merge(tpose,tpose) → tpose</varname></para>
 				<para><varname>merge(tpose[]) → tpose</varname></para>
+				<para><varname>merge(tpose) → tpose</varname></para>
 				<para><varname>mergeAgg(tpose) → tpose</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(merge(tpose

--- a/doc/es/temporal_rigid_geometries.xml
+++ b/doc/es/temporal_rigid_geometries.xml
@@ -679,6 +679,7 @@ SELECT extent(temp) FROM tbl_trgeometry;
 				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
 				<para>Combinar dos trgeometries con la misma geometría de referencia en un único conjunto de secuencias</para>
 				<para><varname>merge(trgeometry, trgeometry) → trgeometry</varname></para>
+				<para><varname>mergeAgg(trgeometry) → trgeometry</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(merge(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(5 0), 0.0)@2001-01-02]',

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -2205,7 +2205,7 @@
 					<title>Modifications</title>
 					<itemizedlist>
 						<listitem>
-							<para><link linkend="tcbuffer_appendInstant"><varname>appendInstant</varname>, <varname>appendSequence</varname></link>: Append a temporal instant or a temporal sequence</para>
+							<para><link linkend="tcbuffer_appendInstant"><varname>appendInstant</varname>, <varname>appendInstantAgg</varname>, <varname>appendSequence</varname>, <varname>appendSequenceAgg</varname></link>: Append a temporal instant or a temporal sequence</para>
 						</listitem>
 
 						<listitem>
@@ -2363,11 +2363,11 @@
 				</listitem>
 
 				<listitem>
-					<para><link linkend="trgeometry_appendInstant"><varname>appendInstant</varname></link>: Append a single instant to an existing trgeometry</para>
+					<para><link linkend="trgeometry_appendInstant"><varname>appendInstant</varname>, <varname>appendInstantAgg</varname></link>: Append a single instant to an existing trgeometry</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="trgeometry_appendSequence"><varname>appendSequence</varname></link>: Append an entire sequence to an existing trgeometry</para>
+					<para><link linkend="trgeometry_appendSequence"><varname>appendSequence</varname>, <varname>appendSequenceAgg</varname></link>: Append an entire sequence to an existing trgeometry</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -2585,7 +2585,7 @@
 				</listitem>
 
 				<listitem>
-					<para><link linkend="trgeometry_merge"><varname>merge</varname></link>: Combine two trgeometries with the same reference geometry into a sequence-set</para>
+					<para><link linkend="trgeometry_merge"><varname>merge</varname>, <varname>mergeAgg</varname></link>: Combine two trgeometries with the same reference geometry into a sequence-set</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3616,10 +3616,10 @@
 					<para><link linkend="tpcpatch_tdensity"><varname>tdensity</varname></link>: Per-instant point density summed across rows</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tpcpoint_merge"><varname>merge</varname></link>: Combine multiple temporal values into a single one</para>
+					<para><link linkend="tpcpoint_merge"><varname>merge</varname>, <varname>mergeAgg</varname></link>: Combine multiple temporal values into a single one</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tpcpoint_append"><varname>appendInstant</varname>, <varname>appendSequence</varname></link>: Streaming construction aggregates</para>
+					<para><link linkend="tpcpoint_append"><varname>appendInstant</varname>, <varname>appendInstantAgg</varname>, <varname>appendSequence</varname>, <varname>appendSequenceAgg</varname></link>: Streaming construction aggregates</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -1048,6 +1048,7 @@ CREATE INDEX ON my_table USING spgist(my_tpcpoint_column tpcpoint_kdtree_ops);
 				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
 				<para>Combine multiple temporal values into a single one with all input instants merged in temporal order. All inputs must share the same pcid and subtype.</para>
 				<para><varname>merge(tpcpoint) → tpcpoint</varname>, <varname>merge(tpcpatch) → tpcpatch</varname></para>
+				<para><varname>mergeAgg(tpcpoint) → tpcpoint</varname>, <varname>mergeAgg(tpcpatch) → tpcpatch</varname></para>
 			</listitem>
 
 			<listitem xml:id="tpcpoint_append">
@@ -1055,7 +1056,9 @@ CREATE INDEX ON my_table USING spgist(my_tpcpoint_column tpcpoint_kdtree_ops);
 				<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
 				<para>Streaming construction aggregates: <varname>appendInstant</varname> assembles instants into a sequence; <varname>appendSequence</varname> assembles sequences into a sequence set. Useful for trajectory loaders that consume rows in time order.</para>
 				<para><varname>appendInstant(tpcpoint[,interp,maxt]) → tpcpoint</varname>, <varname>appendInstant(tpcpatch) → tpcpatch</varname></para>
+				<para><varname>appendInstantAgg(tpcpoint[,interp,maxt]) → tpcpoint</varname>, <varname>appendInstantAgg(tpcpatch) → tpcpatch</varname></para>
 				<para><varname>appendSequence(tpcpoint) → tpcpoint</varname>, <varname>appendSequence(tpcpatch) → tpcpatch</varname></para>
+				<para><varname>appendSequenceAgg(tpcpoint) → tpcpoint</varname>, <varname>appendSequenceAgg(tpcpatch) → tpcpatch</varname></para>
 			</listitem>
 		</itemizedlist>
 	</sect1>

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -986,6 +986,7 @@ SELECT asText(appendSequence(tpose '[Pose(Point(1 1), 0.5)@2001-01-01]', '[Pose(
 				<para><varname>merge(tpose,tpose) → tpose</varname></para>
 				<para><varname>merge(tpose[]) → tpose</varname></para>
 				<para><varname>merge(tpose) → tpose</varname></para>
+				<para><varname>mergeAgg(tpose) → tpose</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(merge(tpose
   '[Pose(Point(1 1 1),1,0,0,0)@2001-01-01, Pose(Point(2 2 2),0,1,0,0)@2001-01-02]',

--- a/doc/temporal_rigid_geometries.xml
+++ b/doc/temporal_rigid_geometries.xml
@@ -679,6 +679,7 @@ SELECT extent(temp) FROM tbl_trgeometry;
 				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
 				<para>Combine two trgeometries with the same reference geometry into a single sequence-set</para>
 				<para><varname>merge(trgeometry, trgeometry) → trgeometry</varname></para>
+				<para><varname>mergeAgg(trgeometry) → trgeometry</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(merge(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(5 0), 0.0)@2001-01-02]',

--- a/mobilitydb/sql/cbuffer/211_tcbuffer_aggfuncs.in.sql
+++ b/mobilitydb/sql/cbuffer/211_tcbuffer_aggfuncs.in.sql
@@ -86,6 +86,16 @@ CREATE AGGREGATE merge(tcbuffer) (
   PARALLEL = safe
 );
 
+CREATE AGGREGATE mergeAgg(tcbuffer) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tcbuffer_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
 /*****************************************************************************
  * Append tinstant aggregate functions
  *****************************************************************************/
@@ -123,6 +133,13 @@ CREATE AGGREGATE appendInstant(tcbuffer) (
   PARALLEL = safe
 );
 
+CREATE AGGREGATE appendInstantAgg(tcbuffer) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tcbuffer,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
 CREATE AGGREGATE appendInstant(tcbuffer, text) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = tcbuffer,
@@ -130,7 +147,21 @@ CREATE AGGREGATE appendInstant(tcbuffer, text) (
   PARALLEL = safe
 );
 
+CREATE AGGREGATE appendInstantAgg(tcbuffer, text) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tcbuffer,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
 CREATE AGGREGATE appendInstant(tcbuffer, text, float, interval) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tcbuffer,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(tcbuffer, text, float, interval) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = tcbuffer,
   FINALFUNC = temporal_append_finalfn,
@@ -146,6 +177,13 @@ CREATE FUNCTION temporal_app_tseq_transfn(tcbuffer, tcbuffer)
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE AGGREGATE appendSequence(tcbuffer) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tcbuffer,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendSequenceAgg(tcbuffer) (
   SFUNC = temporal_app_tseq_transfn,
   STYPE = tcbuffer,
   FINALFUNC = temporal_append_finalfn,

--- a/mobilitydb/sql/geo/068_tgeo_aggfuncs.in.sql
+++ b/mobilitydb/sql/geo/068_tgeo_aggfuncs.in.sql
@@ -147,7 +147,27 @@ CREATE AGGREGATE merge(tgeometry) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = safe
 );
+
+CREATE AGGREGATE mergeAgg(tgeometry) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tgeometry_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
 CREATE AGGREGATE merge(tgeography) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tgeography_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE mergeAgg(tgeography) (
   SFUNC = temporal_merge_transfn,
   STYPE = internal,
   COMBINEFUNC = temporal_merge_combinefn,
@@ -212,7 +232,21 @@ CREATE AGGREGATE appendInstant(tgeometry) (
   FINALFUNC = temporal_append_finalfn,
   PARALLEL = safe
 );
+
+CREATE AGGREGATE appendInstantAgg(tgeometry) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeometry,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
 CREATE AGGREGATE appendInstant(tgeography) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeography,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(tgeography) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = tgeography,
   FINALFUNC = temporal_append_finalfn,
@@ -225,7 +259,21 @@ CREATE AGGREGATE appendInstant(tgeometry, text) (
   FINALFUNC = temporal_append_finalfn,
   PARALLEL = safe
 );
+
+CREATE AGGREGATE appendInstantAgg(tgeometry, text) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeometry,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
 CREATE AGGREGATE appendInstant(tgeography, text) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeography,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(tgeography, text) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = tgeography,
   FINALFUNC = temporal_append_finalfn,
@@ -238,7 +286,21 @@ CREATE AGGREGATE appendInstant(tgeometry, text, float, interval) (
   FINALFUNC = temporal_append_finalfn,
   PARALLEL = safe
 );
+
+CREATE AGGREGATE appendInstantAgg(tgeometry, text, float, interval) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeometry,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
 CREATE AGGREGATE appendInstant(tgeography, text, float, interval) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeography,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(tgeography, text, float, interval) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = tgeography,
   FINALFUNC = temporal_append_finalfn,
@@ -263,7 +325,21 @@ CREATE AGGREGATE appendSequence(tgeometry) (
   FINALFUNC = temporal_append_finalfn,
   PARALLEL = safe
 );
+
+CREATE AGGREGATE appendSequenceAgg(tgeometry) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tgeometry,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
 CREATE AGGREGATE appendSequence(tgeography) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tgeography,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendSequenceAgg(tgeography) (
   SFUNC = temporal_app_tseq_transfn,
   STYPE = tgeography,
   FINALFUNC = temporal_append_finalfn,

--- a/mobilitydb/sql/geo/068_tpoint_aggfuncs.in.sql
+++ b/mobilitydb/sql/geo/068_tpoint_aggfuncs.in.sql
@@ -171,7 +171,27 @@ CREATE AGGREGATE merge(tgeompoint) (
   DESERIALFUNC = taggstate_deserialize,
   PARALLEL = safe
 );
+
+CREATE AGGREGATE mergeAgg(tgeompoint) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tgeompoint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
 CREATE AGGREGATE merge(tgeogpoint) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tgeogpoint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE mergeAgg(tgeogpoint) (
   SFUNC = temporal_merge_transfn,
   STYPE = internal,
   COMBINEFUNC = temporal_merge_combinefn,
@@ -236,7 +256,21 @@ CREATE AGGREGATE appendInstant(tgeompoint) (
   FINALFUNC = temporal_append_finalfn,
   PARALLEL = safe
 );
+
+CREATE AGGREGATE appendInstantAgg(tgeompoint) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeompoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
 CREATE AGGREGATE appendInstant(tgeogpoint) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeogpoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(tgeogpoint) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = tgeogpoint,
   FINALFUNC = temporal_append_finalfn,
@@ -249,7 +283,21 @@ CREATE AGGREGATE appendInstant(tgeompoint, text) (
   FINALFUNC = temporal_append_finalfn,
   PARALLEL = safe
 );
+
+CREATE AGGREGATE appendInstantAgg(tgeompoint, text) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeompoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
 CREATE AGGREGATE appendInstant(tgeogpoint, text) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeogpoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(tgeogpoint, text) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = tgeogpoint,
   FINALFUNC = temporal_append_finalfn,
@@ -262,7 +310,21 @@ CREATE AGGREGATE appendInstant(tgeompoint, text, float, interval) (
   FINALFUNC = temporal_append_finalfn,
   PARALLEL = safe
 );
+
+CREATE AGGREGATE appendInstantAgg(tgeompoint, text, float, interval) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeompoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
 CREATE AGGREGATE appendInstant(tgeogpoint, text, float, interval) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tgeogpoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(tgeogpoint, text, float, interval) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = tgeogpoint,
   FINALFUNC = temporal_append_finalfn,
@@ -287,7 +349,21 @@ CREATE AGGREGATE appendSequence(tgeompoint) (
   FINALFUNC = temporal_append_finalfn,
   PARALLEL = safe
 );
+
+CREATE AGGREGATE appendSequenceAgg(tgeompoint) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tgeompoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
 CREATE AGGREGATE appendSequence(tgeogpoint) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tgeogpoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendSequenceAgg(tgeogpoint) (
   SFUNC = temporal_app_tseq_transfn,
   STYPE = tgeogpoint,
   FINALFUNC = temporal_append_finalfn,

--- a/mobilitydb/sql/json/464_tjsonb_aggfuncs.in.sql
+++ b/mobilitydb/sql/json/464_tjsonb_aggfuncs.in.sql
@@ -98,6 +98,16 @@ CREATE AGGREGATE merge(tjsonb) (
   PARALLEL = safe
 );
 
+CREATE AGGREGATE mergeAgg(tjsonb) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tjsonb_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
 CREATE FUNCTION temporal_app_tinst_transfn(tjsonb, tjsonb)
   RETURNS tjsonb
   AS 'MODULE_PATHNAME', 'Temporal_app_tinst_transfn'
@@ -126,13 +136,34 @@ CREATE AGGREGATE appendInstant(tjsonb) (
   FINALFUNC = temporal_append_finalfn,
   PARALLEL = safe
 );
+
+CREATE AGGREGATE appendInstantAgg(tjsonb) (
+  SFUNC = temporal_app_tinst_transfn(tjsonb, tjsonb),
+  STYPE = tjsonb,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
 CREATE AGGREGATE appendInstant(tjsonb, interp text) (
   SFUNC = temporal_app_tinst_transfn(tjsonb, tjsonb, text),
   STYPE = tjsonb,
   FINALFUNC = temporal_append_finalfn,
   PARALLEL = safe
 );
+
+CREATE AGGREGATE appendInstantAgg(tjsonb, interp text) (
+  SFUNC = temporal_app_tinst_transfn(tjsonb, tjsonb, text),
+  STYPE = tjsonb,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
 CREATE AGGREGATE appendInstant(tjsonb, interp text, maxt interval) (
+  SFUNC = temporal_app_tinst_transfn(tjsonb, tjsonb, text, maxt),
+  STYPE = tjsonb,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(tjsonb, interp text, maxt interval) (
   SFUNC = temporal_app_tinst_transfn(tjsonb, tjsonb, text, maxt),
   STYPE = tjsonb,
   FINALFUNC = temporal_append_finalfn,
@@ -148,6 +179,13 @@ CREATE FUNCTION temporal_app_tseq_transfn(tjsonb, tjsonb)
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE AGGREGATE appendSequence(tjsonb) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tjsonb,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendSequenceAgg(tjsonb) (
   SFUNC = temporal_app_tseq_transfn,
   STYPE = tjsonb,
   FINALFUNC = temporal_append_finalfn,

--- a/mobilitydb/sql/pointcloud/440_tpc_aggfuncs.in.sql
+++ b/mobilitydb/sql/pointcloud/440_tpc_aggfuncs.in.sql
@@ -187,7 +187,27 @@ CREATE AGGREGATE merge(tpcpoint) (
   PARALLEL = safe
 );
 
+CREATE AGGREGATE mergeAgg(tpcpoint) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tpcpoint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
 CREATE AGGREGATE merge(tpcpatch) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tpcpatch_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE mergeAgg(tpcpatch) (
   SFUNC = temporal_merge_transfn,
   STYPE = internal,
   COMBINEFUNC = temporal_merge_combinefn,
@@ -225,7 +245,21 @@ CREATE AGGREGATE appendInstant(tpcpoint) (
   PARALLEL = safe
 );
 
+CREATE AGGREGATE appendInstantAgg(tpcpoint) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tpcpoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
 CREATE AGGREGATE appendInstant(tpcpoint, text, interval) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tpcpoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(tpcpoint, text, interval) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = tpcpoint,
   FINALFUNC = temporal_append_finalfn,
@@ -245,6 +279,13 @@ CREATE FUNCTION temporal_append_finalfn(tpcpatch)
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE AGGREGATE appendInstant(tpcpatch) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tpcpatch,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(tpcpatch) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = tpcpatch,
   FINALFUNC = temporal_append_finalfn,
@@ -272,7 +313,21 @@ CREATE AGGREGATE appendSequence(tpcpoint) (
   PARALLEL = safe
 );
 
+CREATE AGGREGATE appendSequenceAgg(tpcpoint) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tpcpoint,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
 CREATE AGGREGATE appendSequence(tpcpatch) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tpcpatch,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendSequenceAgg(tpcpatch) (
   SFUNC = temporal_app_tseq_transfn,
   STYPE = tpcpatch,
   FINALFUNC = temporal_append_finalfn,

--- a/mobilitydb/sql/pose/111_tpose_aggfuncs.in.sql
+++ b/mobilitydb/sql/pose/111_tpose_aggfuncs.in.sql
@@ -97,6 +97,16 @@ CREATE AGGREGATE merge(tpose) (
   PARALLEL = safe
 );
 
+CREATE AGGREGATE mergeAgg(tpose) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tpose_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
 /*****************************************************************************
  * Append tinstant aggregate functions
  *****************************************************************************/
@@ -134,6 +144,13 @@ CREATE AGGREGATE appendInstant(tpose) (
   PARALLEL = safe
 );
 
+CREATE AGGREGATE appendInstantAgg(tpose) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tpose,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
 CREATE AGGREGATE appendInstant(tpose, text) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = tpose,
@@ -141,7 +158,21 @@ CREATE AGGREGATE appendInstant(tpose, text) (
   PARALLEL = safe
 );
 
+CREATE AGGREGATE appendInstantAgg(tpose, text) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tpose,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
 CREATE AGGREGATE appendInstant(tpose, text, float, interval) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tpose,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(tpose, text, float, interval) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = tpose,
   FINALFUNC = temporal_append_finalfn,
@@ -157,6 +188,13 @@ CREATE FUNCTION temporal_app_tseq_transfn(tpose, tpose)
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE AGGREGATE appendSequence(tpose) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tpose,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendSequenceAgg(tpose) (
   SFUNC = temporal_app_tseq_transfn,
   STYPE = tpose,
   FINALFUNC = temporal_append_finalfn,

--- a/mobilitydb/sql/rgeo/168_trgeo_aggfuncs.in.sql
+++ b/mobilitydb/sql/rgeo/168_trgeo_aggfuncs.in.sql
@@ -86,6 +86,16 @@ CREATE AGGREGATE merge(trgeometry) (
   PARALLEL = safe
 );
 
+CREATE AGGREGATE mergeAgg(trgeometry) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = trgeometry_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
 /*****************************************************************************
  * Append tinstant aggregate functions
  *****************************************************************************/
@@ -123,6 +133,13 @@ CREATE AGGREGATE appendInstant(trgeometry) (
   PARALLEL = safe
 );
 
+CREATE AGGREGATE appendInstantAgg(trgeometry) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = trgeometry,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
 CREATE AGGREGATE appendInstant(trgeometry, text) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = trgeometry,
@@ -130,7 +147,21 @@ CREATE AGGREGATE appendInstant(trgeometry, text) (
   PARALLEL = safe
 );
 
+CREATE AGGREGATE appendInstantAgg(trgeometry, text) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = trgeometry,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
 CREATE AGGREGATE appendInstant(trgeometry, text, float, interval) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = trgeometry,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(trgeometry, text, float, interval) (
   SFUNC = temporal_app_tinst_transfn,
   STYPE = trgeometry,
   FINALFUNC = temporal_append_finalfn,
@@ -146,6 +177,13 @@ CREATE FUNCTION temporal_app_tseq_transfn(trgeometry, trgeometry)
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE AGGREGATE appendSequence(trgeometry) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = trgeometry,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendSequenceAgg(trgeometry) (
   SFUNC = temporal_app_tseq_transfn,
   STYPE = trgeometry,
   FINALFUNC = temporal_append_finalfn,


### PR DESCRIPTION
The names `tMin`, `tMax`, `merge`, `appendInstant`, and `appendSequence` each
denote both a scalar function and an aggregate. The canonical name of the
aggregate form carries an `Agg` suffix (`mergeAgg`, `appendInstantAgg`,
`appendSequenceAgg`, and `tMinAgg` / `tMaxAgg` for the numeric families) so that
the scalar and aggregate names are distinct — a requirement for name-keyed
binding registries that cannot register a scalar and an aggregate under one
name. The bare aggregate name remains as a deprecated backward-compatibility
alias.

The aggregation chapter documents this convention, and the temporal and
network-point families already follow it. This applies it to the remaining
families — circular buffers, geometries, points, JSON, pointcloud, poses, and
rigid geometries — adding the `Agg`-suffixed aggregate (an identical definition
under the distinct name) alongside each existing bare `merge`, `appendInstant`,
and `appendSequence` aggregate, across all their overloads. The bare aggregates
remain as deprecated aliases; the scalar functions keep their bare names.

The reference chapter and the affected family chapters document the `Agg` forms
alongside the bare names, in English and Spanish.
