### PR TITLE
Add the text output to the temporal pgpointcloud types

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3452,6 +3452,15 @@
 			<title>Tipo temporal <varname>tpcpoint</varname></title>
 
 			<sect3>
+				<title>Entrada y salida</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpcpoint_asText"><varname>asText</varname>, <varname>tpcpoint::text</varname></link>: Devolver la representación textual, o convertir a texto</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
 				<title>Constructores</title>
 				<itemizedlist>
 					<listitem>
@@ -3583,6 +3592,15 @@
 
 		<sect2>
 			<title>Tipo temporal <varname>tpcpatch</varname></title>
+
+			<sect3>
+				<title>Entrada y salida</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpcpatch_asText"><varname>asText</varname>, <varname>tpcpatch::text</varname></link>: Devolver la representación textual, o convertir a texto</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
 
 			<sect3>
 				<title>Constructores</title>

--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -1208,6 +1208,31 @@ CREATE INDEX ON my_table USING spgist(my_tpcpoint_column tpcpoint_kdtree_ops);
 		<para>El receptor también necesita que <varname>mobilitydb_init</varname> se haya ejecutado — automático en cualquier backend que haya cargado la extensión <varname>mobilitydb</varname>, ya que el módulo de información de funciones instala allí el hook de análisis de XML.</para>
 	</sect1>
 
+	<sect1 xml:id="tpointcloud_astext">
+		<title>Salida de texto</title>
+
+		<itemizedlist>
+			<listitem xml:id="tpcpoint_asText">
+				<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
+				<para>Devolver la representación textual de un tpcpoint, o de un arreglo de ellos, y convertir un tpcpoint a texto</para>
+				<para><varname>asText(tpcpoint) → text</varname></para>
+				<para><varname>asText(tpcpoint[]) → text[]</varname></para>
+				<para><varname>tpcpoint::text → text</varname></para>
+			</listitem>
+			<listitem xml:id="tpcpatch_asText">
+				<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
+				<para>Devolver la representación textual de un tpcpatch, o de un arreglo de ellos, y convertir un tpcpatch a texto</para>
+				<para><varname>asText(tpcpatch) → text</varname></para>
+				<para><varname>asText(tpcpatch[]) → text[]</varname></para>
+				<para><varname>tpcpatch::text → text</varname></para>
+			</listitem>
+		</itemizedlist>
+
+		<para>A diferencia de los demás tipos temporales espaciales, aquí <varname>asText</varname> no recibe un argumento <varname>maxdecimaldigits</varname>: un <varname>pcpoint</varname> o un <varname>pcpatch</varname> se imprime como el hex-WKB de su forma serializada, que no tiene decimales que redondear. Lo mismo ocurre con <varname>th3index</varname>.</para>
+
+		<para>La salida de texto es el subconjunto seguro de la superficie textual: no existe <varname>tpcpointFromText</varname> / <varname>tpcpatchFromText</varname>, porque <varname>pcpoint_in</varname> / <varname>pcpatch_in</varname> de pgPointCloud solo aceptan hex-WKB y el esquema no se puede reconstruir a partir de la forma textual. Para la ida y vuelta use <varname>asBinary</varname> / <varname>asHexWKB</varname> con sus funciones de análisis correspondientes.</para>
+	</sect1>
+
 	<sect1 xml:id="tpointcloud_mfjson">
 		<title>Salida MF-JSON</title>
 		<itemizedlist>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3430,6 +3430,15 @@
 			<title>Temporal Type <varname>tpcpoint</varname></title>
 
 			<sect3>
+				<title>Input and Output</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpcpoint_asText"><varname>asText</varname>, <varname>tpcpoint::text</varname></link>: Return the text representation, or cast to text</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
 				<title>Constructors</title>
 				<itemizedlist>
 					<listitem>
@@ -3561,6 +3570,15 @@
 
 		<sect2>
 			<title>Temporal Type <varname>tpcpatch</varname></title>
+
+			<sect3>
+				<title>Input and Output</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpcpatch_asText"><varname>asText</varname>, <varname>tpcpatch::text</varname></link>: Return the text representation, or cast to text</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
 
 			<sect3>
 				<title>Constructors</title>

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -1215,6 +1215,31 @@ CREATE INDEX ON my_table USING spgist(my_tpcpoint_column tpcpoint_kdtree_ops);
 		<para>The receiver also needs <varname>mobilitydb_init</varname> to have run — automatic in any backend that has loaded the <varname>mobilitydb</varname> extension, since the function-info module installs the XML-parse hook there.</para>
 	</sect1>
 
+	<sect1 xml:id="tpointcloud_astext">
+		<title>Text output</title>
+
+		<itemizedlist>
+			<listitem xml:id="tpcpoint_asText">
+				<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
+				<para>Return the text representation of a tpcpoint, or of an array of them, and cast a tpcpoint to text</para>
+				<para><varname>asText(tpcpoint) → text</varname></para>
+				<para><varname>asText(tpcpoint[]) → text[]</varname></para>
+				<para><varname>tpcpoint::text → text</varname></para>
+			</listitem>
+			<listitem xml:id="tpcpatch_asText">
+				<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
+				<para>Return the text representation of a tpcpatch, or of an array of them, and cast a tpcpatch to text</para>
+				<para><varname>asText(tpcpatch) → text</varname></para>
+				<para><varname>asText(tpcpatch[]) → text[]</varname></para>
+				<para><varname>tpcpatch::text → text</varname></para>
+			</listitem>
+		</itemizedlist>
+
+		<para>Unlike the other spatial temporal types, <varname>asText</varname> takes no <varname>maxdecimaldigits</varname> argument here: a <varname>pcpoint</varname> or <varname>pcpatch</varname> prints as the hex-WKB of its serialized form, which has no decimal places to round. The same holds for <varname>th3index</varname>.</para>
+
+		<para>Text output is the safe subset of the textual surface: there is no <varname>tpcpointFromText</varname> / <varname>tpcpatchFromText</varname>, because pgPointCloud's <varname>pcpoint_in</varname> / <varname>pcpatch_in</varname> accept hex-WKB only and the schema is not reconstructible from the text form. For round-trip use <varname>asBinary</varname> / <varname>asHexWKB</varname> with their matching parse functions.</para>
+	</sect1>
+
 	<sect1 xml:id="tpointcloud_mfjson">
 		<title>MF-JSON output</title>
 		<itemizedlist>

--- a/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
+++ b/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
@@ -131,6 +131,21 @@ CREATE FUNCTION asMFJSON(tpcpoint, options int4 DEFAULT 0,
   AS 'MODULE_PATHNAME', 'Temporal_as_mfjson'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+-- asText takes no maxdecimaldigits argument: a pcpoint prints as the hex-WKB
+-- of its serialized form, which has no decimal places to round. This mirrors
+-- th3index, the other spatial temporal type whose base value has no
+-- coordinate text form.
+CREATE FUNCTION asText(tpcpoint)
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Temporal_as_text'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION asText(tpcpoint[])
+  RETURNS text[]
+  AS 'MODULE_PATHNAME', 'Temporalarr_as_text'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE CAST (tpcpoint AS text) WITH FUNCTION asText(tpcpoint);
+
 /******************************************************************************
  * Ergonomic pcpoint constructors
  *

--- a/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
+++ b/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
@@ -121,6 +121,21 @@ CREATE FUNCTION asMFJSON(tpcpatch, options int4 DEFAULT 0,
   AS 'MODULE_PATHNAME', 'Temporal_as_mfjson'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+-- asText takes no maxdecimaldigits argument: a pcpatch prints as the hex-WKB
+-- of its serialized form, which has no decimal places to round. This mirrors
+-- th3index, the other spatial temporal type whose base value has no
+-- coordinate text form.
+CREATE FUNCTION asText(tpcpatch)
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Temporal_as_text'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION asText(tpcpatch[])
+  RETURNS text[]
+  AS 'MODULE_PATHNAME', 'Temporalarr_as_text'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE CAST (tpcpatch AS text) WITH FUNCTION asText(tpcpatch);
+
 /******************************************************************************
  * Ergonomic pcpatch constructor
  *

--- a/mobilitydb/test/pointcloud/expected/420_tpcpoint.test.out
+++ b/mobilitydb/test/pointcloud/expected/420_tpcpoint.test.out
@@ -12,6 +12,24 @@ SELECT tpcpoint(pcpoint(1, 1.0, 1.0, 1.0), '2024-01-01'::timestamptz)::text =
  f
 (1 row)
 
+SELECT asText(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) = format('%s', tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz))::text = asText(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT array_length(asText(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz)]), 1);
+ array_length 
+--------------
+            2
+(1 row)
+
 SELECT pcid(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
  pcid 
 ------

--- a/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
+++ b/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
@@ -13,6 +13,24 @@ SELECT numPoints(tpcpatch(
  t
 (1 row)
 
+SELECT asText(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz)) = format('%s', tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz));
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz))::text = asText(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz));
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT array_length(asText(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz)]), 1);
+ array_length 
+--------------
+            2
+(1 row)
+
 SELECT pcid(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz));
  pcid 
 ------

--- a/mobilitydb/test/pointcloud/queries/420_tpcpoint.test.sql
+++ b/mobilitydb/test/pointcloud/queries/420_tpcpoint.test.sql
@@ -49,6 +49,17 @@ SELECT tpcpoint(pcpoint(1, 1.0, 1.0, 1.0), '2024-01-01'::timestamptz)::text =
   (:inst1)::text;
 
 -------------------------------------------------------------------------------
+-- Text output
+-------------------------------------------------------------------------------
+
+-- asText produces the same string as the type's own output function, and the
+-- cast to text goes through it.
+SELECT asText(:inst1) = format('%s', :inst1);
+SELECT (:inst1)::text = asText(:inst1);
+-- The array form maps over the elements.
+SELECT array_length(asText(ARRAY[:inst1, :inst2]), 1);
+
+-------------------------------------------------------------------------------
 -- pcid + subtype size
 -------------------------------------------------------------------------------
 

--- a/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
+++ b/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
@@ -38,6 +38,17 @@ SELECT numPoints(tpcpatch(
   '2024-01-01'::timestamptz)) = 2;
 
 -------------------------------------------------------------------------------
+-- Text output
+-------------------------------------------------------------------------------
+
+-- asText produces the same string as the type's own output function, and the
+-- cast to text goes through it.
+SELECT asText(:inst1) = format('%s', :inst1);
+SELECT (:inst1)::text = asText(:inst1);
+-- The array form maps over the elements.
+SELECT array_length(asText(ARRAY[:inst1, :inst2]), 1);
+
+-------------------------------------------------------------------------------
 -- pcid + per-instant point counts
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
The temporal pgpointcloud types `tpcpoint` and `tpcpatch` have the binary and
MF-JSON output functions but not the text one. This adds, for both types:

- `asText(ttype) → text` and `asText(ttype[]) → text[]`, binding the generic
  `Temporal_as_text` and `Temporalarr_as_text` wrappers
- `CAST(ttype AS text)`

`asText` takes no `maxdecimaldigits` argument here, unlike the coordinate-bearing
spatial temporal types: a `pcpoint` or a `pcpatch` prints as the hex-WKB of its
serialized form, which has no decimal places to round. This follows `th3index`,
the other spatial temporal type whose base value has no coordinate text form.

The input direction stays withheld. pgPointCloud's `pcpoint_in` and `pcpatch_in`
accept hex-WKB only, and the text form does not carry the schema needed to
reconstruct a value, so `asBinary` / `asHexWKB` with their parse functions remain
the round-trip path.

The tests check that `asText` returns the same string as the type's own output
function, that the cast goes through it, and that the array form maps over the
elements. The point cloud chapter gains a Text output section and the reference
its bullets, in English and Spanish.