### PR TITLE
Name the deployed SQL functions in the JSON doxygen tags

### DIFF
--- a/meos/src/json/jsonbset_jsonfuncs.c
+++ b/meos/src/json/jsonbset_jsonfuncs.c
@@ -118,7 +118,7 @@ jsonbset_object_field(const Set *set, const text *key, bool astext,
  * @param[in] set JSONB set
  * @param[in] jb JSONB
  * @param[in] invert True if the arguments must be inverted
- * @csqlfn #Concat_jsonbset_jsonbset()
+ * @csqlfn #Concat_jsonb_jsonbset(), #Concat_jsonbset_jsonb()
  */
 Set *
 concat_jsonbset_jsonb(const Set *set, const Jsonb *jb, bool invert)
@@ -173,6 +173,7 @@ jsonbset_array_element(const Set *set, int idx, bool astext,
  * @brief Delete a key specified by an index from a JSONB set
  * @param[in] set JSONB set
  * @param[in] idx Index
+ * @csqlfn #Jsonbset_delete_index()
  */
 Set *
 jsonbset_delete_index(const Set *set, int idx)
@@ -197,6 +198,7 @@ jsonbset_delete_index(const Set *set, int idx)
  * @brief Delete a key or an array element from a JSONB set
  * @param[in] set JSONB set
  * @param[in] key Key
+ * @csqlfn #Jsonbset_delete()
  */
 Set *
 jsonbset_delete(const Set *set, const text *key)
@@ -220,6 +222,7 @@ jsonbset_delete(const Set *set, const text *key)
  * @param[in] set JSONB set
  * @param[in] keys Keys
  * @param[in] count Number of elements in the input array
+ * @csqlfn #Jsonbset_delete_array()
  */
 Set *
 jsonbset_delete_array(const Set *set, text **keys, int count)
@@ -416,7 +419,7 @@ jsonbset_to_floatset(const Set *set, const char *key,
  * @param[in] set JSONB set object
  * @param[in] key Key to extract
  * @param[in] null_handle States the null value treatment
- * @csqlfn #Jsonbset_to_ttextset_key()
+ * @csqlfn #Jsonbset_to_textset_key()
  */
 Set *
 jsonbset_to_textset_key(const Set *set, const char *key,
@@ -482,6 +485,7 @@ jsonbset_pretty(const Set *set)
  * @param[in] set JSONB set
  * @param[in] path_elems Array of path elements
  * @param[in] path_len Number of elements in the input array
+ * @csqlfn #Jsonbset_delete_path()
  */
 Set *
 jsonbset_delete_path(const Set *set, text **path_elems, int path_len)
@@ -557,6 +561,7 @@ jsonbset_extract_path(const Set *set, text **path_elems, int path_len,
  * @param[in] after When true, if the last path step is an array index that
  * is out of range, the new value is added at the beginning of the array if
  * the index is negative, or at the end of the array if it is positive
+ * @csqlfn #Jsonbset_insert()
  */
 Set *
 jsonbset_insert(const Set *set, text **path_elems, int path_len,

--- a/meos/src/json/tjsonb_jsonfuncs.c
+++ b/meos/src/json/tjsonb_jsonfuncs.c
@@ -769,6 +769,7 @@ tjsonb_array_element(const Temporal *temp, int idx, bool astext,
  * @brief Delete a key specified by an index from a temporal JSONB value
  * @param[in] temp Temporal JSONB value
  * @param[in] idx Index
+ * @csqlfn #Tjsonb_delete_index()
  */
 Temporal *
 tjsonb_delete_index(const Temporal *temp, int idx)
@@ -794,6 +795,7 @@ tjsonb_delete_index(const Temporal *temp, int idx)
  * @brief Delete a key or an array element from a temporal JSONB value
  * @param[in] temp Temporal JSONB value
  * @param[in] key Key
+ * @csqlfn #Tjsonb_delete()
  */
 Temporal *
 tjsonb_delete(const Temporal *temp, const text *key)
@@ -818,6 +820,7 @@ tjsonb_delete(const Temporal *temp, const text *key)
  * @param[in] temp Temporal JSONB value
  * @param[in] keys Keys
  * @param[in] count Number of elements in the input array
+ * @csqlfn #Tjsonb_delete_array()
  */
 Temporal *
 tjsonb_delete_array(const Temporal *temp, text **keys, int count)
@@ -846,6 +849,7 @@ tjsonb_delete_array(const Temporal *temp, text **keys, int count)
  * @brief Delete a key from a temporal JSONB value
  * @param[in] temp Temporal JSONB value
  * @param[in] key Key
+ * @csqlfn #Tjsonb_exists()
  */
 Temporal *
 tjsonb_exists(const Temporal *temp, const text *key)
@@ -1311,6 +1315,7 @@ tjsonb_pretty(const Temporal *temp)
  * @param[in] temp Temporal JSONB value
  * @param[in] path_elems Array of path elements
  * @param[in] path_len Number of elements in the input array
+ * @csqlfn #Tjsonb_delete_path()
  */
 Temporal *
 tjsonb_delete_path(const Temporal *temp, text **path_elems, int path_len)
@@ -1416,6 +1421,7 @@ tjsonb_extract_path(const Temporal *temp, text **path_elems, int path_len,
  * @param[in] after When true, if the last path step is an array index that
  * is out of range, the new value is added at the beginning of the array if
  * the index is negative, or at the end of the array if it is positive
+ * @csqlfn #Tjsonb_insert()
  */
 Temporal *
 tjsonb_insert(const Temporal *temp, text **path_elems, int path_len,

--- a/mobilitydb/src/json/jsonbset.c
+++ b/mobilitydb/src/json/jsonbset.c
@@ -71,7 +71,7 @@ PG_FUNCTION_INFO_V1(Textset_as_jsonbset);
 /**
  * @ingroup mobilitydb_json_jsonbset
  * @brief Transform a text set into a JSONB set
- * @sqlfn ttext()
+ * @sqlfn jsonbset()
  * @sqlop @p ::
  */
 Datum

--- a/mobilitydb/src/json/jsonbset_jsonfuncs.c
+++ b/mobilitydb/src/json/jsonbset_jsonfuncs.c
@@ -198,7 +198,7 @@ PG_FUNCTION_INFO_V1(Concat_jsonbset_jsonb);
 /**
  * @ingroup mobilitydb_json_json
  * @brief Concat a JSONB set with a JSONB value
- * @sqlfn jsonb_concat()
+ * @sqlfn jsonbset_concat()
  * @sqlop @p ||
  */
 Datum
@@ -222,7 +222,7 @@ PG_FUNCTION_INFO_V1(Jsonbset_delete);
 /**
  * @ingroup mobilitydb_json_json
  * @brief Delete a key or an element array from a JSONB set value
- * @sqlfn jsonb_delete_key()
+ * @sqlfn jsonbset_delete()
  * @sqlop @p -
  */
 Datum
@@ -246,7 +246,7 @@ PG_FUNCTION_INFO_V1(Jsonbset_delete_array);
 /**
  * @ingroup mobilitydb_json_json
  * @brief Delete an array of keys or array elements from a JSONB set value
- * @sqlfn jsonb_delete_array()
+ * @sqlfn jsonbset_delete_array()
  * @sqlop @p -
  */
 Datum
@@ -285,7 +285,7 @@ PG_FUNCTION_INFO_V1(Jsonbset_delete_index);
 /**
  * @ingroup mobilitydb_json_json
  * @brief Delete a key specified by an index from a JSONB set value
- * @sqlfn jsonb_delete()
+ * @sqlfn jsonbset_delete_index()
  * @sqlop @p -
  */
 Datum
@@ -683,7 +683,7 @@ PG_FUNCTION_INFO_V1(Jsonbset_to_intset);
 /**
  * @ingroup mobilitydb_json_json
  * @brief Convert a JSONB set value into an integer set
- * @sqlfn tint()
+ * @sqlfn intset()
  */
 Datum
 Jsonbset_to_intset(PG_FUNCTION_ARGS)
@@ -696,7 +696,7 @@ PG_FUNCTION_INFO_V1(Jsonbset_to_bigintset);
 /**
  * @ingroup mobilitydb_json_json
  * @brief Convert a JSONB set value into a big integer set
- * @sqlfn tbigint()
+ * @sqlfn bigintset()
  */
 Datum
 Jsonbset_to_bigintset(PG_FUNCTION_ARGS)
@@ -709,7 +709,7 @@ PG_FUNCTION_INFO_V1(Jsonbset_to_floatset);
 /**
  * @ingroup mobilitydb_json_json
  * @brief Convert a JSONB set value into a float set
- * @sqlfn tfloat()
+ * @sqlfn floatset()
  */
 Datum
 Jsonbset_to_floatset(PG_FUNCTION_ARGS)
@@ -722,7 +722,7 @@ PG_FUNCTION_INFO_V1(Jsonbset_to_textset_key);
 /**
  * @ingroup mobilitydb_json_json
  * @brief Convert a JSONB set value into a text set
- * @sqlfn ttext()
+ * @sqlfn textset()
  */
 Datum
 Jsonbset_to_textset_key(PG_FUNCTION_ARGS)
@@ -915,7 +915,7 @@ PG_FUNCTION_INFO_V1(Jsonbset_path_match_opr);
  * value
  * @details Implementation of operator "tjsonb @@ jsonpath" (2-argument version
  * of jsonbset_path_match())
- * @sqlfn Jsonbset_path_match_opr()
+ * @sqlfn jsonbset_path_match_opr()
  */
 Datum
 Jsonbset_path_match_opr(PG_FUNCTION_ARGS)
@@ -981,7 +981,7 @@ Jsonbset_path_query_array_tz(PG_FUNCTION_ARGS)
 /**
  * @brief Extract the first item specified by a JSON path expression from a
  * JSONB set value. If there are no items, return NULL.
- * @sqlfn jsonbset_query_first(), jsonbset_query_first_tz()
+ * @sqlfn jsonbset_path_query_first(), jsonbset_path_query_first_tz()
  */
 Datum
 Jsonbset_path_query_first_common(FunctionCallInfo fcinfo, bool tz)

--- a/mobilitydb/src/json/tjsonb_jsonfuncs.c
+++ b/mobilitydb/src/json/tjsonb_jsonfuncs.c
@@ -230,7 +230,7 @@ PG_FUNCTION_INFO_V1(Tjson_object_field_opr);
 /**
  * @ingroup mobilitydb_json_json
  * @brief Extract a field from a temporal JSON value
- * @sqlfn tjson_object_field()
+ * @sqlfn tjson_object_field_opr()
  * @sqlop @p ->
  */
 Datum
@@ -360,7 +360,7 @@ PG_FUNCTION_INFO_V1(Concat_tjsonb_jsonb);
 /**
  * @ingroup mobilitydb_json_json
  * @brief Concat a temporal JSONB with a JSONB value
- * @sqlfn jsonb_concat()
+ * @sqlfn tjsonb_concat()
  * @sqlop @p ||
  */
 Datum
@@ -382,7 +382,7 @@ PG_FUNCTION_INFO_V1(Concat_tjsonb_tjsonb);
 /**
  * @ingroup mobilitydb_json_json
  * @brief Concat two temporal JSONB values
- * @sqlfn jsonb_concat()
+ * @sqlfn tjsonb_concat()
  * @sqlop @p ||
  */
 Datum
@@ -408,7 +408,7 @@ PG_FUNCTION_INFO_V1(Tjsonb_delete);
 /**
  * @ingroup mobilitydb_json_json
  * @brief Delete a key or an element array from a temporal JSONB value
- * @sqlfn jsonb_delete_key()
+ * @sqlfn tjsonb_delete()
  * @sqlop @p -
  */
 Datum
@@ -432,7 +432,7 @@ PG_FUNCTION_INFO_V1(Tjsonb_delete_array);
 /**
  * @ingroup mobilitydb_json_json
  * @brief Delete an array of keys or array elements from a temporal JSONB value
- * @sqlfn jsonb_delete_array()
+ * @sqlfn tjsonb_delete_array()
  * @sqlop @p -
  */
 Datum
@@ -471,7 +471,7 @@ PG_FUNCTION_INFO_V1(Tjsonb_delete_index);
 /**
  * @ingroup mobilitydb_json_json
  * @brief Delete a key specified by an index from a temporal JSONB value
- * @sqlfn jsonb_delete()
+ * @sqlfn tjsonb_delete_index()
  * @sqlop @p -
  */
 Datum
@@ -733,7 +733,7 @@ PG_FUNCTION_INFO_V1(Tjson_extract_path_opr);
 /**
  * @ingroup mobilitydb_json_json
  * @brief Extract an item specified by a path from a temporal JSON value as text
- * @sqlfn tjson_extract_path_text()
+ * @sqlfn tjson_extract_path_opr()
  */
 Datum
 Tjson_extract_path_opr(PG_FUNCTION_ARGS)
@@ -1221,7 +1221,7 @@ PG_FUNCTION_INFO_V1(Tjsonb_path_match_opr);
  * value
  * @details Implementation of operator "tjsonb @@ jsonpath" (2-argument version
  * of tjsonb_path_match())
- * @sqlfn Tjsonb_path_match_opr()
+ * @sqlfn tjsonb_path_match_opr()
  */
 Datum
 Tjsonb_path_match_opr(PG_FUNCTION_ARGS)
@@ -1287,7 +1287,7 @@ Tjsonb_path_query_array_tz(PG_FUNCTION_ARGS)
 /**
  * @brief Extract the first item specified by a JSON path expression from a
  * temporal JSONB value. If there are no items, return NULL.
- * @sqlfn tjsonb_query_first(), tjsonb_query_first_tz()
+ * @sqlfn tjsonb_path_query_first(), tjsonb_path_query_first_tz()
  */
 Datum
 Tjsonb_path_query_first_common(FunctionCallInfo fcinfo, bool tz)


### PR DESCRIPTION
The catalog gives a MEOS function its SQL name by following `@csqlfn` to a MobilityDB wrapper and that wrapper's `@sqlfn` to the SQL name. A tag naming something that does not exist breaks the chain: the function reaches the catalog without a SQL name, and every binding generated from it drops the function. PostgreSQL is unaffected, since the wrappers bind their `CREATE FUNCTION` names directly — so the whole class is invisible in SQL and visible only in the bindings.

**Twenty `@sqlfn` tags name a function other than the one the wrapper is bound to.** Fourteen name a function that no `CREATE FUNCTION` deploys anywhere: the concat, delete and path-query surface of both the set and the temporal type carries the plain `jsonb` spelling of an operation each type deploys under its own prefix, and the path-query pair drops the `path` component its deployed names carry.

Five more name the temporal constructor of a base type where the wrapper converts to the *set* of that type — `tint` against `intset`, `tbigint` against `bigintset`, `tfloat` against `floatset`, `ttext` against `textset` and against `jsonbset`. Each deployed name is documented in the reference.

The last is an operator wrapper naming the plain function beside it. Of the 19 `*_opr` wrappers in this family, 16 name their own `_opr` SQL function; the four that did not are corrected here, two of which carried the PascalCase C symbol in the `@sqlfn` position.

**Two `@csqlfn` tags name a wrapper that no `PG_FUNCTION_INFO_V1` registers**, out of 2243. The set concatenation names a jsonbset-to-jsonbset wrapper that does not exist, where the function takes an `invert` flag and backs the two mixed-argument wrappers; the text-set conversion carries a doubled type prefix.

**Eleven MEOS functions carry no `@csqlfn` at all**, so they too reach the catalog without a SQL name. Each is called by exactly one wrapper, which the tag now names.

Every name written here is the `CREATE FUNCTION` name binding that wrapper in its `.in.sql`.

Regenerating the catalog against this tree is the acceptance check:

| MEOS function | before | after |
| --- | --- | --- |
| `concat_jsonbset_jsonb` | no SQL name | `sqlfn=jsonbset_concat`, `sqlop=\|\|` |
| `concat_tjsonb_jsonb` | `jsonb_concat` | `sqlfn=tjsonb_concat` |

Across the family, `@sqlfn` tags naming a function other than their binding go from 20 to 0, and `@csqlfn` references naming an unregistered wrapper from 2 to 0.

**Left as they are.** `Tjson_object_field` carries `tjson_object_field_text` and `Jsonb_as_text` carries `text`; both name nothing deployed, but the wrapper of the latter is bound to no SQL at all, and correcting either needs the intent behind the name rather than a mechanical substitution.

Comments only; no code changes.
