### PR TITLE
Add modification functions to the temporal pgpointcloud types

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3521,6 +3521,21 @@
 			</sect3>
 
 			<sect3>
+				<title>Modificaciones</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpcpoint_insert"><varname>insert</varname>, <varname>update</varname></link>: Insertar un tpcpoint en otro, o actualizar otro con él</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tpcpoint_deleteTime"><varname>deleteTime</varname></link>: Eliminar un selector de tiempo de un tpcpoint</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tpcpoint_appendInstant"><varname>appendInstant</varname>, <varname>appendSequence</varname></link>: Añadir un instante o una secuencia a un tpcpoint</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
 				<title>Operaciones de cuadro delimitador</title>
 				<itemizedlist>
 					<listitem>
@@ -3599,6 +3614,21 @@
 					</listitem>
 					<listitem>
 						<para><link linkend="tpcpatch_atGeometry"><varname>atGeometry</varname>, <varname>minusGeometry</varname></link>: Restringir a (al complemento de) los puntos que intersectan una geometría 2D</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Modificaciones</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpcpatch_insert"><varname>insert</varname>, <varname>update</varname></link>: Insertar un tpcpatch en otro, o actualizar otro con él</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tpcpatch_deleteTime"><varname>deleteTime</varname></link>: Eliminar un selector de tiempo de un tpcpatch</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tpcpatch_appendInstant"><varname>appendInstant</varname>, <varname>appendSequence</varname></link>: Añadir un instante o una secuencia a un tpcpatch</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -741,6 +741,36 @@ SELECT ST_AsText(startValue(tpcpoint(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),
 			</itemizedlist>
 		</sect2>
 
+		<sect2 xml:id="tpcpoint_modifications">
+			<title>Modificaciones</title>
+			<itemizedlist>
+				<listitem xml:id="tpcpoint_insert">
+					<indexterm significance="normal"><primary><varname>insert</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>update</varname></primary></indexterm>
+					<para>Insertar un tpcpoint en otro, o actualizar otro con él</para>
+					<para><varname>insert(tpcpoint,tpcpoint,connect bool=TRUE) → tpcpoint</varname></para>
+					<para><varname>update(tpcpoint,tpcpoint,connect bool=TRUE) → tpcpoint</varname></para>
+				</listitem>
+
+				<listitem xml:id="tpcpoint_deleteTime">
+					<indexterm significance="normal"><primary><varname>deleteTime</varname></primary></indexterm>
+					<para>Eliminar un selector de tiempo (marca de tiempo, conjunto, período o conjunto de spans) de un tpcpoint</para>
+					<para><varname>deleteTime(tpcpoint,timestamptz,connect bool=TRUE) → tpcpoint</varname></para>
+					<para><varname>deleteTime(tpcpoint,tstzset,connect bool=TRUE) → tpcpoint</varname></para>
+					<para><varname>deleteTime(tpcpoint,tstzspan,connect bool=TRUE) → tpcpoint</varname></para>
+					<para><varname>deleteTime(tpcpoint,tstzspanset,connect bool=TRUE) → tpcpoint</varname></para>
+				</listitem>
+
+				<listitem xml:id="tpcpoint_appendInstant">
+					<indexterm significance="normal"><primary><varname>appendInstant</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
+					<para>Añadir un instante o una secuencia a un tpcpoint</para>
+					<para><varname>appendInstant(tpcpoint,tpcpoint) → tpcpoint</varname></para>
+					<para><varname>appendSequence(tpcpoint,tpcpoint) → tpcpoint</varname></para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
 		<sect2 xml:id="tpcpoint_bbox_ops">
 			<title>Operadores de caja delimitadora</title>
 			<para>Los operadores de caja delimitadora evalúan contra el <varname>tpcbox</varname> del valor; véase <xref linkend="tpcbox_topo" /> y <xref linkend="tpcbox_pos" /> para la geometría por operador. Cada operador a continuación está conectado contra <varname>tpcbox</varname>, <varname>tstzspan</varname> y el propio <varname>tpcpoint</varname>.</para>
@@ -936,6 +966,36 @@ SELECT t, point FROM points(tpcpatch(
 					<para>Restringir un tpcpatch a los puntos cuya proyección XY intersecta (o no intersecta, en el caso de minus) una geometría 2D. Z se ignora. El llamador debe garantizar la compatibilidad de SRID entre el esquema del parche y la geometría.</para>
 					<para><varname>atGeometry(tpcpatch,geometry) → tpcpatch</varname></para>
 					<para><varname>minusGeometry(tpcpatch,geometry) → tpcpatch</varname></para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2 xml:id="tpcpatch_modifications">
+			<title>Modificaciones</title>
+			<itemizedlist>
+				<listitem xml:id="tpcpatch_insert">
+					<indexterm significance="normal"><primary><varname>insert</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>update</varname></primary></indexterm>
+					<para>Insertar un tpcpatch en otro, o actualizar otro con él</para>
+					<para><varname>insert(tpcpatch,tpcpatch,connect bool=TRUE) → tpcpatch</varname></para>
+					<para><varname>update(tpcpatch,tpcpatch,connect bool=TRUE) → tpcpatch</varname></para>
+				</listitem>
+
+				<listitem xml:id="tpcpatch_deleteTime">
+					<indexterm significance="normal"><primary><varname>deleteTime</varname></primary></indexterm>
+					<para>Eliminar un selector de tiempo (marca de tiempo, conjunto, período o conjunto de spans) de un tpcpatch</para>
+					<para><varname>deleteTime(tpcpatch,timestamptz,connect bool=TRUE) → tpcpatch</varname></para>
+					<para><varname>deleteTime(tpcpatch,tstzset,connect bool=TRUE) → tpcpatch</varname></para>
+					<para><varname>deleteTime(tpcpatch,tstzspan,connect bool=TRUE) → tpcpatch</varname></para>
+					<para><varname>deleteTime(tpcpatch,tstzspanset,connect bool=TRUE) → tpcpatch</varname></para>
+				</listitem>
+
+				<listitem xml:id="tpcpatch_appendInstant">
+					<indexterm significance="normal"><primary><varname>appendInstant</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
+					<para>Añadir un instante o una secuencia a un tpcpatch</para>
+					<para><varname>appendInstant(tpcpatch,tpcpatch) → tpcpatch</varname></para>
+					<para><varname>appendSequence(tpcpatch,tpcpatch) → tpcpatch</varname></para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3499,6 +3499,21 @@
 			</sect3>
 
 			<sect3>
+				<title>Modifications</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpcpoint_insert"><varname>insert</varname>, <varname>update</varname></link>: Insert a tpcpoint into another one, or update another one with it</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tpcpoint_deleteTime"><varname>deleteTime</varname></link>: Delete a time selector from a tpcpoint</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tpcpoint_appendInstant"><varname>appendInstant</varname>, <varname>appendSequence</varname></link>: Append an instant or a sequence to a tpcpoint</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
 				<title>Bounding-box Operators</title>
 				<itemizedlist>
 					<listitem>
@@ -3577,6 +3592,21 @@
 					</listitem>
 					<listitem>
 						<para><link linkend="tpcpatch_atGeometry"><varname>atGeometry</varname>, <varname>minusGeometry</varname></link>: Restrict to (the complement of) the points intersecting a 2D geometry</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Modifications</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpcpatch_insert"><varname>insert</varname>, <varname>update</varname></link>: Insert a tpcpatch into another one, or update another one with it</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tpcpatch_deleteTime"><varname>deleteTime</varname></link>: Delete a time selector from a tpcpatch</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tpcpatch_appendInstant"><varname>appendInstant</varname>, <varname>appendSequence</varname></link>: Append an instant or a sequence to a tpcpatch</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -746,6 +746,36 @@ SELECT ST_AsText(startValue(tpcpoint(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),
 			</itemizedlist>
 		</sect2>
 
+		<sect2 xml:id="tpcpoint_modifications">
+			<title>Modifications</title>
+			<itemizedlist>
+				<listitem xml:id="tpcpoint_insert">
+					<indexterm significance="normal"><primary><varname>insert</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>update</varname></primary></indexterm>
+					<para>Insert a tpcpoint into another one, or update another one with it</para>
+					<para><varname>insert(tpcpoint,tpcpoint,connect bool=TRUE) → tpcpoint</varname></para>
+					<para><varname>update(tpcpoint,tpcpoint,connect bool=TRUE) → tpcpoint</varname></para>
+				</listitem>
+
+				<listitem xml:id="tpcpoint_deleteTime">
+					<indexterm significance="normal"><primary><varname>deleteTime</varname></primary></indexterm>
+					<para>Delete a time selector (timestamp, set, period, or spanset) from a tpcpoint</para>
+					<para><varname>deleteTime(tpcpoint,timestamptz,connect bool=TRUE) → tpcpoint</varname></para>
+					<para><varname>deleteTime(tpcpoint,tstzset,connect bool=TRUE) → tpcpoint</varname></para>
+					<para><varname>deleteTime(tpcpoint,tstzspan,connect bool=TRUE) → tpcpoint</varname></para>
+					<para><varname>deleteTime(tpcpoint,tstzspanset,connect bool=TRUE) → tpcpoint</varname></para>
+				</listitem>
+
+				<listitem xml:id="tpcpoint_appendInstant">
+					<indexterm significance="normal"><primary><varname>appendInstant</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
+					<para>Append an instant or a sequence to a tpcpoint</para>
+					<para><varname>appendInstant(tpcpoint,tpcpoint) → tpcpoint</varname></para>
+					<para><varname>appendSequence(tpcpoint,tpcpoint) → tpcpoint</varname></para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
 		<sect2 xml:id="tpcpoint_bbox_ops">
 			<title>Bounding-box operators</title>
 			<para>The bbox operators evaluate against the value's <varname>tpcbox</varname>; see <xref linkend="tpcbox_topo" /> and <xref linkend="tpcbox_pos" /> for the per-operator geometry. Each operator below is wired against <varname>tpcbox</varname>, <varname>tstzspan</varname>, and <varname>tpcpoint</varname> itself.</para>
@@ -942,6 +972,36 @@ SELECT t, point FROM points(tpcpatch(
 					<para>Restrict a tpcpatch to the points whose XY projection intersects (or does not intersect, for minus) a 2D geometry. Z is ignored. SRID compatibility between the patch schema and the geometry must be ensured by the caller.</para>
 					<para><varname>atGeometry(tpcpatch,geometry) → tpcpatch</varname></para>
 					<para><varname>minusGeometry(tpcpatch,geometry) → tpcpatch</varname></para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2 xml:id="tpcpatch_modifications">
+			<title>Modifications</title>
+			<itemizedlist>
+				<listitem xml:id="tpcpatch_insert">
+					<indexterm significance="normal"><primary><varname>insert</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>update</varname></primary></indexterm>
+					<para>Insert a tpcpatch into another one, or update another one with it</para>
+					<para><varname>insert(tpcpatch,tpcpatch,connect bool=TRUE) → tpcpatch</varname></para>
+					<para><varname>update(tpcpatch,tpcpatch,connect bool=TRUE) → tpcpatch</varname></para>
+				</listitem>
+
+				<listitem xml:id="tpcpatch_deleteTime">
+					<indexterm significance="normal"><primary><varname>deleteTime</varname></primary></indexterm>
+					<para>Delete a time selector (timestamp, set, period, or spanset) from a tpcpatch</para>
+					<para><varname>deleteTime(tpcpatch,timestamptz,connect bool=TRUE) → tpcpatch</varname></para>
+					<para><varname>deleteTime(tpcpatch,tstzset,connect bool=TRUE) → tpcpatch</varname></para>
+					<para><varname>deleteTime(tpcpatch,tstzspan,connect bool=TRUE) → tpcpatch</varname></para>
+					<para><varname>deleteTime(tpcpatch,tstzspanset,connect bool=TRUE) → tpcpatch</varname></para>
+				</listitem>
+
+				<listitem xml:id="tpcpatch_appendInstant">
+					<indexterm significance="normal"><primary><varname>appendInstant</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
+					<para>Append an instant or a sequence to a tpcpatch</para>
+					<para><varname>appendInstant(tpcpatch,tpcpatch) → tpcpatch</varname></para>
+					<para><varname>appendSequence(tpcpatch,tpcpatch) → tpcpatch</varname></para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
+++ b/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
@@ -475,6 +475,45 @@ CREATE FUNCTION minusTpcbox(tpcpoint, tpcbox, border_inc boolean DEFAULT TRUE)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /******************************************************************************
+ * Modification functions
+ ******************************************************************************/
+
+CREATE FUNCTION insert(tpcpoint, tpcpoint, connect boolean DEFAULT TRUE)
+  RETURNS tpcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_insert'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION update(tpcpoint, tpcpoint, connect boolean DEFAULT TRUE)
+  RETURNS tpcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_update'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION deleteTime(tpcpoint, timestamptz, connect boolean DEFAULT TRUE)
+  RETURNS tpcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_delete_timestamptz'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION deleteTime(tpcpoint, tstzset, connect boolean DEFAULT TRUE)
+  RETURNS tpcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_delete_tstzset'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION deleteTime(tpcpoint, tstzspan, connect boolean DEFAULT TRUE)
+  RETURNS tpcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_delete_tstzspan'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION deleteTime(tpcpoint, tstzspanset, connect boolean DEFAULT TRUE)
+  RETURNS tpcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_delete_tstzspanset'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION appendInstant(tpcpoint, tpcpoint)
+  RETURNS tpcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_append_tinstant'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION appendSequence(tpcpoint, tpcpoint)
+  RETURNS tpcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_append_tsequence'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/******************************************************************************
  * Ever / always predicates
  ******************************************************************************/
 

--- a/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
+++ b/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
@@ -499,6 +499,45 @@ CREATE FUNCTION points(tpcpatch)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /******************************************************************************
+ * Modification functions
+ ******************************************************************************/
+
+CREATE FUNCTION insert(tpcpatch, tpcpatch, connect boolean DEFAULT TRUE)
+  RETURNS tpcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_insert'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION update(tpcpatch, tpcpatch, connect boolean DEFAULT TRUE)
+  RETURNS tpcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_update'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION deleteTime(tpcpatch, timestamptz, connect boolean DEFAULT TRUE)
+  RETURNS tpcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_delete_timestamptz'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION deleteTime(tpcpatch, tstzset, connect boolean DEFAULT TRUE)
+  RETURNS tpcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_delete_tstzset'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION deleteTime(tpcpatch, tstzspan, connect boolean DEFAULT TRUE)
+  RETURNS tpcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_delete_tstzspan'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION deleteTime(tpcpatch, tstzspanset, connect boolean DEFAULT TRUE)
+  RETURNS tpcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_delete_tstzspanset'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION appendInstant(tpcpatch, tpcpatch)
+  RETURNS tpcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_append_tinstant'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION appendSequence(tpcpatch, tpcpatch)
+  RETURNS tpcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_append_tsequence'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/******************************************************************************
  * Ever / always
  ******************************************************************************/
 

--- a/mobilitydb/test/pointcloud/expected/420_tpcpoint.test.out
+++ b/mobilitydb/test/pointcloud/expected/420_tpcpoint.test.out
@@ -244,3 +244,72 @@ SELECT atTpcbox(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-0
  t
 (1 row)
 
+SELECT insert(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz)]),
+  tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)])) IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT insert(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz)]),
+  tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]), false) IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT update(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]),
+  tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz)])) IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT update(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]),
+  tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)])) IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT deleteTime(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]),
+  timestamptz '2024-01-02') IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT deleteTime(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]),
+  tstzset '{2024-01-02}') IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT deleteTime(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]),
+  tstzspan '[2024-01-02, 2024-01-02]') IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT deleteTime(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]),
+  tstzspanset '{[2024-01-02, 2024-01-02]}') IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT appendInstant(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz)]), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)) IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT appendSequence(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)]),
+  tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)])) IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+

--- a/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
+++ b/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
@@ -364,3 +364,72 @@ SELECT count(DISTINCT t)
      2
 (1 row)
 
+SELECT insert(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz)]),
+  tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)])) IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT insert(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz)]),
+  tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)]), false) IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT update(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)]),
+  tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz)])) IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT update(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)]),
+  tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)])) IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT deleteTime(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)]),
+  timestamptz '2024-01-02') IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT deleteTime(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)]),
+  tstzset '{2024-01-02}') IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT deleteTime(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)]),
+  tstzspan '[2024-01-02, 2024-01-02]') IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT deleteTime(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)]),
+  tstzspanset '{[2024-01-02, 2024-01-02]}') IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT appendInstant(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz)]), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)) IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT appendSequence(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz)]),
+  tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)])) IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+

--- a/mobilitydb/test/pointcloud/queries/420_tpcpoint.test.sql
+++ b/mobilitydb/test/pointcloud/queries/420_tpcpoint.test.sql
@@ -131,3 +131,31 @@ SELECT atTpcbox(:inst1, tpcbox_zt(0, 0, 0, 10, 10, 10,
   tstzspan '[2024-01-01, 2024-01-31]', 999, 0)) IS NULL;
 
 -------------------------------------------------------------------------------
+-- Modifications
+-- insert/update take temporal values that share the same value at their
+-- common timestamp; append adds an instant/sequence after the end.
+-------------------------------------------------------------------------------
+
+SELECT insert(tpcpointSeq(ARRAY[:inst1, :inst2]),
+  tpcpointSeq(ARRAY[:inst2, :inst3])) IS NOT NULL;
+SELECT insert(tpcpointSeq(ARRAY[:inst1, :inst2]),
+  tpcpointSeq(ARRAY[:inst2, :inst3]), false) IS NOT NULL;
+SELECT update(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
+  tpcpointSeq(ARRAY[:inst2])) IS NOT NULL;
+SELECT update(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
+  tpcpointSeq(ARRAY[:inst2, :inst3])) IS NOT NULL;
+
+SELECT deleteTime(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
+  timestamptz '2024-01-02') IS NOT NULL;
+SELECT deleteTime(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
+  tstzset '{2024-01-02}') IS NOT NULL;
+SELECT deleteTime(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
+  tstzspan '[2024-01-02, 2024-01-02]') IS NOT NULL;
+SELECT deleteTime(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
+  tstzspanset '{[2024-01-02, 2024-01-02]}') IS NOT NULL;
+
+SELECT appendInstant(tpcpointSeq(ARRAY[:inst1, :inst2]), :inst3) IS NOT NULL;
+SELECT appendSequence(tpcpointSeq(ARRAY[:inst1]),
+  tpcpointSeq(ARRAY[:inst2, :inst3])) IS NOT NULL;
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
+++ b/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
@@ -187,3 +187,31 @@ SELECT count(DISTINCT t)
   FROM points(tpcpatchSeq(ARRAY[:inst1, :inst2]));
 
 -------------------------------------------------------------------------------
+-- Modifications
+-- insert/update take temporal values that share the same value at their
+-- common timestamp; append adds an instant/sequence after the end.
+-------------------------------------------------------------------------------
+
+SELECT insert(tpcpatchSeq(ARRAY[:inst1, :inst2]),
+  tpcpatchSeq(ARRAY[:inst2, :inst3])) IS NOT NULL;
+SELECT insert(tpcpatchSeq(ARRAY[:inst1, :inst2]),
+  tpcpatchSeq(ARRAY[:inst2, :inst3]), false) IS NOT NULL;
+SELECT update(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3]),
+  tpcpatchSeq(ARRAY[:inst2])) IS NOT NULL;
+SELECT update(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3]),
+  tpcpatchSeq(ARRAY[:inst2, :inst3])) IS NOT NULL;
+
+SELECT deleteTime(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3]),
+  timestamptz '2024-01-02') IS NOT NULL;
+SELECT deleteTime(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3]),
+  tstzset '{2024-01-02}') IS NOT NULL;
+SELECT deleteTime(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3]),
+  tstzspan '[2024-01-02, 2024-01-02]') IS NOT NULL;
+SELECT deleteTime(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3]),
+  tstzspanset '{[2024-01-02, 2024-01-02]}') IS NOT NULL;
+
+SELECT appendInstant(tpcpatchSeq(ARRAY[:inst1, :inst2]), :inst3) IS NOT NULL;
+SELECT appendSequence(tpcpatchSeq(ARRAY[:inst1, :inst2]),
+  tpcpatchSeq(ARRAY[:inst3])) IS NOT NULL;
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
The temporal pgpointcloud types `tpcpoint` and `tpcpatch` lack the modification
functions the other temporal types provide. This adds them, each binding the
generic `Temporal` function that already implements the operation:

- `insert(ttype,ttype,connect bool=TRUE)` and `update(ttype,ttype,connect bool=TRUE)`
- `deleteTime(ttype,X,connect bool=TRUE)` for `timestamptz`, `tstzset`, `tstzspan`
  and `tstzspanset`
- `appendInstant(ttype,ttype)` and `appendSequence(ttype,ttype)`

The declarations follow the `tjsonb` ones, which is the reference type for a
temporal type over an opaque variable-length base type.

Tests exercise every added function on both types, and the documentation gains a
Modifications section for each type in the point cloud chapter plus its bullets
in the reference, in English and Spanish.

`merge` is left out: it comes with the scalar-versus-aggregate naming and the
strictness question, which belong together in their own change.