### PR TITLE
Bring the base temporal conversion section under the inherited SQL generator

### DIFF
--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -2196,10 +2196,11 @@ def bootstrap_distance(filetext: str, fam: dict, rendered: str) -> str:
 
 # --- SQL Conversions sub-family (SQL, per-family region-in-file) ------------------
 # The Temporal<T> cast surface every temporal type carries: the CREATE FUNCTION
-# conversion wrappers (timeSpan -> tstzspan, and the cross-type casts to/from the
-# sibling temporal types — tcbuffer<->tgeompoint/tgeometry/tfloat, tnpoint<->
-# tgeompoint, tjsonb<->ttext, tpose->tgeompoint/tgeogpoint, trgeometry->tpose/
-# tgeompoint/tgeogpoint/tgeometry/stbox/geometry) plus the matching CREATE CAST
+# conversion wrappers (timeSpan -> tstzspan, the base numeric cross-casts tbool<->
+# tint<->tbigint<->tfloat plus their valueSpan/tbox casts, and the cross-type casts
+# to/from the sibling temporal types — tcbuffer<->tgeompoint/tgeometry/tfloat,
+# tnpoint<->tgeompoint, tjsonb<->ttext, tpose->tgeompoint/tgeogpoint, trgeometry->
+# tpose/tgeompoint/tgeogpoint/tgeometry/stbox/geometry) plus the matching CREATE CAST
 # statements. Each CREATE FUNCTION is the SAME four-line skeleton
 # (templates/conversions.sql.tmpl); only the signature {SIG}, return {RET}, backing
 # symbol {SYM}, strictness ({STRICT}) and an optional leading comment ({PRE}) differ

--- a/tools/codegen/inherited/manifest.d/conversion_families.yaml
+++ b/tools/codegen/inherited/manifest.d/conversion_families.yaml
@@ -1,4 +1,44 @@
+# The base Temporal<T> file also declares the conversion surface for the three
+# discrete numeric types (tint/tbigint/tbool cross-casts, plus the tint/tbigint/
+# tfloat valueSpan/tbox casts, tfloat pulled in incidentally since its casts share
+# the same chunks). tfloat and ttext are not named here — tfloat already surfaces
+# through these shared numeric chunks and ttext through the json family's ttext<->
+# tjsonb casts — so they are not missing from the class, just covered elsewhere.
+# th3index and tquadbin are NOT modeled: their casts scatter across three
+# non-contiguous locations (the typmod self-cast in the I/O area, the tbigint
+# assignment casts, and the tstzspan cast buried in the Accessors section), so
+# there is no single Conversions section to slice with the begin/end-anchor model
+# every other family here uses. tpcpoint/tpcpatch are reserved for a separate
+# pointcloud session and are likewise absent.
 conversion_families:
+- family: temporal
+  file: mobilitydb/sql/temporal/022_temporal.in.sql
+  reference: true
+  begin: "\n * Conversion functions\n"
+  end: "\n * Accessor functions\n"
+  blocks:
+  - lit: "/******************************************************************************\n * Conversion functions\n ******************************************************************************/\n\n"
+  - fns:
+    - {sig: "valueSpan(tint)", ret: intspan, sym: Tnumber_to_span}
+    - {sig: "valueSpan(tbigint)", ret: bigintspan, sym: Tnumber_to_span}
+    - {sig: "valueSpan(tfloat)", ret: floatspan, sym: Tnumber_to_span}
+  - lit: "\nCREATE CAST (tint AS intspan) WITH FUNCTION valueSpan(tint);\nCREATE CAST (tbigint AS bigintspan) WITH FUNCTION valueSpan(tbigint);\nCREATE CAST (tfloat AS floatspan) WITH FUNCTION valueSpan(tfloat);\n\n"
+  - fns:
+    - {sig: "tint(tbool)", ret: tint, sym: Tbool_to_tint}
+  - lit: "CREATE CAST (tbool AS tint) WITH FUNCTION tint(tbool);\n\n"
+  - fns:
+    - {sig: "tbigint(tint)", ret: tbigint, sym: Tint_to_tbigint}
+    - {sig: "tfloat(tint)", ret: tfloat, sym: Tint_to_tfloat}
+    - {sig: "tint(tbigint)", ret: tint, sym: Tbigint_to_tint}
+    - {sig: "tfloat(tbigint)", ret: tfloat, sym: Tbigint_to_tfloat}
+    - {sig: "tint(tfloat)", ret: tint, sym: Tfloat_to_tint}
+    - {sig: "tbigint(tfloat)", ret: tbigint, sym: Tfloat_to_tbigint}
+  - lit: "\nCREATE CAST (tint AS tbigint) WITH FUNCTION tbigint(tint);\nCREATE CAST (tint AS tfloat) WITH FUNCTION tfloat(tint);\nCREATE CAST (tbigint AS tint) WITH FUNCTION tint(tbigint);\nCREATE CAST (tbigint AS tfloat) WITH FUNCTION tfloat(tbigint);\nCREATE CAST (tfloat AS tint) WITH FUNCTION tint(tfloat);\nCREATE CAST (tfloat AS tbigint) WITH FUNCTION tbigint(tfloat);\n\n"
+  - fns:
+    - {sig: "tbox(tint)", ret: tbox, sym: Tnumber_to_tbox}
+    - {sig: "tbox(tbigint)", ret: tbox, sym: Tnumber_to_tbox}
+    - {sig: "tbox(tfloat)", ret: tbox, sym: Tnumber_to_tbox}
+  - lit: "\nCREATE CAST (tint AS tbox) WITH FUNCTION tbox(tint);\nCREATE CAST (tbigint AS tbox) WITH FUNCTION tbox(tbigint);\nCREATE CAST (tfloat AS tbox) WITH FUNCTION tbox(tfloat);\n\n"
 - family: geo
   file: mobilitydb/sql/geo/052_tgeo.in.sql
   reference: true


### PR DESCRIPTION
## Summary

- Governs the base Temporal<T> file's Conversion functions section — the tbool/tint/tbigint/tfloat cross-casts plus their valueSpan/tbox casts in `mobilitydb/sql/temporal/022_temporal.in.sql` — as one reference family named `temporal` in `manifest.d/conversion_families.yaml`, closing the conversion_families gap for tbool, tint and tbigint. tfloat and ttext already register as covered (tfloat's name appears in the numeric chunks the new family renders, ttext's in the json family's casts), so this PR leaves them untouched.
- Excludes th3index and tquadbin from the manifest: their casts scatter across three non-contiguous locations in each type's `.in.sql` file (the typmod self-cast in the I/O area, the tbigint assignment casts, and the tstzspan cast in the Accessors section), so no single Conversions section fits the begin/end-anchor model this axis uses to slice.
- Leaves tpcpoint and tpcpatch untouched; a separate pointcloud session owns their SQL.
- Contains the manifest-per-axis split commit (branch `refactor/manifest-per-axis`) as this PR's base commit.

## Measurements

- conversion_families: 11/18 -> 14/18 (missing: th3index tquadbin tpcpoint tpcpatch).
- `--validate`: 0 DIFF across every reference family of every axis.
- `--coverage`: ratchet OK.
- `--classes`: OK, 9 classes match the catalog.
- `--gaps`: the full report differs by exactly one line, the conversion_families row above; every other axis row is byte-identical.
- Zero `.in.sql` changes; `yaml.safe_load` parses every file under `manifest.d/`.

## Test plan

- [x] `python3 tools/codegen/inherited/generate.py --validate` exits 0, zero DIFF
- [x] `python3 tools/codegen/inherited/generate.py --coverage` ratchet OK
- [x] `python3 tools/codegen/inherited/generate.py --classes` OK
- [x] `python3 tools/codegen/inherited/generate.py --gaps` shows only the conversion_families row changing