### PR TITLE
Include the standard definitions header in the public MEOS header

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -37,6 +37,7 @@
 
 /* C */
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 /* PostgreSQL */
 #if MEOS


### PR DESCRIPTION
The public header declares the allocator callbacks and the well-known binary functions in terms of the standard size type, while the generated header that consumers include replaces the PostgreSQL includes with the standalone definitions, which bring in only the fixed-width integer types. Including `<stddef.h>` makes a translation unit whose only include is `<meos.h>` compile, where it otherwise stops at `unknown type name 'size_t'` on the allocator typedefs.

Checked by compiling, against an isolated install prefix, one translation unit containing only `#include <meos.h>` and another containing only `#include <meos_geo.h>`, both with `-Wall -Wextra`.

The installed header is written at configure time, so the change reaches the installed copy after cmake runs again, not after a plain build.