### PR TITLE
Fix a SIGSEGV in atGeometry and minusGeometry for tpose and tcbuffer

### DIFF
--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -859,9 +859,17 @@ tcbuffer_disc_within_ctx(const Cbuffer *cb, double dist, const void *ctxv)
 }
 
 /**
- * @brief Append to @p cand the normalized times in (lo,hi) at which the moving
+ * @brief Append to @p cand the normalized times in [lo,hi] at which the moving
  * disc distance to a region equals @p dist, i.e. the roots of
  * (A - DR^2) t^2 + (B - 2 R0 DR) t + (C - R0^2) = 0 with R0 = r1 + dist
+ * @note The bounds are inclusive. The caller splits a segment into
+ * perpendicular/endpoint sub-regions at breakpoints (#tcbuffersegm_edge_within_roots);
+ * when the moving centre crosses the geometry exactly at a polygon vertex, the
+ * crossing time coincides exactly with the breakpoint shared by the two
+ * adjacent sub-regions, and is a genuine root of BOTH regions' equations
+ * there. A strict `> lo && < hi` test drops it from both sides, so the true
+ * crossing silently vanishes from @p cand and the within-distance test
+ * over-extends the sub-period it reports
  */
 static void
 tcbuffer_region_within_roots(double A, double B, double C, double R0,
@@ -875,7 +883,7 @@ tcbuffer_region_within_roots(double A, double B, double C, double R0,
     if (fabs(b) > 1e-18)
     {
       double t = -c / b;
-      if (t > lo && t < hi)
+      if (t >= lo && t <= hi)
         cand[(*nc)++] = t;
     }
     return;
@@ -886,9 +894,9 @@ tcbuffer_region_within_roots(double A, double B, double C, double R0,
   double sd = sqrt(disc);
   double t1 = (-b - sd) / (2.0 * a);
   double t2 = (-b + sd) / (2.0 * a);
-  if (t1 > lo && t1 < hi)
+  if (t1 >= lo && t1 <= hi)
     cand[(*nc)++] = t1;
-  if (t2 > lo && t2 < hi)
+  if (t2 >= lo && t2 <= hi)
     cand[(*nc)++] = t2;
 }
 

--- a/mobilitydb/test/cbuffer/expected/205_tcbuffer_spatialfuncs.test.out
+++ b/mobilitydb/test/cbuffer/expected/205_tcbuffer_spatialfuncs.test.out
@@ -78,6 +78,18 @@ SELECT getTime(minusGeometry(
  {[Sat Jan 01 00:00:00 2000 PST, Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
+SELECT asText(atGeometry(tcbuffer '[Cbuffer(Point(1 1), 0)@2001-01-01, Cbuffer(Point(4 4), 0)@2001-01-04]', 'Polygon((2 2,2 3,3 3,3 2,2 2))'));
+                                                   astext                                                   
+------------------------------------------------------------------------------------------------------------
+ {[Cbuffer(POINT(2 2),0)@Tue Jan 02 00:00:00 2001 PST, Cbuffer(POINT(3 3),0)@Wed Jan 03 00:00:00 2001 PST]}
+(1 row)
+
+SELECT asText(minusGeometry(tcbuffer '[Cbuffer(Point(1 1), 0)@2001-01-01, Cbuffer(Point(4 4), 0)@2001-01-04]', 'Polygon((2 2,2 3,3 3,3 2,2 2))'));
+                                                                                                        astext                                                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[Cbuffer(POINT(1 1),0)@Mon Jan 01 00:00:00 2001 PST, Cbuffer(POINT(2 2),0)@Tue Jan 02 00:00:00 2001 PST), (Cbuffer(POINT(3 3),0)@Wed Jan 03 00:00:00 2001 PST, Cbuffer(POINT(4 4),0)@Thu Jan 04 00:00:00 2001 PST]}
+(1 row)
+
 SELECT centroid(NULL::tcbuffer);
  centroid 
 ----------

--- a/mobilitydb/test/cbuffer/queries/205_tcbuffer_spatialfuncs.test.sql
+++ b/mobilitydb/test/cbuffer/queries/205_tcbuffer_spatialfuncs.test.sql
@@ -67,6 +67,9 @@ SELECT getTime(minusGeometry(
   tcbuffer '[Cbuffer(Point(0 0),1)@2000-01-01, Cbuffer(Point(4 0),1)@2000-01-05]',
   geometry 'Point(2 50)'));
 
+SELECT asText(atGeometry(tcbuffer '[Cbuffer(Point(1 1), 0)@2001-01-01, Cbuffer(Point(4 4), 0)@2001-01-04]', 'Polygon((2 2,2 3,3 3,3 2,2 2))'));
+SELECT asText(minusGeometry(tcbuffer '[Cbuffer(Point(1 1), 0)@2001-01-01, Cbuffer(Point(4 4), 0)@2001-01-04]', 'Polygon((2 2,2 3,3 3,3 2,2 2))'));
+
 -------------------------------------------------------------------------------
 -- Centroid
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/pose/expected/105_tpose_spatialfuncs.test.out
+++ b/mobilitydb/test/pose/expected/105_tpose_spatialfuncs.test.out
@@ -80,6 +80,18 @@ SELECT asText(minusGeometry(
  {[Pose(POINT(0 0),0)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 0),0)@Sun Jan 02 00:00:00 2000 PST), (Pose(POINT(3 0),0)@Tue Jan 04 00:00:00 2000 PST, Pose(POINT(5 0),0)@Thu Jan 06 00:00:00 2000 PST]}
 (1 row)
 
+SELECT asText(atGeometry(tpose '[Pose(Point(1 1), 0.3)@2001-01-01, Pose(Point(4 4), 0.7)@2001-01-04]', 'Polygon((2 2,2 3,3 3,3 2,2 2))'), 6);
+                                                       astext                                                       
+--------------------------------------------------------------------------------------------------------------------
+ {[Pose(POINT(2 2),0.433333)@Tue Jan 02 00:00:00 2001 PST, Pose(POINT(3 3),0.566667)@Wed Jan 03 00:00:00 2001 PST]}
+(1 row)
+
+SELECT asText(minusGeometry(tpose '[Pose(Point(1 1), 0.3)@2001-01-01, Pose(Point(4 4), 0.7)@2001-01-04]', 'Polygon((2 2,2 3,3 3,3 2,2 2))'), 6);
+                                                                                                           astext                                                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[Pose(POINT(1 1),0.3)@Mon Jan 01 00:00:00 2001 PST, Pose(POINT(2 2),0.433333)@Tue Jan 02 00:00:00 2001 PST), (Pose(POINT(3 3),0.566667)@Wed Jan 03 00:00:00 2001 PST, Pose(POINT(4 4),0.7)@Thu Jan 04 00:00:00 2001 PST]}
+(1 row)
+
 SELECT asText(atGeometry(
   tpose '{[Pose(Point(0 0),0)@2000-01-01, Pose(Point(5 0),0)@2000-01-06]}',
   'Polygon((1 -1,3 -1,3 1,1 1,1 -1))'::geometry));

--- a/mobilitydb/test/pose/queries/105_tpose_spatialfuncs.test.sql
+++ b/mobilitydb/test/pose/queries/105_tpose_spatialfuncs.test.sql
@@ -69,6 +69,9 @@ SELECT asText(minusGeometry(
   tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(5 0),0)@2000-01-06]',
   'Polygon((1 -1,3 -1,3 1,1 1,1 -1))'::geometry));
 
+SELECT asText(atGeometry(tpose '[Pose(Point(1 1), 0.3)@2001-01-01, Pose(Point(4 4), 0.7)@2001-01-04]', 'Polygon((2 2,2 3,3 3,3 2,2 2))'), 6);
+SELECT asText(minusGeometry(tpose '[Pose(Point(1 1), 0.3)@2001-01-01, Pose(Point(4 4), 0.7)@2001-01-04]', 'Polygon((2 2,2 3,3 3,3 2,2 2))'), 6);
+
 -------------------------------------------------------------------------------
 -- atGeometry / minusGeometry — sequence set
 


### PR DESCRIPTION
Fix a SIGSEGV and wrong output in atGeometry / minusGeometry for tpose and tcbuffer. The temporal circular-buffer within-distance kernel drops a root when the moving disk's centre crosses a polygon vertex, leaving the restriction with a malformed time span. Handle that crossing so the geometry restriction returns the correct sub-sequence (at) or its complement (minus) without crashing. Adds regression coverage for both families.
