### PR TITLE
Add the text and binary representations to the temporal QUADBIN type

### DIFF
--- a/doc/es/temporal_quadbin_index.xml
+++ b/doc/es/temporal_quadbin_index.xml
@@ -36,6 +36,18 @@ SELECT tquadbin(SequenceSet) '{[480fffffffffffff@2001-01-01, 48427fffffffffff@20
 -- ERROR: el tipo temporal (Instant) no coincide con el tipo de columna (Sequence)
 SELECT tquadbin(Sequence) '480fffffffffffff@2001-01-01';
 </programlisting>
+		<para>Las funciones <varname>asText</varname>, <varname>asBinary</varname> y <varname>asHexWKB</varname> serializan un valor <varname>tquadbin</varname>, y <varname>tquadbinFromBinary</varname> y <varname>tquadbinFromHexWKB</varname> lo reconstruyen. La forma hexadecimal WKB permite que una columna de índice QUADBIN temporal se transfiera de ida y vuelta mediante un <varname>COPY</varname> basado en texto.</para>
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asHexWKB(tquadbin '480fffffffffffff@2001-01-01');
+SELECT tquadbinFromHexWKB(asHexWKB(tquadbin '480fffffffffffff@2001-01-01'));
+-- 480fffffffffffff@2001-01-01
+</programlisting>
+		<para>La representación <emphasis>MF-JSON</emphasis> está disponible mediante <varname>asMFJSON(tquadbin)</varname> y <varname>tquadbinFromMFJSON(text)</varname>. La carga útil de la celda se representa como el identificador int64 de la celda en el arreglo <varname>values</varname>, la misma representación que utiliza <varname>tbigint</varname>.</para>
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asMFJSON(tquadbin '480fffffffffffff@2001-01-01');
+SELECT tquadbinFromMFJSON(asMFJSON(tquadbin '480fffffffffffff@2001-01-01'));
+-- 480fffffffffffff@2001-01-01
+</programlisting>
 	</sect1>
 
 	<sect1 xml:id="tquadbin_conversions">

--- a/doc/temporal_quadbin_index.xml
+++ b/doc/temporal_quadbin_index.xml
@@ -36,6 +36,18 @@ SELECT tquadbin(SequenceSet) '{[480fffffffffffff@2001-01-01, 48427fffffffffff@20
 -- ERROR: temporal type (Instant) does not match column type (Sequence)
 SELECT tquadbin(Sequence) '480fffffffffffff@2001-01-01';
 </programlisting>
+		<para>The functions <varname>asText</varname>, <varname>asBinary</varname>, and <varname>asHexWKB</varname> serialize a <varname>tquadbin</varname> value, and <varname>tquadbinFromBinary</varname> and <varname>tquadbinFromHexWKB</varname> reconstruct it. The hexadecimal WKB form lets a temporal QUADBIN index column round-trip through a text-based <varname>COPY</varname>.</para>
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asHexWKB(tquadbin '480fffffffffffff@2001-01-01');
+SELECT tquadbinFromHexWKB(asHexWKB(tquadbin '480fffffffffffff@2001-01-01'));
+-- 480fffffffffffff@2001-01-01
+</programlisting>
+		<para>The <emphasis>MF-JSON</emphasis> representation is available through <varname>asMFJSON(tquadbin)</varname> and <varname>tquadbinFromMFJSON(text)</varname>. The cell payload renders as the int64 cell identifier in the <varname>values</varname> array, the same representation carried by <varname>tbigint</varname>.</para>
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asMFJSON(tquadbin '480fffffffffffff@2001-01-01');
+SELECT tquadbinFromMFJSON(asMFJSON(tquadbin '480fffffffffffff@2001-01-01'));
+-- 480fffffffffffff@2001-01-01
+</programlisting>
 	</sect1>
 
 	<sect1 xml:id="tquadbin_conversions">

--- a/mobilitydb/sql/quadbin/353_tquadbin.in.sql
+++ b/mobilitydb/sql/quadbin/353_tquadbin.in.sql
@@ -89,6 +89,46 @@ CREATE TYPE tquadbin (
 );
 
 /******************************************************************************
+ * Text and (Hex)WKB I/O (mirrors the tcbuffer / tnpoint / tpose plug-in types)
+ ******************************************************************************/
+
+CREATE FUNCTION asText(tquadbin)
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Temporal_as_text'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION asBinary(tquadbin, endianenconding text DEFAULT '')
+  RETURNS bytea
+  AS 'MODULE_PATHNAME', 'Temporal_as_wkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION asHexWKB(tquadbin, endianenconding text DEFAULT '')
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION asMFJSON(temp tquadbin, options int4 DEFAULT 0,
+    flags int4 DEFAULT 0, maxdecimaldigits int4 DEFAULT 15)
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Temporal_as_mfjson'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION tquadbinFromBinary(bytea)
+  RETURNS tquadbin
+  AS 'MODULE_PATHNAME', 'Temporal_from_wkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION tquadbinFromHexWKB(text)
+  RETURNS tquadbin
+  AS 'MODULE_PATHNAME', 'Temporal_from_hexwkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION tquadbinFromMFJSON(text)
+  RETURNS tquadbin
+  AS 'MODULE_PATHNAME', 'Temporal_from_mfjson'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/******************************************************************************
  * Typmod enforcer + self-cast (mirrors tbigint / tint / tfloat / ttext)
  ******************************************************************************/
 

--- a/mobilitydb/test/quadbin/expected/352_tquadbin.test.out
+++ b/mobilitydb/test/quadbin/expected/352_tquadbin.test.out
@@ -48,6 +48,85 @@ SELECT tquadbin '{[480fffffffffffff@2001-01-01 08:00:00,48427fffffffffff@2001-01
  {[480fffffffffffff@Mon Jan 01 08:00:00 2001 PST, 48427fffffffffff@Mon Jan 01 08:05:00 2001 PST], [48a6227affffffff@Mon Jan 01 08:10:00 2001 PST]}
 (1 row)
 
+SELECT asMFJSON(tquadbin '480fffffffffffff@2012-01-01 08:00:00');
+                                                                                      asmfjson                                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"type":"MovingQuadbin","crs":{"type":"Name","properties":{"name":"EPSG:4326"}},"values":[5192650370358181887],"datetimes":["Sun Jan 01T08:00:00 2012 PST"],"interpolation":"None"}
+(1 row)
+
+SELECT asMFJSON(tquadbin '{480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02}');
+                                                                                                                                   asmfjson                                                                                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"type":"MovingQuadbin","crs":{"type":"Name","properties":{"name":"EPSG:4326"}},"values":[5192650370358181887,5206864856682070015],"datetimes":["Mon Jan 01T00:00:00 2001 PST","Tue Jan 02T00:00:00 2001 PST"],"lower_inc":true,"upper_inc":true,"interpolation":"Discrete"}
+(1 row)
+
+SELECT asMFJSON(tquadbin '[480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02]');
+                                                                                                                                 asmfjson                                                                                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"type":"MovingQuadbin","crs":{"type":"Name","properties":{"name":"EPSG:4326"}},"values":[5192650370358181887,5206864856682070015],"datetimes":["Mon Jan 01T00:00:00 2001 PST","Tue Jan 02T00:00:00 2001 PST"],"lower_inc":true,"upper_inc":true,"interpolation":"Step"}
+(1 row)
+
+SELECT asMFJSON(tquadbin '{[480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02], [48a6227affffffff@2001-01-03, 48a6227affffffff@2001-01-04]}');
+                                                                                                                                                                                                                          asmfjson                                                                                                                                                                                                                           
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"type":"MovingQuadbin","crs":{"type":"Name","properties":{"name":"EPSG:4326"}},"sequences":[{"values":[5192650370358181887,5206864856682070015],"datetimes":["Mon Jan 01T00:00:00 2001 PST","Tue Jan 02T00:00:00 2001 PST"],"lower_inc":true,"upper_inc":true},{"values":[5234909528541102079,5234909528541102079],"datetimes":["Wed Jan 03T00:00:00 2001 PST","Thu Jan 04T00:00:00 2001 PST"],"lower_inc":true,"upper_inc":true}],"interpolation":"Step"}
+(1 row)
+
+SELECT asMFJSON(tquadbin '480fffffffffffff@2012-01-01 08:00:00', 1, 3, 6);
+                   asmfjson                   
+----------------------------------------------
+ {                                           +
+   "type": "MovingQuadbin",                  +
+   "crs": {                                  +
+     "type": "Name",                         +
+     "properties": {                         +
+       "name": "EPSG:4326"                   +
+     }                                       +
+   },                                        +
+   "bbox": [                                 +
+     -85.051129,                             +
+     0                                       +
+   ],                                        +
+   "period": {                               +
+     "begin": "Sun Jan 01T08:00:00 2012 PST",+
+     "end": "Sun Jan 01T08:00:00 2012 PST",  +
+     "lower_inc": true,                      +
+     "upper_inc": true                       +
+   },                                        +
+   "values": [                               +
+     5192650370358181887                     +
+   ],                                        +
+   "datetimes": [                            +
+     "Sun Jan 01T08:00:00 2012 PST"          +
+   ],                                        +
+   "interpolation": "None"                   +
+ }
+(1 row)
+
+SELECT tquadbinFromMFJSON(asMFJSON(tquadbin '480fffffffffffff@2012-01-01 08:00:00'));
+              tquadbinfrommfjson               
+-----------------------------------------------
+ 480fffffffffffff@Sun Jan 01 08:00:00 2012 PST
+(1 row)
+
+SELECT tquadbinFromMFJSON(asMFJSON(tquadbin '{480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02}'));
+                                       tquadbinfrommfjson                                       
+------------------------------------------------------------------------------------------------
+ {480fffffffffffff@Mon Jan 01 00:00:00 2001 PST, 48427fffffffffff@Tue Jan 02 00:00:00 2001 PST}
+(1 row)
+
+SELECT tquadbinFromMFJSON(asMFJSON(tquadbin '[480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02]'));
+                                       tquadbinfrommfjson                                       
+------------------------------------------------------------------------------------------------
+ [480fffffffffffff@Mon Jan 01 00:00:00 2001 PST, 48427fffffffffff@Tue Jan 02 00:00:00 2001 PST]
+(1 row)
+
+SELECT tquadbinFromMFJSON(asMFJSON(tquadbin '{[480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02], [48a6227affffffff@2001-01-03, 48a6227affffffff@2001-01-04]}'));
+                                                                                        tquadbinfrommfjson                                                                                        
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[480fffffffffffff@Mon Jan 01 00:00:00 2001 PST, 48427fffffffffff@Tue Jan 02 00:00:00 2001 PST], [48a6227affffffff@Wed Jan 03 00:00:00 2001 PST, 48a6227affffffff@Thu Jan 04 00:00:00 2001 PST]}
+(1 row)
+
 SELECT tquadbin(Instant) '480fffffffffffff@2012-01-01 08:00:00';
                    tquadbin                    
 -----------------------------------------------
@@ -73,6 +152,42 @@ SELECT tquadbin(Garbage) '480fffffffffffff@2012-01-01 08:00:00';
 ERROR:  Invalid temporal type modifier: garbage
 LINE 1: SELECT tquadbin(Garbage) '480fffffffffffff@2012-01-01 08:00:...
                ^
+SELECT asText(tquadbinFromBinary(asBinary(tquadbin '480fffffffffffff@2001-01-01')));
+                    astext                     
+-----------------------------------------------
+ 480fffffffffffff@Mon Jan 01 00:00:00 2001 PST
+(1 row)
+
+SELECT asText(tquadbinFromBinary(asBinary(tquadbin '{480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02}')));
+                                             astext                                             
+------------------------------------------------------------------------------------------------
+ {480fffffffffffff@Mon Jan 01 00:00:00 2001 PST, 48427fffffffffff@Tue Jan 02 00:00:00 2001 PST}
+(1 row)
+
+SELECT asText(tquadbinFromBinary(asBinary(tquadbin '[480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02]')));
+                                             astext                                             
+------------------------------------------------------------------------------------------------
+ [480fffffffffffff@Mon Jan 01 00:00:00 2001 PST, 48427fffffffffff@Tue Jan 02 00:00:00 2001 PST]
+(1 row)
+
+SELECT asText(tquadbinFromBinary(asBinary(tquadbin '{[480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02], [48a6227affffffff@2001-01-03, 48a6227affffffff@2001-01-04]}')));
+                                                                                              astext                                                                                              
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[480fffffffffffff@Mon Jan 01 00:00:00 2001 PST, 48427fffffffffff@Tue Jan 02 00:00:00 2001 PST], [48a6227affffffff@Wed Jan 03 00:00:00 2001 PST, 48a6227affffffff@Thu Jan 04 00:00:00 2001 PST]}
+(1 row)
+
+SELECT asText(tquadbinFromBinary(asBinary(tquadbin '480fffffffffffff@2001-01-01', 'NDR')));
+                    astext                     
+-----------------------------------------------
+ 480fffffffffffff@Mon Jan 01 00:00:00 2001 PST
+(1 row)
+
+SELECT asText(tquadbinFromHexWKB(asHexWKB(tquadbin '480fffffffffffff@2001-01-01')));
+                    astext                     
+-----------------------------------------------
+ 480fffffffffffff@Mon Jan 01 00:00:00 2001 PST
+(1 row)
+
 SELECT (tquadbin '480fffffffffffff@2012-01-01 08:00:00')::tbigint;
                      tbigint                      
 --------------------------------------------------

--- a/mobilitydb/test/quadbin/queries/352_tquadbin.test.sql
+++ b/mobilitydb/test/quadbin/queries/352_tquadbin.test.sql
@@ -58,6 +58,24 @@ SELECT tquadbin 'Interp=Step;[480fffffffffffff@2001-01-01 08:00:00,48427ffffffff
 SELECT tquadbin '{[480fffffffffffff@2001-01-01 08:00:00,48427fffffffffff@2001-01-01 08:05:00],[48a6227affffffff@2001-01-01 08:10:00]}';
 
 -------------------------------------------------------------------------------
+-- MF-JSON input/output (quadbin cell ids are serialized as their int8 value,
+-- mirroring the tbigint sibling)
+-------------------------------------------------------------------------------
+
+SELECT asMFJSON(tquadbin '480fffffffffffff@2012-01-01 08:00:00');
+SELECT asMFJSON(tquadbin '{480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02}');
+SELECT asMFJSON(tquadbin '[480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02]');
+SELECT asMFJSON(tquadbin '{[480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02], [48a6227affffffff@2001-01-03, 48a6227affffffff@2001-01-04]}');
+-- Bound the bbox precision so the output is platform-independent
+SELECT asMFJSON(tquadbin '480fffffffffffff@2012-01-01 08:00:00', 1, 3, 6);
+
+-- Round-trip: tquadbinFromMFJSON(asMFJSON(...)) preserves the value
+SELECT tquadbinFromMFJSON(asMFJSON(tquadbin '480fffffffffffff@2012-01-01 08:00:00'));
+SELECT tquadbinFromMFJSON(asMFJSON(tquadbin '{480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02}'));
+SELECT tquadbinFromMFJSON(asMFJSON(tquadbin '[480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02]'));
+SELECT tquadbinFromMFJSON(asMFJSON(tquadbin '{[480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02], [48a6227affffffff@2001-01-03, 48a6227affffffff@2001-01-04]}'));
+
+-------------------------------------------------------------------------------
 -- Typmod
 -------------------------------------------------------------------------------
 
@@ -67,6 +85,18 @@ SELECT tquadbin(SequenceSet) '{[480fffffffffffff@2001-01-01, 48427fffffffffff@20
 /* Errors */
 SELECT tquadbin(Instant) '{480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02}';
 SELECT tquadbin(Garbage) '480fffffffffffff@2012-01-01 08:00:00';
+
+-------------------------------------------------------------------------------
+-- WKB / HexWKB round-trips
+-------------------------------------------------------------------------------
+
+SELECT asText(tquadbinFromBinary(asBinary(tquadbin '480fffffffffffff@2001-01-01')));
+SELECT asText(tquadbinFromBinary(asBinary(tquadbin '{480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02}')));
+SELECT asText(tquadbinFromBinary(asBinary(tquadbin '[480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02]')));
+SELECT asText(tquadbinFromBinary(asBinary(tquadbin '{[480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02], [48a6227affffffff@2001-01-03, 48a6227affffffff@2001-01-04]}')));
+-- Little-endian (NDR)
+SELECT asText(tquadbinFromBinary(asBinary(tquadbin '480fffffffffffff@2001-01-01', 'NDR')));
+SELECT asText(tquadbinFromHexWKB(asHexWKB(tquadbin '480fffffffffffff@2001-01-01')));
 
 -------------------------------------------------------------------------------
 -- Assignment casts to/from tbigint (explicit AS ASSIGNMENT, bidirectional)


### PR DESCRIPTION
Add the text and binary serialization surface to the temporal QUADBIN cell-index type `tquadbin`, mirroring the sibling cell index `th3index`.

## Functions

Output:
- `asText(tquadbin)` → `Temporal_as_text`
- `asBinary(tquadbin, endianenconding text DEFAULT '')` → `Temporal_as_wkb`
- `asHexWKB(tquadbin, endianenconding text DEFAULT '')` → `Temporal_as_hexwkb`
- `asMFJSON(tquadbin, options, flags, maxdecimaldigits)` → `Temporal_as_mfjson`

Constructors:
- `tquadbinFromBinary(bytea)` → `Temporal_from_wkb`
- `tquadbinFromHexWKB(text)` → `Temporal_from_hexwkb`
- `tquadbinFromMFJSON(text)` → `Temporal_from_mfjson`

Each binds the generic `Temporal_*` wrapper, so no type-specific C is required — the MEOS serialization already dispatches on the QUADBIN base type. As with the other cell index, there is no `EWKT`/`EWKB`: a QUADBIN cell carries a fixed SRID, so there is no per-value SRID to extend the representation with.

## Tests and documentation

Regression tests exercise the MF-JSON output for all four subtypes plus the `tquadbinFromMFJSON(asMFJSON(...))` and `asText(tquadbinFromBinary(asBinary(...)))` round-trips, including little-endian (NDR) and HexWKB. The QUADBIN chapter in English and Spanish documents the new functions.