### PR TITLE
Bring the base temporal transformation section under the inherited SQL generator

### DIFF
--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -1088,6 +1088,18 @@ def bootstrap_constructors(filetext: str, fam: dict, rendered: str) -> str:
 # reproduced byte-exact. A dual-base family (geo/tpoint) lists both temporal types in
 # `temps` and scopes the per-type Inst/Seq/SeqSet blocks with a block-level `temps`.
 #
+# The base Temporal<T> file (022_temporal) ALSO declares a numeric-only Tnumber value
+# transform trio (shiftValue/scaleValue/shiftScaleValue) whose argument type is the
+# base value domain itself (integer/bigint/float), not a CORE-op fixed type — so it
+# does not fit the `ops` mechanism (which binds fixed non-temporal argument types) and
+# instead uses a `gen` chunk (mirroring the restriction/modification multi-base-type
+# mode): one function expanded over the family's `types:` token table, gated by the
+# same `numeric`/`orderable` presence flags, with `{TEMP}`/`{BASE}` tokens in its
+# `sig`/`ret`. The Seq/SeqSet casts and the odd-indent merge(T,T) overload keep their
+# irregularities (SeqSet's tfloat-only interpolation arg; merge's stray extra indent
+# on tfloat/ttext) as explicit `fns`/`lit` blocks rather than forcing them through
+# either mechanism.
+#
 # Region markers for the eventual Phase-2 emit (mirroring _constructors_markers);
 # Phase-1 --validate extracts the committed hand block by section-header ANCHORS
 # (marker-aware) so the deployed .in.sql files are untouched while the template is
@@ -1174,16 +1186,28 @@ def _xform_ops_block(blk: dict, fam: dict) -> str:
     return "\n".join(_xform_op_fn(op, fam, t) for op in blk["ops"] for t in temps)
 
 
+def _xform_sub(text: str, t: dict) -> str:
+    """Substitute one base type's tokens into a `gen` chunk's sig/ret."""
+    return text.replace("{BASE}", t.get("base", "")).replace("{TEMP}", t["temp"])
+
+
 def render_transformations(fam: dict) -> str:
     """Render one family's transformation block from its `blocks` sequence. A block is
     a verbatim `lit` (a section header/divider/prose comment or a byte-irregular
     function kept exactly as the hand file), an `ops` list (CORE transforms rendered
-    from the family flags/temps, packed with no blank), or an explicit `fns` list (the
-    family-EXTRA overloads: expand/round/appendInstant/appendSequence/merge). Blocks are
-    separated by one blank line, except a `glue` block joins with a single newline (the
-    cbuffer/json dividers whose preceding line carries two trailing spaces, and rgeo's
-    trailing commented-out tsample). The block ends with the blank line that precedes the
-    next section (the section-header anchor slice)."""
+    from the family flags/temps, packed with no blank), an explicit `fns` list (the
+    family-EXTRA overloads: expand/round/appendInstant/appendSequence/merge), or — for
+    the base Temporal<T> multi-base-type mode — a `gen` chunk (ONE function expanded
+    over the family's `types:` pool that its `presence` class selects, mirroring the
+    restriction/modification gen mode). Blocks are separated by one blank line, except
+    a `glue` block joins with a single newline (the cbuffer/json dividers whose
+    preceding line carries two trailing spaces, and rgeo's trailing commented-out
+    tsample). The block ends with the blank line that precedes the next section (the
+    section-header anchor slice)."""
+    types = fam.get("types") or []
+    pools = {"all": types,
+             "numeric": [t for t in types if t.get("numeric")],
+             "orderable": [t for t in types if t.get("orderable")]}
     parts = []
     for blk in fam["blocks"]:
         if "lit" in blk:
@@ -1192,6 +1216,13 @@ def render_transformations(fam: dict) -> str:
             text = "\n".join(_xform_skeleton(f["sig"], f["ret"], f["sym"],
                                              f.get("strict", True), f.get("pre", ""))
                              for f in blk["fns"])
+        elif "gen" in blk:
+            g = blk["gen"]
+            text = "\n".join(_xform_skeleton(_xform_sub(g["sig"], t),
+                                             _xform_sub(g.get("ret", "{TEMP}"), t),
+                                             g["sym"], g.get("strict", True),
+                                             g.get("pre", ""))
+                             for t in pools[g.get("presence", "all")])
         else:
             text = _xform_ops_block(blk, fam)
         parts.append((blk.get("glue", False), text))

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -1860,6 +1860,175 @@ constructor_families:
       ret: trgeometry
       sym: Trgeometry_constructor
 transformation_families:
+# The base Temporal<T> file declares the transformation surface for EVERY base type,
+# op-outer / type-inner. Most CORE ops (Inst/setInterp/shiftTime/scaleTime/
+# shiftScaleTime/tsample) fit the `ops` mechanism unmodified over the family's flat
+# `temps:` list (tprecision restricts to the numeric `temps:` override, tint/tbigint/
+# tfloat). The Seq/SeqSet casts spell their five wrappers as explicit `fns` (SeqSet's
+# tfloat overload alone carries the interpolation arg, a genuine hand-file asymmetry;
+# and only their first wrapper carries the `-- The function is not strict` comment,
+# which the generic `ops` per-type pre marker cannot express). The numeric-only
+# shiftValue/scaleValue/shiftScaleValue trio (whose argument is the type's own base
+# value domain, not a fixed CORE-op type) uses a `gen` chunk over the family's
+# `types:` token table (mirroring the restriction/modification multi-base-type mode),
+# gated `presence: numeric`. merge(T, T)'s tfloat/ttext overloads carry a stray extra
+# `AS` indent in the hand file, reproduced verbatim as a `lit` block.
+- family: temporal
+  file: mobilitydb/sql/temporal/022_temporal.in.sql
+  reference: true
+  begin: "\n * Transformation functions\n"
+  end: "\n * Restriction functions\n"
+  temps:
+  - tbool
+  - tint
+  - tbigint
+  - tfloat
+  - ttext
+  types:
+  - {temp: tbool}
+  - {temp: tint,    base: integer, numeric: true, orderable: true}
+  - {temp: tbigint, base: bigint,  numeric: true, orderable: true}
+  - {temp: tfloat,  base: float,   numeric: true, orderable: true}
+  - {temp: ttext,   orderable: true}
+  blocks:
+  - lit: "/******************************************************************************\n * Transformation functions\n ******************************************************************************/"
+  - ops:
+    - inst
+  - fns:
+    - sig: tboolSeq(tbool, text DEFAULT NULL)
+      ret: tbool
+      sym: Temporal_as_tsequence
+      strict: false
+      pre: '-- The function is not strict
+
+        '
+    - sig: tintSeq(tint, text DEFAULT NULL)
+      ret: tint
+      sym: Temporal_as_tsequence
+      strict: false
+    - sig: tbigintSeq(tbigint, text DEFAULT NULL)
+      ret: tbigint
+      sym: Temporal_as_tsequence
+      strict: false
+    - sig: tfloatSeq(tfloat, text DEFAULT NULL)
+      ret: tfloat
+      sym: Temporal_as_tsequence
+      strict: false
+    - sig: ttextSeq(ttext, text DEFAULT NULL)
+      ret: ttext
+      sym: Temporal_as_tsequence
+      strict: false
+  - fns:
+    - sig: tboolSeqSet(tbool)
+      ret: tbool
+      sym: Temporal_as_tsequenceset
+      strict: false
+      pre: '-- The function is not strict
+
+        '
+    - sig: tintSeqSet(tint)
+      ret: tint
+      sym: Temporal_as_tsequenceset
+      strict: false
+    - sig: tbigintSeqSet(tbigint)
+      ret: tbigint
+      sym: Temporal_as_tsequenceset
+      strict: false
+    - sig: tfloatSeqSet(tfloat, text DEFAULT NULL)
+      ret: tfloat
+      sym: Temporal_as_tsequenceset
+      strict: false
+    - sig: ttextSeqSet(ttext)
+      ret: ttext
+      sym: Temporal_as_tsequenceset
+      strict: false
+  - ops:
+    - setInterp
+  - lit: /******************************************************************************/
+  - gen: {sig: "shiftValue({TEMP}, {BASE})", sym: Tnumber_shift_value, presence: numeric}
+  - gen: {sig: "scaleValue({TEMP}, {BASE})", sym: Tnumber_scale_value, presence: numeric}
+  - gen: {sig: "shiftScaleValue({TEMP}, {BASE}, {BASE})", sym: Tnumber_shift_scale_value, presence: numeric}
+  - lit: /******************************************************************************/
+  - ops:
+    - shiftTime
+  - ops:
+    - scaleTime
+  - ops:
+    - shiftScaleTime
+  - ops:
+    - tprecision
+    temps:
+    - tint
+    - tbigint
+    - tfloat
+  - ops:
+    - tsample
+  - lit: /******************************************************************************/
+  - fns:
+    - sig: appendInstant(tbool, tbool)
+      ret: tbool
+      sym: Temporal_append_tinstant
+    - sig: appendInstant(tint, tint)
+      ret: tint
+      sym: Temporal_append_tinstant
+    - sig: appendInstant(tbigint, tbigint)
+      ret: tbigint
+      sym: Temporal_append_tinstant
+    - sig: appendInstant(tfloat, tfloat)
+      ret: tfloat
+      sym: Temporal_append_tinstant
+    - sig: appendInstant(ttext, ttext)
+      ret: ttext
+      sym: Temporal_append_tinstant
+  - fns:
+    - sig: appendInstant(tbool, tbool, interp text)
+      ret: tbool
+      sym: Temporal_append_tinstant
+    - sig: appendInstant(tint, tint, interp text)
+      ret: tint
+      sym: Temporal_append_tinstant
+    - sig: appendInstant(tbigint, tbigint, interp text)
+      ret: tbigint
+      sym: Temporal_append_tinstant
+    - sig: appendInstant(tfloat, tfloat, interp text)
+      ret: tfloat
+      sym: Temporal_append_tinstant
+    - sig: appendInstant(ttext, ttext, interp text)
+      ret: ttext
+      sym: Temporal_append_tinstant
+  - fns:
+    - sig: appendSequence(tbool, tbool)
+      ret: tbool
+      sym: Temporal_append_tsequence
+    - sig: appendSequence(tint, tint)
+      ret: tint
+      sym: Temporal_append_tsequence
+    - sig: appendSequence(tbigint, tbigint)
+      ret: tbigint
+      sym: Temporal_append_tsequence
+    - sig: appendSequence(tfloat, tfloat)
+      ret: tfloat
+      sym: Temporal_append_tsequence
+    - sig: appendSequence(ttext, ttext)
+      ret: ttext
+      sym: Temporal_append_tsequence
+  - lit: "-- The function is not strict\nCREATE FUNCTION merge(tbool, tbool)\n  RETURNS tbool\n  AS 'MODULE_PATHNAME', 'Temporal_merge'\n  LANGUAGE C IMMUTABLE PARALLEL SAFE;\nCREATE FUNCTION merge(tint, tint)\n  RETURNS tint\n  AS 'MODULE_PATHNAME', 'Temporal_merge'\n  LANGUAGE C IMMUTABLE PARALLEL SAFE;\nCREATE FUNCTION merge(tbigint, tbigint)\n  RETURNS tbigint\n  AS 'MODULE_PATHNAME', 'Temporal_merge'\n  LANGUAGE C IMMUTABLE PARALLEL SAFE;\nCREATE FUNCTION merge(tfloat, tfloat)\n  RETURNS tfloat\n    AS 'MODULE_PATHNAME', 'Temporal_merge'\n  LANGUAGE C IMMUTABLE PARALLEL SAFE;\nCREATE FUNCTION merge(ttext, ttext)\n  RETURNS ttext\n    AS 'MODULE_PATHNAME', 'Temporal_merge'\n  LANGUAGE C IMMUTABLE PARALLEL SAFE;"
+  - fns:
+    - sig: merge(tbool[])
+      ret: tbool
+      sym: Temporal_merge_array
+    - sig: merge(tint[])
+      ret: tint
+      sym: Temporal_merge_array
+    - sig: merge(tbigint[])
+      ret: tbigint
+      sym: Temporal_merge_array
+    - sig: merge(tfloat[])
+      ret: tfloat
+      sym: Temporal_merge_array
+    - sig: merge(ttext[])
+      ret: ttext
+      sym: Temporal_merge_array
 - family: geo
   file: mobilitydb/sql/geo/052_tgeo.in.sql
   reference: true


### PR DESCRIPTION
Governs the transformation section of `022_temporal.in.sql` (77 `CREATE FUNCTION`s over tbool/tint/tbigint/tfloat/ttext — the `Inst`/`Seq`/`SeqSet` casts, `setInterp`, `shiftValue`/`scaleValue`/`shiftScaleValue`, `shiftTime`/`scaleTime`/`shiftScaleTime`, `tprecision`, `tsample`, `appendInstant`/`appendSequence`, `merge`) under the inherited SQL generator (`transformation_families`), proven byte-for-byte by `generate.py --validate`.

Most CORE ops (`Inst`/`setInterp`/`shiftTime`/`scaleTime`/`shiftScaleTime`/`tsample`) render through the existing `ops` mechanism unmodified over the family's flat `temps:` list; `tprecision` restricts to a numeric-only `temps:` override (tint/tbigint/tfloat). The `Seq`/`SeqSet` casts spell their five wrappers as explicit `fns` blocks: `SeqSet`'s tfloat overload alone carries an interpolation argument (a genuine hand-file asymmetry no other type shares), and only the first wrapper of each carries the `-- The function is not strict` comment, which the generic `ops` per-type marker cannot express.

Provides a `gen` chunk mode in the transformation renderer for the numeric-only `shiftValue`/`scaleValue`/`shiftScaleValue` trio, whose argument is the type's own base value domain (integer/bigint/float) rather than a fixed CORE-op type: one function expanded over the family's per-base-type `types:` table, gated `presence: numeric`, in the style of the restriction/modification multi-base-type `gen` mode. `merge(T, T)`'s tfloat/ttext overloads carry a stray extra `AS` indent in the hand file, reproduced verbatim as a `lit` block. The other eleven transformation families keep their explicit `ops`/`fns` blocks and stay byte-identical.

Carries no `.in.sql` line changes: the family is `reference: true`, validate-only, like the other eleven transformation families. `--gaps` reports `transformation_families` 18/18 (restriction_families and modification_families stay 18/18); `--coverage` and `--classes` stay green.