### PR TITLE
Avoid the gnu_printf format attribute under Clang in meos_error.h

### DIFF
--- a/meos/include/meos_error.h
+++ b/meos/include/meos_error.h
@@ -59,11 +59,14 @@ extern void meos_error(int errlevel, int errcode, const char *format, ...)
  * Give meos_error printf-style format checking. In the PostgreSQL-backed
  * build pg_attribute_printf is available and selects the gnu_printf
  * archetype (correct on MinGW, where the default printf archetype is MS
- * semantics). This public header is also consumed standalone, where that
- * macro may not be in scope, so fall back to the gnu_printf attribute
- * directly under GCC/Clang, and to nothing on compilers that lack it.
+ * semantics). Clang is excluded from that path because it rejects the
+ * gnu_printf archetype with -Wignored-attributes; it takes the plain
+ * printf archetype below instead. This public header is also consumed
+ * standalone, where the macro may not be in scope, so fall back to the
+ * gnu_printf attribute directly under GCC, plain printf under Clang, and
+ * to nothing on compilers that lack it.
  */
-#if defined(pg_attribute_printf)
+#if defined(pg_attribute_printf) && !defined(__clang__)
   pg_attribute_printf(3, 4);
 #elif defined(__GNUC__) && !defined(__clang__)
   __attribute__((format(gnu_printf, 3, 4)));


### PR DESCRIPTION
In a PostgreSQL-backed build compiled with Clang, `pg_attribute_printf` is in scope and expands to the `gnu_printf` archetype, which Clang rejects with `-Wignored-attributes` (`'format' attribute argument not supported: gnu_printf`). Guarding that branch with `!defined(__clang__)` lets Clang fall through to the plain `printf` archetype it already uses in the standalone path, keeping `meos_error` format checking live without the warning. GCC and standalone builds are unchanged (the guard only alters which branch Clang takes).
