### PR TITLE
Add time restrictions to the temporal pgpointcloud types

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3529,6 +3529,9 @@
 					<listitem>
 						<para><link linkend="tpcpoint_atTpcbox"><varname>atTpcbox</varname>, <varname>minusTpcbox</varname></link>: Restringir a (al complemento de) la extensión de un tpcbox</para>
 					</listitem>
+					<listitem>
+						<para><link linkend="tpcpoint_beforeTimestamp"><varname>beforeTimestamp</varname>, <varname>afterTimestamp</varname></link>: Restringir a los instantes anteriores o posteriores a una marca de tiempo</para>
+					</listitem>
 				</itemizedlist>
 			</sect3>
 
@@ -3639,6 +3642,9 @@
 					</listitem>
 					<listitem>
 						<para><link linkend="tpcpatch_atGeometry"><varname>atGeometry</varname>, <varname>minusGeometry</varname></link>: Restringir a (al complemento de) los puntos que intersectan una geometría 2D</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tpcpatch_beforeTimestamp"><varname>beforeTimestamp</varname>, <varname>afterTimestamp</varname></link>: Restringir a los instantes anteriores o posteriores a una marca de tiempo</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -758,6 +758,14 @@ SELECT ST_AsText(startValue(tpcpoint(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),
 					<para><varname>atTpcbox(tpcpoint,tpcbox,border_inc bool=TRUE) → tpcpoint</varname></para>
 					<para><varname>minusTpcbox(tpcpoint,tpcbox,border_inc bool=TRUE) → tpcpoint</varname></para>
 				</listitem>
+
+				<listitem xml:id="tpcpoint_beforeTimestamp">
+					<indexterm significance="normal"><primary><varname>beforeTimestamp</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>afterTimestamp</varname></primary></indexterm>
+					<para>Restringir un tpcpoint a los instantes anteriores o posteriores a una marca de tiempo. El indicador strict excluye el instante en la marca de tiempo misma</para>
+					<para><varname>beforeTimestamp(tpcpoint,timestamptz,strict bool=TRUE) → tpcpoint</varname></para>
+					<para><varname>afterTimestamp(tpcpoint,timestamptz,strict bool=TRUE) → tpcpoint</varname></para>
+				</listitem>
 			</itemizedlist>
 		</sect2>
 
@@ -1006,6 +1014,14 @@ SELECT t, point FROM points(tpcpatch(
 					<para>Restringir un tpcpatch a los puntos cuya proyección XY intersecta (o no intersecta, en el caso de minus) una geometría 2D. Z se ignora. El llamador debe garantizar la compatibilidad de SRID entre el esquema del parche y la geometría.</para>
 					<para><varname>atGeometry(tpcpatch,geometry) → tpcpatch</varname></para>
 					<para><varname>minusGeometry(tpcpatch,geometry) → tpcpatch</varname></para>
+				</listitem>
+
+				<listitem xml:id="tpcpatch_beforeTimestamp">
+					<indexterm significance="normal"><primary><varname>beforeTimestamp</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>afterTimestamp</varname></primary></indexterm>
+					<para>Restringir un tpcpatch a los instantes anteriores o posteriores a una marca de tiempo. El indicador strict excluye el instante en la marca de tiempo misma</para>
+					<para><varname>beforeTimestamp(tpcpatch,timestamptz,strict bool=TRUE) → tpcpatch</varname></para>
+					<para><varname>afterTimestamp(tpcpatch,timestamptz,strict bool=TRUE) → tpcpatch</varname></para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3507,6 +3507,9 @@
 					<listitem>
 						<para><link linkend="tpcpoint_atTpcbox"><varname>atTpcbox</varname>, <varname>minusTpcbox</varname></link>: Restrict to (the complement of) the extent of a tpcbox</para>
 					</listitem>
+					<listitem>
+						<para><link linkend="tpcpoint_beforeTimestamp"><varname>beforeTimestamp</varname>, <varname>afterTimestamp</varname></link>: Restrict to the instants before or after a timestamp</para>
+					</listitem>
 				</itemizedlist>
 			</sect3>
 
@@ -3617,6 +3620,9 @@
 					</listitem>
 					<listitem>
 						<para><link linkend="tpcpatch_atGeometry"><varname>atGeometry</varname>, <varname>minusGeometry</varname></link>: Restrict to (the complement of) the points intersecting a 2D geometry</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tpcpatch_beforeTimestamp"><varname>beforeTimestamp</varname>, <varname>afterTimestamp</varname></link>: Restrict to the instants before or after a timestamp</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -763,6 +763,14 @@ SELECT ST_AsText(startValue(tpcpoint(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),
 					<para><varname>atTpcbox(tpcpoint,tpcbox,border_inc bool=TRUE) → tpcpoint</varname></para>
 					<para><varname>minusTpcbox(tpcpoint,tpcbox,border_inc bool=TRUE) → tpcpoint</varname></para>
 				</listitem>
+
+				<listitem xml:id="tpcpoint_beforeTimestamp">
+					<indexterm significance="normal"><primary><varname>beforeTimestamp</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>afterTimestamp</varname></primary></indexterm>
+					<para>Restrict a tpcpoint to the instants before or after a timestamp. The strict flag excludes the instant at the timestamp itself</para>
+					<para><varname>beforeTimestamp(tpcpoint,timestamptz,strict bool=TRUE) → tpcpoint</varname></para>
+					<para><varname>afterTimestamp(tpcpoint,timestamptz,strict bool=TRUE) → tpcpoint</varname></para>
+				</listitem>
 			</itemizedlist>
 		</sect2>
 
@@ -1012,6 +1020,14 @@ SELECT t, point FROM points(tpcpatch(
 					<para>Restrict a tpcpatch to the points whose XY projection intersects (or does not intersect, for minus) a 2D geometry. Z is ignored. SRID compatibility between the patch schema and the geometry must be ensured by the caller.</para>
 					<para><varname>atGeometry(tpcpatch,geometry) → tpcpatch</varname></para>
 					<para><varname>minusGeometry(tpcpatch,geometry) → tpcpatch</varname></para>
+				</listitem>
+
+				<listitem xml:id="tpcpatch_beforeTimestamp">
+					<indexterm significance="normal"><primary><varname>beforeTimestamp</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>afterTimestamp</varname></primary></indexterm>
+					<para>Restrict a tpcpatch to the instants before or after a timestamp. The strict flag excludes the instant at the timestamp itself</para>
+					<para><varname>beforeTimestamp(tpcpatch,timestamptz,strict bool=TRUE) → tpcpatch</varname></para>
+					<para><varname>afterTimestamp(tpcpatch,timestamptz,strict bool=TRUE) → tpcpatch</varname></para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
+++ b/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
@@ -505,6 +505,17 @@ CREATE FUNCTION minusTime(tpcpoint, tstzspanset)
   AS 'MODULE_PATHNAME', 'Temporal_minus_tstzspanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION beforeTimestamp(tpcpoint, timestamptz,
+    strict bool DEFAULT TRUE)
+  RETURNS tpcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_before_timestamptz'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION afterTimestamp(tpcpoint, timestamptz,
+    strict bool DEFAULT TRUE)
+  RETURNS tpcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_after_timestamptz'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 /******************************************************************************
  * TPCBox-based restrictions
  ******************************************************************************/

--- a/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
+++ b/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
@@ -471,6 +471,17 @@ CREATE FUNCTION minusTime(tpcpatch, tstzspanset)
   AS 'MODULE_PATHNAME', 'Temporal_minus_tstzspanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION beforeTimestamp(tpcpatch, timestamptz,
+    strict bool DEFAULT TRUE)
+  RETURNS tpcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_before_timestamptz'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION afterTimestamp(tpcpatch, timestamptz,
+    strict bool DEFAULT TRUE)
+  RETURNS tpcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_after_timestamptz'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 /******************************************************************************
  * TPCBox-based restrictions (patch-level / coarse)
  ******************************************************************************/

--- a/mobilitydb/test/pointcloud/expected/420_tpcpoint.test.out
+++ b/mobilitydb/test/pointcloud/expected/420_tpcpoint.test.out
@@ -295,6 +295,58 @@ SELECT atTpcbox(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-0
  t
 (1 row)
 
+SELECT timeSpan(beforeTimestamp(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]),
+  timestamptz '2024-01-02'));
+                           timespan                           
+--------------------------------------------------------------
+ [Mon Jan 01 00:00:00 2024 PST, Tue Jan 02 00:00:00 2024 PST)
+(1 row)
+
+SELECT timeSpan(beforeTimestamp(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]),
+  timestamptz '2024-01-02', false));
+                           timespan                           
+--------------------------------------------------------------
+ [Mon Jan 01 00:00:00 2024 PST, Tue Jan 02 00:00:00 2024 PST]
+(1 row)
+
+SELECT timeSpan(afterTimestamp(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]),
+  timestamptz '2024-01-02'));
+                           timespan                           
+--------------------------------------------------------------
+ (Tue Jan 02 00:00:00 2024 PST, Wed Jan 03 00:00:00 2024 PST]
+(1 row)
+
+SELECT timeSpan(afterTimestamp(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]),
+  timestamptz '2024-01-02', false));
+                           timespan                           
+--------------------------------------------------------------
+ [Tue Jan 02 00:00:00 2024 PST, Wed Jan 03 00:00:00 2024 PST]
+(1 row)
+
+SELECT beforeTimestamp(tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), timestamptz '2024-01-02') IS NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT afterTimestamp(tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), timestamptz '2024-01-02') IS NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT numInstants(beforeTimestamp(tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), timestamptz '2024-01-02', false));
+ numinstants 
+-------------
+           1
+(1 row)
+
+SELECT numInstants(afterTimestamp(tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), timestamptz '2024-01-02', false));
+ numinstants 
+-------------
+           1
+(1 row)
+
 SELECT insert(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz)]),
   tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)])) IS NOT NULL;
  ?column? 

--- a/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
+++ b/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
@@ -320,6 +320,58 @@ SELECT atTpcbox(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::fl
  t
 (1 row)
 
+SELECT timeSpan(beforeTimestamp(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)]),
+  timestamptz '2024-01-02'));
+                           timespan                           
+--------------------------------------------------------------
+ [Mon Jan 01 00:00:00 2024 PST, Tue Jan 02 00:00:00 2024 PST)
+(1 row)
+
+SELECT timeSpan(beforeTimestamp(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)]),
+  timestamptz '2024-01-02', false));
+                           timespan                           
+--------------------------------------------------------------
+ [Mon Jan 01 00:00:00 2024 PST, Tue Jan 02 00:00:00 2024 PST]
+(1 row)
+
+SELECT timeSpan(afterTimestamp(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)]),
+  timestamptz '2024-01-02'));
+                           timespan                           
+--------------------------------------------------------------
+ (Tue Jan 02 00:00:00 2024 PST, Wed Jan 03 00:00:00 2024 PST]
+(1 row)
+
+SELECT timeSpan(afterTimestamp(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)]),
+  timestamptz '2024-01-02', false));
+                           timespan                           
+--------------------------------------------------------------
+ [Tue Jan 02 00:00:00 2024 PST, Wed Jan 03 00:00:00 2024 PST]
+(1 row)
+
+SELECT beforeTimestamp(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), timestamptz '2024-01-02') IS NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT afterTimestamp(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), timestamptz '2024-01-02') IS NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT numInstants(beforeTimestamp(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), timestamptz '2024-01-02', false));
+ numinstants 
+-------------
+           1
+(1 row)
+
+SELECT numInstants(afterTimestamp(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), timestamptz '2024-01-02', false));
+ numinstants 
+-------------
+           1
+(1 row)
+
 SELECT numInstants(atTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcbox_zt(0, 0, 0, 3, 3, 3,
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0)));
  numinstants 

--- a/mobilitydb/test/pointcloud/queries/420_tpcpoint.test.sql
+++ b/mobilitydb/test/pointcloud/queries/420_tpcpoint.test.sql
@@ -146,6 +146,24 @@ SELECT minusTpcbox(:inst2, tpcbox_zt(0, 0, 0, 10, 10, 10,
 SELECT atTpcbox(:inst1, tpcbox_zt(0, 0, 0, 10, 10, 10,
   tstzspan '[2024-01-01, 2024-01-31]', 999, 0)) IS NULL;
 
+-- Restriction to the instants before / after a timestamp. The strict flag
+-- is true by default and excludes the instant at the timestamp itself, which
+-- on a sequence shows up as the inclusivity of the resulting time span.
+SELECT timeSpan(beforeTimestamp(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
+  timestamptz '2024-01-02'));
+SELECT timeSpan(beforeTimestamp(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
+  timestamptz '2024-01-02', false));
+SELECT timeSpan(afterTimestamp(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
+  timestamptz '2024-01-02'));
+SELECT timeSpan(afterTimestamp(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
+  timestamptz '2024-01-02', false));
+-- An instant is dropped by the strict form at its own timestamp and kept by
+-- the non-strict one.
+SELECT beforeTimestamp(:inst2, timestamptz '2024-01-02') IS NULL;
+SELECT afterTimestamp(:inst2, timestamptz '2024-01-02') IS NULL;
+SELECT numInstants(beforeTimestamp(:inst2, timestamptz '2024-01-02', false));
+SELECT numInstants(afterTimestamp(:inst2, timestamptz '2024-01-02', false));
+
 -------------------------------------------------------------------------------
 -- Modifications
 -- insert/update take temporal values that share the same value at their

--- a/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
+++ b/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
@@ -152,6 +152,24 @@ SELECT minusTpcbox(:inst1, tpcbox_zt(0, 0, 0, 10, 10, 10,
 SELECT atTpcbox(:inst1, tpcbox_zt(0, 0, 0, 10, 10, 10,
   tstzspan '[2024-01-01, 2024-01-31]', 999, 0)) IS NULL;
 
+-- Restriction to the instants before / after a timestamp. The strict flag
+-- is true by default and excludes the instant at the timestamp itself, which
+-- on a sequence shows up as the inclusivity of the resulting time span.
+SELECT timeSpan(beforeTimestamp(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3]),
+  timestamptz '2024-01-02'));
+SELECT timeSpan(beforeTimestamp(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3]),
+  timestamptz '2024-01-02', false));
+SELECT timeSpan(afterTimestamp(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3]),
+  timestamptz '2024-01-02'));
+SELECT timeSpan(afterTimestamp(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3]),
+  timestamptz '2024-01-02', false));
+-- An instant is dropped by the strict form at its own timestamp and kept by
+-- the non-strict one.
+SELECT beforeTimestamp(:inst2, timestamptz '2024-01-02') IS NULL;
+SELECT afterTimestamp(:inst2, timestamptz '2024-01-02') IS NULL;
+SELECT numInstants(beforeTimestamp(:inst2, timestamptz '2024-01-02', false));
+SELECT numInstants(afterTimestamp(:inst2, timestamptz '2024-01-02', false));
+
 -------------------------------------------------------------------------------
 -- Per-point restrictions — atTpcboxFine / minusTpcboxFine.
 -- inst1 has points at (1,1,1) and (2,2,2). A box covering [0,3]^3


### PR DESCRIPTION
The temporal pgpointcloud types `tpcpoint` and `tpcpatch` restrict to a time
selector with `atTime` and `minusTime`, but not to the instants that come
before or after a timestamp. This adds the two functions the other temporal
types provide, each binding the generic `Temporal` function that already
implements the operation:

- `beforeTimestamp(ttype,timestamptz,strict bool=TRUE)`
- `afterTimestamp(ttype,timestamptz,strict bool=TRUE)`

The signature is the uniform one used by every other family.

The tests assert the resulting time span rather than the number of instants,
since on a sequence the strict flag changes the inclusivity of the bound and
not the instant count: `beforeTimestamp` gives `[t1, t2)` when strict and
`[t1, t2]` otherwise, `afterTimestamp` gives `(t2, t3]` and `[t2, t3]`. On a
single instant the strict form returns NULL at the instant's own timestamp and
the non-strict form keeps it.

The documentation gains the pair in the Restrictions section of each type in
the point cloud chapter plus its bullet in the reference, in English and
Spanish.