### PR TITLE
Fix the insert functions miswired to Temporal_update and the geodetic insert signatures

### DIFF
--- a/mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
+++ b/mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
@@ -593,7 +593,7 @@ CREATE FUNCTION stops(tcbuffer, maxdist float DEFAULT 0.0,
 
 CREATE FUNCTION insert(tcbuffer, tcbuffer, connect boolean DEFAULT TRUE)
   RETURNS tcbuffer
-  AS 'MODULE_PATHNAME', 'Temporal_update'
+  AS 'MODULE_PATHNAME', 'Temporal_insert'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION update(tcbuffer, tcbuffer, connect boolean DEFAULT TRUE)

--- a/mobilitydb/sql/geo/052_tgeo.in.sql
+++ b/mobilitydb/sql/geo/052_tgeo.in.sql
@@ -771,11 +771,11 @@ CREATE FUNCTION afterTimestamp(tgeography, timestamptz, strict bool DEFAULT TRUE
 
 CREATE FUNCTION insert(tgeometry, tgeometry, connect boolean DEFAULT TRUE)
   RETURNS tgeometry
-  AS 'MODULE_PATHNAME', 'Temporal_update'
+  AS 'MODULE_PATHNAME', 'Temporal_insert'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION insert(tgeography, tgeometry, connect boolean DEFAULT TRUE)
+CREATE FUNCTION insert(tgeography, tgeography, connect boolean DEFAULT TRUE)
   RETURNS tgeography
-  AS 'MODULE_PATHNAME', 'Temporal_update'
+  AS 'MODULE_PATHNAME', 'Temporal_insert'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION update(tgeometry, tgeometry, connect boolean DEFAULT TRUE)

--- a/mobilitydb/sql/geo/052_tpoint.in.sql
+++ b/mobilitydb/sql/geo/052_tpoint.in.sql
@@ -772,11 +772,11 @@ CREATE FUNCTION afterTimestamp(tgeogpoint, timestamptz, strict bool DEFAULT TRUE
 
 CREATE FUNCTION insert(tgeompoint, tgeompoint, connect boolean DEFAULT TRUE)
   RETURNS tgeompoint
-  AS 'MODULE_PATHNAME', 'Temporal_update'
+  AS 'MODULE_PATHNAME', 'Temporal_insert'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION insert(tgeogpoint, tgeompoint, connect boolean DEFAULT TRUE)
+CREATE FUNCTION insert(tgeogpoint, tgeogpoint, connect boolean DEFAULT TRUE)
   RETURNS tgeogpoint
-  AS 'MODULE_PATHNAME', 'Temporal_update'
+  AS 'MODULE_PATHNAME', 'Temporal_insert'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION update(tgeompoint, tgeompoint, connect boolean DEFAULT TRUE)

--- a/mobilitydb/sql/npoint/302_tnpoint.in.sql
+++ b/mobilitydb/sql/npoint/302_tnpoint.in.sql
@@ -562,7 +562,7 @@ CREATE FUNCTION stops(tnpoint, maxdist float DEFAULT 0.0,
 
 CREATE FUNCTION insert(tnpoint, tnpoint, connect boolean DEFAULT TRUE)
   RETURNS tnpoint
-  AS 'MODULE_PATHNAME', 'Temporal_update'
+  AS 'MODULE_PATHNAME', 'Temporal_insert'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION update(tnpoint, tnpoint, connect boolean DEFAULT TRUE)

--- a/mobilitydb/sql/pose/102_tpose.in.sql
+++ b/mobilitydb/sql/pose/102_tpose.in.sql
@@ -625,7 +625,7 @@ CREATE FUNCTION stops(tpose, maxdist float DEFAULT 0.0,
 
 CREATE FUNCTION insert(tpose, tpose, connect boolean DEFAULT TRUE)
   RETURNS tpose
-  AS 'MODULE_PATHNAME', 'Temporal_update'
+  AS 'MODULE_PATHNAME', 'Temporal_insert'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION update(tpose, tpose, connect boolean DEFAULT TRUE)

--- a/mobilitydb/sql/rgeo/150_trgeo.in.sql
+++ b/mobilitydb/sql/rgeo/150_trgeo.in.sql
@@ -589,7 +589,7 @@ CREATE FUNCTION stops(trgeometry, maxdist float DEFAULT 0.0,
 
 CREATE FUNCTION insert(trgeometry, trgeometry, connect boolean DEFAULT TRUE)
   RETURNS trgeometry
-  AS 'MODULE_PATHNAME', 'Temporal_update'
+  AS 'MODULE_PATHNAME', 'Temporal_insert'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION update(trgeometry, trgeometry, connect boolean DEFAULT TRUE)

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -4009,8 +4009,8 @@ modification_families:
   blocks:
   - lit: "/*****************************************************************************\n * Modification Functions\n *****************************************************************************/\n\n"
   - fns:
-    - {sig: "insert(tgeometry, tgeometry, connect boolean DEFAULT TRUE)", ret: "tgeometry", sym: "Temporal_update"}
-    - {sig: "insert(tgeography, tgeometry, connect boolean DEFAULT TRUE)", ret: "tgeography", sym: "Temporal_update"}
+    - {sig: "insert(tgeometry, tgeometry, connect boolean DEFAULT TRUE)", ret: "tgeometry", sym: "Temporal_insert"}
+    - {sig: "insert(tgeography, tgeography, connect boolean DEFAULT TRUE)", ret: "tgeography", sym: "Temporal_insert"}
   - lit: "\n"
   - fns:
     - {sig: "update(tgeometry, tgeometry, connect boolean DEFAULT TRUE)", ret: "tgeometry", sym: "Temporal_update"}
@@ -4040,8 +4040,8 @@ modification_families:
   blocks:
   - lit: "/*****************************************************************************\n * Modification Functions\n *****************************************************************************/\n\n"
   - fns:
-    - {sig: "insert(tgeompoint, tgeompoint, connect boolean DEFAULT TRUE)", ret: "tgeompoint", sym: "Temporal_update"}
-    - {sig: "insert(tgeogpoint, tgeompoint, connect boolean DEFAULT TRUE)", ret: "tgeogpoint", sym: "Temporal_update"}
+    - {sig: "insert(tgeompoint, tgeompoint, connect boolean DEFAULT TRUE)", ret: "tgeompoint", sym: "Temporal_insert"}
+    - {sig: "insert(tgeogpoint, tgeogpoint, connect boolean DEFAULT TRUE)", ret: "tgeogpoint", sym: "Temporal_insert"}
   - lit: "\n"
   - fns:
     - {sig: "update(tgeompoint, tgeompoint, connect boolean DEFAULT TRUE)", ret: "tgeompoint", sym: "Temporal_update"}
@@ -4071,7 +4071,7 @@ modification_families:
   blocks:
   - lit: "/*****************************************************************************\n * Modification Functions\n *****************************************************************************/\n\n"
   - fns:
-    - {sig: "insert(tcbuffer, tcbuffer, connect boolean DEFAULT TRUE)", ret: "tcbuffer", sym: "Temporal_update"}
+    - {sig: "insert(tcbuffer, tcbuffer, connect boolean DEFAULT TRUE)", ret: "tcbuffer", sym: "Temporal_insert"}
   - lit: "\n"
   - fns:
     - {sig: "update(tcbuffer, tcbuffer, connect boolean DEFAULT TRUE)", ret: "tcbuffer", sym: "Temporal_update"}
@@ -4155,7 +4155,7 @@ modification_families:
   blocks:
   - lit: "/*****************************************************************************\n * Modification Functions\n *****************************************************************************/\n\n"
   - fns:
-    - {sig: "insert(tnpoint, tnpoint, connect boolean DEFAULT TRUE)", ret: "tnpoint", sym: "Temporal_update"}
+    - {sig: "insert(tnpoint, tnpoint, connect boolean DEFAULT TRUE)", ret: "tnpoint", sym: "Temporal_insert"}
   - lit: "\n"
   - fns:
     - {sig: "update(tnpoint, tnpoint, connect boolean DEFAULT TRUE)", ret: "tnpoint", sym: "Temporal_update"}
@@ -4216,7 +4216,7 @@ modification_families:
   blocks:
   - lit: "/*****************************************************************************\n * Modification Functions\n *****************************************************************************/\n\n"
   - fns:
-    - {sig: "insert(tpose, tpose, connect boolean DEFAULT TRUE)", ret: "tpose", sym: "Temporal_update"}
+    - {sig: "insert(tpose, tpose, connect boolean DEFAULT TRUE)", ret: "tpose", sym: "Temporal_insert"}
   - lit: "\n"
   - fns:
     - {sig: "update(tpose, tpose, connect boolean DEFAULT TRUE)", ret: "tpose", sym: "Temporal_update"}
@@ -4269,7 +4269,7 @@ modification_families:
   blocks:
   - lit: "/*****************************************************************************\n * Modification Functions\n *****************************************************************************/\n\n"
   - fns:
-    - {sig: "insert(trgeometry, trgeometry, connect boolean DEFAULT TRUE)", ret: "trgeometry", sym: "Temporal_update"}
+    - {sig: "insert(trgeometry, trgeometry, connect boolean DEFAULT TRUE)", ret: "trgeometry", sym: "Temporal_insert"}
   - lit: "\n"
   - fns:
     - {sig: "update(trgeometry, trgeometry, connect boolean DEFAULT TRUE)", ret: "trgeometry", sym: "Temporal_update"}


### PR DESCRIPTION
## Summary

Fixes insert(ttype, ttype, connect) to bind to Temporal_insert instead of Temporal_update across six families: tgeometry/tgeography, tgeompoint/tgeogpoint, tcbuffer, tnpoint, trgeometry, and tpose. Temporal_insert merges the second temporal value into the first without removing any existing instant, erroring when the two values disagree at a shared instant. Temporal_update instead removes the first value's overlap with the second before merging, an upsert. The update() and deleteTime() functions declared next to each insert() already bind to their correct symbols.

Corrects two geodetic overloads' second argument to match every sibling two-argument modification function in these files, which takes the same type on both sides: insert(tgeography, tgeography, connect) and insert(tgeogpoint, tgeogpoint, connect). The update() overload immediately below each already uses this same-type form.

Keeps tools/codegen/inherited/manifest.yaml's modification_families entries byte-identical to the corresponding blocks in mobilitydb/sql/geo/052_tgeo.in.sql, mobilitydb/sql/geo/052_tpoint.in.sql, mobilitydb/sql/cbuffer/202_tcbuffer.in.sql, mobilitydb/sql/npoint/302_tnpoint.in.sql, mobilitydb/sql/rgeo/150_trgeo.in.sql, and mobilitydb/sql/pose/102_tpose.in.sql.

## Scope

- mobilitydb/sql/geo/052_tgeo.in.sql: insert(tgeometry, tgeometry, ...) and insert(tgeography, tgeography, ...) bind to Temporal_insert
- mobilitydb/sql/geo/052_tpoint.in.sql: insert(tgeompoint, tgeompoint, ...) and insert(tgeogpoint, tgeogpoint, ...) bind to Temporal_insert
- mobilitydb/sql/cbuffer/202_tcbuffer.in.sql: insert(tcbuffer, tcbuffer, ...) binds to Temporal_insert
- mobilitydb/sql/npoint/302_tnpoint.in.sql: insert(tnpoint, tnpoint, ...) binds to Temporal_insert
- mobilitydb/sql/rgeo/150_trgeo.in.sql: insert(trgeometry, trgeometry, ...) binds to Temporal_insert
- mobilitydb/sql/pose/102_tpose.in.sql: insert(tpose, tpose, ...) binds to Temporal_insert

## Test plan

- No test in the SQL test suite calls insert() on tgeometry, tgeography, tgeompoint, tgeogpoint, tcbuffer, tnpoint, trgeometry, or tpose, so this change adds no new expected-output file.