### PR TITLE
Bring the spatial temporal type-I/O sections under the inherited SQL generator

### DIFF
--- a/mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
+++ b/mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
@@ -32,6 +32,8 @@
  * @brief Basic functions for temporal circular buffers
  */
 
+-- GENERATED-IO-BEGIN cbuffer — tools/codegen/inherited/generate.py from templates/comparisons.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.yaml (io_families) and re-run.
 CREATE TYPE tcbuffer;
 
 /*****************************************************************************
@@ -80,6 +82,8 @@ CREATE FUNCTION tcbuffer(tcbuffer, integer)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE CAST (tcbuffer AS tcbuffer) WITH FUNCTION tcbuffer(tcbuffer, integer) AS IMPLICIT;
+
+-- GENERATED-IO-END cbuffer
 
 -- GENERATED-REPRESENTATIONS-BEGIN cbuffer — tools/codegen/inherited/generate.py from templates/representations.sql.tmpl;
 -- DO NOT EDIT BY HAND; edit the template + manifest.yaml (representation_families) and re-run.

--- a/mobilitydb/sql/geo/052_tgeo.in.sql
+++ b/mobilitydb/sql/geo/052_tgeo.in.sql
@@ -32,6 +32,8 @@
  * @brief Basic functions for temporal geometry/geographies
  */
 
+-- GENERATED-IO-BEGIN geo — tools/codegen/inherited/generate.py from templates/comparisons.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.yaml (io_families) and re-run.
 CREATE TYPE tgeometry;
 CREATE TYPE tgeography;
 
@@ -129,6 +131,8 @@ CREATE FUNCTION tgeography(tgeography, integer)
 
 CREATE CAST (tgeometry AS tgeometry) WITH FUNCTION tgeometry(tgeometry, integer) AS IMPLICIT;
 CREATE CAST (tgeography AS tgeography) WITH FUNCTION tgeography(tgeography, integer) AS IMPLICIT;
+
+-- GENERATED-IO-END geo
 
 /******************************************************************************
  * Constructors

--- a/mobilitydb/sql/geo/052_tpoint.in.sql
+++ b/mobilitydb/sql/geo/052_tpoint.in.sql
@@ -32,6 +32,8 @@
  * @brief Basic functions for temporal geometry/geography points
  */
 
+-- GENERATED-IO-BEGIN tpoint — tools/codegen/inherited/generate.py from templates/comparisons.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.yaml (io_families) and re-run.
 CREATE TYPE tgeompoint;
 CREATE TYPE tgeogpoint;
 
@@ -121,6 +123,8 @@ CREATE FUNCTION tgeogpoint(tgeogpoint, integer)
 
 CREATE CAST (tgeompoint AS tgeompoint) WITH FUNCTION tgeompoint(tgeompoint, integer) AS IMPLICIT;
 CREATE CAST (tgeogpoint AS tgeogpoint) WITH FUNCTION tgeogpoint(tgeogpoint, integer) AS IMPLICIT;
+
+-- GENERATED-IO-END tpoint
 
 /******************************************************************************
  * Constructors

--- a/mobilitydb/sql/h3/253_th3index.in.sql
+++ b/mobilitydb/sql/h3/253_th3index.in.sql
@@ -49,6 +49,8 @@
  * are `WITHOUT FUNCTION` — see below.
  */
 
+-- GENERATED-IO-BEGIN h3 — tools/codegen/inherited/generate.py from templates/comparisons.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.yaml (io_families) and re-run.
 CREATE TYPE th3index;
 
 /******************************************************************************
@@ -87,6 +89,8 @@ CREATE TYPE th3index (
   alignment = double,
   analyze = tspatial_analyze
 );
+
+-- GENERATED-IO-END h3
 
 -- GENERATED-REPRESENTATIONS-BEGIN h3 — tools/codegen/inherited/generate.py from templates/representations.sql.tmpl;
 -- DO NOT EDIT BY HAND; edit the template + manifest.yaml (representation_families) and re-run.

--- a/mobilitydb/sql/npoint/302_tnpoint.in.sql
+++ b/mobilitydb/sql/npoint/302_tnpoint.in.sql
@@ -32,6 +32,8 @@
  * @brief Basic functions for temporal network points
  */
 
+-- GENERATED-IO-BEGIN npoint — tools/codegen/inherited/generate.py from templates/comparisons.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.yaml (io_families) and re-run.
 CREATE TYPE tnpoint;
 
 /******************************************************************************
@@ -75,6 +77,8 @@ CREATE FUNCTION tnpoint(tnpoint, integer)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE CAST (tnpoint AS tnpoint) WITH FUNCTION tnpoint(tnpoint, integer) AS IMPLICIT;
+
+-- GENERATED-IO-END npoint
 
 -- GENERATED-REPRESENTATIONS-BEGIN npoint — tools/codegen/inherited/generate.py from templates/representations.sql.tmpl;
 -- DO NOT EDIT BY HAND; edit the template + manifest.yaml (representation_families) and re-run.

--- a/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
+++ b/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
@@ -47,6 +47,8 @@
  * the `tgeompoint(tpcpoint)` XY projection cast are all included.
  */
 
+-- GENERATED-IO-BEGIN pointcloud — tools/codegen/inherited/generate.py from templates/comparisons.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.yaml (io_families) and re-run.
 CREATE TYPE tpcpoint;
 
 /******************************************************************************
@@ -99,6 +101,8 @@ CREATE FUNCTION tpcpoint(tpcpoint, integer)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE CAST (tpcpoint AS tpcpoint)
   WITH FUNCTION tpcpoint(tpcpoint, integer) AS IMPLICIT;
+
+-- GENERATED-IO-END pointcloud
 
 /******************************************************************************
  * WKB / HexWKB helpers

--- a/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
+++ b/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
@@ -46,6 +46,8 @@
  * per-type `pcid(tpcpatch)` and `startNumPoints(tpcpatch)`.
  */
 
+-- GENERATED-IO-BEGIN pointcloud_patch — tools/codegen/inherited/generate.py from templates/comparisons.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.yaml (io_families) and re-run.
 CREATE TYPE tpcpatch;
 
 /******************************************************************************
@@ -89,6 +91,8 @@ CREATE FUNCTION tpcpatch(tpcpatch, integer)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE CAST (tpcpatch AS tpcpatch)
   WITH FUNCTION tpcpatch(tpcpatch, integer) AS IMPLICIT;
+
+-- GENERATED-IO-END pointcloud_patch
 
 /******************************************************************************
  * WKB / HexWKB helpers

--- a/mobilitydb/sql/pose/102_tpose.in.sql
+++ b/mobilitydb/sql/pose/102_tpose.in.sql
@@ -32,6 +32,8 @@
  * @brief Basic functions for temporal poses
  */
 
+-- GENERATED-IO-BEGIN pose — tools/codegen/inherited/generate.py from templates/comparisons.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.yaml (io_families) and re-run.
 CREATE TYPE tpose;
 
 /******************************************************************************
@@ -80,6 +82,8 @@ CREATE FUNCTION tpose(tpose, integer)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE CAST (tpose AS tpose) WITH FUNCTION tpose(tpose, integer) AS IMPLICIT;
+
+-- GENERATED-IO-END pose
 
   /*****************************************************************************
    * Input/output from (E)WKT, (E)WKB, HexEWKB, and MFJSON representation

--- a/mobilitydb/sql/quadbin/353_tquadbin.in.sql
+++ b/mobilitydb/sql/quadbin/353_tquadbin.in.sql
@@ -49,6 +49,8 @@
  * through a real function — see below.
  */
 
+-- GENERATED-IO-BEGIN quadbin — tools/codegen/inherited/generate.py from templates/comparisons.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.yaml (io_families) and re-run.
 CREATE TYPE tquadbin;
 
 /******************************************************************************
@@ -87,6 +89,8 @@ CREATE TYPE tquadbin (
   alignment = double,
   analyze = temporal_analyze
 );
+
+-- GENERATED-IO-END quadbin
 
 -- GENERATED-REPRESENTATIONS-BEGIN quadbin — tools/codegen/inherited/generate.py from templates/representations.sql.tmpl;
 -- DO NOT EDIT BY HAND; edit the template + manifest.yaml (representation_families) and re-run.

--- a/mobilitydb/sql/rgeo/150_trgeo.in.sql
+++ b/mobilitydb/sql/rgeo/150_trgeo.in.sql
@@ -32,6 +32,8 @@
  * @brief Basic functions for temporal rigid geometries
  */
 
+-- GENERATED-IO-BEGIN rgeo — tools/codegen/inherited/generate.py from templates/comparisons.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.yaml (io_families) and re-run.
 CREATE TYPE trgeometry;
 
 /******************************************************************************
@@ -80,6 +82,8 @@ CREATE FUNCTION trgeometry(trgeometry, integer)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE CAST (trgeometry AS trgeometry) WITH FUNCTION trgeometry(trgeometry, integer) AS IMPLICIT;
+
+-- GENERATED-IO-END rgeo
 
 -- GENERATED-REPRESENTATIONS-BEGIN rgeo — tools/codegen/inherited/generate.py from templates/representations.sql.tmpl;
 -- DO NOT EDIT BY HAND; edit the template + manifest.yaml (representation_families) and re-run.

--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -616,12 +616,20 @@ def extract_accessors(filetext: str, family: str) -> str:
 # Trgeometry_* — its reference geometry sits at the start of the text form / end of the
 # binary form), and {OUT_NAME}/{SEND_NAME} the referenced SQL fn name (default
 # temporal_out/temporal_send; pose/rgeo override tpose_out/trgeometry_out).
-def _io_markers(family: str):
+def _io_markers(family: str, tmpl: str = "io_type.sql.tmpl"):
     begin = (f"-- GENERATED-IO-BEGIN {family} — "
-             "tools/codegen/inherited/generate.py from templates/io_type.sql.tmpl;\n"
+             f"tools/codegen/inherited/generate.py from templates/{tmpl};\n"
              "-- DO NOT EDIT BY HAND; edit the template + manifest.yaml "
              "(io_families) and re-run.\n")
     return begin, f"-- GENERATED-IO-END {family}\n"
+
+
+def _io_fam_markers(fam: dict):
+    """A family's io markers: the base op-major template family cites
+    io_type.sql.tmpl; a spatial blocks family renders its CREATE FUNCTIONs from
+    the shared four-line skeleton, so its markers cite comparisons.sql.tmpl."""
+    return _io_markers(fam["family"],
+                       "comparisons.sql.tmpl" if "blocks" in fam else "io_type.sql.tmpl")
 
 
 def _io_sub(text: str, t: dict) -> str:
@@ -635,9 +643,15 @@ def _io_sub(text: str, t: dict) -> str:
 
 
 def render_io_type(fam: dict) -> str:
-    """Render the type-I/O region for one family from its per-type `types` table.
-    A block mentioning {TEMP} repeats per type; a block without it (typmod/analyze)
-    is emitted once. Matches the base file (022_temporal) region byte-for-byte."""
+    """Render the type-I/O region for one family. A spatial `blocks` family renders
+    through the generic blocks engine (lit / stmt / fns / group over its `insts`
+    token table — the vocabulary the set-file I/O entries established), reproducing
+    the type-major hand layout byte-for-byte. The base family renders the op-major
+    io_type.sql.tmpl: a template block mentioning {TEMP} repeats per type; a block
+    without it (typmod/analyze) is emitted once. Matches the committed region
+    byte-for-byte in both shapes."""
+    if "blocks" in fam:
+        return render_spanfile(fam)
     types = fam.get("types") or [{"temp": fam["temp"]}]
     blocks = []
     for blk in (TEMPLATES / "io_type.sql.tmpl").read_text().strip("\n").split("\n\n"):
@@ -648,18 +662,36 @@ def render_io_type(fam: dict) -> str:
     return "\n" + "\n\n".join(blocks) + "\n"
 
 
-def splice_io_type(filetext: str, family: str, rendered: str) -> str:
-    begin, end = _io_markers(family)
+def splice_io_type(filetext: str, fam: dict, rendered: str) -> str:
+    begin, end = _io_fam_markers(fam)
     b = filetext.index(begin) + len(begin)
     e = filetext.index(end)
     return filetext[:b] + rendered + filetext[e:]
 
 
-def extract_io_type(filetext: str, family: str) -> str:
-    begin, end = _io_markers(family)
-    b = filetext.index(begin) + len(begin)
-    e = filetext.index(end)
-    return filetext[b:e]
+def extract_io_type(filetext: str, fam: dict) -> str:
+    """Return the committed type-I/O region. Marker-aware: slice between the
+    GENERATED-IO markers once they exist; before the bootstrap inserts them, a
+    spatial blocks family slices by its exact `begin`/`end` text anchors (the
+    `CREATE TYPE <t>;` shell opening the region and the first text of the next
+    surface), mirroring extract_spanfile."""
+    begin, end = _io_fam_markers(fam)
+    if begin in filetext:
+        b = filetext.index(begin) + len(begin)
+        e = filetext.index(end)
+        return filetext[b:e]
+    return filetext[filetext.index(fam["begin"]):filetext.index(fam["end"])]
+
+
+def bootstrap_io_type(filetext: str, fam: dict, rendered: str) -> str:
+    """Insert the GENERATED-IO markers around a spatial blocks family's committed
+    hand region (sliced by the same exact `begin`/`end` anchors extract uses), so a
+    future non-reference emit is fully declarative with no hand-placed marker.
+    Idempotent: once the markers exist the reference/splice path owns the region."""
+    start = filetext.index(fam["begin"])
+    end = filetext.index(fam["end"])
+    begin_m, end_m = _io_fam_markers(fam)
+    return filetext[:start] + begin_m + rendered + end_m + "\n" + filetext[end:]
 
 
 # --- SQL Input/Output: representations sub-family (sub-family B) ----------------
@@ -2543,8 +2575,8 @@ def _spanfile_sub(text: str, tok: dict) -> str:
     """Substitute one instantiation's tokens: {v} = base value type, {sp} =
     span type, {ss} = spanset type, {vs} = value-set type, {rg}/{mr} = the
     PostgreSQL range/multirange counterparts (absent for float, which has no
-    canonical range type)."""
-    for key in ("ss", "sp", "vs", "mr", "rg", "v"):
+    canonical range type), {t} = temporal type (the spatial type-I/O entries)."""
+    for key in ("ss", "sp", "vs", "mr", "rg", "v", "t"):
         text = text.replace("{" + key + "}", tok.get(key, ""))
     return text
 
@@ -2995,7 +3027,7 @@ def main() -> int:
                 continue
             p = ROOT / fam["file"]
             gen = render_io_type(fam)
-            cur = extract_io_type(p.read_text(), fam["family"]) if p.exists() else ""
+            cur = extract_io_type(p.read_text(), fam) if p.exists() else ""
             same = gen == cur
             ok = ok and same
             print(f"[{'OK ' if same else 'DIFF'}] self-regen io {fam['family']} "
@@ -3395,13 +3427,24 @@ def main() -> int:
         print(f"spliced accessors {fam['family']} -> {fam['file']}")
 
     for fam in mf.get("io_families", []):
+        p = ROOT / fam["file"]
+        text = p.read_text()
+        begin, _ = _io_fam_markers(fam)
+        if begin not in text and "begin" in fam:
+            # No region yet -> BOOTSTRAP it once from the manifest entry (the block is a
+            # bare hand section). After this the markers exist and the splice path owns it.
+            if args.check:
+                print(f"would bootstrap io {fam['family']} -> {fam['file']}")
+                continue
+            p.write_text(bootstrap_io_type(text, fam, render_io_type(fam)))
+            print(f"bootstrapped io {fam['family']} -> {fam['file']}")
+            continue
         if fam.get("reference"):
             continue
-        p = ROOT / fam["file"]
         if args.check:
             print(f"would splice io {fam['family']} -> {fam['file']}")
             continue
-        p.write_text(splice_io_type(p.read_text(), fam["family"], render_io_type(fam)))
+        p.write_text(splice_io_type(text, fam, render_io_type(fam)))
         print(f"spliced io {fam['family']} -> {fam['file']}")
 
     for fam in mf.get("representation_families", []):

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -663,6 +663,291 @@ io_families:
       - {temp: tfloat}
       - {temp: ttext}
 
+# Spatial type-I/O families: the shell CREATE TYPE forward declaration, the
+# _in/_out/_recv/_send quartet, the per-family typmod_in, the shared
+# tspatial_typmod_out/tspatial_analyze hooks (declared once, in the geo file),
+# the CREATE TYPE definition and the typmod-enforcing self-cast. The hand
+# layout is TYPE-major (a type's whole cluster precedes the next type's), so
+# these entries use the generic blocks vocabulary (lit / stmt / fns / group over
+# an `insts` token table, {t} = the temporal type) the set-file I/O entries
+# established, not the op-major io_type.sql.tmpl. Per-family irregularities are
+# kept verbatim: pose/rgeo quartets omit PARALLEL SAFE (rgeo also renames
+# _out/_send to trgeometry_* and its _recv takes bare `internal`); the
+# cbuffer/npoint/pose/rgeo typmod-enforce wrappers have no space after the
+# MODULE_PATHNAME comma; npoint/h3/quadbin reuse temporal_typmod_in/out;
+# tquadbin's CREATE TYPE hooks temporal_analyze where th3index hooks
+# tspatial_analyze; the pointcloud types share the schema-aware tpc_typmod pair
+# (declared once, in the tpcpoint file) and split their self-cast over two lines.
+  - family: geo
+    file: mobilitydb/sql/geo/052_tgeo.in.sql
+    reference: true
+    begin: "CREATE TYPE tgeometry;"
+    end: "/******************************************************************************\n * Constructors\n"
+    order: [geom, geog]
+    insts:
+      geom: {t: tgeometry}
+      geog: {t: tgeography}
+    blocks:
+    - lit: "CREATE TYPE tgeometry;\nCREATE TYPE tgeography;\n\n/******************************************************************************\n * Input/Output\n ******************************************************************************/\n\n"
+    - group:
+      - {sig: "{t}_in(cstring, oid, integer)", ret: "{t}", sym: Tgeo_in}
+      - {sig: "temporal_out({t})", ret: cstring, sym: Temporal_out}
+      - {sig: "{t}_recv(internal, oid, integer)", ret: "{t}", sym: Temporal_recv}
+      - {sig: "temporal_send({t})", ret: bytea, sym: Temporal_send}
+      only: [geom]
+    - lit: "\n"
+    - sig: "{t}_typmod_in(cstring[])"
+      ret: integer
+      sym: Tgeometry_typmod_in
+      over:
+        geog: {sym: Tgeography_typmod_in}
+    - lit: "CREATE FUNCTION tspatial_typmod_out(integer)\n  RETURNS cstring\n  AS 'MODULE_PATHNAME', 'Tspatial_typmod_out'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE FUNCTION tspatial_analyze(internal)\n  RETURNS boolean\n  AS 'MODULE_PATHNAME', 'Tspatial_analyze'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n"
+    - stmt: "CREATE TYPE {t} (\n  internallength = variable,\n  input = {t}_in,\n  output = temporal_out,\n  send = temporal_send,\n  receive = {t}_recv,\n  typmod_in = {t}_typmod_in,\n  typmod_out = tspatial_typmod_out,\n  storage = extended,\n  alignment = double,\n  analyze = tspatial_analyze\n);"
+      only: [geom]
+    - lit: "\n"
+    - group:
+      - {sig: "{t}_in(cstring, oid, integer)", ret: "{t}", sym: Tgeo_in}
+      - {sig: "temporal_out({t})", ret: cstring, sym: Temporal_out}
+      - {sig: "{t}_recv(internal, oid, integer)", ret: "{t}", sym: Temporal_recv}
+      - {sig: "temporal_send({t})", ret: bytea, sym: Temporal_send}
+      only: [geog]
+    - lit: "\n"
+    - stmt: "CREATE TYPE {t} (\n  internallength = variable,\n  input = {t}_in,\n  output = temporal_out,\n  send = temporal_send,\n  receive = {t}_recv,\n  typmod_in = {t}_typmod_in,\n  typmod_out = tspatial_typmod_out,\n  storage = extended,\n  alignment = double,\n  analyze = tspatial_analyze\n);"
+      only: [geog]
+    - lit: "\n-- Special cast for enforcing the typmod restrictions\n"
+    - sig: "{t}({t}, integer)"
+      ret: "{t}"
+      sym: Tspatial_enforce_typmod
+    - lit: "\n"
+    - stmt: "CREATE CAST ({t} AS {t}) WITH FUNCTION {t}({t}, integer) AS IMPLICIT;"
+    - lit: "\n"
+  - family: tpoint
+    file: mobilitydb/sql/geo/052_tpoint.in.sql
+    reference: true
+    begin: "CREATE TYPE tgeompoint;"
+    end: "/******************************************************************************\n * Constructors\n"
+    order: [geom, geog]
+    insts:
+      geom: {t: tgeompoint}
+      geog: {t: tgeogpoint}
+    blocks:
+    - lit: "CREATE TYPE tgeompoint;\nCREATE TYPE tgeogpoint;\n\n/******************************************************************************\n * Input/Output\n ******************************************************************************/\n\n"
+    - group:
+      - {sig: "{t}_in(cstring, oid, integer)", ret: "{t}", sym: Tpoint_in}
+      - {sig: "temporal_out({t})", ret: cstring, sym: Temporal_out}
+      - {sig: "{t}_recv(internal, oid, integer)", ret: "{t}", sym: Temporal_recv}
+      - {sig: "temporal_send({t})", ret: bytea, sym: Temporal_send}
+      only: [geom]
+    - lit: "\n"
+    - sig: "{t}_typmod_in(cstring[])"
+      ret: integer
+      sym: Tgeompoint_typmod_in
+      only: [geom]
+    - lit: "\n"
+    - stmt: "CREATE TYPE {t} (\n  internallength = variable,\n  input = {t}_in,\n  output = temporal_out,\n  send = temporal_send,\n  receive = {t}_recv,\n  typmod_in = {t}_typmod_in,\n  typmod_out = tspatial_typmod_out,\n  storage = extended,\n  alignment = double,\n  analyze = tspatial_analyze\n);"
+      only: [geom]
+    - lit: "\n"
+    - group:
+      - {sig: "{t}_in(cstring, oid, integer)", ret: "{t}", sym: Tpoint_in}
+      - {sig: "temporal_out({t})", ret: cstring, sym: Temporal_out}
+      - {sig: "{t}_recv(internal, oid, integer)", ret: "{t}", sym: Temporal_recv}
+      - {sig: "temporal_send({t})", ret: bytea, sym: Temporal_send}
+      only: [geog]
+    - lit: "\n"
+    - sig: "{t}_typmod_in(cstring[])"
+      ret: integer
+      sym: Tgeogpoint_typmod_in
+      only: [geog]
+    - lit: "\n"
+    - stmt: "CREATE TYPE {t} (\n  internallength = variable,\n  input = {t}_in,\n  output = temporal_out,\n  send = temporal_send,\n  receive = {t}_recv,\n  typmod_in = {t}_typmod_in,\n  typmod_out = tspatial_typmod_out,\n  storage = extended,\n  alignment = double,\n  analyze = tspatial_analyze\n);"
+      only: [geog]
+    - lit: "\n-- Special cast for enforcing the typmod restrictions\n"
+    - sig: "{t}({t}, integer)"
+      ret: "{t}"
+      sym: Tspatial_enforce_typmod
+    - lit: "\n"
+    - stmt: "CREATE CAST ({t} AS {t}) WITH FUNCTION {t}({t}, integer) AS IMPLICIT;"
+    - lit: "\n"
+  - family: cbuffer
+    file: mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
+    reference: true
+    begin: "CREATE TYPE tcbuffer;"
+    end: "-- GENERATED-REPRESENTATIONS-BEGIN cbuffer"
+    order: [cb]
+    insts:
+      cb: {t: tcbuffer}
+    blocks:
+    - lit: "CREATE TYPE tcbuffer;\n\n/*****************************************************************************\n * Input/Output\n *****************************************************************************/\n\n"
+    - group:
+      - {sig: "{t}_in(cstring, oid, integer)", ret: "{t}", sym: Tcbuffer_in}
+      - {sig: "temporal_out({t})", ret: cstring, sym: Temporal_out}
+      - {sig: "{t}_recv(internal, oid, integer)", ret: "{t}", sym: Temporal_recv}
+      - {sig: "temporal_send({t})", ret: bytea, sym: Temporal_send}
+    - lit: "\n"
+    - sig: "{t}_typmod_in(cstring[])"
+      ret: integer
+      sym: Tcbuffer_typmod_in
+    - lit: "\n"
+    - stmt: "CREATE TYPE {t} (\n  internallength = variable,\n  input = {t}_in,\n  output = temporal_out,\n  send = temporal_send,\n  receive = {t}_recv,\n  typmod_in = {t}_typmod_in,\n  typmod_out = tspatial_typmod_out,\n  storage = extended,\n  alignment = double,\n  analyze = tspatial_analyze\n);"
+    - lit: "\n-- Special cast for enforcing the typmod restrictions\nCREATE FUNCTION tcbuffer(tcbuffer, integer)\n  RETURNS tcbuffer\n  AS 'MODULE_PATHNAME','Tcbuffer_enforce_typmod'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE CAST (tcbuffer AS tcbuffer) WITH FUNCTION tcbuffer(tcbuffer, integer) AS IMPLICIT;\n\n"
+  - family: npoint
+    file: mobilitydb/sql/npoint/302_tnpoint.in.sql
+    reference: true
+    begin: "CREATE TYPE tnpoint;"
+    end: "-- GENERATED-REPRESENTATIONS-BEGIN npoint"
+    order: [np]
+    insts:
+      np: {t: tnpoint}
+    blocks:
+    - lit: "CREATE TYPE tnpoint;\n\n/******************************************************************************\n * Input/Output\n ******************************************************************************/\n\n"
+    - group:
+      - {sig: "{t}_in(cstring, oid, integer)", ret: "{t}", sym: Tnpoint_in}
+      - {sig: "temporal_out({t})", ret: cstring, sym: Temporal_out}
+      - {sig: "{t}_recv(internal, oid, integer)", ret: "{t}", sym: Temporal_recv}
+      - {sig: "temporal_send({t})", ret: bytea, sym: Temporal_send}
+    - lit: "\n"
+    - stmt: "CREATE TYPE {t} (\n  internallength = variable,\n  input = {t}_in,\n  output = temporal_out,\n  send = temporal_send,\n  receive = {t}_recv,\n  typmod_in = temporal_typmod_in,\n  typmod_out = temporal_typmod_out,\n  storage = extended,\n  alignment = double,\n  analyze = tspatial_analyze\n);"
+    - lit: "\n-- Special cast for enforcing the typmod restrictions\nCREATE FUNCTION tnpoint(tnpoint, integer)\n  RETURNS tnpoint\n  AS 'MODULE_PATHNAME','Temporal_enforce_typmod'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE CAST (tnpoint AS tnpoint) WITH FUNCTION tnpoint(tnpoint, integer) AS IMPLICIT;\n\n"
+  - family: pose
+    file: mobilitydb/sql/pose/102_tpose.in.sql
+    reference: true
+    begin: "CREATE TYPE tpose;"
+    end: "  /*****************************************************************************\n   * Input/output from (E)WKT"
+    order: [po]
+    insts:
+      po: {t: tpose}
+    blocks:
+    - lit: "CREATE TYPE tpose;\n\n/******************************************************************************\n * Input/output\n ******************************************************************************/\n\nCREATE FUNCTION tpose_in(cstring, oid, integer)\n  RETURNS tpose\n  AS 'MODULE_PATHNAME', 'Tpose_in'\n  LANGUAGE C IMMUTABLE STRICT;\nCREATE FUNCTION temporal_out(tpose)\n  RETURNS cstring\n  AS 'MODULE_PATHNAME', 'Temporal_out'\n  LANGUAGE C IMMUTABLE STRICT;\nCREATE FUNCTION tpose_recv(internal, oid, integer)\n  RETURNS tpose\n  AS 'MODULE_PATHNAME', 'Temporal_recv'\n  LANGUAGE C IMMUTABLE STRICT;\nCREATE FUNCTION temporal_send(tpose)\n  RETURNS bytea\n  AS 'MODULE_PATHNAME', 'Temporal_send'\n  LANGUAGE C IMMUTABLE STRICT;\n\n"
+    - sig: "{t}_typmod_in(cstring[])"
+      ret: integer
+      sym: Tpose_typmod_in
+    - lit: "\n"
+    - stmt: "CREATE TYPE {t} (\n  internallength = variable,\n  input = {t}_in,\n  output = temporal_out,\n  send = temporal_send,\n  receive = {t}_recv,\n  typmod_in = {t}_typmod_in,\n  typmod_out = tspatial_typmod_out,\n  storage = extended,\n  alignment = double,\n  analyze = tspatial_analyze\n);"
+    - lit: "\n-- Special cast for enforcing the typmod restrictions\nCREATE FUNCTION tpose(tpose, integer)\n  RETURNS tpose\n  AS 'MODULE_PATHNAME','Tspatial_enforce_typmod'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE CAST (tpose AS tpose) WITH FUNCTION tpose(tpose, integer) AS IMPLICIT;\n\n"
+  - family: rgeo
+    file: mobilitydb/sql/rgeo/150_trgeo.in.sql
+    reference: true
+    begin: "CREATE TYPE trgeometry;"
+    end: "-- GENERATED-REPRESENTATIONS-BEGIN rgeo"
+    order: [rg]
+    insts:
+      rg: {t: trgeometry}
+    blocks:
+    - lit: "CREATE TYPE trgeometry;\n\n/******************************************************************************\n * Input/Output\n ******************************************************************************/\n\nCREATE FUNCTION trgeometry_in(cstring, oid, integer)\n  RETURNS trgeometry\n  AS 'MODULE_PATHNAME', 'Trgeometry_in'\n  LANGUAGE C IMMUTABLE STRICT;\nCREATE FUNCTION trgeometry_out(trgeometry)\n  RETURNS cstring\n  AS 'MODULE_PATHNAME', 'Trgeometry_out'\n  LANGUAGE C IMMUTABLE STRICT;\nCREATE FUNCTION trgeometry_recv(internal)\n  RETURNS trgeometry\n  AS 'MODULE_PATHNAME', 'Trgeometry_recv'\n  LANGUAGE C IMMUTABLE STRICT;\nCREATE FUNCTION trgeometry_send(trgeometry)\n  RETURNS bytea\n  AS 'MODULE_PATHNAME', 'Trgeometry_send'\n  LANGUAGE C IMMUTABLE STRICT;\n\n"
+    - sig: "{t}_typmod_in(cstring[])"
+      ret: integer
+      sym: Trgeometry_typmod_in
+    - lit: "\n"
+    - stmt: "CREATE TYPE {t} (\n  internallength = variable,\n  input = {t}_in,\n  output = {t}_out,\n  send = {t}_send,\n  receive = {t}_recv,\n  typmod_in = {t}_typmod_in,\n  typmod_out = tspatial_typmod_out,\n  storage = extended,\n  alignment = double,\n  analyze = tspatial_analyze\n);"
+    - lit: "\n-- Special cast for enforcing the typmod restrictions\nCREATE FUNCTION trgeometry(trgeometry, integer)\n  RETURNS trgeometry\n  AS 'MODULE_PATHNAME','Tspatial_enforce_typmod'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE CAST (trgeometry AS trgeometry) WITH FUNCTION trgeometry(trgeometry, integer) AS IMPLICIT;\n\n"
+  - family: h3
+    file: mobilitydb/sql/h3/253_th3index.in.sql
+    reference: true
+    begin: "CREATE TYPE th3index;"
+    end: "-- GENERATED-REPRESENTATIONS-BEGIN h3"
+    order: [h3]
+    insts:
+      h3: {t: th3index}
+    blocks:
+    - lit: "CREATE TYPE th3index;\n\n/******************************************************************************\n * Input / Output\n ******************************************************************************/\n\n"
+    - sig: "{t}_in(cstring, oid, integer)"
+      ret: "{t}"
+      sym: Temporal_in
+    - lit: "\n"
+    - sig: "{t}_recv(internal, oid, integer)"
+      ret: "{t}"
+      sym: Temporal_recv
+    - lit: "\n"
+    - sig: "temporal_out({t})"
+      ret: cstring
+      sym: Temporal_out
+    - lit: "\n"
+    - sig: "temporal_send({t})"
+      ret: bytea
+      sym: Temporal_send
+    - lit: "\n"
+    - stmt: "CREATE TYPE {t} (\n  internallength = variable,\n  input = {t}_in,\n  output = temporal_out,\n  send = temporal_send,\n  receive = {t}_recv,\n  typmod_in = temporal_typmod_in,\n  typmod_out = temporal_typmod_out,\n  storage = extended,\n  alignment = double,\n  analyze = tspatial_analyze\n);"
+    - lit: "\n"
+  - family: quadbin
+    file: mobilitydb/sql/quadbin/353_tquadbin.in.sql
+    reference: true
+    begin: "CREATE TYPE tquadbin;"
+    end: "-- GENERATED-REPRESENTATIONS-BEGIN quadbin"
+    order: [qb]
+    insts:
+      qb: {t: tquadbin}
+    blocks:
+    - lit: "CREATE TYPE tquadbin;\n\n/******************************************************************************\n * Input / Output\n ******************************************************************************/\n\n"
+    - sig: "{t}_in(cstring, oid, integer)"
+      ret: "{t}"
+      sym: Temporal_in
+    - lit: "\n"
+    - sig: "{t}_recv(internal, oid, integer)"
+      ret: "{t}"
+      sym: Temporal_recv
+    - lit: "\n"
+    - sig: "temporal_out({t})"
+      ret: cstring
+      sym: Temporal_out
+    - lit: "\n"
+    - sig: "temporal_send({t})"
+      ret: bytea
+      sym: Temporal_send
+    - lit: "\n"
+    - stmt: "CREATE TYPE {t} (\n  internallength = variable,\n  input = {t}_in,\n  output = temporal_out,\n  send = temporal_send,\n  receive = {t}_recv,\n  typmod_in = temporal_typmod_in,\n  typmod_out = temporal_typmod_out,\n  storage = extended,\n  alignment = double,\n  analyze = temporal_analyze\n);"
+    - lit: "\n"
+  - family: pointcloud
+    file: mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
+    reference: true
+    begin: "CREATE TYPE tpcpoint;"
+    end: "/******************************************************************************\n * WKB / HexWKB helpers\n"
+    order: [pc]
+    insts:
+      pc: {t: tpcpoint}
+    blocks:
+    - lit: "CREATE TYPE tpcpoint;\n\n/******************************************************************************\n * Input / output — all via the generic Temporal_* wrappers\n ******************************************************************************/\n\n"
+    - group:
+      - {sig: "{t}_in(cstring, oid, integer)", ret: "{t}", sym: Temporal_in}
+      - {sig: "temporal_out({t})", ret: cstring, sym: Temporal_out}
+      - {sig: "{t}_recv(internal, oid, integer)", ret: "{t}", sym: Temporal_recv}
+      - {sig: "temporal_send({t})", ret: bytea, sym: Temporal_send}
+    - lit: "\n"
+    - sig: "tpc_typmod_in(cstring[])"
+      ret: integer
+      sym: Tpc_typmod_in
+    - sig: "tpc_typmod_out(integer)"
+      ret: cstring
+      sym: Tpc_typmod_out
+    - lit: "\n"
+    - stmt: "CREATE TYPE {t} (\n  internallength = variable,\n  input = {t}_in,\n  output = temporal_out,\n  send = temporal_send,\n  receive = {t}_recv,\n  typmod_in = tpc_typmod_in,\n  typmod_out = tpc_typmod_out,\n  storage = extended,\n  alignment = double,\n  analyze = tspatial_analyze\n);"
+    - lit: "\n-- Special cast for enforcing the typmod restriction on INSERT / cast.\n"
+    - sig: "{t}({t}, integer)"
+      ret: "{t}"
+      sym: Tpc_enforce_typmod
+    - lit: "CREATE CAST (tpcpoint AS tpcpoint)\n  WITH FUNCTION tpcpoint(tpcpoint, integer) AS IMPLICIT;\n\n"
+  - family: pointcloud_patch
+    file: mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
+    reference: true
+    begin: "CREATE TYPE tpcpatch;"
+    end: "/******************************************************************************\n * WKB / HexWKB helpers\n"
+    order: [pc]
+    insts:
+      pc: {t: tpcpatch}
+    blocks:
+    - lit: "CREATE TYPE tpcpatch;\n\n/******************************************************************************\n * Input / output\n ******************************************************************************/\n\n"
+    - group:
+      - {sig: "{t}_in(cstring, oid, integer)", ret: "{t}", sym: Temporal_in}
+      - {sig: "temporal_out({t})", ret: cstring, sym: Temporal_out}
+      - {sig: "{t}_recv(internal, oid, integer)", ret: "{t}", sym: Temporal_recv}
+      - {sig: "temporal_send({t})", ret: bytea, sym: Temporal_send}
+    - lit: "\n"
+    - stmt: "CREATE TYPE {t} (\n  internallength = variable,\n  input = {t}_in,\n  output = temporal_out,\n  send = temporal_send,\n  receive = {t}_recv,\n  typmod_in = tpc_typmod_in,\n  typmod_out = tpc_typmod_out,\n  storage = extended,\n  alignment = double,\n  analyze = tspatial_analyze\n);"
+    - lit: "\n-- Special cast for enforcing the typmod restriction on INSERT / cast.\n"
+    - sig: "{t}({t}, integer)"
+      ret: "{t}"
+      sym: Tpc_enforce_typmod
+    - lit: "CREATE CAST (tpcpatch AS tpcpatch)\n  WITH FUNCTION tpcpatch(tpcpatch, integer) AS IMPLICIT;\n\n"
+
 # ---------------------------------------------------------------------------
 # Representations sub-family B (SQL, per-family region / dedicated *_inout file).
 # as<Fmt> outputs + <temp>From<Fmt> constructors, all pure wiring to the generic


### PR DESCRIPTION
This adds reference `io_families` entries for the ten spatial temporal type files — `tgeometry`/`tgeography`, `tgeompoint`/`tgeogpoint`, `tcbuffer`, `tnpoint`, `tpose`, `trgeometry`, `th3index`, `tquadbin`, `tpcpoint` and `tpcpatch` — so their type-I/O sections re-render byte-for-byte under `--validate`: the shell `CREATE TYPE` forward declaration, the `_in`/`_out`/`_recv`/`_send` quartet, the per-family `typmod_in`, the shared `tspatial_typmod_out`/`tspatial_analyze` declarations, the `CREATE TYPE` definition and the typmod-enforcing self-cast. The `GENERATED-IO` markers are bootstrapped around them.

The hand layout is type-major, so these entries use the generic `blocks` vocabulary — `lit`/`stmt`/`fns`/`group` over an `insts` token table, with a new `{t}` temporal-type token — that the set-file I/O entries established, dispatched from the `io` axis. `extract`/`splice`/`bootstrap` become marker-aware with an exact-anchor fallback.

Per-family irregularities are encoded verbatim rather than smoothed away: the pose and rgeo quartets omit `PARALLEL SAFE` (rgeo also renames `_out`/`_send` to `trgeometry_*` and its `_recv` takes bare `internal`); the cbuffer, npoint, pose and rgeo typmod-enforce wrappers have no space after the `MODULE_PATHNAME` comma; npoint, th3index and tquadbin reuse `temporal_typmod_in`/`out`; tquadbin's `CREATE TYPE` hooks `temporal_analyze` where th3index hooks `tspatial_analyze`; the pointcloud types share the schema-aware `tpc_typmod` pair and split their self-cast over two lines; th3index and tquadbin blank-separate their quartet in `in`/`recv`/`out`/`send` order.

The SQL gains only the region markers — no function line is added, changed or removed.
