### PR TITLE
Remove the jsonbset position operators

### DIFF
--- a/mobilitydb/sql/json/450_jsonbset.in.sql
+++ b/mobilitydb/sql/json/450_jsonbset.in.sql
@@ -369,31 +369,6 @@ CREATE OPERATOR && (
 
 /*****************************************************************************/
 
--- “Left”/“right” operators, useful for btree spans
-CREATE FUNCTION left(jsonbset, jsonbset)
-  RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Left_set_set'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-CREATE OPERATOR << (
-  PROCEDURE = left,
-  LEFTARG = jsonbset, RIGHTARG = jsonbset,
-  COMMUTATOR = >>
-);
-
-CREATE FUNCTION right(jsonbset, jsonbset)
-  RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Right_set_set'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-CREATE OPERATOR >> (
-  PROCEDURE = right,
-  LEFTARG = jsonbset, RIGHTARG = jsonbset,
-  COMMUTATOR = <<
-);
-
-/*****************************************************************************/
-
 CREATE FUNCTION setUnion(jsonb, jsonbset)
   RETURNS jsonbset
   AS 'MODULE_PATHNAME', 'Union_value_set'

--- a/mobilitydb/test/json/expected/450_jsonbset_tbl.test.out
+++ b/mobilitydb/test/json/expected/450_jsonbset_tbl.test.out
@@ -69,18 +69,6 @@ SELECT COUNT(*) FROM tbl_jsonbset t1, tbl_jsonbset t2 WHERE t1.s && t2.s;
   5614
 (1 row)
 
-SELECT COUNT(*) FROM tbl_jsonbset t1, tbl_jsonbset t2 WHERE t1.s >> t2.s;
- count 
--------
-     0
-(1 row)
-
-SELECT COUNT(*) FROM tbl_jsonbset t1, tbl_jsonbset t2 WHERE t1.s << t2.s;
- count 
--------
-     0
-(1 row)
-
 SELECT MAX(memSize(s || jb)) FROM tbl_jsonbset, tbl_jsonb;
  max 
 -----

--- a/mobilitydb/test/json/queries/450_jsonbset_tbl.test.sql
+++ b/mobilitydb/test/json/queries/450_jsonbset_tbl.test.sql
@@ -66,8 +66,6 @@ SELECT MAX(memSize(set(jb))) FROM tbl_jsonb;
 SELECT COUNT(*) FROM tbl_jsonbset WHERE s @> startValue(s);
 SELECT COUNT(*) FROM tbl_jsonbset WHERE startValue(s) <@ s;
 SELECT COUNT(*) FROM tbl_jsonbset t1, tbl_jsonbset t2 WHERE t1.s && t2.s;
-SELECT COUNT(*) FROM tbl_jsonbset t1, tbl_jsonbset t2 WHERE t1.s >> t2.s;
-SELECT COUNT(*) FROM tbl_jsonbset t1, tbl_jsonbset t2 WHERE t1.s << t2.s;
 
 SELECT MAX(memSize(s || jb)) FROM tbl_jsonbset, tbl_jsonb;
 SELECT MAX(memSize(s - text 'timestamp')) FROM tbl_jsonbset;


### PR DESCRIPTION
## Summary

Removes the `<<` and `>>` position operators on `jsonbset`.

These operators assert that every element of the left set is strictly
less/greater than every element of the right set. `jsonb` has no semantic
order: PostgreSQL's `jsonb` comparison is an implementation-defined ordering
that supports B-tree indexing, not a meaningful ordering of JSON values
(cross-type comparisons simply compare the internal type tag). The operators
claim an ordering guarantee the type does not provide.

Every other set family whose base type lacks a semantic order (`geomset`,
`geogset`, `cbufferset`, `poseset`, `npointset`, `h3indexset`, `quadbinset`,
`pcpointset`, `pcpatchset`) exposes no position operators; `jsonbset` is the
only one with a partial, single-direction pair. Ordered-base sets (`textset`,
`intset`, `floatset`) keep `<< >> &< &>`, and time sets (`tstzset`,
`dateset`) keep the time spelling.

The generic `Left_set_set`/`Right_set_set` C functions stay in place, since
the set families over ordered base types still use them.

## Test plan

- [x] `mobilitydb/test/json/expected/450_jsonbset_tbl.test.out` matches a
      real build; the only diff from the prior oracle is the removal of the
      two queries exercising the dropped operators.
- [x] `ctest` passes for the affected test suite.
