### PR TITLE
Bind the generator's class membership to the catalog predicates

### DIFF
--- a/.github/workflows/check-codegen.yml
+++ b/.github/workflows/check-codegen.yml
@@ -48,3 +48,6 @@ jobs:
 
       - name: Every SQL file is generator-governed or listed as an exception
         run: python3 tools/codegen/inherited/generate.py --coverage
+
+      - name: Class membership matches the catalog predicates
+        run: python3 tools/codegen/inherited/generate.py --classes

--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -3095,6 +3095,80 @@ def strip_banner(text: str) -> str:
 
 COVERAGE_EXCEPTIONS = HERE / "coverage_exceptions.txt"
 
+# BINDING-HEADER-PARSE-OK: this is MobilityDB's own in-repo SQL generator reading
+# the catalog it ships with, not a binding consuming meos-idl.json. The catalog is
+# the single source of truth for class membership, so the generator reads the
+# predicate bodies rather than carrying its own copy of the hierarchy.
+CLASS_PREDICATE_SOURCES = (
+    "meos/src/temporal/meos_catalog.c",
+    "meos/src/temporal/tcellindex.c",
+)
+CATALOG_NAMES = "meos/src/temporal/meos_catalog.c"
+
+
+def catalog_type_names() -> dict:
+    """`T_<X>` -> the canonical lowercase type name from the catalog name array."""
+    src = (ROOT / CATALOG_NAMES).read_text()
+    return dict(re.findall(r'\[(T_[A-Z0-9_]+)\]\s*=\s*"([^"]+)"', src))
+
+
+def parse_class_members(predicate: str, names: dict) -> list:
+    """The temporal types a catalog class predicate accepts, canonically named.
+
+    Every predicate is a flat `type == T_X || type == T_Y` disjunction, so the
+    membership is read directly off the body. Preprocessor lines are ignored: a
+    family gated behind `#if QUADBIN` is still a member of the class. Names are
+    resolved through the catalog name array, never by lowercasing the enum.
+    """
+    for rel in CLASS_PREDICATE_SOURCES:
+        src = (ROOT / rel).read_text()
+        m = re.search(r"\n" + predicate + r"\(MeosType type[^)]*\)\s*\{(.*?)\n\}",
+                      src, re.S)
+        if not m:
+            continue
+        body = "\n".join(l for l in m.group(1).splitlines()
+                         if not l.lstrip().startswith("#"))
+        out = []
+        for enum in re.findall(r"(T_[A-Z0-9_]+)", body):
+            if enum not in names:
+                raise SystemExit(f"{predicate}(): {enum} is absent from the "
+                                 f"catalog name array")
+            out.append(names[enum])
+        return out
+    raise SystemExit(f"class predicate {predicate}() not found in "
+                     f"{', '.join(CLASS_PREDICATE_SOURCES)}")
+
+
+def check_classes(mf: dict) -> int:
+    """The manifest's class membership agrees with the catalog predicates.
+
+    Membership is derived from the predicate bodies; the manifest records the
+    expected result so that adding a type to a class in MEOS fails here until
+    the generated surface follows.
+    """
+    classes = mf.get("classes") or {}
+    if not classes:
+        print("no classes: block in the manifest")
+        return 1
+    names = catalog_type_names()
+    ok = True
+    for name in sorted(classes):
+        spec = classes[name]
+        live = parse_class_members(spec["predicate"], names)
+        want = spec.get("members") or []
+        if live == want:
+            print(f"[OK  ] {name:12} {spec['predicate']:22} {len(live):2} members")
+            continue
+        ok = False
+        print(f"[DRIFT] {name:12} {spec['predicate']}")
+        print(f"        catalog : {' '.join(live)}")
+        print(f"        manifest: {' '.join(want)}")
+    if not ok:
+        print("class membership FAILED - update the manifest and the surface it drives")
+        return 1
+    print(f"class membership OK - {len(classes)} classes match the catalog")
+    return 0
+
 
 def manifest_files(mf: dict) -> set:
     """Every mobilitydb/sql path named by a manifest entry, repo-relative."""
@@ -3157,11 +3231,17 @@ def main() -> int:
     ap.add_argument("--coverage", action="store_true",
                     help="every .in.sql is manifest-governed or listed in "
                          "coverage_exceptions.txt (the list may only shrink)")
+    ap.add_argument("--classes", action="store_true",
+                    help="the manifest classes: block matches the catalog "
+                         "class predicates")
     ap.add_argument("--only", help="restrict to one temp type (e.g. tquadbin)")
     args = ap.parse_args()
 
     if args.coverage:
         return check_coverage(yaml.safe_load(MANIFEST.read_text()))
+
+    if args.classes:
+        return check_classes(yaml.safe_load(MANIFEST.read_text()))
 
     mf = yaml.safe_load(MANIFEST.read_text())
     positions = mf["positions"]

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -8674,3 +8674,37 @@ compops_families:
     - {kind: op_t, op: "#>=", proc: "tGe", L: "ttext", R: "text", comm: "#<="}
     - {kind: op_t, op: "#>=", proc: "tGe", L: "ttext", R: "ttext", comm: "#<="}
   - lit: "\n/*****************************************************************************/"
+
+# Temporal class membership, derived from the catalog class predicates.
+#
+# generate.py --classes re-reads each predicate body and fails when this
+# block disagrees, so adding a type to a class in MEOS cannot land without
+# the generated surface following it.
+classes:
+  temporal:
+    predicate: temporal_type
+    members: [tbool, tdouble2, tdouble3, tdouble4, tfloat, tint, ttext, tgeompoint, tgeogpoint, tnpoint, tpose, tcbuffer, tgeometry, tgeography, trgeometry, tjsonb, tbigint, th3index, tquadbin, tpcpoint, tpcpatch]
+  talpha:
+    predicate: talpha_type
+    members: [tbool, tdouble2, tdouble3, tdouble4, ttext, tjsonb]
+  tnumber:
+    predicate: tnumber_type
+    members: [tfloat, tint, tbigint]
+  tspatial:
+    predicate: tspatial_type
+    members: [tgeompoint, tgeogpoint, tnpoint, tpose, tcbuffer, tgeometry, tgeography, trgeometry, th3index, tquadbin]
+  tgeo:
+    predicate: tgeo_type
+    members: [tgeometry, tgeography]
+  tgeo_all:
+    predicate: tgeo_type_all
+    members: [tgeompoint, tgeogpoint, tgeometry, tgeography]
+  tpoint:
+    predicate: tpoint_type
+    members: [tgeompoint, tgeogpoint]
+  tcellindex:
+    predicate: tcellindex_type
+    members: [tquadbin]
+  tpointcloud:
+    predicate: tpointcloud_temptype
+    members: [tpcpoint, tpcpatch]


### PR DESCRIPTION
The generator has no notion of the temporal class hierarchy. Of the 107 family names in `manifest.yaml`, only `temporal`, `tnumber` and `tpoint` sit at a class level, and `tspatial` does not appear at all — so the `TSpatial<T>` surface is enumerated once per member (`spatialrel_families` holds nine family-by-operation entries such as `geo_ea_dwithin` and `cbuffer_ea_disjoint_intersects`). Widening a class costs one entry per family, and nothing ties those entries back to the catalog that defines the class.

This adds a `classes:` block recording the nine catalog classes with their predicate and members, and a `--classes` mode that re-reads each predicate body from `meos/src/temporal/meos_catalog.c` and `meos/src/temporal/tcellindex.c` and fails on any disagreement:

| class | predicate | members |
|---|---|---|
| `temporal` | `temporal_type` | 21 |
| `talpha` | `talpha_type` | 6 |
| `tnumber` | `tnumber_type` | 3 |
| `tspatial` | `tspatial_type` | 10 |
| `tgeo` / `tgeo_all` | `tgeo_type` / `tgeo_type_all` | 2 / 4 |
| `tpoint` | `tpoint_type` | 2 |
| `tcellindex` | `tcellindex_type` | 1 |
| `tpointcloud` | `tpointcloud_temptype` | 2 |

Membership is derived, never hand-copied. Type names resolve through the catalog's `[T_<X>] = "<name>"` array rather than by lowercasing the enum, and preprocessor lines are skipped so a family behind `#if QUADBIN` still counts as a member. A disagreement prints both sides:

```
[DRIFT] tspatial     tspatial_type
        catalog : … trgeometry th3index tquadbin
        manifest: … trgeometry th3index
```

This is the data a class-level axis consumes, landed on its own so the binding to the catalog is in place and checked before any behaviour moves onto it. Adding a type to a class in MEOS now fails CI until the generated surface follows.

No SQL changes: `--validate` stays at 261 families byte-for-byte, `--coverage` stays green, and the default run emits nothing.
