### PR TITLE
Name the span and span set distance functions with the bare overloaded name

### DIFF
--- a/mobilitydb/sql/temporal/005_span_ops.in.sql
+++ b/mobilitydb/sql/temporal/005_span_ops.in.sql
@@ -1546,147 +1546,147 @@ CREATE OPERATOR - (
  * Distance operators
  *****************************************************************************/
 
-CREATE FUNCTION span_distance(integer, intspan)
+CREATE FUNCTION distance(integer, intspan)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Distance_value_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_distance(intspan, integer)
+CREATE FUNCTION distance(intspan, integer)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Distance_span_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_distance(intspan, intspan)
+CREATE FUNCTION distance(intspan, intspan)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Distance_span_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = integer, RIGHTARG = intspan,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = intspan, RIGHTARG = integer,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = intspan, RIGHTARG = intspan,
   COMMUTATOR = <->
 );
 
-CREATE FUNCTION span_distance(bigint, bigintspan)
+CREATE FUNCTION distance(bigint, bigintspan)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Distance_value_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_distance(bigintspan, bigint)
+CREATE FUNCTION distance(bigintspan, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Distance_span_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_distance(bigintspan, bigintspan)
+CREATE FUNCTION distance(bigintspan, bigintspan)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Distance_span_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = bigint, RIGHTARG = bigintspan,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = bigintspan, RIGHTARG = bigint,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = bigintspan, RIGHTARG = bigintspan,
   COMMUTATOR = <->
 );
 
-CREATE FUNCTION span_distance(float, floatspan)
+CREATE FUNCTION distance(float, floatspan)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_value_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_distance(floatspan, float)
+CREATE FUNCTION distance(floatspan, float)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_span_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_distance(floatspan, floatspan)
+CREATE FUNCTION distance(floatspan, floatspan)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_span_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = float, RIGHTARG = floatspan,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = floatspan, RIGHTARG = float,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = floatspan, RIGHTARG = floatspan,
   COMMUTATOR = <->
 );
 
-CREATE FUNCTION span_distance(date, datespan)
+CREATE FUNCTION distance(date, datespan)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Distance_value_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_distance(datespan, date)
+CREATE FUNCTION distance(datespan, date)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Distance_span_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_distance(datespan, datespan)
+CREATE FUNCTION distance(datespan, datespan)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Distance_span_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = date, RIGHTARG = datespan,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = datespan, RIGHTARG = date,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = datespan, RIGHTARG = datespan,
   COMMUTATOR = <->
 );
 
-CREATE FUNCTION span_distance(timestamptz, tstzspan)
+CREATE FUNCTION distance(timestamptz, tstzspan)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_value_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_distance(tstzspan, timestamptz)
+CREATE FUNCTION distance(tstzspan, timestamptz)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_span_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_distance(tstzspan, tstzspan)
+CREATE FUNCTION distance(tstzspan, tstzspan)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_span_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = timestamptz, RIGHTARG = tstzspan,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = tstzspan, RIGHTARG = timestamptz,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = tstzspan, RIGHTARG = tstzspan,
   COMMUTATOR = <->
 );

--- a/mobilitydb/sql/temporal/009_spanset_ops.in.sql
+++ b/mobilitydb/sql/temporal/009_spanset_ops.in.sql
@@ -2591,237 +2591,237 @@ CREATE OPERATOR * (
  * Distance operators
  *****************************************************************************/
 
-CREATE FUNCTION span_distance(integer, intspanset)
+CREATE FUNCTION distance(integer, intspanset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Distance_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_distance(intspan, intspanset)
+CREATE FUNCTION distance(intspan, intspanset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Distance_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_distance(intspanset, integer)
+CREATE FUNCTION distance(intspanset, integer)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Distance_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_distance(intspanset, intspan)
+CREATE FUNCTION distance(intspanset, intspan)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Distance_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_distance(intspanset, intspanset)
+CREATE FUNCTION distance(intspanset, intspanset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Distance_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = integer, RIGHTARG = intspanset,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = intspan, RIGHTARG = intspanset,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = intspanset, RIGHTARG = integer,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = intspanset, RIGHTARG = intspan,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = intspanset, RIGHTARG = intspanset,
   COMMUTATOR = <->
 );
 
-CREATE FUNCTION span_distance(bigint, bigintspanset)
+CREATE FUNCTION distance(bigint, bigintspanset)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Distance_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_distance(bigintspan, bigintspanset)
+CREATE FUNCTION distance(bigintspan, bigintspanset)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Distance_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_distance(bigintspanset, bigint)
+CREATE FUNCTION distance(bigintspanset, bigint)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Distance_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_distance(bigintspanset, bigintspan)
+CREATE FUNCTION distance(bigintspanset, bigintspan)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Distance_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_distance(bigintspanset, bigintspanset)
+CREATE FUNCTION distance(bigintspanset, bigintspanset)
   RETURNS bigint
   AS 'MODULE_PATHNAME', 'Distance_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = bigint, RIGHTARG = bigintspanset,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = bigintspan, RIGHTARG = bigintspanset,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = bigintspanset, RIGHTARG = bigint,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = bigintspanset, RIGHTARG = bigintspan,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = bigintspanset, RIGHTARG = bigintspanset,
   COMMUTATOR = <->
 );
 
-CREATE FUNCTION span_distance(float, floatspanset)
+CREATE FUNCTION distance(float, floatspanset)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_distance(floatspan, floatspanset)
+CREATE FUNCTION distance(floatspan, floatspanset)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_distance(floatspanset, float)
+CREATE FUNCTION distance(floatspanset, float)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_distance(floatspanset, floatspan)
+CREATE FUNCTION distance(floatspanset, floatspan)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_distance(floatspanset, floatspanset)
+CREATE FUNCTION distance(floatspanset, floatspanset)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = float, RIGHTARG = floatspanset,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = floatspan, RIGHTARG = floatspanset,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = floatspanset, RIGHTARG = float,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = floatspanset, RIGHTARG = floatspan,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = floatspanset, RIGHTARG = floatspanset,
   COMMUTATOR = <->
 );
 
-CREATE FUNCTION span_distance(date, datespanset)
+CREATE FUNCTION distance(date, datespanset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Distance_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_distance(datespan, datespanset)
+CREATE FUNCTION distance(datespan, datespanset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Distance_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_distance(datespanset, date)
+CREATE FUNCTION distance(datespanset, date)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Distance_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_distance(datespanset, datespan)
+CREATE FUNCTION distance(datespanset, datespan)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Distance_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION span_distance(datespanset, datespanset)
+CREATE FUNCTION distance(datespanset, datespanset)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Distance_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = date, RIGHTARG = datespanset,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = datespan, RIGHTARG = datespanset,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = datespanset, RIGHTARG = date,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = datespanset, RIGHTARG = datespan,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = span_distance,
+  PROCEDURE = distance,
   LEFTARG = datespanset, RIGHTARG = datespanset,
   COMMUTATOR = <->
 );
 
-CREATE FUNCTION time_distance(timestamptz, tstzspanset)
+CREATE FUNCTION distance(timestamptz, tstzspanset)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_value_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION time_distance(tstzspan, tstzspanset)
+CREATE FUNCTION distance(tstzspan, tstzspanset)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_span_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION time_distance(tstzspanset, timestamptz)
+CREATE FUNCTION distance(tstzspanset, timestamptz)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_spanset_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION time_distance(tstzspanset, tstzspan)
+CREATE FUNCTION distance(tstzspanset, tstzspan)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_spanset_span'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION time_distance(tstzspanset, tstzspanset)
+CREATE FUNCTION distance(tstzspanset, tstzspanset)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_spanset_spanset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <-> (
-  PROCEDURE = time_distance,
+  PROCEDURE = distance,
   LEFTARG = timestamptz, RIGHTARG = tstzspanset,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = time_distance,
+  PROCEDURE = distance,
   LEFTARG = tstzspan, RIGHTARG = tstzspanset,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = time_distance,
+  PROCEDURE = distance,
   LEFTARG = tstzspanset, RIGHTARG = timestamptz,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = time_distance,
+  PROCEDURE = distance,
   LEFTARG = tstzspanset, RIGHTARG = tstzspan,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
-  PROCEDURE = time_distance,
+  PROCEDURE = distance,
   LEFTARG = tstzspanset, RIGHTARG = tstzspanset,
   COMMUTATOR = <->
 );

--- a/mobilitydb/src/temporal/span_ops.c
+++ b/mobilitydb/src/temporal/span_ops.c
@@ -580,7 +580,7 @@ PG_FUNCTION_INFO_V1(Distance_value_span);
 /**
  * @ingroup mobilitydb_setspan_dist
  * @brief Return the distance between a value and a span
- * @sqlfn span_distance()
+ * @sqlfn distance()
  * @sqlop @p <->
  */
 Datum
@@ -596,7 +596,7 @@ PG_FUNCTION_INFO_V1(Distance_span_value);
 /**
  * @ingroup mobilitydb_setspan_dist
  * @brief Return the distance between a span and a value
- * @sqlfn span_distance()
+ * @sqlfn distance()
  * @sqlop @p <->
  */
 Datum
@@ -612,7 +612,7 @@ PG_FUNCTION_INFO_V1(Distance_span_span);
 /**
  * @ingroup mobilitydb_setspan_dist
  * @brief Return the distance between two spans
- * @sqlfn span_distance()
+ * @sqlfn distance()
  * @sqlop @p <->
  */
 Datum

--- a/mobilitydb/src/temporal/spanset_ops.c
+++ b/mobilitydb/src/temporal/spanset_ops.c
@@ -999,7 +999,7 @@ PG_FUNCTION_INFO_V1(Distance_value_spanset);
 /**
  * @ingroup mobilitydb_setspan_dist
  * @brief Return the distance between a value and a span set
- * @sqlfn span_distance()
+ * @sqlfn distance()
  * @sqlop @p <->
  */
 Datum
@@ -1017,7 +1017,7 @@ PG_FUNCTION_INFO_V1(Distance_span_spanset);
 /**
  * @ingroup mobilitydb_setspan_dist
  * @brief Return the distance in seconds between a span and a span set
- * @sqlfn span_distance()
+ * @sqlfn distance()
  * @sqlop @p <->
  */
 Datum
@@ -1036,7 +1036,7 @@ PG_FUNCTION_INFO_V1(Distance_spanset_value);
 /**
  * @ingroup mobilitydb_setspan_dist
  * @brief Return the distance between a span set and a value
- * @sqlfn span_distance()
+ * @sqlfn distance()
  * @sqlop @p <->
  */
 Datum
@@ -1054,7 +1054,7 @@ PG_FUNCTION_INFO_V1(Distance_spanset_span);
 /**
  * @ingroup mobilitydb_setspan_dist
  * @brief Return the distance between a span set and a span
- * @sqlfn span_distance()
+ * @sqlfn distance()
  * @sqlop @p <->
  */
 Datum
@@ -1072,7 +1072,7 @@ PG_FUNCTION_INFO_V1(Distance_spanset_spanset);
 /**
  * @ingroup mobilitydb_setspan_dist
  * @brief Return the distance between two span sets
- * @sqlfn span_distance()
+ * @sqlfn distance()
  * @sqlop @p <->
  */
 Datum

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -4897,46 +4897,46 @@ span_families:
   - lit: "\n"
   - group:
     - {stmt: "/*****************************************************************************\n * Distance operators\n *****************************************************************************/"}
-    - {stmt: "\nCREATE FUNCTION span_distance({v}, {sp})\n  RETURNS {v}\n  AS 'MODULE_PATHNAME', 'Distance_value_span'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;"}
-    - {sig: "span_distance({sp}, {v})", ret: "{v}", sym: Distance_span_value}
-    - {sig: "span_distance({sp}, {sp})", ret: "{v}", sym: Distance_span_span}
-    - {stmt: "\nCREATE OPERATOR <-> (\n  PROCEDURE = span_distance,\n  LEFTARG = {v}, RIGHTARG = {sp},\n  COMMUTATOR = <->\n);"}
-    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = span_distance,\n  LEFTARG = {sp}, RIGHTARG = {v},\n  COMMUTATOR = <->\n);"}
-    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = span_distance,\n  LEFTARG = {sp}, RIGHTARG = {sp},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "\nCREATE FUNCTION distance({v}, {sp})\n  RETURNS {v}\n  AS 'MODULE_PATHNAME', 'Distance_value_span'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;"}
+    - {sig: "distance({sp}, {v})", ret: "{v}", sym: Distance_span_value}
+    - {sig: "distance({sp}, {sp})", ret: "{v}", sym: Distance_span_span}
+    - {stmt: "\nCREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {v}, RIGHTARG = {sp},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {sp}, RIGHTARG = {v},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {sp}, RIGHTARG = {sp},\n  COMMUTATOR = <->\n);"}
     sep: "\n"
     order: [int]
   - lit: "\n"
   - group:
-    - {sig: "span_distance({v}, {sp})", ret: "{v}", sym: Distance_value_span}
-    - {sig: "span_distance({sp}, {v})", ret: "{v}", sym: Distance_span_value}
-    - {sig: "span_distance({sp}, {sp})", ret: "{v}", sym: Distance_span_span}
-    - {stmt: "\nCREATE OPERATOR <-> (\n  PROCEDURE = span_distance,\n  LEFTARG = {v}, RIGHTARG = {sp},\n  COMMUTATOR = <->\n);"}
-    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = span_distance,\n  LEFTARG = {sp}, RIGHTARG = {v},\n  COMMUTATOR = <->\n);"}
-    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = span_distance,\n  LEFTARG = {sp}, RIGHTARG = {sp},\n  COMMUTATOR = <->\n);"}
+    - {sig: "distance({v}, {sp})", ret: "{v}", sym: Distance_value_span}
+    - {sig: "distance({sp}, {v})", ret: "{v}", sym: Distance_span_value}
+    - {sig: "distance({sp}, {sp})", ret: "{v}", sym: Distance_span_span}
+    - {stmt: "\nCREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {v}, RIGHTARG = {sp},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {sp}, RIGHTARG = {v},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {sp}, RIGHTARG = {sp},\n  COMMUTATOR = <->\n);"}
     sep: "\n"
     order: [bigint]
   - lit: "\n"
   - group:
-    - {sig: "span_distance({v}, {sp})", ret: "{v}", sym: Distance_value_span}
-    - {sig: "span_distance({sp}, {v})", ret: "{v}", sym: Distance_span_value}
-    - {sig: "span_distance({sp}, {sp})", ret: "{v}", sym: Distance_span_span}
-    - {stmt: "\nCREATE OPERATOR <-> (\n  PROCEDURE = span_distance,\n  LEFTARG = {v}, RIGHTARG = {sp},\n  COMMUTATOR = <->\n);"}
-    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = span_distance,\n  LEFTARG = {sp}, RIGHTARG = {v},\n  COMMUTATOR = <->\n);"}
-    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = span_distance,\n  LEFTARG = {sp}, RIGHTARG = {sp},\n  COMMUTATOR = <->\n);"}
+    - {sig: "distance({v}, {sp})", ret: "{v}", sym: Distance_value_span}
+    - {sig: "distance({sp}, {v})", ret: "{v}", sym: Distance_span_value}
+    - {sig: "distance({sp}, {sp})", ret: "{v}", sym: Distance_span_span}
+    - {stmt: "\nCREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {v}, RIGHTARG = {sp},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {sp}, RIGHTARG = {v},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {sp}, RIGHTARG = {sp},\n  COMMUTATOR = <->\n);"}
     sep: "\n"
     order: [float]
-  - lit: "\nCREATE FUNCTION span_distance(date, datespan)\n  RETURNS integer\n  AS 'MODULE_PATHNAME', 'Distance_value_span'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION span_distance(datespan, date)\n  RETURNS integer\n  AS 'MODULE_PATHNAME', 'Distance_span_value'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION span_distance(datespan, datespan)\n  RETURNS integer\n  AS 'MODULE_PATHNAME', 'Distance_span_span'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n"
+  - lit: "\nCREATE FUNCTION distance(date, datespan)\n  RETURNS integer\n  AS 'MODULE_PATHNAME', 'Distance_value_span'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION distance(datespan, date)\n  RETURNS integer\n  AS 'MODULE_PATHNAME', 'Distance_span_value'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION distance(datespan, datespan)\n  RETURNS integer\n  AS 'MODULE_PATHNAME', 'Distance_span_span'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n"
   - group:
-    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = span_distance,\n  LEFTARG = {v}, RIGHTARG = {sp},\n  COMMUTATOR = <->\n);"}
-    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = span_distance,\n  LEFTARG = {sp}, RIGHTARG = {v},\n  COMMUTATOR = <->\n);"}
-    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = span_distance,\n  LEFTARG = {sp}, RIGHTARG = {sp},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {v}, RIGHTARG = {sp},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {sp}, RIGHTARG = {v},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {sp}, RIGHTARG = {sp},\n  COMMUTATOR = <->\n);"}
     sep: "\n"
     order: [date]
-  - lit: "\nCREATE FUNCTION span_distance(timestamptz, tstzspan)\n  RETURNS float\n  AS 'MODULE_PATHNAME', 'Distance_value_span'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION span_distance(tstzspan, timestamptz)\n  RETURNS float\n  AS 'MODULE_PATHNAME', 'Distance_span_value'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION span_distance(tstzspan, tstzspan)\n  RETURNS float\n  AS 'MODULE_PATHNAME', 'Distance_span_span'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n"
+  - lit: "\nCREATE FUNCTION distance(timestamptz, tstzspan)\n  RETURNS float\n  AS 'MODULE_PATHNAME', 'Distance_value_span'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION distance(tstzspan, timestamptz)\n  RETURNS float\n  AS 'MODULE_PATHNAME', 'Distance_span_value'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION distance(tstzspan, tstzspan)\n  RETURNS float\n  AS 'MODULE_PATHNAME', 'Distance_span_span'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n"
   - group:
-    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = span_distance,\n  LEFTARG = {v}, RIGHTARG = {sp},\n  COMMUTATOR = <->\n);"}
-    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = span_distance,\n  LEFTARG = {sp}, RIGHTARG = {v},\n  COMMUTATOR = <->\n);"}
-    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = span_distance,\n  LEFTARG = {sp}, RIGHTARG = {sp},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {v}, RIGHTARG = {sp},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {sp}, RIGHTARG = {v},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {sp}, RIGHTARG = {sp},\n  COMMUTATOR = <->\n);"}
     - {stmt: "\n/*****************************************************************************/"}
     sep: "\n"
     order: [tstz]
@@ -5563,34 +5563,34 @@ span_families:
     order: [tstz]
   - lit: "\n"
   - group:
-    - {sig: "span_distance({v}, {ss})", ret: "{v}", sym: Distance_value_spanset}
-    - {sig: "span_distance({sp}, {ss})", ret: "{v}", sym: Distance_span_spanset}
-    - {sig: "span_distance({ss}, {v})", ret: "{v}", sym: Distance_spanset_value}
-    - {sig: "span_distance({ss}, {sp})", ret: "{v}", sym: Distance_spanset_span}
-    - {sig: "span_distance({ss}, {ss})", ret: "{v}", sym: Distance_spanset_spanset}
-    - {stmt: "\nCREATE OPERATOR <-> (\n  PROCEDURE = span_distance,\n  LEFTARG = {v}, RIGHTARG = {ss},\n  COMMUTATOR = <->\n);"}
-    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = span_distance,\n  LEFTARG = {sp}, RIGHTARG = {ss},\n  COMMUTATOR = <->\n);"}
-    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = span_distance,\n  LEFTARG = {ss}, RIGHTARG = {v},\n  COMMUTATOR = <->\n);"}
-    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = span_distance,\n  LEFTARG = {ss}, RIGHTARG = {sp},\n  COMMUTATOR = <->\n);"}
-    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = span_distance,\n  LEFTARG = {ss}, RIGHTARG = {ss},\n  COMMUTATOR = <->\n);"}
+    - {sig: "distance({v}, {ss})", ret: "{v}", sym: Distance_value_spanset}
+    - {sig: "distance({sp}, {ss})", ret: "{v}", sym: Distance_span_spanset}
+    - {sig: "distance({ss}, {v})", ret: "{v}", sym: Distance_spanset_value}
+    - {sig: "distance({ss}, {sp})", ret: "{v}", sym: Distance_spanset_span}
+    - {sig: "distance({ss}, {ss})", ret: "{v}", sym: Distance_spanset_spanset}
+    - {stmt: "\nCREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {v}, RIGHTARG = {ss},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {sp}, RIGHTARG = {ss},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {ss}, RIGHTARG = {v},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {ss}, RIGHTARG = {sp},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {ss}, RIGHTARG = {ss},\n  COMMUTATOR = <->\n);"}
     sep: "\n"
     order: [int, bigint, float]
-  - lit: "\nCREATE FUNCTION span_distance(date, datespanset)\n  RETURNS integer\n  AS 'MODULE_PATHNAME', 'Distance_value_spanset'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION span_distance(datespan, datespanset)\n  RETURNS integer\n  AS 'MODULE_PATHNAME', 'Distance_span_spanset'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION span_distance(datespanset, date)\n  RETURNS integer\n  AS 'MODULE_PATHNAME', 'Distance_spanset_value'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION span_distance(datespanset, datespan)\n  RETURNS integer\n  AS 'MODULE_PATHNAME', 'Distance_spanset_span'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION span_distance(datespanset, datespanset)\n  RETURNS integer\n  AS 'MODULE_PATHNAME', 'Distance_spanset_spanset'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n"
+  - lit: "\nCREATE FUNCTION distance(date, datespanset)\n  RETURNS integer\n  AS 'MODULE_PATHNAME', 'Distance_value_spanset'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION distance(datespan, datespanset)\n  RETURNS integer\n  AS 'MODULE_PATHNAME', 'Distance_span_spanset'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION distance(datespanset, date)\n  RETURNS integer\n  AS 'MODULE_PATHNAME', 'Distance_spanset_value'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION distance(datespanset, datespan)\n  RETURNS integer\n  AS 'MODULE_PATHNAME', 'Distance_spanset_span'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION distance(datespanset, datespanset)\n  RETURNS integer\n  AS 'MODULE_PATHNAME', 'Distance_spanset_spanset'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n"
   - group:
-    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = span_distance,\n  LEFTARG = {v}, RIGHTARG = {ss},\n  COMMUTATOR = <->\n);"}
-    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = span_distance,\n  LEFTARG = {sp}, RIGHTARG = {ss},\n  COMMUTATOR = <->\n);"}
-    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = span_distance,\n  LEFTARG = {ss}, RIGHTARG = {v},\n  COMMUTATOR = <->\n);"}
-    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = span_distance,\n  LEFTARG = {ss}, RIGHTARG = {sp},\n  COMMUTATOR = <->\n);"}
-    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = span_distance,\n  LEFTARG = {ss}, RIGHTARG = {ss},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {v}, RIGHTARG = {ss},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {sp}, RIGHTARG = {ss},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {ss}, RIGHTARG = {v},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {ss}, RIGHTARG = {sp},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {ss}, RIGHTARG = {ss},\n  COMMUTATOR = <->\n);"}
     sep: "\n"
     order: [date]
-  - lit: "\nCREATE FUNCTION time_distance(timestamptz, tstzspanset)\n  RETURNS float\n  AS 'MODULE_PATHNAME', 'Distance_value_spanset'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION time_distance(tstzspan, tstzspanset)\n  RETURNS float\n  AS 'MODULE_PATHNAME', 'Distance_span_spanset'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION time_distance(tstzspanset, timestamptz)\n  RETURNS float\n  AS 'MODULE_PATHNAME', 'Distance_spanset_value'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION time_distance(tstzspanset, tstzspan)\n  RETURNS float\n  AS 'MODULE_PATHNAME', 'Distance_spanset_span'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION time_distance(tstzspanset, tstzspanset)\n  RETURNS float\n  AS 'MODULE_PATHNAME', 'Distance_spanset_spanset'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n"
+  - lit: "\nCREATE FUNCTION distance(timestamptz, tstzspanset)\n  RETURNS float\n  AS 'MODULE_PATHNAME', 'Distance_value_spanset'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION distance(tstzspan, tstzspanset)\n  RETURNS float\n  AS 'MODULE_PATHNAME', 'Distance_span_spanset'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION distance(tstzspanset, timestamptz)\n  RETURNS float\n  AS 'MODULE_PATHNAME', 'Distance_spanset_value'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION distance(tstzspanset, tstzspan)\n  RETURNS float\n  AS 'MODULE_PATHNAME', 'Distance_spanset_span'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION distance(tstzspanset, tstzspanset)\n  RETURNS float\n  AS 'MODULE_PATHNAME', 'Distance_spanset_spanset'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n"
   - group:
-    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = time_distance,\n  LEFTARG = {v}, RIGHTARG = {ss},\n  COMMUTATOR = <->\n);"}
-    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = time_distance,\n  LEFTARG = {sp}, RIGHTARG = {ss},\n  COMMUTATOR = <->\n);"}
-    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = time_distance,\n  LEFTARG = {ss}, RIGHTARG = {v},\n  COMMUTATOR = <->\n);"}
-    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = time_distance,\n  LEFTARG = {ss}, RIGHTARG = {sp},\n  COMMUTATOR = <->\n);"}
-    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = time_distance,\n  LEFTARG = {ss}, RIGHTARG = {ss},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {v}, RIGHTARG = {ss},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {sp}, RIGHTARG = {ss},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {ss}, RIGHTARG = {v},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {ss}, RIGHTARG = {sp},\n  COMMUTATOR = <->\n);"}
+    - {stmt: "CREATE OPERATOR <-> (\n  PROCEDURE = distance,\n  LEFTARG = {ss}, RIGHTARG = {ss},\n  COMMUTATOR = <->\n);"}
     - {stmt: "\n/*****************************************************************************/"}
     sep: "\n"
     order: [tstz]


### PR DESCRIPTION
The `<->` distance operator over spans and span sets is backed by SQL functions named `span_distance` and `time_distance`, while the same operator over circular buffers is backed by a bare `distance`. The SQL API carries no underscore and the argument types resolve the overload, so this names all of them `distance`.

The 40 span and span set declarations join the 5 circular-buffer ones under a single overloaded name, 45 unique signatures in total. The `tstzspanset` group that spelled itself `time_distance` folds into the same name as its siblings, which also removes its mismatch with the `@sqlfn` tags that already read `span_distance` for those wrappers. The C symbols `Distance_value_span`, `Distance_span_value`, `Distance_span_span` and their span set counterparts, and every MEOS call, are unchanged.

`005_span_ops.in.sql` and `009_spanset_ops.in.sql` are governed by the inherited SQL generator's `span_ops` and `spanset_ops` reference entries, so `manifest.yaml` carries the same rename and `generate.py --validate` re-renders both files byte-for-byte. No test invokes either name directly — they are reached through `<->` — so the expected outputs are unchanged.
