### PR TITLE
Bring the setUnion aggregate section of the set type under the inherited SQL generator

### DIFF
--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -2613,12 +2613,17 @@ def render_spanfile(fam: dict) -> str:
 
 
 def extract_spanfile(filetext: str, fam: dict) -> str:
-    """Return the committed region (marker-aware; else begin_exact + EOF)."""
+    """Return the committed region (marker-aware; else begin_exact + EOF, or —
+    when the entry carries an `end:` anchor because its region is a SECTION of a
+    file whose neighbouring sections belong to other axes, e.g. the Set<T>
+    sections of 001_set.in.sql — begin_exact up to the exact `end:` text)."""
     begin, end = _spanfile_markers(fam["family"])
     if begin in filetext:
         b = filetext.index(begin) + len(begin)
         e = filetext.index(end)
         return filetext[b:e]
+    if "end" in fam:
+        return filetext[filetext.index(fam["begin"]):filetext.index(fam["end"])]
     return filetext[filetext.index(fam["begin"]):]
 
 
@@ -2631,10 +2636,14 @@ def splice_spanfile(filetext: str, family: str, rendered: str) -> str:
 
 def bootstrap_spanfile(filetext: str, fam: dict, rendered: str) -> str:
     """Insert the GENERATED-SPANFILE markers around the file body (everything
-    from the first statement to EOF); idempotent afterward. Not run while the
-    families are reference-only (validate-only)."""
+    from the first statement to EOF, or up to the `end:` anchor for a
+    region-in-file entry); idempotent afterward. Not run while the families are
+    reference-only (validate-only)."""
     start = filetext.index(fam["begin"])
     begin_m, end_m = _spanfile_markers(fam["family"])
+    if "end" in fam:
+        return (filetext[:start] + begin_m + rendered + end_m
+                + filetext[filetext.index(fam["end"]):])
     return filetext[:start] + begin_m + rendered + end_m
 
 

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -5418,6 +5418,31 @@ span_families:
     - {stmt: "\n/******************************************************************************/\n"}
     sep: "\n"
     order: [date]
+- family: set_aggregations
+  file: mobilitydb/sql/temporal/001_set.in.sql
+  reference: true
+  begin: "/******************************************************************************\n * Aggregate functions\n ******************************************************************************/\n"
+  end: "/*****************************************************************************\n * Selectivity functions"
+  order: [int, bigint, float, text, date, tstz]
+  insts:
+    int: {v: integer, vs: intset}
+    bigint: {v: bigint, vs: bigintset}
+    float: {v: float, vs: floatset}
+    text: {v: text, vs: textset}
+    date: {v: date, vs: dateset}
+    tstz: {v: timestamptz, vs: tstzset}
+  blocks:
+  - lit: "/******************************************************************************\n * Aggregate functions\n ******************************************************************************/\n\n-- The function is not STRICT\n"
+  - {stmt: "CREATE FUNCTION set_union_transfn(internal, {v})\n  RETURNS internal\n  AS 'MODULE_PATHNAME', 'Value_union_transfn'\n  LANGUAGE C IMMUTABLE PARALLEL SAFE;"}
+  - lit: "\n-- The function is not STRICT\n"
+  - {stmt: "CREATE FUNCTION set_union_transfn(internal, {vs})\n  RETURNS internal\n  AS 'MODULE_PATHNAME', 'Set_union_transfn'\n  LANGUAGE C IMMUTABLE PARALLEL SAFE;"}
+  - lit: "\n"
+  - {stmt: "CREATE FUNCTION {vs}_union_finalfn(internal)\n  RETURNS {vs}\n  AS 'MODULE_PATHNAME', 'Set_union_finalfn'\n  LANGUAGE C IMMUTABLE PARALLEL SAFE;", order: [int, bigint, float, date, tstz, text]}
+  - lit: "\n"
+  - {stmt: "CREATE AGGREGATE setUnion({v}) (\n  SFUNC = set_union_transfn,\n  STYPE = internal,\n#if POSTGRESQL_VERSION_NUMBER >= 160000\n  COMBINEFUNC = array_agg_combine,\n  SERIALFUNC = array_agg_serialize,\n  DESERIALFUNC = array_agg_deserialize,\n#endif //POSTGRESQL_VERSION_NUMBER >= 160000\n  FINALFUNC = {vs}_union_finalfn,\n  PARALLEL = safe\n);"}
+  - lit: "\n"
+  - {stmt: "CREATE AGGREGATE setUnion({vs}) (\n  SFUNC = set_union_transfn,\n  STYPE = internal,\n#if POSTGRESQL_VERSION_NUMBER >= 160000\n  COMBINEFUNC = array_agg_combine,\n  SERIALFUNC = array_agg_serialize,\n  DESERIALFUNC = array_agg_deserialize,\n#endif //POSTGRESQL_VERSION_NUMBER >= 160000\n  FINALFUNC = {vs}_union_finalfn,\n  PARALLEL = safe\n);"}
+  - lit: "\n"
 
 aggregate_families:
 - family: geo


### PR DESCRIPTION
Brings the `setUnion` aggregate section of `001_set.in.sql` (the hand half of the Set aggregation surface; the `extent` half is already generated via the `015_span_aggfuncs` entry) under `tools/codegen/inherited/`.

- `span_families` gains a region-in-file mode: an entry may carry an exact `end:` anchor so its region is a bounded section of a file whose neighbouring sections belong to other axes (`001_set.in.sql`'s comparison/hash/selectivity sections), instead of running to EOF.
- New reference entry `set_aggregations`: re-renders the `set_union_transfn` / `*_union_finalfn` functions and the twelve `setUnion` aggregates byte-for-byte under `--validate`.
- The irregular declaration order of the final functions (`textset_union_finalfn` last, after date/tstz) is encoded as a stanza-level `order:` override, not normalized.

No `.in.sql` change; validate-only (a full non-validate emit leaves the tree clean).
