### PR TITLE
Bring the tpoint representation section under the inherited SQL generator

### DIFF
--- a/mobilitydb/sql/geo/053_tpoint_inout.in.sql
+++ b/mobilitydb/sql/geo/053_tpoint_inout.in.sql
@@ -33,6 +33,8 @@
  * representation
  */
 
+-- GENERATED-REPRESENTATIONS-BEGIN tpoint — tools/codegen/inherited/generate.py from templates/representations.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.yaml (representation_families) and re-run.
 /*****************************************************************************
  * Input
  *****************************************************************************/
@@ -215,3 +217,4 @@ CREATE FUNCTION asHexEWKB(tgeogpoint, endianenconding text DEFAULT '')
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************/
+-- GENERATED-REPRESENTATIONS-END tpoint

--- a/tools/codegen/inherited/coverage_exceptions.txt
+++ b/tools/codegen/inherited/coverage_exceptions.txt
@@ -5,7 +5,7 @@
 # land unnoticed. The list is a ratchet: it may only shrink. Bring a file
 # under the manifest, then delete its line here.
 #
-# 134 of 182 files remain.
+# 133 of 182 files remain.
 
 mobilitydb/sql/cbuffer/200_cbuffer.in.sql
 mobilitydb/sql/cbuffer/204_tcbuffer_compops.in.sql
@@ -18,7 +18,6 @@ mobilitydb/sql/cbuffer/212_tcbuffer_spatialrels.in.sql
 mobilitydb/sql/cbuffer/216_tcbuffer_indexes.in.sql
 mobilitydb/sql/cbuffer/217_tcbuffer_analytics.in.sql
 mobilitydb/sql/geo/051_stbox.in.sql
-mobilitydb/sql/geo/053_tpoint_inout.in.sql
 mobilitydb/sql/geo/054_tgeo_compops.in.sql
 mobilitydb/sql/geo/054_tpoint_compops.in.sql
 mobilitydb/sql/geo/056_tgeo_spatialfuncs.in.sql

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -1357,10 +1357,6 @@ representation_families:
     - FromBinary
     - FromHexWKB
     - FromMFJSON
-# tjsonb interleaves CREATE CASTs with the representation wrappers (text <-> tjsonb
-# round-trip via FromText/asText, with one commented-out jsonb cast kept verbatim);
-# its asMFJSON is the one single-line signature (mfjson_oneline) and FromText backs
-# onto the plain Temporal_from_text (no spatial E-forms).
 - family: json
   file: mobilitydb/sql/json/452_tjsonb.in.sql
   reference: true
@@ -1379,7 +1375,7 @@ representation_families:
   - lit: "/*****************************************************************************\n * Input/output from WKT, WKB, HexWKB, and MFJSON representation\n *****************************************************************************/"
   - ops:
     - FromText
-  - lit: "CREATE CAST (text AS tjsonb) WITH FUNCTION tjsonbFromText(text);"
+  - lit: CREATE CAST (text AS tjsonb) WITH FUNCTION tjsonbFromText(text);
   - ops:
     - FromBinary
     - FromHexWKB
@@ -1387,15 +1383,13 @@ representation_families:
   - lit: /*****************************************************************************/
   - ops:
     - asText
-  - lit: "-- CREATE CAST (jsonb AS text) WITH FUNCTION asText(jsonb);\nCREATE CAST (tjsonb AS text) WITH FUNCTION asText(tjsonb);"
+  - lit: '-- CREATE CAST (jsonb AS text) WITH FUNCTION asText(jsonb);
+
+      CREATE CAST (tjsonb AS text) WITH FUNCTION asText(tjsonb);'
   - ops:
     - asMFJSON
     - asBinary
     - asHexWKB
-# tpose interleaves its GeoPose exchange-format trio (tposeFromGeoPose / asGeoPose /
-# applyPose, pose-specific OGC GeoPose I/O, not part of the inherited surface) between
-# the From-text and From-binary runs; the section banner is indented by two spaces in
-# the hand file. Both are kept verbatim as lits.
 - family: pose
   file: mobilitydb/sql/pose/102_tpose.in.sql
   reference: true
@@ -1432,11 +1426,6 @@ representation_families:
     - asBinary
     - asEWKB
     - asHexEWKB
-# The pointcloud types have no coordinate text form (a pcpoint/pcpatch prints as the
-# hex-WKB of its serialized form), so asText takes no maxdecimaldigits and there is
-# no FromText/FromMFJSON (asMFJSON is output-only) — a base-type capability. The
-# WKB run and the rationale comments abut their functions with no blank line (fused
-# lit items), reproduced verbatim.
 - family: pointcloud
   file: mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
   reference: true
@@ -1456,11 +1445,25 @@ representation_families:
       - FromHexWKB
       - asBinary
       - asHexWKB
-      - lit: "-- asMFJSON is output-only: the JSON form summarises a tpcpoint by\n-- (coordinates, datetimes) without carrying the schema (pcid + dim\n-- layout) needed to reconstruct the value, so a parse-back path is\n-- intentionally not exposed. Use asBinary / tpcpointFromBinary or\n-- asHexWKB / tpcpointFromHexWKB for round-trip."
+      - lit: '-- asMFJSON is output-only: the JSON form summarises a tpcpoint by
+
+          -- (coordinates, datetimes) without carrying the schema (pcid + dim
+
+          -- layout) needed to reconstruct the value, so a parse-back path is
+
+          -- intentionally not exposed. Use asBinary / tpcpointFromBinary or
+
+          -- asHexWKB / tpcpointFromHexWKB for round-trip.'
       - asMFJSON
-    - - lit: "-- asText takes no maxdecimaldigits argument: a pcpoint prints as the hex-WKB\n-- of its serialized form, which has no decimal places to round. This mirrors\n-- th3index, the other spatial temporal type whose base value has no\n-- coordinate text form."
+    - - lit: '-- asText takes no maxdecimaldigits argument: a pcpoint prints as the hex-WKB
+
+          -- of its serialized form, which has no decimal places to round. This mirrors
+
+          -- th3index, the other spatial temporal type whose base value has no
+
+          -- coordinate text form.'
       - asText
-  - lit: "CREATE CAST (tpcpoint AS text) WITH FUNCTION asText(tpcpoint);"
+  - lit: CREATE CAST (tpcpoint AS text) WITH FUNCTION asText(tpcpoint);
 - family: pointcloud_patch
   file: mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
   reference: true
@@ -1480,24 +1483,71 @@ representation_families:
       - FromHexWKB
       - asBinary
       - asHexWKB
-      - lit: "-- asMFJSON is output-only: the JSON form summarises a tpcpatch by\n-- (pcid, npoints, bounds) per instant without carrying the per-point\n-- payload, so a parse-back path is intentionally not exposed. Use\n-- asBinary / tpcpatchFromBinary or asHexWKB / tpcpatchFromHexWKB for\n-- round-trip."
-      - asMFJSON
-    - - lit: "-- asText takes no maxdecimaldigits argument: a pcpatch prints as the hex-WKB\n-- of its serialized form, which has no decimal places to round. This mirrors\n-- th3index, the other spatial temporal type whose base value has no\n-- coordinate text form."
-      - asText
-  - lit: "CREATE CAST (tpcpatch AS text) WITH FUNCTION asText(tpcpatch);"
+      - lit: '-- asMFJSON is output-only: the JSON form summarises a tpcpatch by
 
-# ---------------------------------------------------------------------------
-# Constructors sub-family (SQL, per-family region-in-file).
-# <temp>(<base>, timestamptz|tstzset|tstzspan|tstzspanset) + the array constructors
-# <temp>Seq/<temp>SeqSet/<temp>SeqSetGaps, all pure wiring to the generic
-# Tinstant_constructor / Tsequence_from_base_* / Tsequenceset_from_base_* /
-# Tsequence_constructor / Tsequenceset_constructor / Tsequenceset_constructor_gaps
-# kernels. Built from ONE skeleton (templates/constructors.sql.tmpl); the per-family
-# op sequence, interpolation default, base-span interp arg, SeqSetGaps arg list +
-# strictness, section-header literals and per-op/per-type symbol + return overrides
-# are data here. `--validate` extracts the committed hand block by section-header
-# anchors (begin/end) so the deployed .in.sql is untouched while the template is
-# proven.
+          -- (pcid, npoints, bounds) per instant without carrying the per-point
+
+          -- payload, so a parse-back path is intentionally not exposed. Use
+
+          -- asBinary / tpcpatchFromBinary or asHexWKB / tpcpatchFromHexWKB for
+
+          -- round-trip.'
+      - asMFJSON
+    - - lit: '-- asText takes no maxdecimaldigits argument: a pcpatch prints as the hex-WKB
+
+          -- of its serialized form, which has no decimal places to round. This mirrors
+
+          -- th3index, the other spatial temporal type whose base value has no
+
+          -- coordinate text form.'
+      - asText
+  - lit: CREATE CAST (tpcpatch AS text) WITH FUNCTION asText(tpcpatch);
+- family: tpoint
+  file: mobilitydb/sql/geo/053_tpoint_inout.in.sql
+  reference: true
+  whole_file: true
+  begin: "\n * Input\n"
+  temps:
+  - temp: tgeompoint
+    maxdd: true
+  - temp: tgeogpoint
+    maxdd: true
+  syms:
+    FromText: Tpoint_from_ewkt
+    FromEWKT: Tpoint_from_ewkt
+    asText: Tspatial_as_text
+    asEWKT: Tspatial_as_ewkt
+    asEWKB: Tspatial_as_ewkb
+    asHexEWKB: Tspatial_as_hexewkb
+  arrsyms:
+    asText: Spatialarr_as_text
+    asEWKT: Spatialarr_as_ewkt
+  blocks:
+  - lit: "/*****************************************************************************\n * Input\n *****************************************************************************/"
+  - ops:
+    - FromText
+    - FromEWKT
+    - FromMFJSON
+    - FromBinary
+    - FromEWKB
+    - FromHexEWKB
+  - lit: "/*****************************************************************************\n * Output\n *****************************************************************************/"
+  - ops:
+    - asText
+  - lit: "CREATE FUNCTION asText(geometry[], maxdecimaldigits int4 DEFAULT 15)\n  RETURNS text[]\n  AS 'MODULE_PATHNAME', 'Spatialarr_as_text'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION asText(geography[], maxdecimaldigits int4 DEFAULT 15)\n  RETURNS text[]\n  AS 'MODULE_PATHNAME', 'Spatialarr_as_text'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;"
+  - ops:
+    - asEWKT
+  - lit: "-- Single base geometry/geography EWKT. In the PostgreSQL extension this rewrites\n-- to PostGIS ST_AsEWKT; the standalone MEOS library and the generated bindings\n-- back the same asEWKT(geometry) surface with the geo_as_ewkt() kernel. Together\n-- with transform(geometry, integer) this lets one portable generator/suite use\n-- MobilityDB names (asEWKT, transform) instead of PostGIS-only ST_AsEWKT/ST_Transform.\nCREATE FUNCTION asEWKT(geometry, maxdecimaldigits int4 DEFAULT 15)\n  RETURNS text\n  AS 'SELECT @extschema@.ST_AsEWKT($1, $2)'\n  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION asEWKT(geography, maxdecimaldigits int4 DEFAULT 15)\n  RETURNS text\n  AS 'SELECT @extschema@.ST_AsEWKT($1, $2)'\n  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE FUNCTION asEWKT(geometry[], maxdecimaldigits int4 DEFAULT 15)\n  RETURNS text[]\n  AS 'MODULE_PATHNAME', 'Spatialarr_as_ewkt'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION asEWKT(geography[], maxdecimaldigits int4 DEFAULT 15)\n  RETURNS text[]\n  AS 'MODULE_PATHNAME', 'Spatialarr_as_ewkt'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;"
+  - ops:
+    - asMFJSON
+    - asBinary
+    - asEWKB
+  - ops:
+    - - lit: "-- asHexWKB: base hex-WKB (variant 0, no SRID) \u2014 portable RFC #861 name,\n-- byte-for-byte identical to MobilityDuck asHexWKB and MobilitySpark asHexWKB."
+      - asHexWKB
+    - - lit: "-- asHexEWKB: extended hex-WKB (WKB_EXTENDED flag, includes SRID) \u2014\n-- mirrors asEWKB() and is consistent with MobilityDuck asHexEWKB."
+      - asHexEWKB
+  - lit: /*****************************************************************************/
 constructor_families:
 - family: geo
   file: mobilitydb/sql/geo/052_tgeo.in.sql


### PR DESCRIPTION
`representation_families` covers every temporal type except `tgeompoint` and `tgeogpoint`, which `--gaps` reports as the members of `Temporal<T>` the axis does not reach. Their surface lives in its own file, `053_tpoint_inout.in.sql`, which no manifest entry names.

This adds a `tpoint` entry re-rendering that file byte-for-byte under `--validate`: the `From{Text,EWKT,MFJSON,Binary,EWKB,HexEWKB}` constructors and the `as{Text,EWKT,MFJSON,Binary,EWKB,HexWKB,HexEWKB}` output functions over both types, with their array variants.

Four differences from the geo sibling are encoded rather than smoothed away:

- `FromText` and `FromEWKT` are backed by `Tpoint_from_ewkt`, where geo uses `Tspatial_from_ewkt`; the `as*` symbols are the shared `Tspatial_as_*` ones.
- The file carries base-type array overloads geo has no equivalent of — `asText(geometry[])` and `asText(geography[])` — sitting between the temporal `asText` run and `asEWKT`.
- `asEWKT(geometry)` and `asEWKT(geography)` are `LANGUAGE SQL` rewrites to PostGIS `ST_AsEWKT`, with their C array variants and the rationale comment explaining why the MobilityDB name is offered alongside the PostGIS one.
- The `asHexWKB` and `asHexEWKB` rationale comments abut their functions with no blank line, so each is fused with its op rather than standing as its own block — the form the pointcloud entries already use, since blocks are joined with a blank line between them.

The section gains its `GENERATED-REPRESENTATIONS` markers: three added lines, nothing removed, no function line changed.

`--validate` goes from 262 to 263 families with 0 DIFF, and:

```
[18/18] representation_families        temporal     missing: -
```

The file leaves `coverage_exceptions.txt`, which drops to 133 — the ratchet fails until that line goes, which is how it is meant to work.
