### PR TITLE
Update the MobilityDB copyright year in the tjsonb comparison SQL script

### DIFF
--- a/mobilitydb/sql/json/458_tjsonb_compops.in.sql
+++ b/mobilitydb/sql/json/458_tjsonb_compops.in.sql
@@ -1,7 +1,7 @@
 /*****************************************************************************
  *
  * This MobilityDB code is provided under The PostgreSQL License.
- * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
  * contributors
  *
  * MobilityDB includes portions of PostGIS version 3 source code released


### PR DESCRIPTION
The MobilityDB copyright line in `mobilitydb/sql/json/458_tjsonb_compops.in.sql` reads `2016-2025` while the sibling SQL scripts (cbuffer, geo, ...) read `2016-2026`. This updates the year to match. The PostGIS `2001-2025` line is left as is, matching the siblings. Comment-only change; no test output is affected.
