### PR TITLE
Name the base-type comparison functions with the bare overloaded names

### DIFF
--- a/mobilitydb/sql/cbuffer/200_cbuffer.in.sql
+++ b/mobilitydb/sql/cbuffer/200_cbuffer.in.sql
@@ -218,67 +218,67 @@ CREATE OPERATOR ~= (
  * Comparisons
  ******************************************************************************/
 
-CREATE FUNCTION cbuffer_eq(cbuffer, cbuffer)
+CREATE FUNCTION eq(cbuffer, cbuffer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Cbuffer_eq'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION cbuffer_ne(cbuffer, cbuffer)
+CREATE FUNCTION ne(cbuffer, cbuffer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Cbuffer_ne'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION cbuffer_lt(cbuffer, cbuffer)
+CREATE FUNCTION lt(cbuffer, cbuffer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Cbuffer_lt'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION cbuffer_le(cbuffer, cbuffer)
+CREATE FUNCTION le(cbuffer, cbuffer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Cbuffer_le'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION cbuffer_ge(cbuffer, cbuffer)
+CREATE FUNCTION ge(cbuffer, cbuffer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Cbuffer_ge'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION cbuffer_gt(cbuffer, cbuffer)
+CREATE FUNCTION gt(cbuffer, cbuffer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Cbuffer_gt'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION cbuffer_cmp(cbuffer, cbuffer)
+CREATE FUNCTION cmp(cbuffer, cbuffer)
   RETURNS int4
   AS 'MODULE_PATHNAME', 'Cbuffer_cmp'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR = (
-  PROCEDURE = cbuffer_eq,
+  PROCEDURE = eq,
   LEFTARG = cbuffer, RIGHTARG = cbuffer,
   COMMUTATOR = =, NEGATOR = <>,
   RESTRICT = eqsel, JOIN = eqjoinsel
 );
 CREATE OPERATOR <> (
-  PROCEDURE = cbuffer_ne,
+  PROCEDURE = ne,
   LEFTARG = cbuffer, RIGHTARG = cbuffer,
   COMMUTATOR = <>, NEGATOR = =,
   RESTRICT = neqsel, JOIN = neqjoinsel
 );
 CREATE OPERATOR < (
-  PROCEDURE = cbuffer_lt,
+  PROCEDURE = lt,
   LEFTARG = cbuffer, RIGHTARG = cbuffer,
   COMMUTATOR = >, NEGATOR = >=,
   RESTRICT = scalarltsel, JOIN = scalarltjoinsel
 );
 CREATE OPERATOR <= (
-  PROCEDURE = cbuffer_le,
+  PROCEDURE = le,
   LEFTARG = cbuffer, RIGHTARG = cbuffer,
   COMMUTATOR = >=, NEGATOR = >,
   RESTRICT = scalarlesel, JOIN = scalarlejoinsel
 );
 CREATE OPERATOR >= (
-  PROCEDURE = cbuffer_ge,
+  PROCEDURE = ge,
   LEFTARG = cbuffer, RIGHTARG = cbuffer,
   COMMUTATOR = <=, NEGATOR = <,
   RESTRICT = scalargesel, JOIN = scalargejoinsel
 );
 CREATE OPERATOR > (
-  PROCEDURE = cbuffer_gt,
+  PROCEDURE = gt,
   LEFTARG = cbuffer, RIGHTARG = cbuffer,
   COMMUTATOR = <, NEGATOR = <=,
   RESTRICT = scalargtsel, JOIN = scalargtjoinsel
@@ -291,7 +291,7 @@ CREATE OPERATOR CLASS cbuffer_btree_ops
   OPERATOR  3 = ,
   OPERATOR  4 >= ,
   OPERATOR  5 > ,
-  FUNCTION  1 cbuffer_cmp(cbuffer, cbuffer);
+  FUNCTION  1 cmp(cbuffer, cbuffer);
 
 /******************************************************************************/
 

--- a/mobilitydb/sql/npoint/300_npoint.in.sql
+++ b/mobilitydb/sql/npoint/300_npoint.in.sql
@@ -292,67 +292,67 @@ CREATE FUNCTION round(nsegment, integer DEFAULT 0)
  * Comparisons
  ******************************************************************************/
 
-CREATE FUNCTION npoint_eq(npoint, npoint)
+CREATE FUNCTION eq(npoint, npoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Npoint_eq'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION npoint_ne(npoint, npoint)
+CREATE FUNCTION ne(npoint, npoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Npoint_ne'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION npoint_lt(npoint, npoint)
+CREATE FUNCTION lt(npoint, npoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Npoint_lt'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION npoint_le(npoint, npoint)
+CREATE FUNCTION le(npoint, npoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Npoint_le'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION npoint_ge(npoint, npoint)
+CREATE FUNCTION ge(npoint, npoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Npoint_ge'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION npoint_gt(npoint, npoint)
+CREATE FUNCTION gt(npoint, npoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Npoint_gt'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION npoint_cmp(npoint, npoint)
+CREATE FUNCTION cmp(npoint, npoint)
   RETURNS int4
   AS 'MODULE_PATHNAME', 'Npoint_cmp'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR = (
-  PROCEDURE = npoint_eq,
+  PROCEDURE = eq,
   LEFTARG = npoint, RIGHTARG = npoint,
   COMMUTATOR = =, NEGATOR = <>,
   RESTRICT = eqsel, JOIN = eqjoinsel
 );
 CREATE OPERATOR <> (
-  PROCEDURE = npoint_ne,
+  PROCEDURE = ne,
   LEFTARG = npoint, RIGHTARG = npoint,
   COMMUTATOR = <>, NEGATOR = =,
   RESTRICT = neqsel, JOIN = neqjoinsel
 );
 CREATE OPERATOR < (
-  PROCEDURE = npoint_lt,
+  PROCEDURE = lt,
   LEFTARG = npoint, RIGHTARG = npoint,
   COMMUTATOR = >, NEGATOR = >=,
   RESTRICT = scalarltsel, JOIN = scalarltjoinsel
 );
 CREATE OPERATOR <= (
-  PROCEDURE = npoint_le,
+  PROCEDURE = le,
   LEFTARG = npoint, RIGHTARG = npoint,
   COMMUTATOR = >=, NEGATOR = >,
   RESTRICT = scalarlesel, JOIN = scalarlejoinsel
 );
 CREATE OPERATOR >= (
-  PROCEDURE = npoint_ge,
+  PROCEDURE = ge,
   LEFTARG = npoint, RIGHTARG = npoint,
   COMMUTATOR = <=, NEGATOR = <,
   RESTRICT = scalargesel, JOIN = scalargejoinsel
 );
 CREATE OPERATOR > (
-  PROCEDURE = npoint_gt,
+  PROCEDURE = gt,
   LEFTARG = npoint, RIGHTARG = npoint,
   COMMUTATOR = <, NEGATOR = <=,
   RESTRICT = scalargtsel, JOIN = scalargtjoinsel
@@ -365,71 +365,71 @@ CREATE OPERATOR CLASS npoint_btree_ops
   OPERATOR  3 = ,
   OPERATOR  4 >= ,
   OPERATOR  5 > ,
-  FUNCTION  1 npoint_cmp(npoint, npoint);
+  FUNCTION  1 cmp(npoint, npoint);
 
 /******************************************************************************/
 
-CREATE FUNCTION nsegment_eq(nsegment, nsegment)
+CREATE FUNCTION eq(nsegment, nsegment)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Nsegment_eq'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION nsegment_ne(nsegment, nsegment)
+CREATE FUNCTION ne(nsegment, nsegment)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Nsegment_ne'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION nsegment_lt(nsegment, nsegment)
+CREATE FUNCTION lt(nsegment, nsegment)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Nsegment_lt'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION nsegment_le(nsegment, nsegment)
+CREATE FUNCTION le(nsegment, nsegment)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Nsegment_le'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION nsegment_ge(nsegment, nsegment)
+CREATE FUNCTION ge(nsegment, nsegment)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Nsegment_ge'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION nsegment_gt(nsegment, nsegment)
+CREATE FUNCTION gt(nsegment, nsegment)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Nsegment_gt'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION nsegment_cmp(nsegment, nsegment)
+CREATE FUNCTION cmp(nsegment, nsegment)
   RETURNS int4
   AS 'MODULE_PATHNAME', 'Nsegment_cmp'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR = (
-  PROCEDURE = nsegment_eq,
+  PROCEDURE = eq,
   LEFTARG = nsegment, RIGHTARG = nsegment,
   COMMUTATOR = =, NEGATOR = <>,
   RESTRICT = eqsel, JOIN = eqjoinsel
 );
 CREATE OPERATOR <> (
-  PROCEDURE = nsegment_ne,
+  PROCEDURE = ne,
   LEFTARG = nsegment, RIGHTARG = nsegment,
   COMMUTATOR = <>, NEGATOR = =,
   RESTRICT = neqsel, JOIN = neqjoinsel
 );
 CREATE OPERATOR < (
-  PROCEDURE = nsegment_lt,
+  PROCEDURE = lt,
   LEFTARG = nsegment, RIGHTARG = nsegment,
   COMMUTATOR = >, NEGATOR = >=,
   RESTRICT = scalarltsel, JOIN = scalarltjoinsel
 );
 CREATE OPERATOR <= (
-  PROCEDURE = nsegment_le,
+  PROCEDURE = le,
   LEFTARG = nsegment, RIGHTARG = nsegment,
   COMMUTATOR = >=, NEGATOR = >,
   RESTRICT = scalarlesel, JOIN = scalarlejoinsel
 );
 CREATE OPERATOR >= (
-  PROCEDURE = nsegment_ge,
+  PROCEDURE = ge,
   LEFTARG = nsegment, RIGHTARG = nsegment,
   COMMUTATOR = <=, NEGATOR = <,
   RESTRICT = scalargesel, JOIN = scalargejoinsel
 );
 CREATE OPERATOR > (
-  PROCEDURE = nsegment_gt,
+  PROCEDURE = gt,
   LEFTARG = nsegment, RIGHTARG = nsegment,
   COMMUTATOR = <, NEGATOR = <=,
   RESTRICT = scalargtsel, JOIN = scalargtjoinsel
@@ -442,6 +442,6 @@ CREATE OPERATOR CLASS nsegment_btree_ops
   OPERATOR  3 = ,
   OPERATOR  4 >= ,
   OPERATOR  5 > ,
-  FUNCTION  1 nsegment_cmp(nsegment, nsegment);
+  FUNCTION  1 cmp(nsegment, nsegment);
 
 /******************************************************************************/

--- a/mobilitydb/sql/pointcloud/410_tpcbox.in.sql
+++ b/mobilitydb/sql/pointcloud/410_tpcbox.in.sql
@@ -284,52 +284,52 @@ CREATE OPERATOR -|- (
  * Comparison / B-tree
  ******************************************************************************/
 
-CREATE FUNCTION tpcbox_eq(tpcbox, tpcbox)
+CREATE FUNCTION eq(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'Tpcbox_eq'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tpcbox_ne(tpcbox, tpcbox)
+CREATE FUNCTION ne(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'Tpcbox_ne'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tpcbox_lt(tpcbox, tpcbox)
+CREATE FUNCTION lt(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'Tpcbox_lt'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tpcbox_le(tpcbox, tpcbox)
+CREATE FUNCTION le(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'Tpcbox_le'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tpcbox_gt(tpcbox, tpcbox)
+CREATE FUNCTION gt(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'Tpcbox_gt'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tpcbox_ge(tpcbox, tpcbox)
+CREATE FUNCTION ge(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'Tpcbox_ge'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tpcbox_cmp(tpcbox, tpcbox)
+CREATE FUNCTION cmp(tpcbox, tpcbox)
   RETURNS integer AS 'MODULE_PATHNAME', 'Tpcbox_cmp'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR = (
-  LEFTARG = tpcbox, RIGHTARG = tpcbox, PROCEDURE = tpcbox_eq,
+  LEFTARG = tpcbox, RIGHTARG = tpcbox, PROCEDURE = eq,
   COMMUTATOR = =, NEGATOR = <>,
   RESTRICT = eqsel, JOIN = eqjoinsel
 );
 CREATE OPERATOR <> (
-  LEFTARG = tpcbox, RIGHTARG = tpcbox, PROCEDURE = tpcbox_ne,
+  LEFTARG = tpcbox, RIGHTARG = tpcbox, PROCEDURE = ne,
   COMMUTATOR = <>, NEGATOR = =,
   RESTRICT = neqsel, JOIN = neqjoinsel
 );
 CREATE OPERATOR < (
-  LEFTARG = tpcbox, RIGHTARG = tpcbox, PROCEDURE = tpcbox_lt,
+  LEFTARG = tpcbox, RIGHTARG = tpcbox, PROCEDURE = lt,
   COMMUTATOR = >, NEGATOR = >=
 );
 CREATE OPERATOR <= (
-  LEFTARG = tpcbox, RIGHTARG = tpcbox, PROCEDURE = tpcbox_le,
+  LEFTARG = tpcbox, RIGHTARG = tpcbox, PROCEDURE = le,
   COMMUTATOR = >=, NEGATOR = >
 );
 CREATE OPERATOR >= (
-  LEFTARG = tpcbox, RIGHTARG = tpcbox, PROCEDURE = tpcbox_ge,
+  LEFTARG = tpcbox, RIGHTARG = tpcbox, PROCEDURE = ge,
   COMMUTATOR = <=, NEGATOR = <
 );
 CREATE OPERATOR > (
-  LEFTARG = tpcbox, RIGHTARG = tpcbox, PROCEDURE = tpcbox_gt,
+  LEFTARG = tpcbox, RIGHTARG = tpcbox, PROCEDURE = gt,
   COMMUTATOR = <, NEGATOR = <=
 );
 
@@ -340,7 +340,7 @@ CREATE OPERATOR CLASS tpcbox_btree_ops
     OPERATOR  3  =,
     OPERATOR  4  >=,
     OPERATOR  5  >,
-    FUNCTION  1  tpcbox_cmp(tpcbox, tpcbox);
+    FUNCTION  1  cmp(tpcbox, tpcbox);
 
 /******************************************************************************
  * Position predicates — strict + overlap variants across X / Y / Z / time.

--- a/mobilitydb/sql/pose/100_pose.in.sql
+++ b/mobilitydb/sql/pose/100_pose.in.sql
@@ -293,67 +293,67 @@ CREATE OPERATOR ~= (
  * Comparisons
  ******************************************************************************/
 
-CREATE FUNCTION pose_eq(pose, pose)
+CREATE FUNCTION eq(pose, pose)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Pose_eq'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION pose_ne(pose, pose)
+CREATE FUNCTION ne(pose, pose)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Pose_ne'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION pose_lt(pose, pose)
+CREATE FUNCTION lt(pose, pose)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Pose_lt'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION pose_le(pose, pose)
+CREATE FUNCTION le(pose, pose)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Pose_le'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION pose_ge(pose, pose)
+CREATE FUNCTION ge(pose, pose)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Pose_ge'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION pose_gt(pose, pose)
+CREATE FUNCTION gt(pose, pose)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Pose_gt'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION pose_cmp(pose, pose)
+CREATE FUNCTION cmp(pose, pose)
   RETURNS int4
   AS 'MODULE_PATHNAME', 'Pose_cmp'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR = (
-  PROCEDURE = pose_eq,
+  PROCEDURE = eq,
   LEFTARG = pose, RIGHTARG = pose,
   COMMUTATOR = =, NEGATOR = <>,
   RESTRICT = eqsel, JOIN = eqjoinsel
 );
 CREATE OPERATOR <> (
-  PROCEDURE = pose_ne,
+  PROCEDURE = ne,
   LEFTARG = pose, RIGHTARG = pose,
   COMMUTATOR = <>, NEGATOR = =,
   RESTRICT = neqsel, JOIN = neqjoinsel
 );
 CREATE OPERATOR < (
-  PROCEDURE = pose_lt,
+  PROCEDURE = lt,
   LEFTARG = pose, RIGHTARG = pose,
   COMMUTATOR = >, NEGATOR = >=,
   RESTRICT = scalarltsel, JOIN = scalarltjoinsel
 );
 CREATE OPERATOR <= (
-  PROCEDURE = pose_le,
+  PROCEDURE = le,
   LEFTARG = pose, RIGHTARG = pose,
   COMMUTATOR = >=, NEGATOR = >,
   RESTRICT = scalarlesel, JOIN = scalarlejoinsel
 );
 CREATE OPERATOR >= (
-  PROCEDURE = pose_ge,
+  PROCEDURE = ge,
   LEFTARG = pose, RIGHTARG = pose,
   COMMUTATOR = <=, NEGATOR = <,
   RESTRICT = scalargesel, JOIN = scalargejoinsel
 );
 CREATE OPERATOR > (
-  PROCEDURE = pose_gt,
+  PROCEDURE = gt,
   LEFTARG = pose, RIGHTARG = pose,
   COMMUTATOR = <, NEGATOR = <=,
   RESTRICT = scalargtsel, JOIN = scalargtjoinsel
@@ -366,7 +366,7 @@ CREATE OPERATOR CLASS pose_btree_ops
   OPERATOR  3 = ,
   OPERATOR  4 >= ,
   OPERATOR  5 > ,
-  FUNCTION  1 pose_cmp(pose, pose);
+  FUNCTION  1 cmp(pose, pose);
 
 /******************************************************************************/
 

--- a/mobilitydb/sql/quadbin/350_quadbin.in.sql
+++ b/mobilitydb/sql/quadbin/350_quadbin.in.sql
@@ -108,37 +108,37 @@ CREATE CAST (quadbin AS bigint) WITHOUT FUNCTION AS ASSIGNMENT;
  * boiler-plate and lets MobilityDuck consume the same primitives.
  ******************************************************************************/
 
-CREATE FUNCTION quadbin_eq(quadbin, quadbin)
+CREATE FUNCTION eq(quadbin, quadbin)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Quadbin_eq'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION quadbin_ne(quadbin, quadbin)
+CREATE FUNCTION ne(quadbin, quadbin)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Quadbin_ne'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION quadbin_lt(quadbin, quadbin)
+CREATE FUNCTION lt(quadbin, quadbin)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Quadbin_lt'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION quadbin_le(quadbin, quadbin)
+CREATE FUNCTION le(quadbin, quadbin)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Quadbin_le'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION quadbin_gt(quadbin, quadbin)
+CREATE FUNCTION gt(quadbin, quadbin)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Quadbin_gt'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION quadbin_ge(quadbin, quadbin)
+CREATE FUNCTION ge(quadbin, quadbin)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Quadbin_ge'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION quadbin_cmp(quadbin, quadbin)
+CREATE FUNCTION cmp(quadbin, quadbin)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Quadbin_cmp'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -150,7 +150,7 @@ CREATE FUNCTION hash(quadbin)
 
 CREATE OPERATOR = (
   LEFTARG = quadbin, RIGHTARG = quadbin,
-  PROCEDURE = quadbin_eq,
+  PROCEDURE = eq,
   COMMUTATOR = =, NEGATOR = <>,
   RESTRICT = eqsel, JOIN = eqjoinsel,
   HASHES, MERGES
@@ -158,35 +158,35 @@ CREATE OPERATOR = (
 
 CREATE OPERATOR <> (
   LEFTARG = quadbin, RIGHTARG = quadbin,
-  PROCEDURE = quadbin_ne,
+  PROCEDURE = ne,
   COMMUTATOR = <>, NEGATOR = =,
   RESTRICT = neqsel, JOIN = neqjoinsel
 );
 
 CREATE OPERATOR < (
   LEFTARG = quadbin, RIGHTARG = quadbin,
-  PROCEDURE = quadbin_lt,
+  PROCEDURE = lt,
   COMMUTATOR = >, NEGATOR = >=,
   RESTRICT = scalarltsel, JOIN = scalarltjoinsel
 );
 
 CREATE OPERATOR <= (
   LEFTARG = quadbin, RIGHTARG = quadbin,
-  PROCEDURE = quadbin_le,
+  PROCEDURE = le,
   COMMUTATOR = >=, NEGATOR = >,
   RESTRICT = scalarlesel, JOIN = scalarlejoinsel
 );
 
 CREATE OPERATOR > (
   LEFTARG = quadbin, RIGHTARG = quadbin,
-  PROCEDURE = quadbin_gt,
+  PROCEDURE = gt,
   COMMUTATOR = <, NEGATOR = <=,
   RESTRICT = scalargtsel, JOIN = scalargtjoinsel
 );
 
 CREATE OPERATOR >= (
   LEFTARG = quadbin, RIGHTARG = quadbin,
-  PROCEDURE = quadbin_ge,
+  PROCEDURE = ge,
   COMMUTATOR = <=, NEGATOR = <,
   RESTRICT = scalargesel, JOIN = scalargejoinsel
 );
@@ -205,7 +205,7 @@ CREATE OPERATOR CLASS quadbin_ops
     OPERATOR  3  =,
     OPERATOR  4  >=,
     OPERATOR  5  >,
-    FUNCTION  1  quadbin_cmp(quadbin, quadbin);
+    FUNCTION  1  cmp(quadbin, quadbin);
 
 CREATE OPERATOR CLASS quadbin_ops
   DEFAULT FOR TYPE quadbin USING hash AS

--- a/mobilitydb/src/cbuffer/cbuffer.c
+++ b/mobilitydb/src/cbuffer/cbuffer.c
@@ -665,7 +665,7 @@ PG_FUNCTION_INFO_V1(Cbuffer_eq);
 /**
  * @ingroup mobilitydb_cbuffer_base_comp
  * @brief Return true if the first circular buffer is equal to the second one
- * @sqlfn cbuffer_eq()
+ * @sqlfn eq()
  * @sqlop @p =
  */
 Datum
@@ -682,7 +682,7 @@ PG_FUNCTION_INFO_V1(Cbuffer_ne);
  * @ingroup mobilitydb_cbuffer_base_comp
  * @brief Return true if the first circular buffer is different from the second
  * one
- * @sqlfn cbuffer_ne()
+ * @sqlfn ne()
  * @sqlop @p <>
  */
 Datum
@@ -700,7 +700,7 @@ PG_FUNCTION_INFO_V1(Cbuffer_cmp);
  * @brief Return -1, 0, or 1 depending on whether the first circular buffer
  * is less than, equal to, or greater than the second one
  * @note Function used for B-tree comparison
- * @sqlfn cbuffer_cmp()
+ * @sqlfn cmp()
  */
 Datum
 Cbuffer_cmp(PG_FUNCTION_ARGS)
@@ -715,7 +715,7 @@ PG_FUNCTION_INFO_V1(Cbuffer_lt);
 /**
  * @ingroup mobilitydb_cbuffer_base_comp
  * @brief Return true if the first circular buffer is less than the second one
- * @sqlfn cbuffer_lt()
+ * @sqlfn lt()
  * @sqlop @p <
  */
 Datum
@@ -732,7 +732,7 @@ PG_FUNCTION_INFO_V1(Cbuffer_le);
  * @ingroup mobilitydb_cbuffer_base_comp
  * @brief Return true if the first circular buffer is less than or equal to the
  * second one
- * @sqlfn cbuffer_le()
+ * @sqlfn le()
  * @sqlop @p <=
  */
 Datum
@@ -749,7 +749,7 @@ PG_FUNCTION_INFO_V1(Cbuffer_ge);
  * @ingroup mobilitydb_cbuffer_base_comp
  * @brief Return true if the first circular buffer is greater than or equal to
  * the second one
- * @sqlfn cbuffer_ge()
+ * @sqlfn ge()
  * @sqlop @p >=
  */
 Datum
@@ -766,7 +766,7 @@ PG_FUNCTION_INFO_V1(Cbuffer_gt);
  * @ingroup mobilitydb_cbuffer_base_comp
  * @brief Return true if the first circular buffer is greater than the second
  * one
- * @sqlfn cbuffer_gt()
+ * @sqlfn gt()
  * @sqlop @p >
  */
 Datum

--- a/mobilitydb/src/npoint/npoint.c
+++ b/mobilitydb/src/npoint/npoint.c
@@ -797,7 +797,7 @@ PG_FUNCTION_INFO_V1(Npoint_eq);
 /**
  * @ingroup mobilitydb_npoint_base_comp
  * @brief Return true if the first network point is equal to the second one
- * @sqlfn npoint_eq()
+ * @sqlfn eq()
  * @sqlop @p =
  */
 Datum
@@ -813,7 +813,7 @@ PG_FUNCTION_INFO_V1(Npoint_ne);
 /**
  * @ingroup mobilitydb_npoint_base_comp
  * @brief Return true if the first network point is not equal to the second one
- * @sqlfn npoint_ne()
+ * @sqlfn ne()
  * @sqlop @p <>
  */
 Datum
@@ -831,7 +831,7 @@ PG_FUNCTION_INFO_V1(Npoint_cmp);
  * @brief Return -1, 0, or 1 depending on whether the first network point
  * is less than, equal to, or greater than the second one
  * @note Function used for B-tree comparison
- * @sqlfn npoint_cmp()
+ * @sqlfn cmp()
  */
 Datum
 Npoint_cmp(PG_FUNCTION_ARGS)
@@ -846,7 +846,7 @@ PG_FUNCTION_INFO_V1(Npoint_lt);
 /**
  * @ingroup mobilitydb_npoint_base_comp
  * @brief Return true if the first network point is less than the second one
- * @sqlfn npoint_lt()
+ * @sqlfn lt()
  * @sqlop @p <
  */
 Datum
@@ -863,7 +863,7 @@ PG_FUNCTION_INFO_V1(Npoint_le);
  * @ingroup mobilitydb_npoint_base_comp
  * @brief Return true if the first network point is less than or equal to the
  * second one
- * @sqlfn npoint_le()
+ * @sqlfn le()
  * @sqlop @p <=
  */
 Datum
@@ -880,7 +880,7 @@ PG_FUNCTION_INFO_V1(Npoint_ge);
  * @ingroup mobilitydb_npoint_base_comp
  * @brief Return true if the first network point is greater than or equal to the
  * second one
- * @sqlfn npoint_ge()
+ * @sqlfn ge()
  * @sqlop @p >=
  */
 Datum
@@ -896,7 +896,7 @@ PG_FUNCTION_INFO_V1(Npoint_gt);
 /**
  * @ingroup mobilitydb_npoint_base_comp
  * @brief Return true if the first network point is greater than the second one
- * @sqlfn npoint_gt()
+ * @sqlfn gt()
  * @sqlop @p >
  */
 Datum
@@ -914,7 +914,7 @@ PG_FUNCTION_INFO_V1(Nsegment_eq);
 /**
  * @ingroup mobilitydb_npoint_base_comp
  * @brief Return true if the first network segment is equal to the second one
- * @sqlfn nsegment_eq()
+ * @sqlfn eq()
  * @sqlop @p =
  */
 Datum
@@ -930,7 +930,7 @@ PG_FUNCTION_INFO_V1(Nsegment_ne);
 /**
  * @ingroup mobilitydb_npoint_base_comp
  * @brief Return true if the first network segment is not equal to the second one
- * @sqlfn nsegment_ne()
+ * @sqlfn ne()
  * @sqlop @p <>
  */
 Datum
@@ -947,7 +947,7 @@ PG_FUNCTION_INFO_V1(Nsegment_cmp);
  * @ingroup mobilitydb_npoint_base_comp
  * @brief Return -1, 0, or 1 depending on whether the first network segment
  * is less than, equal to, or greater than the second one
- * @sqlfn nsegment_cmp()
+ * @sqlfn cmp()
  */
 Datum
 Nsegment_cmp(PG_FUNCTION_ARGS)
@@ -964,7 +964,7 @@ PG_FUNCTION_INFO_V1(Nsegment_lt);
 /**
  * @ingroup mobilitydb_npoint_base_comp
  * @brief Return true if the first network segment is less than the second one
- * @sqlfn nsegment_lt()
+ * @sqlfn lt()
  * @sqlop @p <
  */
 Datum
@@ -981,7 +981,7 @@ PG_FUNCTION_INFO_V1(Nsegment_le);
  * @ingroup mobilitydb_npoint_base_comp
  * @brief Return true if the first network segment is less than or equal to the
  * second one
- * @sqlfn nsegment_le()
+ * @sqlfn le()
  * @sqlop @p <=
  */
 Datum
@@ -998,7 +998,7 @@ PG_FUNCTION_INFO_V1(Nsegment_ge);
  * @ingroup mobilitydb_npoint_base_comp
  * @brief Return true if the first network segment is greater than or equal to the
  * second one
- * @sqlfn nsegment_ge()
+ * @sqlfn ge()
  * @sqlop @p >=
  */
 Datum
@@ -1014,7 +1014,7 @@ PG_FUNCTION_INFO_V1(Nsegment_gt);
 /**
  * @ingroup mobilitydb_npoint_base_comp
  * @brief Return true if the first network segment is greater than the second one
- * @sqlfn nsegment_gt()
+ * @sqlfn gt()
  * @sqlop @p >
  */
 Datum

--- a/mobilitydb/src/pointcloud/tpcbox.c
+++ b/mobilitydb/src/pointcloud/tpcbox.c
@@ -843,7 +843,7 @@ PG_FUNCTION_INFO_V1(Tpcbox_eq);
 /**
  * @ingroup mobilitydb_pointcloud_box_comp
  * @brief PG wrapper: tpcbox = tpcbox
- * @sqlfn tpcbox_eq()
+ * @sqlfn eq()
  * @sqlop @p =
  */
 Datum Tpcbox_eq(PG_FUNCTION_ARGS) { TPCBOX_PRED_2_BODY(tpcbox_eq) }
@@ -853,7 +853,7 @@ PG_FUNCTION_INFO_V1(Tpcbox_ne);
 /**
  * @ingroup mobilitydb_pointcloud_box_comp
  * @brief PG wrapper: tpcbox <> tpcbox
- * @sqlfn tpcbox_ne()
+ * @sqlfn ne()
  * @sqlop @p <>
  */
 Datum Tpcbox_ne(PG_FUNCTION_ARGS) { TPCBOX_PRED_2_BODY(tpcbox_ne) }
@@ -863,7 +863,7 @@ PG_FUNCTION_INFO_V1(Tpcbox_lt);
 /**
  * @ingroup mobilitydb_pointcloud_box_comp
  * @brief PG wrapper: tpcbox < tpcbox
- * @sqlfn tpcbox_lt()
+ * @sqlfn lt()
  * @sqlop @p <
  */
 Datum Tpcbox_lt(PG_FUNCTION_ARGS) { TPCBOX_PRED_2_BODY(tpcbox_lt) }
@@ -873,7 +873,7 @@ PG_FUNCTION_INFO_V1(Tpcbox_le);
 /**
  * @ingroup mobilitydb_pointcloud_box_comp
  * @brief PG wrapper: tpcbox <= tpcbox
- * @sqlfn tpcbox_le()
+ * @sqlfn le()
  * @sqlop @p <=
  */
 Datum Tpcbox_le(PG_FUNCTION_ARGS) { TPCBOX_PRED_2_BODY(tpcbox_le) }
@@ -883,7 +883,7 @@ PG_FUNCTION_INFO_V1(Tpcbox_gt);
 /**
  * @ingroup mobilitydb_pointcloud_box_comp
  * @brief PG wrapper: tpcbox > tpcbox
- * @sqlfn tpcbox_gt()
+ * @sqlfn gt()
  * @sqlop @p >
  */
 Datum Tpcbox_gt(PG_FUNCTION_ARGS) { TPCBOX_PRED_2_BODY(tpcbox_gt) }
@@ -893,7 +893,7 @@ PG_FUNCTION_INFO_V1(Tpcbox_ge);
 /**
  * @ingroup mobilitydb_pointcloud_box_comp
  * @brief PG wrapper: tpcbox >= tpcbox
- * @sqlfn tpcbox_ge()
+ * @sqlfn ge()
  * @sqlop @p >=
  */
 Datum Tpcbox_ge(PG_FUNCTION_ARGS) { TPCBOX_PRED_2_BODY(tpcbox_ge) }
@@ -903,7 +903,7 @@ PG_FUNCTION_INFO_V1(Tpcbox_cmp);
 /**
  * @ingroup mobilitydb_pointcloud_box_comp
  * @brief B-tree comparator for tpcbox
- * @sqlfn tpcbox_cmp()
+ * @sqlfn cmp()
  */
 Datum
 Tpcbox_cmp(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/pose/pose.c
+++ b/mobilitydb/src/pose/pose.c
@@ -792,7 +792,7 @@ PG_FUNCTION_INFO_V1(Pose_eq);
 /**
  * @ingroup mobilitydb_pose_base_comp
  * @brief Return true if the first pose is equal to the second one
- * @sqlfn pose_eq()
+ * @sqlfn eq()
  * @sqlop @p =
  */
 Datum
@@ -808,7 +808,7 @@ PG_FUNCTION_INFO_V1(Pose_ne);
 /**
  * @ingroup mobilitydb_pose_base_comp
  * @brief Return true if the first pose is not equal to the second one
- * @sqlfn pose_ne()
+ * @sqlfn ne()
  * @sqlop @p <>
  */
 Datum
@@ -826,7 +826,7 @@ PG_FUNCTION_INFO_V1(Pose_cmp);
  * @brief Return -1, 0, or 1 depending on whether the first pose is less than,
  * equal to, or greater than the second one
  * @note Function used for B-tree comparison
- * @sqlfn pose_cmp()
+ * @sqlfn cmp()
  */
 Datum
 Pose_cmp(PG_FUNCTION_ARGS)
@@ -841,7 +841,7 @@ PG_FUNCTION_INFO_V1(Pose_lt);
 /**
  * @ingroup mobilitydb_pose_base_comp
  * @brief Return true if the first pose is less than the second one
- * @sqlfn pose_lt()
+ * @sqlfn lt()
  * @sqlop @p <
  */
 Datum
@@ -857,7 +857,7 @@ PG_FUNCTION_INFO_V1(Pose_le);
 /**
  * @ingroup mobilitydb_pose_base_comp
  * @brief Return true if the first pose is less than or equal to the second one
- * @sqlfn pose_le()
+ * @sqlfn le()
  * @sqlop @p <=
  */
 Datum
@@ -874,7 +874,7 @@ PG_FUNCTION_INFO_V1(Pose_ge);
  * @ingroup mobilitydb_pose_base_comp
  * @brief Return true if the first pose is greater than or equal to the second
  * one
- * @sqlfn pose_ge()
+ * @sqlfn ge()
  * @sqlop @p >=
  */
 Datum
@@ -890,7 +890,7 @@ PG_FUNCTION_INFO_V1(Pose_gt);
 /**
  * @ingroup mobilitydb_pose_base_comp
  * @brief Return true if the first pose is greater than the second one
- * @sqlfn pose_gt()
+ * @sqlfn gt()
  * @sqlop @p >
  */
 Datum

--- a/mobilitydb/src/quadbin/quadbin.c
+++ b/mobilitydb/src/quadbin/quadbin.c
@@ -124,7 +124,7 @@ PG_FUNCTION_INFO_V1(Quadbin_eq);
  * @ingroup mobilitydb_quadbin_base_comp
  * @brief Return true if two quadbin values are equal
  * @sqlop @p =
- * @sqlfn quadbin_eq()
+ * @sqlfn eq()
  */
 Datum
 Quadbin_eq(PG_FUNCTION_ARGS)
@@ -138,7 +138,7 @@ PG_FUNCTION_INFO_V1(Quadbin_ne);
  * @ingroup mobilitydb_quadbin_base_comp
  * @brief Return true if two quadbin values are not equal
  * @sqlop @p <>
- * @sqlfn quadbin_ne()
+ * @sqlfn ne()
  */
 Datum
 Quadbin_ne(PG_FUNCTION_ARGS)
@@ -152,7 +152,7 @@ PG_FUNCTION_INFO_V1(Quadbin_lt);
  * @ingroup mobilitydb_quadbin_base_comp
  * @brief Return true if the first quadbin is less than the second
  * @sqlop @p <
- * @sqlfn quadbin_lt()
+ * @sqlfn lt()
  */
 Datum
 Quadbin_lt(PG_FUNCTION_ARGS)
@@ -167,7 +167,7 @@ PG_FUNCTION_INFO_V1(Quadbin_le);
  * @brief Return true if the first quadbin is less than or equal to
  * the second
  * @sqlop @p <=
- * @sqlfn quadbin_le()
+ * @sqlfn le()
  */
 Datum
 Quadbin_le(PG_FUNCTION_ARGS)
@@ -181,7 +181,7 @@ PG_FUNCTION_INFO_V1(Quadbin_gt);
  * @ingroup mobilitydb_quadbin_base_comp
  * @brief Return true if the first quadbin is greater than the second
  * @sqlop @p >
- * @sqlfn quadbin_gt()
+ * @sqlfn gt()
  */
 Datum
 Quadbin_gt(PG_FUNCTION_ARGS)
@@ -196,7 +196,7 @@ PG_FUNCTION_INFO_V1(Quadbin_ge);
  * @brief Return true if the first quadbin is greater than or equal
  * to the second
  * @sqlop @p >=
- * @sqlfn quadbin_ge()
+ * @sqlfn ge()
  */
 Datum
 Quadbin_ge(PG_FUNCTION_ARGS)
@@ -210,7 +210,7 @@ PG_FUNCTION_INFO_V1(Quadbin_cmp);
  * @ingroup mobilitydb_quadbin_base_comp
  * @brief Return the btree-style comparison of two quadbin values
  * (-1 / 0 / +1)
- * @sqlfn quadbin_cmp()
+ * @sqlfn cmp()
  */
 Datum
 Quadbin_cmp(PG_FUNCTION_ARGS)

--- a/mobilitydb/test/npoint/expected/300_npoint.test.out
+++ b/mobilitydb/test/npoint/expected/300_npoint.test.out
@@ -401,10 +401,10 @@ SELECT npoint 'npoint(1,0.5)' >= npoint 'npoint(2,0.5)';
  f
 (1 row)
 
-SELECT nsegment_cmp(nsegment 'nsegment(1,0.3,0.5)', nsegment 'nsegment(1,0.3,0.4)');
- nsegment_cmp 
---------------
-            1
+SELECT cmp(nsegment 'nsegment(1,0.3,0.5)', nsegment 'nsegment(1,0.3,0.4)');
+ cmp 
+-----
+   1
 (1 row)
 
 SELECT nsegment 'nsegment(1,0.3,0.5)' = nsegment 'nsegment(1,0.3,0.5)';

--- a/mobilitydb/test/npoint/queries/300_npoint.test.sql
+++ b/mobilitydb/test/npoint/queries/300_npoint.test.sql
@@ -158,7 +158,7 @@ SELECT npoint 'npoint(1,0.5)' >= npoint 'npoint(1,0.5)';
 SELECT npoint 'npoint(1,0.5)' >= npoint 'npoint(1,0.7)';
 SELECT npoint 'npoint(1,0.5)' >= npoint 'npoint(2,0.5)';
 
-SELECT nsegment_cmp(nsegment 'nsegment(1,0.3,0.5)', nsegment 'nsegment(1,0.3,0.4)');
+SELECT cmp(nsegment 'nsegment(1,0.3,0.5)', nsegment 'nsegment(1,0.3,0.4)');
 
 SELECT nsegment 'nsegment(1,0.3,0.5)' = nsegment 'nsegment(1,0.3,0.5)';
 SELECT nsegment 'nsegment(1,0.3,0.5)' = nsegment 'nsegment(1,0.3,0.7)';


### PR DESCRIPTION
The comparison functions for the `cbuffer`, `npoint`, `nsegment`, `pose`,
`quadbin` and `tpcbox` base types use the bare overloaded names `eq`, `ne`,
`lt`, `le`, `gt`, `ge` and `cmp`, resolved by argument type, instead of the
type-prefixed `<type>_eq` … `<type>_cmp`.

This aligns these base types with the composite types (temporal, span,
spanset, set, tbox, stbox), whose comparison functions already use the bare
names. The `CREATE FUNCTION` names, the operator `PROCEDURE` references, the
btree operator-class `FUNCTION 1` references, and the `@sqlfn` documentation
tags are updated accordingly. The MEOS C functions and the PostgreSQL wrapper
symbols keep their existing names.
