### PR TITLE
Report an error when inserting temporal sequences whose spans overlap

### DIFF
--- a/meos/src/temporal/temporal_modif.c
+++ b/meos/src/temporal/temporal_modif.c
@@ -723,16 +723,33 @@ tcontseq_insert(const TSequence *seq1, const TSequence *seq2)
       sequences[nseqs++] = tofree;
    }
   }
-  else /* overlap on the boundary */
+  else /* the two sequences overlap */
   {
-    MeosType basetype = temptype_basetype(seq1->temptype);
-    if (! ensure_tinstant_same_value(instants[0], instants[1], basetype))
-      return NULL;
+    /* The sequences may only overlap on a single instant, in which case they
+     * must have the same value at it. When they overlap on a period, which
+     * happens when the time span of one sequence contains the one of the
+     * other, the error is reported by #tcontseq_merge_array_iter below */
+    if (timestamptz_cmp_internal(instants[0]->t, instants[1]->t) == 0)
+    {
+      MeosType basetype = temptype_basetype(seq1->temptype);
+      if (! ensure_tinstant_same_value(instants[0], instants[1], basetype))
+      {
+        pfree(sequences);
+        return NULL;
+      }
+    }
   }
   sequences[nseqs++] = (TSequence *) seq2;
 
   int count;
   TSequence **newseqs = tcontseq_merge_array_iter(sequences, nseqs, &count);
+  pfree(sequences);
+  if (! newseqs)
+  {
+    if (tofree)
+      pfree(tofree);
+    return NULL;
+  }
   Temporal *result;
   if (count == 1)
   {
@@ -1118,6 +1135,8 @@ tsequenceset_insert(const TSequenceSet *ss1, const TSequenceSet *ss2)
   if (ss1->count == 1 && ss2->count == 1)
   {
     Temporal *temp = tcontseq_insert(seq1, seq2);
+    if (! temp)
+      return NULL;
     if (temp->subtype == TSEQUENCESET)
       return (TSequenceSet *) temp;
     return tsequence_to_tsequenceset_free((TSequence *) temp);

--- a/mobilitydb/test/temporal/expected/022_temporal.test.out
+++ b/mobilitydb/test/temporal/expected/022_temporal.test.out
@@ -15855,6 +15855,26 @@ SELECT insert(
   tfloat '{[1@2000-01-01, 2@2000-01-02], [3@2000-01-03, 4@2000-01-04], [5@2000-01-05, 6@2000-01-06]}',
   tfloat '{[2@2000-01-02, 4@2000-01-03], [4@2000-01-04, 5@2000-01-05]}', false);
 ERROR:  The temporal values have different value at their common timestamp Mon Jan 03 00:00:00 2000 PST
+/* The time span of one sequence contains the one of the other */
+SELECT insert(
+  tfloat '[1@2000-01-01, 2@2000-01-04]',
+  tfloat '[3@2000-01-02, 3@2000-01-03]');
+ERROR:  The temporal values cannot overlap on time: Tue Jan 04 00:00:00 2000 PST, Sun Jan 02 00:00:00 2000 PST
+SELECT insert(
+  tfloat '[3@2000-01-02, 3@2000-01-03]',
+  tfloat '[1@2000-01-01, 2@2000-01-04]');
+ERROR:  The temporal values cannot overlap on time: Tue Jan 04 00:00:00 2000 PST, Sun Jan 02 00:00:00 2000 PST
+SELECT insert(tfloat '[1@2000-01-01, 2@2000-01-04]', tfloat '[3@2000-01-02]');
+ERROR:  The temporal values cannot overlap on time: Tue Jan 04 00:00:00 2000 PST, Sun Jan 02 00:00:00 2000 PST
+SELECT insert(tint '[1@2000-01-01, 2@2000-01-04]', tint '[3@2000-01-02]');
+ERROR:  The temporal values cannot overlap on time: Tue Jan 04 00:00:00 2000 PST, Sun Jan 02 00:00:00 2000 PST
+SELECT insert(ttext '[AAA@2000-01-01, BBB@2000-01-04]', ttext '[CCC@2000-01-02]');
+ERROR:  The temporal values cannot overlap on time: Tue Jan 04 00:00:00 2000 PST, Sun Jan 02 00:00:00 2000 PST
+/* The two sequences partially overlap */
+SELECT insert(
+  tfloat '[1@2000-01-01, 2@2000-01-04]',
+  tfloat '[3@2000-01-03, 3@2000-01-06]');
+ERROR:  The temporal values cannot overlap on time: Tue Jan 04 00:00:00 2000 PST, Mon Jan 03 00:00:00 2000 PST
 SELECT deleteTime(tbool 't@2000-01-01', timestamptz '2000-01-01');
  deletetime 
 ------------

--- a/mobilitydb/test/temporal/queries/022_temporal.test.sql
+++ b/mobilitydb/test/temporal/queries/022_temporal.test.sql
@@ -3318,6 +3318,20 @@ SELECT insert(
 SELECT insert(
   tfloat '{[1@2000-01-01, 2@2000-01-02], [3@2000-01-03, 4@2000-01-04], [5@2000-01-05, 6@2000-01-06]}',
   tfloat '{[2@2000-01-02, 4@2000-01-03], [4@2000-01-04, 5@2000-01-05]}', false);
+/* The time span of one sequence contains the one of the other */
+SELECT insert(
+  tfloat '[1@2000-01-01, 2@2000-01-04]',
+  tfloat '[3@2000-01-02, 3@2000-01-03]');
+SELECT insert(
+  tfloat '[3@2000-01-02, 3@2000-01-03]',
+  tfloat '[1@2000-01-01, 2@2000-01-04]');
+SELECT insert(tfloat '[1@2000-01-01, 2@2000-01-04]', tfloat '[3@2000-01-02]');
+SELECT insert(tint '[1@2000-01-01, 2@2000-01-04]', tint '[3@2000-01-02]');
+SELECT insert(ttext '[AAA@2000-01-01, BBB@2000-01-04]', ttext '[CCC@2000-01-02]');
+/* The two sequences partially overlap */
+SELECT insert(
+  tfloat '[1@2000-01-01, 2@2000-01-04]',
+  tfloat '[3@2000-01-03, 3@2000-01-06]');
 
 SELECT deleteTime(tbool 't@2000-01-01', timestamptz '2000-01-01');
 SELECT deleteTime(tbool 't@2000-01-02', timestamptz '2000-01-01');


### PR DESCRIPTION
`insert` aborts the backend for every temporal type when the time span of one
sequence contains, or partially overlaps, the time span of the other:

```sql
SELECT insert(tint '[1@2000-01-01, 2@2000-01-04]', tint '[3@2000-01-02]');
-- ensure_tinstant_same_value: Assertion `inst1->t == inst2->t' failed.
-- server process terminated by signal 6: Aborted
```

`tcontseq_insert` orders the two sequences by comparing the last instant of the
first one with the first instant of the second one. That comparison only orders
them when neither span contains the other. With the nested spans above, the swap
puts the instantaneous sequence first, the left test on the two spans is false,
and the sequences reach the branch that assumes they share a single instant. The
same-value check then runs on the instants at `2000-01-02` and `2000-01-01`, and
its assertion on equal timestamps aborts. A build without assertions instead
compares the two values at unrelated timestamps.

This restricts the same-value check to the case it covers, that is, two instants
with the same timestamp, which is the guard that `tcontseq_merge_array_iter`
already applies. Sequences that genuinely overlap on a period fall through to
that merge and get the existing error stating that the temporal values cannot
overlap on time.

It also handles two null results on that path: `tcontseq_insert` dereferences
the merge result and reads an uninitialized count on the error path of the
merge, and `tsequenceset_insert` dereferences the result of `tcontseq_insert`.

Tests cover both orders of the nested spans, an instantaneous sequence inside
another one for tint, tfloat and ttext, and two partially overlapping sequences.