### PR TITLE
Bring the base temporal restriction section under the inherited SQL generator

### DIFF
--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -2263,6 +2263,18 @@ def bootstrap_conversions(filetext: str, fam: dict, rendered: str) -> str:
 # the `lit` blocks, the funcs end with their own trailing newline), so the rendered text
 # is byte-identical to the committed region — the conversion-surface model.
 #
+# The base Temporal<T> file (022_temporal) declares the SAME restriction chunk for EVERY
+# base type, function-outer / type-inner (all five types' atValue, then all five types'
+# minusValue, ...), with three presence classes: every type carries the value/time
+# restrictions, only the orderable types (`orderable: true` — tint/tbigint/tfloat/ttext)
+# carry atValues/minusValues and the min/max reductions, and only the numeric types
+# (`numeric: true` — tint/tbigint/tfloat) carry the span/spanset/tbox restrictions —
+# the same per-base-type `types:` token table and presence flags as the accessor
+# multi-base-type mode. A `gen` block is one such chunk: its `sig`/`ret` carry
+# {TEMP}/{BASE}/{SET}/{SPAN}/{SPANSET} tokens expanded once per type in the pool that
+# its `presence` (all/orderable/numeric, default all) selects. Single-type families
+# spell their wrappers explicitly in `fns` blocks and are untouched by this mode.
+#
 # `--validate` extracts the committed hand block by section-header ANCHORS (marker-aware,
 # mirroring extract_conversions: sliced by GENERATED-RESTRICTIONS markers once they exist,
 # else by the Restriction banner header down to the `/*` of the next non-restriction
@@ -2288,18 +2300,41 @@ def _restr_skeleton(sig: str, ret: str, sym: str, strict: bool, pre: str) -> str
                 .replace("{STRICT}", " STRICT" if strict else "").rstrip("\n"))
 
 
+def _restr_sub(text: str, t: dict) -> str:
+    """Substitute one base type's tokens into a `gen` chunk's sig/ret. {SPANSET} before
+    {SPAN} so the longer token is never clipped by the shorter one's replacement."""
+    return (text.replace("{SPANSET}", t.get("spanset", ""))
+                .replace("{SPAN}", t.get("span", ""))
+                .replace("{SET}", t.get("set", ""))
+                .replace("{BASE}", t.get("base", ""))
+                .replace("{TEMP}", t["temp"]))
+
+
 def render_restrictions(fam: dict) -> str:
     """Render one family's restriction block from its `blocks` sequence. A block is a
     verbatim `lit` (the section banners, blank lines, commented-out placeholders and any
-    multi-line-signature wrapper, kept exactly as the hand file) or a `fns` list (the
+    multi-line-signature wrapper, kept exactly as the hand file), a `fns` list (the
     restriction CREATE FUNCTIONs rendered from the shared skeleton, packed with no blank
-    line and closed by one trailing newline). Blocks concatenate with no automatic
-    separator — every separator is baked into the `lit` blocks — so the rendered text is
-    byte-identical to the committed region (the conversion-surface model)."""
+    line and closed by one trailing newline), or — for the base Temporal<T> multi-base-type
+    mode — a `gen` chunk (ONE function expanded over the family's `types:` pool that its
+    `presence` class selects, packed like a `fns` list). Blocks concatenate with no
+    automatic separator — every separator is baked into the `lit` blocks — so the rendered
+    text is byte-identical to the committed region (the conversion-surface model)."""
+    types = fam.get("types") or []
+    pools = {"all": types,
+             "numeric": [t for t in types if t.get("numeric")],
+             "orderable": [t for t in types if t.get("orderable")]}
     out = ""
     for blk in fam["blocks"]:
         if "lit" in blk:
             out += blk["lit"]
+        elif "gen" in blk:
+            g = blk["gen"]
+            out += "\n".join(_restr_skeleton(_restr_sub(g["sig"], t),
+                                             _restr_sub(g.get("ret", "{TEMP}"), t),
+                                             g["sym"], g.get("strict", True),
+                                             g.get("pre", ""))
+                             for t in pools[g.get("presence", "all")]) + "\n"
         else:
             out += "\n".join(_restr_skeleton(f["sig"], f["ret"], f["sym"],
                                              f.get("strict", True), f.get("pre", ""))

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -3347,6 +3347,73 @@ conversion_families:
     - {sig: "geometry(trgeometry)", ret: geometry, sym: Trgeometry_to_geom}
   - lit: "\nCREATE CAST (trgeometry AS geometry) WITH FUNCTION geometry(trgeometry);\n\n"
 restriction_families:
+# The base Temporal<T> file declares the restriction surface for EVERY base type,
+# function-outer / type-inner; `types:` (per-base-type tokens) selects the `gen`
+# chunk mode, whose presence classes gate each function on the accessor-mode flags:
+# every type carries the value/time restrictions, `orderable` (tint/tbigint/tfloat/
+# ttext) adds atValues/minusValues and the min/max reductions, `numeric`
+# (tint/tbigint/tfloat) adds the span/spanset/tbox restrictions.
+- family: temporal
+  file: mobilitydb/sql/temporal/022_temporal.in.sql
+  reference: true
+  begin: "\n * Restriction functions\n"
+  end: "\n * Modification Functions\n"
+  types:
+  - {temp: tbool,   base: boolean}
+  - {temp: tint,    base: integer, set: intset,    span: intspan,    spanset: intspanset,    numeric: true, orderable: true}
+  - {temp: tbigint, base: bigint,  set: bigintset, span: bigintspan, spanset: bigintspanset, numeric: true, orderable: true}
+  - {temp: tfloat,  base: float,   set: floatset,  span: floatspan,  spanset: floatspanset,  numeric: true, orderable: true}
+  - {temp: ttext,   base: text,    set: textset,   orderable: true}
+  blocks:
+  - lit: "/*****************************************************************************\n * Restriction functions\n *****************************************************************************/\n\n"
+  - gen: {sig: "atValue({TEMP}, {BASE})", sym: Temporal_at_value}
+  - lit: "\n"
+  - gen: {sig: "minusValue({TEMP}, {BASE})", sym: Temporal_minus_value}
+  - lit: "\n"
+  - gen: {sig: "atValues({TEMP}, {SET})", sym: Temporal_at_values, presence: orderable}
+  - lit: "\n"
+  - gen: {sig: "minusValues({TEMP}, {SET})", sym: Temporal_minus_values, presence: orderable}
+  - lit: "\n"
+  - gen: {sig: "atSpan({TEMP}, {SPAN})", sym: Tnumber_at_span, presence: numeric}
+  - lit: "\n"
+  - gen: {sig: "minusSpan({TEMP}, {SPAN})", sym: Tnumber_minus_span, presence: numeric}
+  - lit: "\n"
+  - gen: {sig: "atSpanset({TEMP}, {SPANSET})", sym: Tnumber_at_spanset, presence: numeric}
+  - lit: "\n"
+  - gen: {sig: "minusSpanset({TEMP}, {SPANSET})", sym: Tnumber_minus_spanset, presence: numeric}
+  - lit: "\n"
+  - gen: {sig: "atMin({TEMP})", sym: Temporal_at_min, presence: orderable}
+  - lit: "\n"
+  - gen: {sig: "minusMin({TEMP})", sym: Temporal_minus_min, presence: orderable}
+  - lit: "\n"
+  - gen: {sig: "atMax({TEMP})", sym: Temporal_at_max, presence: orderable}
+  - lit: "\n"
+  - gen: {sig: "minusMax({TEMP})", sym: Temporal_minus_max, presence: orderable}
+  - lit: "\n"
+  - gen: {sig: "atTbox({TEMP}, tbox)", sym: Tnumber_at_tbox, presence: numeric}
+  - lit: "\n"
+  - gen: {sig: "minusTbox({TEMP}, tbox)", sym: Tnumber_minus_tbox, presence: numeric}
+  - lit: "\n"
+  - gen: {sig: "atTime({TEMP}, timestamptz)", sym: Temporal_at_timestamptz}
+  - lit: "\n"
+  - gen: {sig: "minusTime({TEMP}, timestamptz)", sym: Temporal_minus_timestamptz}
+  - lit: "\n"
+  - gen: {sig: "atTime({TEMP}, tstzset)", sym: Temporal_at_tstzset}
+  - lit: "\n"
+  - gen: {sig: "minusTime({TEMP}, tstzset)", sym: Temporal_minus_tstzset}
+  - lit: "\n"
+  - gen: {sig: "atTime({TEMP}, tstzspan)", sym: Temporal_at_tstzspan}
+  - lit: "\n"
+  - gen: {sig: "minusTime({TEMP}, tstzspan)", sym: Temporal_minus_tstzspan}
+  - lit: "\n"
+  - gen: {sig: "atTime({TEMP}, tstzspanset)", sym: Temporal_at_tstzspanset}
+  - lit: "\n"
+  - gen: {sig: "minusTime({TEMP}, tstzspanset)", sym: Temporal_minus_tstzspanset}
+  - lit: "\n"
+  - gen: {sig: "beforeTimestamp({TEMP}, timestamptz, strict bool DEFAULT TRUE)", sym: Temporal_before_timestamptz}
+  - lit: "\n"
+  - gen: {sig: "afterTimestamp({TEMP}, timestamptz, strict bool DEFAULT TRUE)", sym: Temporal_after_timestamptz}
+  - lit: "\n"
 - family: geo
   file: mobilitydb/sql/geo/052_tgeo.in.sql
   reference: true


### PR DESCRIPTION
Governs the restriction section of `022_temporal.in.sql` (102 `CREATE FUNCTION`s over tbool/tint/tbigint/tfloat/ttext, `atValue`…`afterTimestamp`) under the inherited SQL generator (`restriction_families`), proven byte-for-byte by `generate.py --validate`.

Adds a `gen` chunk mode to the restriction renderer for the base Temporal<T> multi-base-type file: one function expanded over the family's per-base-type `types:` table, gated by the same `numeric`/`orderable` presence flags as the accessor multi-base-type mode. Every base type carries the value and time restrictions; the orderable types (tint/tbigint/tfloat/ttext) add `atValues`/`minusValues` and the min/max reductions; the numeric types (tint/tbigint/tfloat) add the span/spanset/tbox restrictions. Single-type families keep their explicit `fns` blocks and stay byte-identical.

Carries no `.in.sql` line changes: the family is `reference: true`, validate-only, like the other twelve restriction families. `--gaps` reports `restriction_families` 18/18; `--coverage` and `--classes` stay green.