### PR TITLE
Emit the representation surface into generated regions

### DIFF
--- a/mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
+++ b/mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
@@ -81,6 +81,8 @@ CREATE FUNCTION tcbuffer(tcbuffer, integer)
 
 CREATE CAST (tcbuffer AS tcbuffer) WITH FUNCTION tcbuffer(tcbuffer, integer) AS IMPLICIT;
 
+-- GENERATED-REPRESENTATIONS-BEGIN cbuffer — tools/codegen/inherited/generate.py from templates/representations.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.yaml (representation_families) and re-run.
 /*****************************************************************************
  * Input/output from (E)WKT, (E)WKB, and HexEWKB representation
  *****************************************************************************/
@@ -155,6 +157,8 @@ CREATE FUNCTION asHexEWKB(tcbuffer, endianenconding text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- GENERATED-REPRESENTATIONS-END cbuffer
 
 /*****************************************************************************
  * Constructors

--- a/mobilitydb/sql/geo/053_tgeo_inout.in.sql
+++ b/mobilitydb/sql/geo/053_tgeo_inout.in.sql
@@ -33,6 +33,8 @@
  * MF-JSON representation
  */
 
+-- GENERATED-REPRESENTATIONS-BEGIN geo — tools/codegen/inherited/generate.py from templates/representations.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.yaml (representation_families) and re-run.
 /*****************************************************************************
  * Input
  *****************************************************************************/
@@ -179,3 +181,4 @@ CREATE FUNCTION asHexEWKB(tgeography, endianenconding text DEFAULT '')
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************/
+-- GENERATED-REPRESENTATIONS-END geo

--- a/mobilitydb/sql/h3/253_th3index.in.sql
+++ b/mobilitydb/sql/h3/253_th3index.in.sql
@@ -88,6 +88,8 @@ CREATE TYPE th3index (
   analyze = tspatial_analyze
 );
 
+-- GENERATED-REPRESENTATIONS-BEGIN h3 — tools/codegen/inherited/generate.py from templates/representations.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.yaml (representation_families) and re-run.
 /******************************************************************************
  * Text and (Hex)WKB I/O (mirrors the tcbuffer / tnpoint / tpose plug-in types)
  ******************************************************************************/
@@ -127,6 +129,8 @@ CREATE FUNCTION th3indexFromMFJSON(text)
   RETURNS th3index
   AS 'MODULE_PATHNAME', 'Temporal_from_mfjson'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- GENERATED-REPRESENTATIONS-END h3
 
 /******************************************************************************
  * Typmod enforcer + self-cast (mirrors tbigint / tint / tfloat / ttext)

--- a/mobilitydb/sql/npoint/302_tnpoint.in.sql
+++ b/mobilitydb/sql/npoint/302_tnpoint.in.sql
@@ -76,6 +76,8 @@ CREATE FUNCTION tnpoint(tnpoint, integer)
 
 CREATE CAST (tnpoint AS tnpoint) WITH FUNCTION tnpoint(tnpoint, integer) AS IMPLICIT;
 
+-- GENERATED-REPRESENTATIONS-BEGIN npoint — tools/codegen/inherited/generate.py from templates/representations.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.yaml (representation_families) and re-run.
 /*****************************************************************************
  * Input/output from (E)WKT, (E)WKB, and HexEWKB
  *****************************************************************************/
@@ -120,6 +122,8 @@ CREATE FUNCTION asMFJSON(tnpoint, options int4 DEFAULT 0,
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_mfjson'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- GENERATED-REPRESENTATIONS-END npoint
 
 /******************************************************************************
  * Constructors

--- a/mobilitydb/sql/quadbin/353_tquadbin.in.sql
+++ b/mobilitydb/sql/quadbin/353_tquadbin.in.sql
@@ -88,6 +88,8 @@ CREATE TYPE tquadbin (
   analyze = temporal_analyze
 );
 
+-- GENERATED-REPRESENTATIONS-BEGIN quadbin — tools/codegen/inherited/generate.py from templates/representations.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.yaml (representation_families) and re-run.
 /******************************************************************************
  * Text and (Hex)WKB I/O (mirrors the tcbuffer / tnpoint / tpose plug-in types)
  ******************************************************************************/
@@ -127,6 +129,8 @@ CREATE FUNCTION tquadbinFromMFJSON(text)
   RETURNS tquadbin
   AS 'MODULE_PATHNAME', 'Temporal_from_mfjson'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- GENERATED-REPRESENTATIONS-END quadbin
 
 /******************************************************************************
  * Typmod enforcer + self-cast (mirrors tbigint / tint / tfloat / ttext)

--- a/mobilitydb/sql/rgeo/150_trgeo.in.sql
+++ b/mobilitydb/sql/rgeo/150_trgeo.in.sql
@@ -81,6 +81,8 @@ CREATE FUNCTION trgeometry(trgeometry, integer)
 
 CREATE CAST (trgeometry AS trgeometry) WITH FUNCTION trgeometry(trgeometry, integer) AS IMPLICIT;
 
+-- GENERATED-REPRESENTATIONS-BEGIN rgeo — tools/codegen/inherited/generate.py from templates/representations.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.yaml (representation_families) and re-run.
 /*****************************************************************************
  * Input/output from (E)WKT, (E)WKB, HexEWKB, and MFJSON representation
  *****************************************************************************/
@@ -155,6 +157,8 @@ CREATE FUNCTION asHexEWKB(trgeometry, endianenconding text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- GENERATED-REPRESENTATIONS-END rgeo
 
 /******************************************************************************
  * Constructors

--- a/mobilitydb/sql/temporal/023_temporal_inout.in.sql
+++ b/mobilitydb/sql/temporal/023_temporal_inout.in.sql
@@ -33,6 +33,8 @@
  * representation
  */
 
+-- GENERATED-REPRESENTATIONS-BEGIN temporal — tools/codegen/inherited/generate.py from templates/representations.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.yaml (representation_families) and re-run.
 /*****************************************************************************
  * Input
  *****************************************************************************/
@@ -222,3 +224,4 @@ CREATE FUNCTION asHexWKB(ttext, endianenconding text DEFAULT '')
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************/
+-- GENERATED-REPRESENTATIONS-END temporal

--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -812,10 +812,16 @@ def render_representations(fam: dict) -> str:
 
 
 def extract_representations(filetext: str, fam: dict) -> str:
-    """Return the committed hand representation block, sliced by section-header
-    anchors (no in-file markers needed): from the `/*` opening the block's header
-    down to (exclusive) the `/*` opening the next section's header, or EOF for a
-    whole-file family."""
+    """Return the committed representation block. Once the GENERATED-REPRESENTATIONS
+    markers are in place, slice by them (like extract_io_type); before the bootstrap
+    inserts them, fall back to the section-header anchors: from the `/*` opening the
+    block's header down to (exclusive) the `/*` opening the next section's header, or
+    EOF for a whole-file family."""
+    begin, end_marker = _representations_markers(fam["family"])
+    if begin in filetext:
+        b = filetext.index(begin) + len(begin)
+        e = filetext.index(end_marker)
+        return filetext[b:e]
     i = filetext.index(fam["begin"])
     start = filetext.rfind("/*", 0, i)
     if fam.get("whole_file"):
@@ -877,6 +883,23 @@ def bootstrap_accessors(filetext: str, fam: dict, rendered: str) -> str:
     begin, end = _accessors_markers(fam["family"])
     text = prefix + begin + rendered + end + "\n" + rest
     return re.sub(r"\n\n\n+", "\n\n", text)  # tidy the blank runs left by the removals
+
+
+def bootstrap_representations(filetext: str, fam: dict, rendered: str) -> str:
+    """Create the GENERATED-REPRESENTATIONS region for a family whose representation
+    block is still a bare hand-written section (no markers). Unlike accessors the block
+    is CONTIGUOUS — the same section-header anchors extract_representations slices by —
+    so wrap exactly that span with the markers; the enclosed text is the rendered block,
+    byte-identical to the committed hand block (--validate proves it before the flip).
+    Idempotent afterward: the markers exist, so the splice path reproduces this output."""
+    i = filetext.index(fam["begin"])
+    start = filetext.rfind("/*", 0, i)
+    begin, end = _representations_markers(fam["family"])
+    if fam.get("whole_file"):
+        return filetext[:start] + begin + rendered + end
+    j = filetext.index(fam["end"])
+    block_end = filetext.rfind("/*", 0, j)
+    return filetext[:start] + begin + rendered + end + "\n" + filetext[block_end:]
 
 
 def target_path(behaviour: str, sub: dict, positions: dict) -> pathlib.Path:
@@ -1125,6 +1148,27 @@ def main() -> int:
             continue
         p.write_text(splice_io_type(p.read_text(), fam["family"], render_io_type(fam)))
         print(f"spliced io {fam['family']} -> {fam['file']}")
+
+    for fam in mf.get("representation_families", []):
+        p = ROOT / fam["file"]
+        text = p.read_text()
+        begin, _ = _representations_markers(fam["family"])
+        if begin not in text:
+            # No region yet -> BOOTSTRAP it once from the manifest entry (the block is a
+            # bare hand section). After this the markers exist and the splice path owns it.
+            if args.check:
+                print(f"would bootstrap representations {fam['family']} -> {fam['file']}")
+                continue
+            p.write_text(bootstrap_representations(text, fam, render_representations(fam)))
+            print(f"bootstrapped representations {fam['family']} -> {fam['file']}")
+            continue
+        if fam.get("reference"):
+            continue
+        if args.check:
+            print(f"would splice representations {fam['family']} -> {fam['file']}")
+            continue
+        p.write_text(splice_representations(text, fam["family"], render_representations(fam)))
+        print(f"spliced representations {fam['family']} -> {fam['file']}")
     return 0
 
 


### PR DESCRIPTION
Wrap each temporal family's text and binary representation block in a `GENERATED-REPRESENTATIONS` region so the inherited SQL generator owns it, the same way the accessor and type-I/O surfaces are already generated.

## Mechanism

- `bootstrap_representations` inserts the region markers around the existing block the first time; the splice path reproduces the region on every subsequent run.
- `extract_representations` slices by the markers once they exist and by the section-header anchors before, so `--validate` stays exact across the transition.
- The enclosed functions are byte-identical to the committed block — the diff adds only the region markers.

## Scope

Seven families carry the region: `temporal`, `geo`, `cbuffer`, `npoint`, `rgeo`, `h3`, `quadbin`. Their `asText` / `asBinary` / `asHexWKB` / `asMFJSON` outputs and `From{Binary,HexWKB,MFJSON}` constructors are unchanged. The `check-codegen` job regenerates the regions and diffs the tree, so a hand edit that drifts from the template fails CI.