### PR TITLE
Bring the base temporal constructor section under the inherited SQL generator

### DIFF
--- a/tools/codegen/inherited/manifest.yaml
+++ b/tools/codegen/inherited/manifest.yaml
@@ -1548,7 +1548,118 @@ representation_families:
     - - lit: "-- asHexEWKB: extended hex-WKB (WKB_EXTENDED flag, includes SRID) \u2014\n-- mirrors asEWKB() and is consistent with MobilityDuck asHexEWKB."
       - asHexEWKB
   - lit: /*****************************************************************************/
+# The base Temporal<T> file ALSO declares the constructor surface for every base
+# scalar type (tbool/tint/tbigint/tfloat/ttext), mirroring the spatial/cell
+# families' shape but with a twist the family-level span_interp/gaps_maxdist
+# flags cannot express: within this ONE family the interpolation default is
+# per-type, not per-family (tfloat alone is continuous/'linear', the other four
+# are discrete/'step'), and the SeqSetGaps maxdist argument is per-type too
+# (present for the three numeric types tint/tbigint/tfloat, absent for
+# tbool/ttext, with only tfloat additionally carrying the trailing interpolation
+# text arg). Instant/from_tstzset/SeqSet are uniform across all five types (no
+# interpolation argument anywhere) and fit the generic `ops` mechanism over a
+# flat five-pair `pairs:` list; from_tstzspan/from_tstzspanset/Seq/SeqSetGaps
+# vary per type and are spelled as explicit `fns` blocks, reproduced byte-exact
+# from the hand file (SeqSetGaps keeps its `-- The function is not strict`
+# marker on the first entry only, exactly as the generic seqsetgaps op does).
 constructor_families:
+- family: temporal
+  file: mobilitydb/sql/temporal/022_temporal.in.sql
+  reference: true
+  begin: "\n * Constructor functions\n"
+  end: "\n * Conversion functions\n"
+  pairs:
+  - base: boolean
+    temp: tbool
+  - base: integer
+    temp: tint
+  - base: bigint
+    temp: tbigint
+  - base: float
+    temp: tfloat
+  - base: text
+    temp: ttext
+  blocks:
+  - lit: "/******************************************************************************\n * Constructor functions\n ******************************************************************************/"
+  - ops:
+    - instant
+  - ops:
+    - from_tstzset
+  - fns:
+    - sig: tbool(boolean, tstzspan)
+      ret: tbool
+      sym: Tsequence_from_base_tstzspan
+    - sig: tint(integer, tstzspan)
+      ret: tint
+      sym: Tsequence_from_base_tstzspan
+    - sig: tbigint(bigint, tstzspan)
+      ret: tbigint
+      sym: Tsequence_from_base_tstzspan
+    - sig: "tfloat(float, tstzspan, text DEFAULT 'linear')"
+      ret: tfloat
+      sym: Tsequence_from_base_tstzspan
+    - sig: ttext(text, tstzspan)
+      ret: ttext
+      sym: Tsequence_from_base_tstzspan
+  - fns:
+    - sig: tbool(boolean, tstzspanset)
+      ret: tbool
+      sym: Tsequenceset_from_base_tstzspanset
+    - sig: tint(integer, tstzspanset)
+      ret: tint
+      sym: Tsequenceset_from_base_tstzspanset
+    - sig: tbigint(bigint, tstzspanset)
+      ret: tbigint
+      sym: Tsequenceset_from_base_tstzspanset
+    - sig: "tfloat(float, tstzspanset, text DEFAULT 'linear')"
+      ret: tfloat
+      sym: Tsequenceset_from_base_tstzspanset
+    - sig: ttext(text, tstzspanset)
+      ret: ttext
+      sym: Tsequenceset_from_base_tstzspanset
+  - lit: /******************************************************************************/
+  - fns:
+    - sig: "tboolSeq(tbool[], text DEFAULT 'step',\n    lowerInc boolean DEFAULT true, upperInc boolean DEFAULT true)"
+      ret: tbool
+      sym: Tsequence_constructor
+    - sig: "tintSeq(tint[], text DEFAULT 'step',\n    lowerInc boolean DEFAULT true, upperInc boolean DEFAULT true)"
+      ret: tint
+      sym: Tsequence_constructor
+    - sig: "tbigintSeq(tbigint[], text DEFAULT 'step',\n    lowerInc boolean DEFAULT true, upperInc boolean DEFAULT true)"
+      ret: tbigint
+      sym: Tsequence_constructor
+    - sig: "tfloatSeq(tfloat[], text DEFAULT 'linear',\n    lowerInc boolean DEFAULT true, upperInc boolean DEFAULT true)"
+      ret: tfloat
+      sym: Tsequence_constructor
+    - sig: "ttextSeq(ttext[], text DEFAULT 'step',\n    lowerInc boolean DEFAULT true, upperInc boolean DEFAULT true)"
+      ret: ttext
+      sym: Tsequence_constructor
+  - ops:
+    - seqset
+  - fns:
+    - sig: tboolSeqSetGaps(tbool[], maxt interval DEFAULT NULL)
+      ret: tbool
+      sym: Tsequenceset_constructor_gaps
+      strict: false
+      pre: '-- The function is not strict
+
+        '
+    - sig: "tintSeqSetGaps(tint[], maxt interval DEFAULT NULL,\n    maxdist float DEFAULT NULL)"
+      ret: tint
+      sym: Tsequenceset_constructor_gaps
+      strict: false
+    - sig: "tbigintSeqSetGaps(tbigint[], maxt interval DEFAULT NULL,\n    maxdist float DEFAULT NULL)"
+      ret: tbigint
+      sym: Tsequenceset_constructor_gaps
+      strict: false
+    - sig: "tfloatSeqSetGaps(tfloat[], maxt interval DEFAULT NULL,\n    maxdist float DEFAULT NULL, text DEFAULT 'linear')"
+      ret: tfloat
+      sym: Tsequenceset_constructor_gaps
+      strict: false
+    - sig: ttextSeqSetGaps(ttext[], maxt interval DEFAULT NULL)
+      ret: ttext
+      sym: Tsequenceset_constructor_gaps
+      strict: false
 - family: geo
   file: mobilitydb/sql/geo/052_tgeo.in.sql
   reference: true


### PR DESCRIPTION
Governs the constructor section of the base Temporal<T> file (`mobilitydb/sql/temporal/022_temporal.in.sql`, the `tbool`/`tint`/`tbigint`/`tfloat`/`ttext` instant/from_tstzset/from_tstzspan/from_tstzspanset/Seq/SeqSet/SeqSetGaps functions) under the inherited SQL generator (`constructor_families`), proven byte-for-byte by `generate.py --validate`.

The new `family: temporal` entry sits alongside the eleven spatial/cell families (geo, tpoint, cbuffer, h3, json, npoint, tpcpoint, tpcpatch, pose, quadbin, rgeo) already governed there, but its shape does not reduce entirely to those families' family-level `span_interp`/`gaps_maxdist` flags: within this ONE family the interpolation default is per-type, not per-family (`tfloat` alone is continuous/`'linear'`, the other four are discrete/`'step'`), and the SeqSetGaps `maxdist` argument is per-type too (present for the three numeric types `tint`/`tbigint`/`tfloat`, absent for `tbool`/`ttext`, with only `tfloat` additionally carrying the trailing interpolation `text` arg). Instant, from_tstzset and SeqSet are uniform across all five types (no interpolation argument anywhere) and render through the generic `ops` mechanism over a flat five-pair `pairs:` list; from_tstzspan, from_tstzspanset, Seq and SeqSetGaps carry that per-type variance and are spelled as explicit `fns` blocks, reproduced byte-exact from the hand file (SeqSetGaps keeps its `-- The function is not strict` marker on the first entry only, exactly as the generic seqsetgaps op already does for sibling families).

`tfloat` measured as already "covered" on this axis before this change, but only as a side effect of the coverage scanner matching the word `tfloat` inside `cbuffer`'s explicit `tcbuffer(tgeompoint, tfloat)` constructor overload signature — no dedicated constructor governance of `tfloat`'s own section existed. This PR adds real governance for all five base types, including `tfloat`.

Carries zero `.in.sql` changes: the family is `reference: true`, validate-only. `--gaps` reports `constructor_families` 18/18, up from 14/18 on master (missing `tbool`/`tint`/`ttext`/`tbigint`). No other `--gaps` axis changes (`aggregate_families` stays 16/18, `comparison_families` stays 16/18). `--coverage` and `--classes` stay green.