### PR TITLE
Add an in-memory space-partitioning index (quad-tree and k-d tree) to MEOS

### DIFF
--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -116,6 +116,8 @@ jobs:
           ./rtree_knn_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o rtree_span_test rtree_span_test.c -L/usr/local/lib -lmeos -lm
           ./rtree_span_test
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o sptree_test sptree_test.c -L/usr/local/lib -lmeos -lm
+          ./sptree_test
 
   threaded:
     name: Thread-safety (TSan)

--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -382,6 +382,37 @@ extern RTreeNNCursor *rtree_nn_cursor_open(const RTree *rtree, const void *query
 extern bool rtree_nn_cursor_next(RTreeNNCursor *cursor, int *id_out, double *dist_out);
 extern void rtree_nn_cursor_close(RTreeNNCursor *cursor);
 
+/**
+ * @brief Enumeration that defines the kind of an in-memory space-partitioning
+ * index
+ */
+typedef enum
+{
+  SPTREE_QUADTREE,   /**< Quad-tree (2^dims children per node) */
+  SPTREE_KDTREE      /**< K-d tree (two children per node) */
+} SPTreeKind;
+
+/**
+ * Structure for the in-memory space-partitioning index (quad-tree, k-d tree)
+ */
+typedef struct SPTree SPTree;
+
+/* SPTree functions */
+
+extern SPTree *sptree_create_intspan(SPTreeKind kind);
+extern SPTree *sptree_create_bigintspan(SPTreeKind kind);
+extern SPTree *sptree_create_floatspan(SPTreeKind kind);
+extern SPTree *sptree_create_datespan(SPTreeKind kind);
+extern SPTree *sptree_create_tstzspan(SPTreeKind kind);
+extern SPTree *sptree_create_tbox(SPTreeKind kind);
+extern void sptree_free(SPTree *sptree);
+extern void sptree_insert(SPTree *sptree, void *box, int id);
+extern void sptree_insert_temporal(SPTree *sptree, const Temporal *temp, int id);
+extern void sptree_insert_temporal_split(SPTree *sptree, const Temporal *temp, int id, int maxboxes);
+extern int sptree_search(const SPTree *sptree, RTreeSearchOp op, const void *query, MeosArray *result);
+extern int sptree_search_temporal(const SPTree *sptree, RTreeSearchOp op, const Temporal *temp, MeosArray *result);
+extern int sptree_search_temporal_dedup(const SPTree *sptree, RTreeSearchOp op, const Temporal *temp, int maxboxes, MeosArray *result);
+
 /*****************************************************************************
  * Initialization of the MEOS library
  *****************************************************************************/

--- a/meos/include/temporal/temporal_sptree.h
+++ b/meos/include/temporal/temporal_sptree.h
@@ -1,0 +1,97 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @brief In-memory space-partitioning index (quad-tree and k-d tree) for MEOS
+ * bounding boxes, i.e., for Span and TBox
+ */
+
+#ifndef __TEMPORAL_SPTREE__
+#define __TEMPORAL_SPTREE__
+
+/* MEOS */
+#include <meos.h>
+
+#include "temporal/meos_catalog.h"
+
+/*****************************************************************************
+ * SPTree
+ *****************************************************************************/
+
+/**
+ * @brief Maximum size in bytes of an inner node region (SpanNode, TboxNode)
+ */
+#define SPTREE_NODEBOX_MAXSIZE 512
+
+/**
+ * @brief Node of an in-memory space-partitioning tree
+ * @details A node is a stored bounding box (the @p centroid) that splits the
+ * space into @p nchild children; the box lives in the flexible tail. An empty
+ * child slot is a @p NULL pointer.
+ */
+typedef struct SPNode
+{
+  int id;                     /**< Identifier of the box stored at this node */
+  struct SPNode **children;   /**< Array of @p nchild child pointers */
+  char centroid[];            /**< The bounding box of this node */
+} SPNode;
+
+/**
+ * @brief In-memory space-partitioning index (quad-tree or k-d tree)
+ * @details Works on Span and TBox. Each node is a data box that partitions the
+ * space; the family-specific geometry (quadrant assignment, child region, and
+ * consistency tests) is provided through function pointers, reusing the same
+ * routines as the SP-GiST operator classes.
+ */
+struct SPTree
+{
+  MeosType bboxtype;    /**< Type of the bounding box */
+  MeosType spantype;    /**< Span type (span box types only) */
+  MeosType basetype;    /**< Base type (span box types only) */
+  size_t boxsize;       /**< Size of a bounding box */
+  size_t nodeboxsize;   /**< Size of an inner node region */
+  int dims;             /**< Number of dimensions of the box */
+  int nchild;           /**< Number of children per node */
+  SPTreeKind kind;      /**< Quad-tree or k-d tree */
+  SPNode *root;         /**< Root node, or @p NULL when empty */
+  uint8 (*get_quadrant)(const void *centroid, const void *key);
+  void (*nodebox_init)(void *nodebox, const void *centroid,
+    const struct SPTree *sptree);
+  void (*quadtree_next)(const void *nodebox, const void *centroid,
+    uint8 quadrant, void *next);
+  void (*kdtree_next)(const void *nodebox, const void *centroid, uint8 node,
+    int level, void *next);
+  bool (*inner_consistent)(const void *nodebox, const void *query,
+    RTreeSearchOp op);
+  bool (*leaf_consistent)(const void *key, const void *query, RTreeSearchOp op);
+};
+
+/*****************************************************************************/
+
+#endif /* __TEMPORAL_SPTREE__ */

--- a/meos/src/temporal/CMakeLists.txt
+++ b/meos/src/temporal/CMakeLists.txt
@@ -27,6 +27,7 @@ set(TEMPORAL_SOURCES
   temporal_modif.c
   temporal_restrict.c
   temporal_rtree.c
+  temporal_sptree.c
   temporal_tile.c
   temporal_waggfuncs.c
   tinstant.c

--- a/meos/src/temporal/temporal_sptree.c
+++ b/meos/src/temporal/temporal_sptree.c
@@ -1,0 +1,663 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief In-memory space-partitioning index (quad-tree and k-d tree) for MEOS
+ * bounding boxes, i.e., for Span and TBox
+ * @details Each node is a data box (its centroid) that partitions the space
+ * into `2^dims` quadrants (quad-tree) or two halves alternating one dimension
+ * per level (k-d tree). Insertion descends to an empty child slot and stores
+ * the box there; a search descends every child whose region is consistent with
+ * the query, collecting the ids of the stored boxes that match. The family
+ * geometry — quadrant assignment, child region, and the consistency tests — is
+ * the same as the SP-GiST operator classes, reused through function pointers.
+ */
+
+/* C */
+#include <stdlib.h>
+/* MEOS */
+#include <meos.h>
+#include <meos_internal.h>
+#include "temporal/temporal.h"
+#include "temporal/span_index.h"
+#include "temporal/tbox_index.h"
+#include "temporal/temporal_sptree.h"
+
+/*****************************************************************************
+ * Family-specific adapters (Span)
+ *****************************************************************************/
+
+static uint8
+span_get_quadrant(const void *centroid, const void *key)
+{
+  return getQuadrant2D((const Span *) centroid, (const Span *) key);
+}
+
+static void
+span_nodebox_init(void *nodebox, const void *centroid UNUSED,
+  const struct SPTree *sptree)
+{
+  spannode_init((SpanNode *) nodebox, sptree->spantype, sptree->basetype);
+}
+
+static void
+span_quadtree_next(const void *nodebox, const void *centroid, uint8 quadrant,
+  void *next)
+{
+  spannode_quadtree_next((const SpanNode *) nodebox, (const Span *) centroid,
+    quadrant, (SpanNode *) next);
+}
+
+static void
+span_kdtree_next(const void *nodebox, const void *centroid, uint8 node,
+  int level, void *next)
+{
+  spannode_kdtree_next((const SpanNode *) nodebox, (const Span *) centroid,
+    node, level, (SpanNode *) next);
+}
+
+static bool
+span_inner_consistent(const void *nodebox, const void *query, RTreeSearchOp op)
+{
+  const SpanNode *n = (const SpanNode *) nodebox;
+  const Span *q = (const Span *) query;
+  if (op == RTREE_CONTAINS)
+    return contain2D(n, q);
+  /* RTREE_OVERLAPS and RTREE_CONTAINED_BY prune on overlap */
+  return overlap2D(n, q);
+}
+
+static bool
+span_leaf_consistent(const void *key, const void *query, RTreeSearchOp op)
+{
+  const Span *k = (const Span *) key;
+  const Span *q = (const Span *) query;
+  if (op == RTREE_CONTAINS)
+    return contains_span_span(k, q);
+  if (op == RTREE_CONTAINED_BY)
+    return contains_span_span(q, k);
+  return overlaps_span_span(k, q);
+}
+
+/*****************************************************************************
+ * Family-specific adapters (TBox)
+ *****************************************************************************/
+
+static uint8
+tbox_get_quadrant(const void *centroid, const void *key)
+{
+  return getQuadrant4D((const TBox *) centroid, (const TBox *) key);
+}
+
+static void
+tbox_nodebox_init(void *nodebox, const void *centroid,
+  const struct SPTree *sptree UNUSED)
+{
+  tboxnode_init((TBox *) centroid, (TboxNode *) nodebox);
+}
+
+static void
+tbox_quadtree_next(const void *nodebox, const void *centroid, uint8 quadrant,
+  void *next)
+{
+  tboxnode_quadtree_next((const TboxNode *) nodebox, (const TBox *) centroid,
+    quadrant, (TboxNode *) next);
+}
+
+static void
+tbox_kdtree_next(const void *nodebox, const void *centroid, uint8 node,
+  int level, void *next)
+{
+  tboxnode_kdtree_next((const TboxNode *) nodebox, (const TBox *) centroid,
+    node, level, (TboxNode *) next);
+}
+
+static bool
+tbox_inner_consistent(const void *nodebox, const void *query, RTreeSearchOp op)
+{
+  const TboxNode *n = (const TboxNode *) nodebox;
+  const TBox *q = (const TBox *) query;
+  if (op == RTREE_CONTAINS)
+    return contain4D(n, q);
+  return overlap4D(n, q);
+}
+
+static bool
+tbox_leaf_consistent(const void *key, const void *query, RTreeSearchOp op)
+{
+  const TBox *k = (const TBox *) key;
+  const TBox *q = (const TBox *) query;
+  if (op == RTREE_CONTAINS)
+    return contains_tbox_tbox(k, q);
+  if (op == RTREE_CONTAINED_BY)
+    return contains_tbox_tbox(q, k);
+  return overlaps_tbox_tbox(k, q);
+}
+
+/*****************************************************************************
+ * Creation
+ *****************************************************************************/
+
+/**
+ * @brief Create an in-memory space-partitioning index for a bounding box type
+ * @param[in] bboxtype Type of the bounding box (a span type or @p T_TBOX)
+ * @param[in] kind Quad-tree or k-d tree
+ * @return SPTree initialized
+ */
+SPTree *
+sptree_create(MeosType bboxtype, SPTreeKind kind)
+{
+  assert(span_type(bboxtype) || bboxtype == T_TBOX);
+  SPTree *sptree = palloc0(sizeof(SPTree));
+  sptree->bboxtype = bboxtype;
+  sptree->boxsize = bbox_get_size(bboxtype);
+  sptree->kind = kind;
+  sptree->root = NULL;
+  if (span_type(bboxtype))
+  {
+    sptree->spantype = bboxtype;
+    sptree->basetype = spantype_basetype(bboxtype);
+    sptree->dims = 2;
+    sptree->nodeboxsize = sizeof(SpanNode);
+    sptree->get_quadrant = &span_get_quadrant;
+    sptree->nodebox_init = &span_nodebox_init;
+    sptree->quadtree_next = &span_quadtree_next;
+    sptree->kdtree_next = &span_kdtree_next;
+    sptree->inner_consistent = &span_inner_consistent;
+    sptree->leaf_consistent = &span_leaf_consistent;
+  }
+  else /* bboxtype == T_TBOX */
+  {
+    sptree->dims = 4;
+    sptree->nodeboxsize = sizeof(TboxNode);
+    sptree->get_quadrant = &tbox_get_quadrant;
+    sptree->nodebox_init = &tbox_nodebox_init;
+    sptree->quadtree_next = &tbox_quadtree_next;
+    sptree->kdtree_next = &tbox_kdtree_next;
+    sptree->inner_consistent = &tbox_inner_consistent;
+    sptree->leaf_consistent = &tbox_leaf_consistent;
+  }
+  sptree->nchild = (kind == SPTREE_QUADTREE) ? (1 << sptree->dims) : 2;
+  assert(sptree->nodeboxsize <= SPTREE_NODEBOX_MAXSIZE);
+  return sptree;
+}
+
+/**
+ * @ingroup meos_misc
+ * @brief Create an in-memory space-partitioning index for integer spans
+ * @param[in] kind Quad-tree or k-d tree
+ * @return SPTree initialized
+ */
+SPTree *
+sptree_create_intspan(SPTreeKind kind)
+{
+  return sptree_create(T_INTSPAN, kind);
+}
+
+/**
+ * @ingroup meos_misc
+ * @brief Create an in-memory space-partitioning index for big integer spans
+ * @param[in] kind Quad-tree or k-d tree
+ * @return SPTree initialized
+ */
+SPTree *
+sptree_create_bigintspan(SPTreeKind kind)
+{
+  return sptree_create(T_BIGINTSPAN, kind);
+}
+
+/**
+ * @ingroup meos_misc
+ * @brief Create an in-memory space-partitioning index for float spans
+ * @param[in] kind Quad-tree or k-d tree
+ * @return SPTree initialized
+ */
+SPTree *
+sptree_create_floatspan(SPTreeKind kind)
+{
+  return sptree_create(T_FLOATSPAN, kind);
+}
+
+/**
+ * @ingroup meos_misc
+ * @brief Create an in-memory space-partitioning index for date spans
+ * @param[in] kind Quad-tree or k-d tree
+ * @return SPTree initialized
+ */
+SPTree *
+sptree_create_datespan(SPTreeKind kind)
+{
+  return sptree_create(T_DATESPAN, kind);
+}
+
+/**
+ * @ingroup meos_misc
+ * @brief Create an in-memory space-partitioning index for timestamptz spans
+ * @param[in] kind Quad-tree or k-d tree
+ * @return SPTree initialized
+ */
+SPTree *
+sptree_create_tstzspan(SPTreeKind kind)
+{
+  return sptree_create(T_TSTZSPAN, kind);
+}
+
+/**
+ * @ingroup meos_misc
+ * @brief Create an in-memory space-partitioning index for temporal boxes
+ * @param[in] kind Quad-tree or k-d tree
+ * @return SPTree initialized
+ */
+SPTree *
+sptree_create_tbox(SPTreeKind kind)
+{
+  return sptree_create(T_TBOX, kind);
+}
+
+/*****************************************************************************
+ * Insertion
+ *****************************************************************************/
+
+/**
+ * @brief Return a new node holding a bounding box
+ */
+static SPNode *
+spnode_make(const SPTree *sptree, const void *box, int id)
+{
+  SPNode *node = palloc0(sizeof(SPNode) + sptree->boxsize);
+  node->id = id;
+  node->children = palloc0((size_t) sptree->nchild * sizeof(SPNode *));
+  memcpy(node->centroid, box, sptree->boxsize);
+  return node;
+}
+
+/**
+ * @ingroup meos_temporal_box_index
+ * @brief Insert a bounding box into an in-memory space-partitioning index
+ * @details The box is stored at the first empty child slot reached while
+ * descending from the root by quadrant. Equal boxes chain through the first
+ * child, so the search still finds every id.
+ * @param[in] sptree The SPTree previously initialized
+ * @param[in] box The bounding box to insert
+ * @param[in] id The id associated with the box
+ */
+void
+sptree_insert(SPTree *sptree, void *box, int id)
+{
+  SPNode **slot = &sptree->root;
+  int level = 0;
+  while (*slot != NULL)
+  {
+    uint8 quadrant = sptree->get_quadrant((*slot)->centroid, box);
+    int child = (sptree->kind == SPTREE_QUADTREE) ? (int) quadrant :
+      (int) ((quadrant >> (level % sptree->dims)) & 1);
+    slot = &(*slot)->children[child];
+    level++;
+  }
+  *slot = spnode_make(sptree, box, id);
+  return;
+}
+
+/*****************************************************************************
+ * Search
+ *****************************************************************************/
+
+/**
+ * @brief Recursively collect the ids of the boxes consistent with the query
+ * @param[in] sptree The SPTree
+ * @param[in] node The node being visited
+ * @param[in] nodebox The region covered by @p node
+ * @param[in] op The search operation
+ * @param[in] query The query bounding box
+ * @param[in] level The depth of @p node (drives the k-d tree dimension)
+ * @param[out] result MeosArray collecting the matching ids
+ */
+static void
+spnode_search(const SPTree *sptree, const SPNode *node, const void *nodebox,
+  RTreeSearchOp op, const void *query, int level, MeosArray *result)
+{
+  if (sptree->leaf_consistent(node->centroid, query, op))
+  {
+    int id = node->id;
+    meos_array_add(result, &id);
+  }
+  for (int quadrant = 0; quadrant < sptree->nchild; quadrant++)
+  {
+    const SPNode *child = node->children[quadrant];
+    if (! child)
+      continue;
+    char next[SPTREE_NODEBOX_MAXSIZE];
+    if (sptree->kind == SPTREE_QUADTREE)
+      sptree->quadtree_next(nodebox, node->centroid, (uint8) quadrant, next);
+    else
+      sptree->kdtree_next(nodebox, node->centroid, (uint8) quadrant, level,
+        next);
+    if (sptree->inner_consistent(next, query, op))
+      spnode_search(sptree, child, next, op, query, level + 1, result);
+  }
+  return;
+}
+
+/**
+ * @ingroup meos_temporal_box_index
+ * @brief Search an in-memory space-partitioning index with a bounding box,
+ * collecting matching ids into a MeosArray
+ * @details The result array is reset before the search.
+ * @param[in] sptree The SPTree to query
+ * @param[in] op The search operation: @p RTREE_OVERLAPS finds boxes that
+ * overlap the query, @p RTREE_CONTAINS finds boxes that contain the query,
+ * @p RTREE_CONTAINED_BY finds boxes contained by the query
+ * @param[in] query The bounding box that serves as query
+ * @param[out] result MeosArray of int to collect matching ids
+ * @return Number of matching ids
+ */
+int
+sptree_search(const SPTree *sptree, RTreeSearchOp op, const void *query,
+  MeosArray *result)
+{
+  meos_array_reset(result);
+  if (sptree->root)
+  {
+    char rootbox[SPTREE_NODEBOX_MAXSIZE];
+    sptree->nodebox_init(rootbox, sptree->root->centroid, sptree);
+    spnode_search(sptree, sptree->root, rootbox, op, query, 0, result);
+  }
+  return meos_array_count(result);
+}
+
+/*****************************************************************************
+ * Temporal and multi-entry (MEST) functions
+ *
+ * The bounding box of a temporal value is extracted (single-box path) or the
+ * value is decomposed into several tight per-segment boxes sharing one id
+ * (multi-entry path), reusing the same per-type splitters as the R-tree index.
+ * The tree and search algorithms are unchanged; only the build-side
+ * decomposition and a search-time deduplication of repeated ids are added.
+ *****************************************************************************/
+
+/**
+ * @brief Return true if the SPTree's bounding box type is compatible with the
+ * temporal type, report an error otherwise
+ * @param[in] sptree Pointer to the SPTree structure
+ * @param[in] temp Temporal value
+ */
+static bool
+ensure_sptree_temporal_compatible(const SPTree *sptree, const Temporal *temp)
+{
+  MeosType temptype = temp->temptype;
+  bool compatible =
+    (talpha_type(temptype) && sptree->bboxtype == T_TSTZSPAN) ||
+    (tnumber_type(temptype) && sptree->bboxtype == T_TBOX);
+  if (! compatible)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_TYPE,
+      "SPTree bounding box type (%s) is not compatible with temporal type (%s)",
+      meostype_name(sptree->bboxtype), meostype_name(temptype));
+    return false;
+  }
+  return true;
+}
+
+/**
+ * @ingroup meos_temporal_box_index
+ * @brief Insert a temporal value into an in-memory space-partitioning index
+ * @details The bounding box is automatically extracted from the temporal value.
+ * The temporal type must be compatible with the SPTree's bounding box type:
+ * temporal alphas (tbool, ttext) require a timestamptz-span-based SPTree and
+ * temporal numbers (tint, tfloat) require a TBox-based SPTree.
+ * @param[in] sptree The SPTree previously initialized
+ * @param[in] temp The temporal value to be inserted
+ * @param[in] id The id of the temporal value being inserted
+ */
+void
+sptree_insert_temporal(SPTree *sptree, const Temporal *temp, int id)
+{
+  if (! ensure_sptree_temporal_compatible(sptree, temp))
+    return;
+  /* Use a stack buffer large enough for any MEOS bounding box type */
+  char buf[sizeof(STBox)];
+  memset(buf, 0, sizeof(buf));
+  temporal_set_bbox(temp, buf);
+  sptree_insert(sptree, buf, id);
+  return;
+}
+
+/**
+ * @ingroup meos_temporal_box_index
+ * @brief Search an in-memory space-partitioning index using a temporal value's
+ * bounding box, collecting matching ids into a MeosArray
+ * @details The bounding box is automatically extracted from the temporal value
+ * and used as the search query. The result array is reset before the search.
+ * @param[in] sptree The SPTree to query
+ * @param[in] op The search operation
+ * @param[in] temp The temporal value whose bounding box serves as query
+ * @param[out] result MeosArray of int to collect matching ids
+ * @return Number of matching ids
+ */
+int
+sptree_search_temporal(const SPTree *sptree, RTreeSearchOp op,
+  const Temporal *temp, MeosArray *result)
+{
+  if (! ensure_sptree_temporal_compatible(sptree, temp))
+  {
+    meos_array_reset(result);
+    return 0;
+  }
+  /* Use a stack buffer large enough for any MEOS bounding box type */
+  char buf[sizeof(STBox)];
+  memset(buf, 0, sizeof(buf));
+  temporal_set_bbox(temp, buf);
+  return sptree_search(sptree, op, buf, result);
+}
+
+/**
+ * @brief Decompose a temporal value into an array of tight per-segment
+ * bounding boxes whose element type matches the SPTree's bounding box type
+ * @details The decomposition reuses the same per-segment machinery as the
+ * single-box path: temporal alphas are split with #temporal_split_n_spans and
+ * temporal numbers with #tnumber_split_n_tboxes. When `maxboxes <= 1` or the
+ * temporal value is an instant, the function degenerates to the single minimum
+ * bounding box, byte-identical to the result of #temporal_set_bbox used by
+ * #sptree_insert_temporal.
+ * @param[in] sptree The SPTree whose bounding box type drives the element type
+ * @param[in] temp The temporal value to decompose
+ * @param[in] maxboxes Maximum number of boxes produced for `temp`
+ * @param[out] count Number of boxes in the returned array
+ * @return Allocated array of `*count` bounding boxes, each of `sptree->boxsize`
+ * bytes
+ * @pre `temp` is compatible with `sptree` (verified by the callers)
+ */
+static void *
+sptree_temporal_split_boxes(const SPTree *sptree, const Temporal *temp,
+  int maxboxes, int *count)
+{
+  assert(sptree); assert(temp); assert(count);
+
+  /* Degenerate single minimum bounding box */
+  if (maxboxes <= 1 || temp->subtype == TINSTANT)
+  {
+    void *result = palloc0(sptree->boxsize);
+    temporal_set_bbox(temp, result);
+    *count = 1;
+    return result;
+  }
+
+  /* Multi-box decomposition reusing the existing per-type splitters */
+  MeosType temptype = temp->temptype;
+  if (talpha_type(temptype))
+    return temporal_split_n_spans(temp, maxboxes, count);
+  if (tnumber_type(temptype))
+    return tnumber_split_n_tboxes(temp, maxboxes, count);
+
+  /* No per-segment splitter: fall back to the single minimum bounding box */
+  void *result = palloc0(sptree->boxsize);
+  temporal_set_bbox(temp, result);
+  *count = 1;
+  return result;
+}
+
+/**
+ * @ingroup meos_temporal_box_index
+ * @brief Insert a temporal value into an in-memory space-partitioning index as
+ * several tight per-segment bounding boxes sharing the same id (multi-entry)
+ * @details The temporal value is decomposed into at most `maxboxes` tight
+ * per-segment bounding boxes, all inserted under `id`. This yields a more
+ * selective index than #sptree_insert_temporal for wiggly or high-extent
+ * temporal values. When `maxboxes <= 1` or the temporal value is an instant,
+ * the behaviour is identical to #sptree_insert_temporal. Search results may
+ * contain the same id several times; use #sptree_search_temporal_dedup to
+ * collapse them.
+ * @param[in] sptree The SPTree previously initialized
+ * @param[in] temp The temporal value to be inserted
+ * @param[in] id The id shared by every box produced for `temp`
+ * @param[in] maxboxes Maximum number of bounding boxes produced for `temp`
+ * @see sptree_insert_temporal
+ */
+void
+sptree_insert_temporal_split(SPTree *sptree, const Temporal *temp, int id,
+  int maxboxes)
+{
+  if (! ensure_sptree_temporal_compatible(sptree, temp))
+    return;
+  int count;
+  void *boxes = sptree_temporal_split_boxes(sptree, temp, maxboxes, &count);
+  if (! boxes)
+    return;
+  for (int i = 0; i < count; i++)
+    sptree_insert(sptree, (char *) boxes + (size_t) i * sptree->boxsize, id);
+  pfree(boxes);
+  return;
+}
+
+/**
+ * @ingroup meos_temporal_box_index
+ * @brief Search an in-memory space-partitioning index built with
+ * #sptree_insert_temporal_split using a temporal value, returning each matching
+ * id exactly once
+ * @details The query temporal value is decomposed into the same tight
+ * per-segment bounding boxes as #sptree_insert_temporal_split, the existing
+ * #sptree_search is run for every query box, and the union of matching ids is
+ * deduplicated so that each surviving id appears exactly once. The result array
+ * is reset before the search.
+ * @param[in] sptree The SPTree to query
+ * @param[in] op The search operation
+ * @param[in] temp The temporal value whose per-segment bounding boxes serve as
+ * queries
+ * @param[in] maxboxes Maximum number of query boxes derived from `temp`
+ * @param[out] result MeosArray of int to collect the deduplicated matching ids
+ * @return Number of distinct matching ids
+ * @see sptree_search_temporal
+ */
+int
+sptree_search_temporal_dedup(const SPTree *sptree, RTreeSearchOp op,
+  const Temporal *temp, int maxboxes, MeosArray *result)
+{
+  meos_array_reset(result);
+  if (! ensure_sptree_temporal_compatible(sptree, temp))
+    return 0;
+
+  int count;
+  void *boxes = sptree_temporal_split_boxes(sptree, temp, maxboxes, &count);
+  if (! boxes)
+    return 0;
+
+  /* Accumulate the raw (possibly duplicated) candidate ids of every query
+   * box, tracking the maximum id seen to size the dedup bitset */
+  MeosArray *raw = meos_array_create(sizeof(int));
+  MeosArray *hits = meos_array_create(sizeof(int));
+  int maxid = -1;
+  for (int i = 0; i < count; i++)
+  {
+    int nhits = sptree_search(sptree, op,
+      (char *) boxes + (size_t) i * sptree->boxsize, hits);
+    for (int j = 0; j < nhits; j++)
+    {
+      int id = *(int *) meos_array_get(hits, j);
+      if (id > maxid)
+        maxid = id;
+      meos_array_add(raw, &id);
+    }
+  }
+  pfree(boxes);
+  meos_array_destroy(hits);
+
+  /* Collapse duplicates with a seen-set sized to the maximum id */
+  int nraw = meos_array_count(raw);
+  if (maxid >= 0 && nraw > 0)
+  {
+    bool *seen = palloc0((size_t) (maxid + 1) * sizeof(bool));
+    for (int i = 0; i < nraw; i++)
+    {
+      int id = *(int *) meos_array_get(raw, i);
+      if (! seen[id])
+      {
+        seen[id] = true;
+        meos_array_add(result, &id);
+      }
+    }
+    pfree(seen);
+  }
+  meos_array_destroy(raw);
+  return meos_array_count(result);
+}
+
+/*****************************************************************************
+ * Free
+ *****************************************************************************/
+
+/**
+ * @brief Recursively free a node and its children
+ */
+static void
+spnode_free(const SPTree *sptree, SPNode *node)
+{
+  if (! node)
+    return;
+  for (int i = 0; i < sptree->nchild; i++)
+    spnode_free(sptree, node->children[i]);
+  pfree(node->children);
+  pfree(node);
+  return;
+}
+
+/**
+ * @ingroup meos_temporal_box_index
+ * @brief Free an in-memory space-partitioning index
+ * @param[in] sptree The SPTree to free
+ */
+void
+sptree_free(SPTree *sptree)
+{
+  spnode_free(sptree, sptree->root);
+  pfree(sptree);
+  return;
+}
+
+/*****************************************************************************/

--- a/meos/test/sptree_test.c
+++ b/meos/test/sptree_test.c
@@ -1,0 +1,411 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief A program that tests the in-memory space-partitioning index
+ * (quad-tree and k-d tree), i.e., sptree_create_*, sptree_insert and
+ * sptree_search, against an exact brute-force oracle.
+ *
+ * For the integer span, float span and temporal box bounding box types, and
+ * for both the quad-tree and the k-d tree kinds, a set of random boxes is
+ * inserted and the overlaps, contains and contained-by searches are compared
+ * with the exact set of boxes satisfying the operator. Two properties are
+ * asserted per configuration and operator:
+ *  (i)  no false negatives: every box satisfying the operator is a candidate;
+ *  (ii) no false positives: every candidate satisfies the operator.
+ *
+ * The program can be built as follows
+ * @code
+ * gcc -Wall -g -I/usr/local/include -o sptree_test sptree_test.c -L/usr/local/lib -lmeos -lm
+ * @endcode
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <meos.h>
+
+/* Number of boxes inserted into every index */
+#define NUM_BOXES 2048
+/* Number of temporal values in the multi-entry test */
+#define NUM_TRIPS 1000
+/* Number of instants per (wiggly) temporal value */
+#define TRIP_LEN 40
+/* Maximum number of boxes produced per temporal value in the MEST index */
+#define MAX_BOXES 16
+/* Maximum length in characters of a temporal value in text format */
+#define MAX_LEN_TRIP 8192
+
+/* Return a pseudo-random double in [min, max] */
+static double
+random_double(double min, double max)
+{
+  return min + (max - min) * ((double) rand() / (double) RAND_MAX);
+}
+
+static int failures = 0;
+
+static void
+check(const char *name, bool ok)
+{
+  printf("  %-58s %s\n", name, ok ? "OK" : "FAIL");
+  if (! ok)
+    failures++;
+}
+
+/* Return a pseudo-random integer in [min, max] */
+static int
+random_int(int min, int max)
+{
+  return min + rand() % (max - min + 1);
+}
+
+/*
+ * Compare the candidate ids returned by the index for an operator against the
+ * exact truth values computed by brute force. `truth[i]` is whether box i
+ * satisfies the operator against the query.
+ */
+static void
+compare(const char *label, const SPTree *sptree, RTreeSearchOp op,
+  const void *query, const bool *truth)
+{
+  MeosArray *result = meos_array_create(sizeof(int));
+  int count = sptree_search(sptree, op, query, result);
+  bool *in_index = calloc(NUM_BOXES, sizeof(bool));
+  for (int i = 0; i < count; i++)
+    in_index[*(int *) meos_array_get(result, i)] = true;
+
+  int missed = 0, extra = 0;
+  for (int i = 0; i < NUM_BOXES; i++)
+  {
+    if (truth[i] && ! in_index[i])
+      missed++;
+    if (! truth[i] && in_index[i])
+      extra++;
+  }
+  char name[128];
+  snprintf(name, sizeof(name), "%s no false negatives", label);
+  check(name, missed == 0);
+  snprintf(name, sizeof(name), "%s no false positives", label);
+  check(name, extra == 0);
+
+  free(in_index);
+  meos_array_destroy(result);
+}
+
+/*****************************************************************************
+ * Integer span
+ *****************************************************************************/
+
+static void
+test_intspan(SPTreeKind kind, const char *kindname)
+{
+  Span **spans = malloc(NUM_BOXES * sizeof(Span *));
+  SPTree *sptree = sptree_create_intspan(kind);
+  for (int i = 0; i < NUM_BOXES; i++)
+  {
+    int lo = random_int(-10000, 10000);
+    spans[i] = intspan_make(lo, lo + random_int(1, 200), true, false);
+    sptree_insert(sptree, spans[i], i);
+  }
+  int qlo = random_int(-10000, 10000);
+  Span *query = intspan_make(qlo, qlo + 300, true, false);
+
+  bool *ov = calloc(NUM_BOXES, sizeof(bool));
+  bool *co = calloc(NUM_BOXES, sizeof(bool));
+  bool *cb = calloc(NUM_BOXES, sizeof(bool));
+  for (int i = 0; i < NUM_BOXES; i++)
+  {
+    ov[i] = overlaps_span_span(spans[i], query);
+    co[i] = contains_span_span(spans[i], query);
+    cb[i] = contains_span_span(query, spans[i]);
+  }
+
+  printf("Integer span %s (%d random spans):\n", kindname, NUM_BOXES);
+  compare("  overlaps    ", sptree, RTREE_OVERLAPS, query, ov);
+  compare("  contains    ", sptree, RTREE_CONTAINS, query, co);
+  compare("  contained by", sptree, RTREE_CONTAINED_BY, query, cb);
+
+  for (int i = 0; i < NUM_BOXES; i++)
+    free(spans[i]);
+  free(spans); free(query); free(ov); free(co); free(cb);
+  sptree_free(sptree);
+}
+
+/*****************************************************************************
+ * Float span
+ *****************************************************************************/
+
+static void
+test_floatspan(SPTreeKind kind, const char *kindname)
+{
+  Span **spans = malloc(NUM_BOXES * sizeof(Span *));
+  SPTree *sptree = sptree_create_floatspan(kind);
+  for (int i = 0; i < NUM_BOXES; i++)
+  {
+    double lo = random_int(-10000, 10000) / 10.0;
+    spans[i] = floatspan_make(lo, lo + random_int(1, 200) / 10.0, true, false);
+    sptree_insert(sptree, spans[i], i);
+  }
+  double qlo = random_int(-10000, 10000) / 10.0;
+  Span *query = floatspan_make(qlo, qlo + 30.0, true, false);
+
+  bool *ov = calloc(NUM_BOXES, sizeof(bool));
+  bool *co = calloc(NUM_BOXES, sizeof(bool));
+  bool *cb = calloc(NUM_BOXES, sizeof(bool));
+  for (int i = 0; i < NUM_BOXES; i++)
+  {
+    ov[i] = overlaps_span_span(spans[i], query);
+    co[i] = contains_span_span(spans[i], query);
+    cb[i] = contains_span_span(query, spans[i]);
+  }
+
+  printf("Float span %s (%d random spans):\n", kindname, NUM_BOXES);
+  compare("  overlaps    ", sptree, RTREE_OVERLAPS, query, ov);
+  compare("  contains    ", sptree, RTREE_CONTAINS, query, co);
+  compare("  contained by", sptree, RTREE_CONTAINED_BY, query, cb);
+
+  for (int i = 0; i < NUM_BOXES; i++)
+    free(spans[i]);
+  free(spans); free(query); free(ov); free(co); free(cb);
+  sptree_free(sptree);
+}
+
+/*****************************************************************************
+ * Temporal box
+ *****************************************************************************/
+
+static TBox *
+random_tbox(int vspan, int tspan)
+{
+  double vlo = random_int(-10000, 10000) / 10.0;
+  Span *v = floatspan_make(vlo, vlo + random_int(1, vspan) / 10.0, true, false);
+  TimestampTz tlo = (TimestampTz) random_int(0, 1000000) * 1000000;
+  Span *t = tstzspan_make(tlo, tlo + (TimestampTz) random_int(1, tspan) *
+    1000000, true, false);
+  TBox *box = tbox_make(v, t);
+  free(v); free(t);
+  return box;
+}
+
+static void
+test_tbox(SPTreeKind kind, const char *kindname)
+{
+  TBox **boxes = malloc(NUM_BOXES * sizeof(TBox *));
+  SPTree *sptree = sptree_create_tbox(kind);
+  for (int i = 0; i < NUM_BOXES; i++)
+  {
+    boxes[i] = random_tbox(200, 50);
+    sptree_insert(sptree, boxes[i], i);
+  }
+  TBox *query = random_tbox(3000, 400);
+
+  bool *ov = calloc(NUM_BOXES, sizeof(bool));
+  bool *co = calloc(NUM_BOXES, sizeof(bool));
+  bool *cb = calloc(NUM_BOXES, sizeof(bool));
+  for (int i = 0; i < NUM_BOXES; i++)
+  {
+    ov[i] = overlaps_tbox_tbox(boxes[i], query);
+    co[i] = contains_tbox_tbox(boxes[i], query);
+    cb[i] = contains_tbox_tbox(query, boxes[i]);
+  }
+
+  printf("Temporal box %s (%d random boxes):\n", kindname, NUM_BOXES);
+  compare("  overlaps    ", sptree, RTREE_OVERLAPS, query, ov);
+  compare("  contains    ", sptree, RTREE_CONTAINS, query, co);
+  compare("  contained by", sptree, RTREE_CONTAINED_BY, query, cb);
+
+  for (int i = 0; i < NUM_BOXES; i++)
+    free(boxes[i]);
+  free(boxes); free(query); free(ov); free(co); free(cb);
+  sptree_free(sptree);
+}
+
+/*****************************************************************************
+ * Multi-entry (MEST) indexing over temporal numbers
+ *****************************************************************************/
+
+/*
+ * Build a deliberately wiggly, high-extent tfloat: a sinusoidal signal that
+ * sweeps a large value range even though every individual segment is short.
+ * This is the shape for which a single bounding box is a poor approximation
+ * and per-segment MEST boxes are far more selective.
+ */
+static Temporal *
+make_wiggly_tfloat(int seed, char *buf, size_t bufsize)
+{
+  double base = random_double(0, 900);
+  double amp = random_double(40, 90);
+  double phase = random_double(0, 6.28);
+  size_t pos = 0;
+  pos += (size_t) snprintf(buf + pos, bufsize - pos, "[");
+  for (int k = 0; k < TRIP_LEN; k++)
+  {
+    double v = base + amp * sin(phase + k * 0.9 + seed * 0.01);
+    int mm = k / 60, ss = k % 60;
+    pos += (size_t) snprintf(buf + pos, bufsize - pos,
+      "%s%.4f@2020-01-01 %02d:%02d:00+00", (k == 0) ? "" : ", ", v, mm, ss);
+  }
+  snprintf(buf + pos, bufsize - pos, "]");
+  return tfloat_in(buf);
+}
+
+static void
+test_mest(void)
+{
+  char buf[MAX_LEN_TRIP];
+  Temporal **trips = malloc(sizeof(Temporal *) * NUM_TRIPS);
+  SPTree *single = sptree_create_tbox(SPTREE_QUADTREE);
+  SPTree *mest = sptree_create_tbox(SPTREE_QUADTREE);
+  SPTree *deg = sptree_create_tbox(SPTREE_QUADTREE);
+  for (int i = 0; i < NUM_TRIPS; i++)
+  {
+    trips[i] = make_wiggly_tfloat(i, buf, sizeof(buf));
+    sptree_insert_temporal(single, trips[i], i);
+    sptree_insert_temporal_split(mest, trips[i], i, MAX_BOXES);
+    sptree_insert_temporal_split(deg, trips[i], i, 1);
+  }
+  Temporal *query = make_wiggly_tfloat(123456, buf, sizeof(buf));
+
+  MeosArray *single_ids = meos_array_create(sizeof(int));
+  MeosArray *mest_ids = meos_array_create(sizeof(int));
+  MeosArray *deg_ids = meos_array_create(sizeof(int));
+  int single_count = sptree_search_temporal(single, RTREE_OVERLAPS, query,
+    single_ids);
+  int mest_count = sptree_search_temporal_dedup(mest, RTREE_OVERLAPS, query,
+    MAX_BOXES, mest_ids);
+  int deg_count = sptree_search_temporal_dedup(deg, RTREE_OVERLAPS, query, 1,
+    deg_ids);
+
+  bool *in_single = calloc(NUM_TRIPS, sizeof(bool));
+  bool *in_mest = calloc(NUM_TRIPS, sizeof(bool));
+  bool *in_deg = calloc(NUM_TRIPS, sizeof(bool));
+  int *mest_seen = calloc(NUM_TRIPS, sizeof(int));
+  int *deg_seen = calloc(NUM_TRIPS, sizeof(int));
+  for (int i = 0; i < single_count; i++)
+    in_single[*(int *) meos_array_get(single_ids, i)] = true;
+  for (int i = 0; i < mest_count; i++)
+  {
+    int id = *(int *) meos_array_get(mest_ids, i);
+    in_mest[id] = true;
+    mest_seen[id]++;
+  }
+  for (int i = 0; i < deg_count; i++)
+  {
+    int id = *(int *) meos_array_get(deg_ids, i);
+    in_deg[id] = true;
+    deg_seen[id]++;
+  }
+
+  printf("MEST SPTree (tfloat, %d wiggly values, maxboxes=%d):\n",
+    NUM_TRIPS, MAX_BOXES);
+
+  /* (i) No false negatives against the exact per-segment oracle: a value is a
+   * true candidate iff one of its split boxes overlaps one of the query's
+   * split boxes; the MEST search must return a superset of this set */
+  int qn;
+  TBox *qboxes = tnumber_split_n_tboxes(query, MAX_BOXES, &qn);
+  int missed = 0;
+  for (int i = 0; i < NUM_TRIPS; i++)
+  {
+    int tn;
+    TBox *tboxes = tnumber_split_n_tboxes(trips[i], MAX_BOXES, &tn);
+    bool overlap = false;
+    for (int a = 0; a < tn && ! overlap; a++)
+      for (int b = 0; b < qn && ! overlap; b++)
+        if (overlaps_tbox_tbox(&tboxes[a], &qboxes[b]))
+          overlap = true;
+    free(tboxes);
+    if (overlap && ! in_mest[i])
+      missed++;
+  }
+  free(qboxes);
+  check("(i) no false negatives vs exact per-segment oracle", missed == 0);
+
+  /* (ii) Dedup: each surviving id appears exactly once */
+  bool dedup_ok = true;
+  for (int i = 0; i < NUM_TRIPS; i++)
+    if (mest_seen[i] > 1 || deg_seen[i] > 1)
+      dedup_ok = false;
+  check("(ii) every surviving id appears exactly once", dedup_ok);
+
+  /* (iii) The MEST candidate set is contained in the single-box candidate set
+   * (every MEST box is contained in the value's minimum bounding box) */
+  bool subset_ok = (mest_count <= single_count);
+  for (int i = 0; i < NUM_TRIPS; i++)
+    if (in_mest[i] && ! in_single[i])
+      subset_ok = false;
+  check("(iii) MEST candidate set <= single-box candidate set", subset_ok);
+
+  /* (iv) Degeneracy: maxboxes <= 1 reproduces the single-box result exactly */
+  bool deg_ok = (deg_count == single_count);
+  for (int i = 0; i < NUM_TRIPS && deg_ok; i++)
+    if (in_deg[i] != in_single[i])
+      deg_ok = false;
+  check("(iv) maxboxes<=1 identical to single-box result", deg_ok);
+
+  free(in_single); free(in_mest); free(in_deg);
+  free(mest_seen); free(deg_seen);
+  meos_array_destroy(single_ids);
+  meos_array_destroy(mest_ids);
+  meos_array_destroy(deg_ids);
+  free(query);
+  for (int i = 0; i < NUM_TRIPS; i++)
+    free(trips[i]);
+  free(trips);
+  sptree_free(single);
+  sptree_free(mest);
+  sptree_free(deg);
+}
+
+int
+main(void)
+{
+  meos_initialize();
+  meos_initialize_timezone("UTC");
+  srand(1);
+
+  test_intspan(SPTREE_QUADTREE, "quad-tree");
+  test_intspan(SPTREE_KDTREE, "k-d tree");
+  test_floatspan(SPTREE_QUADTREE, "quad-tree");
+  test_floatspan(SPTREE_KDTREE, "k-d tree");
+  test_tbox(SPTREE_QUADTREE, "quad-tree");
+  test_tbox(SPTREE_KDTREE, "k-d tree");
+  test_mest();
+
+  meos_finalize();
+
+  if (failures == 0)
+    printf("\nAll space-partitioning index tests passed.\n");
+  else
+    printf("\n%d space-partitioning index test(s) FAILED.\n", failures);
+  return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
The R-tree is the only in-memory index in MEOS. This adds its space-partitioning counterpart — a quad-tree and a k-d tree — for MEOS bounding boxes, matching the SP-GiST operator classes on the PostgreSQL side and answering the long-standing request for in-memory quad-tree and k-d tree indexes.

Each node is a data box that partitions the space into 2^dims quadrants (quad-tree) or two halves alternating one dimension per level (k-d tree); a search descends every child whose region is consistent with the query and collects the ids of the boxes that overlap, contain or are contained by it. The family geometry — quadrant assignment, child region and consistency tests — is exactly the geometry already exported for the SP-GiST operator classes (span_index.h, tbox_index.h), reused through function pointers, so a single engine serves the span and temporal box bounding box types.

The public API mirrors the R-tree one: SPTree with sptree_create_intspan, sptree_create_bigintspan, sptree_create_floatspan, sptree_create_datespan, sptree_create_tstzspan and sptree_create_tbox (each taking the tree kind), sptree_insert and sptree_search for raw bounding boxes, sptree_insert_temporal and sptree_search_temporal for temporal values, and the multi-entry variants sptree_insert_temporal_split and sptree_search_temporal_dedup that decompose a temporal value into several tight per-segment boxes sharing one id.

A brute-force test over random integer spans, float spans and temporal boxes checks both kinds and the three search operators against an exact oracle, and a multi-entry test over wiggly temporal numbers checks the per-segment selectivity and the deduplication; both run alongside the other RTree tests in the MEOS workflow.
