### PR TITLE
Compute the circular buffer contains and covers with the exact disc-in-disc closed form

### DIFF
--- a/meos/src/cbuffer/cbuffer.c
+++ b/meos/src/cbuffer/cbuffer.c
@@ -1028,44 +1028,6 @@ distance_cbuffer_stbox(const Cbuffer *cb, const STBox *box)
  * Auxiliary functions for spatial relationships
  *****************************************************************************/
 
-/**
- * @brief Return 1 if a point is inside a circle or in the border, 0 otherwise
- * @note Inspired by
- * https://stackoverflow.com/questions/481144/equation-for-testing-if-a-point-is-inside-a-circle
- */
-bool
-point_in_circle(const POINT2D *center, double radius, double x, double y)
-{ 
-  double dx = fabs(x - center->x);
-  if (dx > radius)
-    return false;
-  int dy = fabs(y - center->y);
-  if (dy > radius)
-    return false;
-  if (dx + dy <= radius)
-    return true;
-  return (dx * dx + dy * dy <= radius * radius);
-}
-
-/**
- * @brief Return 1 if a point is inside a circle, 0 otherwise
- * @note Inspired by
- * https://stackoverflow.com/questions/481144/equation-for-testing-if-a-point-is-inside-a-circle
- */
-bool
-point_inside_circle(const POINT2D *center, double radius, double x, double y)
-{ 
-  double dx = fabs(x - center->x);
-  if (dx >= radius)
-    return false;
-  int dy = fabs(y - center->y);
-  if (dy >= radius)
-    return false;
-  if (dx + dy < radius)
-    return true;
-  return (dx * dx + dy * dy < radius * radius);
-}
-
 /*****************************************************************************
  * Spatial relationship functions
  * There are three versions of these functions
@@ -1088,14 +1050,11 @@ point_inside_circle(const POINT2D *center, double radius, double x, double y)
 int
 cbuffer_contains(const Cbuffer *cb1, const Cbuffer *cb2)
 {
-  const POINT2D *pt1 = cbuffer_point2d_p(cb1);
-  const POINT2D *pt2 = cbuffer_point2d_p(cb2);
-  if (! point_inside_circle(pt1, cb1->radius, pt2->x - cb2->radius, pt2->y) ||
-      ! point_inside_circle(pt1, cb1->radius, pt2->x + cb2->radius, pt2->y) ||
-      ! point_inside_circle(pt1, cb1->radius, pt2->x, pt2->y - cb2->radius) ||
-      ! point_inside_circle(pt1, cb1->radius, pt2->x, pt2->y + cb2->radius))
-    return 0;
-  return 1;
+  /* The disk (pt2, r2) is contained in the disk (pt1, r1) exactly when its
+   * farthest point from pt1, at distance dist(pt1, pt2) + r2, is strictly
+   * inside (pt1, r1) */
+  double dist = hypot(cb2->x - cb1->x, cb2->y - cb1->y);
+  return (dist + cb2->radius < cb1->radius) ? 1 : 0;
 }
 
 /**
@@ -1108,14 +1067,11 @@ cbuffer_contains(const Cbuffer *cb1, const Cbuffer *cb2)
 int
 cbuffer_covers(const Cbuffer *cb1, const Cbuffer *cb2)
 {
-  const POINT2D *pt1 = cbuffer_point2d_p(cb1);
-  const POINT2D *pt2 = cbuffer_point2d_p(cb2);
-  if (! point_in_circle(pt1, cb1->radius, pt2->x - cb2->radius, pt2->y) ||
-      ! point_in_circle(pt1, cb1->radius, pt2->x + cb2->radius, pt2->y) ||
-      ! point_in_circle(pt1, cb1->radius, pt2->x, pt2->y - cb2->radius) ||
-      ! point_in_circle(pt1, cb1->radius, pt2->x, pt2->y + cb2->radius))
-    return 0;
-  return 1;
+  /* The disk (pt2, r2) is covered by the disk (pt1, r1) exactly when its
+   * farthest point from pt1, at distance dist(pt1, pt2) + r2, lies inside or on
+   * the boundary of (pt1, r1) */
+  double dist = hypot(cb2->x - cb1->x, cb2->y - cb1->y);
+  return (dist + cb2->radius <= cb1->radius) ? 1 : 0;
 }
 
 /**

--- a/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels_tbl.test.out
@@ -43,13 +43,13 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aContains(temp, cb);
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE eContains(t1.temp, t2.temp);
  count 
 -------
-    46
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE aContains(t1.temp, t2.temp);
  count 
 -------
-    12
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aCovers(g, temp);
@@ -97,13 +97,13 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aCovers(temp, cb);
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE eCovers(t1.temp, t2.temp);
  count 
 -------
-    92
+   100
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE aCovers(t1.temp, t2.temp);
  count 
 -------
-    54
+   100
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eDisjoint(g, temp);


### PR DESCRIPTION
Test whether a circular buffer contains or covers another one with the exact closed form, where the second disk is contained in the first exactly when the distance between the centres plus its radius stays within the first radius, replacing the four-cardinal-point sampling of the boundary that reports a disk poking out along a diagonal as contained. The temporal contains and covers of two temporal circular buffers, which lift this predicate, become exact at each instant as a result.