### PR TITLE
Bring the base temporal tiling section under the inherited SQL generator

### DIFF
--- a/tools/codegen/inherited/coverage_exceptions.txt
+++ b/tools/codegen/inherited/coverage_exceptions.txt
@@ -127,7 +127,6 @@ mobilitydb/sql/rgeo/175_trgeo_geom_clip.in.sql
 mobilitydb/sql/rgeo/176_trgeo_vclip.in.sql
 mobilitydb/sql/temporal/019_geo_constructors.in.sql
 mobilitydb/sql/temporal/021_tbox.in.sql
-mobilitydb/sql/temporal/025_temporal_tile.in.sql
 mobilitydb/sql/temporal/028_tbool_boolops.in.sql
 mobilitydb/sql/temporal/029_ttext_textfuncs.in.sql
 mobilitydb/sql/temporal/032_temporal_boxops.in.sql

--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -2939,12 +2939,25 @@ def bootstrap_aggregates(filetext: str, fam: dict, rendered: str) -> str:
 # _tile and 445_tpcpoint_tile delegate through dollar-quoted `LANGUAGE SQL ... AS $$
 # <body> $$;` cast chains instead of the `AS '<sym-or-select>'` one-liner — a `body`
 # fn entry (the verbatim dollar-quoted SQL) selects templates/tiling_delegate.sql
-# .tmpl instead. TWO tiling homes remain absent from the manifest because they don't
-# anchor on the "Multidimensional tiling" section header at all: 025_temporal_tile
-# groups the alpha base-type quartet (the template-class pass, the 022_temporal
-# precedent), and th3index/tquadbin run their bannerless time_<temp>/timeSplit
-# material straight after the modification block with no section header to anchor.
-# Both are classified out by omission from the data, never by a code-level skip.
+# .tmpl instead. 025_temporal_tile groups the base-type quintet (tbool/tint/tbigint/
+# tfloat/ttext) function-outer / type-inner, the 022_temporal restriction/modification
+# precedent: a `gen` chunk (ONE function expanded over the family's `types:` pool that
+# its `presence` class selects — `all` every type, `numeric` tint/tbigint/tfloat only)
+# with {TEMP}/{BASE}/{BASEFULL}/{SPAN}/{VDEF} tokens in its sig/ret (`_tiling_sub`,
+# mirroring `_restr_sub`); the non-multiplied span/tbox-generic bins()/getBin()/
+# valueTiles()/timeTiles()/valueTimeTiles()/getValueTile()/getTBoxTimeTile()/
+# getValueTimeTile() functions that precede/interleave the per-type groups appear
+# exactly once each, so they stay verbatim `lit` text rather than going through a
+# `gen`/`fns` skeleton. th3index/tquadbin carry the SAME time_<temp>/timeSplit
+# material as the single/dual-type spatial families above (a `lit` composite type +
+# one `fns` timeSplit + the spans()/splitNSpans()/splitEachNSpans() trio also present
+# in the json/tjsonb family) but run it straight after the Modification block with NO
+# "Multidimensional tiling" section header to anchor on — `begin_exact: true` anchors
+# the family's `begin` string (the literal `CREATE TYPE time_th3index AS (` text) at
+# its own index instead of backing up to a preceding `/*` comment open, mirroring the
+# comparison/hash/setops/topops/posops axes' `begin_exact`/`end_exact` convention; the
+# `end` anchor (the "Comparison functions and B-tree / hash indexing" banner) still
+# resolves by the default backward `/*` search since that IS a real banner.
 def _tiling_markers(family: str):
     begin = (f"-- GENERATED-TILING-BEGIN {family} — "
              "tools/codegen/inherited/generate.py from templates/tiling.sql.tmpl;\n"
@@ -2980,18 +2993,43 @@ def _tiling_skeleton(f: dict, fam: dict = None) -> str:
                 .replace("{LANG}", lang).rstrip("\n"))
 
 
+def _tiling_sub(text: str, t: dict) -> str:
+    """Substitute one base type's tokens into a `gen` chunk's sig/ret, mirroring
+    `_restr_sub`. {BASEFULL} before {BASE} so the longer token is never clipped by
+    the shorter one's replacement."""
+    return (text.replace("{BASEFULL}", t.get("basefull", ""))
+                .replace("{BASE}", t.get("base", ""))
+                .replace("{SPAN}", t.get("span", ""))
+                .replace("{VDEF}", t.get("vdef", ""))
+                .replace("{TEMP}", t["temp"]))
+
+
 def render_tiling(fam: dict) -> str:
     """Render one family's tiling block from its `blocks` sequence. A block is a
     verbatim `lit` (the section banners, CREATE TYPE statements and blank lines, kept
-    exactly as the hand file) or a `fns` list (the tiling CREATE FUNCTIONs rendered
+    exactly as the hand file), a `fns` list (the tiling CREATE FUNCTIONs rendered
     from the shared skeleton, packed with no blank line and closed by one trailing
-    newline). Blocks concatenate with no automatic separator — every separator is
-    baked into the `lit` blocks — so the rendered text is byte-identical to the
-    committed region (the conversion-surface model)."""
+    newline), or — for the base Temporal<T> multi-base-type mode (025_temporal_tile)
+    — a `gen` chunk (ONE function expanded over the family's `types:` pool that its
+    `presence` class selects, packed like a `fns` list, mirroring render_restrictions).
+    Blocks concatenate with no automatic separator — every separator is baked into
+    the `lit` blocks — so the rendered text is byte-identical to the committed region
+    (the conversion-surface model)."""
+    types = fam.get("types") or []
+    pools = {"all": types, "numeric": [t for t in types if t.get("numeric")]}
     out = ""
     for blk in fam["blocks"]:
         if "lit" in blk:
             out += blk["lit"]
+        elif "gen" in blk:
+            g = blk["gen"]
+            items = []
+            for t in pools[g.get("presence", "all")]:
+                f = dict(g)
+                f["sig"] = _tiling_sub(g["sig"], t)
+                f["ret"] = _tiling_sub(g.get("ret", "{TEMP}"), t)
+                items.append(_tiling_skeleton(f, fam))
+            out += "\n".join(items) + "\n"
         else:
             out += "\n".join(_tiling_skeleton(f, fam) for f in blk["fns"]) + "\n"
     return out
@@ -3002,14 +3040,16 @@ def extract_tiling(filetext: str, fam: dict) -> str:
     region exists, slice between its markers; otherwise slice from the `/*` opening
     the tiling banner (found via the family's `begin` anchor) down to EOF for a
     whole-file family, or to the `/*` opening the next section (the family's `end`
-    anchor), mirroring extract_representations."""
+    anchor), mirroring extract_representations. `begin_exact` (th3index/tquadbin,
+    whose timeSplit material has no "Multidimensional tiling" banner to back up to)
+    anchors `begin` at its own index instead, mirroring the comparison/hash axes."""
     begin, end = _tiling_markers(fam["family"])
     if begin in filetext:
         b = filetext.index(begin) + len(begin)
         e = filetext.index(end)
         return filetext[b:e]
     i = filetext.index(fam["begin"])
-    start = filetext.rfind("/*", 0, i)
+    start = i if fam.get("begin_exact") else filetext.rfind("/*", 0, i)
     if fam.get("whole_file"):
         return filetext[start:len(filetext)]
     j = filetext.index(fam["end"])
@@ -3030,7 +3070,7 @@ def bootstrap_tiling(filetext: str, fam: dict, rendered: str) -> str:
     the reference/splice path owns the region. Not run while the families are
     reference-only (validate-only)."""
     i = filetext.index(fam["begin"])
-    start = filetext.rfind("/*", 0, i)
+    start = i if fam.get("begin_exact") else filetext.rfind("/*", 0, i)
     begin_m, end_m = _tiling_markers(fam["family"])
     if fam.get("whole_file"):
         return filetext[:start] + begin_m + rendered + end_m

--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -8454,6 +8454,59 @@ tiling_families:
     - {sig: "spaceTimeSplit(tpcpoint, size float, interval,\n    sorigin geometry DEFAULT 'Point(0 0 0)',\n    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,\n    borderInc boolean DEFAULT TRUE)", ret: "SETOF point_time_tpcpoint", body: "    SELECT @extschema@.spaceTimeSplit($1, $2, $2, $2, $3, $4, $5, $6, $7)"}
     - {sig: "spaceTimeSplit(tpcpoint, xsize float, ysize float, interval,\n    sorigin geometry DEFAULT 'Point(0 0 0)',\n    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,\n    borderInc boolean DEFAULT TRUE)", ret: "SETOF point_time_tpcpoint", body: "    SELECT @extschema@.spaceTimeSplit($1, $2, $3, $2, $4, $5, $6, $7, $8)"}
   - lit: "\n/*****************************************************************************/"
+- family: temporal
+  file: mobilitydb/sql/temporal/025_temporal_tile.in.sql
+  reference: true
+  whole_file: true
+  begin: "@brief Bin and tile functions for temporal types"
+  types:
+  - {temp: tbool}
+  - {temp: tint, base: int, basefull: integer, span: intspan, vdef: "0", numeric: true}
+  - {temp: tbigint, base: bigint, basefull: bigint, span: bigintspan, vdef: "0", numeric: true}
+  - {temp: tfloat, base: float, basefull: float, span: floatspan, vdef: "0.0", numeric: true}
+  - {temp: ttext}
+  blocks:
+  - lit: "/**\n * @file\n * @brief Bin and tile functions for temporal types\n * @note The time bin function are inspired from TimescaleDB\n * https://docs.timescale.com/api/latest/hyperfunctions/time_bucket/\n */\n\n/*****************************************************************************\n * Bins\n *****************************************************************************/\n\nCREATE FUNCTION bins(intspan, vsize int, vorigin int DEFAULT 0)\n  RETURNS intspan[]\n  AS 'MODULE_PATHNAME', 'Span_bins'\n  LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;\nCREATE FUNCTION bins(bigintspan, vsize bigint, vorigin int DEFAULT 0)\n  RETURNS intspan[]\n  AS 'MODULE_PATHNAME', 'Span_bins'\n  LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;\nCREATE FUNCTION bins(floatspan, vsize float, vorigin float DEFAULT 0.0)\n  RETURNS floatspan[]\n  AS 'MODULE_PATHNAME', 'Span_bins'\n  LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;\n\nCREATE FUNCTION bins(datespan, tsize interval,\n    torigin date DEFAULT '2000-01-01')\n  RETURNS datespan[]\n  AS 'MODULE_PATHNAME', 'Span_bins'\n  LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;\nCREATE FUNCTION bins(tstzspan, tsize interval,\n    torigin timestamptz DEFAULT '2000-01-03')\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Span_bins'\n  LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;\n\n/*****************************************************************************/\n\nCREATE FUNCTION bins(intspanset, vsize int, vorigin int DEFAULT 0)\n  RETURNS intspan[]\n  AS 'MODULE_PATHNAME', 'Spanset_bins'\n  LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;\nCREATE FUNCTION bins(bigintspanset, vsize bigint, vorigin int DEFAULT 0)\n  RETURNS intspan[]\n  AS 'MODULE_PATHNAME', 'Spanset_bins'\n  LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;\nCREATE FUNCTION bins(floatspanset, vsize float, vorigin float DEFAULT 0.0)\n  RETURNS floatspan[]\n  AS 'MODULE_PATHNAME', 'Spanset_bins'\n  LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;\n\nCREATE FUNCTION bins(datespanset, tsize interval,\n    torigin date DEFAULT '2000-01-01')\n  RETURNS datespan[]\n  AS 'MODULE_PATHNAME', 'Spanset_bins'\n  LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;\nCREATE FUNCTION bins(tstzspanset, tsize interval,\n    torigin timestamptz DEFAULT '2000-01-03')\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Spanset_bins'\n  LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;\n\n/*****************************************************************************/\n\nCREATE FUNCTION getBin(\"value\" integer, size integer, origin integer DEFAULT 0)\n  RETURNS intspan\n  AS 'MODULE_PATHNAME', 'Value_bin'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION getBin(\"value\" bigint, size bigint, origin bigint DEFAULT 0)\n  RETURNS bigintspan\n  AS 'MODULE_PATHNAME', 'Value_bin'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION getBin(\"value\" float, size float, origin float DEFAULT 0.0)\n  RETURNS floatspan\n  AS 'MODULE_PATHNAME', 'Value_bin'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE FUNCTION getBin(date, interval, date DEFAULT '2000-01-03')\n  RETURNS datespan\n  AS 'MODULE_PATHNAME', 'Date_bin'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION getBin(timestamptz, interval, timestamptz DEFAULT '2000-01-03')\n  RETURNS tstzspan\n  AS 'MODULE_PATHNAME', 'Timestamptz_bin'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n/*****************************************************************************/\n\n"
+  - gen: {sig: "timeBins({TEMP}, tsize interval,\n    torigin timestamptz DEFAULT '2000-01-03')", ret: "tstzspan[]", sym: Temporal_time_bins}
+  - lit: "\n"
+  - gen: {sig: "valueBins({TEMP}, vsize {BASE}, vorigin {BASE} DEFAULT {VDEF})", ret: "{SPAN}[]", sym: Tnumber_value_bins, presence: numeric}
+  - lit: "\n/*****************************************************************************\n * Multidimensional tiling\n *****************************************************************************/\n\nCREATE TYPE index_tbox AS (\n  index integer,\n  tile tbox\n);\n\nCREATE FUNCTION valueTiles(tbox, vsize float, vorigin float DEFAULT 0.0)\n  RETURNS SETOF index_tbox\n  AS 'MODULE_PATHNAME', 'Tbox_value_tiles'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE FUNCTION timeTiles(tbox, duration interval,\n  torigin timestamptz DEFAULT '2000-01-03')\n  RETURNS SETOF index_tbox\n  AS 'MODULE_PATHNAME', 'Tbox_time_tiles'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE FUNCTION valueTimeTiles(tbox, vsize float, duration interval,\n  vorigin float DEFAULT 0.0, torigin timestamptz DEFAULT '2000-01-03')\n  RETURNS SETOF index_tbox\n  AS 'MODULE_PATHNAME', 'Tbox_value_time_tiles'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n/*****************************************************************************/\n\nCREATE FUNCTION getValueTile(v float, vsize float, vorigin float DEFAULT 0.0)\n  RETURNS tbox\n  AS 'MODULE_PATHNAME', 'Tbox_get_value_tile'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE FUNCTION getTBoxTimeTile(t timestamptz, duration interval,\n  torigin timestamptz DEFAULT '2000-01-03')\n  RETURNS tbox\n  AS 'MODULE_PATHNAME', 'Tbox_get_time_tile'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE FUNCTION getValueTimeTile(v float, t timestamptz, vsize float,\n  duration interval, vorigin float DEFAULT 0.0,\n  torigin timestamptz DEFAULT '2000-01-03')\n  RETURNS tbox\n  AS 'MODULE_PATHNAME', 'Tbox_get_value_time_tile'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n/*****************************************************************************\n * Boxes\n *****************************************************************************/\n\n"
+  - gen: {sig: "valueBoxes({TEMP}, vsize {BASE}, vorigin {BASE} DEFAULT {VDEF})", ret: "tbox[]", sym: Tnumber_value_boxes, presence: numeric}
+  - lit: "\n"
+  - gen: {sig: "timeBoxes({TEMP}, tsize interval,\n    torigin timestamptz DEFAULT '2000-01-03')", ret: "tbox[]", sym: Tnumber_time_boxes, presence: numeric}
+  - lit: "\n"
+  - gen: {sig: "valueTimeBoxes({TEMP}, vsize {BASE}, tsize interval,\n    vorigin {BASE} DEFAULT {VDEF}, torigin timestamptz DEFAULT '2000-01-03')", ret: "tbox[]", sym: Tnumber_value_time_boxes, presence: numeric}
+  - lit: "\n/*****************************************************************************\n * Splitting\n *****************************************************************************/\n\nCREATE TYPE number_tint AS (\n  number integer,\n  tnumber tint\n);\nCREATE TYPE number_tbigint AS (\n  number bigint,\n  tnumber tbigint\n);\nCREATE TYPE number_tfloat AS (\n  number float,\n  tnumber tfloat\n);\n\n"
+  - gen: {sig: "valueSplit({TEMP}, size {BASEFULL}, origin {BASEFULL} DEFAULT {VDEF})", ret: "SETOF number_{TEMP}", sym: Tnumber_value_split, presence: numeric}
+  - lit: "\n/*****************************************************************************/\n\nCREATE TYPE time_tbool AS (\n  time timestamptz,\n  temp tbool\n);\nCREATE TYPE time_tint AS (\n  time timestamptz,\n  temp tint\n);\nCREATE TYPE time_tbigint AS (\n  time timestamptz,\n  temp tbigint\n);\nCREATE TYPE time_tfloat AS (\n  time timestamptz,\n  temp tfloat\n);\nCREATE TYPE time_ttext AS (\n  time timestamptz,\n  temp ttext\n);\n\n"
+  - gen: {sig: "timeSplit({TEMP}, size interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "SETOF time_{TEMP}", sym: Temporal_time_split}
+  - lit: "\n/*****************************************************************************/\n\nCREATE TYPE number_time_tint AS (\n  number integer,\n  time timestamptz,\n  tnumber tint\n);\nCREATE TYPE number_time_tbigint AS (\n  number bigint,\n  time timestamptz,\n  tnumber tbigint\n);\nCREATE TYPE number_time_tfloat AS (\n  number float,\n  time timestamptz,\n  tnumber tfloat\n);\n\n"
+  - gen: {sig: "valueTimeSplit({TEMP}, size {BASEFULL}, duration interval,\n    vorigin {BASEFULL} DEFAULT {VDEF}, torigin timestamptz DEFAULT '2000-01-03')", ret: "SETOF number_time_{TEMP}", sym: Tnumber_value_time_split, presence: numeric}
+  - lit: "\n/*****************************************************************************/\n\n\n"
+- family: th3index
+  file: mobilitydb/sql/h3/253_th3index.in.sql
+  reference: true
+  begin: "CREATE TYPE time_th3index AS ("
+  begin_exact: true
+  end: "\n * Comparison functions and B-tree / hash indexing\n"
+  blocks:
+  - lit: "CREATE TYPE time_th3index AS (\n  time timestamptz,\n  temp th3index\n);\n\n"
+  - fns:
+    - {sig: "timeSplit(th3index, bin_width interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_th3index", sym: "Temporal_time_split"}
+  - lit: "\n/******************************************************************************/\n\n-- spans()\nCREATE FUNCTION spans(th3index)\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Temporal_spans'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- splitNSpans()\nCREATE FUNCTION splitNSpans(th3index, integer)\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Temporal_split_n_spans'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- splitEachNSpans()\nCREATE FUNCTION splitEachNSpans(th3index, integer)\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Temporal_split_each_n_spans'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n"
+
+- family: quadbin
+  file: mobilitydb/sql/quadbin/353_tquadbin.in.sql
+  reference: true
+  begin: "CREATE TYPE time_tquadbin AS ("
+  begin_exact: true
+  end: "\n * Comparison functions and B-tree / hash indexing\n"
+  blocks:
+  - lit: "CREATE TYPE time_tquadbin AS (\n  time timestamptz,\n  temp tquadbin\n);\n\n"
+  - fns:
+    - {sig: "timeSplit(tquadbin, bin_width interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tquadbin", sym: "Temporal_time_split"}
+  - lit: "\n/******************************************************************************/\n\n-- spans()\nCREATE FUNCTION spans(tquadbin)\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Temporal_spans'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- splitNSpans()\nCREATE FUNCTION splitNSpans(tquadbin, integer)\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Temporal_split_n_spans'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- splitEachNSpans()\nCREATE FUNCTION splitEachNSpans(tquadbin, integer)\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Temporal_split_each_n_spans'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n"
+
 
 compops_families:
 - family: temporal


### PR DESCRIPTION
Governs the tiling surface of `025_temporal_tile.in.sql` (the tbool/tint/tbigint/tfloat/ttext `bins`/`getBin`/`timeBins`/`valueBins`/`valueTiles`/`timeTiles`/`valueTimeTiles`/`getValueTile`/`getTBoxTimeTile`/`getValueTimeTile`/`valueBoxes`/`timeBoxes`/`valueTimeBoxes`/`valueSplit`/`timeSplit`/`valueTimeSplit` functions) and the bannerless `timeSplit`/`spans`/`splitNSpans`/`splitEachNSpans` material in `253_th3index.in.sql`/`353_tquadbin.in.sql` under the inherited SQL generator (`tiling_families`), proven byte-for-byte by `generate.py --validate`.

`025_temporal_tile` groups the base-type quintet function-outer / type-inner, the `022_temporal` restriction/modification/transformation precedent: a `gen` chunk (ONE function expanded over the family's `types:` pool, gated `all` or `numeric` presence) renders `timeBins`/`valueBins`/`valueBoxes`/`timeBoxes`/`valueTimeBoxes`/`valueSplit`/`timeSplit`/`valueTimeSplit` with `{TEMP}`/`{BASE}`/`{BASEFULL}`/`{SPAN}`/`{VDEF}` tokens in the style of the restriction/modification/transformation multi-base-type `gen` mode. The span/tbox-generic `bins()`/`getBin()`/`valueTiles()`/`timeTiles()`/`valueTimeTiles()`/`getValueTile()`/`getTBoxTimeTile()`/`getValueTimeTile()` functions appear only once each (not multiplied per base type), so they stay verbatim `lit` text rather than going through a `gen`/`fns` skeleton.

`th3index`/`tquadbin` carry the same `time_<temp>` composite type + `timeSplit` shape already generated for json/tjsonb, but run it straight after the Modification block with no "Multidimensional tiling" section banner to anchor on. Adds a `begin_exact` flag to the tiling axis (mirroring the comparison/hash axes' existing `begin_exact`/`end_exact` convention) so the family's `begin` string anchors at its own index instead of backing up to a preceding `/*` comment open; the `end` anchor resolves by the default backward `/*` search since the "Comparison functions and B-tree / hash indexing" banner it targets is a real comment.

Removes `025_temporal_tile.in.sql` from `coverage_exceptions.txt`: the file is fully generator-governed. `th3index`/`tquadbin` are already governed by other axes, so their listing is unchanged.

Carries zero `.in.sql` line changes: every family here is `reference: true`, validate-only. `--gaps` reports `tiling_families` 18/18 (`restriction_families`, `modification_families` and `transformation_families` stay 18/18); `--coverage` and `--classes` stay green.