### PR TITLE
Add unnest and timeSplit to the temporal pgpointcloud types

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3563,6 +3563,18 @@
 			</sect3>
 
 			<sect3>
+				<title>Fragmentación</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpcpoint_unnest"><varname>unnest</varname></link>: Devolver los valores distintos de un tpcpoint con el conjunto de spans durante el cual toma cada uno de ellos</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tpcpoint_timeSplit"><varname>timeSplit</varname></link>: Fragmentar un tpcpoint en fragmentos, uno por cada intervalo de tiempo</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
 				<title>Operaciones de cuadro delimitador</title>
 				<itemizedlist>
 					<listitem>
@@ -3681,6 +3693,18 @@
 					</listitem>
 					<listitem>
 						<para><link linkend="tpcpatch_appendInstant"><varname>appendInstant</varname>, <varname>appendSequence</varname></link>: Añadir un instante o una secuencia a un tpcpatch</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Fragmentación</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpcpatch_unnest"><varname>unnest</varname></link>: Devolver los valores distintos de un tpcpatch con el conjunto de spans durante el cual toma cada uno de ellos</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tpcpatch_timeSplit"><varname>timeSplit</varname></link>: Fragmentar un tpcpatch en fragmentos, uno por cada intervalo de tiempo</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -824,6 +824,43 @@ SELECT ST_AsText(startValue(tpcpoint(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),
 			</itemizedlist>
 		</sect2>
 
+		<sect2 xml:id="tpcpoint_splitting">
+			<title>Fragmentación</title>
+			<itemizedlist>
+				<listitem xml:id="tpcpoint_unnest">
+					<indexterm significance="normal"><primary><varname>unnest</varname></primary></indexterm>
+					<para>Devolver los valores distintos de un tpcpoint con el conjunto de spans durante el cual toma cada uno de ellos</para>
+					<para><varname>unnest(tpcpoint) → {(value,time)}</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT (un).time
+FROM (SELECT unnest(tpcpointSeq(ARRAY[
+  tpcpoint(pcpoint(1, 1, 1, 1), '2024-01-01'::timestamptz),
+  tpcpoint(pcpoint(1, 2, 2, 2), '2024-01-02'::timestamptz),
+  tpcpoint(pcpoint(1, 1, 1, 1), '2024-01-03'::timestamptz)])) AS un) t;
+-- {[2024-01-01, 2024-01-02), [2024-01-03, 2024-01-03]}
+-- {[2024-01-02, 2024-01-03)}
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="tpcpoint_timeSplit">
+					<indexterm significance="normal"><primary><varname>timeSplit</varname></primary></indexterm>
+					<para>Fragmentar un tpcpoint en fragmentos, uno por cada intervalo de tiempo</para>
+					<para><varname>timeSplit(tpcpoint,bin_width interval,origin timestamptz='2000-01-03') → {(time,tpcpoint)}</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT (ts).time, numInstants((ts).temp)
+FROM (SELECT timeSplit(tpcpointSeq(ARRAY[
+  tpcpoint(pcpoint(1, 1, 1, 1), '2024-01-01'::timestamptz),
+  tpcpoint(pcpoint(1, 2, 2, 2), '2024-01-02'::timestamptz),
+  tpcpoint(pcpoint(1, 3, 3, 3), '2024-01-03'::timestamptz)]),
+  interval '1 day', '2024-01-01'::timestamptz) AS ts) t;
+-- 2024-01-01 | 2
+-- 2024-01-02 | 2
+-- 2024-01-03 | 1
+</programlisting>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
 		<sect2 xml:id="tpcpoint_bbox_ops">
 			<title>Operadores de caja delimitadora</title>
 			<para>Los operadores de caja delimitadora evalúan contra el <varname>tpcbox</varname> del valor; véase <xref linkend="tpcbox_topo" /> y <xref linkend="tpcbox_pos" /> para la geometría por operador. Cada operador a continuación está conectado contra <varname>tpcbox</varname>, <varname>tstzspan</varname> y el propio <varname>tpcpoint</varname>.</para>
@@ -1077,6 +1114,43 @@ SELECT t, point FROM points(tpcpatch(
 					<para>Añadir un instante o una secuencia a un tpcpatch</para>
 					<para><varname>appendInstant(tpcpatch,tpcpatch) → tpcpatch</varname></para>
 					<para><varname>appendSequence(tpcpatch,tpcpatch) → tpcpatch</varname></para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2 xml:id="tpcpatch_splitting">
+			<title>Fragmentación</title>
+			<itemizedlist>
+				<listitem xml:id="tpcpatch_unnest">
+					<indexterm significance="normal"><primary><varname>unnest</varname></primary></indexterm>
+					<para>Devolver los valores distintos de un tpcpatch con el conjunto de spans durante el cual toma cada uno de ellos</para>
+					<para><varname>unnest(tpcpatch) → {(value,time)}</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT (un).time
+FROM (SELECT unnest(tpcpatchSeq(ARRAY[
+  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)), '2024-01-01'::timestamptz),
+  tpcpatch(pcpatch(1, pcpoint(1, 5, 5, 5), pcpoint(1, 6, 6, 6)), '2024-01-02'::timestamptz),
+  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)), '2024-01-03'::timestamptz)])) AS un) t;
+-- {[2024-01-02, 2024-01-03)}
+-- {[2024-01-01, 2024-01-02), [2024-01-03, 2024-01-03]}
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="tpcpatch_timeSplit">
+					<indexterm significance="normal"><primary><varname>timeSplit</varname></primary></indexterm>
+					<para>Fragmentar un tpcpatch en fragmentos, uno por cada intervalo de tiempo</para>
+					<para><varname>timeSplit(tpcpatch,bin_width interval,origin timestamptz='2000-01-03') → {(time,tpcpatch)}</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT (ts).time, numInstants((ts).temp)
+FROM (SELECT timeSplit(tpcpatchSeq(ARRAY[
+  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)), '2024-01-01'::timestamptz),
+  tpcpatch(pcpatch(1, pcpoint(1, 5, 5, 5), pcpoint(1, 6, 6, 6)), '2024-01-02'::timestamptz),
+  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)), '2024-01-03'::timestamptz)]),
+  interval '1 day', '2024-01-01'::timestamptz) AS ts) t;
+-- 2024-01-01 | 2
+-- 2024-01-02 | 2
+-- 2024-01-03 | 1
+</programlisting>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3541,6 +3541,18 @@
 			</sect3>
 
 			<sect3>
+				<title>Splitting</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpcpoint_unnest"><varname>unnest</varname></link>: Return the distinct values of a tpcpoint with the span set on which each of them is taken</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tpcpoint_timeSplit"><varname>timeSplit</varname></link>: Split a tpcpoint into fragments, one per time bin</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
 				<title>Bounding-box Operators</title>
 				<itemizedlist>
 					<listitem>
@@ -3659,6 +3671,18 @@
 					</listitem>
 					<listitem>
 						<para><link linkend="tpcpatch_appendInstant"><varname>appendInstant</varname>, <varname>appendSequence</varname></link>: Append an instant or a sequence to a tpcpatch</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
+				<title>Splitting</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tpcpatch_unnest"><varname>unnest</varname></link>: Return the distinct values of a tpcpatch with the span set on which each of them is taken</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tpcpatch_timeSplit"><varname>timeSplit</varname></link>: Split a tpcpatch into fragments, one per time bin</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -829,6 +829,43 @@ SELECT ST_AsText(startValue(tpcpoint(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),
 			</itemizedlist>
 		</sect2>
 
+		<sect2 xml:id="tpcpoint_splitting">
+			<title>Splitting</title>
+			<itemizedlist>
+				<listitem xml:id="tpcpoint_unnest">
+					<indexterm significance="normal"><primary><varname>unnest</varname></primary></indexterm>
+					<para>Return the distinct values of a tpcpoint with the span set on which each of them is taken</para>
+					<para><varname>unnest(tpcpoint) → {(value,time)}</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT (un).time
+FROM (SELECT unnest(tpcpointSeq(ARRAY[
+  tpcpoint(pcpoint(1, 1, 1, 1), '2024-01-01'::timestamptz),
+  tpcpoint(pcpoint(1, 2, 2, 2), '2024-01-02'::timestamptz),
+  tpcpoint(pcpoint(1, 1, 1, 1), '2024-01-03'::timestamptz)])) AS un) t;
+-- {[2024-01-01, 2024-01-02), [2024-01-03, 2024-01-03]}
+-- {[2024-01-02, 2024-01-03)}
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="tpcpoint_timeSplit">
+					<indexterm significance="normal"><primary><varname>timeSplit</varname></primary></indexterm>
+					<para>Split a tpcpoint into fragments, one per time bin</para>
+					<para><varname>timeSplit(tpcpoint,bin_width interval,origin timestamptz='2000-01-03') → {(time,tpcpoint)}</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT (ts).time, numInstants((ts).temp)
+FROM (SELECT timeSplit(tpcpointSeq(ARRAY[
+  tpcpoint(pcpoint(1, 1, 1, 1), '2024-01-01'::timestamptz),
+  tpcpoint(pcpoint(1, 2, 2, 2), '2024-01-02'::timestamptz),
+  tpcpoint(pcpoint(1, 3, 3, 3), '2024-01-03'::timestamptz)]),
+  interval '1 day', '2024-01-01'::timestamptz) AS ts) t;
+-- 2024-01-01 | 2
+-- 2024-01-02 | 2
+-- 2024-01-03 | 1
+</programlisting>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
 		<sect2 xml:id="tpcpoint_bbox_ops">
 			<title>Bounding-box operators</title>
 			<para>The bbox operators evaluate against the value's <varname>tpcbox</varname>; see <xref linkend="tpcbox_topo" /> and <xref linkend="tpcbox_pos" /> for the per-operator geometry. Each operator below is wired against <varname>tpcbox</varname>, <varname>tstzspan</varname>, and <varname>tpcpoint</varname> itself.</para>
@@ -1083,6 +1120,43 @@ SELECT t, point FROM points(tpcpatch(
 					<para>Append an instant or a sequence to a tpcpatch</para>
 					<para><varname>appendInstant(tpcpatch,tpcpatch) → tpcpatch</varname></para>
 					<para><varname>appendSequence(tpcpatch,tpcpatch) → tpcpatch</varname></para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2 xml:id="tpcpatch_splitting">
+			<title>Splitting</title>
+			<itemizedlist>
+				<listitem xml:id="tpcpatch_unnest">
+					<indexterm significance="normal"><primary><varname>unnest</varname></primary></indexterm>
+					<para>Return the distinct values of a tpcpatch with the span set on which each of them is taken</para>
+					<para><varname>unnest(tpcpatch) → {(value,time)}</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT (un).time
+FROM (SELECT unnest(tpcpatchSeq(ARRAY[
+  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)), '2024-01-01'::timestamptz),
+  tpcpatch(pcpatch(1, pcpoint(1, 5, 5, 5), pcpoint(1, 6, 6, 6)), '2024-01-02'::timestamptz),
+  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)), '2024-01-03'::timestamptz)])) AS un) t;
+-- {[2024-01-02, 2024-01-03)}
+-- {[2024-01-01, 2024-01-02), [2024-01-03, 2024-01-03]}
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="tpcpatch_timeSplit">
+					<indexterm significance="normal"><primary><varname>timeSplit</varname></primary></indexterm>
+					<para>Split a tpcpatch into fragments, one per time bin</para>
+					<para><varname>timeSplit(tpcpatch,bin_width interval,origin timestamptz='2000-01-03') → {(time,tpcpatch)}</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT (ts).time, numInstants((ts).temp)
+FROM (SELECT timeSplit(tpcpatchSeq(ARRAY[
+  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)), '2024-01-01'::timestamptz),
+  tpcpatch(pcpatch(1, pcpoint(1, 5, 5, 5), pcpoint(1, 6, 6, 6)), '2024-01-02'::timestamptz),
+  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)), '2024-01-03'::timestamptz)]),
+  interval '1 day', '2024-01-01'::timestamptz) AS ts) t;
+-- 2024-01-01 | 2
+-- 2024-01-02 | 2
+-- 2024-01-03 | 1
+</programlisting>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
+++ b/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
@@ -585,6 +585,35 @@ CREATE FUNCTION appendSequence(tpcpoint, tpcpoint)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /******************************************************************************
+ * Unnest
+ ******************************************************************************/
+
+CREATE TYPE pcpoint_tstzspanset AS (
+  value pcpoint,
+  time tstzspanset
+);
+
+CREATE FUNCTION unnest(tpcpoint)
+  RETURNS SETOF pcpoint_tstzspanset
+  AS 'MODULE_PATHNAME', 'Temporal_unnest'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/******************************************************************************
+ * Multidimensional tiling
+ ******************************************************************************/
+
+CREATE TYPE time_tpcpoint AS (
+  time timestamptz,
+  temp tpcpoint
+);
+
+CREATE FUNCTION timeSplit(tpcpoint, bin_width interval,
+    origin timestamptz DEFAULT '2000-01-03')
+  RETURNS setof time_tpcpoint
+  AS 'MODULE_PATHNAME', 'Temporal_time_split'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+/******************************************************************************
  * Comparison / B-tree / hash
  ******************************************************************************/
 

--- a/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
+++ b/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
@@ -609,6 +609,35 @@ CREATE FUNCTION appendSequence(tpcpatch, tpcpatch)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /******************************************************************************
+ * Unnest
+ ******************************************************************************/
+
+CREATE TYPE pcpatch_tstzspanset AS (
+  value pcpatch,
+  time tstzspanset
+);
+
+CREATE FUNCTION unnest(tpcpatch)
+  RETURNS SETOF pcpatch_tstzspanset
+  AS 'MODULE_PATHNAME', 'Temporal_unnest'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/******************************************************************************
+ * Multidimensional tiling
+ ******************************************************************************/
+
+CREATE TYPE time_tpcpatch AS (
+  time timestamptz,
+  temp tpcpatch
+);
+
+CREATE FUNCTION timeSplit(tpcpatch, bin_width interval,
+    origin timestamptz DEFAULT '2000-01-03')
+  RETURNS setof time_tpcpatch
+  AS 'MODULE_PATHNAME', 'Temporal_time_split'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+/******************************************************************************
  * Comparison / B-tree / hash
  ******************************************************************************/
 

--- a/mobilitydb/test/pointcloud/expected/420_tpcpoint.test.out
+++ b/mobilitydb/test/pointcloud/expected/420_tpcpoint.test.out
@@ -440,3 +440,66 @@ SELECT appendSequence(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0,
  t
 (1 row)
 
+SELECT count(*) FROM unnest(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]));
+ count 
+-------
+     3
+(1 row)
+
+SELECT count(*) FROM unnest(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-03'::timestamptz)]));
+ count 
+-------
+     2
+(1 row)
+
+SELECT numSpans((u).time) FROM
+  unnest(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-03'::timestamptz)])) u
+  WHERE (u).value::text = (pcpoint(1, 1.0, 1.0, 1.0))::text;
+ numspans 
+----------
+        2
+(1 row)
+
+SELECT bool_and((u).time <@ timeSpan(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)])))
+  FROM unnest(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)])) u;
+ bool_and 
+----------
+ t
+(1 row)
+
+SELECT count(*) FROM
+  timeSplit(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]), interval '1 day');
+ count 
+-------
+     3
+(1 row)
+
+SELECT count(*) FROM
+  timeSplit(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]), interval '1 week');
+ count 
+-------
+     1
+(1 row)
+
+SELECT count(*) FROM timeSplit(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]),
+  interval '2 days', timestamptz '2024-01-01');
+ count 
+-------
+     2
+(1 row)
+
+SELECT bool_and(time <= startTimestamp(temp))
+  FROM timeSplit(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]), interval '1 day');
+ bool_and 
+----------
+ t
+(1 row)
+
+SELECT bool_and(timeSpan(temp) <@
+    timeSpan(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)])))
+  FROM timeSplit(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]), interval '1 day');
+ bool_and 
+----------
+ t
+(1 row)
+

--- a/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
+++ b/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
@@ -577,3 +577,66 @@ SELECT appendSequence(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, 
  t
 (1 row)
 
+SELECT count(*) FROM unnest(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz)]));
+ count 
+-------
+     2
+(1 row)
+
+SELECT count(*) FROM unnest(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)]));
+ count 
+-------
+     2
+(1 row)
+
+SELECT numSpans((u).time) FROM
+  unnest(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)])) u
+  WHERE (u).value::text = (PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]))::text;
+ numspans 
+----------
+        2
+(1 row)
+
+SELECT bool_and((u).time <@ timeSpan(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)])))
+  FROM unnest(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)])) u;
+ bool_and 
+----------
+ t
+(1 row)
+
+SELECT count(*) FROM
+  timeSplit(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)]), interval '1 day');
+ count 
+-------
+     3
+(1 row)
+
+SELECT count(*) FROM
+  timeSplit(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)]), interval '1 week');
+ count 
+-------
+     1
+(1 row)
+
+SELECT count(*) FROM timeSplit(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)]),
+  interval '2 days', timestamptz '2024-01-01');
+ count 
+-------
+     2
+(1 row)
+
+SELECT bool_and(time <= startTimestamp(temp))
+  FROM timeSplit(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)]), interval '1 day');
+ bool_and 
+----------
+ t
+(1 row)
+
+SELECT bool_and(timeSpan(temp) <@
+    timeSpan(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)])))
+  FROM timeSplit(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)]), interval '1 day');
+ bool_and 
+----------
+ t
+(1 row)
+

--- a/mobilitydb/test/pointcloud/queries/420_tpcpoint.test.sql
+++ b/mobilitydb/test/pointcloud/queries/420_tpcpoint.test.sql
@@ -36,6 +36,8 @@
 \set inst1 'tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), ''2024-01-01''::timestamptz)'
 \set inst2 'tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), ''2024-01-02''::timestamptz)'
 \set inst3 'tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), ''2024-01-03''::timestamptz)'
+-- Same value as inst1 at a later timestamp.
+\set inst1rep 'tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), ''2024-01-03''::timestamptz)'
 
 -------------------------------------------------------------------------------
 -- Ergonomic pcpoint constructors — same value as the verbose form.
@@ -205,5 +207,41 @@ SELECT deleteTime(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
 SELECT appendInstant(tpcpointSeq(ARRAY[:inst1, :inst2]), :inst3) IS NOT NULL;
 SELECT appendSequence(tpcpointSeq(ARRAY[:inst1]),
   tpcpointSeq(ARRAY[:inst2, :inst3])) IS NOT NULL;
+
+-------------------------------------------------------------------------------
+-- Unnest
+-- One row per distinct value, with the span set on which the temporal value
+-- takes it. A value occurring twice yields one row whose span set has two
+-- spans, so the row count is the number of DISTINCT values.
+-------------------------------------------------------------------------------
+
+SELECT count(*) FROM unnest(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]));
+SELECT count(*) FROM unnest(tpcpointSeq(ARRAY[:inst1, :inst2, :inst1rep]));
+SELECT numSpans((u).time) FROM
+  unnest(tpcpointSeq(ARRAY[:inst1, :inst2, :inst1rep])) u
+  WHERE (u).value::text = (pcpoint(1, 1.0, 1.0, 1.0))::text;
+-- Every span set is contained in the time span of the temporal value.
+SELECT bool_and((u).time <@ timeSpan(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3])))
+  FROM unnest(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3])) u;
+
+-------------------------------------------------------------------------------
+-- Multidimensional tiling
+-- timeSplit cuts a temporal value into the fragments falling in each time bin.
+-------------------------------------------------------------------------------
+
+SELECT count(*) FROM
+  timeSplit(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]), interval '1 day');
+SELECT count(*) FROM
+  timeSplit(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]), interval '1 week');
+-- The bins start at the origin, so shifting it shifts the fragments.
+SELECT count(*) FROM timeSplit(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
+  interval '2 days', timestamptz '2024-01-01');
+-- Each fragment starts at or after the bin it is labelled with, and stays
+-- inside the time span of the value it was cut from.
+SELECT bool_and(time <= startTimestamp(temp))
+  FROM timeSplit(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]), interval '1 day');
+SELECT bool_and(timeSpan(temp) <@
+    timeSpan(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3])))
+  FROM timeSplit(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]), interval '1 day');
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
+++ b/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
@@ -275,3 +275,39 @@ SELECT appendSequence(tpcpatchSeq(ARRAY[:inst1, :inst2]),
   tpcpatchSeq(ARRAY[:inst3])) IS NOT NULL;
 
 -------------------------------------------------------------------------------
+-- Unnest
+-- One row per distinct value, with the span set on which the temporal value
+-- takes it. inst1 and inst3 carry the same patch, so the sequence of the
+-- three has two rows and the patch1 row has two spans.
+-------------------------------------------------------------------------------
+
+SELECT count(*) FROM unnest(tpcpatchSeq(ARRAY[:inst1, :inst2]));
+SELECT count(*) FROM unnest(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3]));
+SELECT numSpans((u).time) FROM
+  unnest(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3])) u
+  WHERE (u).value::text = (:patch1)::text;
+-- Every span set is contained in the time span of the temporal value.
+SELECT bool_and((u).time <@ timeSpan(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3])))
+  FROM unnest(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3])) u;
+
+-------------------------------------------------------------------------------
+-- Multidimensional tiling
+-- timeSplit cuts a temporal value into the fragments falling in each time bin.
+-------------------------------------------------------------------------------
+
+SELECT count(*) FROM
+  timeSplit(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3]), interval '1 day');
+SELECT count(*) FROM
+  timeSplit(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3]), interval '1 week');
+-- The bins start at the origin, so shifting it shifts the fragments.
+SELECT count(*) FROM timeSplit(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3]),
+  interval '2 days', timestamptz '2024-01-01');
+-- Each fragment starts at or after the bin it is labelled with, and stays
+-- inside the time span of the value it was cut from.
+SELECT bool_and(time <= startTimestamp(temp))
+  FROM timeSplit(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3]), interval '1 day');
+SELECT bool_and(timeSpan(temp) <@
+    timeSpan(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3])))
+  FROM timeSplit(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3]), interval '1 day');
+
+-------------------------------------------------------------------------------

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -3229,7 +3229,7 @@ modification_families:
   file: mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
   reference: true
   begin: "\n * Modification functions\n"
-  end: "\n * Comparison / B-tree / hash\n"
+  end: "\n * Unnest\n"
   blocks:
   - lit: "/******************************************************************************\n * Modification functions\n ******************************************************************************/\n\n"
   - fns:
@@ -3250,7 +3250,7 @@ modification_families:
   file: mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
   reference: true
   begin: "\n * Modification functions\n"
-  end: "\n * Comparison / B-tree / hash\n"
+  end: "\n * Unnest\n"
   blocks:
   - lit: "/******************************************************************************\n * Modification functions\n ******************************************************************************/\n\n"
   - fns:
@@ -7122,6 +7122,26 @@ tiling_families:
   - lit: "/******************************************************************************\n * Multidimensional tiling\n ******************************************************************************/\n\nCREATE TYPE time_tnpoint AS (\n  time timestamptz,\n  temp tnpoint\n);\n\n"
   - fns:
     - {sig: "timeSplit(tnpoint, bin_width interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tnpoint", sym: "Temporal_time_split"}
+  - lit: "\n"
+- family: tpcpoint
+  file: mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
+  reference: true
+  begin: "\n * Unnest\n"
+  end: "\n * Comparison / B-tree / hash\n"
+  blocks:
+  - lit: "/******************************************************************************\n * Unnest\n ******************************************************************************/\n\nCREATE TYPE pcpoint_tstzspanset AS (\n  value pcpoint,\n  time tstzspanset\n);\n\nCREATE FUNCTION unnest(tpcpoint)\n  RETURNS SETOF pcpoint_tstzspanset\n  AS 'MODULE_PATHNAME', 'Temporal_unnest'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n/******************************************************************************\n * Multidimensional tiling\n ******************************************************************************/\n\nCREATE TYPE time_tpcpoint AS (\n  time timestamptz,\n  temp tpcpoint\n);\n\n"
+  - fns:
+    - {sig: "timeSplit(tpcpoint, bin_width interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tpcpoint", sym: "Temporal_time_split"}
+  - lit: "\n"
+- family: tpcpatch
+  file: mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
+  reference: true
+  begin: "\n * Unnest\n"
+  end: "\n * Comparison / B-tree / hash\n"
+  blocks:
+  - lit: "/******************************************************************************\n * Unnest\n ******************************************************************************/\n\nCREATE TYPE pcpatch_tstzspanset AS (\n  value pcpatch,\n  time tstzspanset\n);\n\nCREATE FUNCTION unnest(tpcpatch)\n  RETURNS SETOF pcpatch_tstzspanset\n  AS 'MODULE_PATHNAME', 'Temporal_unnest'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n/******************************************************************************\n * Multidimensional tiling\n ******************************************************************************/\n\nCREATE TYPE time_tpcpatch AS (\n  time timestamptz,\n  temp tpcpatch\n);\n\n"
+  - fns:
+    - {sig: "timeSplit(tpcpatch, bin_width interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tpcpatch", sym: "Temporal_time_split"}
   - lit: "\n"
 - family: pose
   file: mobilitydb/sql/pose/102_tpose.in.sql


### PR DESCRIPTION
This adds `unnest`, which returns one row per distinct value with the span set
on which the value is taken, and `timeSplit`, which cuts a temporal value into
the fragments falling in each time bin. Every other temporal family exposes
both; the pgpointcloud types are the only ones that lack them.

Both bind the generic `Temporal_unnest` and `Temporal_time_split` wrappers, as
the other families do, together with the composite row types they return:
`pcpoint_tstzspanset` and `pcpatch_tstzspanset` for `unnest`, `time_tpcpoint`
and `time_tpcpatch` for `timeSplit`. The sections sit between the modification
and the comparison sections, matching `th3index` and `tquadbin`.

The tiling half is registered with the inherited SQL generator, which
re-renders it byte for byte under `--validate`, and the modification entry of
each type file is anchored at the new section.

Not included: `spans`, `splitNSpans` and `splitEachNSpans`. Those exist only
for the core types, the geo families and `tjsonb`, and are equally absent for
`tcbuffer`, `tnpoint`, `tpose`, `th3index` and `tquadbin`, so they are a
cross-family gap rather than a pointcloud one.

The documentation entries carry examples whose results come from a live
server, in English and Spanish.