### PR TITLE
Measure the pcpatch reserved tail from the buffer-aligned header

### DIFF
--- a/meos/src/pointcloud/pcpatch.c
+++ b/meos/src/pointcloud/pcpatch.c
@@ -35,18 +35,35 @@
 #include <meos.h>
 
 /*****************************************************************************
- * Struct-tail padding
+ * Reserved tail
  *
- * Same phenomenon as pcpoint.c — pgpointcloud's @c pc_patch_serialize*
- * allocates @c sizeof(SERIALIZED_PATCH) - 1 + <packed-points size> and
- * leaves the struct-tail padding uninitialized. For SERIALIZED_PATCH:
+ * Same phenomenon as pcpoint.c, but the amount reserved is NOT the tail
+ * padding of the structure. A serialized patch is sized as
+ *
+ *   BUFFERALIGN(sizeof(SERIALIZED_PATCH)) - 1 + pc_stats_size + <data size>
+ *
+ * (upstream @c pc_patch_serialize, mirrored by @c meos_pc_patch_serialize in
+ * pgsql_compat.c), and the statistics and packed points are written from
+ * @c offsetof(SERIALIZED_PATCH, data) onwards. For SERIALIZED_PATCH:
  *
  *   { uint32_t size; uint32_t pcid; uint32_t compression;
  *     uint32_t npoints; PCBOUNDS bounds; uint8_t data[1]; }
  *
- * PCBOUNDS is 4 doubles (alignment 8), so @c data[1] sits at offset 48
- * and the struct rounds to 56 — 7 bytes of tail padding on x86_64.
- * Truncate @c VARSIZE by that amount for cmp/hash.
+ * PCBOUNDS is 4 doubles (alignment 8), so @c data[1] sits at offset 48 and
+ * the structure rounds to 56. BUFFERALIGN rounds that up to 64, so the bytes
+ * that are reserved but never written are
+ *
+ *   BUFFERALIGN(sizeof) - 1 - offsetof(data)
+ *
+ * which is 15, not the 7 the structure alone accounts for. The buffer comes
+ * from @c palloc, so those bytes hold whatever the heap held before; deriving
+ * the amount from the structure leaves 8 of them inside the compared prefix
+ * and makes @c pcpatch_cmp and @c pcpatch_hash depend on uninitialized
+ * memory. Truncate @c VARSIZE by the reserved amount for cmp/hash.
+ *
+ * The point counterpart needs no such rounding: a serialized point is sized
+ * as @c sizeof(SERIALIZED_POINT) - 1 + schema->size, with no BUFFERALIGN, so
+ * pcpoint.c measures its reserve from the structure alone.
  *****************************************************************************/
 
 /**
@@ -63,13 +80,14 @@ typedef struct
 } PcpatchLayoutShadow;
 
 #define PCPATCH_TAIL_PADDING \
-  (sizeof(PcpatchLayoutShadow) - offsetof(PcpatchLayoutShadow, data) - 1)
+  (BUFFERALIGN(sizeof(PcpatchLayoutShadow)) - 1 - \
+   offsetof(PcpatchLayoutShadow, data))
 
 /**
  * @brief Return the comparable byte length of a pcpatch.
- * @details Strips the trailing zero-padding that pgpointcloud's varlena
- * layout reserves for the in-place data area, so that
- * @c pcpatch_cmp / @c pcpatch_hash do not depend on padding bytes.
+ * @details Strips the trailing bytes that pgpointcloud's varlena layout
+ * reserves past the statistics and packed points, so that
+ * @c pcpatch_cmp / @c pcpatch_hash do not depend on them.
  */
 static inline size_t
 pcpatch_meaningful_size(const Pcpatch *pa)
@@ -181,6 +199,11 @@ pcpatch_hex_in(const char *str)
  * @brief Return the textual (hex-WKB) representation of a pcpatch
  * @param[in] pa Patch
  * @param[in] maxdd Unused (kept for API uniformity with set_out)
+ * @note The bytes past the meaningful prefix are the reserved tail described
+ * at the top of this file, which the allocation leaves uninitialized. They
+ * are emitted as zeros so that two patches holding the same points always
+ * print the same string, keeping the full @c VARSIZE length that the
+ * deserializer's size check expects.
  */
 char *
 pcpatch_hex_out(const Pcpatch *pa, int maxdd)
@@ -188,10 +211,14 @@ pcpatch_hex_out(const Pcpatch *pa, int maxdd)
   (void) maxdd;
   assert(pa);
   size_t byte_len = VARSIZE(pa);
+  size_t meaningful = pcpatch_meaningful_size(pa);
   size_t hex_len = byte_len * 2;
   char *result = palloc(hex_len + 1);
-  for (size_t i = 0; i < byte_len; i++)
+  size_t i = 0;
+  for (; i < meaningful; i++)
     deparse_hex(((const uint8_t *) pa)[i], result + 2 * i);
+  for (; i < byte_len; i++)
+    deparse_hex(0, result + 2 * i);
   result[hex_len] = '\0';
   return result;
 }

--- a/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
+++ b/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
@@ -229,6 +229,22 @@ SELECT (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), 
  t
 (1 row)
 
+SELECT numValues(set(ARRAY[PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]),
+  PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]),
+    PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])])]));
+ numvalues 
+-----------
+         1
+(1 row)
+
+SELECT (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz)) = tpcpatch(PC_Patch(ARRAY[
+  PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]),
+  PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz);
+ ?column? 
+----------
+ t
+(1 row)
+
 SELECT tpcpatchInst(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz)) IS NOT NULL;
  ?column? 
 ----------

--- a/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
+++ b/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
@@ -123,6 +123,17 @@ SELECT (:inst1) = (:inst2);
 SELECT (:inst1) <> (:inst2);
 SELECT (:inst1) < (:inst2);
 
+-- Two patches built by separate calls from the same points deduplicate into
+-- one set value, and compare equal once lifted: the comparison must not reach
+-- the bytes the serialized layout reserves past the statistics and the packed
+-- points.
+SELECT numValues(set(ARRAY[:patch1,
+  PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]),
+    PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])])]));
+SELECT (:inst1) = tpcpatch(PC_Patch(ARRAY[
+  PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]),
+  PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz);
+
 -------------------------------------------------------------------------------
 -- Transformations
 -------------------------------------------------------------------------------


### PR DESCRIPTION
`pcpatch_cmp` and `pcpatch_hash` read uninitialized memory.

A serialized patch is sized as `BUFFERALIGN(sizeof(SERIALIZED_PATCH)) - 1` plus
the statistics and the packed points, and those are written from the offset of
the `data` member onwards. With `ALIGNOF_BUFFER` 32 the header rounds from 56 to
64, so the bytes reserved past the last one written are

```
BUFFERALIGN(sizeof) - 1 - offsetof(data) = 64 - 1 - 48 = 15
```

`pcpatch.c` derives the amount from the structure alone, which gives 7. The
buffer comes from `palloc`, so the eight bytes in between hold whatever the heap
held before, and `pcpatch_meaningful_size` keeps them inside the prefix that
`pcpatch_cmp` compares and `pcpatch_hash` hashes. Two patches built from the
same points can therefore compare unequal, which reaches equality, ordering,
set deduplication, and the B-tree and hash operator classes.

This takes the amount from the same expression the serialized size uses. The
point counterpart needs no such rounding, since a serialized point is sized as
`sizeof(SERIALIZED_POINT) - 1` plus the schema point size, and keeps measuring
its reserve from the structure.

`pcpatch_hex_out` emits the reserved bytes as zeros, as its point counterpart
does, keeping the full length the deserializer expects.

Tests assert that two patches built by separate calls from the same points
deduplicate into a single set value and compare equal once lifted.

Note that the point values in the regression suite carry zeros in the affected
bytes, so the representation is unchanged and `431_tpcpatch_cmp` and
`430_tpcpatch_tbl` produce identical output: the change corrects which bytes
participate in a comparison rather than the result of any comparison the suite
already covers.