### PR TITLE
Support spatiotemporal boxes in the in-memory space-partitioning index

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -405,6 +405,7 @@ extern SPTree *sptree_create_floatspan(SPTreeKind kind);
 extern SPTree *sptree_create_datespan(SPTreeKind kind);
 extern SPTree *sptree_create_tstzspan(SPTreeKind kind);
 extern SPTree *sptree_create_tbox(SPTreeKind kind);
+extern SPTree *sptree_create_stbox(SPTreeKind kind);
 extern void sptree_free(SPTree *sptree);
 extern void sptree_insert(SPTree *sptree, void *box, int id);
 extern void sptree_insert_temporal(SPTree *sptree, const Temporal *temp, int id);

--- a/meos/include/temporal/temporal_sptree.h
+++ b/meos/include/temporal/temporal_sptree.h
@@ -80,6 +80,8 @@ struct SPTree
   int nchild;           /**< Number of children per node */
   SPTreeKind kind;      /**< Quad-tree or k-d tree */
   SPNode *root;         /**< Root node, or @p NULL when empty */
+  int (*box_dims)(const void *box);  /**< Dimensions of a box, or @p NULL when
+                                          fixed at creation */
   uint8 (*get_quadrant)(const void *centroid, const void *key);
   void (*nodebox_init)(void *nodebox, const void *centroid,
     const struct SPTree *sptree);

--- a/meos/src/temporal/temporal_sptree.c
+++ b/meos/src/temporal/temporal_sptree.c
@@ -44,10 +44,12 @@
 #include <stdlib.h>
 /* MEOS */
 #include <meos.h>
+#include <meos_geo.h>
 #include <meos_internal.h>
 #include "temporal/temporal.h"
 #include "temporal/span_index.h"
 #include "temporal/tbox_index.h"
+#include "geo/stbox_index.h"
 #include "temporal/temporal_sptree.h"
 
 /*****************************************************************************
@@ -162,6 +164,67 @@ tbox_leaf_consistent(const void *key, const void *query, RTreeSearchOp op)
 }
 
 /*****************************************************************************
+ * Family-specific adapters (STBox)
+ *****************************************************************************/
+
+static int
+stbox_box_dims(const void *box)
+{
+  return MEOS_FLAGS_GET_Z(((const STBox *) box)->flags) ? 8 : 6;
+}
+
+static uint8
+stbox_get_quadrant(const void *centroid, const void *key)
+{
+  return getQuadrant8D((const STBox *) centroid, (const STBox *) key);
+}
+
+static void
+stbox_nodebox_init(void *nodebox, const void *centroid,
+  const struct SPTree *sptree UNUSED)
+{
+  stboxnode_init((const STBox *) centroid, (STboxNode *) nodebox);
+}
+
+static void
+stbox_quadtree_next(const void *nodebox, const void *centroid, uint8 quadrant,
+  void *next)
+{
+  stboxnode_quadtree_next((const STboxNode *) nodebox, (const STBox *) centroid,
+    quadrant, (STboxNode *) next);
+}
+
+static void
+stbox_kdtree_next(const void *nodebox, const void *centroid, uint8 node,
+  int level, void *next)
+{
+  stboxnode_kdtree_next((const STboxNode *) nodebox, (const STBox *) centroid,
+    node, level, (STboxNode *) next);
+}
+
+static bool
+stbox_inner_consistent(const void *nodebox, const void *query, RTreeSearchOp op)
+{
+  const STboxNode *n = (const STboxNode *) nodebox;
+  const STBox *q = (const STBox *) query;
+  if (op == RTREE_CONTAINS)
+    return contain8D(n, q);
+  return overlap8D(n, q);
+}
+
+static bool
+stbox_leaf_consistent(const void *key, const void *query, RTreeSearchOp op)
+{
+  const STBox *k = (const STBox *) key;
+  const STBox *q = (const STBox *) query;
+  if (op == RTREE_CONTAINS)
+    return contains_stbox_stbox(k, q);
+  if (op == RTREE_CONTAINED_BY)
+    return contains_stbox_stbox(q, k);
+  return overlaps_stbox_stbox(k, q);
+}
+
+/*****************************************************************************
  * Creation
  *****************************************************************************/
 
@@ -174,7 +237,7 @@ tbox_leaf_consistent(const void *key, const void *query, RTreeSearchOp op)
 SPTree *
 sptree_create(MeosType bboxtype, SPTreeKind kind)
 {
-  assert(span_type(bboxtype) || bboxtype == T_TBOX);
+  assert(span_type(bboxtype) || bboxtype == T_TBOX || bboxtype == T_STBOX);
   SPTree *sptree = palloc0(sizeof(SPTree));
   sptree->bboxtype = bboxtype;
   sptree->boxsize = bbox_get_size(bboxtype);
@@ -193,7 +256,7 @@ sptree_create(MeosType bboxtype, SPTreeKind kind)
     sptree->inner_consistent = &span_inner_consistent;
     sptree->leaf_consistent = &span_leaf_consistent;
   }
-  else /* bboxtype == T_TBOX */
+  else if (bboxtype == T_TBOX)
   {
     sptree->dims = 4;
     sptree->nodeboxsize = sizeof(TboxNode);
@@ -204,7 +267,22 @@ sptree_create(MeosType bboxtype, SPTreeKind kind)
     sptree->inner_consistent = &tbox_inner_consistent;
     sptree->leaf_consistent = &tbox_leaf_consistent;
   }
-  sptree->nchild = (kind == SPTREE_QUADTREE) ? (1 << sptree->dims) : 2;
+  else /* bboxtype == T_STBOX */
+  {
+    /* The dimensions (6 for 2D+T, 8 for 3D+T) and hence the number of children
+     * are determined at the first insertion from the Z flag of the box */
+    sptree->dims = -1;
+    sptree->nodeboxsize = sizeof(STboxNode);
+    sptree->box_dims = &stbox_box_dims;
+    sptree->get_quadrant = &stbox_get_quadrant;
+    sptree->nodebox_init = &stbox_nodebox_init;
+    sptree->quadtree_next = &stbox_quadtree_next;
+    sptree->kdtree_next = &stbox_kdtree_next;
+    sptree->inner_consistent = &stbox_inner_consistent;
+    sptree->leaf_consistent = &stbox_leaf_consistent;
+  }
+  sptree->nchild = (sptree->dims < 0) ? -1 :
+    ((kind == SPTREE_QUADTREE) ? (1 << sptree->dims) : 2);
   assert(sptree->nodeboxsize <= SPTREE_NODEBOX_MAXSIZE);
   return sptree;
 }
@@ -281,6 +359,18 @@ sptree_create_tbox(SPTreeKind kind)
   return sptree_create(T_TBOX, kind);
 }
 
+/**
+ * @ingroup meos_misc
+ * @brief Create an in-memory space-partitioning index for spatiotemporal boxes
+ * @param[in] kind Quad-tree or k-d tree
+ * @return SPTree initialized
+ */
+SPTree *
+sptree_create_stbox(SPTreeKind kind)
+{
+  return sptree_create(T_STBOX, kind);
+}
+
 /*****************************************************************************
  * Insertion
  *****************************************************************************/
@@ -311,6 +401,14 @@ spnode_make(const SPTree *sptree, const void *box, int id)
 void
 sptree_insert(SPTree *sptree, void *box, int id)
 {
+  /* Determine the deferred dimensions from the first box (STBox: 6 for 2D+T,
+   * 8 for 3D+T) and hence the number of children per node */
+  if (sptree->dims < 0)
+  {
+    sptree->dims = sptree->box_dims(box);
+    sptree->nchild = (sptree->kind == SPTREE_QUADTREE) ?
+      (1 << sptree->dims) : 2;
+  }
   SPNode **slot = &sptree->root;
   int level = 0;
   while (*slot != NULL)
@@ -414,7 +512,8 @@ ensure_sptree_temporal_compatible(const SPTree *sptree, const Temporal *temp)
   MeosType temptype = temp->temptype;
   bool compatible =
     (talpha_type(temptype) && sptree->bboxtype == T_TSTZSPAN) ||
-    (tnumber_type(temptype) && sptree->bboxtype == T_TBOX);
+    (tnumber_type(temptype) && sptree->bboxtype == T_TBOX) ||
+    (tspatial_type(temptype) && sptree->bboxtype == T_STBOX);
   if (! compatible)
   {
     meos_error(ERROR, MEOS_ERR_INVALID_ARG_TYPE,
@@ -515,8 +614,11 @@ sptree_temporal_split_boxes(const SPTree *sptree, const Temporal *temp,
     return temporal_split_n_spans(temp, maxboxes, count);
   if (tnumber_type(temptype))
     return tnumber_split_n_tboxes(temp, maxboxes, count);
+  if (tgeo_type_all(temptype))
+    return tgeo_split_n_stboxes(temp, maxboxes, count);
 
-  /* No per-segment splitter: fall back to the single minimum bounding box */
+  /* No per-segment splitter (e.g. tcbuffer, tnpoint, tpose): fall back to the
+   * single minimum bounding box */
   void *result = palloc0(sptree->boxsize);
   temporal_set_bbox(temp, result);
   *count = 1;

--- a/meos/test/sptree_test.c
+++ b/meos/test/sptree_test.c
@@ -52,6 +52,7 @@
 #include <string.h>
 #include <math.h>
 #include <meos.h>
+#include <meos_geo.h>
 
 /* Number of boxes inserted into every index */
 #define NUM_BOXES 2048
@@ -250,6 +251,58 @@ test_tbox(SPTreeKind kind, const char *kindname)
 }
 
 /*****************************************************************************
+ * Spatiotemporal box
+ *****************************************************************************/
+
+static STBox *
+random_stbox(int sspan, int tspan)
+{
+  double xlo = random_int(-10000, 10000) / 10.0;
+  double ylo = random_int(-10000, 10000) / 10.0;
+  TimestampTz tlo = (TimestampTz) random_int(0, 1000000) * 1000000;
+  Span *t = tstzspan_make(tlo, tlo + (TimestampTz) random_int(1, tspan) *
+    1000000, true, false);
+  STBox *box = stbox_make(true, false, false, 0, xlo,
+    xlo + random_int(1, sspan) / 10.0, ylo, ylo + random_int(1, sspan) / 10.0,
+    0, 0, t);
+  free(t);
+  return box;
+}
+
+static void
+test_stbox(SPTreeKind kind, const char *kindname)
+{
+  STBox **boxes = malloc(NUM_BOXES * sizeof(STBox *));
+  SPTree *sptree = sptree_create_stbox(kind);
+  for (int i = 0; i < NUM_BOXES; i++)
+  {
+    boxes[i] = random_stbox(200, 50);
+    sptree_insert(sptree, boxes[i], i);
+  }
+  STBox *query = random_stbox(3000, 400);
+
+  bool *ov = calloc(NUM_BOXES, sizeof(bool));
+  bool *co = calloc(NUM_BOXES, sizeof(bool));
+  bool *cb = calloc(NUM_BOXES, sizeof(bool));
+  for (int i = 0; i < NUM_BOXES; i++)
+  {
+    ov[i] = overlaps_stbox_stbox(boxes[i], query);
+    co[i] = contains_stbox_stbox(boxes[i], query);
+    cb[i] = contains_stbox_stbox(query, boxes[i]);
+  }
+
+  printf("Spatiotemporal box %s (%d random boxes):\n", kindname, NUM_BOXES);
+  compare("  overlaps    ", sptree, RTREE_OVERLAPS, query, ov);
+  compare("  contains    ", sptree, RTREE_CONTAINS, query, co);
+  compare("  contained by", sptree, RTREE_CONTAINED_BY, query, cb);
+
+  for (int i = 0; i < NUM_BOXES; i++)
+    free(boxes[i]);
+  free(boxes); free(query); free(ov); free(co); free(cb);
+  sptree_free(sptree);
+}
+
+/*****************************************************************************
  * Multi-entry (MEST) indexing over temporal numbers
  *****************************************************************************/
 
@@ -386,6 +439,134 @@ test_mest(void)
   sptree_free(deg);
 }
 
+/*****************************************************************************
+ * Multi-entry (MEST) indexing over temporal geos
+ *****************************************************************************/
+
+/* Build a deliberately wiggly, high-extent tgeompoint trip */
+static Temporal *
+make_wiggly_trip(int seed, char *buf, size_t bufsize)
+{
+  double ox = random_double(0, 900);
+  double oy = random_double(0, 900);
+  double amp = random_double(40, 90);
+  double phase = random_double(0, 6.28);
+  size_t pos = 0;
+  pos += (size_t) snprintf(buf + pos, bufsize - pos, "SRID=0;[");
+  for (int k = 0; k < TRIP_LEN; k++)
+  {
+    double x = ox + k * 2.0;
+    double y = oy + amp * sin(phase + k * 0.9 + seed * 0.01);
+    int mm = k / 60, ss = k % 60;
+    pos += (size_t) snprintf(buf + pos, bufsize - pos,
+      "%sPoint(%.4f %.4f)@2020-01-01 %02d:%02d:00+00",
+      (k == 0) ? "" : ", ", x, y, mm, ss);
+  }
+  snprintf(buf + pos, bufsize - pos, "]");
+  return tgeompoint_in(buf);
+}
+
+static void
+test_stbox_mest(void)
+{
+  char buf[MAX_LEN_TRIP];
+  Temporal **trips = malloc(sizeof(Temporal *) * NUM_TRIPS);
+  SPTree *single = sptree_create_stbox(SPTREE_QUADTREE);
+  SPTree *mest = sptree_create_stbox(SPTREE_QUADTREE);
+  SPTree *deg = sptree_create_stbox(SPTREE_QUADTREE);
+  for (int i = 0; i < NUM_TRIPS; i++)
+  {
+    trips[i] = make_wiggly_trip(i, buf, sizeof(buf));
+    sptree_insert_temporal(single, trips[i], i);
+    sptree_insert_temporal_split(mest, trips[i], i, MAX_BOXES);
+    sptree_insert_temporal_split(deg, trips[i], i, 1);
+  }
+  Temporal *query = make_wiggly_trip(123456, buf, sizeof(buf));
+
+  MeosArray *single_ids = meos_array_create(sizeof(int));
+  MeosArray *mest_ids = meos_array_create(sizeof(int));
+  MeosArray *deg_ids = meos_array_create(sizeof(int));
+  int single_count = sptree_search_temporal(single, RTREE_OVERLAPS, query,
+    single_ids);
+  int mest_count = sptree_search_temporal_dedup(mest, RTREE_OVERLAPS, query,
+    MAX_BOXES, mest_ids);
+  int deg_count = sptree_search_temporal_dedup(deg, RTREE_OVERLAPS, query, 1,
+    deg_ids);
+
+  bool *in_single = calloc(NUM_TRIPS, sizeof(bool));
+  bool *in_mest = calloc(NUM_TRIPS, sizeof(bool));
+  bool *in_deg = calloc(NUM_TRIPS, sizeof(bool));
+  int *mest_seen = calloc(NUM_TRIPS, sizeof(int));
+  int *deg_seen = calloc(NUM_TRIPS, sizeof(int));
+  for (int i = 0; i < single_count; i++)
+    in_single[*(int *) meos_array_get(single_ids, i)] = true;
+  for (int i = 0; i < mest_count; i++)
+  {
+    int id = *(int *) meos_array_get(mest_ids, i);
+    in_mest[id] = true;
+    mest_seen[id]++;
+  }
+  for (int i = 0; i < deg_count; i++)
+  {
+    int id = *(int *) meos_array_get(deg_ids, i);
+    in_deg[id] = true;
+    deg_seen[id]++;
+  }
+
+  printf("MEST SPTree (tgeompoint, %d wiggly trips, maxboxes=%d):\n",
+    NUM_TRIPS, MAX_BOXES);
+
+  int qn;
+  STBox *qboxes = tgeo_split_n_stboxes(query, MAX_BOXES, &qn);
+  int missed = 0;
+  for (int i = 0; i < NUM_TRIPS; i++)
+  {
+    int tn;
+    STBox *tboxes = tgeo_split_n_stboxes(trips[i], MAX_BOXES, &tn);
+    bool overlap = false;
+    for (int a = 0; a < tn && ! overlap; a++)
+      for (int b = 0; b < qn && ! overlap; b++)
+        if (overlaps_stbox_stbox(&tboxes[a], &qboxes[b]))
+          overlap = true;
+    free(tboxes);
+    if (overlap && ! in_mest[i])
+      missed++;
+  }
+  free(qboxes);
+  check("(i) no false negatives vs exact per-segment oracle", missed == 0);
+
+  bool dedup_ok = true;
+  for (int i = 0; i < NUM_TRIPS; i++)
+    if (mest_seen[i] > 1 || deg_seen[i] > 1)
+      dedup_ok = false;
+  check("(ii) every surviving id appears exactly once", dedup_ok);
+
+  bool subset_ok = (mest_count <= single_count);
+  for (int i = 0; i < NUM_TRIPS; i++)
+    if (in_mest[i] && ! in_single[i])
+      subset_ok = false;
+  check("(iii) MEST candidate set <= single-box candidate set", subset_ok);
+
+  bool deg_ok = (deg_count == single_count);
+  for (int i = 0; i < NUM_TRIPS && deg_ok; i++)
+    if (in_deg[i] != in_single[i])
+      deg_ok = false;
+  check("(iv) maxboxes<=1 identical to single-box result", deg_ok);
+
+  free(in_single); free(in_mest); free(in_deg);
+  free(mest_seen); free(deg_seen);
+  meos_array_destroy(single_ids);
+  meos_array_destroy(mest_ids);
+  meos_array_destroy(deg_ids);
+  free(query);
+  for (int i = 0; i < NUM_TRIPS; i++)
+    free(trips[i]);
+  free(trips);
+  sptree_free(single);
+  sptree_free(mest);
+  sptree_free(deg);
+}
+
 int
 main(void)
 {
@@ -399,7 +580,10 @@ main(void)
   test_floatspan(SPTREE_KDTREE, "k-d tree");
   test_tbox(SPTREE_QUADTREE, "quad-tree");
   test_tbox(SPTREE_KDTREE, "k-d tree");
+  test_stbox(SPTREE_QUADTREE, "quad-tree");
+  test_stbox(SPTREE_KDTREE, "k-d tree");
   test_mest();
+  test_stbox_mest();
 
   meos_finalize();
 


### PR DESCRIPTION
This extends the in-memory space-partitioning index (quad-tree and k-d tree) to the STBox bounding box type, so the spatiotemporal types are indexed by the space-partitioning counterpart of the R-tree, matching the SP-GiST operator classes on the PostgreSQL side.

The STBox geometry — the 8-dimensional quadrant assignment, child region and consistency tests — is the geometry already exported for the SP-GiST operator class (stbox_index.h), reused through the same function pointers as the span and temporal box types. The number of dimensions of an STBox is 6 for a 2D+T box and 8 for a 3D+T box, so it is determined from the first inserted box, exactly as the R-tree already does.

The public API adds sptree_create_stbox; the temporal and multi-entry variants accept the spatiotemporal types through the same functions, with the per-segment decomposition using tgeo_split_n_stboxes.

A brute-force test over random spatiotemporal boxes checks both kinds and the three search operators against an exact oracle, and a multi-entry test over wiggly temporal geos checks the per-segment selectivity and the deduplication; both run alongside the other RTree tests in the MEOS workflow.
