### PR TITLE
Make a TPCBox begin with a whole STBox and read the SRID of a tpcpoint

### DIFF
--- a/meos/include/meos_pointcloud.h
+++ b/meos/include/meos_pointcloud.h
@@ -70,23 +70,43 @@ typedef struct
   double ymax;        /**< maximum y value */
   double zmax;        /**< maximum z value */
   int32_t srid;       /**< SRID */
-  uint32_t pcid;      /**< pgpointcloud schema id */
   int16 flags;        /**< flags */
-  char padding[6];    /**< explicit pad to 8-byte alignment */
+  /* Every field above is byte-identical to STBox, so a TPCBox is read
+   * through an @p STBox pointer by the shared spatiotemporal code. The
+   * pgpointcloud schema id follows that common prefix. */
+  char padding[2];    /**< explicit pad, kept zero: send/recv copy the struct */
+  uint32_t pcid;      /**< pgpointcloud schema id */
 } TPCBox;
 
-/* TPCBox shares its leading layout with STBox so that a TPCBox can be
- * projected to an STBox by dropping the trailing pcid + padding. The
- * layout-compatibility cast (CREATE CAST tpcbox AS stbox) and any
- * future tooling that converts between the two rely on this. */
+/* A TPCBox begins with a whole STBox: every STBox field sits at the same
+ * offset, so the shared spatiotemporal code reads a TPCBox through an
+ * @p STBox pointer, and a TPCBox is projected to an STBox by dropping the
+ * trailing pcid. The layout-compatibility cast (CREATE CAST tpcbox AS
+ * stbox) relies on this, as does the SRID accessor.
+ *
+ * ⛔ The flags offset is the one that matters most: nearly every box
+ * operation reads the X / Z / T / GEODETIC bits, so a divergence there
+ * silently misreads every box rather than failing loudly. */
 static_assert(offsetof(TPCBox, period) == offsetof(STBox, period),
                "TPCBox and STBox must share the period offset");
 static_assert(offsetof(TPCBox, xmin) == offsetof(STBox, xmin),
                "TPCBox and STBox must share the xmin offset");
+static_assert(offsetof(TPCBox, ymin) == offsetof(STBox, ymin),
+               "TPCBox and STBox must share the ymin offset");
+static_assert(offsetof(TPCBox, zmin) == offsetof(STBox, zmin),
+               "TPCBox and STBox must share the zmin offset");
+static_assert(offsetof(TPCBox, xmax) == offsetof(STBox, xmax),
+               "TPCBox and STBox must share the xmax offset");
+static_assert(offsetof(TPCBox, ymax) == offsetof(STBox, ymax),
+               "TPCBox and STBox must share the ymax offset");
 static_assert(offsetof(TPCBox, zmax) == offsetof(STBox, zmax),
                "TPCBox and STBox must share the zmax offset");
 static_assert(offsetof(TPCBox, srid) == offsetof(STBox, srid),
                "TPCBox and STBox must share the srid offset");
+static_assert(offsetof(TPCBox, flags) == offsetof(STBox, flags),
+               "TPCBox and STBox must share the flags offset");
+static_assert(offsetof(TPCBox, pcid) >= sizeof(STBox),
+               "the pcid of a TPCBox must follow the whole STBox prefix");
 
 /*****************************************************************************
  * Validity macros

--- a/meos/src/geo/tspatial_srid.c
+++ b/meos/src/geo/tspatial_srid.c
@@ -94,7 +94,15 @@
 int32_t
 spatial_srid(Datum d, MeosType basetype)
 {
+  /* T_PCPOINT is deliberately outside spatial_basetype(): the other
+   * spatial_* dispatchers have no pgpointcloud case, and deriving a
+   * pcpoint's flags needs its schema. Only the SRID is available without
+   * one, so it is admitted here rather than catalog-wide. */
+#if POINTCLOUD
+  assert(spatial_basetype(basetype) || basetype == T_PCPOINT);
+#else
   assert(spatial_basetype(basetype));
+#endif
   switch (basetype)
   {
     case T_GEOMETRY:
@@ -243,7 +251,13 @@ spatialset_set_srid(const Set *s, int32_t srid)
 int32_t
 tspatialinst_srid(const TInstant *inst)
 {
-  assert(inst); assert(tspatial_type(inst->temptype));
+  assert(inst);
+#if POINTCLOUD
+  assert(tspatial_type(inst->temptype) ||
+    tpointcloud_temptype(inst->temptype));
+#else
+  assert(tspatial_type(inst->temptype));
+#endif
   MeosType basetype = temptype_basetype(inst->temptype);
   return spatial_srid(tinstant_value_p(inst), basetype);
 }
@@ -258,8 +272,20 @@ tspatialinst_srid(const TInstant *inst)
 int32_t
 tspatial_srid(const Temporal *temp)
 {
-  /* Ensure the validity of the arguments */
+  /* Ensure the validity of the arguments. The pgpointcloud temporal types
+   * are accepted alongside the spatiotemporal ones: they are excluded from
+   * tspatial_type() because their bounding box is a TPCBox rather than an
+   * STBox, but a TPCBox begins with a whole STBox (see the static_asserts in
+   * meos_pointcloud.h), so the SRID is read from the same offset. This
+   * mirrors how temporal_boxops.c admits them beside tspatial_type(). */
+#if POINTCLOUD
+  if (! ensure_not_null((void *) temp))
+    return SRID_INVALID;
+  if (! tpointcloud_temptype(temp->temptype))
+    VALIDATE_TSPATIAL(temp, SRID_INVALID);
+#else
   VALIDATE_TSPATIAL(temp, SRID_INVALID);
+#endif
   const STBox *box;
   assert(temptype_subtype(temp->subtype));
   switch (temp->subtype)

--- a/mobilitydb/test/pointcloud/expected/420_tpcpoint.test.out
+++ b/mobilitydb/test/pointcloud/expected/420_tpcpoint.test.out
@@ -440,6 +440,36 @@ SELECT appendSequence(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0,
  t
 (1 row)
 
+SELECT SRID(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
+ srid 
+------
+    0
+(1 row)
+
+SELECT SRID(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz)]));
+ srid 
+------
+    0
+(1 row)
+
+SELECT SRID(tpcpointSeqSet(ARRAY[tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz)])]));
+ srid 
+------
+    0
+(1 row)
+
+SELECT SRID(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) = (SELECT srid FROM pointcloud_formats WHERE pcid = 1);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT SRID(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz)])) = SRID(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
+ ?column? 
+----------
+ t
+(1 row)
+
 SELECT count(*) FROM unnest(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]));
  count 
 -------

--- a/mobilitydb/test/pointcloud/queries/420_tpcpoint.test.sql
+++ b/mobilitydb/test/pointcloud/queries/420_tpcpoint.test.sql
@@ -209,6 +209,20 @@ SELECT appendSequence(tpcpointSeq(ARRAY[:inst1]),
   tpcpointSeq(ARRAY[:inst2, :inst3])) IS NOT NULL;
 
 -------------------------------------------------------------------------------
+-- SRID
+-- Reading the SRID of a tpcpoint goes through the generic spatiotemporal
+-- dispatcher. The instant form reads the schema of the value; the sequence
+-- form reads the bounding box, whose leading layout is that of an STBox.
+-- Both agree with the schema registered in pointcloud_formats.
+-------------------------------------------------------------------------------
+
+SELECT SRID(:inst1);
+SELECT SRID(tpcpointSeq(ARRAY[:inst1, :inst2]));
+SELECT SRID(tpcpointSeqSet(ARRAY[tpcpointSeq(ARRAY[:inst1, :inst2])]));
+SELECT SRID(:inst1) = (SELECT srid FROM pointcloud_formats WHERE pcid = 1);
+SELECT SRID(tpcpointSeq(ARRAY[:inst1, :inst2])) = SRID(:inst1);
+
+-------------------------------------------------------------------------------
 -- Unnest
 -- One row per distinct value, with the span set on which the temporal value
 -- takes it. A value occurring twice yields one row whose span set has two


### PR DESCRIPTION
Reading the SRID of a tpcpoint aborts the server:

```sql
SELECT SRID(tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz));
-- server closed the connection unexpectedly
```

`postgres.log` reports `terminated by signal 6: Aborted` from
`tspatial_srid.c: Assertion 'tspatial_type(temp->temptype)' failed`.
`SRID(tpcpoint)` binds the generic spatiotemporal dispatcher, whose guard is
`tspatial_type()`, and the pgpointcloud temporal types sit outside it. A debug
build aborts; under `NDEBUG` the assertion is compiled out and the function
runs on a type it never validated.

The pgpointcloud types stay outside `tspatial_type()`. That predicate also
selects the bounding box representation at some twenty sites in
`temporal_boxops.c`, plus `temporal_sptree.c`, `temporal_rtree.c` and
`type_out.c`, and their box is a TPCBox rather than an STBox. They are
admitted beside it, which is what `temporal_boxops.c` already does through
`tpointcloud_temptype()`.

A TPCBox begins with a whole STBox. Its schema id moves after the flags, so
every STBox field keeps its offset, and the assertions covering the shared
layout grow from four fields to all of them, including the flags, plus the
requirement that the schema id follow the STBox prefix. The flags offset is
the one that matters: nearly every box operation reads the X, Z, T and
geodetic bits, so a divergence there misreads a box rather than failing.

⚠️ This changes the binary representation. The recv and send paths copy the
struct, and the box carried inline by a tpcpoint or a tpcpatch is a TPCBox,
so stored values need a dump and reload.

The base type stays outside `spatial_basetype()` for the same reason as the
temporal ones: the other spatial dispatchers have no pgpointcloud case, and
deriving the flags of a pcpoint needs its schema, while the SRID is readable
without one.

The tests cover the SRID of the three subtypes, its agreement with the schema
registered in `pointcloud_formats`, and the sequence agreeing with the
instant. The rest of the expected output is unchanged, which is the evidence
that moving the field preserves behaviour.

Future: the nineteen `tpcbox_*` functions that have an `stbox_*` namesake can
delegate to it, the compile-time assertions making that sound. Each
delegation has to keep its schema id guard, since boxes of different schemas
must not compare or union.