### PR TITLE
Correct the return type of the geography from-tstzspanset constructors

### DIFF
--- a/mobilitydb/sql/geo/052_tgeo.in.sql
+++ b/mobilitydb/sql/geo/052_tgeo.in.sql
@@ -166,7 +166,7 @@ CREATE FUNCTION tgeometry(geometry, tstzspanset, text DEFAULT 'step')
   AS 'MODULE_PATHNAME', 'Tsequenceset_from_base_tstzspanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION tgeography(geography, tstzspanset, text DEFAULT 'step')
-  RETURNS tgeometry
+  RETURNS tgeography
   AS 'MODULE_PATHNAME', 'Tsequenceset_from_base_tstzspanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 

--- a/mobilitydb/sql/geo/052_tpoint.in.sql
+++ b/mobilitydb/sql/geo/052_tpoint.in.sql
@@ -158,7 +158,7 @@ CREATE FUNCTION tgeompoint(geometry, tstzspanset, text DEFAULT 'linear')
   AS 'MODULE_PATHNAME', 'Tsequenceset_from_base_tstzspanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION tgeogpoint(geography, tstzspanset, text DEFAULT 'linear')
-  RETURNS tgeompoint
+  RETURNS tgeogpoint
   AS 'MODULE_PATHNAME', 'Tsequenceset_from_base_tstzspanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -880,7 +880,6 @@ constructor_families:
     temp: tgeometry
   - base: geography
     temp: tgeography
-    spanset_ret: tgeometry
   blocks:
   - lit: "/******************************************************************************\n * Constructors\n ******************************************************************************/"
   - ops:
@@ -915,7 +914,6 @@ constructor_families:
   - base: geography
     temp: tgeogpoint
     ibase: geography(Point)
-    spanset_ret: tgeompoint
   blocks:
   - lit: "/******************************************************************************\n * Constructors\n ******************************************************************************/"
   - ops:


### PR DESCRIPTION
The `tgeography(geography, tstzspanset)` and `tgeogpoint(geography, tstzspanset)` constructors declare `RETURNS tgeometry` / `tgeompoint`, labeling a geodetic result as the planar type. Their `tstzset` and `tstzspan` siblings already return `tgeography` / `tgeogpoint`; the `tstzspanset` overload is a copy-paste slip from the geometry block.

Return the geodetic type so the result column carries the correct type. The value itself is unchanged — the underlying `Tsequenceset_from_base_tstzspanset` builds a geodetic temporal from the geography base regardless of the declared type — so the fix is a type-label correction with no change to any regression output; it makes the result usable where a `tgeography` / `tgeogpoint` is expected.

The inherited generator's `constructor_families` entries drop the `spanset_ret` overrides that reproduced the slip, so the generated block matches the corrected SQL and `--validate` stays byte-exact.