### PR TITLE
Correct the copyright year in the tjsonb comparison SQL

### DIFF
--- a/mobilitydb/sql/json/458_tjsonb_compops.in.sql
+++ b/mobilitydb/sql/json/458_tjsonb_compops.in.sql
@@ -1,7 +1,7 @@
 /*****************************************************************************
  *
  * This MobilityDB code is provided under The PostgreSQL License.
- * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
  * contributors
  *
  * MobilityDB includes portions of PostGIS version 3 source code released


### PR DESCRIPTION
Correct the MobilityDB copyright year on the tjsonb comparison SQL header from 2025 to 2026, matching the sibling files. Comment-only change with no effect on any function or test output.
