### PR TITLE
Count a type as covered only where its surface is declared

### DIFF
--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -3206,8 +3206,18 @@ AXIS_RENDERERS = {
 }
 
 
+# A declaration's subject is its name and its arguments. The RETURNS clause is
+# dropped before matching: a type merely produced by a function is not covered by
+# it, or `applyPose(geometry, tpose) RETURNS tgeompoint` would report tgeompoint
+# as having a representation surface. Constructors still resolve, because there
+# the type is in the function name (`tjsonbFromBinary(bytea) RETURNS tjsonb`).
+DECLARATION = re.compile(
+    r"CREATE (?:OR REPLACE )?(?:FUNCTION|TYPE|CAST|OPERATOR)[^\n;]*", re.I)
+RETURNS_CLAUSE = re.compile(r"\bRETURNS\s+\w+", re.I)
+
+
 def rendered_temp_types(axis: str, entries: list, candidates: list) -> set:
-    """The temporal types named by the SQL an axis renders."""
+    """The temporal types an axis's rendered SQL declares a surface for."""
     render = AXIS_RENDERERS.get(axis)
     if render is None:
         return set()
@@ -3219,9 +3229,11 @@ def rendered_temp_types(axis: str, entries: list, candidates: list) -> set:
             text = render(entry)
         except Exception:
             continue
-        for temp in candidates:
-            if re.search(rf"\b{temp}\b", text):
-                out.add(temp)
+        for decl in DECLARATION.finditer(text):
+            subject = RETURNS_CLAUSE.sub("", decl.group(0))
+            for temp in candidates:
+                if temp not in out and re.search(rf"\b{temp}\b", subject):
+                    out.add(temp)
     return out
 
 


### PR DESCRIPTION
`--gaps` reads coverage from the SQL each entry renders and counts a type wherever its name appears, so a type merely *produced* by a function counts as covered by it.

`representation_families` reports `tgeompoint` as covered because the `pose` entry renders

```sql
CREATE FUNCTION applyPose(geometry, tpose)
  RETURNS tgeompoint
```

which declares no representation surface for `tgeompoint` at all — the axis has no `tpoint` entry.

This matches against a declaration's name and arguments, dropping the `RETURNS` clause. Constructors still resolve, because there the type is in the function name: `tjsonbFromBinary(bytea) RETURNS tjsonb` still counts for `tjsonb`.

Three axes carry an overcount and now report the surface they actually declare:

| axis | reports | corrected |
|---|---|---|
| `representation_families` | 17/18 | 16/18 — `tgeompoint` and `tgeogpoint` have none |
| `constructor_families` | 16/18 | 14/18 |
| `native_tempspatialrel_families` | `temporal` 2/18 | `tspatial` 1/10 |

The last row is a consequence rather than a separate change: with the spurious types gone, the smallest-containing-class lookup resolves the axis to `tspatial`, the class it belongs to.

`--validate`, `--coverage` and `--classes` are unchanged and the default run emits nothing.
