### PR TITLE
Fix the tpcbox restriction of tpcpoint and tpcpatch for boxes without every dimension

### DIFF
--- a/mobilitydb/src/pointcloud/tpcpatch.c
+++ b/mobilitydb/src/pointcloud/tpcpatch.c
@@ -198,8 +198,11 @@ pcpatch_passes_tpcbox(const Pcpatch *pa, TimestampTz t, const TPCBox *box,
 {
   if (pa->pcid != box->pcid)
     return false;
-  if (! contains_span_timestamptz(&box->period, t))
+  if (MEOS_FLAGS_GET_T(box->flags) &&
+      ! contains_span_timestamptz(&box->period, t))
     return false;
+  if (! MEOS_FLAGS_GET_X(box->flags))
+    return true;
   /* PCBOUNDS layout: {xmin, xmax, ymin, ymax} — see pc_api.h. */
   double pxmin = pa->bounds[0], pxmax = pa->bounds[1];
   double pymin = pa->bounds[2], pymax = pa->bounds[3];

--- a/mobilitydb/src/pointcloud/tpcpoint.c
+++ b/mobilitydb/src/pointcloud/tpcpoint.c
@@ -410,23 +410,29 @@ tpcpoint_restrict_tpcbox(const Temporal *temp, const TPCBox *box,
 
   /* TPCBox shares the period + xyz + srid prefix of STBox, but inserts
    * pcid before flags, so the flags byte offsets differ.  Build the
-   * STBox explicitly with X/Y/Z/T set and GEODETIC cleared. */
+   * STBox explicitly, mirroring the box's own dimension flags, with
+   * GEODETIC cleared. */
   STBox sbox;
   memset(&sbox, 0, sizeof(STBox));
-  sbox.period = box->period;
+  bool hast = MEOS_FLAGS_GET_T(box->flags);
+  if (hast)
+    sbox.period = box->period;
   sbox.xmin = box->xmin; sbox.ymin = box->ymin; sbox.zmin = box->zmin;
   sbox.xmax = box->xmax; sbox.ymax = box->ymax; sbox.zmax = box->zmax;
   sbox.srid = box->srid;
-  MEOS_FLAGS_SET_X(sbox.flags, true);
-  MEOS_FLAGS_SET_Z(sbox.flags, true);
-  MEOS_FLAGS_SET_T(sbox.flags, true);
+  MEOS_FLAGS_SET_X(sbox.flags, MEOS_FLAGS_GET_X(box->flags));
+  MEOS_FLAGS_SET_Z(sbox.flags, MEOS_FLAGS_GET_Z(box->flags));
+  MEOS_FLAGS_SET_T(sbox.flags, hast);
   MEOS_FLAGS_SET_GEODETIC(sbox.flags, false);
 
-  /* Restrict projection by the equivalent stbox. */
+  /* Restrict projection by the equivalent stbox.  An empty restriction
+   * of the pcid-matched projection is an empty result for at and minus
+   * alike: a NULL minus means no part of the value lies outside the
+   * box. */
   Temporal *tpoint_rest = tgeo_restrict_stbox(tpoint, &sbox, border_inc, atfunc);
   pfree(tpoint);
   if (! tpoint_rest)
-    return atfunc ? NULL : temporal_copy(temp);
+    return NULL;
 
   /* Lift the result's time span back onto the ORIGINAL tpcpoint to
    * recover the full pcpoint values at each surviving instant. */

--- a/mobilitydb/test/pointcloud/expected/420_tpcpoint.test.out
+++ b/mobilitydb/test/pointcloud/expected/420_tpcpoint.test.out
@@ -309,7 +309,7 @@ SELECT minusTpcbox(tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '202
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) IS NULL;
  ?column? 
 ----------
- f
+ t
 (1 row)
 
 SELECT atTpcbox(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcbox_zt(0, 0, 0, 10, 10, 10,
@@ -317,6 +317,27 @@ SELECT atTpcbox(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-0
  ?column? 
 ----------
  t
+(1 row)
+
+SELECT numInstants(atTpcbox(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]),
+  tpcbox_z(0, 0, 0, 2, 2, 2, 1)));
+ numinstants 
+-------------
+           2
+(1 row)
+
+SELECT minusTpcbox(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]),
+  tpcbox_z(0, 0, 0, 10, 10, 10, 1)) IS NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT numInstants(atTpcbox(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]),
+  tpcbox_t(tstzspan '[2024-01-01, 2024-01-02]', 1)));
+ numinstants 
+-------------
+           2
 (1 row)
 
 SELECT timeSpan(beforeTimestamp(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]),

--- a/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
+++ b/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
@@ -360,6 +360,27 @@ SELECT atTpcbox(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::fl
  t
 (1 row)
 
+SELECT numInstants(atTpcbox(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz)]),
+  tpcbox(0, 0, 3, 3, 1)));
+ numinstants 
+-------------
+           1
+(1 row)
+
+SELECT numInstants(minusTpcbox(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz)]),
+  tpcbox(0, 0, 3, 3, 1)));
+ numinstants 
+-------------
+           2
+(1 row)
+
+SELECT numInstants(atTpcbox(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz)]),
+  tpcbox_t(tstzspan '[2024-01-01, 2024-01-01]', 1)));
+ numinstants 
+-------------
+           1
+(1 row)
+
 SELECT timeSpan(beforeTimestamp(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-03'::timestamptz)]),
   timestamptz '2024-01-02'));
                            timespan                           

--- a/mobilitydb/test/pointcloud/queries/420_tpcpoint.test.sql
+++ b/mobilitydb/test/pointcloud/queries/420_tpcpoint.test.sql
@@ -162,6 +162,16 @@ SELECT minusTpcbox(:inst2, tpcbox_zt(0, 0, 0, 10, 10, 10,
 SELECT atTpcbox(:inst1, tpcbox_zt(0, 0, 0, 10, 10, 10,
   tstzspan '[2024-01-01, 2024-01-31]', 999, 0)) IS NULL;
 
+-- Boxes without every dimension: a spatial-only box restricts spatially, a
+-- temporal-only box temporally. Minus of a box covering the whole value is
+-- empty.
+SELECT numInstants(atTpcbox(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
+  tpcbox_z(0, 0, 0, 2, 2, 2, 1)));
+SELECT minusTpcbox(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
+  tpcbox_z(0, 0, 0, 10, 10, 10, 1)) IS NULL;
+SELECT numInstants(atTpcbox(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
+  tpcbox_t(tstzspan '[2024-01-01, 2024-01-02]', 1)));
+
 -- Restriction to the instants before / after a timestamp. The strict flag
 -- is true by default and excludes the instant at the timestamp itself, which
 -- on a sequence shows up as the inclusivity of the resulting time span.

--- a/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
+++ b/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
@@ -177,6 +177,15 @@ SELECT minusTpcbox(:inst1, tpcbox_zt(0, 0, 0, 10, 10, 10,
 SELECT atTpcbox(:inst1, tpcbox_zt(0, 0, 0, 10, 10, 10,
   tstzspan '[2024-01-01, 2024-01-31]', 999, 0)) IS NULL;
 
+-- Boxes without every dimension: a spatial-only box applies the PCBOUNDS
+-- test alone, a temporal-only box the period test alone.
+SELECT numInstants(atTpcbox(tpcpatchSeq(ARRAY[:inst1, :inst2]),
+  tpcbox(0, 0, 3, 3, 1)));
+SELECT numInstants(minusTpcbox(tpcpatchSeq(ARRAY[:inst1, :inst2]),
+  tpcbox(0, 0, 3, 3, 1)));
+SELECT numInstants(atTpcbox(tpcpatchSeq(ARRAY[:inst1, :inst2]),
+  tpcbox_t(tstzspan '[2024-01-01, 2024-01-01]', 1)));
+
 -- Restriction to the instants before / after a timestamp. The strict flag
 -- is true by default and excludes the instant at the timestamp itself, which
 -- on a sequence shows up as the inclusivity of the resulting time span.


### PR DESCRIPTION
A tpcbox carries any subset of the X/Z/T dimensions, but the restriction paths assume all of them are present:

- **tpcpatch — backend crash.** `atTpcbox`/`minusTpcbox` with a box lacking a time span abort the server: the per-instant predicate consults `box->period` unconditionally, and for such a box the period is a zero-initialized span, so `contains_span_timestamptz` hits its `spantype == T_TSTZSPAN` assertion. This change applies the period test only when the box has a T dimension, and the PCBOUNDS test only when it has an X dimension. Reproducer: `SELECT atTpcbox(tpcpatchSeq(...), tpcbox(0, 0, 2, 2, 1));`
- **tpcpoint — spatial-only boxes match nothing.** The STBox equivalent of the tpcbox carries the X/Z/T flags all forced on, so a box without a time span restricts against an empty period and `atTpcbox` is always empty (and a temporal-only box is likewise mishandled). This change builds the STBox mirroring the box's own dimension flags.
- **tpcpoint — minus of a covering box returns the full value.** When the restriction of a pcid-matched projection is empty, the minus path returns a copy of the whole value; an empty minus projection means nothing lies outside the box, so this change returns an empty result. This also makes the existing test `minusTpcbox(inst, covering-box) IS NULL` return true, matching its assertion; the expected output is updated accordingly.

Unit tests cover spatial-only and temporal-only boxes on both types.

Note: with a box carrying both X and T dimensions, `minusTpcbox` on tpcpoint inherits the `tgeo_restrict_stbox` minus semantics, which are addressed separately.