### PR TITLE
Move the raster restriction and predicate functions into MEOS

### DIFF
--- a/meos/include/meos_raster.h
+++ b/meos/include/meos_raster.h
@@ -123,6 +123,15 @@ typedef bool (*raster_sample_fn)(void *ctx, const GSERIALIZED *point,
 extern Temporal *raster_value(const Temporal *traj, const STBox *box,
   raster_sample_fn sample, void *ctx);
 
+extern Temporal *raster_at_value(const Temporal *traj, const STBox *box,
+  raster_sample_fn sample, void *ctx, const Span *vspan);
+extern Temporal *raster_minus_value(const Temporal *traj, const STBox *box,
+  raster_sample_fn sample, void *ctx, const Span *vspan);
+extern int eraster_value(const Temporal *traj, const STBox *box,
+  raster_sample_fn sample, void *ctx, const Span *vspan);
+extern int araster_value(const Temporal *traj, const STBox *box,
+  raster_sample_fn sample, void *ctx, const Span *vspan);
+
 extern Temporal *raster_tile_value_quadbin(const uint8_t *pixels,
   uint16_t width, uint16_t height, uint64 quadbin, MeosPixType pixtype,
   double nodata, bool has_nodata, const Temporal *traj);

--- a/meos/src/raster/raster_quadbin.c
+++ b/meos/src/raster/raster_quadbin.c
@@ -449,6 +449,156 @@ raster_value(const Temporal *traj, const STBox *box, raster_sample_fn sample,
 }
 
 /*****************************************************************************
+ * raster_at_value / raster_minus_value / eraster_value / araster_value
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_raster
+ * @brief Return a trajectory restricted to the instants where the sampled
+ * raster pixel value falls inside a float span
+ * @details Equivalent to, with @p v = #raster_value(traj, box, sample, ctx):
+ * @code
+ * atTime(traj, getTime(atSpan(v, vspan)))
+ * @endcode
+ * composed here in C (on top of #tnumber_restrict_span, #temporal_time and
+ * #temporal_restrict_tstzspanset) so that any MEOS caller supplying a
+ * @p sample callback gets the restriction, not just the PostGIS raster PG
+ * binding.
+ * @param[in] traj Trajectory (temporal geometry point)
+ * @param[in] box Bounding box of the raster used as a pre-filter, may be
+ * @p NULL
+ * @param[in] sample Callback returning the pixel value at a point
+ * @param[in] ctx Opaque context passed through to the callback
+ * @param[in] vspan Float value range (inclusive bounds)
+ * @return A trajectory restricted to the qualifying instants, or @p NULL
+ * when none qualify
+ * @csqlfn #Raster_at_value()
+ */
+Temporal *
+raster_at_value(const Temporal *traj, const STBox *box,
+  raster_sample_fn sample, void *ctx, const Span *vspan)
+{
+  VALIDATE_NOT_NULL(traj, NULL); VALIDATE_NOT_NULL((void *) sample, NULL);
+  VALIDATE_NOT_NULL(vspan, NULL);
+
+  Temporal *v = raster_value(traj, box, sample, ctx);
+  if (! v)
+    return NULL;
+  Temporal *v1 = tnumber_restrict_span(v, vspan, REST_AT);
+  pfree(v);
+  if (! v1)
+    return NULL;
+  SpanSet *ss = temporal_time(v1);
+  pfree(v1);
+  Temporal *result = temporal_restrict_tstzspanset(traj, ss, REST_AT);
+  pfree(ss);
+  return result;
+}
+
+/**
+ * @ingroup meos_raster
+ * @brief Return a trajectory restricted to the instants where the sampled
+ * raster pixel value falls outside a float span
+ * @details Equivalent to, with @p v = #raster_value(traj, box, sample, ctx):
+ * @code
+ * atTime(traj, getTime(minusSpan(v, vspan)))
+ * @endcode
+ * @param[in] traj Trajectory (temporal geometry point)
+ * @param[in] box Bounding box of the raster used as a pre-filter, may be
+ * @p NULL
+ * @param[in] sample Callback returning the pixel value at a point
+ * @param[in] ctx Opaque context passed through to the callback
+ * @param[in] vspan Float value range to exclude
+ * @return A trajectory restricted to the qualifying instants, or @p NULL
+ * when none qualify
+ * @csqlfn #Raster_minus_value()
+ */
+Temporal *
+raster_minus_value(const Temporal *traj, const STBox *box,
+  raster_sample_fn sample, void *ctx, const Span *vspan)
+{
+  VALIDATE_NOT_NULL(traj, NULL); VALIDATE_NOT_NULL((void *) sample, NULL);
+  VALIDATE_NOT_NULL(vspan, NULL);
+
+  Temporal *v = raster_value(traj, box, sample, ctx);
+  if (! v)
+    return NULL;
+  Temporal *v1 = tnumber_restrict_span(v, vspan, REST_MINUS);
+  pfree(v);
+  if (! v1)
+    return NULL;
+  SpanSet *ss = temporal_time(v1);
+  pfree(v1);
+  Temporal *result = temporal_restrict_tstzspanset(traj, ss, REST_AT);
+  pfree(ss);
+  return result;
+}
+
+/**
+ * @ingroup meos_raster
+ * @brief Return true if a trajectory ever samples a raster pixel value
+ * inside a float span
+ * @param[in] traj Trajectory (temporal geometry point)
+ * @param[in] box Bounding box of the raster used as a pre-filter, may be
+ * @p NULL
+ * @param[in] sample Callback returning the pixel value at a point
+ * @param[in] ctx Opaque context passed through to the callback
+ * @param[in] vspan Float value range
+ * @return 1 if the trajectory ever samples a value inside @p vspan, 0 if
+ * not, and -1 on error
+ * @csqlfn #Eraster_value()
+ */
+int
+eraster_value(const Temporal *traj, const STBox *box,
+  raster_sample_fn sample, void *ctx, const Span *vspan)
+{
+  VALIDATE_NOT_NULL(traj, -1); VALIDATE_NOT_NULL((void *) sample, -1);
+  VALIDATE_NOT_NULL(vspan, -1);
+
+  Temporal *v = raster_value(traj, box, sample, ctx);
+  if (! v)
+    return 0;
+  Temporal *v1 = tnumber_restrict_span(v, vspan, REST_AT);
+  pfree(v);
+  bool result = (v1 != NULL);
+  if (v1)
+    pfree(v1);
+  return result ? 1 : 0;
+}
+
+/**
+ * @ingroup meos_raster
+ * @brief Return true if every in-raster-extent instant of a trajectory
+ * samples a pixel value inside a float span
+ * @param[in] traj Trajectory (temporal geometry point)
+ * @param[in] box Bounding box of the raster used as a pre-filter, may be
+ * @p NULL
+ * @param[in] sample Callback returning the pixel value at a point
+ * @param[in] ctx Opaque context passed through to the callback
+ * @param[in] vspan Float value range
+ * @return 1 if every sampled value falls inside @p vspan, 0 if not, and -1
+ * on error
+ * @csqlfn #Araster_value()
+ */
+int
+araster_value(const Temporal *traj, const STBox *box,
+  raster_sample_fn sample, void *ctx, const Span *vspan)
+{
+  VALIDATE_NOT_NULL(traj, -1); VALIDATE_NOT_NULL((void *) sample, -1);
+  VALIDATE_NOT_NULL(vspan, -1);
+
+  Temporal *v = raster_value(traj, box, sample, ctx);
+  if (! v)
+    return 0;
+  Temporal *v1 = tnumber_restrict_span(v, vspan, REST_MINUS);
+  pfree(v);
+  bool result = (v1 == NULL);
+  if (v1)
+    pfree(v1);
+  return result ? 1 : 0;
+}
+
+/*****************************************************************************
  * trajectory_quadbins
  *****************************************************************************/
 

--- a/mobilitydb/sql/raster/500_raster.in.sql
+++ b/mobilitydb/sql/raster/500_raster.in.sql
@@ -243,10 +243,9 @@ CREATE OR REPLACE FUNCTION atRasterValue(
     rast  raster,
     vspan floatspan,
     band  integer DEFAULT 1
-) RETURNS tgeompoint AS $$
-  SELECT atTime($1, getTime(atSpan(v, $3)))
-  FROM (SELECT raster_value($2, $1, $4) AS v) t
-$$ LANGUAGE SQL STRICT;
+) RETURNS tgeompoint
+  AS 'MODULE_PATHNAME', 'Raster_at_value'
+  LANGUAGE C STRICT;
 
 /******************************************************************************
  * minusRasterValue
@@ -267,10 +266,9 @@ CREATE OR REPLACE FUNCTION minusRasterValue(
     rast  raster,
     vspan floatspan,
     band  integer DEFAULT 1
-) RETURNS tgeompoint AS $$
-  SELECT atTime($1, getTime(minusSpan(v, $3)))
-  FROM (SELECT raster_value($2, $1, $4) AS v) t
-$$ LANGUAGE SQL STRICT;
+) RETURNS tgeompoint
+  AS 'MODULE_PATHNAME', 'Raster_minus_value'
+  LANGUAGE C STRICT;
 
 /******************************************************************************
  * eRasterValue
@@ -291,9 +289,9 @@ CREATE OR REPLACE FUNCTION eRasterValue(
     traj  tgeompoint,
     vspan floatspan,
     band  integer DEFAULT 1
-) RETURNS boolean AS $$
-  SELECT atSpan(raster_value($1, $2, $4), $3) IS NOT NULL
-$$ LANGUAGE SQL STRICT;
+) RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Eraster_value'
+  LANGUAGE C STRICT;
 
 /******************************************************************************
  * aRasterValue
@@ -314,10 +312,9 @@ CREATE OR REPLACE FUNCTION aRasterValue(
     traj  tgeompoint,
     vspan floatspan,
     band  integer DEFAULT 1
-) RETURNS boolean AS $$
-  SELECT v IS NOT NULL AND minusSpan(v, $3) IS NULL
-  FROM (SELECT raster_value($1, $2, $4) AS v) t
-$$ LANGUAGE SQL STRICT;
+) RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Araster_value'
+  LANGUAGE C STRICT;
 
 /******************************************************************************
  * Accessors for raquet tiles

--- a/mobilitydb/src/raster/temporal_raster.c
+++ b/mobilitydb/src/raster/temporal_raster.c
@@ -68,6 +68,7 @@ extern text *cstring_to_text(const char *s);
 #include <meos_raster.h>      /* MeosPixType, raster_tile_value_quadbin */
 #include "geo/stbox.h"        /* PG_RETURN_STBOX_P */
 #include "raster/raquet.h"    /* Raquet, PG_GETARG_RAQUET_P, raquet_pixtype_size */
+#include "temporal/span.h"    /* PG_GETARG_SPAN_P */
 #include "temporal/tinstant.h"
 #include "temporal/tsequence.h"
 #include "temporal/type_util.h" /* bstring2bytea */
@@ -117,17 +118,6 @@ init_oids(void)
  * raster_value
  *****************************************************************************/
 
-PGDLLEXPORT Datum Raster_value(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Raster_value);
-/**
- * @ingroup mobilitydb_raster
- * @brief Return the values of a raster band sampled at the instants of a
- * trajectory
- * @param[in] rast Raster
- * @param[in] traj Trajectory
- * @param[in] band Band number (1-based, default 1)
- * @csqlfn #Raster_value()
- */
 /**
  * @brief Raster sampling callback backed by PostGIS raster's ST_Value: the
  * context is a prepared FunctionCallInfo whose raster/band/nodata/resample
@@ -147,13 +137,19 @@ raster_st_value_sample(void *ctx, const GSERIALIZED *point, double *value)
   return true;
 }
 
-Datum
-Raster_value(PG_FUNCTION_ARGS)
+/**
+ * @brief Build the convex-hull STBox pre-filter and the reusable ST_Value
+ * FunctionCallInfo shared by every raster sampling/restriction/predicate
+ * wrapper
+ * @details Arg 2 (the point) of @p fcinfo_val is left uninitialized: it is
+ * set on every call by #raster_st_value_sample. The FmgrInfo backing
+ * @p fcinfo_val is palloc'd so that its lifetime matches the calling
+ * wrapper's memory context, same as the LOCAL_FCINFO buffer itself.
+ */
+static void
+raster_value_setup(Datum rast_datum, int32 band, STBox *box,
+  FunctionCallInfo fcinfo_val)
 {
-  Datum     rast_datum = PG_GETARG_DATUM(0);
-  Temporal *traj       = PG_GETARG_TEMPORAL_P(1);
-  int32     band       = PG_ARGISNULL(2) ? 1 : PG_GETARG_INT32(2);
-
   /* OID resolution (once per session) */
   init_oids();
 
@@ -164,19 +160,16 @@ Raster_value(PG_FUNCTION_ARGS)
   GBOX         hull_box;
   gserialized_get_gbox_p(hull_gs, &hull_box);
   pfree(hull_gs);
-  STBox box;
-  memset(&box, 0, sizeof(STBox));
-  box.xmin = hull_box.xmin;
-  box.xmax = hull_box.xmax;
-  box.ymin = hull_box.ymin;
-  box.ymax = hull_box.ymax;
+  memset(box, 0, sizeof(STBox));
+  box->xmin = hull_box.xmin;
+  box->xmax = hull_box.xmax;
+  box->ymin = hull_box.ymin;
+  box->ymax = hull_box.ymax;
 
   /* Prepare a reusable FunctionCallInfo for ST_Value (handles NULL returns) */
-  FmgrInfo flinfo;
-  fmgr_info(st_value_oid, &flinfo);
-
-  LOCAL_FCINFO(fcinfo_val, 5);
-  InitFunctionCallInfoData(*fcinfo_val, &flinfo, 5,
+  FmgrInfo *flinfo = palloc0(sizeof(FmgrInfo));
+  fmgr_info(st_value_oid, flinfo);
+  InitFunctionCallInfoData(*fcinfo_val, flinfo, 5,
                            DEFAULT_COLLATION_OID, NULL, NULL);
   /* Arg 0 (raster) and Arg 1 (band) are constant for every instant */
   fcinfo_val->args[0].value  = rast_datum;
@@ -190,6 +183,29 @@ Raster_value(PG_FUNCTION_ARGS)
   /* Arg 4 (resample) = 'nearest' — PostGIS 3.6+ added this parameter */
   fcinfo_val->args[4].value  = PointerGetDatum(cstring_to_text("nearest"));
   fcinfo_val->args[4].isnull = false;
+}
+
+PGDLLEXPORT Datum Raster_value(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_value);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the values of a raster band sampled at the instants of a
+ * trajectory
+ * @param[in] rast Raster
+ * @param[in] traj Trajectory
+ * @param[in] band Band number (1-based, default 1)
+ * @csqlfn #Raster_value()
+ */
+Datum
+Raster_value(PG_FUNCTION_ARGS)
+{
+  Datum     rast_datum = PG_GETARG_DATUM(0);
+  Temporal *traj       = PG_GETARG_TEMPORAL_P(1);
+  int32     band       = PG_ARGISNULL(2) ? 1 : PG_GETARG_INT32(2);
+
+  STBox box;
+  LOCAL_FCINFO(fcinfo_val, 5);
+  raster_value_setup(rast_datum, band, &box, fcinfo_val);
 
   Temporal *result = raster_value(traj, &box, &raster_st_value_sample,
     fcinfo_val);
@@ -198,6 +214,142 @@ Raster_value(PG_FUNCTION_ARGS)
   if (result == NULL)
     PG_RETURN_NULL();
   PG_RETURN_POINTER(result);
+}
+
+/*****************************************************************************
+ * atRasterValue / minusRasterValue / eRasterValue / aRasterValue
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Raster_at_value(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_at_value);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the instants of a trajectory where the sampled raster pixel
+ * value falls inside a float range
+ * @param[in] traj Trajectory (SRID matching the raster)
+ * @param[in] rast Raster
+ * @param[in] vspan Float value range (inclusive bounds)
+ * @param[in] band Band number (1-based, default 1)
+ * @csqlfn #atRasterValue()
+ */
+Datum
+Raster_at_value(PG_FUNCTION_ARGS)
+{
+  Temporal *traj       = PG_GETARG_TEMPORAL_P(0);
+  Datum     rast_datum = PG_GETARG_DATUM(1);
+  Span     *vspan      = PG_GETARG_SPAN_P(2);
+  int32     band       = PG_ARGISNULL(3) ? 1 : PG_GETARG_INT32(3);
+
+  STBox box;
+  LOCAL_FCINFO(fcinfo_val, 5);
+  raster_value_setup(rast_datum, band, &box, fcinfo_val);
+
+  Temporal *result = raster_at_value(traj, &box, &raster_st_value_sample,
+    fcinfo_val, vspan);
+
+  PG_FREE_IF_COPY(traj, 0);
+  if (result == NULL)
+    PG_RETURN_NULL();
+  PG_RETURN_POINTER(result);
+}
+
+PGDLLEXPORT Datum Raster_minus_value(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_minus_value);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the instants of a trajectory where the sampled raster pixel
+ * value falls outside a float range
+ * @param[in] traj Trajectory (SRID matching the raster)
+ * @param[in] rast Raster
+ * @param[in] vspan Float value range to exclude
+ * @param[in] band Band number (1-based, default 1)
+ * @csqlfn #minusRasterValue()
+ */
+Datum
+Raster_minus_value(PG_FUNCTION_ARGS)
+{
+  Temporal *traj       = PG_GETARG_TEMPORAL_P(0);
+  Datum     rast_datum = PG_GETARG_DATUM(1);
+  Span     *vspan      = PG_GETARG_SPAN_P(2);
+  int32     band       = PG_ARGISNULL(3) ? 1 : PG_GETARG_INT32(3);
+
+  STBox box;
+  LOCAL_FCINFO(fcinfo_val, 5);
+  raster_value_setup(rast_datum, band, &box, fcinfo_val);
+
+  Temporal *result = raster_minus_value(traj, &box, &raster_st_value_sample,
+    fcinfo_val, vspan);
+
+  PG_FREE_IF_COPY(traj, 0);
+  if (result == NULL)
+    PG_RETURN_NULL();
+  PG_RETURN_POINTER(result);
+}
+
+PGDLLEXPORT Datum Eraster_value(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Eraster_value);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return true if a trajectory ever samples a raster pixel value
+ * inside a float range
+ * @param[in] rast Raster
+ * @param[in] traj Trajectory (SRID matching the raster)
+ * @param[in] vspan Float value range
+ * @param[in] band Band number (1-based, default 1)
+ * @csqlfn #eRasterValue()
+ */
+Datum
+Eraster_value(PG_FUNCTION_ARGS)
+{
+  Datum     rast_datum = PG_GETARG_DATUM(0);
+  Temporal *traj       = PG_GETARG_TEMPORAL_P(1);
+  Span     *vspan      = PG_GETARG_SPAN_P(2);
+  int32     band       = PG_ARGISNULL(3) ? 1 : PG_GETARG_INT32(3);
+
+  STBox box;
+  LOCAL_FCINFO(fcinfo_val, 5);
+  raster_value_setup(rast_datum, band, &box, fcinfo_val);
+
+  int result = eraster_value(traj, &box, &raster_st_value_sample,
+    fcinfo_val, vspan);
+
+  PG_FREE_IF_COPY(traj, 1);
+  if (result < 0)
+    PG_RETURN_NULL();
+  PG_RETURN_BOOL(result);
+}
+
+PGDLLEXPORT Datum Araster_value(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Araster_value);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return true if every in-raster-extent instant of a trajectory
+ * samples a pixel value inside a float range
+ * @param[in] rast Raster
+ * @param[in] traj Trajectory (SRID matching the raster)
+ * @param[in] vspan Float value range
+ * @param[in] band Band number (1-based, default 1)
+ * @csqlfn #aRasterValue()
+ */
+Datum
+Araster_value(PG_FUNCTION_ARGS)
+{
+  Datum     rast_datum = PG_GETARG_DATUM(0);
+  Temporal *traj       = PG_GETARG_TEMPORAL_P(1);
+  Span     *vspan      = PG_GETARG_SPAN_P(2);
+  int32     band       = PG_ARGISNULL(3) ? 1 : PG_GETARG_INT32(3);
+
+  STBox box;
+  LOCAL_FCINFO(fcinfo_val, 5);
+  raster_value_setup(rast_datum, band, &box, fcinfo_val);
+
+  int result = araster_value(traj, &box, &raster_st_value_sample,
+    fcinfo_val, vspan);
+
+  PG_FREE_IF_COPY(traj, 1);
+  if (result < 0)
+    PG_RETURN_NULL();
+  PG_RETURN_BOOL(result);
 }
 
 /*****************************************************************************


### PR DESCRIPTION
`atRasterValue`, `minusRasterValue`, `eRasterValue`, and `aRasterValue` compose `raster_value` with span restriction purely in SQL, so only the PostgreSQL extension can reach them — no MEOS binding inherits the restriction/predicate behavior.

This moves the composition into MEOS: `raster_at_value`, `raster_minus_value`, `eraster_value`, and `araster_value` live in `meos/src/raster/raster_quadbin.c`, parameterised the same way as `raster_value` (trajectory, bounding box, sample callback, context) plus the restricting float span. They compose the existing public restriction primitives `tnumber_restrict_span`, `temporal_time`, and `temporal_restrict_tstzspanset`. `eraster_value`/`araster_value` return `int` following the ever/always 3-valued convention (1/0/-1), mirroring the spatial-relationship predicates.

The PG wrappers in `mobilitydb/src/raster/temporal_raster.c` are thin argument-parsing and ST_Value-callback wiring over these MEOS functions, sharing the convex-hull/`FunctionCallInfo` setup with `Raster_value` through a new static helper. The SQL definitions in `500_raster.in.sql` are `LANGUAGE C` wrappers with the same signatures and semantics as before.

## Test plan
- [x] `ctest -R '(500_raster|500_raster_tbl)'` passes with the committed expected output unchanged
- [x] Clean build with `-DMEOS=off -DRASTER=on` (PG extension) and `-DMEOS=on -DRASTER=on` (MEOS standalone), zero warnings on the raster files
