### PR TITLE
Bring the base temporal modification section under the inherited SQL generator

### DIFF
--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -2398,15 +2398,24 @@ def bootstrap_restrictions(filetext: str, fam: dict, rendered: str) -> str:
 # with their own trailing newline), so the rendered text is byte-identical to the
 # committed region — the conversion-surface model.
 #
+# The base Temporal<T> file (022_temporal) declares the SAME modification chunk for EVERY
+# base type, function-outer / type-inner (all five types' insert, then all five types'
+# update, ...). Unlike the restriction surface, no orderable/numeric gating applies to
+# this chunk — every base type carries the same insert/update/deleteTime wrappers — but
+# the family keeps the same per-base-type `types:` token table and presence-pool
+# mechanism (all/orderable/numeric) as the restriction and accessor multi-base-type
+# modes for consistency. A `gen` block is one such chunk: its `sig`/`ret` carry a {TEMP}
+# token expanded once per type in the pool that its `presence` (all/orderable/numeric,
+# default all) selects. Single-type and dual-type families spell their wrappers
+# explicitly in `fns` blocks and are untouched by this mode.
+#
 # `--validate` extracts the committed hand block by section-header ANCHORS
 # (marker-aware, mirroring extract_conversions: sliced by GENERATED-MODIFICATIONS
 # markers once they exist, else by the Modification banner header down to the `/*` of
 # the next section, or — when the family sets `raw_end` because its hand file runs the
 # tiling material straight after deleteTime with no separating banner (th3index,
 # tquadbin) — down to the exact `end` anchor text itself), so the deployed .in.sql
-# files are untouched while the template is proven. The base temporal file
-# (022_temporal.in.sql) keeps its hand block: its region interleaves the tbool/tint/
-# tfloat/ttext quartet, left for the template-class pass.
+# files are untouched while the template is proven.
 def _modifications_markers(family: str):
     begin = (f"-- GENERATED-MODIFICATIONS-BEGIN {family} — "
              "tools/codegen/inherited/generate.py from templates/modifications.sql.tmpl;\n"
@@ -2425,18 +2434,36 @@ def _modif_skeleton(sig: str, ret: str, sym: str, strict: bool, pre: str) -> str
                 .replace("{STRICT}", " STRICT" if strict else "").rstrip("\n"))
 
 
+def _modif_sub(text: str, t: dict) -> str:
+    """Substitute one base type's {TEMP} token into a `gen` chunk's sig/ret."""
+    return text.replace("{TEMP}", t["temp"])
+
+
 def render_modifications(fam: dict) -> str:
     """Render one family's modification block from its `blocks` sequence. A block is a
     verbatim `lit` (the section banners, blank lines and comment lines, kept exactly as
-    the hand file) or a `fns` list (the modification CREATE FUNCTIONs rendered from the
-    shared skeleton, packed with no blank line and closed by one trailing newline).
-    Blocks concatenate with no automatic separator — every separator is baked into the
-    `lit` blocks — so the rendered text is byte-identical to the committed region (the
-    conversion-surface model)."""
+    the hand file), a `fns` list (the modification CREATE FUNCTIONs rendered from the
+    shared skeleton, packed with no blank line and closed by one trailing newline), or —
+    for the base Temporal<T> multi-base-type mode — a `gen` chunk (ONE function expanded
+    over the family's `types:` pool that its `presence` class selects, packed like a
+    `fns` list). Blocks concatenate with no automatic separator — every separator is
+    baked into the `lit` blocks — so the rendered text is byte-identical to the
+    committed region (the conversion-surface model)."""
+    types = fam.get("types") or []
+    pools = {"all": types,
+             "numeric": [t for t in types if t.get("numeric")],
+             "orderable": [t for t in types if t.get("orderable")]}
     out = ""
     for blk in fam["blocks"]:
         if "lit" in blk:
             out += blk["lit"]
+        elif "gen" in blk:
+            g = blk["gen"]
+            out += "\n".join(_modif_skeleton(_modif_sub(g["sig"], t),
+                                             _modif_sub(g.get("ret", "{TEMP}"), t),
+                                             g["sym"], g.get("strict", True),
+                                             g.get("pre", ""))
+                             for t in pools[g.get("presence", "all")]) + "\n"
         else:
             out += "\n".join(_modif_skeleton(f["sig"], f["ret"], f["sym"],
                                              f.get("strict", True), f.get("pre", ""))

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -3970,6 +3970,37 @@ setfamilies:
   - {set: pcpointset, base: pcpoint,     ordered: false,                         metric: false, spatial: false}
   - {set: pcpatchset, base: pcpatch,     ordered: false,                         metric: false, spatial: false}
 modification_families:
+# The base Temporal<T> file declares the modification surface for EVERY base type,
+# function-outer / type-inner; `types:` (per-base-type tokens) selects the `gen` chunk
+# mode. Every type carries the SAME insert/update/deleteTime wrappers — no orderable/
+# numeric gating applies to this surface, but the family keeps the same per-base-type
+# `types:` table and presence-pool mechanism as the restriction and accessor
+# multi-base-type modes for consistency.
+- family: temporal
+  file: mobilitydb/sql/temporal/022_temporal.in.sql
+  reference: true
+  begin: "\n * Modification Functions\n"
+  end: "\n * Segment Duration Functions\n"
+  types:
+  - {temp: tbool}
+  - {temp: tint,    numeric: true, orderable: true}
+  - {temp: tbigint, numeric: true, orderable: true}
+  - {temp: tfloat,  numeric: true, orderable: true}
+  - {temp: ttext,   orderable: true}
+  blocks:
+  - lit: "/*****************************************************************************\n * Modification Functions\n *****************************************************************************/\n\n"
+  - gen: {sig: "insert({TEMP}, {TEMP}, connect boolean DEFAULT TRUE)", sym: Temporal_insert}
+  - lit: "\n"
+  - gen: {sig: "update({TEMP}, {TEMP}, connect boolean DEFAULT TRUE)", sym: Temporal_update}
+  - lit: "\n"
+  - gen: {sig: "deleteTime({TEMP}, timestamptz, connect boolean DEFAULT TRUE)", sym: Temporal_delete_timestamptz}
+  - lit: "\n"
+  - gen: {sig: "deleteTime({TEMP}, tstzset, connect boolean DEFAULT TRUE)", sym: Temporal_delete_tstzset}
+  - lit: "\n"
+  - gen: {sig: "deleteTime({TEMP}, tstzspan, connect boolean DEFAULT TRUE)", sym: Temporal_delete_tstzspan}
+  - lit: "\n"
+  - gen: {sig: "deleteTime({TEMP}, tstzspanset, connect boolean DEFAULT TRUE)", sym: Temporal_delete_tstzspanset}
+  - lit: "\n"
 - family: geo
   file: mobilitydb/sql/geo/052_tgeo.in.sql
   reference: true


### PR DESCRIPTION
Governs the modification section of `022_temporal.in.sql` (30 `CREATE FUNCTION`s over tbool/tint/tbigint/tfloat/ttext, `insert`/`update`/`deleteTime`) under the inherited SQL generator (`modification_families`), proven byte-for-byte by `generate.py --validate`.

Adds a `gen` chunk mode to the modification renderer for the base Temporal<T> multi-base-type file, mirroring the restriction renderer's `gen` mode from #1703: one function expanded over the family's per-base-type `types:` table. Every base type carries the same six wrappers — insert/update/deleteTime(timestamptz)/deleteTime(tstzset)/deleteTime(tstzspan)/deleteTime(tstzspanset) — with no orderable/numeric gating needed, but the family keeps the same per-base-type `types:` table and presence-pool mechanism as the restriction and accessor multi-base-type modes for consistency. The other eleven modification families keep their explicit `fns` blocks and stay byte-identical.

Carries no `.in.sql` line changes: the family is `reference: true`, validate-only, like the other eleven modification families. `--gaps` reports `modification_families` 18/18; `--coverage` and `--classes` stay green.
