### PR TITLE
Add a nearest-neighbour cursor to the in-memory RTree index

### DIFF
--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -112,6 +112,8 @@ jobs:
           ./parse_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o rtree_mest_test rtree_mest_test.c -L/usr/local/lib -lmeos -lm
           ./rtree_mest_test
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o rtree_knn_test rtree_knn_test.c -L/usr/local/lib -lmeos -lm
+          ./rtree_knn_test
 
   threaded:
     name: Thread-safety (TSan)

--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -373,6 +373,15 @@ extern int rtree_search(const RTree *rtree, RTreeSearchOp op, const void *query,
 extern int rtree_search_temporal(const RTree *rtree, RTreeSearchOp op, const Temporal *temp, MeosArray *result);
 extern int rtree_search_temporal_dedup(const RTree *rtree, RTreeSearchOp op, const Temporal *temp, int maxboxes, MeosArray *result);
 
+/**
+ * Cursor for a nearest-neighbour scan of an in-memory Rtree index
+ */
+typedef struct RTreeNNCursor RTreeNNCursor;
+
+extern RTreeNNCursor *rtree_nn_cursor_open(const RTree *rtree, const void *query);
+extern bool rtree_nn_cursor_next(RTreeNNCursor *cursor, int *id_out, double *dist_out);
+extern void rtree_nn_cursor_close(RTreeNNCursor *cursor);
+
 /*****************************************************************************
  * Initialization of the MEOS library
  *****************************************************************************/

--- a/meos/src/temporal/temporal_rtree.c
+++ b/meos/src/temporal/temporal_rtree.c
@@ -1333,6 +1333,262 @@ rtree_search_temporal_dedup(const RTree *rtree, RTreeSearchOp op,
   return meos_array_count(result);
 }
 
+/*****************************************************************************
+ * Nearest-neighbour (kNN) cursor
+ *
+ * An incremental best-first traversal (Hjaltason and Samet) that yields the
+ * indexed ids in order of increasing distance to a query bounding box. A
+ * binary min-heap holds two kinds of entries: tree nodes still to be expanded
+ * and leaf ids ready to be emitted, both keyed by the minimum distance between
+ * the query box and the entry's bounding box. Because a node's box distance is
+ * a lower bound on the distance of every entry it contains, when a leaf id
+ * reaches the top of the heap no unexpanded node can be closer, so ids pop in
+ * exact distance order. The caller controls how many ids are consumed (e.g. to
+ * honour a `LIMIT k`), so the traversal never materialises more of the tree
+ * than the caller reads. The distance is the same box-to-box nearest approach
+ * distance used by the `|=|` operator; an entry whose box does not share the
+ * query's time extent (for temporal box types with a time dimension on both
+ * sides) is reported at infinity and ordered last.
+ *****************************************************************************/
+
+/**
+ * @brief Return the nearest approach distance between two bounding boxes of
+ * the RTree's box type
+ * @details Dispatches on the RTree box type to the canonical box-to-box
+ * distance so the cursor orders entries exactly as the `|=|` operator. For
+ * spatiotemporal boxes the distance is spatial and, when both boxes carry a
+ * time dimension, infinite if their time extents are disjoint (mirroring
+ * #nad_stbox_stbox); for temporal boxes the same holds through
+ * #nad_tbox_tbox; for spans it is the one-dimensional gap.
+ * @param[in] rtree The RTree providing the box type
+ * @param[in] query,box Bounding boxes of type @p rtree->bboxtype
+ */
+static double
+rtree_bbox_distance(const RTree *rtree, const void *query, const void *box)
+{
+  if (rtree->bboxtype == T_TBOX)
+    return nad_tbox_tbox((const TBox *) query, (const TBox *) box);
+  if (rtree->bboxtype == T_STBOX)
+    return nad_stbox_stbox((const STBox *) query, (const STBox *) box);
+#if POINTCLOUD
+  if (rtree->bboxtype == T_TPCBOX)
+    /* TPCBox shares the STBox prefix layout (see get_axis_tpcbox) */
+    return nad_stbox_stbox((const STBox *) query, (const STBox *) box);
+#endif
+  /* Span types: the one-dimensional gap between the two spans, zero when they
+   * overlap, read through the box's axis accessor */
+  double qlo = rtree->get_axis(query, 0, false);
+  double qup = rtree->get_axis(query, 0, true);
+  double blo = rtree->get_axis(box, 0, false);
+  double bup = rtree->get_axis(box, 0, true);
+  if (bup < qlo)
+    return qlo - bup;
+  if (qup < blo)
+    return blo - qup;
+  return 0.0;
+}
+
+/**
+ * @brief A single entry of the kNN cursor's priority queue
+ * @details An entry is either a tree node still to be expanded
+ * (@p is_leaf_entry false, @p node set) or a leaf id ready to be emitted
+ * (@p is_leaf_entry true, @p id set), keyed by @p dist, the distance from the
+ * query box to the entry's bounding box.
+ */
+typedef struct RTreeNNEntry
+{
+  double dist;             /**< Distance from the query to the entry's box */
+  bool is_leaf_entry;      /**< True for an emittable id, false for a node */
+  int id;                  /**< Leaf id (when @p is_leaf_entry) */
+  const RTreeNode *node;   /**< Tree node to expand (when not @p is_leaf_entry) */
+} RTreeNNEntry;
+
+/**
+ * @brief Incremental nearest-neighbour cursor over an RTree
+ */
+struct RTreeNNCursor
+{
+  const RTree *rtree;      /**< Indexed RTree (borrowed, not owned) */
+  void *query;            /**< Private copy of the query bounding box */
+  RTreeNNEntry *heap;     /**< Binary min-heap keyed by distance */
+  int count;              /**< Number of entries currently in the heap */
+  int capacity;           /**< Allocated capacity of the heap array */
+};
+
+/**
+ * @brief Push an entry onto the cursor's min-heap, growing it if needed
+ * @param[in] cursor The cursor whose heap receives the entry
+ * @param[in] entry The entry to insert
+ */
+static void
+nn_heap_push(RTreeNNCursor *cursor, RTreeNNEntry entry)
+{
+  if (cursor->count == cursor->capacity)
+  {
+    cursor->capacity *= 2;
+    cursor->heap = repalloc(cursor->heap,
+      (size_t) cursor->capacity * sizeof(RTreeNNEntry));
+  }
+  int i = cursor->count++;
+  cursor->heap[i] = entry;
+  /* Sift up while the child is closer than its parent */
+  while (i > 0)
+  {
+    int parent = (i - 1) / 2;
+    if (cursor->heap[parent].dist <= cursor->heap[i].dist)
+      break;
+    RTreeNNEntry tmp = cursor->heap[parent];
+    cursor->heap[parent] = cursor->heap[i];
+    cursor->heap[i] = tmp;
+    i = parent;
+  }
+  return;
+}
+
+/**
+ * @brief Pop and return the minimum-distance entry of the cursor's heap
+ * @param[in] cursor The cursor whose heap is non-empty
+ * @pre `cursor->count > 0`
+ */
+static RTreeNNEntry
+nn_heap_pop(RTreeNNCursor *cursor)
+{
+  assert(cursor->count > 0);
+  RTreeNNEntry top = cursor->heap[0];
+  cursor->heap[0] = cursor->heap[--cursor->count];
+  /* Sift down towards the closer child */
+  int i = 0;
+  while (true)
+  {
+    int left = 2 * i + 1, right = 2 * i + 2, smallest = i;
+    if (left < cursor->count &&
+        cursor->heap[left].dist < cursor->heap[smallest].dist)
+      smallest = left;
+    if (right < cursor->count &&
+        cursor->heap[right].dist < cursor->heap[smallest].dist)
+      smallest = right;
+    if (smallest == i)
+      break;
+    RTreeNNEntry tmp = cursor->heap[i];
+    cursor->heap[i] = cursor->heap[smallest];
+    cursor->heap[smallest] = tmp;
+    i = smallest;
+  }
+  return top;
+}
+
+/**
+ * @ingroup meos_geo_box_index
+ * @brief Open a nearest-neighbour cursor that yields the ids stored in an
+ * RTree in order of increasing distance to a query bounding box
+ * @details The cursor performs an incremental best-first traversal: repeated
+ * calls to #rtree_nn_cursor_next return the indexed ids from nearest to
+ * farthest, using the same box-to-box distance as the `|=|` operator. The
+ * caller stops consuming when it has enough neighbours (e.g. after `k`
+ * results), so no more of the tree is visited than required. The query box is
+ * copied into the cursor, so the caller may free or reuse it immediately. The
+ * query box must have the same box type as the RTree; a spatial-only query on
+ * an STBox index yields a purely spatial ordering, while a query carrying a
+ * time dimension additionally requires overlapping time extents (as for
+ * `|=|`). Close the cursor with #rtree_nn_cursor_close.
+ * @param[in] rtree The RTree to query
+ * @param[in] query The query bounding box of type @p rtree->bboxtype
+ * @return A cursor to be freed with #rtree_nn_cursor_close
+ */
+RTreeNNCursor *
+rtree_nn_cursor_open(const RTree *rtree, const void *query)
+{
+  assert(rtree); assert(query);
+  RTreeNNCursor *cursor = palloc0(sizeof(RTreeNNCursor));
+  cursor->rtree = rtree;
+  cursor->query = palloc(rtree->bboxsize);
+  memcpy(cursor->query, query, rtree->bboxsize);
+  cursor->capacity = MAXITEMS;
+  cursor->heap = palloc((size_t) cursor->capacity * sizeof(RTreeNNEntry));
+  cursor->count = 0;
+  /* Seed the heap with the root, which is always expanded first */
+  if (rtree->root)
+  {
+    RTreeNNEntry root_entry;
+    root_entry.dist = 0.0;
+    root_entry.is_leaf_entry = false;
+    root_entry.id = 0;
+    root_entry.node = rtree->root;
+    nn_heap_push(cursor, root_entry);
+  }
+  return cursor;
+}
+
+/**
+ * @ingroup meos_geo_box_index
+ * @brief Advance a nearest-neighbour cursor to the next closest id
+ * @details Returns the next id in order of increasing distance to the query
+ * box. When @p id_out or @p dist_out is not @p NULL it receives the id and its
+ * distance. An id whose box has no valid distance to the query (e.g. disjoint
+ * time extents for temporal box types) is reported last with an infinite
+ * distance.
+ * @param[in] cursor The cursor previously opened with #rtree_nn_cursor_open
+ * @param[out] id_out Receives the id of the next neighbour, or @p NULL
+ * @param[out] dist_out Receives the distance of the next neighbour, or @p NULL
+ * @return @p true if a neighbour was produced, @p false once exhausted
+ */
+bool
+rtree_nn_cursor_next(RTreeNNCursor *cursor, int *id_out, double *dist_out)
+{
+  assert(cursor);
+  while (cursor->count > 0)
+  {
+    RTreeNNEntry entry = nn_heap_pop(cursor);
+    if (entry.is_leaf_entry)
+    {
+      /* A leaf id reached the top of the heap: nothing unexpanded is closer */
+      if (id_out)
+        *id_out = entry.id;
+      if (dist_out)
+        *dist_out = entry.dist;
+      return true;
+    }
+    /* Expand the node: push every child keyed by its box distance */
+    const RTreeNode *node = entry.node;
+    for (int i = 0; i < node->count; i++)
+    {
+      RTreeNNEntry child;
+      child.dist = rtree_bbox_distance(cursor->rtree, cursor->query,
+        RTREE_NODE_BBOX_N(node, i));
+      if (node->node_type == RTREE_LEAF)
+      {
+        child.is_leaf_entry = true;
+        child.id = node->ids[i];
+        child.node = NULL;
+      }
+      else
+      {
+        child.is_leaf_entry = false;
+        child.id = 0;
+        child.node = node->nodes[i];
+      }
+      nn_heap_push(cursor, child);
+    }
+  }
+  return false;
+}
+
+/**
+ * @ingroup meos_geo_box_index
+ * @brief Close a nearest-neighbour cursor and free its resources
+ * @param[in] cursor The cursor to close; @p NULL is ignored
+ */
+void
+rtree_nn_cursor_close(RTreeNNCursor *cursor)
+{
+  if (! cursor)
+    return;
+  pfree(cursor->heap);
+  pfree(cursor->query);
+  pfree(cursor);
+  return;
+}
+
 /**
  * @brief Frees the memory allocated for an RTree node
  * @details The function recursively frees the memory of an RTree node.

--- a/meos/test/rtree_knn_test.c
+++ b/meos/test/rtree_knn_test.c
@@ -1,0 +1,308 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief A program that tests the nearest-neighbour cursor of the in-memory
+ * RTree index, i.e., rtree_nn_cursor_open, rtree_nn_cursor_next and
+ * rtree_nn_cursor_close, against an exact brute-force oracle.
+ *
+ * Two box types are exercised: a spatial STBox index over random 2-D points
+ * and a TBox index over random numeric values. Since the reported distance is
+ * the box-to-box nearest approach distance, spatial-only boxes make the STBox
+ * distance a pure Euclidean distance and single-value boxes sharing one time
+ * make the TBox distance a pure numeric distance, so the brute-force oracle is
+ * a direct scan.
+ *
+ * Five properties are asserted per box type:
+ *  (i)   completeness: a full drain yields every inserted id exactly once;
+ *  (ii)  monotonicity: the reported distances are non-decreasing;
+ *  (iii) correct distance: each reported distance equals the box distance
+ *        between the query and that id's box;
+ *  (iv)  correct order: the drained distance sequence equals the sorted
+ *        brute-force distances element by element (tie-robust);
+ *  (v)   early stop: taking only the first k results matches the first k of
+ *        the full drain, so a LIMIT k caller reads the true k neighbours.
+ *
+ * The program can be built as follows
+ * @code
+ * gcc -Wall -g -I/usr/local/include -o rtree_knn_test rtree_knn_test.c -L/usr/local/lib -lmeos -lm
+ * @endcode
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <meos.h>
+#include <meos_geo.h>
+
+/* Number of boxes inserted into the index */
+#define NUM_BOXES 2048
+/* Number of nearest neighbours checked by the early-stop property */
+#define K 20
+/* Tolerance for floating-point distance comparisons */
+#define EPS 1e-9
+
+static int failures = 0;
+
+static void
+check(const char *name, bool ok)
+{
+  printf("  %-58s %s\n", name, ok ? "OK" : "FAIL");
+  if (! ok)
+    failures++;
+}
+
+/* Return a pseudo-random double in [min, max] */
+static double
+random_double(double min, double max)
+{
+  return min + (max - min) * ((double) rand() / (double) RAND_MAX);
+}
+
+/* Comparison function sorting doubles in ascending order */
+static int
+cmp_double(const void *a, const void *b)
+{
+  double da = *(const double *) a, db = *(const double *) b;
+  return (da > db) - (da < db);
+}
+
+/*****************************************************************************
+ * Spatial STBox nearest-neighbour test over random 2-D points
+ *****************************************************************************/
+
+static void
+test_stbox_knn(void)
+{
+  RTree *rtree = rtree_create_stbox();
+  STBox **boxes = malloc(NUM_BOXES * sizeof(STBox *));
+
+  /* Insert spatial-only boxes built from random 2-D points. A spatial-only
+   * box makes the nearest approach distance a pure Euclidean distance, with
+   * no time dimension to gate it. */
+  for (int i = 0; i < NUM_BOXES; i++)
+  {
+    GSERIALIZED *gs = geompoint_make2d(0, random_double(-1000, 1000),
+      random_double(-1000, 1000));
+    boxes[i] = geo_to_stbox(gs);
+    rtree_insert(rtree, boxes[i], i);
+    free(gs);
+  }
+
+  /* Build the query box from another random point */
+  GSERIALIZED *qgs = geompoint_make2d(0, random_double(-1000, 1000),
+    random_double(-1000, 1000));
+  STBox *query = geo_to_stbox(qgs);
+  free(qgs);
+
+  /* Brute-force oracle: the distance from the query to every inserted box */
+  double *brute = malloc(NUM_BOXES * sizeof(double));
+  for (int i = 0; i < NUM_BOXES; i++)
+    brute[i] = nad_stbox_stbox(query, boxes[i]);
+  double *sorted = malloc(NUM_BOXES * sizeof(double));
+  memcpy(sorted, brute, NUM_BOXES * sizeof(double));
+  qsort(sorted, NUM_BOXES, sizeof(double), cmp_double);
+
+  /* Full drain of the cursor */
+  int *seen = calloc(NUM_BOXES, sizeof(int));
+  double *cur_dist = malloc(NUM_BOXES * sizeof(double));
+  int *cur_id = malloc(NUM_BOXES * sizeof(int));
+  RTreeNNCursor *cursor = rtree_nn_cursor_open(rtree, query);
+  int n = 0, id;
+  double dist;
+  while (rtree_nn_cursor_next(cursor, &id, &dist))
+  {
+    if (n < NUM_BOXES)
+    {
+      cur_id[n] = id;
+      cur_dist[n] = dist;
+    }
+    if (id >= 0 && id < NUM_BOXES)
+      seen[id]++;
+    n++;
+  }
+  rtree_nn_cursor_close(cursor);
+
+  printf("STBox NN cursor (%d random 2-D points):\n", NUM_BOXES);
+
+  /* (i) Completeness: every id appears exactly once */
+  bool complete = (n == NUM_BOXES);
+  for (int i = 0; i < NUM_BOXES; i++)
+    if (seen[i] != 1)
+      complete = false;
+  check("(i) full drain returns every id exactly once", complete);
+
+  /* (ii) Monotonicity: distances are non-decreasing */
+  bool monotone = true;
+  for (int i = 1; i < n; i++)
+    if (cur_dist[i] < cur_dist[i - 1] - EPS)
+      monotone = false;
+  check("(ii) reported distances are non-decreasing", monotone);
+
+  /* (iii) Correct distance: each reported distance matches the box distance */
+  bool dist_ok = true;
+  for (int i = 0; i < n; i++)
+    if (fabs(cur_dist[i] - brute[cur_id[i]]) > EPS)
+      dist_ok = false;
+  check("(iii) reported distance equals the box distance", dist_ok);
+
+  /* (iv) Correct order: drained distances equal the sorted brute-force ones */
+  bool order_ok = (n == NUM_BOXES);
+  for (int i = 0; i < n && order_ok; i++)
+    if (fabs(cur_dist[i] - sorted[i]) > EPS)
+      order_ok = false;
+  check("(iv) drained order matches the sorted brute-force distances",
+    order_ok);
+
+  /* (v) Early stop: the first K results match the first K of the full drain */
+  bool early_ok = true;
+  RTreeNNCursor *kcursor = rtree_nn_cursor_open(rtree, query);
+  for (int i = 0; i < K && early_ok; i++)
+  {
+    int kid;
+    double kdist;
+    if (! rtree_nn_cursor_next(kcursor, &kid, &kdist) ||
+        kid != cur_id[i] || fabs(kdist - cur_dist[i]) > EPS)
+      early_ok = false;
+  }
+  rtree_nn_cursor_close(kcursor);
+  check("(v) first K results match the full-drain prefix", early_ok);
+
+  /* Cleanup */
+  for (int i = 0; i < NUM_BOXES; i++)
+    free(boxes[i]);
+  free(boxes); free(query); free(brute); free(sorted);
+  free(seen); free(cur_dist); free(cur_id);
+  rtree_free(rtree);
+}
+
+/*****************************************************************************
+ * Numeric TBox nearest-neighbour test over random values
+ *****************************************************************************/
+
+static void
+test_tbox_knn(void)
+{
+  RTree *rtree = rtree_create_tbox();
+  TBox **boxes = malloc(NUM_BOXES * sizeof(TBox *));
+  double *val = malloc(NUM_BOXES * sizeof(double));
+  /* A single shared instant makes every box overlap in time, so the nearest
+   * approach distance reduces to the numeric distance between the values */
+  TimestampTz t = 0;
+
+  for (int i = 0; i < NUM_BOXES; i++)
+  {
+    val[i] = random_double(-1000, 1000);
+    boxes[i] = float_timestamptz_to_tbox(val[i], t);
+    rtree_insert(rtree, boxes[i], i);
+  }
+
+  double qval = random_double(-1000, 1000);
+  TBox *query = float_timestamptz_to_tbox(qval, t);
+
+  double *brute = malloc(NUM_BOXES * sizeof(double));
+  for (int i = 0; i < NUM_BOXES; i++)
+    brute[i] = fabs(qval - val[i]);
+  double *sorted = malloc(NUM_BOXES * sizeof(double));
+  memcpy(sorted, brute, NUM_BOXES * sizeof(double));
+  qsort(sorted, NUM_BOXES, sizeof(double), cmp_double);
+
+  int *seen = calloc(NUM_BOXES, sizeof(int));
+  double *cur_dist = malloc(NUM_BOXES * sizeof(double));
+  int *cur_id = malloc(NUM_BOXES * sizeof(int));
+  RTreeNNCursor *cursor = rtree_nn_cursor_open(rtree, query);
+  int n = 0, id;
+  double dist;
+  while (rtree_nn_cursor_next(cursor, &id, &dist))
+  {
+    if (n < NUM_BOXES)
+    {
+      cur_id[n] = id;
+      cur_dist[n] = dist;
+    }
+    if (id >= 0 && id < NUM_BOXES)
+      seen[id]++;
+    n++;
+  }
+  rtree_nn_cursor_close(cursor);
+
+  printf("TBox NN cursor (%d random numeric values):\n", NUM_BOXES);
+
+  bool complete = (n == NUM_BOXES);
+  for (int i = 0; i < NUM_BOXES; i++)
+    if (seen[i] != 1)
+      complete = false;
+  check("(i) full drain returns every id exactly once", complete);
+
+  bool monotone = true;
+  for (int i = 1; i < n; i++)
+    if (cur_dist[i] < cur_dist[i - 1] - EPS)
+      monotone = false;
+  check("(ii) reported distances are non-decreasing", monotone);
+
+  bool dist_ok = true;
+  for (int i = 0; i < n; i++)
+    if (fabs(cur_dist[i] - brute[cur_id[i]]) > EPS)
+      dist_ok = false;
+  check("(iii) reported distance equals the numeric distance", dist_ok);
+
+  bool order_ok = (n == NUM_BOXES);
+  for (int i = 0; i < n && order_ok; i++)
+    if (fabs(cur_dist[i] - sorted[i]) > EPS)
+      order_ok = false;
+  check("(iv) drained order matches the sorted brute-force distances",
+    order_ok);
+
+  /* Cleanup */
+  for (int i = 0; i < NUM_BOXES; i++)
+    free(boxes[i]);
+  free(boxes); free(val); free(query);
+  free(brute); free(sorted); free(seen); free(cur_dist); free(cur_id);
+  rtree_free(rtree);
+}
+
+int
+main(void)
+{
+  meos_initialize();
+  srand(1);
+
+  test_stbox_knn();
+  test_tbox_knn();
+
+  meos_finalize();
+
+  if (failures == 0)
+    printf("\nAll NN RTree tests passed.\n");
+  else
+    printf("\n%d NN RTree test(s) FAILED.\n", failures);
+  return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
The in-memory RTree exposes overlap, contains and contained-by searches but no nearest-neighbour scan, so a query of the form "order by column |=| q limit k" has to scan and sort the whole relation. This adds an incremental best-first traversal that yields the indexed ids in order of increasing distance to a query bounding box, stopping as soon as the caller has read enough results.

The cursor keeps a binary min-heap of tree nodes still to expand and leaf ids ready to emit, both keyed by the minimum distance between the query box and the entry bounding box. Because a node box distance is a lower bound on the distance of every entry it contains, an id reaches the top of the heap only once nothing unexpanded can be closer, so ids pop in exact distance order and the traversal never visits more of the tree than required. The distance is the same box-to-box nearest approach distance used by the |=| operator: the spatial distance for spatiotemporal boxes (infinite when both boxes carry disjoint time extents), the numeric distance for temporal boxes, and the one-dimensional gap for spans.

The public API adds an opaque RTreeNNCursor with rtree_nn_cursor_open, rtree_nn_cursor_next and rtree_nn_cursor_close. A brute-force test over random spatial and numeric boxes checks completeness, monotonicity, the reported distances, the full order against a sorted oracle, and that the first k results match a full drain; it is compiled and run alongside the existing RTree test in the MEOS workflow.

This is the MEOS side of the nearest-neighbour work tracked in https://github.com/MobilityDB/MobilityDB/issues/840; the MobilityDuck consumer that replaces its sequential-scan fallback is a separate change in that repository.