### PR TITLE
Support the numeric span types in the in-memory RTree

### DIFF
--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -114,6 +114,8 @@ jobs:
           ./rtree_mest_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o rtree_knn_test rtree_knn_test.c -L/usr/local/lib -lmeos -lm
           ./rtree_knn_test
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o rtree_span_test rtree_span_test.c -L/usr/local/lib -lmeos -lm
+          ./rtree_span_test
 
   threaded:
     name: Thread-safety (TSan)

--- a/meos/src/temporal/temporal_boxops.c
+++ b/meos/src/temporal/temporal_boxops.c
@@ -89,8 +89,8 @@ bbox_type(MeosType bboxtype)
 size_t
 bbox_get_size(MeosType bboxtype)
 {
-  assert(bbox_type(bboxtype));
-  if (bboxtype == T_TSTZSPAN)
+  assert(bbox_type(bboxtype) || span_type(bboxtype));
+  if (span_type(bboxtype))
     return sizeof(Span);
   if (bboxtype == T_TBOX)
     return sizeof(TBox);

--- a/meos/test/rtree_span_test.c
+++ b/meos/test/rtree_span_test.c
@@ -1,0 +1,181 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief A program that tests the in-memory RTree index for the numeric span
+ * bounding box types, i.e., the indexes built with rtree_create_intspan and
+ * rtree_create_floatspan, against an exact brute-force oracle.
+ *
+ * For each span type a set of random spans is inserted, an overlap search is
+ * run for a query span, and the candidate id set is compared with the exact
+ * set of spans that overlap the query. Two properties are asserted per type:
+ *  (i)  no false negatives: every span overlapping the query is a candidate;
+ *  (ii) no false positives: every candidate overlaps the query.
+ *
+ * The program can be built as follows
+ * @code
+ * gcc -Wall -g -I/usr/local/include -o rtree_span_test rtree_span_test.c -L/usr/local/lib -lmeos -lm
+ * @endcode
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <meos.h>
+
+/* Number of spans inserted into the index */
+#define NUM_SPANS 2048
+
+static int failures = 0;
+
+static void
+check(const char *name, bool ok)
+{
+  printf("  %-58s %s\n", name, ok ? "OK" : "FAIL");
+  if (! ok)
+    failures++;
+}
+
+/* Return a pseudo-random integer in [min, max] */
+static int
+random_int(int min, int max)
+{
+  return min + rand() % (max - min + 1);
+}
+
+/*****************************************************************************
+ * Integer span index
+ *****************************************************************************/
+
+static void
+test_intspan_rtree(void)
+{
+  RTree *rtree = rtree_create_intspan();
+  Span **spans = malloc(NUM_SPANS * sizeof(Span *));
+  for (int i = 0; i < NUM_SPANS; i++)
+  {
+    int lo = random_int(-10000, 10000);
+    spans[i] = intspan_make(lo, lo + random_int(1, 100), true, false);
+    rtree_insert(rtree, spans[i], i);
+  }
+  int qlo = random_int(-10000, 10000);
+  Span *query = intspan_make(qlo, qlo + 500, true, false);
+
+  MeosArray *result = meos_array_create(sizeof(int));
+  int count = rtree_search(rtree, RTREE_OVERLAPS, query, result);
+
+  bool *in_index = calloc(NUM_SPANS, sizeof(bool));
+  for (int i = 0; i < count; i++)
+    in_index[*(int *) meos_array_get(result, i)] = true;
+
+  printf("Integer span RTree (%d random spans):\n", NUM_SPANS);
+
+  int missed = 0, extra = 0;
+  for (int i = 0; i < NUM_SPANS; i++)
+  {
+    bool truth = overlaps_span_span(query, spans[i]);
+    if (truth && ! in_index[i])
+      missed++;
+    if (! truth && in_index[i])
+      extra++;
+  }
+  check("(i) no false negatives vs brute-force overlap", missed == 0);
+  check("(ii) no false positives vs brute-force overlap", extra == 0);
+
+  for (int i = 0; i < NUM_SPANS; i++)
+    free(spans[i]);
+  free(spans); free(query); free(in_index);
+  meos_array_destroy(result);
+  rtree_free(rtree);
+}
+
+/*****************************************************************************
+ * Float span index
+ *****************************************************************************/
+
+static void
+test_floatspan_rtree(void)
+{
+  RTree *rtree = rtree_create_floatspan();
+  Span **spans = malloc(NUM_SPANS * sizeof(Span *));
+  for (int i = 0; i < NUM_SPANS; i++)
+  {
+    double lo = random_int(-10000, 10000) / 10.0;
+    spans[i] = floatspan_make(lo, lo + random_int(1, 100) / 10.0, true, false);
+    rtree_insert(rtree, spans[i], i);
+  }
+  double qlo = random_int(-10000, 10000) / 10.0;
+  Span *query = floatspan_make(qlo, qlo + 50.0, true, false);
+
+  MeosArray *result = meos_array_create(sizeof(int));
+  int count = rtree_search(rtree, RTREE_OVERLAPS, query, result);
+
+  bool *in_index = calloc(NUM_SPANS, sizeof(bool));
+  for (int i = 0; i < count; i++)
+    in_index[*(int *) meos_array_get(result, i)] = true;
+
+  printf("Float span RTree (%d random spans):\n", NUM_SPANS);
+
+  int missed = 0, extra = 0;
+  for (int i = 0; i < NUM_SPANS; i++)
+  {
+    bool truth = overlaps_span_span(query, spans[i]);
+    if (truth && ! in_index[i])
+      missed++;
+    if (! truth && in_index[i])
+      extra++;
+  }
+  check("(i) no false negatives vs brute-force overlap", missed == 0);
+  check("(ii) no false positives vs brute-force overlap", extra == 0);
+
+  for (int i = 0; i < NUM_SPANS; i++)
+    free(spans[i]);
+  free(spans); free(query); free(in_index);
+  meos_array_destroy(result);
+  rtree_free(rtree);
+}
+
+int
+main(void)
+{
+  meos_initialize();
+  srand(1);
+
+  test_intspan_rtree();
+  test_floatspan_rtree();
+
+  meos_finalize();
+
+  if (failures == 0)
+    printf("\nAll span RTree tests passed.\n");
+  else
+    printf("\n%d span RTree test(s) FAILED.\n", failures);
+  return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
The in-memory RTree constructors rtree_create_intspan, rtree_create_bigintspan, rtree_create_floatspan and rtree_create_datespan build an index whose bounding box is a span, but bbox_get_size only sized the timestamptz span, so creating one of these indexes tripped the bbox_type assertion in a debug build. Every span shares the same Span representation, so this sizes any span box as a Span, letting the four numeric span indexes build and answer searches exactly like the timestamptz one.

A brute-force test over random integer and float spans checks that the overlap search returns exactly the spans that overlap the query, and is compiled and run alongside the existing RTree tests in the MEOS workflow.
