### PR TITLE
Keep the heap round-trip of points out of the temporal point kernels

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -51,6 +51,7 @@
 #include <lwgeom_log.h>
 #include <intervaltree.h>
 #include <lwgeom_geos.h>
+#include <measures.h>
 /* MEOS */
 #include <meos.h>
 #include <meos_internal.h>
@@ -949,6 +950,22 @@ geom_distance2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 {
   assert(gs1); assert(gs2);
   assert(gserialized_get_srid(gs1) == gserialized_get_srid(gs2));
+
+  /* Fast path: the distance between two points is computed from their
+   * coordinates with the primitive that the general computation reaches, which
+   * avoids deserializing the geometries. This keeps the deserialization out of
+   * the temporal-distance hot path, where the lifting loop computes the
+   * distance for every synchronized pair of instants */
+  if (gserialized_get_type(gs1) == POINTTYPE &&
+      gserialized_get_type(gs2) == POINTTYPE &&
+      ! gserialized_is_empty(gs1) && ! gserialized_is_empty(gs2))
+  {
+    DISTPTS dl;
+    lw_dist2d_distpts_init(&dl, DIST_MIN);
+    lw_dist2d_pt_pt(GSERIALIZED_POINT2D_P(gs1), GSERIALIZED_POINT2D_P(gs2),
+      &dl);
+    return dl.distance;
+  }
 
   LWGEOM *geom1 = lwgeom_from_gserialized(gs1);
   LWGEOM *geom2 = lwgeom_from_gserialized(gs2);

--- a/meos/src/geo/tgeo_spatialfuncs.c
+++ b/meos/src/geo/tgeo_spatialfuncs.c
@@ -110,12 +110,23 @@ GSERIALIZED *
 geopoint_make(double x, double y, double z, bool hasz, bool geodetic,
   int32_t srid)
 {
-  LWPOINT *point = hasz ?
-    lwpoint_make3dz(srid, x, y, z) : lwpoint_make2d(srid, x, y);
-  FLAGS_SET_GEODETIC(point->flags, geodetic);
-  GSERIALIZED *result = geo_serialize((LWGEOM *) point);
-  lwpoint_free(point);
-  return result;
+  /* The coordinate list, the point array, and the point are in the stack,
+   * since only the serialized result outlives the function */
+  double coords[3] = {x, y, z};
+  lwflags_t flags = 0;
+  FLAGS_SET_Z(flags, hasz);
+  FLAGS_SET_GEODETIC(flags, geodetic);
+  POINTARRAY pa;
+  pa.npoints = pa.maxpoints = 1;
+  pa.flags = flags;
+  pa.serialized_pointlist = (uint8_t *) coords;
+  LWPOINT point;
+  point.bbox = NULL;
+  point.point = &pa;
+  point.srid = srid;
+  point.flags = flags;
+  point.type = POINTTYPE;
+  return geo_serialize((LWGEOM *) &point);
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
Two changes to the point paths that the temporal point operations run per instant, both keeping the computed values unchanged.

`geopoint_make` serializes a point built from a coordinate list, a point array, and a point that live in the stack, instead of allocating and freeing an `LWPOINT` scaffolding for every point it returns.

`geom_distance2d` reaches the point-to-point primitive directly when both arguments are non-empty points, reading their coordinates in place instead of deserializing both geometries. It calls `lw_dist2d_pt_pt` with the same `DISTPTS` initialization the general computation uses, so the returned distance is the same value, down to the last bit.

Measured with callgrind over 60 real AIS trajectories of 500 instants each (`tsample`, `atTime`, `tDistance` against a point and against a polygon, `simplify`, `cumulativeLength`, `speed`), instructions inside the measured region:

| | before | after |
| --- | --- | --- |
| total | 240,474,105 | 196,536,159 (−18.3%) |
| `geom_distance2d` | 45,393,616 | 5,705,973 (−87.4%) |
| `geopoint_make` | 10,957,644 | 3,560,660 (−67.5%) |

The hexadecimal WKB of every result over that corpus carries the same value on both sides of the change (`6d387070933ede5bf957395251e78787`).