### PR TITLE
Name the hash functions with the canonical bare hash/hashExtended

### DIFF
--- a/mobilitydb/sql/cbuffer/200_cbuffer.in.sql
+++ b/mobilitydb/sql/cbuffer/200_cbuffer.in.sql
@@ -295,11 +295,11 @@ CREATE OPERATOR CLASS cbuffer_btree_ops
 
 /******************************************************************************/
 
-CREATE FUNCTION cbuffer_hash(cbuffer)
+CREATE FUNCTION hash(cbuffer)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Cbuffer_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION cbuffer_hash_extended(cbuffer, bigint)
+CREATE FUNCTION hashExtended(cbuffer, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Cbuffer_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -307,7 +307,7 @@ CREATE FUNCTION cbuffer_hash_extended(cbuffer, bigint)
 CREATE OPERATOR CLASS cbuffer_hash_ops
   DEFAULT FOR TYPE cbuffer USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   cbuffer_hash(cbuffer),
-    FUNCTION    2   cbuffer_hash_extended(cbuffer, bigint);
+    FUNCTION    1   hash(cbuffer),
+    FUNCTION    2   hashExtended(cbuffer, bigint);
 
 /******************************************************************************/

--- a/mobilitydb/sql/cbuffer/201_cbufferset.in.sql
+++ b/mobilitydb/sql/cbuffer/201_cbufferset.in.sql
@@ -321,11 +321,11 @@ CREATE OPERATOR CLASS cbufferset_btree_ops
 
 /******************************************************************************/
 
-CREATE FUNCTION set_hash(cbufferset)
+CREATE FUNCTION hash(cbufferset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Set_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_hash_extended(cbufferset, bigint)
+CREATE FUNCTION hashExtended(cbufferset, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Set_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -333,8 +333,8 @@ CREATE FUNCTION set_hash_extended(cbufferset, bigint)
 CREATE OPERATOR CLASS cbufferset_hash_ops
   DEFAULT FOR TYPE cbufferset USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   set_hash(cbufferset),
-    FUNCTION    2   set_hash_extended(cbufferset, bigint);
+    FUNCTION    1   hash(cbufferset),
+    FUNCTION    2   hashExtended(cbufferset, bigint);
 
 /******************************************************************************
  * Operators

--- a/mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
+++ b/mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
@@ -731,11 +731,11 @@ CREATE OPERATOR CLASS tcbuffer_btree_ops
 
 /*****************************************************************************/
 
-CREATE FUNCTION temporal_hash(tcbuffer)
+CREATE FUNCTION hash(tcbuffer)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Temporal_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION temporal_hash_extended(tcbuffer, bigint)
+CREATE FUNCTION hashExtended(tcbuffer, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Temporal_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -743,7 +743,7 @@ CREATE FUNCTION temporal_hash_extended(tcbuffer, bigint)
 CREATE OPERATOR CLASS tcbuffer_hash_ops
   DEFAULT FOR TYPE tcbuffer USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   temporal_hash(tcbuffer),
-    FUNCTION    2   temporal_hash_extended(tcbuffer, bigint);
+    FUNCTION    1   hash(tcbuffer),
+    FUNCTION    2   hashExtended(tcbuffer, bigint);
 
 /*****************************************************************************/

--- a/mobilitydb/sql/geo/050_geoset.in.sql
+++ b/mobilitydb/sql/geo/050_geoset.in.sql
@@ -584,20 +584,20 @@ CREATE OPERATOR CLASS geogset_btree_ops
 
 /******************************************************************************/
 
-CREATE FUNCTION set_hash(geomset)
+CREATE FUNCTION hash(geomset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Set_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_hash(geogset)
+CREATE FUNCTION hash(geogset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Set_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION set_hash_extended(geomset, bigint)
+CREATE FUNCTION hashExtended(geomset, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Set_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_hash_extended(geogset, bigint)
+CREATE FUNCTION hashExtended(geogset, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Set_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -605,13 +605,13 @@ CREATE FUNCTION set_hash_extended(geogset, bigint)
 CREATE OPERATOR CLASS geomset_hash_ops
   DEFAULT FOR TYPE geomset USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   set_hash(geomset),
-    FUNCTION    2   set_hash_extended(geomset, bigint);
+    FUNCTION    1   hash(geomset),
+    FUNCTION    2   hashExtended(geomset, bigint);
 CREATE OPERATOR CLASS geogset_hash_ops
   DEFAULT FOR TYPE geogset USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   set_hash(geogset),
-    FUNCTION    2   set_hash_extended(geogset, bigint);
+    FUNCTION    1   hash(geogset),
+    FUNCTION    2   hashExtended(geogset, bigint);
 
 /******************************************************************************
  * Operators

--- a/mobilitydb/sql/geo/051_stbox.in.sql
+++ b/mobilitydb/sql/geo/051_stbox.in.sql
@@ -744,12 +744,12 @@ CREATE OPERATOR CLASS stbox_btree_ops
 
 /*****************************************************************************/
 
-CREATE FUNCTION stbox_hash(stbox)
+CREATE FUNCTION hash(stbox)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Stbox_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION stbox_hash_extended(stbox, bigint)
+CREATE FUNCTION hashExtended(stbox, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Stbox_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -757,7 +757,7 @@ CREATE FUNCTION stbox_hash_extended(stbox, bigint)
 CREATE OPERATOR CLASS stbox_hash_ops
   DEFAULT FOR TYPE stbox USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   stbox_hash(stbox),
-    FUNCTION    2   stbox_hash_extended(stbox, bigint);
+    FUNCTION    1   hash(stbox),
+    FUNCTION    2   hashExtended(stbox, bigint);
 
 /*****************************************************************************/

--- a/mobilitydb/sql/geo/052_tgeo.in.sql
+++ b/mobilitydb/sql/geo/052_tgeo.in.sql
@@ -1025,19 +1025,19 @@ CREATE OPERATOR CLASS tgeography_btree_ops
 
 /******************************************************************************/
 
-CREATE FUNCTION temporal_hash(tgeometry)
+CREATE FUNCTION hash(tgeometry)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Temporal_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION temporal_hash_extended(tgeometry, bigint)
+CREATE FUNCTION hashExtended(tgeometry, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Temporal_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION temporal_hash(tgeography)
+CREATE FUNCTION hash(tgeography)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Temporal_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION temporal_hash_extended(tgeography, bigint)
+CREATE FUNCTION hashExtended(tgeography, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Temporal_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -1045,13 +1045,13 @@ CREATE FUNCTION temporal_hash_extended(tgeography, bigint)
 CREATE OPERATOR CLASS tgeometry_hash_ops
   DEFAULT FOR TYPE tgeometry USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   temporal_hash(tgeometry),
-    FUNCTION    2   temporal_hash_extended(tgeometry, bigint);
+    FUNCTION    1   hash(tgeometry),
+    FUNCTION    2   hashExtended(tgeometry, bigint);
 CREATE OPERATOR CLASS tgeography_hash_ops
   DEFAULT FOR TYPE tgeography USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   temporal_hash(tgeography),
-    FUNCTION    2   temporal_hash_extended(tgeography, bigint);
+    FUNCTION    1   hash(tgeography),
+    FUNCTION    2   hashExtended(tgeography, bigint);
 
 /******************************************************************************/
 

--- a/mobilitydb/sql/geo/052_tpoint.in.sql
+++ b/mobilitydb/sql/geo/052_tpoint.in.sql
@@ -1026,19 +1026,19 @@ CREATE OPERATOR CLASS tgeogpoint_btree_ops
 
 /******************************************************************************/
 
-CREATE FUNCTION temporal_hash(tgeompoint)
+CREATE FUNCTION hash(tgeompoint)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Temporal_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION temporal_hash_extended(tgeompoint, bigint)
+CREATE FUNCTION hashExtended(tgeompoint, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Temporal_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION temporal_hash(tgeogpoint)
+CREATE FUNCTION hash(tgeogpoint)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Temporal_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION temporal_hash_extended(tgeogpoint, bigint)
+CREATE FUNCTION hashExtended(tgeogpoint, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Temporal_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -1046,13 +1046,13 @@ CREATE FUNCTION temporal_hash_extended(tgeogpoint, bigint)
 CREATE OPERATOR CLASS tgeompoint_hash_ops
   DEFAULT FOR TYPE tgeompoint USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   temporal_hash(tgeompoint),
-    FUNCTION    2   temporal_hash_extended(tgeompoint, bigint);
+    FUNCTION    1   hash(tgeompoint),
+    FUNCTION    2   hashExtended(tgeompoint, bigint);
 CREATE OPERATOR CLASS tgeogpoint_hash_ops
   DEFAULT FOR TYPE tgeogpoint USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   temporal_hash(tgeogpoint),
-    FUNCTION    2   temporal_hash_extended(tgeogpoint, bigint);
+    FUNCTION    1   hash(tgeogpoint),
+    FUNCTION    2   hashExtended(tgeogpoint, bigint);
 
 /******************************************************************************/
 

--- a/mobilitydb/sql/h3/250_h3index.in.sql
+++ b/mobilitydb/sql/h3/250_h3index.in.sql
@@ -174,7 +174,7 @@ CREATE FUNCTION h3index_cmp(h3index, h3index)
   AS 'MODULE_PATHNAME', 'H3index_cmp'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION h3index_hash(h3index)
+CREATE FUNCTION hash(h3index)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'H3index_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -241,7 +241,7 @@ CREATE OPERATOR CLASS h3index_ops
 CREATE OPERATOR CLASS h3index_ops
   DEFAULT FOR TYPE h3index USING hash AS
     OPERATOR  1  =,
-    FUNCTION  1  h3index_hash(h3index);
+    FUNCTION  1  hash(h3index);
 
 /******************************************************************************
  * Validity predicates

--- a/mobilitydb/sql/h3/251_h3indexset.in.sql
+++ b/mobilitydb/sql/h3/251_h3indexset.in.sql
@@ -181,7 +181,7 @@ CREATE FUNCTION gt(h3indexset, h3indexset)
 CREATE FUNCTION cmp(h3indexset, h3indexset)
   RETURNS integer AS 'MODULE_PATHNAME', 'Set_cmp'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_hash(h3indexset)
+CREATE FUNCTION hash(h3indexset)
   RETURNS integer AS 'MODULE_PATHNAME', 'Set_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
@@ -216,7 +216,7 @@ CREATE OPERATOR CLASS h3indexset_btree_ops
 CREATE OPERATOR CLASS h3indexset_hash_ops
   DEFAULT FOR TYPE h3indexset USING hash AS
     OPERATOR  1  =,
-    FUNCTION  1  set_hash(h3indexset);
+    FUNCTION  1  hash(h3indexset);
 
 /******************************************************************************
  * unnest — SETOF expansion

--- a/mobilitydb/sql/h3/253_th3index.in.sql
+++ b/mobilitydb/sql/h3/253_th3index.in.sql
@@ -655,11 +655,11 @@ CREATE OPERATOR CLASS th3index_btree_ops
 
 /******************************************************************************/
 
-CREATE FUNCTION temporal_hash(th3index)
+CREATE FUNCTION hash(th3index)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Temporal_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION temporal_hash_extended(th3index, bigint)
+CREATE FUNCTION hashExtended(th3index, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Temporal_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -667,7 +667,7 @@ CREATE FUNCTION temporal_hash_extended(th3index, bigint)
 CREATE OPERATOR CLASS th3index_hash_ops
   DEFAULT FOR TYPE th3index USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   temporal_hash(th3index),
-    FUNCTION    2   temporal_hash_extended(th3index, bigint);
+    FUNCTION    1   hash(th3index),
+    FUNCTION    2   hashExtended(th3index, bigint);
 
 /******************************************************************************/

--- a/mobilitydb/sql/json/450_jsonbset.in.sql
+++ b/mobilitydb/sql/json/450_jsonbset.in.sql
@@ -293,11 +293,11 @@ CREATE OPERATOR CLASS jsonbset_btree_ops
 
 /******************************************************************************/
 
-CREATE FUNCTION set_hash(jsonbset)
+CREATE FUNCTION hash(jsonbset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Set_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_hash_extended(jsonbset, bigint)
+CREATE FUNCTION hashExtended(jsonbset, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Set_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -305,8 +305,8 @@ CREATE FUNCTION set_hash_extended(jsonbset, bigint)
 CREATE OPERATOR CLASS jsonbset_hash_ops
   DEFAULT FOR TYPE jsonbset USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   set_hash(jsonbset),
-    FUNCTION    2   set_hash_extended(jsonbset, bigint);
+    FUNCTION    1   hash(jsonbset),
+    FUNCTION    2   hashExtended(jsonbset, bigint);
 
 /*****************************************************************************
  * JSONB Functions

--- a/mobilitydb/sql/json/452_tjsonb.in.sql
+++ b/mobilitydb/sql/json/452_tjsonb.in.sql
@@ -702,11 +702,11 @@ CREATE OPERATOR CLASS tjsonb_btree_ops
 
 /*****************************************************************************/
 
-CREATE FUNCTION temporal_hash(tjsonb)
+CREATE FUNCTION hash(tjsonb)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Temporal_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION temporal_hash_extended(tjsonb, bigint)
+CREATE FUNCTION hashExtended(tjsonb, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Temporal_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -714,8 +714,8 @@ CREATE FUNCTION temporal_hash_extended(tjsonb, bigint)
 CREATE OPERATOR CLASS tjsonb_hash_ops
   DEFAULT FOR TYPE tjsonb USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   temporal_hash(tjsonb),
-    FUNCTION    2   temporal_hash_extended(tjsonb, bigint);
+    FUNCTION    1   hash(tjsonb),
+    FUNCTION    2   hashExtended(tjsonb, bigint);
 
 /*****************************************************************************/
 

--- a/mobilitydb/sql/npoint/301_npointset.in.sql
+++ b/mobilitydb/sql/npoint/301_npointset.in.sql
@@ -314,11 +314,11 @@ CREATE OPERATOR CLASS npointset_btree_ops
 
 /******************************************************************************/
 
-CREATE FUNCTION set_hash(npointset)
+CREATE FUNCTION hash(npointset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Set_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_hash_extended(npointset, bigint)
+CREATE FUNCTION hashExtended(npointset, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Set_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -326,8 +326,8 @@ CREATE FUNCTION set_hash_extended(npointset, bigint)
 CREATE OPERATOR CLASS npointset_hash_ops
   DEFAULT FOR TYPE npointset USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   set_hash(npointset),
-    FUNCTION    2   set_hash_extended(npointset, bigint);
+    FUNCTION    1   hash(npointset),
+    FUNCTION    2   hashExtended(npointset, bigint);
 
 /******************************************************************************
  * Operators

--- a/mobilitydb/sql/npoint/302_tnpoint.in.sql
+++ b/mobilitydb/sql/npoint/302_tnpoint.in.sql
@@ -679,11 +679,11 @@ CREATE OPERATOR CLASS tnpoint_btree_ops
 
 /******************************************************************************/
 
-CREATE FUNCTION temporal_hash(tnpoint)
+CREATE FUNCTION hash(tnpoint)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Temporal_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION temporal_hash_extended(tnpoint, bigint)
+CREATE FUNCTION hashExtended(tnpoint, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Temporal_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -691,7 +691,7 @@ CREATE FUNCTION temporal_hash_extended(tnpoint, bigint)
 CREATE OPERATOR CLASS tnpoint_hash_ops
   DEFAULT FOR TYPE tnpoint USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   temporal_hash(tnpoint),
-    FUNCTION    2   temporal_hash_extended(tnpoint, bigint);
+    FUNCTION    1   hash(tnpoint),
+    FUNCTION    2   hashExtended(tnpoint, bigint);
 
 /******************************************************************************/

--- a/mobilitydb/sql/pointcloud/400_pcset.in.sql
+++ b/mobilitydb/sql/pointcloud/400_pcset.in.sql
@@ -303,11 +303,11 @@ CREATE OPERATOR CLASS pcpointset_btree_ops
     OPERATOR  5  >,
     FUNCTION  1  cmp(pcpointset, pcpointset);
 
-CREATE FUNCTION set_hash(pcpointset)
+CREATE FUNCTION hash(pcpointset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Set_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_hash_extended(pcpointset, bigint)
+CREATE FUNCTION hashExtended(pcpointset, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Set_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -315,8 +315,8 @@ CREATE FUNCTION set_hash_extended(pcpointset, bigint)
 CREATE OPERATOR CLASS pcpointset_hash_ops
   DEFAULT FOR TYPE pcpointset USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   set_hash(pcpointset),
-    FUNCTION    2   set_hash_extended(pcpointset, bigint);
+    FUNCTION    1   hash(pcpointset),
+    FUNCTION    2   hashExtended(pcpointset, bigint);
 
 /******************************************************************************
  * pcpointset — Set operations (value ↔ set, set ↔ set)
@@ -670,11 +670,11 @@ CREATE OPERATOR CLASS pcpatchset_btree_ops
     OPERATOR  5  >,
     FUNCTION  1  cmp(pcpatchset, pcpatchset);
 
-CREATE FUNCTION set_hash(pcpatchset)
+CREATE FUNCTION hash(pcpatchset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Set_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_hash_extended(pcpatchset, bigint)
+CREATE FUNCTION hashExtended(pcpatchset, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Set_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -682,8 +682,8 @@ CREATE FUNCTION set_hash_extended(pcpatchset, bigint)
 CREATE OPERATOR CLASS pcpatchset_hash_ops
   DEFAULT FOR TYPE pcpatchset USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   set_hash(pcpatchset),
-    FUNCTION    2   set_hash_extended(pcpatchset, bigint);
+    FUNCTION    1   hash(pcpatchset),
+    FUNCTION    2   hashExtended(pcpatchset, bigint);
 
 /******************************************************************************
  * pcpatchset — Set operations

--- a/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
+++ b/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
@@ -675,11 +675,11 @@ CREATE OPERATOR CLASS tpcpoint_btree_ops
     OPERATOR  5  >,
     FUNCTION  1  cmp(tpcpoint, tpcpoint);
 
-CREATE FUNCTION temporal_hash(tpcpoint)
+CREATE FUNCTION hash(tpcpoint)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Temporal_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION temporal_hash_extended(tpcpoint, bigint)
+CREATE FUNCTION hashExtended(tpcpoint, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Temporal_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -687,7 +687,7 @@ CREATE FUNCTION temporal_hash_extended(tpcpoint, bigint)
 CREATE OPERATOR CLASS tpcpoint_hash_ops
   DEFAULT FOR TYPE tpcpoint USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   temporal_hash(tpcpoint),
-    FUNCTION    2   temporal_hash_extended(tpcpoint, bigint);
+    FUNCTION    1   hash(tpcpoint),
+    FUNCTION    2   hashExtended(tpcpoint, bigint);
 
 /*****************************************************************************/

--- a/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
+++ b/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
@@ -699,11 +699,11 @@ CREATE OPERATOR CLASS tpcpatch_btree_ops
     OPERATOR  5  >,
     FUNCTION  1  cmp(tpcpatch, tpcpatch);
 
-CREATE FUNCTION temporal_hash(tpcpatch)
+CREATE FUNCTION hash(tpcpatch)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Temporal_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION temporal_hash_extended(tpcpatch, bigint)
+CREATE FUNCTION hashExtended(tpcpatch, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Temporal_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -711,7 +711,7 @@ CREATE FUNCTION temporal_hash_extended(tpcpatch, bigint)
 CREATE OPERATOR CLASS tpcpatch_hash_ops
   DEFAULT FOR TYPE tpcpatch USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   temporal_hash(tpcpatch),
-    FUNCTION    2   temporal_hash_extended(tpcpatch, bigint);
+    FUNCTION    1   hash(tpcpatch),
+    FUNCTION    2   hashExtended(tpcpatch, bigint);
 
 /*****************************************************************************/

--- a/mobilitydb/sql/pose/100_pose.in.sql
+++ b/mobilitydb/sql/pose/100_pose.in.sql
@@ -370,11 +370,11 @@ CREATE OPERATOR CLASS pose_btree_ops
 
 /******************************************************************************/
 
-CREATE FUNCTION pose_hash(pose)
+CREATE FUNCTION hash(pose)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Pose_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION pose_hash_extended(pose, bigint)
+CREATE FUNCTION hashExtended(pose, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Pose_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -382,7 +382,7 @@ CREATE FUNCTION pose_hash_extended(pose, bigint)
 CREATE OPERATOR CLASS pose_hash_ops
   DEFAULT FOR TYPE pose USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   pose_hash(pose),
-    FUNCTION    2   pose_hash_extended(pose, bigint);
+    FUNCTION    1   hash(pose),
+    FUNCTION    2   hashExtended(pose, bigint);
 
 /******************************************************************************/

--- a/mobilitydb/sql/pose/101_poseset.in.sql
+++ b/mobilitydb/sql/pose/101_poseset.in.sql
@@ -336,11 +336,11 @@ CREATE OPERATOR CLASS poseset_btree_ops
 
 /******************************************************************************/
 
-CREATE FUNCTION set_hash(poseset)
+CREATE FUNCTION hash(poseset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Set_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_hash_extended(poseset, bigint)
+CREATE FUNCTION hashExtended(poseset, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Set_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -348,8 +348,8 @@ CREATE FUNCTION set_hash_extended(poseset, bigint)
 CREATE OPERATOR CLASS poseset_hash_ops
   DEFAULT FOR TYPE poseset USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   set_hash(poseset),
-    FUNCTION    2   set_hash_extended(poseset, bigint);
+    FUNCTION    1   hash(poseset),
+    FUNCTION    2   hashExtended(poseset, bigint);
 
 /******************************************************************************
  * Operators

--- a/mobilitydb/sql/pose/102_tpose.in.sql
+++ b/mobilitydb/sql/pose/102_tpose.in.sql
@@ -762,11 +762,11 @@ CREATE OPERATOR CLASS tpose_btree_ops
 
 /******************************************************************************/
 
-CREATE FUNCTION temporal_hash(tpose)
+CREATE FUNCTION hash(tpose)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Temporal_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION temporal_hash_extended(tpose, bigint)
+CREATE FUNCTION hashExtended(tpose, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Temporal_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -774,7 +774,7 @@ CREATE FUNCTION temporal_hash_extended(tpose, bigint)
 CREATE OPERATOR CLASS tpose_hash_ops
   DEFAULT FOR TYPE tpose USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   temporal_hash(tpose),
-    FUNCTION    2   temporal_hash_extended(tpose, bigint);
+    FUNCTION    1   hash(tpose),
+    FUNCTION    2   hashExtended(tpose, bigint);
 
 /******************************************************************************/

--- a/mobilitydb/sql/quadbin/350_quadbin.in.sql
+++ b/mobilitydb/sql/quadbin/350_quadbin.in.sql
@@ -143,7 +143,7 @@ CREATE FUNCTION quadbin_cmp(quadbin, quadbin)
   AS 'MODULE_PATHNAME', 'Quadbin_cmp'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION quadbin_hash(quadbin)
+CREATE FUNCTION hash(quadbin)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Quadbin_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -210,7 +210,7 @@ CREATE OPERATOR CLASS quadbin_ops
 CREATE OPERATOR CLASS quadbin_ops
   DEFAULT FOR TYPE quadbin USING hash AS
     OPERATOR  1  =,
-    FUNCTION  1  quadbin_hash(quadbin);
+    FUNCTION  1  hash(quadbin);
 
 /******************************************************************************
  * Validity predicates

--- a/mobilitydb/sql/quadbin/351_quadbinset.in.sql
+++ b/mobilitydb/sql/quadbin/351_quadbinset.in.sql
@@ -181,7 +181,7 @@ CREATE FUNCTION gt(quadbinset, quadbinset)
 CREATE FUNCTION cmp(quadbinset, quadbinset)
   RETURNS integer AS 'MODULE_PATHNAME', 'Set_cmp'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_hash(quadbinset)
+CREATE FUNCTION hash(quadbinset)
   RETURNS integer AS 'MODULE_PATHNAME', 'Set_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
@@ -216,7 +216,7 @@ CREATE OPERATOR CLASS quadbinset_btree_ops
 CREATE OPERATOR CLASS quadbinset_hash_ops
   DEFAULT FOR TYPE quadbinset USING hash AS
     OPERATOR  1  =,
-    FUNCTION  1  set_hash(quadbinset);
+    FUNCTION  1  hash(quadbinset);
 
 /******************************************************************************
  * unnest — SETOF expansion

--- a/mobilitydb/sql/quadbin/353_tquadbin.in.sql
+++ b/mobilitydb/sql/quadbin/353_tquadbin.in.sql
@@ -657,11 +657,11 @@ CREATE OPERATOR CLASS tquadbin_btree_ops
 
 /******************************************************************************/
 
-CREATE FUNCTION temporal_hash(tquadbin)
+CREATE FUNCTION hash(tquadbin)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Temporal_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION temporal_hash_extended(tquadbin, bigint)
+CREATE FUNCTION hashExtended(tquadbin, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Temporal_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -669,7 +669,7 @@ CREATE FUNCTION temporal_hash_extended(tquadbin, bigint)
 CREATE OPERATOR CLASS tquadbin_hash_ops
   DEFAULT FOR TYPE tquadbin USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   temporal_hash(tquadbin),
-    FUNCTION    2   temporal_hash_extended(tquadbin, bigint);
+    FUNCTION    1   hash(tquadbin),
+    FUNCTION    2   hashExtended(tquadbin, bigint);
 
 /******************************************************************************/

--- a/mobilitydb/sql/raster/500_raster.in.sql
+++ b/mobilitydb/sql/raster/500_raster.in.sql
@@ -425,12 +425,12 @@ CREATE OPERATOR CLASS raquet_btree_ops
 
 /*****************************************************************************/
 
-CREATE FUNCTION raquet_hash(raquet)
+CREATE FUNCTION hash(raquet)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Raquet_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION raquet_hash_extended(raquet, bigint)
+CREATE FUNCTION hashExtended(raquet, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Raquet_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -438,8 +438,8 @@ CREATE FUNCTION raquet_hash_extended(raquet, bigint)
 CREATE OPERATOR CLASS raquet_hash_ops
   DEFAULT FOR TYPE raquet USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   raquet_hash(raquet),
-    FUNCTION    2   raquet_hash_extended(raquet, bigint);
+    FUNCTION    1   hash(raquet),
+    FUNCTION    2   hashExtended(raquet, bigint);
 
 /*****************************************************************************/
 

--- a/mobilitydb/sql/rgeo/150_trgeo.in.sql
+++ b/mobilitydb/sql/rgeo/150_trgeo.in.sql
@@ -730,11 +730,11 @@ CREATE OPERATOR CLASS trgeometry_btree_ops
 
 /******************************************************************************/
 
-CREATE FUNCTION temporal_hash(trgeometry)
+CREATE FUNCTION hash(trgeometry)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Temporal_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION temporal_hash_extended(trgeometry, bigint)
+CREATE FUNCTION hashExtended(trgeometry, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Temporal_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -742,7 +742,7 @@ CREATE FUNCTION temporal_hash_extended(trgeometry, bigint)
 CREATE OPERATOR CLASS trgeometry_hash_ops
   DEFAULT FOR TYPE trgeometry USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   temporal_hash(trgeometry),
-    FUNCTION    2   temporal_hash_extended(trgeometry, bigint);
+    FUNCTION    1   hash(trgeometry),
+    FUNCTION    2   hashExtended(trgeometry, bigint);
 
 /******************************************************************************/

--- a/mobilitydb/sql/temporal/001_set.in.sql
+++ b/mobilitydb/sql/temporal/001_set.in.sql
@@ -1422,52 +1422,52 @@ CREATE OPERATOR CLASS tstzset_btree_ops
  * Hash functions for defining hash indexes
  ******************************************************************************/
 
-CREATE FUNCTION set_hash(intset)
+CREATE FUNCTION hash(intset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Set_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_hash(bigintset)
+CREATE FUNCTION hash(bigintset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Set_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_hash(floatset)
+CREATE FUNCTION hash(floatset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Set_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_hash(textset)
+CREATE FUNCTION hash(textset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Set_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_hash(dateset)
+CREATE FUNCTION hash(dateset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Set_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_hash(tstzset)
+CREATE FUNCTION hash(tstzset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Set_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION set_hash_extended(intset, bigint)
+CREATE FUNCTION hashExtended(intset, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Set_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_hash_extended(bigintset, bigint)
+CREATE FUNCTION hashExtended(bigintset, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Set_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_hash_extended(floatset, bigint)
+CREATE FUNCTION hashExtended(floatset, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Set_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_hash_extended(textset, bigint)
+CREATE FUNCTION hashExtended(textset, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Set_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_hash_extended(dateset, bigint)
+CREATE FUNCTION hashExtended(dateset, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Set_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION set_hash_extended(tstzset, bigint)
+CREATE FUNCTION hashExtended(tstzset, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Set_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -1475,32 +1475,32 @@ CREATE FUNCTION set_hash_extended(tstzset, bigint)
 CREATE OPERATOR CLASS intset_hash_ops
   DEFAULT FOR TYPE intset USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   set_hash(intset),
-    FUNCTION    2   set_hash_extended(intset, bigint);
+    FUNCTION    1   hash(intset),
+    FUNCTION    2   hashExtended(intset, bigint);
 CREATE OPERATOR CLASS bigintset_hash_ops
   DEFAULT FOR TYPE bigintset USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   set_hash(bigintset),
-    FUNCTION    2   set_hash_extended(bigintset, bigint);
+    FUNCTION    1   hash(bigintset),
+    FUNCTION    2   hashExtended(bigintset, bigint);
 CREATE OPERATOR CLASS floatset_hash_ops
   DEFAULT FOR TYPE floatset USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   set_hash(floatset),
-    FUNCTION    2   set_hash_extended(floatset, bigint);
+    FUNCTION    1   hash(floatset),
+    FUNCTION    2   hashExtended(floatset, bigint);
 CREATE OPERATOR CLASS textset_hash_ops
   DEFAULT FOR TYPE textset USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   set_hash(textset),
-    FUNCTION    2   set_hash_extended(textset, bigint);
+    FUNCTION    1   hash(textset),
+    FUNCTION    2   hashExtended(textset, bigint);
 CREATE OPERATOR CLASS dateset_hash_ops
   DEFAULT FOR TYPE dateset USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   set_hash(dateset),
-    FUNCTION    2   set_hash_extended(dateset, bigint);
+    FUNCTION    1   hash(dateset),
+    FUNCTION    2   hashExtended(dateset, bigint);
 CREATE OPERATOR CLASS tstzset_hash_ops
   DEFAULT FOR TYPE tstzset USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   set_hash(tstzset),
-    FUNCTION    2   set_hash_extended(tstzset, bigint);
+    FUNCTION    1   hash(tstzset),
+    FUNCTION    2   hashExtended(tstzset, bigint);
 
 /******************************************************************************/

--- a/mobilitydb/sql/temporal/003_span.in.sql
+++ b/mobilitydb/sql/temporal/003_span.in.sql
@@ -1162,44 +1162,44 @@ CREATE OPERATOR CLASS tstzspan_btree_ops
 
 /******************************************************************************/
 
-CREATE FUNCTION span_hash(intspan)
+CREATE FUNCTION hash(intspan)
   RETURNS integer
  AS 'MODULE_PATHNAME', 'Span_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_hash(bigintspan)
+CREATE FUNCTION hash(bigintspan)
   RETURNS integer
  AS 'MODULE_PATHNAME', 'Span_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_hash(floatspan)
+CREATE FUNCTION hash(floatspan)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Span_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_hash(datespan)
+CREATE FUNCTION hash(datespan)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Span_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_hash(tstzspan)
+CREATE FUNCTION hash(tstzspan)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Span_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION span_hash_extended(intspan, bigint)
+CREATE FUNCTION hashExtended(intspan, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Span_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_hash_extended(bigintspan, bigint)
+CREATE FUNCTION hashExtended(bigintspan, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Span_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_hash_extended(floatspan, bigint)
+CREATE FUNCTION hashExtended(floatspan, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Span_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_hash_extended(datespan, bigint)
+CREATE FUNCTION hashExtended(datespan, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Span_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_hash_extended(tstzspan, bigint)
+CREATE FUNCTION hashExtended(tstzspan, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Span_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -1207,27 +1207,27 @@ CREATE FUNCTION span_hash_extended(tstzspan, bigint)
 CREATE OPERATOR CLASS intspan_hash_ops
   DEFAULT FOR TYPE intspan USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   span_hash(intspan),
-    FUNCTION    2   span_hash_extended(intspan, bigint);
+    FUNCTION    1   hash(intspan),
+    FUNCTION    2   hashExtended(intspan, bigint);
 CREATE OPERATOR CLASS bigintspan_hash_ops
   DEFAULT FOR TYPE bigintspan USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   span_hash(bigintspan),
-    FUNCTION    2   span_hash_extended(bigintspan, bigint);
+    FUNCTION    1   hash(bigintspan),
+    FUNCTION    2   hashExtended(bigintspan, bigint);
 CREATE OPERATOR CLASS floatspan_hash_ops
   DEFAULT FOR TYPE floatspan USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   span_hash(floatspan),
-    FUNCTION    2   span_hash_extended(floatspan, bigint);
+    FUNCTION    1   hash(floatspan),
+    FUNCTION    2   hashExtended(floatspan, bigint);
 CREATE OPERATOR CLASS datespan_hash_ops
   DEFAULT FOR TYPE datespan USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   span_hash(datespan),
-    FUNCTION    2   span_hash_extended(datespan, bigint);
+    FUNCTION    1   hash(datespan),
+    FUNCTION    2   hashExtended(datespan, bigint);
 CREATE OPERATOR CLASS tstzspan_hash_ops
   DEFAULT FOR TYPE tstzspan USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   span_hash(tstzspan),
-    FUNCTION    2   span_hash_extended(tstzspan, bigint);
+    FUNCTION    1   hash(tstzspan),
+    FUNCTION    2   hashExtended(tstzspan, bigint);
 
 /******************************************************************************/

--- a/mobilitydb/sql/temporal/007_spanset.in.sql
+++ b/mobilitydb/sql/temporal/007_spanset.in.sql
@@ -1292,44 +1292,44 @@ CREATE OPERATOR CLASS tstzspanset_btree_ops
 
 /******************************************************************************/
 
-CREATE FUNCTION spanset_hash(intspanset)
+CREATE FUNCTION hash(intspanset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Spanset_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanset_hash(bigintspanset)
+CREATE FUNCTION hash(bigintspanset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Spanset_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanset_hash(floatspanset)
+CREATE FUNCTION hash(floatspanset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Spanset_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanset_hash(datespanset)
+CREATE FUNCTION hash(datespanset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Spanset_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanset_hash(tstzspanset)
+CREATE FUNCTION hash(tstzspanset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Spanset_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION spanset_hash_extended(intspanset, bigint)
+CREATE FUNCTION hashExtended(intspanset, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Spanset_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanset_hash_extended(bigintspanset, bigint)
+CREATE FUNCTION hashExtended(bigintspanset, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Spanset_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanset_hash_extended(floatspanset, bigint)
+CREATE FUNCTION hashExtended(floatspanset, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Spanset_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanset_hash_extended(datespanset, bigint)
+CREATE FUNCTION hashExtended(datespanset, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Spanset_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spanset_hash_extended(tstzspanset, bigint)
+CREATE FUNCTION hashExtended(tstzspanset, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Spanset_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -1337,28 +1337,28 @@ CREATE FUNCTION spanset_hash_extended(tstzspanset, bigint)
 CREATE OPERATOR CLASS intspanset_hash_ops
   DEFAULT FOR TYPE intspanset USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   spanset_hash(intspanset),
-    FUNCTION    2   spanset_hash_extended(intspanset, bigint);
+    FUNCTION    1   hash(intspanset),
+    FUNCTION    2   hashExtended(intspanset, bigint);
 CREATE OPERATOR CLASS bigintspanset_hash_ops
   DEFAULT FOR TYPE bigintspanset USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   spanset_hash(bigintspanset),
-    FUNCTION    2   spanset_hash_extended(bigintspanset, bigint);
+    FUNCTION    1   hash(bigintspanset),
+    FUNCTION    2   hashExtended(bigintspanset, bigint);
 CREATE OPERATOR CLASS floatspanset_hash_ops
   DEFAULT FOR TYPE floatspanset USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   spanset_hash(floatspanset),
-    FUNCTION    2   spanset_hash_extended(floatspanset, bigint);
+    FUNCTION    1   hash(floatspanset),
+    FUNCTION    2   hashExtended(floatspanset, bigint);
 CREATE OPERATOR CLASS datespanset_hash_ops
   DEFAULT FOR TYPE datespanset USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   spanset_hash(datespanset),
-    FUNCTION    2   spanset_hash_extended(datespanset, bigint);
+    FUNCTION    1   hash(datespanset),
+    FUNCTION    2   hashExtended(datespanset, bigint);
 CREATE OPERATOR CLASS tstzspanset_hash_ops
   DEFAULT FOR TYPE tstzspanset USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   spanset_hash(tstzspanset),
-    FUNCTION    2   spanset_hash_extended(tstzspanset, bigint);
+    FUNCTION    1   hash(tstzspanset),
+    FUNCTION    2   hashExtended(tstzspanset, bigint);
 
 
 /******************************************************************************/

--- a/mobilitydb/sql/temporal/021_tbox.in.sql
+++ b/mobilitydb/sql/temporal/021_tbox.in.sql
@@ -664,12 +664,12 @@ CREATE OPERATOR CLASS tbox_btree_ops
 
 /*****************************************************************************/
 
-CREATE FUNCTION tbox_hash(tbox)
+CREATE FUNCTION hash(tbox)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Tbox_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION tbox_hash_extended(tbox, bigint)
+CREATE FUNCTION hashExtended(tbox, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Tbox_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -677,7 +677,7 @@ CREATE FUNCTION tbox_hash_extended(tbox, bigint)
 CREATE OPERATOR CLASS tbox_hash_ops
   DEFAULT FOR TYPE tbox USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   tbox_hash(tbox),
-    FUNCTION    2   tbox_hash_extended(tbox, bigint);
+    FUNCTION    1   hash(tbox),
+    FUNCTION    2   hashExtended(tbox, bigint);
 
 /*****************************************************************************/

--- a/mobilitydb/sql/temporal/022_temporal.in.sql
+++ b/mobilitydb/sql/temporal/022_temporal.in.sql
@@ -2715,44 +2715,44 @@ CREATE OPERATOR CLASS ttext_btree_ops
 
 /******************************************************************************/
 
-CREATE FUNCTION temporal_hash(tbool)
+CREATE FUNCTION hash(tbool)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Temporal_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION temporal_hash(tint)
+CREATE FUNCTION hash(tint)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Temporal_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION temporal_hash(tbigint)
+CREATE FUNCTION hash(tbigint)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Temporal_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION temporal_hash(tfloat)
+CREATE FUNCTION hash(tfloat)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Temporal_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION temporal_hash(ttext)
+CREATE FUNCTION hash(ttext)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Temporal_hash'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION temporal_hash_extended(tbool, bigint)
+CREATE FUNCTION hashExtended(tbool, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Temporal_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION temporal_hash_extended(tint, bigint)
+CREATE FUNCTION hashExtended(tint, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Temporal_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION temporal_hash_extended(tbigint, bigint)
+CREATE FUNCTION hashExtended(tbigint, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Temporal_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION temporal_hash_extended(tfloat, bigint)
+CREATE FUNCTION hashExtended(tfloat, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Temporal_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION temporal_hash_extended(ttext, bigint)
+CREATE FUNCTION hashExtended(ttext, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Temporal_hash_extended'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -2760,27 +2760,27 @@ CREATE FUNCTION temporal_hash_extended(ttext, bigint)
 CREATE OPERATOR CLASS tbool_hash_ops
   DEFAULT FOR TYPE tbool USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   temporal_hash(tbool),
-    FUNCTION    2   temporal_hash_extended(tbool, bigint);
+    FUNCTION    1   hash(tbool),
+    FUNCTION    2   hashExtended(tbool, bigint);
 CREATE OPERATOR CLASS tint_hash_ops
   DEFAULT FOR TYPE tint USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   temporal_hash(tint),
-    FUNCTION    2   temporal_hash_extended(tint, bigint);
+    FUNCTION    1   hash(tint),
+    FUNCTION    2   hashExtended(tint, bigint);
 CREATE OPERATOR CLASS tbigint_hash_ops
   DEFAULT FOR TYPE tbigint USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   temporal_hash(tbigint),
-    FUNCTION    2   temporal_hash_extended(tbigint, bigint);
+    FUNCTION    1   hash(tbigint),
+    FUNCTION    2   hashExtended(tbigint, bigint);
 CREATE OPERATOR CLASS tfloat_hash_ops
   DEFAULT FOR TYPE tfloat USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   temporal_hash(tfloat),
-    FUNCTION    2   temporal_hash_extended(tfloat, bigint);
+    FUNCTION    1   hash(tfloat),
+    FUNCTION    2   hashExtended(tfloat, bigint);
 CREATE OPERATOR CLASS ttext_hash_ops
   DEFAULT FOR TYPE ttext USING hash AS
     OPERATOR    1   = ,
-    FUNCTION    1   temporal_hash(ttext),
-    FUNCTION    2   temporal_hash_extended(ttext, bigint);
+    FUNCTION    1   hash(ttext),
+    FUNCTION    2   hashExtended(ttext, bigint);
 
 /******************************************************************************/

--- a/mobilitydb/src/cbuffer/cbuffer.c
+++ b/mobilitydb/src/cbuffer/cbuffer.c
@@ -802,7 +802,7 @@ PG_FUNCTION_INFO_V1(Cbuffer_hash_extended);
 /**
  * @ingroup mobilitydb_cbuffer_base_accessor
  * @brief Return the 64-bit hash value of a circular buffer using a seed
- * @sqlfn hash_extended()
+ * @sqlfn hashExtended()
  */
 Datum
 Cbuffer_hash_extended(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/geo/stbox.c
+++ b/mobilitydb/src/geo/stbox.c
@@ -1765,7 +1765,7 @@ PG_FUNCTION_INFO_V1(Stbox_hash);
 /**
  * @ingroup mobilitydb_geo_box_comp
  * @brief Return the hash value of a spatiotemporal box
- * @sqlfn stbox_hash()
+ * @sqlfn hash()
  */
 Datum
 Stbox_hash(PG_FUNCTION_ARGS)
@@ -1779,7 +1779,7 @@ PG_FUNCTION_INFO_V1(Stbox_hash_extended);
 /**
  * @ingroup mobilitydb_geo_box_comp
  * @brief Return the hash value of a spatiotemporal box
- * @sqlfn stbox_hash_extended()
+ * @sqlfn hashExtended()
  */
 Datum
 Stbox_hash_extended(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/h3/h3index.c
+++ b/mobilitydb/src/h3/h3index.c
@@ -299,6 +299,7 @@ PG_FUNCTION_INFO_V1(H3index_hash);
 /**
  * @ingroup mobilitydb_h3_base_accessor
  * @brief Return the hash code of an h3index value
+ * @sqlfn hash()
  */
 Datum
 H3index_hash(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/pose/pose.c
+++ b/mobilitydb/src/pose/pose.c
@@ -926,7 +926,7 @@ PG_FUNCTION_INFO_V1(Pose_hash_extended);
 /**
  * @ingroup mobilitydb_pose_base_accessor
  * @brief Return the 64-bit hash value of a pose using a seed
- * @sqlfn hash_extended()
+ * @sqlfn hashExtended()
  */
 Datum
 Pose_hash_extended(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/quadbin/quadbin.c
+++ b/mobilitydb/src/quadbin/quadbin.c
@@ -223,7 +223,7 @@ PG_FUNCTION_INFO_V1(Quadbin_hash);
 /**
  * @ingroup mobilitydb_quadbin_base_accessor
  * @brief Return the hash code of a quadbin value
- * @sqlfn quadbin_hash()
+ * @sqlfn hash()
  */
 Datum
 Quadbin_hash(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/raster/temporal_raster.c
+++ b/mobilitydb/src/raster/temporal_raster.c
@@ -743,7 +743,7 @@ PG_FUNCTION_INFO_V1(Raquet_hash);
 /**
  * @ingroup mobilitydb_raster
  * @brief Return the 32-bit hash of a Raquet tile
- * @sqlfn raquet_hash()
+ * @sqlfn hash()
  */
 Datum
 Raquet_hash(PG_FUNCTION_ARGS)
@@ -759,7 +759,7 @@ PG_FUNCTION_INFO_V1(Raquet_hash_extended);
 /**
  * @ingroup mobilitydb_raster
  * @brief Return the 64-bit hash of a Raquet tile using a seed
- * @sqlfn raquet_hash_extended()
+ * @sqlfn hashExtended()
  */
 Datum
 Raquet_hash_extended(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/temporal/set.c
+++ b/mobilitydb/src/temporal/set.c
@@ -943,7 +943,7 @@ PG_FUNCTION_INFO_V1(Set_hash_extended);
 /**
  * @ingroup mobilitydb_setspan_accessor
  * @brief Return the 64-bit hash value of a set using a seed
- * @sqlfn hash_extended()
+ * @sqlfn hashExtended()
  */
 Datum
 Set_hash_extended(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/temporal/span.c
+++ b/mobilitydb/src/temporal/span.c
@@ -958,7 +958,7 @@ PG_FUNCTION_INFO_V1(Span_hash);
 /**
  * @ingroup mobilitydb_setspan_accessor
  * @brief Return the 32-bit hash value of a span
- * @sqlfn span_hash()
+ * @sqlfn hash()
  */
 Datum
 Span_hash(PG_FUNCTION_ARGS)
@@ -972,7 +972,7 @@ PG_FUNCTION_INFO_V1(Span_hash_extended);
 /**
  * @ingroup mobilitydb_setspan_accessor
  * @brief Return the 64-bit hash value of a span using a seed
- * @sqlfn hash_extended()
+ * @sqlfn hashExtended()
  */
 Datum
 Span_hash_extended(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/temporal/spanset.c
+++ b/mobilitydb/src/temporal/spanset.c
@@ -1238,7 +1238,7 @@ PG_FUNCTION_INFO_V1(Spanset_hash);
 /**
  * @ingroup mobilitydb_setspan_accessor
  * @brief Return the 32-bit hash value of a span set
- * @sqlfn spanset_hash()
+ * @sqlfn hash()
  */
 Datum
 Spanset_hash(PG_FUNCTION_ARGS)
@@ -1254,7 +1254,7 @@ PG_FUNCTION_INFO_V1(Spanset_hash_extended);
 /**
  * @ingroup mobilitydb_setspan_accessor
  * @brief Return the 64-bit hash value of a span set using a seed
- * @sqlfn spanset_hash_extended()
+ * @sqlfn hashExtended()
  */
 Datum
 Spanset_hash_extended(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/temporal/tbox.c
+++ b/mobilitydb/src/temporal/tbox.c
@@ -1232,7 +1232,7 @@ PG_FUNCTION_INFO_V1(Tbox_hash);
 /**
  * @ingroup mobilitydb_temporal_box_comp
  * @brief Return the hash value of a temporal box
- * @sqlfn tbox_hash()
+ * @sqlfn hash()
  */
 Datum
 Tbox_hash(PG_FUNCTION_ARGS)
@@ -1246,7 +1246,7 @@ PG_FUNCTION_INFO_V1(Tbox_hash_extended);
 /**
  * @ingroup mobilitydb_temporal_box_comp
  * @brief Return the hash value of a temporal box
- * @sqlfn tbox_hash_extended()
+ * @sqlfn hashExtended()
  */
 Datum
 Tbox_hash_extended(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/temporal/temporal.c
+++ b/mobilitydb/src/temporal/temporal.c
@@ -3039,7 +3039,7 @@ PG_FUNCTION_INFO_V1(Temporal_hash);
 /**
  * @ingroup mobilitydb_temporal_accessor
  * @brief Return the hash value of a temporal value
- * @sqlfn temporal_hash()
+ * @sqlfn hash()
  */
 Datum
 Temporal_hash(PG_FUNCTION_ARGS)
@@ -3055,7 +3055,7 @@ PG_FUNCTION_INFO_V1(Temporal_hash_extended);
 /**
  * @ingroup mobilitydb_temporal_accessor
  * @brief Return the 64-bit hash value of a temporal value using a seed
- * @sqlfn temporal_hash_extended()
+ * @sqlfn hashExtended()
  */
 Datum
 Temporal_hash_extended(PG_FUNCTION_ARGS)

--- a/mobilitydb/test/cbuffer/expected/201_cbufferset_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/201_cbufferset_tbl.test.out
@@ -139,13 +139,13 @@ SELECT COUNT(*) FROM tbl_cbufferset t1, tbl_cbufferset t2 WHERE t1.s >= t2.s;
   4950
 (1 row)
 
-SELECT MAX(set_hash(s)) FROM tbl_cbufferset;
+SELECT MAX(hash(s)) FROM tbl_cbufferset;
     max     
 ------------
  2092598553
 (1 row)
 
-SELECT MAX(set_hash_extended(s, 1)) FROM tbl_cbufferset;
+SELECT MAX(hashExtended(s, 1)) FROM tbl_cbufferset;
          max         
 ---------------------
  8663420753996198537

--- a/mobilitydb/test/cbuffer/queries/201_cbufferset_tbl.test.sql
+++ b/mobilitydb/test/cbuffer/queries/201_cbufferset_tbl.test.sql
@@ -95,9 +95,9 @@ SELECT COUNT(*) FROM tbl_cbufferset t1, tbl_cbufferset t2 WHERE t1.s <= t2.s;
 SELECT COUNT(*) FROM tbl_cbufferset t1, tbl_cbufferset t2 WHERE t1.s > t2.s;
 SELECT COUNT(*) FROM tbl_cbufferset t1, tbl_cbufferset t2 WHERE t1.s >= t2.s;
 
-SELECT MAX(set_hash(s)) FROM tbl_cbufferset;
+SELECT MAX(hash(s)) FROM tbl_cbufferset;
 
-SELECT MAX(set_hash_extended(s, 1)) FROM tbl_cbufferset;
+SELECT MAX(hashExtended(s, 1)) FROM tbl_cbufferset;
 
 -------------------------------------------------------------------------------
 -- Aggregation functions

--- a/mobilitydb/test/geo/expected/050_set_tbl.test.out
+++ b/mobilitydb/test/geo/expected/050_set_tbl.test.out
@@ -333,13 +333,13 @@ SELECT COUNT(*) FROM tbl_geogset t1, tbl_geogset t2 WHERE t1.g >= t2.g;
   4950
 (1 row)
 
-SELECT MAX(set_hash(g)) FROM tbl_geomset;
+SELECT MAX(hash(g)) FROM tbl_geomset;
     max     
 ------------
  2098051068
 (1 row)
 
-SELECT MAX(set_hash(g)) FROM tbl_geogset;
+SELECT MAX(hash(g)) FROM tbl_geogset;
     max     
 ------------
  2135464549

--- a/mobilitydb/test/geo/expected/051_stbox.test.out
+++ b/mobilitydb/test/geo/expected/051_stbox.test.out
@@ -1933,50 +1933,50 @@ SELECT COUNT(*) FROM tbl_stbox t1, tbl_stbox t2 WHERE t1.b >= t2.b;
   5050
 (1 row)
 
-SELECT stbox_hash(stbox 'SRID=5676;STBOX X((1,1),(2,2))');
- stbox_hash 
-------------
-  831058784
+SELECT hash(stbox 'SRID=5676;STBOX X((1,1),(2,2))');
+   hash    
+-----------
+ 831058784
 (1 row)
 
-SELECT stbox_hash_extended(stbox 'SRID=5676;STBOX X((1,1),(2,2))', 1);
- stbox_hash_extended  
+SELECT hashExtended(stbox 'SRID=5676;STBOX X((1,1),(2,2))', 1);
+     hashextended     
 ----------------------
  -8881480602313019783
 (1 row)
 
-SELECT stbox_hash(stbox 'STBOX T([2001-01-03,2001-01-03])');
- stbox_hash  
+SELECT hash(stbox 'STBOX T([2001-01-03,2001-01-03])');
+    hash     
 -------------
  -1269428925
 (1 row)
 
-SELECT stbox_hash_extended(stbox 'STBOX T([2001-01-03,2001-01-03])', 1);
- stbox_hash_extended  
+SELECT hashExtended(stbox 'STBOX T([2001-01-03,2001-01-03])', 1);
+     hashextended     
 ----------------------
  -6599699962919275454
 (1 row)
 
-SELECT stbox_hash(stbox 'STBOX XT(((1,2),(1,2)),[2001-01-03,2001-01-03])');
- stbox_hash 
-------------
-  -14833343
+SELECT hash(stbox 'STBOX XT(((1,2),(1,2)),[2001-01-03,2001-01-03])');
+   hash    
+-----------
+ -14833343
 (1 row)
 
-SELECT stbox_hash_extended(stbox 'STBOX XT(((1,2),(1,2)),[2001-01-03,2001-01-03])', 1);
- stbox_hash_extended 
----------------------
-  -16171094012104722
+SELECT hashExtended(stbox 'STBOX XT(((1,2),(1,2)),[2001-01-03,2001-01-03])', 1);
+    hashextended    
+--------------------
+ -16171094012104722
 (1 row)
 
-SELECT stbox_hash(stbox 'STBOX ZT(((1,2,3),(1,2,3)),[2001-01-04,2001-01-04])');
- stbox_hash  
+SELECT hash(stbox 'STBOX ZT(((1,2,3),(1,2,3)),[2001-01-04,2001-01-04])');
+    hash     
 -------------
  -1924364340
 (1 row)
 
-SELECT stbox_hash_extended(stbox 'STBOX ZT(((1,2,3),(1,2,3)),[2001-01-04,2001-01-04])', 1);
- stbox_hash_extended 
+SELECT hashExtended(stbox 'STBOX ZT(((1,2,3),(1,2,3)),[2001-01-04,2001-01-04])', 1);
+    hashextended     
 ---------------------
  4942726506971401033
 (1 row)

--- a/mobilitydb/test/geo/expected/052_tgeo.test.out
+++ b/mobilitydb/test/geo/expected/052_tgeo.test.out
@@ -5748,51 +5748,51 @@ SELECT 1 WHERE tgeography '{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-0
         1
 (1 row)
 
-SELECT temporal_hash(tgeometry 'Point(1 1)@2000-01-01');
- temporal_hash 
----------------
-    -662351635
+SELECT hash(tgeometry 'Point(1 1)@2000-01-01');
+    hash    
+------------
+ -662351635
 (1 row)
 
-SELECT temporal_hash(tgeometry '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03}');
- temporal_hash 
----------------
-     952722557
+SELECT hash(tgeometry '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03}');
+   hash    
+-----------
+ 952722557
 (1 row)
 
-SELECT temporal_hash(tgeometry '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03]');
- temporal_hash 
----------------
-     952722557
+SELECT hash(tgeometry '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03]');
+   hash    
+-----------
+ 952722557
 (1 row)
 
-SELECT temporal_hash(tgeometry '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03],[Point(3 3)@2000-01-04, Point(3 3)@2000-01-05]}');
- temporal_hash 
----------------
-    1578504766
+SELECT hash(tgeometry '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03],[Point(3 3)@2000-01-04, Point(3 3)@2000-01-05]}');
+    hash    
+------------
+ 1578504766
 (1 row)
 
-SELECT temporal_hash(tgeography 'Point(1.5 1.5)@2000-01-01');
- temporal_hash 
----------------
-    -106066283
+SELECT hash(tgeography 'Point(1.5 1.5)@2000-01-01');
+    hash    
+------------
+ -106066283
 (1 row)
 
-SELECT temporal_hash(tgeography '{Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03}');
- temporal_hash 
----------------
-    1270938069
+SELECT hash(tgeography '{Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03}');
+    hash    
+------------
+ 1270938069
 (1 row)
 
-SELECT temporal_hash(tgeography '[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03]');
- temporal_hash 
----------------
-    1270938069
+SELECT hash(tgeography '[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03]');
+    hash    
+------------
+ 1270938069
 (1 row)
 
-SELECT temporal_hash(tgeography '{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03],[Point(3.5 3.5)@2000-01-04, Point(3.5 3.5)@2000-01-05]}');
- temporal_hash 
----------------
-     263421688
+SELECT hash(tgeography '{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03],[Point(3.5 3.5)@2000-01-04, Point(3.5 3.5)@2000-01-05]}');
+   hash    
+-----------
+ 263421688
 (1 row)
 

--- a/mobilitydb/test/geo/expected/052_tpoint.test.out
+++ b/mobilitydb/test/geo/expected/052_tpoint.test.out
@@ -5857,51 +5857,51 @@ SELECT 1 WHERE tgeogpoint '{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-0
         1
 (1 row)
 
-SELECT temporal_hash(tgeompoint 'Point(1 1)@2000-01-01');
- temporal_hash 
----------------
-    -662351635
+SELECT hash(tgeompoint 'Point(1 1)@2000-01-01');
+    hash    
+------------
+ -662351635
 (1 row)
 
-SELECT temporal_hash(tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03}');
- temporal_hash 
----------------
-     952722557
+SELECT hash(tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03}');
+   hash    
+-----------
+ 952722557
 (1 row)
 
-SELECT temporal_hash(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03]');
- temporal_hash 
----------------
-     952722557
+SELECT hash(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03]');
+   hash    
+-----------
+ 952722557
 (1 row)
 
-SELECT temporal_hash(tgeompoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03],[Point(3 3)@2000-01-04, Point(3 3)@2000-01-05]}');
- temporal_hash 
----------------
-    1578504766
+SELECT hash(tgeompoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03],[Point(3 3)@2000-01-04, Point(3 3)@2000-01-05]}');
+    hash    
+------------
+ 1578504766
 (1 row)
 
-SELECT temporal_hash(tgeogpoint 'Point(1.5 1.5)@2000-01-01');
- temporal_hash 
----------------
-    -106066283
+SELECT hash(tgeogpoint 'Point(1.5 1.5)@2000-01-01');
+    hash    
+------------
+ -106066283
 (1 row)
 
-SELECT temporal_hash(tgeogpoint '{Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03}');
- temporal_hash 
----------------
-    1270938069
+SELECT hash(tgeogpoint '{Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03}');
+    hash    
+------------
+ 1270938069
 (1 row)
 
-SELECT temporal_hash(tgeogpoint '[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03]');
- temporal_hash 
----------------
-    1270938069
+SELECT hash(tgeogpoint '[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03]');
+    hash    
+------------
+ 1270938069
 (1 row)
 
-SELECT temporal_hash(tgeogpoint '{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03],[Point(3.5 3.5)@2000-01-04, Point(3.5 3.5)@2000-01-05]}');
- temporal_hash 
----------------
-     263421688
+SELECT hash(tgeogpoint '{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03],[Point(3.5 3.5)@2000-01-04, Point(3.5 3.5)@2000-01-05]}');
+   hash    
+-----------
+ 263421688
 (1 row)
 

--- a/mobilitydb/test/geo/queries/050_set_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/050_set_tbl.test.sql
@@ -146,12 +146,12 @@ SELECT COUNT(*) FROM tbl_geogset t1, tbl_geogset t2 WHERE t1.g <= t2.g;
 SELECT COUNT(*) FROM tbl_geogset t1, tbl_geogset t2 WHERE t1.g > t2.g;
 SELECT COUNT(*) FROM tbl_geogset t1, tbl_geogset t2 WHERE t1.g >= t2.g;
 
-SELECT MAX(set_hash(g)) FROM tbl_geomset;
-SELECT MAX(set_hash(g)) FROM tbl_geogset;
+SELECT MAX(hash(g)) FROM tbl_geomset;
+SELECT MAX(hash(g)) FROM tbl_geogset;
 
 -- PostGIS currently does not provide an extended hash function
--- SELECT MAX(set_hash_extended(g, 1)) FROM tbl_geomset;
--- SELECT MAX(set_hash_extended(g, 1)) FROM tbl_geogset;
+-- SELECT MAX(hashExtended(g, 1)) FROM tbl_geomset;
+-- SELECT MAX(hashExtended(g, 1)) FROM tbl_geogset;
 
 -------------------------------------------------------------------------------
 -- Aggregation functions

--- a/mobilitydb/test/geo/queries/051_stbox.test.sql
+++ b/mobilitydb/test/geo/queries/051_stbox.test.sql
@@ -561,17 +561,17 @@ SELECT COUNT(*) FROM tbl_stbox t1, tbl_stbox t2 WHERE t1.b >= t2.b;
 
 -------------------------------------------------------------------------------
 
-SELECT stbox_hash(stbox 'SRID=5676;STBOX X((1,1),(2,2))');
-SELECT stbox_hash_extended(stbox 'SRID=5676;STBOX X((1,1),(2,2))', 1);
+SELECT hash(stbox 'SRID=5676;STBOX X((1,1),(2,2))');
+SELECT hashExtended(stbox 'SRID=5676;STBOX X((1,1),(2,2))', 1);
 
-SELECT stbox_hash(stbox 'STBOX T([2001-01-03,2001-01-03])');
-SELECT stbox_hash_extended(stbox 'STBOX T([2001-01-03,2001-01-03])', 1);
+SELECT hash(stbox 'STBOX T([2001-01-03,2001-01-03])');
+SELECT hashExtended(stbox 'STBOX T([2001-01-03,2001-01-03])', 1);
 
-SELECT stbox_hash(stbox 'STBOX XT(((1,2),(1,2)),[2001-01-03,2001-01-03])');
-SELECT stbox_hash_extended(stbox 'STBOX XT(((1,2),(1,2)),[2001-01-03,2001-01-03])', 1);
+SELECT hash(stbox 'STBOX XT(((1,2),(1,2)),[2001-01-03,2001-01-03])');
+SELECT hashExtended(stbox 'STBOX XT(((1,2),(1,2)),[2001-01-03,2001-01-03])', 1);
 
-SELECT stbox_hash(stbox 'STBOX ZT(((1,2,3),(1,2,3)),[2001-01-04,2001-01-04])');
-SELECT stbox_hash_extended(stbox 'STBOX ZT(((1,2,3),(1,2,3)),[2001-01-04,2001-01-04])', 1);
+SELECT hash(stbox 'STBOX ZT(((1,2,3),(1,2,3)),[2001-01-04,2001-01-04])');
+SELECT hashExtended(stbox 'STBOX ZT(((1,2,3),(1,2,3)),[2001-01-04,2001-01-04])', 1);
 
 -------------------------------------------------------------------------------
 -- Regression: stbox_level_cmp must not call the time comparators when the

--- a/mobilitydb/test/geo/queries/052_tgeo.test.sql
+++ b/mobilitydb/test/geo/queries/052_tgeo.test.sql
@@ -1501,13 +1501,13 @@ SELECT 1 WHERE tgeography '{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-0
 
 -------------------------------------------------------------------------------
 
-SELECT temporal_hash(tgeometry 'Point(1 1)@2000-01-01');
-SELECT temporal_hash(tgeometry '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03}');
-SELECT temporal_hash(tgeometry '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03]');
-SELECT temporal_hash(tgeometry '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03],[Point(3 3)@2000-01-04, Point(3 3)@2000-01-05]}');
-SELECT temporal_hash(tgeography 'Point(1.5 1.5)@2000-01-01');
-SELECT temporal_hash(tgeography '{Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03}');
-SELECT temporal_hash(tgeography '[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03]');
-SELECT temporal_hash(tgeography '{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03],[Point(3.5 3.5)@2000-01-04, Point(3.5 3.5)@2000-01-05]}');
+SELECT hash(tgeometry 'Point(1 1)@2000-01-01');
+SELECT hash(tgeometry '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03}');
+SELECT hash(tgeometry '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03]');
+SELECT hash(tgeometry '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03],[Point(3 3)@2000-01-04, Point(3 3)@2000-01-05]}');
+SELECT hash(tgeography 'Point(1.5 1.5)@2000-01-01');
+SELECT hash(tgeography '{Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03}');
+SELECT hash(tgeography '[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03]');
+SELECT hash(tgeography '{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03],[Point(3.5 3.5)@2000-01-04, Point(3.5 3.5)@2000-01-05]}');
 
 ------------------------------------------------------------------------------

--- a/mobilitydb/test/geo/queries/052_tpoint.test.sql
+++ b/mobilitydb/test/geo/queries/052_tpoint.test.sql
@@ -1531,13 +1531,13 @@ SELECT 1 WHERE tgeogpoint '{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-0
 
 -------------------------------------------------------------------------------
 
-SELECT temporal_hash(tgeompoint 'Point(1 1)@2000-01-01');
-SELECT temporal_hash(tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03}');
-SELECT temporal_hash(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03]');
-SELECT temporal_hash(tgeompoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03],[Point(3 3)@2000-01-04, Point(3 3)@2000-01-05]}');
-SELECT temporal_hash(tgeogpoint 'Point(1.5 1.5)@2000-01-01');
-SELECT temporal_hash(tgeogpoint '{Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03}');
-SELECT temporal_hash(tgeogpoint '[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03]');
-SELECT temporal_hash(tgeogpoint '{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03],[Point(3.5 3.5)@2000-01-04, Point(3.5 3.5)@2000-01-05]}');
+SELECT hash(tgeompoint 'Point(1 1)@2000-01-01');
+SELECT hash(tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03}');
+SELECT hash(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03]');
+SELECT hash(tgeompoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03],[Point(3 3)@2000-01-04, Point(3 3)@2000-01-05]}');
+SELECT hash(tgeogpoint 'Point(1.5 1.5)@2000-01-01');
+SELECT hash(tgeogpoint '{Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03}');
+SELECT hash(tgeogpoint '[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03]');
+SELECT hash(tgeogpoint '{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03],[Point(3.5 3.5)@2000-01-04, Point(3.5 3.5)@2000-01-05]}');
 
 ------------------------------------------------------------------------------

--- a/mobilitydb/test/json/expected/450_jsonbset_tbl.test.out
+++ b/mobilitydb/test/json/expected/450_jsonbset_tbl.test.out
@@ -217,13 +217,13 @@ SELECT COUNT(*) FROM tbl_jsonbset t1, tbl_jsonbset t2 WHERE t1.s >= t2.s;
   9244
 (1 row)
 
-SELECT MAX(set_hash(s)) FROM tbl_jsonbset;
+SELECT MAX(hash(s)) FROM tbl_jsonbset;
     max     
 ------------
  2107504745
 (1 row)
 
-SELECT MAX(set_hash_extended(s, 1)) FROM tbl_jsonbset;
+SELECT MAX(hashExtended(s, 1)) FROM tbl_jsonbset;
          max         
 ---------------------
  9209195217540800445

--- a/mobilitydb/test/json/queries/450_jsonbset_tbl.test.sql
+++ b/mobilitydb/test/json/queries/450_jsonbset_tbl.test.sql
@@ -111,9 +111,9 @@ SELECT COUNT(*) FROM tbl_jsonbset t1, tbl_jsonbset t2 WHERE t1.s <= t2.s;
 SELECT COUNT(*) FROM tbl_jsonbset t1, tbl_jsonbset t2 WHERE t1.s > t2.s;
 SELECT COUNT(*) FROM tbl_jsonbset t1, tbl_jsonbset t2 WHERE t1.s >= t2.s;
 
-SELECT MAX(set_hash(s)) FROM tbl_jsonbset;
+SELECT MAX(hash(s)) FROM tbl_jsonbset;
 
-SELECT MAX(set_hash_extended(s, 1)) FROM tbl_jsonbset;
+SELECT MAX(hashExtended(s, 1)) FROM tbl_jsonbset;
 
 -------------------------------------------------------------------------------
 -- Aggregation functions

--- a/mobilitydb/test/npoint/expected/301_npointset_tbl.test.out
+++ b/mobilitydb/test/npoint/expected/301_npointset_tbl.test.out
@@ -169,13 +169,13 @@ SELECT COUNT(*) FROM tbl_npointset t1, tbl_npointset t2 WHERE t1.n >= t2.n;
   4950
 (1 row)
 
-SELECT MAX(set_hash(n)) FROM tbl_npointset;
+SELECT MAX(hash(n)) FROM tbl_npointset;
     max     
 ------------
  2135309225
 (1 row)
 
-SELECT MAX(set_hash_extended(n, 1)) FROM tbl_npointset;
+SELECT MAX(hashExtended(n, 1)) FROM tbl_npointset;
          max         
 ---------------------
  9200703917019737513

--- a/mobilitydb/test/npoint/expected/302_tnpoint_tbl.test.out
+++ b/mobilitydb/test/npoint/expected/302_tnpoint_tbl.test.out
@@ -591,7 +591,7 @@ WHERE t1.temp >= t2.temp;
   5050
 (1 row)
 
-SELECT MAX(temporal_hash(temp)) FROM tbl_tnpoint;
+SELECT MAX(hash(temp)) FROM tbl_tnpoint;
     max     
 ------------
  2137747695

--- a/mobilitydb/test/npoint/queries/301_npointset_tbl.test.sql
+++ b/mobilitydb/test/npoint/queries/301_npointset_tbl.test.sql
@@ -102,9 +102,9 @@ SELECT COUNT(*) FROM tbl_npointset t1, tbl_npointset t2 WHERE t1.n <= t2.n;
 SELECT COUNT(*) FROM tbl_npointset t1, tbl_npointset t2 WHERE t1.n > t2.n;
 SELECT COUNT(*) FROM tbl_npointset t1, tbl_npointset t2 WHERE t1.n >= t2.n;
 
-SELECT MAX(set_hash(n)) FROM tbl_npointset;
+SELECT MAX(hash(n)) FROM tbl_npointset;
 
-SELECT MAX(set_hash_extended(n, 1)) FROM tbl_npointset;
+SELECT MAX(hashExtended(n, 1)) FROM tbl_npointset;
 
 -------------------------------------------------------------------------------
 -- Aggregation functions

--- a/mobilitydb/test/npoint/queries/302_tnpoint_tbl.test.sql
+++ b/mobilitydb/test/npoint/queries/302_tnpoint_tbl.test.sql
@@ -288,7 +288,7 @@ WHERE t1.temp >= t2.temp;
 -------------------------------------------------------------------------------
 
 -- This test currently shows different result on github
-SELECT MAX(temporal_hash(temp)) FROM tbl_tnpoint;
+SELECT MAX(hash(temp)) FROM tbl_tnpoint;
 
 -------------------------------------------------------------------------------
 -- Test index support function for ever/always equal and intersects<Time>

--- a/mobilitydb/test/pose/expected/100_pose.test.out
+++ b/mobilitydb/test/pose/expected/100_pose.test.out
@@ -382,8 +382,8 @@ SELECT poseFromBinary(asBinary(pose 'Pose(Point(0 0 0), -0.5, -0.5, -0.5, -0.5)'
  t
 (1 row)
 
-SELECT pose_hash(pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)')
-     = pose_hash(pose 'Pose(Point(0 0 0), -0.5, -0.5, -0.5, -0.5)') AS hash_canonical;
+SELECT hash(pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)')
+     = hash(pose 'Pose(Point(0 0 0), -0.5, -0.5, -0.5, -0.5)') AS hash_canonical;
  hash_canonical 
 ----------------
  t

--- a/mobilitydb/test/pose/expected/101_poseset_tbl.test.out
+++ b/mobilitydb/test/pose/expected/101_poseset_tbl.test.out
@@ -139,7 +139,7 @@ SELECT COUNT(*) FROM tbl_poseset2d t1, tbl_poseset2d t2 WHERE t1.s >= t2.s;
   4950
 (1 row)
 
-SELECT MAX(set_hash(s)) FROM tbl_poseset2d;
+SELECT MAX(hash(s)) FROM tbl_poseset2d;
     max     
 ------------
  2141422679

--- a/mobilitydb/test/pose/queries/100_pose.test.sql
+++ b/mobilitydb/test/pose/queries/100_pose.test.sql
@@ -187,8 +187,8 @@ SELECT pose(0::float, 0::float, 0::float, 0.5::float, 0.5::float, 0.5::float, 0.
      = pose(0::float, 0::float, 0::float, -0.5::float, -0.5::float, -0.5::float, -0.5::float, 0) AS ctor_canonical;
 SELECT poseFromBinary(asBinary(pose 'Pose(Point(0 0 0), -0.5, -0.5, -0.5, -0.5)'))
      = pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)' AS wkb_canonical;
-SELECT pose_hash(pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)')
-     = pose_hash(pose 'Pose(Point(0 0 0), -0.5, -0.5, -0.5, -0.5)') AS hash_canonical;
+SELECT hash(pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)')
+     = hash(pose 'Pose(Point(0 0 0), -0.5, -0.5, -0.5, -0.5)') AS hash_canonical;
 SELECT pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)' ~= pose 'Pose(Point(0 0 0), -0.5, -0.5, -0.5, -0.5)' AS approx_canonical;
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/pose/queries/101_poseset_tbl.test.sql
+++ b/mobilitydb/test/pose/queries/101_poseset_tbl.test.sql
@@ -95,7 +95,7 @@ SELECT COUNT(*) FROM tbl_poseset2d t1, tbl_poseset2d t2 WHERE t1.s <= t2.s;
 SELECT COUNT(*) FROM tbl_poseset2d t1, tbl_poseset2d t2 WHERE t1.s > t2.s;
 SELECT COUNT(*) FROM tbl_poseset2d t1, tbl_poseset2d t2 WHERE t1.s >= t2.s;
 
-SELECT MAX(set_hash(s)) FROM tbl_poseset2d;
+SELECT MAX(hash(s)) FROM tbl_poseset2d;
 
 -------------------------------------------------------------------------------
 -- Aggregation functions

--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -401,13 +401,13 @@ FROM tiles;
      3 |              2 | t
 (1 row)
 
-SELECT raquet_hash(raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint,
+SELECT hash(raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint,
          'UINT8')) =
-       raquet_hash(raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint,
+       hash(raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint,
          'UINT8')) AS equal_tiles_hash_equally,
-       raquet_hash_extended(raquet('\x0102'::bytea, 2, 1,
+       hashExtended(raquet('\x0102'::bytea, 2, 1,
          5193776270265024512::bigint, 'UINT8'), 0) <>
-       raquet_hash_extended(raquet('\x0102'::bytea, 2, 1,
+       hashExtended(raquet('\x0102'::bytea, 2, 1,
          5193776270265024512::bigint, 'UINT8'), 1) AS seed_changes_hash;
  equal_tiles_hash_equally | seed_changes_hash 
 --------------------------+-------------------

--- a/mobilitydb/test/raster/expected/500_raster_tbl.test.out
+++ b/mobilitydb/test/raster/expected/500_raster_tbl.test.out
@@ -101,7 +101,7 @@ WHERE (cmp(t1.tile, t2.tile) = 0) <> (t1.tile = t2.tile);
 (1 row)
 
 SELECT COUNT(*) FROM tbl_raquet t1, tbl_raquet t2
-WHERE t1.tile = t2.tile AND raquet_hash(t1.tile) <> raquet_hash(t2.tile);
+WHERE t1.tile = t2.tile AND hash(t1.tile) <> hash(t2.tile);
  count 
 -------
      0
@@ -109,7 +109,7 @@ WHERE t1.tile = t2.tile AND raquet_hash(t1.tile) <> raquet_hash(t2.tile);
 
 SELECT COUNT(*) FROM tbl_raquet t1, tbl_raquet t2
 WHERE t1.tile = t2.tile
-  AND raquet_hash_extended(t1.tile, 1) <> raquet_hash_extended(t2.tile, 1);
+  AND hashExtended(t1.tile, 1) <> hashExtended(t2.tile, 1);
  count 
 -------
      0

--- a/mobilitydb/test/raster/queries/500_raster.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster.test.sql
@@ -446,13 +446,13 @@ SELECT count(*) AS total, count(DISTINCT tile) AS distinct_tiles,
 FROM tiles;
 
 -- Equal tiles hash equally, and the seeded hash varies with the seed.
-SELECT raquet_hash(raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint,
+SELECT hash(raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint,
          'UINT8')) =
-       raquet_hash(raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint,
+       hash(raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint,
          'UINT8')) AS equal_tiles_hash_equally,
-       raquet_hash_extended(raquet('\x0102'::bytea, 2, 1,
+       hashExtended(raquet('\x0102'::bytea, 2, 1,
          5193776270265024512::bigint, 'UINT8'), 0) <>
-       raquet_hash_extended(raquet('\x0102'::bytea, 2, 1,
+       hashExtended(raquet('\x0102'::bytea, 2, 1,
          5193776270265024512::bigint, 'UINT8'), 1) AS seed_changes_hash;
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/raster/queries/500_raster_tbl.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster_tbl.test.sql
@@ -78,10 +78,10 @@ WHERE (cmp(t1.tile, t2.tile) = 0) <> (t1.tile = t2.tile);
 
 -- Equal tiles hash equally, which is what the hash operator class requires
 SELECT COUNT(*) FROM tbl_raquet t1, tbl_raquet t2
-WHERE t1.tile = t2.tile AND raquet_hash(t1.tile) <> raquet_hash(t2.tile);
+WHERE t1.tile = t2.tile AND hash(t1.tile) <> hash(t2.tile);
 SELECT COUNT(*) FROM tbl_raquet t1, tbl_raquet t2
 WHERE t1.tile = t2.tile
-  AND raquet_hash_extended(t1.tile, 1) <> raquet_hash_extended(t2.tile, 1);
+  AND hashExtended(t1.tile, 1) <> hashExtended(t2.tile, 1);
 
 -------------------------------------------------------------------------------
 -- Tile footprint

--- a/mobilitydb/test/temporal/expected/001_set.test.out
+++ b/mobilitydb/test/temporal/expected/001_set.test.out
@@ -494,49 +494,49 @@ SELECT tstzset '{2000-01-01}' >= tstzset '{2000-01-01, 2000-01-02, 2000-01-03}';
  f
 (1 row)
 
-SELECT set_hash(dateset '{2000-01-01,2000-01-02}') = set_hash(dateset '{2000-01-01,2000-01-02}');
+SELECT hash(dateset '{2000-01-01,2000-01-02}') = hash(dateset '{2000-01-01,2000-01-02}');
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT set_hash(dateset '{2000-01-01,2000-01-02}') <> set_hash(dateset '{2000-01-01,2000-01-02}');
+SELECT hash(dateset '{2000-01-01,2000-01-02}') <> hash(dateset '{2000-01-01,2000-01-02}');
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT set_hash(tstzset '{2000-01-01,2000-01-02}') = set_hash(tstzset '{2000-01-01,2000-01-02}');
+SELECT hash(tstzset '{2000-01-01,2000-01-02}') = hash(tstzset '{2000-01-01,2000-01-02}');
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT set_hash(tstzset '{2000-01-01,2000-01-02}') <> set_hash(tstzset '{2000-01-01,2000-01-02}');
+SELECT hash(tstzset '{2000-01-01,2000-01-02}') <> hash(tstzset '{2000-01-01,2000-01-02}');
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT set_hash_extended(dateset '{2000-01-01,2000-01-02}', 1) = set_hash_extended(dateset '{2000-01-01,2000-01-02}', 1);
+SELECT hashExtended(dateset '{2000-01-01,2000-01-02}', 1) = hashExtended(dateset '{2000-01-01,2000-01-02}', 1);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT set_hash_extended(dateset '{2000-01-01,2000-01-02}', 1) <> set_hash_extended(dateset '{2000-01-01,2000-01-02}', 1);
+SELECT hashExtended(dateset '{2000-01-01,2000-01-02}', 1) <> hashExtended(dateset '{2000-01-01,2000-01-02}', 1);
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT set_hash_extended(tstzset '{2000-01-01,2000-01-02}', 1) = set_hash_extended(tstzset '{2000-01-01,2000-01-02}', 1);
+SELECT hashExtended(tstzset '{2000-01-01,2000-01-02}', 1) = hashExtended(tstzset '{2000-01-01,2000-01-02}', 1);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT set_hash_extended(tstzset '{2000-01-01,2000-01-02}', 1) <> set_hash_extended(tstzset '{2000-01-01,2000-01-02}', 1);
+SELECT hashExtended(tstzset '{2000-01-01,2000-01-02}', 1) <> hashExtended(tstzset '{2000-01-01,2000-01-02}', 1);
  ?column? 
 ----------
  f

--- a/mobilitydb/test/temporal/expected/001_set_tbl.test.out
+++ b/mobilitydb/test/temporal/expected/001_set_tbl.test.out
@@ -496,73 +496,73 @@ SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE t1.t >= t2.t;
   4950
 (1 row)
 
-SELECT MAX(set_hash(i)) FROM tbl_intset;
+SELECT MAX(hash(i)) FROM tbl_intset;
     max     
 ------------
  2141239878
 (1 row)
 
-SELECT MAX(set_hash(b)) FROM tbl_bigintset;
+SELECT MAX(hash(b)) FROM tbl_bigintset;
     max     
 ------------
  2140877551
 (1 row)
 
-SELECT MAX(set_hash(f)) FROM tbl_floatset;
+SELECT MAX(hash(f)) FROM tbl_floatset;
     max     
 ------------
  2055509444
 (1 row)
 
-SELECT MAX(set_hash(t)) FROM tbl_textset;
+SELECT MAX(hash(t)) FROM tbl_textset;
     max     
 ------------
  2103330560
 (1 row)
 
-SELECT MAX(set_hash(d)) FROM tbl_dateset;
+SELECT MAX(hash(d)) FROM tbl_dateset;
     max     
 ------------
  2110432128
 (1 row)
 
-SELECT MAX(set_hash(t)) FROM tbl_tstzset;
+SELECT MAX(hash(t)) FROM tbl_tstzset;
     max     
 ------------
  2092387697
 (1 row)
 
-SELECT MAX(set_hash_extended(i, 1)) FROM tbl_intset;
+SELECT MAX(hashExtended(i, 1)) FROM tbl_intset;
          max         
 ---------------------
  9215683723210280632
 (1 row)
 
-SELECT MAX(set_hash_extended(b, 1)) FROM tbl_bigintset;
+SELECT MAX(hashExtended(b, 1)) FROM tbl_bigintset;
          max         
 ---------------------
  9180839711525586122
 (1 row)
 
-SELECT MAX(set_hash_extended(f, 1)) FROM tbl_floatset;
+SELECT MAX(hashExtended(f, 1)) FROM tbl_floatset;
          max         
 ---------------------
  9095733649313892665
 (1 row)
 
-SELECT MAX(set_hash_extended(t, 1)) FROM tbl_textset;
+SELECT MAX(hashExtended(t, 1)) FROM tbl_textset;
          max         
 ---------------------
  9062921563989445173
 (1 row)
 
-SELECT MAX(set_hash_extended(d, 1)) FROM tbl_dateset;
+SELECT MAX(hashExtended(d, 1)) FROM tbl_dateset;
          max         
 ---------------------
  7923652065342676515
 (1 row)
 
-SELECT MAX(set_hash_extended(t, 1)) FROM tbl_tstzset;
+SELECT MAX(hashExtended(t, 1)) FROM tbl_tstzset;
          max         
 ---------------------
  9173177012091756054

--- a/mobilitydb/test/temporal/expected/003_span.test.out
+++ b/mobilitydb/test/temporal/expected/003_span.test.out
@@ -412,25 +412,25 @@ SELECT tstzspan '[2000-01-01,2000-01-01]' = tstzspan '(2000-01-01,2000-01-02)';
  f
 (1 row)
 
-SELECT span_hash(tstzspan '[2000-01-01,2000-01-02]') = span_hash(tstzspan '[2000-01-01,2000-01-02]');
+SELECT hash(tstzspan '[2000-01-01,2000-01-02]') = hash(tstzspan '[2000-01-01,2000-01-02]');
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT span_hash(tstzspan '[2000-01-01,2000-01-02]') <> span_hash(tstzspan '[2000-01-02,2000-01-02]');
+SELECT hash(tstzspan '[2000-01-01,2000-01-02]') <> hash(tstzspan '[2000-01-02,2000-01-02]');
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT span_hash_extended(tstzspan '[2000-01-01,2000-01-02]', 1) = span_hash_extended(tstzspan '[2000-01-01,2000-01-02]', 1);
+SELECT hashExtended(tstzspan '[2000-01-01,2000-01-02]', 1) = hashExtended(tstzspan '[2000-01-01,2000-01-02]', 1);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT span_hash_extended(tstzspan '[2000-01-01,2000-01-02]', 1) <> span_hash_extended(tstzspan '[2000-01-02,2000-01-02]', 1);
+SELECT hashExtended(tstzspan '[2000-01-01,2000-01-02]', 1) <> hashExtended(tstzspan '[2000-01-02,2000-01-02]', 1);
  ?column? 
 ----------
  t

--- a/mobilitydb/test/temporal/expected/003_span_tbl.test.out
+++ b/mobilitydb/test/temporal/expected/003_span_tbl.test.out
@@ -535,13 +535,13 @@ SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE t1.t >= t2.t;
   4950
 (1 row)
 
-SELECT MAX(span_hash(t)) != 0 FROM tbl_tstzspan;
+SELECT MAX(hash(t)) != 0 FROM tbl_tstzspan;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT MAX(span_hash_extended(t, 1)) != 0 FROM tbl_tstzspan;
+SELECT MAX(hashExtended(t, 1)) != 0 FROM tbl_tstzspan;
  ?column? 
 ----------
  t

--- a/mobilitydb/test/temporal/expected/007_spanset.test.out
+++ b/mobilitydb/test/temporal/expected/007_spanset.test.out
@@ -1478,97 +1478,97 @@ SELECT tstzspanset '{[2000-01-01,2000-01-01]}' >= tstzspanset '{(2000-01-01,2000
  f
 (1 row)
 
-SELECT spanset_hash(intspanset '{[1,2]}') = spanset_hash(intspanset '{[1,2]}');
+SELECT hash(intspanset '{[1,2]}') = hash(intspanset '{[1,2]}');
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT spanset_hash(intspanset '{[1,2]}') <> spanset_hash(intspanset '{[2,2]}');
+SELECT hash(intspanset '{[1,2]}') <> hash(intspanset '{[2,2]}');
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT spanset_hash(floatspanset '{[1.5,2.5]}') = spanset_hash(floatspanset '{[1.5,2.5]}');
+SELECT hash(floatspanset '{[1.5,2.5]}') = hash(floatspanset '{[1.5,2.5]}');
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT spanset_hash(floatspanset '{[1.5,2.5]}') <> spanset_hash(floatspanset '{[2.5,2.5]}');
+SELECT hash(floatspanset '{[1.5,2.5]}') <> hash(floatspanset '{[2.5,2.5]}');
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT spanset_hash(datespanset '{[2000-01-01,2000-01-02]}') = spanset_hash(datespanset '{[2000-01-01,2000-01-02]}');
+SELECT hash(datespanset '{[2000-01-01,2000-01-02]}') = hash(datespanset '{[2000-01-01,2000-01-02]}');
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT spanset_hash(datespanset '{[2000-01-01,2000-01-02]}') <> spanset_hash(datespanset '{[2000-01-02,2000-01-02]}');
+SELECT hash(datespanset '{[2000-01-01,2000-01-02]}') <> hash(datespanset '{[2000-01-02,2000-01-02]}');
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT spanset_hash(tstzspanset '{[2000-01-01,2000-01-02]}') = spanset_hash(tstzspanset '{[2000-01-01,2000-01-02]}');
+SELECT hash(tstzspanset '{[2000-01-01,2000-01-02]}') = hash(tstzspanset '{[2000-01-01,2000-01-02]}');
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT spanset_hash(tstzspanset '{[2000-01-01,2000-01-02]}') <> spanset_hash(tstzspanset '{[2000-01-02,2000-01-02]}');
+SELECT hash(tstzspanset '{[2000-01-01,2000-01-02]}') <> hash(tstzspanset '{[2000-01-02,2000-01-02]}');
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT spanset_hash_extended(intspanset '{[1,2]}', 1) = spanset_hash_extended(intspanset '{[1,2]}', 1);
+SELECT hashExtended(intspanset '{[1,2]}', 1) = hashExtended(intspanset '{[1,2]}', 1);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT spanset_hash_extended(intspanset '{[1,2]}', 1) <> spanset_hash_extended(intspanset '{[2,2]}', 1);
+SELECT hashExtended(intspanset '{[1,2]}', 1) <> hashExtended(intspanset '{[2,2]}', 1);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT spanset_hash_extended(floatspanset '{[1,2]}', 1) = spanset_hash_extended(floatspanset '{[1,2]}', 1);
+SELECT hashExtended(floatspanset '{[1,2]}', 1) = hashExtended(floatspanset '{[1,2]}', 1);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT spanset_hash_extended(floatspanset '{[1,2]}', 1) <> spanset_hash_extended(floatspanset '{[2,2]}', 1);
+SELECT hashExtended(floatspanset '{[1,2]}', 1) <> hashExtended(floatspanset '{[2,2]}', 1);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT spanset_hash_extended(datespanset '{[2000-01-01,2000-01-02]}', 1) = spanset_hash_extended(datespanset '{[2000-01-01,2000-01-02]}', 1);
+SELECT hashExtended(datespanset '{[2000-01-01,2000-01-02]}', 1) = hashExtended(datespanset '{[2000-01-01,2000-01-02]}', 1);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT spanset_hash_extended(datespanset '{[2000-01-01,2000-01-02]}', 1) <> spanset_hash_extended(datespanset '{[2000-01-02,2000-01-02]}', 1);
+SELECT hashExtended(datespanset '{[2000-01-01,2000-01-02]}', 1) <> hashExtended(datespanset '{[2000-01-02,2000-01-02]}', 1);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT spanset_hash_extended(tstzspanset '{[2000-01-01,2000-01-02]}', 1) = spanset_hash_extended(tstzspanset '{[2000-01-01,2000-01-02]}', 1);
+SELECT hashExtended(tstzspanset '{[2000-01-01,2000-01-02]}', 1) = hashExtended(tstzspanset '{[2000-01-01,2000-01-02]}', 1);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT spanset_hash_extended(tstzspanset '{[2000-01-01,2000-01-02]}', 1) <> spanset_hash_extended(tstzspanset '{[2000-01-02,2000-01-02]}', 1);
+SELECT hashExtended(tstzspanset '{[2000-01-01,2000-01-02]}', 1) <> hashExtended(tstzspanset '{[2000-01-02,2000-01-02]}', 1);
  ?column? 
 ----------
  t

--- a/mobilitydb/test/temporal/expected/007_spanset_tbl.test.out
+++ b/mobilitydb/test/temporal/expected/007_spanset_tbl.test.out
@@ -775,13 +775,13 @@ SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE t1.t >= t2.t;
   4950
 (1 row)
 
-SELECT MAX(spanset_hash(t)) != 0 FROM tbl_tstzspanset;
+SELECT MAX(hash(t)) != 0 FROM tbl_tstzspanset;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT MAX(spanset_hash_extended(t, 1)) != 0 FROM tbl_tstzspanset;
+SELECT MAX(hashExtended(t, 1)) != 0 FROM tbl_tstzspanset;
  ?column? 
 ----------
  t

--- a/mobilitydb/test/temporal/expected/021_tbox.test.out
+++ b/mobilitydb/test/temporal/expected/021_tbox.test.out
@@ -1439,38 +1439,38 @@ SELECT COUNT(*) FROM tbl_tboxfloat t1, tbl_tboxfloat t2 WHERE t1.b >= t2.b;
   4950
 (1 row)
 
-SELECT tbox_hash(tbox 'TBOXFLOAT X([1.0,1.0])');
- tbox_hash 
+SELECT hash(tbox 'TBOXFLOAT X([1.0,1.0])');
+   hash    
 -----------
  968363612
 (1 row)
 
-SELECT tbox_hash_extended(tbox 'TBOXFLOAT X([1.0,1.0])', 1);
- tbox_hash_extended  
+SELECT hashExtended(tbox 'TBOXFLOAT X([1.0,1.0])', 1);
+    hashextended     
 ---------------------
  4991639173001897668
 (1 row)
 
-SELECT tbox_hash(tbox 'TBOXFLOAT T([2000-01-02,2000-01-02])');
- tbox_hash  
+SELECT hash(tbox 'TBOXFLOAT T([2000-01-02,2000-01-02])');
+    hash    
 ------------
  1472778806
 (1 row)
 
-SELECT tbox_hash_extended(tbox 'TBOXFLOAT T([2000-01-02,2000-01-02])', 1);
- tbox_hash_extended  
+SELECT hashExtended(tbox 'TBOXFLOAT T([2000-01-02,2000-01-02])', 1);
+    hashextended     
 ---------------------
  6393472602966114521
 (1 row)
 
-SELECT tbox_hash(tbox 'TBOXFLOAT XT([1.0,1.0],[2000-01-02,2000-01-02])');
- tbox_hash  
+SELECT hash(tbox 'TBOXFLOAT XT([1.0,1.0],[2000-01-02,2000-01-02])');
+    hash    
 ------------
  1124885432
 (1 row)
 
-SELECT tbox_hash_extended(tbox 'TBOXFLOAT XT([1.0,1.0],[2000-01-02,2000-01-02])', 1);
- tbox_hash_extended  
+SELECT hashExtended(tbox 'TBOXFLOAT XT([1.0,1.0],[2000-01-02,2000-01-02])', 1);
+    hashextended     
 ---------------------
  2841424149611304447
 (1 row)

--- a/mobilitydb/test/temporal/expected/022_temporal.test.out
+++ b/mobilitydb/test/temporal/expected/022_temporal.test.out
@@ -19769,163 +19769,163 @@ SELECT tfloat '{1@2000-01-01, 1@2000-01-02}' = tfloat '{[1@2000-01-01], [1@2000-
  t
 (1 row)
 
-SELECT temporal_hash(tbool 't@2000-01-01');
- temporal_hash 
----------------
-    -730813778
+SELECT hash(tbool 't@2000-01-01');
+    hash    
+------------
+ -730813778
 (1 row)
 
-SELECT temporal_hash(tbool '{t@2000-01-01, f@2000-01-02, t@2000-01-03}');
- temporal_hash 
----------------
-    1211447549
+SELECT hash(tbool '{t@2000-01-01, f@2000-01-02, t@2000-01-03}');
+    hash    
+------------
+ 1211447549
 (1 row)
 
-SELECT temporal_hash(tbool '[t@2000-01-01, f@2000-01-02, t@2000-01-03]');
- temporal_hash 
----------------
-    1211447549
+SELECT hash(tbool '[t@2000-01-01, f@2000-01-02, t@2000-01-03]');
+    hash    
+------------
+ 1211447549
 (1 row)
 
-SELECT temporal_hash(tbool '{[t@2000-01-01, f@2000-01-02, t@2000-01-03],[t@2000-01-04, t@2000-01-05]}');
- temporal_hash 
----------------
-    -591025512
+SELECT hash(tbool '{[t@2000-01-01, f@2000-01-02, t@2000-01-03],[t@2000-01-04, t@2000-01-05]}');
+    hash    
+------------
+ -591025512
 (1 row)
 
-SELECT temporal_hash(tint '1@2000-01-01');
- temporal_hash 
----------------
-    -730813778
+SELECT hash(tint '1@2000-01-01');
+    hash    
+------------
+ -730813778
 (1 row)
 
-SELECT temporal_hash(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03}');
- temporal_hash 
----------------
-   -1737216208
+SELECT hash(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03}');
+    hash     
+-------------
+ -1737216208
 (1 row)
 
-SELECT temporal_hash(tint '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03]');
- temporal_hash 
----------------
-   -1737216208
+SELECT hash(tint '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03]');
+    hash     
+-------------
+ -1737216208
 (1 row)
 
-SELECT temporal_hash(tint '{[1@2000-01-01, 2@2000-01-02, 1@2000-01-03],[3@2000-01-04, 3@2000-01-05]}');
- temporal_hash 
----------------
-   -1669707579
+SELECT hash(tint '{[1@2000-01-01, 2@2000-01-02, 1@2000-01-03],[3@2000-01-04, 3@2000-01-05]}');
+    hash     
+-------------
+ -1669707579
 (1 row)
 
-SELECT temporal_hash(tbigint '1@2000-01-01');
- temporal_hash 
----------------
-    -730813778
+SELECT hash(tbigint '1@2000-01-01');
+    hash    
+------------
+ -730813778
 (1 row)
 
-SELECT temporal_hash(tbigint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03}');
- temporal_hash 
----------------
-   -1737216208
+SELECT hash(tbigint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03}');
+    hash     
+-------------
+ -1737216208
 (1 row)
 
-SELECT temporal_hash(tbigint '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03]');
- temporal_hash 
----------------
-   -1737216208
+SELECT hash(tbigint '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03]');
+    hash     
+-------------
+ -1737216208
 (1 row)
 
-SELECT temporal_hash(tbigint '{[1@2000-01-01, 2@2000-01-02, 1@2000-01-03],[3@2000-01-04, 3@2000-01-05]}');
- temporal_hash 
----------------
-   -1669707579
+SELECT hash(tbigint '{[1@2000-01-01, 2@2000-01-02, 1@2000-01-03],[3@2000-01-04, 3@2000-01-05]}');
+    hash     
+-------------
+ -1669707579
 (1 row)
 
-SELECT temporal_hash(tfloat '1.5@2000-01-01');
- temporal_hash 
----------------
-   -2086480185
+SELECT hash(tfloat '1.5@2000-01-01');
+    hash     
+-------------
+ -2086480185
 (1 row)
 
-SELECT temporal_hash(tfloat '{1.5@2000-01-01, 2.5@2000-01-02, 1.5@2000-01-03}');
- temporal_hash 
----------------
-     888218486
+SELECT hash(tfloat '{1.5@2000-01-01, 2.5@2000-01-02, 1.5@2000-01-03}');
+   hash    
+-----------
+ 888218486
 (1 row)
 
-SELECT temporal_hash(tfloat '[1.5@2000-01-01, 2.5@2000-01-02, 1.5@2000-01-03]');
- temporal_hash 
----------------
-     888218486
+SELECT hash(tfloat '[1.5@2000-01-01, 2.5@2000-01-02, 1.5@2000-01-03]');
+   hash    
+-----------
+ 888218486
 (1 row)
 
-SELECT temporal_hash(tfloat '{[1.5@2000-01-01, 2.5@2000-01-02, 1.5@2000-01-03],[3.5@2000-01-04, 3.5@2000-01-05]}');
- temporal_hash 
----------------
-    1141009453
+SELECT hash(tfloat '{[1.5@2000-01-01, 2.5@2000-01-02, 1.5@2000-01-03],[3.5@2000-01-04, 3.5@2000-01-05]}');
+    hash    
+------------
+ 1141009453
 (1 row)
 
-SELECT temporal_hash(ttext 'AAA@2000-01-01');
- temporal_hash 
----------------
-   -1096081680
+SELECT hash(ttext 'AAA@2000-01-01');
+    hash     
+-------------
+ -1096081680
 (1 row)
 
-SELECT temporal_hash(ttext '{AAA@2000-01-01, BBB@2000-01-02, AAA@2000-01-03}');
- temporal_hash 
----------------
-    -423817091
+SELECT hash(ttext '{AAA@2000-01-01, BBB@2000-01-02, AAA@2000-01-03}');
+    hash    
+------------
+ -423817091
 (1 row)
 
-SELECT temporal_hash(ttext '[AAA@2000-01-01, BBB@2000-01-02, AAA@2000-01-03]');
- temporal_hash 
----------------
-    -423817091
+SELECT hash(ttext '[AAA@2000-01-01, BBB@2000-01-02, AAA@2000-01-03]');
+    hash    
+------------
+ -423817091
 (1 row)
 
-SELECT temporal_hash(ttext '{[AAA@2000-01-01, BBB@2000-01-02, AAA@2000-01-03],[CCC@2000-01-04, CCC@2000-01-05]}');
- temporal_hash 
----------------
-     743475694
+SELECT hash(ttext '{[AAA@2000-01-01, BBB@2000-01-02, AAA@2000-01-03],[CCC@2000-01-04, CCC@2000-01-05]}');
+   hash    
+-----------
+ 743475694
 (1 row)
 
-SELECT temporal_hash_extended(tint '1@2000-01-01', 1);
- temporal_hash_extended 
-------------------------
-     667224924826861377
+SELECT hashExtended(tint '1@2000-01-01', 1);
+    hashextended    
+--------------------
+ 667224924826861377
 (1 row)
 
-SELECT temporal_hash_extended(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03}', 1);
- temporal_hash_extended 
-------------------------
-   -6188152960460677780
+SELECT hashExtended(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03}', 1);
+     hashextended     
+----------------------
+ -6188152960460677780
 (1 row)
 
-SELECT temporal_hash_extended(tint '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03]', 1);
- temporal_hash_extended 
-------------------------
-   -6188152960460677780
+SELECT hashExtended(tint '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03]', 1);
+     hashextended     
+----------------------
+ -6188152960460677780
 (1 row)
 
-SELECT temporal_hash_extended(tint '{[1@2000-01-01, 2@2000-01-02],[3@2000-01-04, 3@2000-01-05]}', 1);
- temporal_hash_extended 
-------------------------
-    3041570321549013770
+SELECT hashExtended(tint '{[1@2000-01-01, 2@2000-01-02],[3@2000-01-04, 3@2000-01-05]}', 1);
+    hashextended     
+---------------------
+ 3041570321549013770
 (1 row)
 
-SELECT temporal_hash_extended(ttext '[AAA@2000-01-01, BBB@2000-01-02]', 1);
- temporal_hash_extended 
-------------------------
-    2961285134100988927
+SELECT hashExtended(ttext '[AAA@2000-01-01, BBB@2000-01-02]', 1);
+    hashextended     
+---------------------
+ 2961285134100988927
 (1 row)
 
-SELECT temporal_hash_extended(tint '1@2000-01-01', 1) = temporal_hash_extended(tint '1@2000-01-01', 1);
+SELECT hashExtended(tint '1@2000-01-01', 1) = hashExtended(tint '1@2000-01-01', 1);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT temporal_hash_extended(tint '1@2000-01-01', 1) <> temporal_hash_extended(tint '1@2000-01-01', 2);
+SELECT hashExtended(tint '1@2000-01-01', 1) <> hashExtended(tint '1@2000-01-01', 2);
  ?column? 
 ----------
  t

--- a/mobilitydb/test/temporal/queries/001_set.test.sql
+++ b/mobilitydb/test/temporal/queries/001_set.test.sql
@@ -166,15 +166,15 @@ SELECT tstzset '{2000-01-01}' <= tstzset '{2000-01-01, 2000-01-02, 2000-01-03}';
 SELECT tstzset '{2000-01-01}' > tstzset '{2000-01-01, 2000-01-02, 2000-01-03}';
 SELECT tstzset '{2000-01-01}' >= tstzset '{2000-01-01, 2000-01-02, 2000-01-03}';
 
-SELECT set_hash(dateset '{2000-01-01,2000-01-02}') = set_hash(dateset '{2000-01-01,2000-01-02}');
-SELECT set_hash(dateset '{2000-01-01,2000-01-02}') <> set_hash(dateset '{2000-01-01,2000-01-02}');
-SELECT set_hash(tstzset '{2000-01-01,2000-01-02}') = set_hash(tstzset '{2000-01-01,2000-01-02}');
-SELECT set_hash(tstzset '{2000-01-01,2000-01-02}') <> set_hash(tstzset '{2000-01-01,2000-01-02}');
+SELECT hash(dateset '{2000-01-01,2000-01-02}') = hash(dateset '{2000-01-01,2000-01-02}');
+SELECT hash(dateset '{2000-01-01,2000-01-02}') <> hash(dateset '{2000-01-01,2000-01-02}');
+SELECT hash(tstzset '{2000-01-01,2000-01-02}') = hash(tstzset '{2000-01-01,2000-01-02}');
+SELECT hash(tstzset '{2000-01-01,2000-01-02}') <> hash(tstzset '{2000-01-01,2000-01-02}');
 
-SELECT set_hash_extended(dateset '{2000-01-01,2000-01-02}', 1) = set_hash_extended(dateset '{2000-01-01,2000-01-02}', 1);
-SELECT set_hash_extended(dateset '{2000-01-01,2000-01-02}', 1) <> set_hash_extended(dateset '{2000-01-01,2000-01-02}', 1);
-SELECT set_hash_extended(tstzset '{2000-01-01,2000-01-02}', 1) = set_hash_extended(tstzset '{2000-01-01,2000-01-02}', 1);
-SELECT set_hash_extended(tstzset '{2000-01-01,2000-01-02}', 1) <> set_hash_extended(tstzset '{2000-01-01,2000-01-02}', 1);
+SELECT hashExtended(dateset '{2000-01-01,2000-01-02}', 1) = hashExtended(dateset '{2000-01-01,2000-01-02}', 1);
+SELECT hashExtended(dateset '{2000-01-01,2000-01-02}', 1) <> hashExtended(dateset '{2000-01-01,2000-01-02}', 1);
+SELECT hashExtended(tstzset '{2000-01-01,2000-01-02}', 1) = hashExtended(tstzset '{2000-01-01,2000-01-02}', 1);
+SELECT hashExtended(tstzset '{2000-01-01,2000-01-02}', 1) <> hashExtended(tstzset '{2000-01-01,2000-01-02}', 1);
 
 -------------------------------------------------------------------------------
 -- Transformations

--- a/mobilitydb/test/temporal/queries/001_set_tbl.test.sql
+++ b/mobilitydb/test/temporal/queries/001_set_tbl.test.sql
@@ -198,19 +198,19 @@ SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE t1.t <= t2.t;
 SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE t1.t > t2.t;
 SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE t1.t >= t2.t;
 
-SELECT MAX(set_hash(i)) FROM tbl_intset;
-SELECT MAX(set_hash(b)) FROM tbl_bigintset;
-SELECT MAX(set_hash(f)) FROM tbl_floatset;
-SELECT MAX(set_hash(t)) FROM tbl_textset;
-SELECT MAX(set_hash(d)) FROM tbl_dateset;
-SELECT MAX(set_hash(t)) FROM tbl_tstzset;
+SELECT MAX(hash(i)) FROM tbl_intset;
+SELECT MAX(hash(b)) FROM tbl_bigintset;
+SELECT MAX(hash(f)) FROM tbl_floatset;
+SELECT MAX(hash(t)) FROM tbl_textset;
+SELECT MAX(hash(d)) FROM tbl_dateset;
+SELECT MAX(hash(t)) FROM tbl_tstzset;
 
-SELECT MAX(set_hash_extended(i, 1)) FROM tbl_intset;
-SELECT MAX(set_hash_extended(b, 1)) FROM tbl_bigintset;
-SELECT MAX(set_hash_extended(f, 1)) FROM tbl_floatset;
-SELECT MAX(set_hash_extended(t, 1)) FROM tbl_textset;
-SELECT MAX(set_hash_extended(d, 1)) FROM tbl_dateset;
-SELECT MAX(set_hash_extended(t, 1)) FROM tbl_tstzset;
+SELECT MAX(hashExtended(i, 1)) FROM tbl_intset;
+SELECT MAX(hashExtended(b, 1)) FROM tbl_bigintset;
+SELECT MAX(hashExtended(f, 1)) FROM tbl_floatset;
+SELECT MAX(hashExtended(t, 1)) FROM tbl_textset;
+SELECT MAX(hashExtended(d, 1)) FROM tbl_dateset;
+SELECT MAX(hashExtended(t, 1)) FROM tbl_tstzset;
 
 -------------------------------------------------------------------------------
 -- Aggregation functions

--- a/mobilitydb/test/temporal/queries/003_span.test.sql
+++ b/mobilitydb/test/temporal/queries/003_span.test.sql
@@ -141,11 +141,11 @@ SELECT tstzspan '[2000-01-01,2000-01-01]' > tstzspan '(2000-01-01,2000-01-02)';
 SELECT tstzspan '[2000-01-01,2000-01-01]' >= tstzspan '(2000-01-01,2000-01-02)';
 SELECT tstzspan '[2000-01-01,2000-01-01]' = tstzspan '(2000-01-01,2000-01-02)';
 
-SELECT span_hash(tstzspan '[2000-01-01,2000-01-02]') = span_hash(tstzspan '[2000-01-01,2000-01-02]');
-SELECT span_hash(tstzspan '[2000-01-01,2000-01-02]') <> span_hash(tstzspan '[2000-01-02,2000-01-02]');
+SELECT hash(tstzspan '[2000-01-01,2000-01-02]') = hash(tstzspan '[2000-01-01,2000-01-02]');
+SELECT hash(tstzspan '[2000-01-01,2000-01-02]') <> hash(tstzspan '[2000-01-02,2000-01-02]');
 
-SELECT span_hash_extended(tstzspan '[2000-01-01,2000-01-02]', 1) = span_hash_extended(tstzspan '[2000-01-01,2000-01-02]', 1);
-SELECT span_hash_extended(tstzspan '[2000-01-01,2000-01-02]', 1) <> span_hash_extended(tstzspan '[2000-01-02,2000-01-02]', 1);
+SELECT hashExtended(tstzspan '[2000-01-01,2000-01-02]', 1) = hashExtended(tstzspan '[2000-01-01,2000-01-02]', 1);
+SELECT hashExtended(tstzspan '[2000-01-01,2000-01-02]', 1) <> hashExtended(tstzspan '[2000-01-02,2000-01-02]', 1);
 
 -------------------------------------------------------------------------------
 

--- a/mobilitydb/test/temporal/queries/003_span_tbl.test.sql
+++ b/mobilitydb/test/temporal/queries/003_span_tbl.test.sql
@@ -183,8 +183,8 @@ SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE t1.t <= t2.t;
 SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE t1.t > t2.t;
 SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE t1.t >= t2.t;
 
-SELECT MAX(span_hash(t)) != 0 FROM tbl_tstzspan;
-SELECT MAX(span_hash_extended(t, 1)) != 0 FROM tbl_tstzspan;
+SELECT MAX(hash(t)) != 0 FROM tbl_tstzspan;
+SELECT MAX(hashExtended(t, 1)) != 0 FROM tbl_tstzspan;
 
 -------------------------------------------------------------------------------
 -- Aggregation functions

--- a/mobilitydb/test/temporal/queries/007_spanset.test.sql
+++ b/mobilitydb/test/temporal/queries/007_spanset.test.sql
@@ -366,23 +366,23 @@ SELECT tstzspanset '{[2000-01-01,2000-01-01]}' <= tstzspanset '{(2000-01-01,2000
 SELECT tstzspanset '{[2000-01-01,2000-01-01]}' > tstzspanset '{(2000-01-01,2000-01-02),(2000-01-02,2000-01-03),(2000-01-03,2000-01-04)}';
 SELECT tstzspanset '{[2000-01-01,2000-01-01]}' >= tstzspanset '{(2000-01-01,2000-01-02),(2000-01-02,2000-01-03),(2000-01-03,2000-01-04)}';
 
-SELECT spanset_hash(intspanset '{[1,2]}') = spanset_hash(intspanset '{[1,2]}');
-SELECT spanset_hash(intspanset '{[1,2]}') <> spanset_hash(intspanset '{[2,2]}');
-SELECT spanset_hash(floatspanset '{[1.5,2.5]}') = spanset_hash(floatspanset '{[1.5,2.5]}');
-SELECT spanset_hash(floatspanset '{[1.5,2.5]}') <> spanset_hash(floatspanset '{[2.5,2.5]}');
-SELECT spanset_hash(datespanset '{[2000-01-01,2000-01-02]}') = spanset_hash(datespanset '{[2000-01-01,2000-01-02]}');
-SELECT spanset_hash(datespanset '{[2000-01-01,2000-01-02]}') <> spanset_hash(datespanset '{[2000-01-02,2000-01-02]}');
-SELECT spanset_hash(tstzspanset '{[2000-01-01,2000-01-02]}') = spanset_hash(tstzspanset '{[2000-01-01,2000-01-02]}');
-SELECT spanset_hash(tstzspanset '{[2000-01-01,2000-01-02]}') <> spanset_hash(tstzspanset '{[2000-01-02,2000-01-02]}');
+SELECT hash(intspanset '{[1,2]}') = hash(intspanset '{[1,2]}');
+SELECT hash(intspanset '{[1,2]}') <> hash(intspanset '{[2,2]}');
+SELECT hash(floatspanset '{[1.5,2.5]}') = hash(floatspanset '{[1.5,2.5]}');
+SELECT hash(floatspanset '{[1.5,2.5]}') <> hash(floatspanset '{[2.5,2.5]}');
+SELECT hash(datespanset '{[2000-01-01,2000-01-02]}') = hash(datespanset '{[2000-01-01,2000-01-02]}');
+SELECT hash(datespanset '{[2000-01-01,2000-01-02]}') <> hash(datespanset '{[2000-01-02,2000-01-02]}');
+SELECT hash(tstzspanset '{[2000-01-01,2000-01-02]}') = hash(tstzspanset '{[2000-01-01,2000-01-02]}');
+SELECT hash(tstzspanset '{[2000-01-01,2000-01-02]}') <> hash(tstzspanset '{[2000-01-02,2000-01-02]}');
 
-SELECT spanset_hash_extended(intspanset '{[1,2]}', 1) = spanset_hash_extended(intspanset '{[1,2]}', 1);
-SELECT spanset_hash_extended(intspanset '{[1,2]}', 1) <> spanset_hash_extended(intspanset '{[2,2]}', 1);
-SELECT spanset_hash_extended(floatspanset '{[1,2]}', 1) = spanset_hash_extended(floatspanset '{[1,2]}', 1);
-SELECT spanset_hash_extended(floatspanset '{[1,2]}', 1) <> spanset_hash_extended(floatspanset '{[2,2]}', 1);
-SELECT spanset_hash_extended(datespanset '{[2000-01-01,2000-01-02]}', 1) = spanset_hash_extended(datespanset '{[2000-01-01,2000-01-02]}', 1);
-SELECT spanset_hash_extended(datespanset '{[2000-01-01,2000-01-02]}', 1) <> spanset_hash_extended(datespanset '{[2000-01-02,2000-01-02]}', 1);
-SELECT spanset_hash_extended(tstzspanset '{[2000-01-01,2000-01-02]}', 1) = spanset_hash_extended(tstzspanset '{[2000-01-01,2000-01-02]}', 1);
-SELECT spanset_hash_extended(tstzspanset '{[2000-01-01,2000-01-02]}', 1) <> spanset_hash_extended(tstzspanset '{[2000-01-02,2000-01-02]}', 1);
+SELECT hashExtended(intspanset '{[1,2]}', 1) = hashExtended(intspanset '{[1,2]}', 1);
+SELECT hashExtended(intspanset '{[1,2]}', 1) <> hashExtended(intspanset '{[2,2]}', 1);
+SELECT hashExtended(floatspanset '{[1,2]}', 1) = hashExtended(floatspanset '{[1,2]}', 1);
+SELECT hashExtended(floatspanset '{[1,2]}', 1) <> hashExtended(floatspanset '{[2,2]}', 1);
+SELECT hashExtended(datespanset '{[2000-01-01,2000-01-02]}', 1) = hashExtended(datespanset '{[2000-01-01,2000-01-02]}', 1);
+SELECT hashExtended(datespanset '{[2000-01-01,2000-01-02]}', 1) <> hashExtended(datespanset '{[2000-01-02,2000-01-02]}', 1);
+SELECT hashExtended(tstzspanset '{[2000-01-01,2000-01-02]}', 1) = hashExtended(tstzspanset '{[2000-01-01,2000-01-02]}', 1);
+SELECT hashExtended(tstzspanset '{[2000-01-01,2000-01-02]}', 1) <> hashExtended(tstzspanset '{[2000-01-02,2000-01-02]}', 1);
 
 -------------------------------------------------------------------------------
 -- Transformation functions

--- a/mobilitydb/test/temporal/queries/007_spanset_tbl.test.sql
+++ b/mobilitydb/test/temporal/queries/007_spanset_tbl.test.sql
@@ -223,8 +223,8 @@ SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE t1.t <= t2.t;
 SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE t1.t > t2.t;
 SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE t1.t >= t2.t;
 
-SELECT MAX(spanset_hash(t)) != 0 FROM tbl_tstzspanset;
-SELECT MAX(spanset_hash_extended(t, 1)) != 0 FROM tbl_tstzspanset;
+SELECT MAX(hash(t)) != 0 FROM tbl_tstzspanset;
+SELECT MAX(hashExtended(t, 1)) != 0 FROM tbl_tstzspanset;
 
 -------------------------------------------------------------------------------
 -- Transformation Functions

--- a/mobilitydb/test/temporal/queries/021_tbox.test.sql
+++ b/mobilitydb/test/temporal/queries/021_tbox.test.sql
@@ -445,13 +445,13 @@ SELECT COUNT(*) FROM tbl_tboxfloat t1, tbl_tboxfloat t2 WHERE t1.b >= t2.b;
 
 -------------------------------------------------------------------------------
 
-SELECT tbox_hash(tbox 'TBOXFLOAT X([1.0,1.0])');
-SELECT tbox_hash_extended(tbox 'TBOXFLOAT X([1.0,1.0])', 1);
+SELECT hash(tbox 'TBOXFLOAT X([1.0,1.0])');
+SELECT hashExtended(tbox 'TBOXFLOAT X([1.0,1.0])', 1);
 
-SELECT tbox_hash(tbox 'TBOXFLOAT T([2000-01-02,2000-01-02])');
-SELECT tbox_hash_extended(tbox 'TBOXFLOAT T([2000-01-02,2000-01-02])', 1);
+SELECT hash(tbox 'TBOXFLOAT T([2000-01-02,2000-01-02])');
+SELECT hashExtended(tbox 'TBOXFLOAT T([2000-01-02,2000-01-02])', 1);
 
-SELECT tbox_hash(tbox 'TBOXFLOAT XT([1.0,1.0],[2000-01-02,2000-01-02])');
-SELECT tbox_hash_extended(tbox 'TBOXFLOAT XT([1.0,1.0],[2000-01-02,2000-01-02])', 1);
+SELECT hash(tbox 'TBOXFLOAT XT([1.0,1.0],[2000-01-02,2000-01-02])');
+SELECT hashExtended(tbox 'TBOXFLOAT XT([1.0,1.0],[2000-01-02,2000-01-02])', 1);
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/temporal/queries/022_temporal.test.sql
+++ b/mobilitydb/test/temporal/queries/022_temporal.test.sql
@@ -4055,34 +4055,34 @@ SELECT tfloat '{1@2000-01-01, 1@2000-01-02}' = tfloat '{[1@2000-01-01], [1@2000-
 
 -------------------------------------------------------------------------------
 
-SELECT temporal_hash(tbool 't@2000-01-01');
-SELECT temporal_hash(tbool '{t@2000-01-01, f@2000-01-02, t@2000-01-03}');
-SELECT temporal_hash(tbool '[t@2000-01-01, f@2000-01-02, t@2000-01-03]');
-SELECT temporal_hash(tbool '{[t@2000-01-01, f@2000-01-02, t@2000-01-03],[t@2000-01-04, t@2000-01-05]}');
-SELECT temporal_hash(tint '1@2000-01-01');
-SELECT temporal_hash(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03}');
-SELECT temporal_hash(tint '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03]');
-SELECT temporal_hash(tint '{[1@2000-01-01, 2@2000-01-02, 1@2000-01-03],[3@2000-01-04, 3@2000-01-05]}');
-SELECT temporal_hash(tbigint '1@2000-01-01');
-SELECT temporal_hash(tbigint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03}');
-SELECT temporal_hash(tbigint '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03]');
-SELECT temporal_hash(tbigint '{[1@2000-01-01, 2@2000-01-02, 1@2000-01-03],[3@2000-01-04, 3@2000-01-05]}');
-SELECT temporal_hash(tfloat '1.5@2000-01-01');
-SELECT temporal_hash(tfloat '{1.5@2000-01-01, 2.5@2000-01-02, 1.5@2000-01-03}');
-SELECT temporal_hash(tfloat '[1.5@2000-01-01, 2.5@2000-01-02, 1.5@2000-01-03]');
-SELECT temporal_hash(tfloat '{[1.5@2000-01-01, 2.5@2000-01-02, 1.5@2000-01-03],[3.5@2000-01-04, 3.5@2000-01-05]}');
-SELECT temporal_hash(ttext 'AAA@2000-01-01');
-SELECT temporal_hash(ttext '{AAA@2000-01-01, BBB@2000-01-02, AAA@2000-01-03}');
-SELECT temporal_hash(ttext '[AAA@2000-01-01, BBB@2000-01-02, AAA@2000-01-03]');
-SELECT temporal_hash(ttext '{[AAA@2000-01-01, BBB@2000-01-02, AAA@2000-01-03],[CCC@2000-01-04, CCC@2000-01-05]}');
+SELECT hash(tbool 't@2000-01-01');
+SELECT hash(tbool '{t@2000-01-01, f@2000-01-02, t@2000-01-03}');
+SELECT hash(tbool '[t@2000-01-01, f@2000-01-02, t@2000-01-03]');
+SELECT hash(tbool '{[t@2000-01-01, f@2000-01-02, t@2000-01-03],[t@2000-01-04, t@2000-01-05]}');
+SELECT hash(tint '1@2000-01-01');
+SELECT hash(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03}');
+SELECT hash(tint '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03]');
+SELECT hash(tint '{[1@2000-01-01, 2@2000-01-02, 1@2000-01-03],[3@2000-01-04, 3@2000-01-05]}');
+SELECT hash(tbigint '1@2000-01-01');
+SELECT hash(tbigint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03}');
+SELECT hash(tbigint '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03]');
+SELECT hash(tbigint '{[1@2000-01-01, 2@2000-01-02, 1@2000-01-03],[3@2000-01-04, 3@2000-01-05]}');
+SELECT hash(tfloat '1.5@2000-01-01');
+SELECT hash(tfloat '{1.5@2000-01-01, 2.5@2000-01-02, 1.5@2000-01-03}');
+SELECT hash(tfloat '[1.5@2000-01-01, 2.5@2000-01-02, 1.5@2000-01-03]');
+SELECT hash(tfloat '{[1.5@2000-01-01, 2.5@2000-01-02, 1.5@2000-01-03],[3.5@2000-01-04, 3.5@2000-01-05]}');
+SELECT hash(ttext 'AAA@2000-01-01');
+SELECT hash(ttext '{AAA@2000-01-01, BBB@2000-01-02, AAA@2000-01-03}');
+SELECT hash(ttext '[AAA@2000-01-01, BBB@2000-01-02, AAA@2000-01-03]');
+SELECT hash(ttext '{[AAA@2000-01-01, BBB@2000-01-02, AAA@2000-01-03],[CCC@2000-01-04, CCC@2000-01-05]}');
 
-SELECT temporal_hash_extended(tint '1@2000-01-01', 1);
-SELECT temporal_hash_extended(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03}', 1);
-SELECT temporal_hash_extended(tint '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03]', 1);
-SELECT temporal_hash_extended(tint '{[1@2000-01-01, 2@2000-01-02],[3@2000-01-04, 3@2000-01-05]}', 1);
-SELECT temporal_hash_extended(ttext '[AAA@2000-01-01, BBB@2000-01-02]', 1);
+SELECT hashExtended(tint '1@2000-01-01', 1);
+SELECT hashExtended(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03}', 1);
+SELECT hashExtended(tint '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03]', 1);
+SELECT hashExtended(tint '{[1@2000-01-01, 2@2000-01-02],[3@2000-01-04, 3@2000-01-05]}', 1);
+SELECT hashExtended(ttext '[AAA@2000-01-01, BBB@2000-01-02]', 1);
 -- Equal values hash equal; the seed changes the hash
-SELECT temporal_hash_extended(tint '1@2000-01-01', 1) = temporal_hash_extended(tint '1@2000-01-01', 1);
-SELECT temporal_hash_extended(tint '1@2000-01-01', 1) <> temporal_hash_extended(tint '1@2000-01-01', 2);
+SELECT hashExtended(tint '1@2000-01-01', 1) = hashExtended(tint '1@2000-01-01', 1);
+SELECT hashExtended(tint '1@2000-01-01', 1) <> hashExtended(tint '1@2000-01-01', 2);
 
 ------------------------------------------------------------------------------

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -1585,7 +1585,7 @@ comparison_families:
   file: mobilitydb/sql/geo/052_tgeo.in.sql
   reference: true
   begin: "\n * Comparison functions and B-tree indexing\n"
-  end: temporal_hash
+  end: "CREATE FUNCTION hash("
   blocks:
   - lit: "/******************************************************************************\n * Comparison functions and B-tree indexing\n ******************************************************************************/\n\n"
   - funcs: tgeometry
@@ -1596,7 +1596,7 @@ comparison_families:
   file: mobilitydb/sql/geo/052_tpoint.in.sql
   reference: true
   begin: "\n * Comparison functions and B-tree indexing\n"
-  end: temporal_hash
+  end: "CREATE FUNCTION hash("
   blocks:
   - lit: "/******************************************************************************\n * Comparison functions and B-tree indexing\n ******************************************************************************/\n\n"
   - funcs: tgeompoint
@@ -1607,7 +1607,7 @@ comparison_families:
   file: mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
   reference: true
   begin: "\n * Comparison functions and B-tree indexing\n"
-  end: temporal_hash
+  end: "CREATE FUNCTION hash("
   blocks:
   - lit: "/*****************************************************************************\n * Comparison functions and B-tree indexing\n *****************************************************************************/\n\n"
   - funcs: tcbuffer
@@ -1616,7 +1616,7 @@ comparison_families:
   file: mobilitydb/sql/h3/253_th3index.in.sql
   reference: true
   begin: "\n * Comparison functions and B-tree / hash indexing\n"
-  end: temporal_hash
+  end: "CREATE FUNCTION hash("
   blocks:
   - lit: "/******************************************************************************\n * Comparison functions and B-tree / hash indexing\n *\n * All th3index values share the exact same on-disk layout as every\n * other temporal type, so the generic Temporal_* dispatch in the\n * backend is enough \u2014 no th3index-specific wrappers required.\n ******************************************************************************/\n\n"
   - funcs: th3index
@@ -1625,7 +1625,7 @@ comparison_families:
   file: mobilitydb/sql/json/452_tjsonb.in.sql
   reference: true
   begin: "\n * Comparison functions and B-tree indexing\n"
-  end: temporal_hash
+  end: "CREATE FUNCTION hash("
   blocks:
   - lit: "/*****************************************************************************\n * Comparison functions and B-tree indexing\n *****************************************************************************/\n\n"
   - funcs: tjsonb
@@ -1634,7 +1634,7 @@ comparison_families:
   file: mobilitydb/sql/npoint/302_tnpoint.in.sql
   reference: true
   begin: "\n * Comparison functions and B-tree indexing\n"
-  end: temporal_hash
+  end: "CREATE FUNCTION hash("
   blocks:
   - lit: "/******************************************************************************\n * Comparison functions and B-tree indexing\n ******************************************************************************/\n\n"
   - funcs: tnpoint
@@ -1643,7 +1643,7 @@ comparison_families:
   file: mobilitydb/sql/pose/102_tpose.in.sql
   reference: true
   begin: "\n * Comparison functions and B-tree indexing\n"
-  end: temporal_hash
+  end: "CREATE FUNCTION hash("
   blocks:
   - lit: "/******************************************************************************\n * Comparison functions and B-tree indexing\n ******************************************************************************/\n\n"
   - funcs: tpose
@@ -1652,7 +1652,7 @@ comparison_families:
   file: mobilitydb/sql/quadbin/353_tquadbin.in.sql
   reference: true
   begin: "\n * Comparison functions and B-tree / hash indexing\n"
-  end: temporal_hash
+  end: "CREATE FUNCTION hash("
   blocks:
   - lit: "/******************************************************************************\n * Comparison functions and B-tree / hash indexing\n *\n * All tquadbin values share the exact same on-disk layout as every\n * other temporal type, so the generic Temporal_* dispatch in the\n * backend is enough \u2014 no tquadbin-specific wrappers required.\n ******************************************************************************/\n\n"
   - funcs: tquadbin
@@ -1661,7 +1661,7 @@ comparison_families:
   file: mobilitydb/sql/rgeo/150_trgeo.in.sql
   reference: true
   begin: "\n * Comparison functions and B-tree indexing\n"
-  end: temporal_hash
+  end: "CREATE FUNCTION hash("
   blocks:
   - lit: "/******************************************************************************\n * Comparison functions and B-tree indexing\n ******************************************************************************/\n\n"
   - funcs: trgeometry


### PR DESCRIPTION
The public SQL hash functions use a single overloaded name across all
families: `hash()` for the 32-bit hash code and `hashExtended()` for the
64-bit seeded hash, resolved by argument type.

This replaces the per-family names `set_hash`, `span_hash`, `spanset_hash`,
`temporal_hash`, `tbox_hash`, `stbox_hash`, `cbuffer_hash`, `pose_hash`,
`quadbin_hash`, `h3index_hash`, `raquet_hash` and their `_extended`
variants, folding one concept spread over many underscore-carrying names
into a single overload set. This follows the same convention as the
overloaded `contains` and the other bare set/span predicates.

Updated: the `CREATE FUNCTION` registrations, the hash operator-class
function references, the `@sqlfn` documentation tags, and the regression
tests. The MEOS C functions and the PostgreSQL wrapper symbols keep their
existing names.
