### PR TITLE
Compute the tcbuffer contains and covers of a circular buffer with the exact disc-in-disc clearance

### DIFF
--- a/meos/include/cbuffer/tcbuffer.h
+++ b/meos/include/cbuffer/tcbuffer.h
@@ -76,6 +76,9 @@ extern int tcbuffersegm_distance_turnpt(Datum start1, Datum end1, Datum start2,
 
 extern void *tcbuffer_geo_ctx_make(const GSERIALIZED *gs);
 extern void tcbuffer_geo_ctx_free(void *ctx);
+extern void *tcbuffer_disc_ctx_make(const Cbuffer *cb,
+  bool container_is_temporal);
+extern void tcbuffer_disc_ctx_free(void *ctx);
 extern int tcbuffer_geo_ctx_nsegs(const void *ctx);
 extern bool tcbuffer_disc_within_ctx(const Cbuffer *cb, double dist,
   const void *ctx);

--- a/meos/include/cbuffer/tcbuffer_tempspatialrels.h
+++ b/meos/include/cbuffer/tcbuffer_tempspatialrels.h
@@ -52,6 +52,10 @@ extern int eatouches_tcbuffer_geo_native(const Temporal *temp,
   const GSERIALIZED *gs, bool ever);
 extern int eacontains_tcbuffer_geo_native(const Temporal *temp,
   const GSERIALIZED *gs, bool ever, bool strict);
+extern int eacontains_tcbuffer_cbuffer_native(const Temporal *temp,
+  const Cbuffer *cb, bool ever, bool container_is_temporal, bool strict);
+extern Temporal *tcontains_disc_tcbuffer_native(const Temporal *temp,
+  const Cbuffer *cb, bool container_is_temporal, bool strict);
 // extern Temporal *tinterrel_tcbuffer_tcbuffer(const Temporal *temp1,
 //   const Temporal *temp2, bool tinter);
 

--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -715,6 +715,13 @@ shortestline_tcbuffer_geo_analytic(const Temporal *temp, const GSERIALIZED *gs)
  * nearest-approach value.
  *****************************************************************************/
 
+/* Context kind discriminator shared as the first member of every context
+ * struct, so the ever/always/spanset scan kernels can be reused verbatim for a
+ * geometry boundary (#TcbufferGeoCtx) or for a single static circular buffer
+ * (#TcbufferDiscCtx) */
+#define TCBUF_CTX_GEO 0
+#define TCBUF_CTX_DISC 1
+
 /**
  * @brief Reusable geometry context that owns the boundary segments and the
  * bucket hierarchy, so many discs and segments can be tested against one
@@ -722,9 +729,24 @@ shortestline_tcbuffer_geo_analytic(const Temporal *temp, const GSERIALIZED *gs)
  */
 typedef struct
 {
+  int kind;             /**< Always #TCBUF_CTX_GEO */
   GeoDistEdge *segs;
   GeoDistGeom g;
 } TcbufferGeoCtx;
+
+/**
+ * @brief Reusable disc context that owns a single static circular buffer, so
+ * the contains/covers scan kernels test a moving disk against it exactly (disc
+ * in disc, no polygon approximation of the boundary)
+ */
+typedef struct
+{
+  int kind;             /**< Always #TCBUF_CTX_DISC */
+  Cbuffer cb;           /**< The static circular buffer */
+  bool container_is_temporal; /**< True if the temporal disk is the container
+                                   (temp contains cb), false if @p cb contains
+                                   the temporal disk */
+} TcbufferDiscCtx;
 
 /**
  * @brief Build the reusable geometry context for the native within kernel from
@@ -755,6 +777,7 @@ tcbuffer_geo_ctx_make(const GSERIALIZED *gs)
     if (segs[k].ymax > gymax) gymax = segs[k].ymax;
   }
   TcbufferGeoCtx *ctx = palloc(sizeof(TcbufferGeoCtx));
+  ctx->kind = TCBUF_CTX_GEO;
   ctx->segs = segs;
   ctx->g = (GeoDistGeom) { segs, n, has_poly, gxmin, gymin, gxmax, gymax, NULL,
     0, geodist_geom_build_rtree(segs, n) };
@@ -784,12 +807,42 @@ tcbuffer_geo_ctx_free(void *ctx)
 }
 
 /**
- * @brief Return the number of boundary segments in a geometry context, used to
- * size the per-segment within-interval output
+ * @brief Build a disc context wrapping a single static circular buffer for the
+ * exact disc-in-disc contains/covers scan kernels
+ * @param[in] cb Static circular buffer
+ * @param[in] container_is_temporal True if the temporal disk is the container
+ * (temp contains @p cb), false if @p cb is the container (@p cb contains temp)
+ */
+void *
+tcbuffer_disc_ctx_make(const Cbuffer *cb, bool container_is_temporal)
+{
+  TcbufferDiscCtx *ctx = palloc(sizeof(TcbufferDiscCtx));
+  ctx->kind = TCBUF_CTX_DISC;
+  ctx->cb = *cb;
+  ctx->container_is_temporal = container_is_temporal;
+  return ctx;
+}
+
+/**
+ * @brief Free a disc context built by #tcbuffer_disc_ctx_make
+ */
+void
+tcbuffer_disc_ctx_free(void *ctx)
+{
+  if (ctx)
+    pfree(ctx);
+}
+
+/**
+ * @brief Return the number of boundary segments in a context, used to size the
+ * per-segment root output (a disc boundary yields at most the two roots of the
+ * quadratic clearance equation)
  */
 int
 tcbuffer_geo_ctx_nsegs(const void *ctxv)
 {
+  if (*(const int *) ctxv == TCBUF_CTX_DISC)
+    return 1;
   return ((const TcbufferGeoCtx *) ctxv)->g.n;
 }
 
@@ -1136,6 +1189,19 @@ tcbuffer_disc_touch_ctx(const Cbuffer *cb, const void *ctxv)
 bool
 tcbuffer_disc_contains_ctx(const Cbuffer *cb, const void *ctxv, bool strict)
 {
+  if (*(const int *) ctxv == TCBUF_CTX_DISC)
+  {
+    /* Exact disc-in-disc test: a disk (C, rc) is contained in a disk (P, R)
+     * iff dist(P, C) + rc <= R (covers) / < R (contains). The moving disk is
+     * @p cb; the static disk and the containment direction come from the
+     * context */
+    const TcbufferDiscCtx *d = (const TcbufferDiscCtx *) ctxv;
+    const Cbuffer *outer = d->container_is_temporal ? cb : &d->cb;
+    const Cbuffer *inner = d->container_is_temporal ? &d->cb : cb;
+    double gap = hypot(inner->x - outer->x, inner->y - outer->y) +
+      inner->radius - outer->radius;
+    return strict ? (gap < - TCBUFFER_TOUCH_EPS) : (gap <= TCBUFFER_TOUCH_EPS);
+  }
   const TcbufferGeoCtx *ctx = (const TcbufferGeoCtx *) ctxv;
   const POINT2D *p = cbuffer_point2d_p(cb);
   bool inside;
@@ -1246,10 +1312,61 @@ tcbufferseg_touch_roots(const Cbuffer *cb1, const Cbuffer *cb2,
  * containment changes but no touch occurs. Returns the number of times written
  * (at most @p maxout)
  */
+/**
+ * @brief Append to @p outt the interior times in (0,1) at which a linearly
+ * moving disk starts or stops containing/covering (or being contained/covered
+ * by) the static disk of a disc context
+ * @details Over the segment the moving disk is P(t)=(x0+t dx, y0+t dy),
+ * R(t)=r0+t dr. Containment flips where the clearance g(t)=||P(t)-C||-thr(t)
+ * vanishes, thr(t)=m+s t being R(t)-rc (temporal container) or rc-R(t) (static
+ * container). Squaring the non-negative ||P(t)-C|| gives the quadratic
+ * Q(t)=(a-s^2)t^2+(b-2ms)t+(c-m^2); a root is a genuine clearance zero only
+ * where thr>=0, which discards the spurious branch introduced by squaring.
+ */
+static int
+tcbuffer_disc_seg_roots(const Cbuffer *cb1, const Cbuffer *cb2,
+  const TcbufferDiscCtx *d, double *outt, int maxout)
+{
+  double x0 = cb1->x, y0 = cb1->y, r0 = cb1->radius;
+  double dx = cb2->x - cb1->x, dy = cb2->y - cb1->y, dr = cb2->radius - r0;
+  double cx = d->cb.x, cy = d->cb.y, rc = d->cb.radius;
+  double m, s;
+  if (d->container_is_temporal) { m = r0 - rc; s = dr; }
+  else { m = rc - r0; s = -dr; }
+  double ex = x0 - cx, ey = y0 - cy;
+  double a = dx * dx + dy * dy, b = 2 * (ex * dx + ey * dy), c = ex * ex + ey * ey;
+  double A = a - s * s, B = b - 2 * m * s, C = c - m * m;
+  double cand[2];
+  int ncand = 0;
+  if (fabs(A) > 1e-12)
+  {
+    double disc = B * B - 4 * A * C;
+    if (disc >= 0)
+    {
+      double sq = sqrt(disc);
+      cand[ncand++] = (-B - sq) / (2 * A);
+      cand[ncand++] = (-B + sq) / (2 * A);
+    }
+  }
+  else if (fabs(B) > 1e-12)
+    cand[ncand++] = -C / B;
+  int n = 0;
+  for (int i = 0; i < ncand && n < maxout; i++)
+  {
+    double t = cand[i];
+    if (t > 0.0 && t < 1.0 && (m + s * t) >= - TCBUFFER_TOUCH_EPS)
+      outt[n++] = t;
+  }
+  return n;
+}
+
 int
 tcbufferseg_boundary_roots(const Cbuffer *cb1, const Cbuffer *cb2,
   const void *ctxv, double *outt, int maxout)
 {
+  if (*(const int *) ctxv == TCBUF_CTX_DISC)
+    return tcbuffer_disc_seg_roots(cb1, cb2, (const TcbufferDiscCtx *) ctxv,
+      outt, maxout);
   return tcbufferseg_sg_roots(cb1, cb2, ctxv, outt, maxout, false);
 }
 

--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -643,13 +643,9 @@ int
 ea_contains_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp,
   bool ever)
 {
-  const char p[] = "T********";
-  int result = ever ?
-    ea_spatialrel_tcbuffer_cbuffer(temp, cb, PointerGetDatum(p),
-      (varfunc) &datum_geom_relate_pattern, 3, ever, INVERT) :
-    ea_spatialrel_tcbuffer_cbuffer(temp, cb, (Datum) NULL,
-      (varfunc) &datum_geom_contains, 2, ever, INVERT);
-  return result;
+  if (! ensure_valid_tcbuffer_cbuffer(temp, cb))
+    return -1;
+  return eacontains_tcbuffer_cbuffer_native(temp, cb, ever, false, true);
 }
 
 /**
@@ -693,13 +689,9 @@ int
 ea_contains_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb,
   bool ever)
 {
-  const char p[] = "T********";
-  int result = ever ?
-    ea_spatialrel_tcbuffer_cbuffer(temp, cb, PointerGetDatum(p),
-      (varfunc) &datum_geom_relate_pattern, 3, ever, INVERT_NO) :
-    ea_spatialrel_tcbuffer_cbuffer(temp, cb, (Datum) NULL,
-      (varfunc) &datum_geom_contains, 2, ever, INVERT_NO);
-  return result;
+  if (! ensure_valid_tcbuffer_cbuffer(temp, cb))
+    return -1;
+  return eacontains_tcbuffer_cbuffer_native(temp, cb, ever, true, true);
 }
 
 /**
@@ -893,8 +885,9 @@ int
 ea_covers_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp,
   bool ever)
 {
-  return ea_spatialrel_tcbuffer_cbuffer(temp, cb, (Datum) NULL,
-    (varfunc) &datum_geom_covers, 2, ever, INVERT);
+  if (! ensure_valid_tcbuffer_cbuffer(temp, cb))
+    return -1;
+  return eacontains_tcbuffer_cbuffer_native(temp, cb, ever, false, false);
 }
 
 /**
@@ -938,8 +931,9 @@ int
 ea_covers_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb,
   bool ever)
 {
-  return ea_spatialrel_tcbuffer_cbuffer(temp, cb, (Datum) NULL,
-    (varfunc) &datum_geom_covers, 2, ever, INVERT_NO);
+  if (! ensure_valid_tcbuffer_cbuffer(temp, cb))
+    return -1;
+  return eacontains_tcbuffer_cbuffer_native(temp, cb, ever, true, false);
 }
 
 /**

--- a/meos/src/cbuffer/tcbuffer_tempspatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_tempspatialrels.c
@@ -1123,6 +1123,8 @@ tspatialrel_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb,
  * per-instant lifting path */
 static Temporal *tcontains_geo_tcbuffer_native(const Temporal *temp,
   const GSERIALIZED *gs, bool strict);
+extern Temporal *tcontains_disc_tcbuffer_native(const Temporal *temp,
+  const Cbuffer *cb, bool container_is_temporal, bool strict);
 
 /**
  * @ingroup meos_cbuffer_rel_temp
@@ -1175,8 +1177,7 @@ tcontains_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tcbuffer_cbuffer(temp, cb))
     return NULL;
-  return tspatialrel_tspatial_base(temp, PointerGetDatum(cb),
-    (Datum) NULL, (varfunc) &datum_cbuffer_contains, 0, INVERT);
+  return tcontains_disc_tcbuffer_native(temp, cb, false, true);
 }
 
 /**
@@ -1193,8 +1194,7 @@ tcontains_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tcbuffer_cbuffer(temp, cb))
     return NULL;
-  return tspatialrel_tspatial_base(temp, PointerGetDatum(cb),
-    (Datum) NULL, (varfunc) &datum_cbuffer_contains, 0, INVERT_NO);
+  return tcontains_disc_tcbuffer_native(temp, cb, true, true);
 }
 
 /**
@@ -1262,7 +1262,10 @@ tcovers_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 Temporal *
 tcovers_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 {
-  return tspatialrel_tcbuffer_cbuffer(temp, cb, INVERT, &datum_cbuffer_covers);
+  /* Ensure the validity of the arguments */
+  if (! ensure_valid_tcbuffer_cbuffer(temp, cb))
+    return NULL;
+  return tcontains_disc_tcbuffer_native(temp, cb, false, false);
 }
 
 /**
@@ -1276,8 +1279,10 @@ tcovers_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
 Temporal *
 tcovers_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 {
-  return tspatialrel_tcbuffer_cbuffer(temp, cb, INVERT_NO,
-    &datum_cbuffer_covers);
+  /* Ensure the validity of the arguments */
+  if (! ensure_valid_tcbuffer_cbuffer(temp, cb))
+    return NULL;
+  return tcontains_disc_tcbuffer_native(temp, cb, true, false);
 }
 
 /**
@@ -2204,27 +2209,16 @@ tcbufferseq_always_contains_native(const TSequence *seq, const void *ctx,
  * @param[in] ever True for the ever semantics, false for the always semantics
  * @param[in] strict True for contains, false for covers
  */
-int
-eacontains_tcbuffer_geo_native(const Temporal *temp, const GSERIALIZED *gs,
+/**
+ * @brief Return 1 if a context (@p strict) ever/always contains or covers a
+ * temporal circular buffer, 0 if not, scanning the instants and per-segment
+ * sub-intervals; the context abstracts either a geometry boundary or a static
+ * disc
+ */
+static int
+eacontains_tcbuffer_ctx_native(const Temporal *temp, const void *ctx,
   bool ever, bool strict)
 {
-  if (gserialized_is_empty(gs))
-    return -1;
-
-  /* Bounding box test: a moving disk whose radius-aware bounding box is
-   * disjoint from the geometry is never inside it, so it never contains/covers
-   * at any instant. This constant-time reject avoids the per-segment clearance
-   * scan on the common non-overlapping case (e.g. a spatial join over disjoint
-   * extents), giving 0 for both the ever and always semantics */
-  STBox box1, box2;
-  tspatial_set_stbox(temp, &box1);
-  geo_set_stbox(gs, &box2);
-  if (! overlaps_stbox_stbox(&box1, &box2))
-    return 0;
-
-  void *ctx = tcbuffer_geo_ctx_make(gs);
-  if (! ctx)
-    return -1;
   int result;
   assert(temptype_subtype(temp->subtype));
   if (temp->subtype == TINSTANT)
@@ -2251,7 +2245,97 @@ eacontains_tcbuffer_geo_native(const Temporal *temp, const GSERIALIZED *gs,
       if (! ever && ! r) { result = 0; break; }
     }
   }
+  return result;
+}
+
+int
+eacontains_tcbuffer_geo_native(const Temporal *temp, const GSERIALIZED *gs,
+  bool ever, bool strict)
+{
+  if (gserialized_is_empty(gs))
+    return -1;
+
+  /* Bounding box test: a moving disk whose radius-aware bounding box is
+   * disjoint from the geometry is never inside it, so it never contains/covers
+   * at any instant. This constant-time reject avoids the per-segment clearance
+   * scan on the common non-overlapping case (e.g. a spatial join over disjoint
+   * extents), giving 0 for both the ever and always semantics */
+  STBox box1, box2;
+  tspatial_set_stbox(temp, &box1);
+  geo_set_stbox(gs, &box2);
+  if (! overlaps_stbox_stbox(&box1, &box2))
+    return 0;
+
+  void *ctx = tcbuffer_geo_ctx_make(gs);
+  if (! ctx)
+    return -1;
+  int result = eacontains_tcbuffer_ctx_native(temp, ctx, ever, strict);
   tcbuffer_geo_ctx_free(ctx);
+  return result;
+}
+
+/**
+ * @ingroup meos_internal_cbuffer_rel_ever
+ * @brief Return 1 if a temporal circular buffer ever/always contains (@p strict)
+ * or covers a static circular buffer, or the static circular buffer the
+ * temporal one, 0 if not
+ * @param[in] temp Temporal circular buffer
+ * @param[in] cb Static circular buffer
+ * @param[in] ever True for the ever semantics, false for the always semantics
+ * @param[in] container_is_temporal True if @p temp is the container
+ * @param[in] strict True for contains, false for covers
+ */
+int
+eacontains_tcbuffer_cbuffer_native(const Temporal *temp, const Cbuffer *cb,
+  bool ever, bool container_is_temporal, bool strict)
+{
+  /* Bounding box test: two disjoint radius-aware bounding boxes cannot contain
+   * one another at any instant */
+  STBox box1, box2;
+  tspatial_set_stbox(temp, &box1);
+  cbuffer_set_stbox(cb, &box2);
+  if (! overlaps_stbox_stbox(&box1, &box2))
+    return 0;
+
+  void *ctx = tcbuffer_disc_ctx_make(cb, container_is_temporal);
+  int result = eacontains_tcbuffer_ctx_native(temp, ctx, ever, strict);
+  tcbuffer_disc_ctx_free(ctx);
+  return result;
+}
+
+/**
+ * @brief Native temporal contains/covers Boolean for a temporal circular buffer
+ * and a static circular buffer, exact disc in disc
+ */
+Temporal *
+tcontains_disc_tcbuffer_native(const Temporal *temp, const Cbuffer *cb,
+  bool container_is_temporal, bool strict)
+{
+  /* Bounding box test: a false everywhere the boxes are disjoint */
+  STBox box1, box2;
+  tspatial_set_stbox(temp, &box1);
+  cbuffer_set_stbox(cb, &box2);
+  if (! overlaps_stbox_stbox(&box1, &box2))
+    return temporal_from_base_temp(BoolGetDatum(false), T_TBOOL, temp);
+
+  void *ctx = tcbuffer_disc_ctx_make(cb, container_is_temporal);
+  Temporal *result = NULL;
+  assert(temptype_subtype(temp->subtype));
+  switch (temp->subtype)
+  {
+    case TINSTANT:
+      result = tcontains_tcbufferinst_geo_native((TInstant *) temp, ctx,
+        strict);
+      break;
+    case TSEQUENCE:
+      result = tcontains_tcbufferseq_geo_native((TSequence *) temp, ctx,
+        strict);
+      break;
+    default: /* TSEQUENCESET */
+      result = tcontains_tcbufferseqset_geo_native((TSequenceSet *) temp, ctx,
+        strict);
+  }
+  tcbuffer_disc_ctx_free(ctx);
   return result;
 }
 

--- a/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels.test.out
@@ -1,49 +1,49 @@
 SELECT eContains(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
  econtains 
 -----------
- t
+ f
 (1 row)
 
 SELECT eContains(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}');
  econtains 
 -----------
- t
+ f
 (1 row)
 
 SELECT eContains(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]');
  econtains 
 -----------
- t
+ f
 (1 row)
 
 SELECT eContains(cbuffer 'Cbuffer(Point(1 1),0.5)', tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}');
  econtains 
 -----------
- t
+ f
 (1 row)
 
 SELECT eContains(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', cbuffer 'Cbuffer(Point(1 1),0.5)');
  econtains 
 -----------
- t
+ f
 (1 row)
 
 SELECT eContains(tcbuffer '{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03}', cbuffer 'Cbuffer(Point(1 1),0.5)');
  econtains 
 -----------
- t
+ f
 (1 row)
 
 SELECT eContains(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03]', cbuffer 'Cbuffer(Point(1 1),0.5)');
  econtains 
 -----------
- t
+ f
 (1 row)
 
 SELECT eContains(tcbuffer '{[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.5)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}', cbuffer 'Cbuffer(Point(1 1),0.5)');
  econtains 
 -----------
- t
+ f
 (1 row)
 
 SELECT eContains(tcbuffer '[Cbuffer(Point(4 2),0.5)@2000-01-01, Cbuffer(Point(2 4),0.5)@2000-01-02]', geometry 'Linestring(1 1,3 3)');

--- a/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels_tbl.test.out
@@ -19,7 +19,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aContains(temp, g);
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eContains(cb, temp);
  count 
 -------
-  1833
+   411
 (1 row)
 
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aContains(cb, temp);
@@ -31,13 +31,13 @@ SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aContains(cb, temp);
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eContains(temp, cb);
  count 
 -------
-  1833
+   493
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aContains(temp, cb);
  count 
 -------
-     9
+     1
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE eContains(t1.temp, t2.temp);
@@ -73,7 +73,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aCovers(temp, g);
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eCovers(cb, temp);
  count 
 -------
-     9
+   411
 (1 row)
 
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aCovers(cb, temp);
@@ -85,13 +85,13 @@ SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE aCovers(cb, temp);
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE eCovers(temp, cb);
  count 
 -------
-   488
+   493
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aCovers(temp, cb);
  count 
 -------
-     9
+     1
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE eCovers(t1.temp, t2.temp);

--- a/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels_tbl.test.out
@@ -37,7 +37,7 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tContains(g, temp) ?= true
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE tContains(cb, temp) ?= true <> eContains(cb, temp);
  count 
 -------
-  1756
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE tCovers(g, temp) IS NOT NULL;


### PR DESCRIPTION
Route the ever, always and temporal contains and covers of a temporal circular buffer and a static circular buffer through a native per-segment disc-in-disc clearance kernel instead of the polygon approximation of the disc. A moving disk contains a static one exactly when the distance between the centres plus the static radius stays within the moving radius; the clearance is convex over each linear segment, so the always semantics reduces to the two segment endpoints and the ever semantics to the sub-interval bounded by the roots of the quadratic clearance equation, keeping the roots where the signed threshold is non-negative. The disc context reuses the geometry contains and covers scan kernels through a shared context-kind discriminator, and the temporal, ever and always forms all derive from this one clearance test so that eContains equals ever of tContains.