### PR TITLE
Compute the distance between two 3D points without deserializing them

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -52,6 +52,7 @@
 #include <intervaltree.h>
 #include <lwgeom_geos.h>
 #include <measures.h>
+#include <measures3d.h>
 /* MEOS */
 #include <meos.h>
 #include <meos_internal.h>
@@ -987,6 +988,25 @@ geom_distance3d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 {
   assert(gs1); assert(gs2);
   assert(gserialized_get_srid(gs1) == gserialized_get_srid(gs2));
+
+  /* Fast path: the distance between two points with Z is computed from their
+   * coordinates with the primitive that the general computation reaches, which
+   * avoids deserializing the geometries */
+  if (gserialized_get_type(gs1) == POINTTYPE &&
+      gserialized_get_type(gs2) == POINTTYPE &&
+      gserialized_has_z(gs1) && gserialized_has_z(gs2) &&
+      ! gserialized_is_empty(gs1) && ! gserialized_is_empty(gs2))
+  {
+    DISTPTS3D dl;
+    memset(&dl, 0, sizeof(DISTPTS3D));
+    dl.mode = DIST_MIN;
+    dl.distance = DBL_MAX;
+    dl.tolerance = 0.0;
+    dl.twisted = -1;
+    lw_dist3d_pt_pt(GSERIALIZED_POINT3DZ_P(gs1), GSERIALIZED_POINT3DZ_P(gs2),
+      &dl);
+    return dl.distance;
+  }
 
   LWGEOM *geom1 = lwgeom_from_gserialized(gs1);
   LWGEOM *geom2 = lwgeom_from_gserialized(gs2);


### PR DESCRIPTION
The three-dimensional distance between two geometries reaches the point-to-point primitive directly when both arguments are non-empty points carrying a Z coordinate, reading their coordinates in place instead of deserializing both geometries. It calls `lw_dist3d_pt_pt` with the same `DISTPTS3D` initialization the general computation uses, so the returned distance is the same value, down to the last bit. This is the three-dimensional counterpart of the two-dimensional fast path.

Measured with callgrind over 60 real AIS trajectories of 500 instants each carrying a Z coordinate, `tDistance` against a 3D point, instructions attributed to `geom_distance3d`:

| | before | after |
| --- | --- | --- |
| `geom_distance3d` | 39,939,816 | 6,825,142 (−82.9%) |

The hexadecimal WKB of every result over that corpus carries the same value on both sides of the change (`e075ad3de1d67f010d539b6d1e82a019`).