### PR TITLE
Move the raster trajectory sampling into the MEOS library

### DIFF
--- a/meos/include/meos_raster.h
+++ b/meos/include/meos_raster.h
@@ -48,6 +48,7 @@
 #include <stdint.h>
 /* MEOS */
 #include <meos.h>
+#include <meos_geo.h>
 
 /**
  * @brief Pixel data type for raster chip sampling.
@@ -110,6 +111,17 @@ extern bool raquet_ge(const Raquet *rq1, const Raquet *rq2);
 extern bool raquet_gt(const Raquet *rq1, const Raquet *rq2);
 
 /* Sampling functions */
+
+/**
+ * @brief Callback returning the raster pixel value at a point: return true
+ * and set @p value, or return false when the point lies outside the raster
+ * or on a nodata pixel
+ */
+typedef bool (*raster_sample_fn)(void *ctx, const GSERIALIZED *point,
+  double *value);
+
+extern Temporal *raster_value(const Temporal *traj, const STBox *box,
+  raster_sample_fn sample, void *ctx);
 
 extern Temporal *raster_tile_value_quadbin(const uint8_t *pixels,
   uint16_t width, uint16_t height, uint64 quadbin, MeosPixType pixtype,

--- a/meos/src/raster/raster_quadbin.c
+++ b/meos/src/raster/raster_quadbin.c
@@ -57,6 +57,8 @@
 /* MEOS */
 #include <meos.h>
 #include <meos_internal.h>
+#include <meos_raster.h>
+#include "temporal/temporal.h"
 #include "temporal/tinstant.h"
 #include "temporal/tsequence.h"
 /* Raster */
@@ -367,6 +369,69 @@ raster_tile_value_quadbin(const uint8_t *pixels, uint16_t width,
     double pixval = read_pixel(pixels, col, row, width, pixtype);
     if (has_nodata && pixval == nodata)
       continue;
+
+    result_insts[ninsts++] =
+      tinstant_make(Float8GetDatum(pixval), T_TFLOAT, insts[i]->t);
+  }
+
+  pfree(insts);
+
+  if (ninsts == 0)
+  {
+    pfree(result_insts);
+    return NULL;
+  }
+  return (Temporal *) tsequence_make_free(result_insts, ninsts,
+                                          true, true, DISCRETE, NORMALIZE);
+}
+
+/**
+ * @ingroup meos_raster
+ * @brief Return the values of a raster sampled at the instants of a
+ * trajectory
+ * @details The pixel access is delegated to the @p sample callback so that
+ * the one algorithm serves any raster engine: the MobilityDB extension
+ * samples through PostGIS raster's @p ST_Value, a program using the MEOS
+ * library samples through GDAL or any other reader.
+ * @param[in] traj Trajectory (temporal geometry point)
+ * @param[in] box Bounding box of the raster used as a pre-filter, may be
+ * @p NULL
+ * @param[in] sample Callback returning the pixel value at a point
+ * @param[in] ctx Opaque context passed through to the callback
+ * @return A temporal float, or @p NULL when no instant of @p traj falls
+ * inside the raster or survives nodata filtering
+ * @csqlfn #Raster_value()
+ */
+Temporal *
+raster_value(const Temporal *traj, const STBox *box, raster_sample_fn sample,
+  void *ctx)
+{
+  VALIDATE_NOT_NULL(traj, NULL); VALIDATE_NOT_NULL((void *) sample, NULL);
+
+  /* Iterate over trajectory instants */
+  int count;
+  const TInstant **insts = temporal_insts_p(traj, &count);
+  TInstant **result_insts = palloc(sizeof(TInstant *) * count);
+  int ninsts = 0;
+
+  for (int i = 0; i < count; i++)
+  {
+    GSERIALIZED *pt_gs =
+      (GSERIALIZED *) DatumGetPointer(tinstant_value(insts[i]));
+
+    /* Bounding-box pre-filter: for a point the GBOX is degenerate */
+    if (box)
+    {
+      GBOX pt_box;
+      gserialized_get_gbox_p(pt_gs, &pt_box);
+      if (pt_box.xmin < box->xmin || pt_box.xmin > box->xmax ||
+          pt_box.ymin < box->ymin || pt_box.ymin > box->ymax)
+        continue;
+    }
+
+    double pixval;
+    if (! sample(ctx, pt_gs, &pixval))
+      continue;   /* nodata pixel or geometry outside the pixel grid */
 
     result_insts[ninsts++] =
       tinstant_make(Float8GetDatum(pixval), T_TFLOAT, insts[i]->t);

--- a/mobilitydb/src/raster/temporal_raster.c
+++ b/mobilitydb/src/raster/temporal_raster.c
@@ -128,31 +128,48 @@ PG_FUNCTION_INFO_V1(Raster_value);
  * @param[in] band Band number (1-based, default 1)
  * @csqlfn #Raster_value()
  */
+/**
+ * @brief Raster sampling callback backed by PostGIS raster's ST_Value: the
+ * context is a prepared FunctionCallInfo whose raster/band/nodata/resample
+ * arguments are constant, only the point argument varies per call
+ */
+static bool
+raster_st_value_sample(void *ctx, const GSERIALIZED *point, double *value)
+{
+  FunctionCallInfo fcinfo_val = (FunctionCallInfo) ctx;
+  fcinfo_val->args[2].value  = PointerGetDatum(point);
+  fcinfo_val->args[2].isnull = false;
+  fcinfo_val->isnull         = false;   /* reset before every call */
+  Datum pixval = FunctionCallInvoke(fcinfo_val);
+  if (fcinfo_val->isnull)
+    return false;   /* nodata pixel or geometry outside the pixel grid */
+  *value = DatumGetFloat8(pixval);
+  return true;
+}
+
 Datum
 Raster_value(PG_FUNCTION_ARGS)
 {
-  /* ── arguments ──────────────────────────────────────────────────────── */
   Datum     rast_datum = PG_GETARG_DATUM(0);
   Temporal *traj       = PG_GETARG_TEMPORAL_P(1);
   int32     band       = PG_ARGISNULL(2) ? 1 : PG_GETARG_INT32(2);
 
-  /* ── OID resolution (once per session) ──────────────────────────────── */
+  /* OID resolution (once per session) */
   init_oids();
 
-  /* ── Raster convex hull — used as a bounding-box pre-filter ─────────── */
+  /* Raster convex hull — the bounding-box pre-filter of the MEOS kernel */
   Datum hull_datum =
     OidFunctionCall1(st_convexhull_raster_oid, rast_datum);
   GSERIALIZED *hull_gs = (GSERIALIZED *) DatumGetPointer(hull_datum);
   GBOX         hull_box;
   gserialized_get_gbox_p(hull_gs, &hull_box);
   pfree(hull_gs);
-
-  /* ── Iterate over trajectory instants ───────────────────────────────── */
-  int count;
-  const TInstant **insts = temporal_insts_p(traj, &count);
-
-  TInstant **result_insts = palloc(sizeof(TInstant *) * count);
-  int ninsts = 0;
+  STBox box;
+  memset(&box, 0, sizeof(STBox));
+  box.xmin = hull_box.xmin;
+  box.xmax = hull_box.xmax;
+  box.ymin = hull_box.ymin;
+  box.ymax = hull_box.ymax;
 
   /* Prepare a reusable FunctionCallInfo for ST_Value (handles NULL returns) */
   FmgrInfo flinfo;
@@ -174,45 +191,12 @@ Raster_value(PG_FUNCTION_ARGS)
   fcinfo_val->args[4].value  = PointerGetDatum(cstring_to_text("nearest"));
   fcinfo_val->args[4].isnull = false;
 
-  for (int i = 0; i < count; i++)
-  {
-    Datum geom_datum = tinstant_value(insts[i]);
-
-    /* ── Bounding-box pre-filter ─────────────────────────────────────── */
-    GSERIALIZED *pt_gs = (GSERIALIZED *) DatumGetPointer(geom_datum);
-    GBOX         pt_box;
-    gserialized_get_gbox_p(pt_gs, &pt_box);
-    /* For a POINT, pt_box.xmin == xmax and ymin == ymax */
-    if (pt_box.xmin < hull_box.xmin || pt_box.xmin > hull_box.xmax ||
-        pt_box.ymin < hull_box.ymin || pt_box.ymin > hull_box.ymax)
-      continue;
-
-    /* ── ST_Value call with NULL detection ───────────────────────────── */
-    fcinfo_val->args[2].value  = geom_datum;
-    fcinfo_val->args[2].isnull = false;
-    fcinfo_val->isnull         = false;   /* reset before every call */
-
-    Datum pixval = FunctionCallInvoke(fcinfo_val);
-    if (fcinfo_val->isnull)
-      continue;   /* nodata pixel or geometry outside the pixel grid */
-
-    result_insts[ninsts++] =
-      tinstant_make(pixval, T_TFLOAT, insts[i]->t);
-  }
-
-  pfree(insts);
-
-  if (ninsts == 0)
-  {
-    pfree(result_insts);
-    PG_FREE_IF_COPY(traj, 1);
-    PG_RETURN_NULL();
-  }
-
-  TSequence *result =
-    tsequence_make_free(result_insts, ninsts, true, true, DISCRETE, NORMALIZE);
+  Temporal *result = raster_value(traj, &box, &raster_st_value_sample,
+    fcinfo_val);
 
   PG_FREE_IF_COPY(traj, 1);
+  if (result == NULL)
+    PG_RETURN_NULL();
   PG_RETURN_POINTER(result);
 }
 


### PR DESCRIPTION
The trajectory-sampling algorithm for PostGIS rasters — instant iteration, bounding-box pre-filter, discrete sequence assembly — lives in MEOS as `raster_value(traj, box, sample, ctx)` in `meos/src/raster/raster_quadbin.c`, with pixel access delegated to a `raster_sample_fn` callback declared in `meos_raster.h`. Every binding inherits the algorithm with its own pixel backend: GDAL in the library, `ST_Value` in the extension.

The PG wrapper `Raster_value` supplies an `ST_Value`-backed callback and the convex-hull bounding box — pure wiring.

The raster regression suite is unchanged.