### PR TITLE
Bring the temporal hash sections under the inherited SQL generator

### DIFF
--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -1457,6 +1457,12 @@ _HASH_OPS = [
     ("hash({t})", "integer", "Set_hash"),
     ("hashExtended({t}, bigint)", "bigint", "Set_hash_extended"),
 ]
+# The Temporal<T> hash surface is the same two-function skeleton backed by the
+# Temporal_* kernels; selected via `ops: temporal`.
+_TEMP_HASH_OPS = [
+    ("hash({t})", "integer", "Temporal_hash"),
+    ("hashExtended({t}, bigint)", "bigint", "Temporal_hash_extended"),
+]
 # The canonical hash opclass block (one per type, packed when a file has several).
 _HASH_OPCLASS = ("CREATE OPERATOR CLASS {t}_hash_ops\n"
                  "  DEFAULT FOR TYPE {t} USING hash AS\n"
@@ -1465,17 +1471,18 @@ _HASH_OPCLASS = ("CREATE OPERATOR CLASS {t}_hash_ops\n"
                  "    FUNCTION    2   hashExtended({t}, bigint);")
 
 
-def _hash_funcs(types) -> str:
+def _hash_funcs(types, ops=_HASH_OPS) -> str:
     """Render the two hash CREATE FUNCTIONs from the shared skeleton, mirroring
     _cmp_funcs: one type token (packed) or a token list (op-outer / type-inner,
-    op groups separated by one blank line)."""
+    op groups separated by one blank line). `ops` selects the kernel table
+    (Set_* by default, Temporal_* for the temporal families)."""
     tmpl = (TEMPLATES / "comparisons.sql.tmpl").read_text().rstrip("\n")
     if isinstance(types, str):
         types = [types]
     groups = ["\n".join(tmpl.replace("{SIG}", sig.format(t=t))
                             .replace("{RET}", ret).replace("{SYM}", sym)
                         for t in types)
-              for sig, ret, sym in _HASH_OPS]
+              for sig, ret, sym in ops]
     return ("\n\n" if len(types) > 1 else "\n").join(groups) + "\n"
 
 
@@ -1493,12 +1500,13 @@ def render_hash(fam: dict) -> str:
     `opcls` type token(s) (the canonical opclass). Blocks concatenate with no
     automatic separator, so the rendered text is byte-identical to the committed
     region."""
+    ops = _TEMP_HASH_OPS if fam.get("ops") == "temporal" else _HASH_OPS
     out = ""
     for blk in fam["blocks"]:
         if "lit" in blk:
             out += blk["lit"]
         elif "funcs" in blk:
-            out += _hash_funcs(blk["funcs"])
+            out += _hash_funcs(blk["funcs"], ops)
         else:
             out += _hash_opclasses(blk["opcls"])
     return out

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -1795,6 +1795,171 @@ comparison_families:
   blocks:
   - lit: "/******************************************************************************\n * Comparison operators + btree / hash opclasses\n ******************************************************************************/\n\nCREATE FUNCTION eq(quadbinset, quadbinset)\n  RETURNS boolean AS 'MODULE_PATHNAME', 'Set_eq'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION ne(quadbinset, quadbinset)\n  RETURNS boolean AS 'MODULE_PATHNAME', 'Set_ne'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION lt(quadbinset, quadbinset)\n  RETURNS boolean AS 'MODULE_PATHNAME', 'Set_lt'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION le(quadbinset, quadbinset)\n  RETURNS boolean AS 'MODULE_PATHNAME', 'Set_le'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION ge(quadbinset, quadbinset)\n  RETURNS boolean AS 'MODULE_PATHNAME', 'Set_ge'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION gt(quadbinset, quadbinset)\n  RETURNS boolean AS 'MODULE_PATHNAME', 'Set_gt'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION cmp(quadbinset, quadbinset)\n  RETURNS integer AS 'MODULE_PATHNAME', 'Set_cmp'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION hash(quadbinset)\n  RETURNS integer AS 'MODULE_PATHNAME', 'Set_hash'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE OPERATOR = (LEFTARG = quadbinset, RIGHTARG = quadbinset,\n  PROCEDURE = eq, COMMUTATOR = =, NEGATOR = <>,\n  RESTRICT = eqsel, JOIN = eqjoinsel, HASHES, MERGES);\nCREATE OPERATOR <> (LEFTARG = quadbinset, RIGHTARG = quadbinset,\n  PROCEDURE = ne, COMMUTATOR = <>, NEGATOR = =,\n  RESTRICT = neqsel, JOIN = neqjoinsel);\nCREATE OPERATOR < (LEFTARG = quadbinset, RIGHTARG = quadbinset,\n  PROCEDURE = lt, COMMUTATOR = >, NEGATOR = >=,\n  RESTRICT = span_sel, JOIN = span_joinsel);\nCREATE OPERATOR <= (LEFTARG = quadbinset, RIGHTARG = quadbinset,\n  PROCEDURE = le, COMMUTATOR = >=, NEGATOR = >,\n  RESTRICT = span_sel, JOIN = span_joinsel);\nCREATE OPERATOR > (LEFTARG = quadbinset, RIGHTARG = quadbinset,\n  PROCEDURE = gt, COMMUTATOR = <, NEGATOR = <=,\n  RESTRICT = span_sel, JOIN = span_joinsel);\nCREATE OPERATOR >= (LEFTARG = quadbinset, RIGHTARG = quadbinset,\n  PROCEDURE = ge, COMMUTATOR = <=, NEGATOR = <,\n  RESTRICT = span_sel, JOIN = span_joinsel);\n\nCREATE OPERATOR CLASS quadbinset_btree_ops\n  DEFAULT FOR TYPE quadbinset USING btree AS\n    OPERATOR  1  <,\n    OPERATOR  2  <=,\n    OPERATOR  3  =,\n    OPERATOR  4  >=,\n    OPERATOR  5  >,\n    FUNCTION  1  cmp(quadbinset, quadbinset);\n\n"
 hash_families:
+# The Temporal<T> hash surface: the same two-function skeleton backed by the
+# Temporal_* kernels (ops: temporal) plus the canonical hash opclass, closing
+# each temporal type file's tail. The base file groups its five types op-outer
+# (every hash, then every hashExtended); tgeo/tpoint group type-major with the
+# two types' function pairs packed; the opclasses pack per file.
+- family: temporal
+  file: mobilitydb/sql/temporal/022_temporal.in.sql
+  reference: true
+  ops: temporal
+  begin: "CREATE FUNCTION hash(tbool"
+  whole_file: true
+  blocks:
+  - lit: "/******************************************************************************/\n\n"
+  - funcs:
+    - tbool
+    - tint
+    - tbigint
+    - tfloat
+    - ttext
+  - lit: "\n"
+  - opcls:
+    - tbool
+    - tint
+    - tbigint
+    - tfloat
+    - ttext
+  - lit: "\n/******************************************************************************/\n"
+- family: geo
+  file: mobilitydb/sql/geo/052_tgeo.in.sql
+  reference: true
+  ops: temporal
+  begin: "CREATE FUNCTION hash(tgeometry"
+  whole_file: true
+  blocks:
+  - lit: "/******************************************************************************/\n\n"
+  - funcs: tgeometry
+  - funcs: tgeography
+  - lit: "\n"
+  - opcls:
+    - tgeometry
+    - tgeography
+  - lit: "\n/******************************************************************************/\n\n"
+- family: tpoint
+  file: mobilitydb/sql/geo/052_tpoint.in.sql
+  reference: true
+  ops: temporal
+  begin: "CREATE FUNCTION hash(tgeompoint"
+  whole_file: true
+  blocks:
+  - lit: "/******************************************************************************/\n\n"
+  - funcs: tgeompoint
+  - funcs: tgeogpoint
+  - lit: "\n"
+  - opcls:
+    - tgeompoint
+    - tgeogpoint
+  - lit: "\n/******************************************************************************/\n\n"
+- family: cbuffer
+  file: mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
+  reference: true
+  ops: temporal
+  begin: "CREATE FUNCTION hash(tcbuffer"
+  whole_file: true
+  blocks:
+  - lit: "/*****************************************************************************/\n\n"
+  - funcs: tcbuffer
+  - lit: "\n"
+  - opcls: tcbuffer
+  - lit: "\n/*****************************************************************************/\n"
+- family: npoint
+  file: mobilitydb/sql/npoint/302_tnpoint.in.sql
+  reference: true
+  ops: temporal
+  begin: "CREATE FUNCTION hash(tnpoint"
+  whole_file: true
+  blocks:
+  - lit: "/******************************************************************************/\n\n"
+  - funcs: tnpoint
+  - lit: "\n"
+  - opcls: tnpoint
+  - lit: "\n/******************************************************************************/\n"
+- family: pose
+  file: mobilitydb/sql/pose/102_tpose.in.sql
+  reference: true
+  ops: temporal
+  begin: "CREATE FUNCTION hash(tpose"
+  whole_file: true
+  blocks:
+  - lit: "/******************************************************************************/\n\n"
+  - funcs: tpose
+  - lit: "\n"
+  - opcls: tpose
+  - lit: "\n/******************************************************************************/\n"
+- family: rgeo
+  file: mobilitydb/sql/rgeo/150_trgeo.in.sql
+  reference: true
+  ops: temporal
+  begin: "CREATE FUNCTION hash(trgeometry"
+  whole_file: true
+  blocks:
+  - lit: "/******************************************************************************/\n\n"
+  - funcs: trgeometry
+  - lit: "\n"
+  - opcls: trgeometry
+  - lit: "\n/******************************************************************************/\n"
+- family: h3
+  file: mobilitydb/sql/h3/253_th3index.in.sql
+  reference: true
+  ops: temporal
+  begin: "CREATE FUNCTION hash(th3index"
+  whole_file: true
+  blocks:
+  - lit: "/******************************************************************************/\n\n"
+  - funcs: th3index
+  - lit: "\n"
+  - opcls: th3index
+  - lit: "\n/******************************************************************************/\n"
+- family: quadbin
+  file: mobilitydb/sql/quadbin/353_tquadbin.in.sql
+  reference: true
+  ops: temporal
+  begin: "CREATE FUNCTION hash(tquadbin"
+  whole_file: true
+  blocks:
+  - lit: "/******************************************************************************/\n\n"
+  - funcs: tquadbin
+  - lit: "\n"
+  - opcls: tquadbin
+  - lit: "\n/******************************************************************************/\n"
+- family: json
+  file: mobilitydb/sql/json/452_tjsonb.in.sql
+  reference: true
+  ops: temporal
+  begin: "CREATE FUNCTION hash(tjsonb"
+  whole_file: true
+  blocks:
+  - lit: "/*****************************************************************************/\n\n"
+  - funcs: tjsonb
+  - lit: "\n"
+  - opcls: tjsonb
+  - lit: "\n/*****************************************************************************/\n\n"
+- family: pointcloud
+  file: mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
+  reference: true
+  ops: temporal
+  begin: "CREATE FUNCTION hash(tpcpoint"
+  whole_file: true
+  blocks:
+  - lit: "/******************************************************************************\n * Comparison / B-tree / hash\n ******************************************************************************/\n\nCREATE FUNCTION eq(tpcpoint, tpcpoint)\n  RETURNS boolean\n  AS 'MODULE_PATHNAME', 'Temporal_eq'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION ne(tpcpoint, tpcpoint)\n  RETURNS boolean\n  AS 'MODULE_PATHNAME', 'Temporal_ne'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION lt(tpcpoint, tpcpoint)\n  RETURNS boolean\n  AS 'MODULE_PATHNAME', 'Temporal_lt'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION le(tpcpoint, tpcpoint)\n  RETURNS boolean\n  AS 'MODULE_PATHNAME', 'Temporal_le'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION ge(tpcpoint, tpcpoint)\n  RETURNS boolean\n  AS 'MODULE_PATHNAME', 'Temporal_ge'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION gt(tpcpoint, tpcpoint)\n  RETURNS boolean\n  AS 'MODULE_PATHNAME', 'Temporal_gt'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION cmp(tpcpoint, tpcpoint)\n  RETURNS integer\n  AS 'MODULE_PATHNAME', 'Temporal_cmp'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE OPERATOR = (\n  LEFTARG = tpcpoint, RIGHTARG = tpcpoint, PROCEDURE = eq,\n  COMMUTATOR = =, NEGATOR = <>,\n  RESTRICT = eqsel, JOIN = eqjoinsel\n);\nCREATE OPERATOR <> (\n  LEFTARG = tpcpoint, RIGHTARG = tpcpoint, PROCEDURE = ne,\n  COMMUTATOR = <>, NEGATOR = =,\n  RESTRICT = neqsel, JOIN = neqjoinsel\n);\nCREATE OPERATOR < (\n  LEFTARG = tpcpoint, RIGHTARG = tpcpoint, PROCEDURE = lt,\n  COMMUTATOR = >, NEGATOR = >=\n);\nCREATE OPERATOR <= (\n  LEFTARG = tpcpoint, RIGHTARG = tpcpoint, PROCEDURE = le,\n  COMMUTATOR = >=, NEGATOR = >\n);\nCREATE OPERATOR >= (\n  LEFTARG = tpcpoint, RIGHTARG = tpcpoint, PROCEDURE = ge,\n  COMMUTATOR = <=, NEGATOR = <\n);\nCREATE OPERATOR > (\n  LEFTARG = tpcpoint, RIGHTARG = tpcpoint, PROCEDURE = gt,\n  COMMUTATOR = <, NEGATOR = <=\n);\n\nCREATE OPERATOR CLASS tpcpoint_btree_ops\n  DEFAULT FOR TYPE tpcpoint USING btree AS\n    OPERATOR  1  <,\n    OPERATOR  2  <=,\n    OPERATOR  3  =,\n    OPERATOR  4  >=,\n    OPERATOR  5  >,\n    FUNCTION  1  cmp(tpcpoint, tpcpoint);\n\n"
+  - funcs: tpcpoint
+  - lit: "\n"
+  - opcls: tpcpoint
+  - lit: "\n/*****************************************************************************/\n"
+- family: pointcloud_patch
+  file: mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
+  reference: true
+  ops: temporal
+  begin: "CREATE FUNCTION hash(tpcpatch"
+  whole_file: true
+  blocks:
+  - lit: "/******************************************************************************\n * Comparison / B-tree / hash\n ******************************************************************************/\n\nCREATE FUNCTION eq(tpcpatch, tpcpatch)\n  RETURNS boolean\n  AS 'MODULE_PATHNAME', 'Temporal_eq'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION ne(tpcpatch, tpcpatch)\n  RETURNS boolean\n  AS 'MODULE_PATHNAME', 'Temporal_ne'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION lt(tpcpatch, tpcpatch)\n  RETURNS boolean\n  AS 'MODULE_PATHNAME', 'Temporal_lt'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION le(tpcpatch, tpcpatch)\n  RETURNS boolean\n  AS 'MODULE_PATHNAME', 'Temporal_le'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION ge(tpcpatch, tpcpatch)\n  RETURNS boolean\n  AS 'MODULE_PATHNAME', 'Temporal_ge'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION gt(tpcpatch, tpcpatch)\n  RETURNS boolean\n  AS 'MODULE_PATHNAME', 'Temporal_gt'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION cmp(tpcpatch, tpcpatch)\n  RETURNS integer\n  AS 'MODULE_PATHNAME', 'Temporal_cmp'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE OPERATOR = (\n  LEFTARG = tpcpatch, RIGHTARG = tpcpatch, PROCEDURE = eq,\n  COMMUTATOR = =, NEGATOR = <>,\n  RESTRICT = eqsel, JOIN = eqjoinsel\n);\nCREATE OPERATOR <> (\n  LEFTARG = tpcpatch, RIGHTARG = tpcpatch, PROCEDURE = ne,\n  COMMUTATOR = <>, NEGATOR = =,\n  RESTRICT = neqsel, JOIN = neqjoinsel\n);\nCREATE OPERATOR < (\n  LEFTARG = tpcpatch, RIGHTARG = tpcpatch, PROCEDURE = lt,\n  COMMUTATOR = >, NEGATOR = >=\n);\nCREATE OPERATOR <= (\n  LEFTARG = tpcpatch, RIGHTARG = tpcpatch, PROCEDURE = le,\n  COMMUTATOR = >=, NEGATOR = >\n);\nCREATE OPERATOR >= (\n  LEFTARG = tpcpatch, RIGHTARG = tpcpatch, PROCEDURE = ge,\n  COMMUTATOR = <=, NEGATOR = <\n);\nCREATE OPERATOR > (\n  LEFTARG = tpcpatch, RIGHTARG = tpcpatch, PROCEDURE = gt,\n  COMMUTATOR = <, NEGATOR = <=\n);\n\nCREATE OPERATOR CLASS tpcpatch_btree_ops\n  DEFAULT FOR TYPE tpcpatch USING btree AS\n    OPERATOR  1  <,\n    OPERATOR  2  <=,\n    OPERATOR  3  =,\n    OPERATOR  4  >=,\n    OPERATOR  5  >,\n    FUNCTION  1  cmp(tpcpatch, tpcpatch);\n\n"
+  - funcs: tpcpatch
+  - lit: "\n"
+  - opcls: tpcpatch
+  - lit: "\n/*****************************************************************************/\n"
 - family: set
   file: mobilitydb/sql/temporal/001_set.in.sql
   reference: true


### PR DESCRIPTION
The generator already validate-governs the hash surface of the ten set families. This extends `hash_families` with the twelve temporal type files — `022_temporal`, `tgeo`, `tpoint`, `tcbuffer`, `tnpoint`, `tpose`, `trgeo`, `th3index`, `tquadbin`, `tjsonb`, `tpcpoint` and `tpcpatch` — so each file's closing hash surface re-renders byte-for-byte under `--validate`: `hash` returning `integer` and `hashExtended(x, bigint)` returning `bigint` over the `Temporal_hash`/`Temporal_hash_extended` kernels, plus the canonical hash opclass.

A new `ops: temporal` kernel table selects those kernels on the shared two-function skeleton. The base file groups its five types op-outer — every `hash`, then every `hashExtended` — while `tgeo`/`tpoint` group type-major with the two types' function pairs packed; the opclasses pack per file and the surrounding dividers stay verbatim `lits`.

All twelve entries are `reference: true`, so generation emits nothing. Only `tools/codegen/` changes; the SQL is untouched.
