### PR TITLE
Add examples to the function reference entries of five chapters

### DIFF
--- a/doc/es/temporal_circular_buffers.xml
+++ b/doc/es/temporal_circular_buffers.xml
@@ -706,6 +706,19 @@ SELECT asText(centroid(tcbuffer '[Cbuffer(Point(1 1), 0.5)@2001-01-01,
 				<para>Devuelve la envolvente convexa del área atravesada por el búfer circular temporal</para>
 				<para><varname>convexHull(tcbuffer) → geometry</varname></para>
 				<para>La envolvente convexa se calcula sobre el área atravesada linealizada: los arcos circulares que delimitan la región barrida se convierten primero en segmentos rectos y la envolvente se calcula luego con GEOS. Por lo tanto, el resultado es un <varname>POLYGON</varname> lineal que aproxima el contorno circular, no un <varname>CURVEDPOLYGON</varname> curvo. Utilice <varname>traversedArea</varname> para obtener la región barrida curva exacta.</para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_GeometryType(convexHull(tcbuffer
+  '[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(4 0), 1)@2001-01-02]'));
+-- ST_Polygon
+SELECT ST_NPoints(convexHull(tcbuffer
+  '[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(4 0), 1)@2001-01-02]'));
+-- 131
+SELECT round(ST_Area(convexHull(tcbuffer
+  '[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(4 0), 1)@2001-01-02]'))::numeric, 3);
+-- 11.140
+-- The exact swept region has area pi + 8 = 11.1416; the stroked hull is
+-- slightly smaller because the arcs are replaced by chords.
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>

--- a/doc/es/temporal_h3_index.xml
+++ b/doc/es/temporal_h3_index.xml
@@ -104,9 +104,9 @@ SELECT geoToH3IndexSet(geometry 'SRID=4326;Point(4.35 50.85)', 7);
 			</listitem>
 
 			<listitem xml:id="th3_ever_eq_set">
-				<indexterm significance="normal"><primary><varname>ever_eq</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>eEq</varname></primary></indexterm>
 				<para>Devuelve si una trayectoria H3 temporal toma alguna vez una de las celdas de un conjunto de celdas. Combinada con <varname>geoToH3IndexSet</varname> responde si un viaje pasa alguna vez por una región, sin materializar la geometría de la trayectoria — el prefiltro robusto y conservador para el predicado exacto <varname>eIntersects(geometry,th3index)</varname>.</para>
-				<para><varname>ever_eq(h3indexset,th3index) → boolean</varname></para>
+				<para><varname>eEq(h3indexset,th3index) → boolean</varname></para>
 				<para><varname>h3indexset ?= th3index → boolean</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geoToH3IndexSet(geometry 'SRID=4326;Point(4.35 50.85)', 7) ?=
@@ -187,6 +187,9 @@ SELECT th3GetResolution(th3index '831c02fffffffff@2001-01-01');
 				<indexterm significance="normal"><primary><varname>th3GetBaseCellNumber</varname></primary></indexterm>
 				<para>Devolver el número de celda base temporal (0–121) de cada celda en una trayectoria</para>
 				<para><varname>th3GetBaseCellNumber(th3index) → tint</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3GetBaseCellNumber(th3index '831c02fffffffff@2001-01-01');
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_is_valid_cell">
@@ -203,12 +206,22 @@ SELECT isValidCell(th3index '0@2001-01-01');
 				<indexterm significance="normal"><primary><varname>th3IsResClassIii</varname></primary></indexterm>
 				<para>Devolver un booleano temporal que indica si cada celda tiene orientación de Clase III. La Clase III se alterna con la resolución: las resoluciones impares son de clase III, las pares son de clase II.</para>
 				<para><varname>th3IsResClassIii(th3index) → tbool</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3IsResClassIii(th3index '871fa44a8ffffff@2001-01-01');
+-- t@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_is_pentagon">
 				<indexterm significance="normal"><primary><varname>th3IsPentagon</varname></primary></indexterm>
 				<para>Devolver un booleano temporal que indica si cada celda es un pentágono (12 celdas por resolución son pentágonos; las restantes 110 en cada celda base descienden como hexágonos)</para>
 				<para><varname>th3IsPentagon(th3index) → tbool</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3IsPentagon(th3index '831c00fffffffff@2001-01-01');
+-- t@2001-01-01
+SELECT th3IsPentagon(th3index '831c02fffffffff@2001-01-01');
+-- f@2001-01-01
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -221,6 +234,11 @@ SELECT isValidCell(th3index '0@2001-01-01');
 				<para>Devolver la celda padre temporal en la resolución dada. La forma sin argumento desciende a la siguiente resolución más gruesa.</para>
 				<para><varname>th3CellToParent(th3index,integer) → th3index</varname></para>
 				<para><varname>th3CellToParent(th3index) → th3index</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3GetResolution(
+  th3CellToParent(th3index '8a2a1072b59ffff@2001-01-01', 5));
+-- 5@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_cell_to_center_child">
@@ -228,18 +246,33 @@ SELECT isValidCell(th3index '0@2001-01-01');
 				<para>Devolver la celda hijo central temporal en la resolución dada. La forma sin argumento desciende a la siguiente resolución más fina.</para>
 				<para><varname>th3CellToCenterChild(th3index,integer) → th3index</varname></para>
 				<para><varname>th3CellToCenterChild(th3index) → th3index</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3CellToCenterChild(th3index '871fa44a8ffffff@2001-01-01', 8);
+-- 881fa44a81fffff@2001-01-01
+-- Without a resolution the child is one level finer.
+SELECT th3CellToCenterChild(th3index '871fa44a8ffffff@2001-01-01');
+-- 881fa44a81fffff@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_cell_to_child_pos">
 				<indexterm significance="normal"><primary><varname>th3CellToChildPos</varname></primary></indexterm>
 				<para>Devolver la posición ordinal (basada en 0) de cada celda entre los hijos de su padre en la resolución dada</para>
 				<para><varname>th3CellToChildPos(th3index,integer) → tbigint</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3CellToChildPos(th3index '871fa44a8ffffff@2001-01-01', 6);
+-- 0@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_child_pos_to_cell">
 				<indexterm significance="normal"><primary><varname>th3ChildPosToCell</varname></primary></indexterm>
 				<para>Devolver la celda hijo temporal en una posición ordinal dada del padre dado, en la resolución de hijo dada. Los dos operandos temporales se sincronizan sobre su eje de tiempo compartido.</para>
 				<para><varname>th3ChildPosToCell(tbigint,th3index,integer) → th3index</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3ChildPosToCell(tbigint '0@2001-01-01', th3index '871fa44a8ffffff@2001-01-01', 8);
+-- 881fa44a81fffff@2001-01-01
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -248,11 +281,18 @@ SELECT isValidCell(th3index '0@2001-01-01');
 		<title>Conversiones de Latitud/Longitud</title>
 		<itemizedlist>
 			<listitem xml:id="th3_tgeompoint_to_th3">
-				<indexterm significance="normal"><primary><varname>tgeompoint_to_th3</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>tgeogpoint_to_th3</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>th3index</varname></primary></indexterm>
 				<para>Devolver la celda H3 temporal en la resolución dada que contiene cada punto de un punto temporal geodésico o planar (el SRID debe ser 4326 para la sobrecarga de <varname>tgeompoint</varname>)</para>
-				<para><varname>tgeogpoint_to_th3(tgeogpoint,integer) → th3index</varname></para>
-				<para><varname>tgeompoint_to_th3(tgeompoint,integer) → th3index</varname></para>
+				<para><varname>th3index(tgeogpoint,integer) → th3index</varname></para>
+				<para><varname>th3index(tgeompoint,integer) → th3index</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3GetResolution(th3index(
+  tgeogpoint 'POINT(-73.96 40.78)@2001-01-01', 9));
+-- 9@2001-01-01
+SELECT th3GetResolution(th3index(
+  tgeompoint 'SRID=4326;POINT(-73.96 40.78)@2001-01-01', 9));
+-- 9@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_cell_to_latlng">
@@ -260,12 +300,25 @@ SELECT isValidCell(th3index '0@2001-01-01');
 				<para>Devolver el centroide geodésico temporal de cada celda en una trayectoria. Una sobrecarga planar (SRID 4326) está disponible bajo el nombre <varname>th3CellToLatlngTgeompoint</varname>.</para>
 				<para><varname>th3CellToLatlng(th3index) → tgeogpoint</varname></para>
 				<para><varname>th3CellToLatlngTgeompoint(th3index) → tgeompoint</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(th3CellToLatlng(th3index '871fa44a8ffffff@2001-01-01'), 6);
+-- POINT(4.297401 50.8043)@2001-01-01
+SELECT asText(th3CellToLatlngTgeompoint(th3index '871fa44a8ffffff@2001-01-01'), 6);
+-- POINT(4.297401 50.8043)@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_cell_to_boundary">
 				<indexterm significance="normal"><primary><varname>th3CellToBoundary</varname></primary></indexterm>
 				<para>Devolver el límite poligonal temporal de cada celda en una trayectoria, como una geografía temporal</para>
 				<para><varname>th3CellToBoundary(th3index) → tgeography</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_GeometryType(getValue(th3CellToBoundary(th3index '871fa44a8ffffff@2001-01-01'))::geometry);
+-- ST_Polygon
+-- A hexagon closes on its first vertex, so it has seven points.
+SELECT ST_NPoints(getValue(th3CellToBoundary(th3index '871fa44a8ffffff@2001-01-01'))::geometry);
+-- 7
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -278,18 +331,36 @@ SELECT isValidCell(th3index '0@2001-01-01');
 				<indexterm significance="normal"><primary><varname>th3AreNeighborCells</varname></primary></indexterm>
 				<para>Devolver un booleano temporal que indica si dos celdas temporales son vecinas en la cuadrícula en cada instante. Los dos operandos se sincronizan.</para>
 				<para><varname>th3AreNeighborCells(th3index,th3index) → tbool</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3AreNeighborCells(
+  th3index '880326b885fffff@2001-01-01',
+  th3index '880326b88dfffff@2001-01-01');
+-- t@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_cells_to_directed_edge">
 				<indexterm significance="normal"><primary><varname>th3CellsToDirectedEdge</varname></primary></indexterm>
 				<para>Devolver un identificador de arista dirigida temporal a partir de un par de celdas temporales origen/destino</para>
 				<para><varname>th3CellsToDirectedEdge(th3index,th3index) → th3index</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
+    th3index '871fa44aeffffff@2001-01-01');
+-- 1671fa44a8ffffff@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_is_valid_directed_edge">
 				<indexterm significance="normal"><primary><varname>isValidDirectedEdge</varname></primary></indexterm>
 				<para>Devolver un booleano temporal que indica en cada instante si el valor es una arista dirigida H3 válida</para>
 				<para><varname>isValidDirectedEdge(th3index) → tbool</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT isValidDirectedEdge(th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
+    th3index '871fa44aeffffff@2001-01-01'));
+-- t@2001-01-01
+SELECT isValidDirectedEdge(th3index '871fa44a8ffffff@2001-01-01');
+-- f@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_get_directed_edge_origin">
@@ -298,12 +369,26 @@ SELECT isValidCell(th3index '0@2001-01-01');
 				<para>Devolver la celda origen o destino temporal de una arista dirigida temporal</para>
 				<para><varname>th3GetDirectedEdgeOrigin(th3index) → th3index</varname></para>
 				<para><varname>th3GetDirectedEdgeDestination(th3index) → th3index</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3GetDirectedEdgeOrigin(th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
+    th3index '871fa44aeffffff@2001-01-01'));
+-- 871fa44a8ffffff@2001-01-01
+SELECT th3GetDirectedEdgeDestination(th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
+    th3index '871fa44aeffffff@2001-01-01'));
+-- 871fa44aeffffff@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_directed_edge_to_boundary">
 				<indexterm significance="normal"><primary><varname>th3DirectedEdgeToBoundary</varname></primary></indexterm>
 				<para>Devolver el límite poligonal temporal de cada arista dirigida en una trayectoria, como una geografía temporal</para>
 				<para><varname>th3DirectedEdgeToBoundary(th3index) → tgeography</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_NPoints(getValue(th3DirectedEdgeToBoundary(
+  th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
+    th3index '871fa44aeffffff@2001-01-01')))::geometry);
+-- 3
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -315,18 +400,30 @@ SELECT isValidCell(th3index '0@2001-01-01');
 				<indexterm significance="normal"><primary><varname>th3CellToVertex</varname></primary></indexterm>
 				<para>Devolver el vértice H3 temporal en el número de vértice dado (0–5 para hexágonos, 0–4 para pentágonos)</para>
 				<para><varname>th3CellToVertex(th3index,integer) → th3index</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3CellToVertex(th3index '871fa44a8ffffff@2001-01-01', 0);
+-- 2071fa44a8ffffff@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_vertex_to_latlng">
 				<indexterm significance="normal"><primary><varname>th3VertexToLatlng</varname></primary></indexterm>
 				<para>Devolver las coordenadas geodésicas temporales de cada vértice en una trayectoria</para>
 				<para><varname>th3VertexToLatlng(th3index) → tgeogpoint</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(th3VertexToLatlng(th3CellToVertex(th3index '871fa44a8ffffff@2001-01-01', 0)), 6);
+-- POINT(4.280027 50.807655)@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_is_valid_vertex">
 				<indexterm significance="normal"><primary><varname>isValidVertex</varname></primary></indexterm>
 				<para>Devolver un booleano temporal que indica en cada instante si el valor es un vértice H3 válido</para>
 				<para><varname>isValidVertex(th3index) → tbool</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT isValidVertex(th3CellToVertex(th3index '871fa44a8ffffff@2001-01-01', 0));
+-- t@2001-01-01
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -353,6 +450,16 @@ SELECT th3index '880326b885fffff@2001-01-01'
 				<para>Convertir entre una celda temporal y un par de coordenadas locales (I, J) temporales relativas a una celda temporal de origen. La coordenada local se expone como un <varname>tgeompoint</varname> con el eje I en el slot <varname>x</varname> y J en <varname>y</varname>.</para>
 				<para><varname>th3CellToLocalIj(th3index,th3index) → tgeompoint</varname></para>
 				<para><varname>th3LocalIjToCell(th3index,tgeompoint) → th3index</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(th3CellToLocalIj(th3index '871fa44a8ffffff@2001-01-01',
+  th3index '871fa44aeffffff@2001-01-01'));
+-- POINT(497 320)@2001-01-01
+-- The two are inverse of each other.
+SELECT th3LocalIjToCell(th3index '871fa44a8ffffff@2001-01-01',
+  th3CellToLocalIj(th3index '871fa44a8ffffff@2001-01-01',
+    th3index '871fa44aeffffff@2001-01-01'));
+-- 871fa44aeffffff@2001-01-01
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -365,18 +472,34 @@ SELECT th3index '880326b885fffff@2001-01-01'
 				<indexterm significance="normal"><primary><varname>th3CellArea</varname></primary></indexterm>
 				<para>Devolver el área temporal de cada celda en una trayectoria, en la unidad solicitada</para>
 				<para><varname>th3CellArea(th3index,text='km2') → tfloat</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3CellArea(th3index '871fa44a8ffffff@2001-01-01');
+-- 4.441914270110932@2001-01-01
+SELECT th3CellArea(th3index '871fa44a8ffffff@2001-01-01', 'm2');
+-- 4441914.270110932@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_edge_length">
 				<indexterm significance="normal"><primary><varname>th3EdgeLength</varname></primary></indexterm>
 				<para>Devolver la longitud temporal de cada arista dirigida en una trayectoria, en la unidad solicitada</para>
 				<para><varname>th3EdgeLength(th3index,text='km') → tfloat</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3EdgeLength(th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
+    th3index '871fa44aeffffff@2001-01-01'));
+-- 1.272084901305088@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_great_circle_distance">
 				<indexterm significance="normal"><primary><varname>greatCircleDistance</varname></primary></indexterm>
 				<para>Devolver la distancia temporal del gran círculo entre dos puntos geodésicos temporales (no entre celdas). Los dos operandos se sincronizan.</para>
 				<para><varname>greatCircleDistance(tgeogpoint,tgeogpoint,text='km') → tfloat</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT greatCircleDistance(tgeogpoint 'Point(0 0)@2001-01-01',
+  tgeogpoint 'Point(1 0)@2001-01-01');
+-- 111.19505197522943@2001-01-01
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -390,39 +513,57 @@ SELECT th3index '880326b885fffff@2001-01-01'
 
 			<itemizedlist>
 				<listitem xml:id="th3_ever_eq">
-					<indexterm significance="normal"><primary><varname>ever_eq</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>eEq</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>?=</varname></primary></indexterm>
 					<para>Devolver <varname>true</varname> si una celda H3 temporal es alguna vez igual a la prueba en al menos un instante</para>
-					<para><varname>ever_eq({h3index,th3index},th3index) → boolean</varname></para>
-					<para><varname>ever_eq(th3index,h3index) → boolean</varname></para>
+					<para><varname>eEq({h3index,th3index},th3index) → boolean</varname></para>
+					<para><varname>eEq(th3index,h3index) → boolean</varname></para>
 					<para><varname>{h3index,th3index} ?= th3index</varname></para>
 					<para><varname>th3index ?= h3index</varname></para>
+									<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3index
+  '[831c02fffffffff@2001-01-01, 880326b885fffff@2001-01-05]'
+  ?= 880326b885fffff::h3index;
+-- true
+</programlisting>
 				</listitem>
 
 				<listitem xml:id="th3_always_eq">
-					<indexterm significance="normal"><primary><varname>always_eq</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>aEq</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>%=</varname></primary></indexterm>
 					<para>Devolver <varname>true</varname> si una celda H3 temporal es siempre igual a la prueba a lo largo de todo su eje de tiempo</para>
-					<para><varname>always_eq({h3index,th3index},th3index) → boolean</varname></para>
-					<para><varname>always_eq(th3index,h3index) → boolean</varname></para>
+					<para><varname>aEq({h3index,th3index},th3index) → boolean</varname></para>
+					<para><varname>aEq(th3index,h3index) → boolean</varname></para>
 					<para><varname>{h3index,th3index} %= th3index</varname></para>
 					<para><varname>th3index %= h3index</varname></para>
+									<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT aEq(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44a8ffffff');
+-- t
+</programlisting>
 				</listitem>
 
 				<listitem xml:id="th3_ever_ne">
-					<indexterm significance="normal"><primary><varname>ever_ne</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>eNe</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>?&lt;&gt;</varname></primary></indexterm>
 					<para>Devolver <varname>true</varname> si una celda H3 temporal es alguna vez diferente de la prueba</para>
-					<para><varname>ever_ne({h3index,th3index},th3index) → boolean</varname></para>
-					<para><varname>ever_ne(th3index,h3index) → boolean</varname></para>
+					<para><varname>eNe({h3index,th3index},th3index) → boolean</varname></para>
+					<para><varname>eNe(th3index,h3index) → boolean</varname></para>
+									<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT eNe(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44aeffffff');
+-- t
+</programlisting>
 				</listitem>
 
 				<listitem xml:id="th3_always_ne">
-					<indexterm significance="normal"><primary><varname>always_ne</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>aNe</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>%&lt;&gt;</varname></primary></indexterm>
 					<para>Devolver <varname>true</varname> si una celda H3 temporal es siempre diferente de la prueba</para>
-					<para><varname>always_ne({h3index,th3index},th3index) → boolean</varname></para>
-					<para><varname>always_ne(th3index,h3index) → boolean</varname></para>
+					<para><varname>aNe({h3index,th3index},th3index) → boolean</varname></para>
+					<para><varname>aNe(th3index,h3index) → boolean</varname></para>
+									<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT aNe(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44aeffffff');
+-- t
+</programlisting>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -431,15 +572,21 @@ SELECT th3index '880326b885fffff@2001-01-01'
 			<title>Comparaciones Temporales</title>
 			<itemizedlist>
 				<listitem xml:id="th3_temporal_teq">
-					<indexterm significance="normal"><primary><varname>temporal_teq</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>tEq</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>#=</varname></primary></indexterm>
-					<indexterm significance="normal"><primary><varname>temporal_tne</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>tNe</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>#&lt;&gt;</varname></primary></indexterm>
 					<para>Devolver un booleano temporal que da la igualdad (o desigualdad) por instante entre una celda H3 temporal y una prueba</para>
-					<para><varname>temporal_teq({h3index,th3index},th3index) → tbool</varname></para>
-					<para><varname>temporal_teq(th3index,h3index) → tbool</varname></para>
-					<para><varname>temporal_tne({h3index,th3index},th3index) → tbool</varname></para>
-					<para><varname>temporal_tne(th3index,h3index) → tbool</varname></para>
+					<para><varname>tEq({h3index,th3index},th3index) → tbool</varname></para>
+					<para><varname>tEq(th3index,h3index) → tbool</varname></para>
+					<para><varname>tNe({h3index,th3index},th3index) → tbool</varname></para>
+					<para><varname>tNe(th3index,h3index) → tbool</varname></para>
+									<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT tEq(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44a8ffffff');
+-- t@2001-01-01
+SELECT tNe(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44a8ffffff');
+-- f@2001-01-01
+</programlisting>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -466,6 +613,12 @@ SELECT th3index '880326b885fffff@2001-01-01'
 				<para><varname>th3index &lt;@ {tstzspan,stbox,th3index} → boolean</varname></para>
 				<para><varname>th3index ~= {tstzspan,stbox,th3index} → boolean</varname></para>
 				<para><varname>th3index -|- {tstzspan,stbox,th3index} → boolean</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3index '871fa44a8ffffff@2001-01-01' &amp;&amp; tstzspan '[2001-01-01, 2001-01-02]';
+-- t
+SELECT th3index '871fa44a8ffffff@2001-01-01' ~= th3index '871fa44a8ffffff@2001-01-01';
+-- t
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_space_position">
@@ -486,6 +639,11 @@ SELECT th3index '880326b885fffff@2001-01-01'
 				<para><varname>th3index &amp;&lt;| {stbox,th3index} → boolean</varname></para>
 				<para><varname>th3index |&amp;&gt; {stbox,th3index} → boolean</varname></para>
 				<para><varname>th3index |&gt;&gt; {stbox,th3index} → boolean</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3index '871fa44a8ffffff@2001-01-01' &lt;&lt;
+  th3index '871fa44aeffffff@2001-01-01';
+-- f
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_time_position">
@@ -498,6 +656,14 @@ SELECT th3index '880326b885fffff@2001-01-01'
 				<para><varname>th3index &amp;&lt;# {tstzspan,stbox,th3index} → boolean</varname></para>
 				<para><varname>th3index #&gt;&gt; {tstzspan,stbox,th3index} → boolean</varname></para>
 				<para><varname>th3index #&amp;&gt; {tstzspan,stbox,th3index} → boolean</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3index '871fa44a8ffffff@2001-01-01' &lt;&lt;#
+  th3index '871fa44aeffffff@2001-01-05';
+-- t
+SELECT th3index '871fa44a8ffffff@2001-01-01' #&gt;&gt;
+  th3index '871fa44aeffffff@2001-01-05';
+-- f
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -511,54 +677,97 @@ SELECT th3index '880326b885fffff@2001-01-01'
 				<indexterm significance="normal"><primary><varname>h3GridDisk</varname></primary></indexterm>
 				<para>Todas las celdas dentro de <varname>k</varname> pasos de cuadrícula del origen (incluyendo el origen cuando k=0).</para>
 				<para><varname>h3GridDisk(h3index, integer) → h3indexset</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT h3GridDisk(h3index '871fa44a8ffffff', 1);
+-- {"871fa44a8ffffff", "871fa44a9ffffff", "871fa44aaffffff", "871fa44abffffff",
+--  "871fa44acffffff", "871fa44adffffff", "871fa44aeffffff"}
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_grid_ring">
 				<indexterm significance="normal"><primary><varname>h3GridRing</varname></primary></indexterm>
 				<para>Las celdas a <emphasis>exactamente</emphasis> <varname>k</varname> pasos de cuadrícula del origen. Falla cerca de pentágonos.</para>
 				<para><varname>h3GridRing(h3index, integer) → h3indexset</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT h3GridRing(h3index '871fa44a8ffffff', 1);
+-- {"871fa44a9ffffff", "871fa44aaffffff", "871fa44abffffff", "871fa44acffffff",
+--  "871fa44adffffff", "871fa44aeffffff"}
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_grid_path_cells">
 				<indexterm significance="normal"><primary><varname>h3GridPathCells</varname></primary></indexterm>
 				<para>El camino inclusivo de celdas entre dos celdas de la misma resolución.</para>
 				<para><varname>h3GridPathCells(h3index, h3index) → h3indexset</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT h3GridPathCells(h3index '871fa44a8ffffff', h3index '871fa44b1ffffff');
+-- {"871fa4484ffffff", "871fa44a3ffffff", "871fa44a8ffffff", "871fa44aeffffff",
+--  "871fa44b1ffffff"}
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_cell_to_children">
 				<indexterm significance="normal"><primary><varname>h3CellToChildren</varname></primary></indexterm>
 				<para>Todas las celdas hijas de una celda en la resolución objetivo.</para>
 				<para><varname>h3CellToChildren(h3index, integer) → h3indexset</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT h3CellToChildren(h3index '831c02fffffffff', 4);
+-- {"841c021ffffffff", "841c023ffffffff", "841c025ffffffff", "841c027ffffffff",
+--  "841c029ffffffff", "841c02bffffffff", "841c02dffffffff"}
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_compact_cells">
 				<indexterm significance="normal"><primary><varname>h3CompactCells</varname></primary></indexterm>
 				<para>Representación compactada de un conjunto de celdas — las celdas más finas se fusionan en su padre cuando el conjunto hexagonal completo de hermanas está presente.</para>
 				<para><varname>h3CompactCells(h3indexset) → h3indexset</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT h3CompactCells(h3CellToChildren(h3index '831c02fffffffff', 4));
+-- {"831c02fffffffff"}
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_uncompact_cells">
 				<indexterm significance="normal"><primary><varname>h3UncompactCells</varname></primary></indexterm>
 				<para>Representación descompactada a la resolución dada — la inversa de <varname>h3CompactCells</varname>.</para>
 				<para><varname>h3UncompactCells(h3indexset, integer) → h3indexset</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT numValues(h3UncompactCells(
+  h3CompactCells(h3CellToChildren(h3index '831c02fffffffff', 4)), 4));
+-- 7
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_origin_to_directed_edges">
 				<indexterm significance="normal"><primary><varname>h3OriginToDirectedEdges</varname></primary></indexterm>
 				<para>Todas las aristas dirigidas salientes de una celda (6 para hexágonos, 5 para pentágonos).</para>
 				<para><varname>h3OriginToDirectedEdges(h3index) → h3indexset</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT h3OriginToDirectedEdges(h3index '871fa44a8ffffff');
+-- {"1171fa44a8ffffff", "1271fa44a8ffffff", "1371fa44a8ffffff",
+--  "1471fa44a8ffffff", "1571fa44a8ffffff", "1671fa44a8ffffff"}
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_cell_to_vertexes">
 				<indexterm significance="normal"><primary><varname>h3CellToVertexes</varname></primary></indexterm>
 				<para>Todos los vértices de una celda (6 para hexágonos, 5 para pentágonos).</para>
 				<para><varname>h3CellToVertexes(h3index) → h3indexset</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT h3CellToVertexes(h3index '871fa44a8ffffff');
+-- {"2071fa44a8ffffff", "2171fa44a8ffffff", "2271fa44a8ffffff",
+--  "2371fa44a8ffffff", "2471fa44a8ffffff", "2571fa44a8ffffff"}
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_get_icosahedron_faces">
 				<indexterm significance="normal"><primary><varname>h3GetIcosahedronFaces</varname></primary></indexterm>
 				<para>Los índices de caras del icosaedro (0..19) intersectadas por una celda.</para>
 				<para><varname>h3GetIcosahedronFaces(h3index) → intset</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT h3GetIcosahedronFaces(h3index '831c02fffffffff');
+-- {6, 11}
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>

--- a/doc/es/temporal_quadbin_index.xml
+++ b/doc/es/temporal_quadbin_index.xml
@@ -91,6 +91,14 @@ SELECT (tquadbin '480fffffffffffff@2001-01-01')::tgeompoint;
 				<indexterm significance="normal"><primary><varname>isValidIndex</varname></primary></indexterm>
 				<para>Devuelve si un valor es un identificador QUADBIN estructuralmente válido (etiqueta de cabecera y campo de resolución correctos)</para>
 				<para><varname>isValidIndex(quadbin) → boolean</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT isValidIndex(quadbin '480fffffffffffff');
+-- t
+-- The input function already rejects malformed text, so a value that is
+-- structurally invalid can only arrive through the bigint conversion.
+SELECT isValidIndex(0::bigint::quadbin);
+-- f
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="quadbin_is_valid_cell">
@@ -265,6 +273,14 @@ SELECT geoToQuadbinCell(geometry 'SRID=4326;POINT(4.35 50.85)', 10)
 				<para>Devuelve el centroide de una celda como un punto SRID 4326. La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el centroide de cada celda de una trayectoria como un <varname>tgeompoint</varname>.</para>
 				<para><varname>quadbinCellToPoint(quadbin) → geometry</varname></para>
 				<para><varname>tquadbinCellToPoint(tquadbin) → tgeompoint</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_AsText(quadbinCellToPoint(quadbin '48427fffffffffff'));
+-- POINT(-101.25 48.92249926375824)
+SELECT asText(tquadbinCellToPoint(tquadbin
+  '{480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02}'));
+-- {POINT(0 0)@2001-01-01,
+--  POINT(-101.25 48.92249926375824)@2001-01-02}
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="tquadbin_quadbin_cell_to_boundary">
@@ -272,6 +288,12 @@ SELECT geoToQuadbinCell(geometry 'SRID=4326;POINT(4.35 50.85)', 10)
 				<para>Devuelve el contorno poligonal cuadrado de una celda como una geometría SRID 4326. La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el contorno de cada celda de una trayectoria como un <varname>tgeometry</varname>.</para>
 				<para><varname>quadbinCellToBoundary(quadbin) → geometry</varname></para>
 				<para><varname>tquadbinCellToBoundary(tquadbin) → tgeometry</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_AsText(quadbinCellToBoundary(quadbin '480fffffffffffff'));
+-- POLYGON((-180 -85.0511287798066,180 -85.0511287798066,
+--          180 85.0511287798066,-180 85.0511287798066,
+--          -180 -85.0511287798066))
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -333,6 +355,12 @@ SELECT quadbinCellToQuadkey(quadbin '48a6227affffffff');
 				<para>Devuelve el área de una celda sobre la esfera, en metros cuadrados. La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el área de cada celda de una trayectoria como un <varname>tfloat</varname>. El área de la celda se reduce hacia los polos, ya que los cuadrados web-mercator cubren progresivamente menos terreno a latitudes más altas.</para>
 				<para><varname>quadbinCellArea(quadbin) → float8</varname></para>
 				<para><varname>tquadbinCellArea(tquadbin) → tfloat</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT round(quadbinCellArea(quadbin '480fffffffffffff')::numeric, 0);
+-- 508164135963886
+SELECT round(quadbinCellArea(quadbin '48427fffffffffff')::numeric, 0);
+-- 2726563416104
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>

--- a/doc/es/temporal_raster.xml
+++ b/doc/es/temporal_raster.xml
@@ -208,24 +208,44 @@ GROUP BY t.tripid, t.trip4326;
 				<indexterm significance="normal"><primary><varname>quadbin</varname></primary></indexterm>
 				<para>Devolver la celda QUADBIN de una tesela Raquet</para>
 				<para><varname>quadbin(raquet) → bigint</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT quadbin(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
+-- 5193776270265024512
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="raquet_width">
 				<indexterm significance="normal"><primary><varname>width</varname></primary></indexterm>
 				<para>Devolver el ancho en píxeles de una tesela Raquet</para>
 				<para><varname>width(raquet) → integer</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT width(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
+-- 2
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="raquet_height">
 				<indexterm significance="normal"><primary><varname>height</varname></primary></indexterm>
 				<para>Devolver el alto en píxeles de una tesela Raquet</para>
 				<para><varname>height(raquet) → integer</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT height(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
+-- 2
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="raquet_nodata">
 				<indexterm significance="normal"><primary><varname>nodata</varname></primary></indexterm>
 				<para>Devolver el valor centinela nodata de una tesela Raquet</para>
 				<para><varname>nodata(raquet) → float8</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT nodata(raquet('\x01020304'::bytea, 2, 2,
+  5193776270265024512, 'UINT8', 255));
+-- 255
+-- The sentinel defaults to 0 when the constructor omits it.
+SELECT nodata(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
+-- 0
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="raquet_pixtype">

--- a/doc/es/temporal_rigid_geometries.xml
+++ b/doc/es/temporal_rigid_geometries.xml
@@ -53,7 +53,7 @@ SELECT trgeometry 'Interp=Step;Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 
 				<para><varname>asText({trgeometry,trgeometry[]} [, maxdecimaldigits int=15]) → text</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1.123456789 1.123456789), 0.5)@2000-01-01', 6);
--- POLYGON((1 1,2 2,3 1,1 1));Pose(POINT(1.123457 1.123457),0.5)@Sat Jan 01 00:00:00 2000 PST
+-- POLYGON((1 1,2 2,3 1,1 1));Pose(POINT(1.123457 1.123457),0.5)@2000-01-01
 </programlisting>
 			</listitem>
 
@@ -63,7 +63,7 @@ SELECT asText(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1.123456789 1.12
 				<para><varname>asEWKT({trgeometry,trgeometry[]} [, maxdecimaldigits int=15]) → text</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(trgeometry 'SRID=25832;Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1),0.5)@2000-01-01');
--- SRID=25832;POLYGON((1 1,2 2,3 1,1 1));Pose(POINT(1 1),0.5)@Sat Jan 01 00:00:00 2000 PST
+-- SRID=25832;POLYGON((1 1,2 2,3 1,1 1));Pose(POINT(1 1),0.5)@2000-01-01
 </programlisting>
 			</listitem>
 
@@ -81,6 +81,13 @@ SELECT asMFJSON(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0),0)@20
 				<para>Devuelve la representación extendida binaria conocida (Extended Well-Known Binary o EWKB)</para>
 				<para><varname>asEWKB(trgeometry [, endian text]) → bytea</varname></para>
 				<para>La función complementaria <varname>asHexEWKB</varname> devuelve los mismos bytes como un texto codificado en hexadecimal.</para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT length(asEWKB(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(1 1), 0.5)@2001-01-01'));
+-- 130
+-- The bytes round-trip through the matching input function.
+SELECT asText(trgeometryFromHexEWKB(asHexEWKB(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(1 1), 0.5)@2001-01-01')));
+-- POLYGON((0 0,1 0,1 1,0 1,0 0));Pose(POINT(1 1),0.5)@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="trgeometry_fromText">
@@ -93,6 +100,13 @@ SELECT asMFJSON(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0),0)@20
 				<para><varname>trgeometryFromMFJSON(text) → trgeometry</varname></para>
 				<para><varname>trgeometryFromEWKB(bytea) → trgeometry</varname></para>
 				<para><varname>trgeometryFromHexEWKB(text) → trgeometry</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(trgeometryFromEWKT('SRID=4326;Polygon((0 0,1 0,1 1,0 1,0 0));
+  Pose(Point(1 1), 0.5)@2001-01-01'));
+-- POLYGON((0 0,1 0,1 1,0 1,0 0));Pose(POINT(1 1),0.5)@2001-01-01
+SELECT asText(trgeometryFromHexEWKB(asHexEWKB(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(1 1), 0.5)@2001-01-01')));
+-- POLYGON((0 0,1 0,1 1,0 1,0 0));Pose(POINT(1 1),0.5)@2001-01-01
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -108,10 +122,10 @@ SELECT asMFJSON(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0),0)@20
 				<para>Construir una geometría rígida temporal a partir de una geometría de referencia y una pose temporal</para>
 				<para><varname>trgeometry(geometry, tpose) → trgeometry</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT trgeometry(
+SELECT asText(trgeometry(
   geometry 'Polygon((0 0,1 0,1 1,0 1,0 0))',
-  tpose 'Pose(Point(0 0), 0.0)@2001-01-01');
--- POLYGON((0 0,1 0,1 1,0 1,0 0));Pose(POINT(0 0),0)@Mon Jan 01 00:00:00 2001 PST
+  tpose 'Pose(Point(0 0), 0.0)@2001-01-01'));
+-- POLYGON((0 0,1 0,1 1,0 1,0 0));Pose(POINT(0 0),0)@2001-01-01
 </programlisting>
 				<para>Ambos argumentos deben compartir el mismo SRID. La geometría de referencia puede ser un polígono o una superficie poliédrica; la pose puede ser de cualquier subtipo temporal.</para>
 			</listitem>
@@ -131,6 +145,15 @@ SELECT appendInstant(
 				<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
 				<para>Agregar una secuencia completa a una trgeometry existente</para>
 				<para><varname>appendSequence(trgeometry, trgeometry) → trgeometry</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(appendSequence(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]',
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(20 0), 0.0)@2001-01-03, Pose(Point(30 0), 0.0)@2001-01-04]'));
+-- POLYGON((0 0,1 0,1 1,0 1,0 0));
+-- {[Pose(POINT(0 0),0)@2001-01-01, Pose(POINT(10 0),0)@2001-01-02],
+--   [Pose(POINT(20 0),0)@2001-01-03, Pose(POINT(30 0),0)@2001-01-04]}
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -197,6 +220,17 @@ SELECT asText(valueAtTimestamp(
 				<para><varname>numInstants(trgeometry) → integer</varname></para>
 				<para><varname>numSequences(trgeometry) → integer</varname></para>
 				<para><varname>numTimestamps(trgeometry) → integer</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT numInstants(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]');
+-- 2
+SELECT numSequences(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]');
+-- 1
+SELECT numTimestamps(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]');
+-- 2
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="trgeometry_instants">
@@ -332,6 +366,11 @@ SELECT length(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@200
 				<indexterm significance="normal"><primary><varname>speed</varname></primary></indexterm>
 				<para>Devuelve la velocidad del centroide como un flotante temporal</para>
 				<para><varname>speed(trgeometry) → tfloat</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT speed(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]');
+-- Interp=Step;[0.000115740740741@2001-01-01, 0.000115740740741@2001-01-02]
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="trgeometry_twcentroid">
@@ -368,6 +407,13 @@ SELECT asText(round(
 				<indexterm significance="normal"><primary><varname>setInterp</varname></primary></indexterm>
 				<para>Convertir entre interpolaciones lineal y escalonada</para>
 				<para><varname>setInterp(trgeometry, text) → trgeometry</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(setInterp(trgeometry 'Interp=Step;Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]', 'linear'));
+-- POLYGON((0 0,1 0,1 1,0 1,0 0));
+-- {[Pose(POINT(0 0),0)@2001-01-01, Pose(POINT(0 0),0)@2001-01-02),
+--  [Pose(POINT(10 0),0)@2001-01-02]}
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="trgeometry_shiftTime">
@@ -378,6 +424,20 @@ SELECT asText(round(
 				<para><varname>shiftTime(trgeometry, interval) → trgeometry</varname></para>
 				<para><varname>scaleTime(trgeometry, interval) → trgeometry</varname></para>
 				<para><varname>shiftScaleTime(trgeometry, interval, interval) → trgeometry</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(shiftTime(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]', interval '1 day'));
+-- POLYGON((0 0,1 0,1 1,0 1,0 0));
+-- [Pose(POINT(0 0),0)@2001-01-02, Pose(POINT(10 0),0)@2001-01-03]
+SELECT asText(scaleTime(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]', interval '2 days'));
+-- POLYGON((0 0,1 0,1 1,0 1,0 0));
+-- [Pose(POINT(0 0),0)@2001-01-01, Pose(POINT(10 0),0)@2001-01-03]
+SELECT asText(shiftScaleTime(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]', interval '1 day', interval '2 days'));
+-- POLYGON((0 0,1 0,1 1,0 1,0 0));
+-- [Pose(POINT(0 0),0)@2001-01-02, Pose(POINT(10 0),0)@2001-01-04]
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -529,6 +589,22 @@ SELECT round(hausdorffDistance(
 				<para>Devuelve los pares de correspondencia entre dos geometrías rígidas temporales con respecto a la distancia de Fréchet discreta o a la distancia de deformación dinámica del tiempo (Dynamic Time Warp), como un conjunto de pares de índices de instante <varname>(i,j)</varname></para>
 				<para><varname>frechetDistancePath(trgeometry, trgeometry) → {(i,j)}</varname></para>
 				<para><varname>dynTimeWarpPath(trgeometry, trgeometry) → {(i,j)}</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT frechetDistancePath(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+    [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]',
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+    [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(20 0), 0.0)@2001-01-02]');
+-- (0,0)
+-- (1,1)
+SELECT dynTimeWarpPath(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+    [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]',
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+    [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(20 0), 0.0)@2001-01-02]');
+-- (0,0)
+-- (1,1)
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -545,6 +621,16 @@ SELECT round(hausdorffDistance(
 				<para>Probar la (des)igualdad exacta de dos trgeometries</para>
 				<para><varname>trgeometry = trgeometry → boolean</varname></para>
 				<para><varname>trgeometry &lt;&gt; trgeometry → boolean</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]' = trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]';
+-- t
+SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]' &lt;&gt; trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]';
+-- f
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="trgeometry_evereq">
@@ -566,6 +652,12 @@ SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01
 				<para>Probar si la geometría materializada es siempre (no) igual al operando</para>
 				<para><varname>{geometry,trgeometry} %= {geometry,trgeometry} → boolean</varname></para>
 				<para><varname>{geometry,trgeometry} %&lt;&gt; {geometry,trgeometry} → boolean</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]' %= trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]';
+-- t
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -640,6 +732,14 @@ SELECT array_length(spaceBoxes(
 				<para>Devuelve el arreglo de cajas espaciotemporales o lapsos de tiempo de los segmentos de una geometría rígida temporal</para>
 				<para><varname>stboxes(trgeometry) → stbox[]</varname></para>
 				<para><varname>spans(trgeometry) → tstzspan[]</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT stboxes(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]');
+-- {"STBOX XT(((0,0),(11,1)),[2001-01-01, 2001-01-02])"}
+SELECT spans(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]');
+-- {"[2001-01-01, 2001-01-02]"}
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="trgeometry_split_boxes">
@@ -652,6 +752,14 @@ SELECT array_length(spaceBoxes(
 				<para><varname>splitEachNStboxes(trgeometry, integer) → stbox[]</varname></para>
 				<para><varname>splitNSpans(trgeometry, integer) → tstzspan[]</varname></para>
 				<para><varname>splitEachNSpans(trgeometry, integer) → tstzspan[]</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT splitNStboxes(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]', 2);
+-- {"STBOX XT(((0,0),(11,1)),[2001-01-01, 2001-01-02])"}
+SELECT splitNSpans(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]', 2);
+-- {"[2001-01-01, 2001-01-02]"}
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -664,6 +772,11 @@ SELECT array_length(spaceBoxes(
 				<indexterm significance="normal"><primary><varname>tcount</varname></primary></indexterm>
 				<para>Número de trgeometries solapadas en cada instante, equivalente a <varname>tcount</varname> sobre la tpose subyacente</para>
 				<para><varname>tcount(trgeometry) → tint</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT tcount(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]');
+-- {[1@2001-01-01, 1@2001-01-02]}
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="trgeometry_extent">

--- a/doc/temporal_circular_buffers.xml
+++ b/doc/temporal_circular_buffers.xml
@@ -707,6 +707,19 @@ SELECT asText(centroid(tcbuffer '[Cbuffer(Point(1 1), 0.5)@2001-01-01,
 				<para>Return the convex hull of the area traversed by the temporal circular buffer</para>
 				<para><varname>convexHull(tcbuffer) → geometry</varname></para>
 				<para>The convex hull is computed on the linearized traversed area: the circular arcs bounding the swept region are first stroked into straight segments and the hull is then computed with GEOS. The result is therefore a linear <varname>POLYGON</varname> that approximates the circular boundary, not a curved <varname>CURVEDPOLYGON</varname>. Use <varname>traversedArea</varname> to obtain the exact curved swept region.</para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_GeometryType(convexHull(tcbuffer
+  '[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(4 0), 1)@2001-01-02]'));
+-- ST_Polygon
+SELECT ST_NPoints(convexHull(tcbuffer
+  '[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(4 0), 1)@2001-01-02]'));
+-- 131
+SELECT round(ST_Area(convexHull(tcbuffer
+  '[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(4 0), 1)@2001-01-02]'))::numeric, 3);
+-- 11.140
+-- The exact swept region has area pi + 8 = 11.1416; the stroked hull is
+-- slightly smaller because the arcs are replaced by chords.
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>

--- a/doc/temporal_h3_index.xml
+++ b/doc/temporal_h3_index.xml
@@ -104,9 +104,9 @@ SELECT geoToH3IndexSet(geometry 'SRID=4326;Point(4.35 50.85)', 7);
 			</listitem>
 
 			<listitem xml:id="th3_ever_eq_set">
-				<indexterm significance="normal"><primary><varname>ever_eq</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>eEq</varname></primary></indexterm>
 				<para>Return whether a temporal H3 trajectory ever takes one of the cells in a cell set. Combined with <varname>geoToH3IndexSet</varname> it answers whether a trip ever passes through a region, without materialising the trajectory geometry — the sound, conservative prefilter for the exact <varname>eIntersects(geometry,th3index)</varname>.</para>
-				<para><varname>ever_eq(h3indexset,th3index) → boolean</varname></para>
+				<para><varname>eEq(h3indexset,th3index) → boolean</varname></para>
 				<para><varname>h3indexset ?= th3index → boolean</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geoToH3IndexSet(geometry 'SRID=4326;Point(4.35 50.85)', 7) ?=
@@ -216,6 +216,10 @@ SELECT isValidCell(th3index '0@2001-01-01');
 				<indexterm significance="normal"><primary><varname>th3IsResClassIii</varname></primary></indexterm>
 				<para>Return a temporal boolean stating whether each cell has Class-III orientation. Class III alternates with resolution: odd resolutions are class III, even are class II.</para>
 				<para><varname>th3IsResClassIii(th3index) → tbool</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3IsResClassIii(th3index '871fa44a8ffffff@2001-01-01');
+-- t@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_is_pentagon">
@@ -252,18 +256,33 @@ SELECT th3GetResolution(
 				<para>Return the temporal center-child cell at the given resolution. The no-argument form drops to the next-finer resolution.</para>
 				<para><varname>th3CellToCenterChild(th3index,integer) → th3index</varname></para>
 				<para><varname>th3CellToCenterChild(th3index) → th3index</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3CellToCenterChild(th3index '871fa44a8ffffff@2001-01-01', 8);
+-- 881fa44a81fffff@2001-01-01
+-- Without a resolution the child is one level finer.
+SELECT th3CellToCenterChild(th3index '871fa44a8ffffff@2001-01-01');
+-- 881fa44a81fffff@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_cell_to_child_pos">
 				<indexterm significance="normal"><primary><varname>th3CellToChildPos</varname></primary></indexterm>
 				<para>Return the ordinal position (0-based) of each cell among the children of its parent at the given resolution</para>
 				<para><varname>th3CellToChildPos(th3index,integer) → tbigint</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3CellToChildPos(th3index '871fa44a8ffffff@2001-01-01', 6);
+-- 0@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_child_pos_to_cell">
 				<indexterm significance="normal"><primary><varname>th3ChildPosToCell</varname></primary></indexterm>
 				<para>Return the temporal child cell at a given ordinal position of the given parent, at the given child resolution. The two temporal operands are synchronised over their shared time axis.</para>
 				<para><varname>th3ChildPosToCell(tbigint,th3index,integer) → th3index</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3ChildPosToCell(tbigint '0@2001-01-01', th3index '871fa44a8ffffff@2001-01-01', 8);
+-- 881fa44a81fffff@2001-01-01
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -272,14 +291,16 @@ SELECT th3GetResolution(
 		<title>Lat/Lng Conversions</title>
 		<itemizedlist>
 			<listitem xml:id="th3_tgeompoint_to_th3">
-				<indexterm significance="normal"><primary><varname>tgeompoint_to_th3</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>tgeogpoint_to_th3</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>th3index</varname></primary></indexterm>
 				<para>Return the temporal H3 cell at the given resolution that contains each point in a temporal geodetic or planar point (SRID must be 4326 for the <varname>tgeompoint</varname> overload)</para>
-				<para><varname>tgeogpoint_to_th3(tgeogpoint,integer) → th3index</varname></para>
-				<para><varname>tgeompoint_to_th3(tgeompoint,integer) → th3index</varname></para>
+				<para><varname>th3index(tgeogpoint,integer) → th3index</varname></para>
+				<para><varname>th3index(tgeompoint,integer) → th3index</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT th3GetResolution(tgeogpoint_to_th3(
+SELECT th3GetResolution(th3index(
   tgeogpoint 'POINT(-73.96 40.78)@2001-01-01', 9));
+-- 9@2001-01-01
+SELECT th3GetResolution(th3index(
+  tgeompoint 'SRID=4326;POINT(-73.96 40.78)@2001-01-01', 9));
 -- 9@2001-01-01
 </programlisting>
 			</listitem>
@@ -289,12 +310,25 @@ SELECT th3GetResolution(tgeogpoint_to_th3(
 				<para>Return the temporal geodetic centroid of each cell in a trajectory. A planar (SRID 4326) overload is available under the name <varname>th3CellToLatlngTgeompoint</varname>.</para>
 				<para><varname>th3CellToLatlng(th3index) → tgeogpoint</varname></para>
 				<para><varname>th3CellToLatlngTgeompoint(th3index) → tgeompoint</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(th3CellToLatlng(th3index '871fa44a8ffffff@2001-01-01'), 6);
+-- POINT(4.297401 50.8043)@2001-01-01
+SELECT asText(th3CellToLatlngTgeompoint(th3index '871fa44a8ffffff@2001-01-01'), 6);
+-- POINT(4.297401 50.8043)@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_cell_to_boundary">
 				<indexterm significance="normal"><primary><varname>th3CellToBoundary</varname></primary></indexterm>
 				<para>Return the temporal polygon boundary of each cell in a trajectory, as a temporal geography</para>
 				<para><varname>th3CellToBoundary(th3index) → tgeography</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_GeometryType(getValue(th3CellToBoundary(th3index '871fa44a8ffffff@2001-01-01'))::geometry);
+-- ST_Polygon
+-- A hexagon closes on its first vertex, so it has seven points.
+SELECT ST_NPoints(getValue(th3CellToBoundary(th3index '871fa44a8ffffff@2001-01-01'))::geometry);
+-- 7
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -319,12 +353,24 @@ SELECT th3AreNeighborCells(
 				<indexterm significance="normal"><primary><varname>th3CellsToDirectedEdge</varname></primary></indexterm>
 				<para>Return a temporal directed-edge identifier from an origin/destination pair of temporal cells</para>
 				<para><varname>th3CellsToDirectedEdge(th3index,th3index) → th3index</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
+    th3index '871fa44aeffffff@2001-01-01');
+-- 1671fa44a8ffffff@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_is_valid_directed_edge">
 				<indexterm significance="normal"><primary><varname>isValidDirectedEdge</varname></primary></indexterm>
 				<para>Return a temporal boolean stating at each instant whether the value is a valid H3 directed edge</para>
 				<para><varname>isValidDirectedEdge(th3index) → tbool</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT isValidDirectedEdge(th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
+    th3index '871fa44aeffffff@2001-01-01'));
+-- t@2001-01-01
+SELECT isValidDirectedEdge(th3index '871fa44a8ffffff@2001-01-01');
+-- f@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_get_directed_edge_origin">
@@ -333,12 +379,26 @@ SELECT th3AreNeighborCells(
 				<para>Return the temporal origin or destination cell of a temporal directed edge</para>
 				<para><varname>th3GetDirectedEdgeOrigin(th3index) → th3index</varname></para>
 				<para><varname>th3GetDirectedEdgeDestination(th3index) → th3index</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3GetDirectedEdgeOrigin(th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
+    th3index '871fa44aeffffff@2001-01-01'));
+-- 871fa44a8ffffff@2001-01-01
+SELECT th3GetDirectedEdgeDestination(th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
+    th3index '871fa44aeffffff@2001-01-01'));
+-- 871fa44aeffffff@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_directed_edge_to_boundary">
 				<indexterm significance="normal"><primary><varname>th3DirectedEdgeToBoundary</varname></primary></indexterm>
 				<para>Return the temporal polygon boundary of each directed edge in a trajectory, as a temporal geography</para>
 				<para><varname>th3DirectedEdgeToBoundary(th3index) → tgeography</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_NPoints(getValue(th3DirectedEdgeToBoundary(
+  th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
+    th3index '871fa44aeffffff@2001-01-01')))::geometry);
+-- 3
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -350,18 +410,30 @@ SELECT th3AreNeighborCells(
 				<indexterm significance="normal"><primary><varname>th3CellToVertex</varname></primary></indexterm>
 				<para>Return the temporal H3 vertex at the given vertex number (0–5 for hexagons, 0–4 for pentagons)</para>
 				<para><varname>th3CellToVertex(th3index,integer) → th3index</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3CellToVertex(th3index '871fa44a8ffffff@2001-01-01', 0);
+-- 2071fa44a8ffffff@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_vertex_to_latlng">
 				<indexterm significance="normal"><primary><varname>th3VertexToLatlng</varname></primary></indexterm>
 				<para>Return the temporal geodetic coordinates of each vertex in a trajectory</para>
 				<para><varname>th3VertexToLatlng(th3index) → tgeogpoint</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(th3VertexToLatlng(th3CellToVertex(th3index '871fa44a8ffffff@2001-01-01', 0)), 6);
+-- POINT(4.280027 50.807655)@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_is_valid_vertex">
 				<indexterm significance="normal"><primary><varname>isValidVertex</varname></primary></indexterm>
 				<para>Return a temporal boolean stating at each instant whether the value is a valid H3 vertex</para>
 				<para><varname>isValidVertex(th3index) → tbool</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT isValidVertex(th3CellToVertex(th3index '871fa44a8ffffff@2001-01-01', 0));
+-- t@2001-01-01
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -388,6 +460,16 @@ SELECT th3index '880326b885fffff@2001-01-01'
 				<para>Convert between a temporal cell and a temporal local (I, J) coordinate pair relative to an origin temporal cell. The local coordinate is exposed as a <varname>tgeompoint</varname> with the I axis in the <varname>x</varname> slot and J in <varname>y</varname>.</para>
 				<para><varname>th3CellToLocalIj(th3index,th3index) → tgeompoint</varname></para>
 				<para><varname>th3LocalIjToCell(th3index,tgeompoint) → th3index</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(th3CellToLocalIj(th3index '871fa44a8ffffff@2001-01-01',
+  th3index '871fa44aeffffff@2001-01-01'));
+-- POINT(497 320)@2001-01-01
+-- The two are inverse of each other.
+SELECT th3LocalIjToCell(th3index '871fa44a8ffffff@2001-01-01',
+  th3CellToLocalIj(th3index '871fa44a8ffffff@2001-01-01',
+    th3index '871fa44aeffffff@2001-01-01'));
+-- 871fa44aeffffff@2001-01-01
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -400,18 +482,34 @@ SELECT th3index '880326b885fffff@2001-01-01'
 				<indexterm significance="normal"><primary><varname>th3CellArea</varname></primary></indexterm>
 				<para>Return the temporal area of each cell in a trajectory, in the requested unit</para>
 				<para><varname>th3CellArea(th3index,text='km2') → tfloat</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3CellArea(th3index '871fa44a8ffffff@2001-01-01');
+-- 4.441914270110932@2001-01-01
+SELECT th3CellArea(th3index '871fa44a8ffffff@2001-01-01', 'm2');
+-- 4441914.270110932@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_edge_length">
 				<indexterm significance="normal"><primary><varname>th3EdgeLength</varname></primary></indexterm>
 				<para>Return the temporal length of each directed edge in a trajectory, in the requested unit</para>
 				<para><varname>th3EdgeLength(th3index,text='km') → tfloat</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3EdgeLength(th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
+    th3index '871fa44aeffffff@2001-01-01'));
+-- 1.272084901305088@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_great_circle_distance">
 				<indexterm significance="normal"><primary><varname>greatCircleDistance</varname></primary></indexterm>
 				<para>Return the temporal great-circle distance between two temporal geodetic points (not between cells). The two operands are synchronised.</para>
 				<para><varname>greatCircleDistance(tgeogpoint,tgeogpoint,text='km') → tfloat</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT greatCircleDistance(tgeogpoint 'Point(0 0)@2001-01-01',
+  tgeogpoint 'Point(1 0)@2001-01-01');
+-- 111.19505197522943@2001-01-01
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -425,11 +523,11 @@ SELECT th3index '880326b885fffff@2001-01-01'
 
 			<itemizedlist>
 				<listitem xml:id="th3_ever_eq">
-					<indexterm significance="normal"><primary><varname>ever_eq</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>eEq</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>?=</varname></primary></indexterm>
 					<para>Return <varname>true</varname> if a temporal H3 cell is ever equal to the probe at at least one instant</para>
-					<para><varname>ever_eq({h3index,th3index},th3index) → boolean</varname></para>
-					<para><varname>ever_eq(th3index,h3index) → boolean</varname></para>
+					<para><varname>eEq({h3index,th3index},th3index) → boolean</varname></para>
+					<para><varname>eEq(th3index,h3index) → boolean</varname></para>
 					<para><varname>{h3index,th3index} ?= th3index</varname></para>
 					<para><varname>th3index ?= h3index</varname></para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -441,33 +539,45 @@ SELECT th3index
 				</listitem>
 
 				<listitem xml:id="th3_always_eq">
-					<indexterm significance="normal"><primary><varname>always_eq</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>aEq</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>%=</varname></primary></indexterm>
 					<para>Return <varname>true</varname> if a temporal H3 cell is always equal to the probe across its entire time axis</para>
-					<para><varname>always_eq({h3index,th3index},th3index) → boolean</varname></para>
-					<para><varname>always_eq(th3index,h3index) → boolean</varname></para>
+					<para><varname>aEq({h3index,th3index},th3index) → boolean</varname></para>
+					<para><varname>aEq(th3index,h3index) → boolean</varname></para>
 					<para><varname>{h3index,th3index} %= th3index</varname></para>
 					<para><varname>th3index %= h3index</varname></para>
+									<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT aEq(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44a8ffffff');
+-- t
+</programlisting>
 				</listitem>
 
 				<listitem xml:id="th3_ever_ne">
-					<indexterm significance="normal"><primary><varname>ever_ne</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>eNe</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>?&lt;&gt;</varname></primary></indexterm>
 					<para>Return <varname>true</varname> if a temporal H3 cell is ever different from the probe</para>
-					<para><varname>ever_ne({h3index,th3index},th3index) → boolean</varname></para>
-					<para><varname>ever_ne(th3index,h3index) → boolean</varname></para>
+					<para><varname>eNe({h3index,th3index},th3index) → boolean</varname></para>
+					<para><varname>eNe(th3index,h3index) → boolean</varname></para>
 					<para><varname>{h3index,th3index} ?&lt;&gt; th3index</varname></para>
 					<para><varname>th3index ?&lt;&gt; h3index</varname></para>
+									<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT eNe(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44aeffffff');
+-- t
+</programlisting>
 				</listitem>
 
 				<listitem xml:id="th3_always_ne">
-					<indexterm significance="normal"><primary><varname>always_ne</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>aNe</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>%&lt;&gt;</varname></primary></indexterm>
 					<para>Return <varname>true</varname> if a temporal H3 cell is always different from the probe</para>
-					<para><varname>always_ne({h3index,th3index},th3index) → boolean</varname></para>
-					<para><varname>always_ne(th3index,h3index) → boolean</varname></para>
+					<para><varname>aNe({h3index,th3index},th3index) → boolean</varname></para>
+					<para><varname>aNe(th3index,h3index) → boolean</varname></para>
 					<para><varname>{h3index,th3index} %&lt;&gt; th3index</varname></para>
 					<para><varname>th3index %&lt;&gt; h3index</varname></para>
+									<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT aNe(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44aeffffff');
+-- t
+</programlisting>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -476,19 +586,25 @@ SELECT th3index
 			<title>Temporal Comparisons</title>
 			<itemizedlist>
 				<listitem xml:id="th3_temporal_teq">
-					<indexterm significance="normal"><primary><varname>temporal_teq</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>tEq</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>#=</varname></primary></indexterm>
-					<indexterm significance="normal"><primary><varname>temporal_tne</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>tNe</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>#&lt;&gt;</varname></primary></indexterm>
 					<para>Return a temporal boolean giving the per-instant equality (or inequality) between a temporal H3 cell and a probe</para>
-					<para><varname>temporal_teq({h3index,th3index},th3index) → tbool</varname></para>
-					<para><varname>temporal_teq(th3index,h3index) → tbool</varname></para>
-					<para><varname>temporal_tne({h3index,th3index},th3index) → tbool</varname></para>
-					<para><varname>temporal_tne(th3index,h3index) → tbool</varname></para>
+					<para><varname>tEq({h3index,th3index},th3index) → tbool</varname></para>
+					<para><varname>tEq(th3index,h3index) → tbool</varname></para>
+					<para><varname>tNe({h3index,th3index},th3index) → tbool</varname></para>
+					<para><varname>tNe(th3index,h3index) → tbool</varname></para>
 					<para><varname>{h3index,th3index} #= th3index</varname></para>
 					<para><varname>th3index #= h3index</varname></para>
 					<para><varname>{h3index,th3index} #&lt;&gt; th3index</varname></para>
 					<para><varname>th3index #&lt;&gt; h3index</varname></para>
+									<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT tEq(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44a8ffffff');
+-- t@2001-01-01
+SELECT tNe(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44a8ffffff');
+-- f@2001-01-01
+</programlisting>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -515,6 +631,12 @@ SELECT th3index
 				<para><varname>th3index &lt;@ {tstzspan,stbox,th3index} → boolean</varname></para>
 				<para><varname>th3index ~= {tstzspan,stbox,th3index} → boolean</varname></para>
 				<para><varname>th3index -|- {tstzspan,stbox,th3index} → boolean</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3index '871fa44a8ffffff@2001-01-01' &amp;&amp; tstzspan '[2001-01-01, 2001-01-02]';
+-- t
+SELECT th3index '871fa44a8ffffff@2001-01-01' ~= th3index '871fa44a8ffffff@2001-01-01';
+-- t
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_space_position">
@@ -535,6 +657,11 @@ SELECT th3index
 				<para><varname>th3index &amp;&lt;| {stbox,th3index} → boolean</varname></para>
 				<para><varname>th3index |&amp;&gt; {stbox,th3index} → boolean</varname></para>
 				<para><varname>th3index |&gt;&gt; {stbox,th3index} → boolean</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3index '871fa44a8ffffff@2001-01-01' &lt;&lt;
+  th3index '871fa44aeffffff@2001-01-01';
+-- f
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_time_position">
@@ -547,6 +674,14 @@ SELECT th3index
 				<para><varname>th3index &amp;&lt;# {tstzspan,stbox,th3index} → boolean</varname></para>
 				<para><varname>th3index #&gt;&gt; {tstzspan,stbox,th3index} → boolean</varname></para>
 				<para><varname>th3index #&amp;&gt; {tstzspan,stbox,th3index} → boolean</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT th3index '871fa44a8ffffff@2001-01-01' &lt;&lt;#
+  th3index '871fa44aeffffff@2001-01-05';
+-- t
+SELECT th3index '871fa44a8ffffff@2001-01-01' #&gt;&gt;
+  th3index '871fa44aeffffff@2001-01-05';
+-- f
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -560,54 +695,97 @@ SELECT th3index
 				<indexterm significance="normal"><primary><varname>h3GridDisk</varname></primary></indexterm>
 				<para>All cells within <varname>k</varname> grid steps of the origin (inclusive of the origin at k=0).</para>
 				<para><varname>h3GridDisk(h3index, integer) → h3indexset</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT h3GridDisk(h3index '871fa44a8ffffff', 1);
+-- {"871fa44a8ffffff", "871fa44a9ffffff", "871fa44aaffffff", "871fa44abffffff",
+--  "871fa44acffffff", "871fa44adffffff", "871fa44aeffffff"}
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_grid_ring">
 				<indexterm significance="normal"><primary><varname>h3GridRing</varname></primary></indexterm>
 				<para>The cells at <emphasis>exactly</emphasis> <varname>k</varname> grid steps from the origin. Fails near pentagons.</para>
 				<para><varname>h3GridRing(h3index, integer) → h3indexset</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT h3GridRing(h3index '871fa44a8ffffff', 1);
+-- {"871fa44a9ffffff", "871fa44aaffffff", "871fa44abffffff", "871fa44acffffff",
+--  "871fa44adffffff", "871fa44aeffffff"}
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_grid_path_cells">
 				<indexterm significance="normal"><primary><varname>h3GridPathCells</varname></primary></indexterm>
 				<para>The inclusive path of cells between two cells of the same resolution.</para>
 				<para><varname>h3GridPathCells(h3index, h3index) → h3indexset</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT h3GridPathCells(h3index '871fa44a8ffffff', h3index '871fa44b1ffffff');
+-- {"871fa4484ffffff", "871fa44a3ffffff", "871fa44a8ffffff", "871fa44aeffffff",
+--  "871fa44b1ffffff"}
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_cell_to_children">
 				<indexterm significance="normal"><primary><varname>h3CellToChildren</varname></primary></indexterm>
 				<para>All children of a cell at the given target resolution.</para>
 				<para><varname>h3CellToChildren(h3index, integer) → h3indexset</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT h3CellToChildren(h3index '831c02fffffffff', 4);
+-- {"841c021ffffffff", "841c023ffffffff", "841c025ffffffff", "841c027ffffffff",
+--  "841c029ffffffff", "841c02bffffffff", "841c02dffffffff"}
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_compact_cells">
 				<indexterm significance="normal"><primary><varname>h3CompactCells</varname></primary></indexterm>
 				<para>Compacted representation of a cell set — finer cells are merged into their parent whenever a full hexagonal set of siblings is present.</para>
 				<para><varname>h3CompactCells(h3indexset) → h3indexset</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT h3CompactCells(h3CellToChildren(h3index '831c02fffffffff', 4));
+-- {"831c02fffffffff"}
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_uncompact_cells">
 				<indexterm significance="normal"><primary><varname>h3UncompactCells</varname></primary></indexterm>
 				<para>Uncompacted representation at the given resolution — the inverse of <varname>h3CompactCells</varname>.</para>
 				<para><varname>h3UncompactCells(h3indexset, integer) → h3indexset</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT numValues(h3UncompactCells(
+  h3CompactCells(h3CellToChildren(h3index '831c02fffffffff', 4)), 4));
+-- 7
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_origin_to_directed_edges">
 				<indexterm significance="normal"><primary><varname>h3OriginToDirectedEdges</varname></primary></indexterm>
 				<para>All outgoing directed edges of a cell (6 for hexagons, 5 for pentagons).</para>
 				<para><varname>h3OriginToDirectedEdges(h3index) → h3indexset</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT h3OriginToDirectedEdges(h3index '871fa44a8ffffff');
+-- {"1171fa44a8ffffff", "1271fa44a8ffffff", "1371fa44a8ffffff",
+--  "1471fa44a8ffffff", "1571fa44a8ffffff", "1671fa44a8ffffff"}
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_cell_to_vertexes">
 				<indexterm significance="normal"><primary><varname>h3CellToVertexes</varname></primary></indexterm>
 				<para>All vertexes of a cell (6 for hexagons, 5 for pentagons).</para>
 				<para><varname>h3CellToVertexes(h3index) → h3indexset</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT h3CellToVertexes(h3index '871fa44a8ffffff');
+-- {"2071fa44a8ffffff", "2171fa44a8ffffff", "2271fa44a8ffffff",
+--  "2371fa44a8ffffff", "2471fa44a8ffffff", "2571fa44a8ffffff"}
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="th3_h3_get_icosahedron_faces">
 				<indexterm significance="normal"><primary><varname>h3GetIcosahedronFaces</varname></primary></indexterm>
 				<para>The icosahedron face indexes (0..19) intersected by a cell.</para>
 				<para><varname>h3GetIcosahedronFaces(h3index) → intset</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT h3GetIcosahedronFaces(h3index '831c02fffffffff');
+-- {6, 11}
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>

--- a/doc/temporal_quadbin_index.xml
+++ b/doc/temporal_quadbin_index.xml
@@ -91,6 +91,14 @@ SELECT (tquadbin '480fffffffffffff@2001-01-01')::tgeompoint;
 				<indexterm significance="normal"><primary><varname>isValidIndex</varname></primary></indexterm>
 				<para>Return whether a value is a structurally valid QUADBIN identifier (correct header tag and resolution field)</para>
 				<para><varname>isValidIndex(quadbin) → boolean</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT isValidIndex(quadbin '480fffffffffffff');
+-- t
+-- The input function already rejects malformed text, so a value that is
+-- structurally invalid can only arrive through the bigint conversion.
+SELECT isValidIndex(0::bigint::quadbin);
+-- f
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="quadbin_is_valid_cell">
@@ -265,6 +273,14 @@ SELECT geoToQuadbinCell(geometry 'SRID=4326;POINT(4.35 50.85)', 10)
 				<para>Return the centroid of a cell as an SRID-4326 point. The static form takes a single <varname>quadbin</varname>; the temporal form returns the centroid of each cell in a trajectory as a <varname>tgeompoint</varname>.</para>
 				<para><varname>quadbinCellToPoint(quadbin) → geometry</varname></para>
 				<para><varname>tquadbinCellToPoint(tquadbin) → tgeompoint</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_AsText(quadbinCellToPoint(quadbin '48427fffffffffff'));
+-- POINT(-101.25 48.92249926375824)
+SELECT asText(tquadbinCellToPoint(tquadbin
+  '{480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02}'));
+-- {POINT(0 0)@2001-01-01,
+--  POINT(-101.25 48.92249926375824)@2001-01-02}
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="tquadbin_quadbin_cell_to_boundary">
@@ -272,6 +288,12 @@ SELECT geoToQuadbinCell(geometry 'SRID=4326;POINT(4.35 50.85)', 10)
 				<para>Return the square polygon boundary of a cell as an SRID-4326 geometry. The static form takes a single <varname>quadbin</varname>; the temporal form returns the boundary of each cell in a trajectory as a <varname>tgeometry</varname>.</para>
 				<para><varname>quadbinCellToBoundary(quadbin) → geometry</varname></para>
 				<para><varname>tquadbinCellToBoundary(tquadbin) → tgeometry</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_AsText(quadbinCellToBoundary(quadbin '480fffffffffffff'));
+-- POLYGON((-180 -85.0511287798066,180 -85.0511287798066,
+--          180 85.0511287798066,-180 85.0511287798066,
+--          -180 -85.0511287798066))
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -333,6 +355,12 @@ SELECT quadbinCellToQuadkey(quadbin '48a6227affffffff');
 				<para>Return the area of a cell on the sphere, in square metres. The static form takes a single <varname>quadbin</varname>; the temporal form returns the area of each cell in a trajectory as a <varname>tfloat</varname>. Cell area shrinks toward the poles, as web-mercator squares cover progressively less ground at higher latitudes.</para>
 				<para><varname>quadbinCellArea(quadbin) → float8</varname></para>
 				<para><varname>tquadbinCellArea(tquadbin) → tfloat</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT round(quadbinCellArea(quadbin '480fffffffffffff')::numeric, 0);
+-- 508164135963886
+SELECT round(quadbinCellArea(quadbin '48427fffffffffff')::numeric, 0);
+-- 2726563416104
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>

--- a/doc/temporal_raster.xml
+++ b/doc/temporal_raster.xml
@@ -210,24 +210,44 @@ GROUP BY t.tripid, t.trip4326;
 				<indexterm significance="normal"><primary><varname>quadbin</varname></primary></indexterm>
 				<para>Return the QUADBIN cell of a Raquet tile</para>
 				<para><varname>quadbin(raquet) → bigint</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT quadbin(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
+-- 5193776270265024512
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="raquet_width">
 				<indexterm significance="normal"><primary><varname>width</varname></primary></indexterm>
 				<para>Return the width in pixels of a Raquet tile</para>
 				<para><varname>width(raquet) → integer</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT width(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
+-- 2
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="raquet_height">
 				<indexterm significance="normal"><primary><varname>height</varname></primary></indexterm>
 				<para>Return the height in pixels of a Raquet tile</para>
 				<para><varname>height(raquet) → integer</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT height(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
+-- 2
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="raquet_nodata">
 				<indexterm significance="normal"><primary><varname>nodata</varname></primary></indexterm>
 				<para>Return the nodata sentinel value of a Raquet tile</para>
 				<para><varname>nodata(raquet) → float8</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT nodata(raquet('\x01020304'::bytea, 2, 2,
+  5193776270265024512, 'UINT8', 255));
+-- 255
+-- The sentinel defaults to 0 when the constructor omits it.
+SELECT nodata(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
+-- 0
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="raquet_pixtype">

--- a/doc/temporal_rigid_geometries.xml
+++ b/doc/temporal_rigid_geometries.xml
@@ -53,7 +53,7 @@ SELECT trgeometry 'Interp=Step;Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 
 				<para><varname>asText({trgeometry,trgeometry[]} [, maxdecimaldigits int=15]) → text</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1.123456789 1.123456789), 0.5)@2000-01-01', 6);
--- POLYGON((1 1,2 2,3 1,1 1));Pose(POINT(1.123457 1.123457),0.5)@Sat Jan 01 00:00:00 2000 PST
+-- POLYGON((1 1,2 2,3 1,1 1));Pose(POINT(1.123457 1.123457),0.5)@2000-01-01
 </programlisting>
 			</listitem>
 
@@ -63,7 +63,7 @@ SELECT asText(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1.123456789 1.12
 				<para><varname>asEWKT({trgeometry,trgeometry[]} [, maxdecimaldigits int=15]) → text</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(trgeometry 'SRID=25832;Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1),0.5)@2000-01-01');
--- SRID=25832;POLYGON((1 1,2 2,3 1,1 1));Pose(POINT(1 1),0.5)@Sat Jan 01 00:00:00 2000 PST
+-- SRID=25832;POLYGON((1 1,2 2,3 1,1 1));Pose(POINT(1 1),0.5)@2000-01-01
 </programlisting>
 			</listitem>
 
@@ -81,6 +81,13 @@ SELECT asMFJSON(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0),0)@20
 				<para>Return the Extended Well-Known Binary (EWKB) representation</para>
 				<para><varname>asEWKB(trgeometry [, endian text]) → bytea</varname></para>
 				<para>Companion <varname>asHexEWKB</varname> returns the same bytes as a hex-encoded text.</para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT length(asEWKB(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(1 1), 0.5)@2001-01-01'));
+-- 130
+-- The bytes round-trip through the matching input function.
+SELECT asText(trgeometryFromHexEWKB(asHexEWKB(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(1 1), 0.5)@2001-01-01')));
+-- POLYGON((0 0,1 0,1 1,0 1,0 0));Pose(POINT(1 1),0.5)@2001-01-01
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="trgeometry_fromText">
@@ -93,6 +100,13 @@ SELECT asMFJSON(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0),0)@20
 				<para><varname>trgeometryFromMFJSON(text) → trgeometry</varname></para>
 				<para><varname>trgeometryFromEWKB(bytea) → trgeometry</varname></para>
 				<para><varname>trgeometryFromHexEWKB(text) → trgeometry</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(trgeometryFromEWKT('SRID=4326;Polygon((0 0,1 0,1 1,0 1,0 0));
+  Pose(Point(1 1), 0.5)@2001-01-01'));
+-- POLYGON((0 0,1 0,1 1,0 1,0 0));Pose(POINT(1 1),0.5)@2001-01-01
+SELECT asText(trgeometryFromHexEWKB(asHexEWKB(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(1 1), 0.5)@2001-01-01')));
+-- POLYGON((0 0,1 0,1 1,0 1,0 0));Pose(POINT(1 1),0.5)@2001-01-01
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -108,10 +122,10 @@ SELECT asMFJSON(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0),0)@20
 				<para>Construct a temporal rigid geometry from a reference geometry and a temporal pose</para>
 				<para><varname>trgeometry(geometry, tpose) → trgeometry</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT trgeometry(
+SELECT asText(trgeometry(
   geometry 'Polygon((0 0,1 0,1 1,0 1,0 0))',
-  tpose 'Pose(Point(0 0), 0.0)@2001-01-01');
--- POLYGON((0 0,1 0,1 1,0 1,0 0));Pose(POINT(0 0),0)@Mon Jan 01 00:00:00 2001 PST
+  tpose 'Pose(Point(0 0), 0.0)@2001-01-01'));
+-- POLYGON((0 0,1 0,1 1,0 1,0 0));Pose(POINT(0 0),0)@2001-01-01
 </programlisting>
 				<para>Both arguments must share the same SRID. The reference geometry may be a polygon or a polyhedral surface; the pose may be of any temporal subtype.</para>
 			</listitem>
@@ -131,6 +145,15 @@ SELECT appendInstant(
 				<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
 				<para>Append an entire sequence to an existing trgeometry</para>
 				<para><varname>appendSequence(trgeometry, trgeometry) → trgeometry</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(appendSequence(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]',
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(20 0), 0.0)@2001-01-03, Pose(Point(30 0), 0.0)@2001-01-04]'));
+-- POLYGON((0 0,1 0,1 1,0 1,0 0));
+-- {[Pose(POINT(0 0),0)@2001-01-01, Pose(POINT(10 0),0)@2001-01-02],
+--   [Pose(POINT(20 0),0)@2001-01-03, Pose(POINT(30 0),0)@2001-01-04]}
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -197,6 +220,17 @@ SELECT asText(valueAtTimestamp(
 				<para><varname>numInstants(trgeometry) → integer</varname></para>
 				<para><varname>numSequences(trgeometry) → integer</varname></para>
 				<para><varname>numTimestamps(trgeometry) → integer</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT numInstants(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]');
+-- 2
+SELECT numSequences(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]');
+-- 1
+SELECT numTimestamps(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]');
+-- 2
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="trgeometry_instants">
@@ -332,6 +366,11 @@ SELECT length(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@200
 				<indexterm significance="normal"><primary><varname>speed</varname></primary></indexterm>
 				<para>Return the speed of the centroid as a temporal float</para>
 				<para><varname>speed(trgeometry) → tfloat</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT speed(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]');
+-- Interp=Step;[0.000115740740741@2001-01-01, 0.000115740740741@2001-01-02]
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="trgeometry_twcentroid">
@@ -368,6 +407,13 @@ SELECT asText(round(
 				<indexterm significance="normal"><primary><varname>setInterp</varname></primary></indexterm>
 				<para>Convert between linear and step interpolations</para>
 				<para><varname>setInterp(trgeometry, text) → trgeometry</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(setInterp(trgeometry 'Interp=Step;Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]', 'linear'));
+-- POLYGON((0 0,1 0,1 1,0 1,0 0));
+-- {[Pose(POINT(0 0),0)@2001-01-01, Pose(POINT(0 0),0)@2001-01-02),
+--  [Pose(POINT(10 0),0)@2001-01-02]}
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="trgeometry_shiftTime">
@@ -378,6 +424,20 @@ SELECT asText(round(
 				<para><varname>shiftTime(trgeometry, interval) → trgeometry</varname></para>
 				<para><varname>scaleTime(trgeometry, interval) → trgeometry</varname></para>
 				<para><varname>shiftScaleTime(trgeometry, interval, interval) → trgeometry</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(shiftTime(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]', interval '1 day'));
+-- POLYGON((0 0,1 0,1 1,0 1,0 0));
+-- [Pose(POINT(0 0),0)@2001-01-02, Pose(POINT(10 0),0)@2001-01-03]
+SELECT asText(scaleTime(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]', interval '2 days'));
+-- POLYGON((0 0,1 0,1 1,0 1,0 0));
+-- [Pose(POINT(0 0),0)@2001-01-01, Pose(POINT(10 0),0)@2001-01-03]
+SELECT asText(shiftScaleTime(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]', interval '1 day', interval '2 days'));
+-- POLYGON((0 0,1 0,1 1,0 1,0 0));
+-- [Pose(POINT(0 0),0)@2001-01-02, Pose(POINT(10 0),0)@2001-01-04]
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -529,6 +589,22 @@ SELECT round(hausdorffDistance(
 				<para>Return the correspondence pairs between two temporal rigid geometries with respect to the discrete Fréchet distance or the Dynamic Time Warp distance, as a set of <varname>(i,j)</varname> instant-index pairs</para>
 				<para><varname>frechetDistancePath(trgeometry, trgeometry) → {(i,j)}</varname></para>
 				<para><varname>dynTimeWarpPath(trgeometry, trgeometry) → {(i,j)}</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT frechetDistancePath(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+    [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]',
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+    [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(20 0), 0.0)@2001-01-02]');
+-- (0,0)
+-- (1,1)
+SELECT dynTimeWarpPath(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+    [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]',
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+    [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(20 0), 0.0)@2001-01-02]');
+-- (0,0)
+-- (1,1)
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -545,6 +621,16 @@ SELECT round(hausdorffDistance(
 				<para>Test exact (in)equality of two trgeometries</para>
 				<para><varname>trgeometry = trgeometry → boolean</varname></para>
 				<para><varname>trgeometry &lt;&gt; trgeometry → boolean</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]' = trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]';
+-- t
+SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]' &lt;&gt; trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]';
+-- f
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="trgeometry_evereq">
@@ -566,6 +652,12 @@ SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01
 				<para>Test whether the materialised geometry is always (not) equal to the operand</para>
 				<para><varname>{geometry,trgeometry} %= {geometry,trgeometry} → boolean</varname></para>
 				<para><varname>{geometry,trgeometry} %&lt;&gt; {geometry,trgeometry} → boolean</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]' %= trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]';
+-- t
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -640,6 +732,14 @@ SELECT array_length(spaceBoxes(
 				<para>Return the array of spatiotemporal boxes or time spans of the segments of a temporal rigid geometry</para>
 				<para><varname>stboxes(trgeometry) → stbox[]</varname></para>
 				<para><varname>spans(trgeometry) → tstzspan[]</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT stboxes(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]');
+-- {"STBOX XT(((0,0),(11,1)),[2001-01-01, 2001-01-02])"}
+SELECT spans(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]');
+-- {"[2001-01-01, 2001-01-02]"}
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="trgeometry_split_boxes">
@@ -652,6 +752,14 @@ SELECT array_length(spaceBoxes(
 				<para><varname>splitEachNStboxes(trgeometry, integer) → stbox[]</varname></para>
 				<para><varname>splitNSpans(trgeometry, integer) → tstzspan[]</varname></para>
 				<para><varname>splitEachNSpans(trgeometry, integer) → tstzspan[]</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT splitNStboxes(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]', 2);
+-- {"STBOX XT(((0,0),(11,1)),[2001-01-01, 2001-01-02])"}
+SELECT splitNSpans(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]', 2);
+-- {"[2001-01-01, 2001-01-02]"}
+</programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
@@ -664,6 +772,11 @@ SELECT array_length(spaceBoxes(
 				<indexterm significance="normal"><primary><varname>tcount</varname></primary></indexterm>
 				<para>Number of overlapping trgeometries at each instant — equivalent to <varname>tcount</varname> on the underlying tpose</para>
 				<para><varname>tcount(trgeometry) → tint</varname></para>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT tcount(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]');
+-- {[1@2001-01-01, 1@2001-01-02]}
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="trgeometry_extent">


### PR DESCRIPTION
Every function entry of the circular buffer, quadbin, raster, rigid geometry
and h3 chapters shows the function in use, in English and Spanish. The results
come from a live server rather than from reading the code.

Running them is what makes the difference. Three entries name functions the
extension does not define, so their signatures are corrected first: the h3
comparisons are `eEq`, `aEq`, `eNe`, `aNe`, `tEq` and `tNe` rather than
`ever_eq`, `always_eq`, `ever_ne`, `always_ne`, `temporal_teq` and
`temporal_tne`, and the h3 conversion is `th3index` rather than
`tgeogpoint_to_th3` and `tgeompoint_to_th3`. The conversion entry also ships
an example calling the name that does not exist:

```
SELECT th3GetResolution(tgeogpoint_to_th3(tgeogpoint 'POINT(-73.96 40.78)@2001-01-01', 9));
-- ERROR:  function tgeogpoint_to_th3(tgeogpoint, integer) does not exist
```

The section anchors keep their spelling, since `reference.xml` links to them.

The three rigid geometry listings that print timestamps in the server locale
form are rewritten in the ISO form the other seventeen chapters use, so one
format holds throughout the manual: the manual shows results with midnight
timestamps abbreviated, and 729 of the 732 result comments already read that
way. One of the three also gains the `asText` call its result already assumes,
the bare constructor returning the hex form.

Six h3 entries carry a listing in English and none in Spanish; the Spanish
chapter takes the same six, the listings being SQL.

Future: the pointcloud chapter has 53 entries left. An entry that already
carries an example is not necessarily right either, since nothing checks that
a listing still runs.