### PR TITLE
Normalize the operator ordering in the tgeo and tpoint comparison blocks

### DIFF
--- a/mobilitydb/sql/geo/054_tgeo_compops.in.sql
+++ b/mobilitydb/sql/geo/054_tgeo_compops.in.sql
@@ -270,13 +270,13 @@ CREATE FUNCTION aEq(tgeography, tgeography)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR %= (
-  LEFTARG = tgeography, RIGHTARG = tgeography,
+  LEFTARG = tgeometry, RIGHTARG = tgeometry,
   PROCEDURE = aEq,
   NEGATOR = ?<>,
   RESTRICT = tspatial_sel, JOIN = tspatial_joinsel
 );
 CREATE OPERATOR %= (
-  LEFTARG = tgeometry, RIGHTARG = tgeometry,
+  LEFTARG = tgeography, RIGHTARG = tgeography,
   PROCEDURE = aEq,
   NEGATOR = ?<>,
   RESTRICT = tspatial_sel, JOIN = tspatial_joinsel

--- a/mobilitydb/sql/geo/054_tpoint_compops.in.sql
+++ b/mobilitydb/sql/geo/054_tpoint_compops.in.sql
@@ -73,13 +73,13 @@ CREATE FUNCTION aEq(geography, tgeogpoint)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR %= (
-  LEFTARG = geography, RIGHTARG = tgeogpoint,
+  LEFTARG = geometry, RIGHTARG = tgeompoint,
   PROCEDURE = aEq,
   NEGATOR = ?<>,
   RESTRICT = tspatial_sel, JOIN = tspatial_joinsel
 );
 CREATE OPERATOR %= (
-  LEFTARG = geometry, RIGHTARG = tgeompoint,
+  LEFTARG = geography, RIGHTARG = tgeogpoint,
   PROCEDURE = aEq,
   NEGATOR = ?<>,
   RESTRICT = tspatial_sel, JOIN = tspatial_joinsel
@@ -167,13 +167,13 @@ CREATE FUNCTION aEq(tgeogpoint, geography)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR %= (
-  LEFTARG = tgeogpoint, RIGHTARG = geography,
+  LEFTARG = tgeompoint, RIGHTARG = geometry,
   PROCEDURE = aEq,
   NEGATOR = ?<>,
   RESTRICT = tspatial_sel, JOIN = tspatial_joinsel
 );
 CREATE OPERATOR %= (
-  LEFTARG = tgeompoint, RIGHTARG = geometry,
+  LEFTARG = tgeogpoint, RIGHTARG = geography,
   PROCEDURE = aEq,
   NEGATOR = ?<>,
   RESTRICT = tspatial_sel, JOIN = tspatial_joinsel
@@ -261,13 +261,13 @@ CREATE FUNCTION aEq(tgeogpoint, tgeogpoint)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR %= (
-  LEFTARG = tgeogpoint, RIGHTARG = tgeogpoint,
+  LEFTARG = tgeompoint, RIGHTARG = tgeompoint,
   PROCEDURE = aEq,
   NEGATOR = ?<>,
   RESTRICT = tspatial_sel, JOIN = tspatial_joinsel
 );
 CREATE OPERATOR %= (
-  LEFTARG = tgeompoint, RIGHTARG = tgeompoint,
+  LEFTARG = tgeogpoint, RIGHTARG = tgeogpoint,
   PROCEDURE = aEq,
   NEGATOR = ?<>,
   RESTRICT = tspatial_sel, JOIN = tspatial_joinsel


### PR DESCRIPTION
Normalize the one operator pair emitted geodetic-first in the tgeo and tpoint comparison blocks to the planar-first order the rest of each block uses, so the section is internally consistent. Operator definition order does not change semantics, so no regression output changes.
