### PR TITLE
Bring the geo and tpoint accessor surface under the inherited SQL generator

### DIFF
--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -483,6 +483,40 @@ def _accessors_markers(family: str):
     return begin, f"-- GENERATED-ACCESSORS-END {family}\n"
 
 
+def _acc_skeleton(sig: str, ret: str, sym: str, pre: str = "") -> str:
+    """One accessor CREATE FUNCTION assembled inline from a fixed four-line skeleton
+    (always STRICT — every accessor in the hand files is). `pre` is a leading
+    comment line (with its own trailing newline) or ''. Mirrors `_restr_skeleton`'s
+    shape but kept local: accessors carry no PRE/STRICT template file of their own,
+    and every existing accessor's body is this exact skeleton."""
+    return (f"{pre}CREATE FUNCTION {sig}\n"
+            f"  RETURNS {ret}\n"
+            f"  AS 'MODULE_PATHNAME', '{sym}'\n"
+            f"  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;")
+
+
+def render_accessor_blocks(fam: dict) -> str:
+    """Render one family's accessor region from its `blocks` sequence — the same
+    lit/fns architecture render_restrictions uses. tgeo/tpoint fold `getValues`
+    into a differently-named/positioned `valueSet`, relocate `valueAtTimestamp`
+    under Restriction Functions, and drop `timeSpan` (declared earlier as a cast
+    target), so the fixed canonical order the shared accessors.sql.tmpl assumes
+    cannot reproduce them; a family with an explicit `blocks` list is rendered
+    here instead of by the templated `types` path. `lit` is verbatim text (the
+    banner, blank-line separators, hand comments); `fns` is a list of
+    {sig, ret, sym[, pre]} rendered with `_acc_skeleton`, packed with no blank
+    line and closed by one trailing newline — byte-identical to the committed
+    hand region, every separator baked into a `lit` block."""
+    out = ""
+    for blk in fam["blocks"]:
+        if "lit" in blk:
+            out += blk["lit"]
+        else:
+            out += "\n".join(_acc_skeleton(f["sig"], f["ret"], f["sym"], f.get("pre", ""))
+                             for f in blk["fns"]) + "\n"
+    return out
+
+
 def render_accessors(fam: dict) -> str:
     """Render the accessor region for one family from its per-base-type `types`
     table. ONE renderer serves every family: a spatial subtype is a single-element
@@ -491,7 +525,12 @@ def render_accessors(fam: dict) -> str:
     types. An old {temp/base/baseset} family is normalized to a one-element table,
     so this reproduces the merged subtype regions byte-for-byte. Groups are emitted
     accessor-outer / type-inner and separated by one blank line; the gated accessors
-    slot in at their canonical positions for the types that carry them."""
+    slot in at their canonical positions for the types that carry them.
+
+    A family carrying `blocks` instead of `types` diverges from the shared
+    canonical order (see render_accessor_blocks) and is delegated there."""
+    if "blocks" in fam:
+        return render_accessor_blocks(fam)
     types = fam.get("types") or [{"temp": fam["temp"],
                                   "base": fam.get("base", ""),
                                   "baseset": fam.get("baseset", "")}]
@@ -616,11 +655,25 @@ def splice_accessors(filetext: str, family: str, rendered: str) -> str:
     return filetext[:b] + rendered + filetext[e:]
 
 
-def extract_accessors(filetext: str, family: str) -> str:
+def extract_accessors(filetext: str, fam) -> str:
+    """The committed hand accessor block. Marker-aware, mirroring
+    extract_restrictions: if the GENERATED-ACCESSORS region exists, slice between
+    its markers (every `types`-mode family, once bootstrapped); otherwise — a
+    `blocks`-mode family, still a bare hand-written section — slice from the `/*`
+    opening the family's `begin` banner anchor down to, exclusive, the `/*` opening
+    the `end` anchor, with NO file mutation (`fam` may still be passed as a bare
+    family-name string by a `types`-mode-only caller, since the marker branch never
+    needs the dict)."""
+    family = fam if isinstance(fam, str) else fam["family"]
     begin, end = _accessors_markers(family)
-    b = filetext.index(begin) + len(begin)
-    e = filetext.index(end)
-    return filetext[b:e]
+    if begin in filetext:
+        b = filetext.index(begin) + len(begin)
+        e = filetext.index(end)
+        return filetext[b:e]
+    i = filetext.index(fam["begin"])
+    start = filetext.rfind("/*", 0, i)
+    j = filetext.index(fam["end"])
+    return filetext[start:filetext.rfind("/*", 0, j)]
 
 
 # --- SQL Input/Output: type-I/O sub-family -------------------------------------
@@ -3612,7 +3665,7 @@ def main() -> int:
                 continue
             p = ROOT / fam["file"]
             gen = render_accessors(fam)
-            cur = extract_accessors(p.read_text(), fam["family"]) if p.exists() else ""
+            cur = extract_accessors(p.read_text(), fam) if p.exists() else ""
             same = gen == cur
             ok = ok and same
             print(f"[{'OK ' if same else 'DIFF'}] self-regen accessors {fam['family']} "
@@ -4029,6 +4082,11 @@ def main() -> int:
         print(f"spliced spatialrels {fam['family']} -> {fam['file']}")
 
     for fam in mf.get("accessor_families", []):
+        if fam.get("reference"):
+            # A reference family self-regenerates for --validate to prove against
+            # (marker-bound once bootstrapped, anchor-bound if still `blocks`-mode
+            # bare hand text); never write it here, matching every other axis.
+            continue
         p = ROOT / fam["file"]
         text = p.read_text()
         begin, _ = _accessors_markers(fam["family"])
@@ -4040,8 +4098,6 @@ def main() -> int:
                 continue
             p.write_text(bootstrap_accessors(text, fam, render_accessors(fam)))
             print(f"bootstrapped accessors {fam['family']} -> {fam['file']}")
-            continue
-        if fam.get("reference"):
             continue
         if args.check:
             print(f"would splice accessors {fam['family']} -> {fam['file']}")

--- a/tools/codegen/inherited/manifest.d/accessor_families.yaml
+++ b/tools/codegen/inherited/manifest.d/accessor_families.yaml
@@ -79,3 +79,269 @@ accessor_families:
     reference: true
     types:
       - {temp: tpcpatch, base: pcpatch, baseset: pcpatchset}
+
+  # tgeo/tpoint diverge from the shared accessors.sql.tmpl order: getValues is
+  # renamed valueSet (returning geomset/geogset) and moved next to valueN,
+  # timeSpan is declared earlier as a cast target (io_families), and
+  # valueAtTimestamp is folded into the Restriction Functions section
+  # (restriction_families) instead — so these two use an explicit `blocks`
+  # sequence (mirroring restriction_families) rather than the templated `types`
+  # renderer every other accessor_families entry uses.
+  - family:    geo
+    file:      mobilitydb/sql/geo/052_tgeo.in.sql
+    reference: true
+    begin:     "\n * Accessor Functions\n"
+    end:       "\n * Shift and scale functions\n"
+    blocks:
+      - lit: "/******************************************************************************\n * Accessor Functions\n ******************************************************************************/\n"
+      - lit: "\n"
+      - fns:
+        - {sig: "tempSubtype(tgeometry)", ret: text, sym: Temporal_subtype}
+        - {sig: "tempBasetype(tgeometry)", ret: text, sym: Temporal_basetype_name}
+        - {sig: "tempSubtype(tgeography)", ret: text, sym: Temporal_subtype}
+        - {sig: "tempBasetype(tgeography)", ret: text, sym: Temporal_basetype_name}
+      - lit: "\n"
+      - fns:
+        - {sig: "interp(tgeometry)", ret: text, sym: Temporal_interp}
+        - {sig: "interp(tgeography)", ret: text, sym: Temporal_interp}
+      - lit: "\n"
+      - fns:
+        - {sig: "memSize(tgeometry)", ret: integer, sym: Temporal_mem_size}
+        - {sig: "memSize(tgeography)", ret: integer, sym: Temporal_mem_size}
+      - lit: "\n"
+      - fns:
+        - {sig: "getValue(tgeometry)", ret: geometry, sym: Tinstant_value, pre: "-- value is a reserved word in SQL\n"}
+        - {sig: "getValue(tgeography)", ret: geography, sym: Tinstant_value}
+      - lit: "\n"
+      - lit: "-- There is no getValues() function for temporal geos,\n-- it is called traversedArea() for temporal geos\n"
+      - lit: "\n"
+      - fns:
+        - {sig: "getTimestamp(tgeometry)", ret: timestamptz, sym: Tinstant_timestamptz}
+        - {sig: "getTimestamp(tgeography)", ret: timestamptz, sym: Tinstant_timestamptz}
+      - lit: "\n"
+      - fns:
+        - {sig: "valueSet(tgeometry)", ret: geomset, sym: Temporal_valueset}
+        - {sig: "valueSet(tgeography)", ret: geogset, sym: Temporal_valueset}
+      - lit: "\n"
+      - fns:
+        - {sig: "valueN(tgeometry, integer)", ret: geometry, sym: Temporal_value_n}
+        - {sig: "valueN(tgeography, integer)", ret: geography, sym: Temporal_value_n}
+      - lit: "\n"
+      - fns:
+        - {sig: "getTime(tgeometry)", ret: tstzspanset, sym: Temporal_time, pre: "-- time is a reserved word in SQL\n"}
+        - {sig: "getTime(tgeography)", ret: tstzspanset, sym: Temporal_time}
+      - lit: "\n"
+      - fns:
+        - {sig: "startValue(tgeometry)", ret: geometry, sym: Temporal_start_value}
+        - {sig: "startValue(tgeography)", ret: geography, sym: Temporal_start_value}
+      - lit: "\n"
+      - fns:
+        - {sig: "endValue(tgeometry)", ret: geometry, sym: Temporal_end_value}
+        - {sig: "endValue(tgeography)", ret: geography, sym: Temporal_end_value}
+      - lit: "\n"
+      - fns:
+        - {sig: "duration(tgeometry, boundspan boolean DEFAULT FALSE)", ret: interval, sym: Temporal_duration}
+        - {sig: "duration(tgeography, boundspan boolean DEFAULT FALSE)", ret: interval, sym: Temporal_duration}
+      - lit: "\n"
+      - fns:
+        - {sig: "lowerInc(tgeometry)", ret: bool, sym: Temporal_lower_inc}
+        - {sig: "lowerInc(tgeography)", ret: bool, sym: Temporal_lower_inc}
+      - lit: "\n"
+      - fns:
+        - {sig: "upperInc(tgeometry)", ret: bool, sym: Temporal_upper_inc}
+        - {sig: "upperInc(tgeography)", ret: bool, sym: Temporal_upper_inc}
+      - lit: "\n"
+      - fns:
+        - {sig: "numInstants(tgeometry)", ret: integer, sym: Temporal_num_instants}
+        - {sig: "numInstants(tgeography)", ret: integer, sym: Temporal_num_instants}
+      - lit: "\n"
+      - fns:
+        - {sig: "startInstant(tgeometry)", ret: tgeometry, sym: Temporal_start_instant}
+        - {sig: "startInstant(tgeography)", ret: tgeography, sym: Temporal_start_instant}
+      - lit: "\n"
+      - fns:
+        - {sig: "endInstant(tgeometry)", ret: tgeometry, sym: Temporal_end_instant}
+        - {sig: "endInstant(tgeography)", ret: tgeography, sym: Temporal_end_instant}
+      - lit: "\n"
+      - fns:
+        - {sig: "instantN(tgeometry, integer)", ret: tgeometry, sym: Temporal_instant_n}
+        - {sig: "instantN(tgeography, integer)", ret: tgeography, sym: Temporal_instant_n}
+      - lit: "\n"
+      - fns:
+        - {sig: "instants(tgeometry)", ret: "tgeometry[]", sym: Temporal_instants}
+        - {sig: "instants(tgeography)", ret: "tgeography[]", sym: Temporal_instants}
+      - lit: "\n"
+      - fns:
+        - {sig: "numTimestamps(tgeometry)", ret: integer, sym: Temporal_num_timestamps}
+        - {sig: "numTimestamps(tgeography)", ret: integer, sym: Temporal_num_timestamps}
+      - lit: "\n"
+      - fns:
+        - {sig: "startTimestamp(tgeometry)", ret: timestamptz, sym: Temporal_start_timestamptz}
+        - {sig: "startTimestamp(tgeography)", ret: timestamptz, sym: Temporal_start_timestamptz}
+      - lit: "\n"
+      - fns:
+        - {sig: "endTimestamp(tgeometry)", ret: timestamptz, sym: Temporal_end_timestamptz}
+        - {sig: "endTimestamp(tgeography)", ret: timestamptz, sym: Temporal_end_timestamptz}
+      - lit: "\n"
+      - fns:
+        - {sig: "timestampN(tgeometry, integer)", ret: timestamptz, sym: Temporal_timestamptz_n}
+        - {sig: "timestampN(tgeography, integer)", ret: timestamptz, sym: Temporal_timestamptz_n}
+      - lit: "\n"
+      - fns:
+        - {sig: "timestamps(tgeometry)", ret: "timestamptz[]", sym: Temporal_timestamps}
+        - {sig: "timestamps(tgeography)", ret: "timestamptz[]", sym: Temporal_timestamps}
+      - lit: "\n"
+      - fns:
+        - {sig: "numSequences(tgeometry)", ret: integer, sym: Temporal_num_sequences}
+        - {sig: "numSequences(tgeography)", ret: integer, sym: Temporal_num_sequences}
+      - lit: "\n"
+      - fns:
+        - {sig: "startSequence(tgeometry)", ret: tgeometry, sym: Temporal_start_sequence}
+        - {sig: "startSequence(tgeography)", ret: tgeography, sym: Temporal_start_sequence}
+      - lit: "\n"
+      - fns:
+        - {sig: "endSequence(tgeometry)", ret: tgeometry, sym: Temporal_end_sequence}
+        - {sig: "endSequence(tgeography)", ret: tgeography, sym: Temporal_end_sequence}
+      - lit: "\n"
+      - fns:
+        - {sig: "sequenceN(tgeometry, integer)", ret: tgeometry, sym: Temporal_sequence_n}
+        - {sig: "sequenceN(tgeography, integer)", ret: tgeography, sym: Temporal_sequence_n}
+      - lit: "\n"
+      - fns:
+        - {sig: "sequences(tgeometry)", ret: "tgeometry[]", sym: Temporal_sequences}
+        - {sig: "sequences(tgeography)", ret: "tgeography[]", sym: Temporal_sequences}
+      - lit: "\n"
+      - fns:
+        - {sig: "segments(tgeometry)", ret: "tgeometry[]", sym: Temporal_segments}
+        - {sig: "segments(tgeography)", ret: "tgeography[]", sym: Temporal_segments}
+      - lit: "\n"
+
+  - family:    tpoint
+    file:      mobilitydb/sql/geo/052_tpoint.in.sql
+    reference: true
+    begin:     "\n * Accessor Functions\n"
+    end:       "\n * Shift and scale functions\n"
+    blocks:
+      - lit: "/******************************************************************************\n * Accessor Functions\n ******************************************************************************/\n"
+      - lit: "\n"
+      - fns:
+        - {sig: "tempSubtype(tgeompoint)", ret: text, sym: Temporal_subtype}
+        - {sig: "tempBasetype(tgeompoint)", ret: text, sym: Temporal_basetype_name}
+        - {sig: "tempSubtype(tgeogpoint)", ret: text, sym: Temporal_subtype}
+        - {sig: "tempBasetype(tgeogpoint)", ret: text, sym: Temporal_basetype_name}
+      - lit: "\n"
+      - fns:
+        - {sig: "interp(tgeompoint)", ret: text, sym: Temporal_interp}
+        - {sig: "interp(tgeogpoint)", ret: text, sym: Temporal_interp}
+      - lit: "\n"
+      - fns:
+        - {sig: "memSize(tgeompoint)", ret: integer, sym: Temporal_mem_size}
+        - {sig: "memSize(tgeogpoint)", ret: integer, sym: Temporal_mem_size}
+      - lit: "\n"
+      - fns:
+        - {sig: "getValue(tgeompoint)", ret: "geometry(Point)", sym: Tinstant_value, pre: "-- value is a reserved word in SQL\n"}
+        - {sig: "getValue(tgeogpoint)", ret: "geography(Point)", sym: Tinstant_value}
+      - lit: "\n"
+      - lit: "-- There is no getValues() function for temporal points,\n-- it is called trajectory() for temporal points\n"
+      - lit: "\n"
+      - fns:
+        - {sig: "getTimestamp(tgeompoint)", ret: timestamptz, sym: Tinstant_timestamptz}
+        - {sig: "getTimestamp(tgeogpoint)", ret: timestamptz, sym: Tinstant_timestamptz}
+      - lit: "\n"
+      - fns:
+        - {sig: "valueSet(tgeompoint)", ret: geomset, sym: Temporal_valueset}
+        - {sig: "valueSet(tgeogpoint)", ret: geogset, sym: Temporal_valueset}
+      - lit: "\n"
+      - fns:
+        - {sig: "valueN(tgeompoint, integer)", ret: geometry, sym: Temporal_value_n}
+        - {sig: "valueN(tgeogpoint, integer)", ret: geography, sym: Temporal_value_n}
+      - lit: "\n"
+      - fns:
+        - {sig: "getTime(tgeompoint)", ret: tstzspanset, sym: Temporal_time, pre: "-- time is a reserved word in SQL\n"}
+        - {sig: "getTime(tgeogpoint)", ret: tstzspanset, sym: Temporal_time}
+      - lit: "\n"
+      - fns:
+        - {sig: "startValue(tgeompoint)", ret: "geometry(Point)", sym: Temporal_start_value}
+        - {sig: "startValue(tgeogpoint)", ret: "geography(Point)", sym: Temporal_start_value}
+      - lit: "\n"
+      - fns:
+        - {sig: "endValue(tgeompoint)", ret: "geometry(Point)", sym: Temporal_end_value}
+        - {sig: "endValue(tgeogpoint)", ret: "geography(Point)", sym: Temporal_end_value}
+      - lit: "\n"
+      - fns:
+        - {sig: "duration(tgeompoint, boundspan boolean DEFAULT FALSE)", ret: interval, sym: Temporal_duration}
+        - {sig: "duration(tgeogpoint, boundspan boolean DEFAULT FALSE)", ret: interval, sym: Temporal_duration}
+      - lit: "\n"
+      - fns:
+        - {sig: "lowerInc(tgeompoint)", ret: bool, sym: Temporal_lower_inc}
+        - {sig: "lowerInc(tgeogpoint)", ret: bool, sym: Temporal_lower_inc}
+      - lit: "\n"
+      - fns:
+        - {sig: "upperInc(tgeompoint)", ret: bool, sym: Temporal_upper_inc}
+        - {sig: "upperInc(tgeogpoint)", ret: bool, sym: Temporal_upper_inc}
+      - lit: "\n"
+      - fns:
+        - {sig: "numInstants(tgeompoint)", ret: integer, sym: Temporal_num_instants}
+        - {sig: "numInstants(tgeogpoint)", ret: integer, sym: Temporal_num_instants}
+      - lit: "\n"
+      - fns:
+        - {sig: "startInstant(tgeompoint)", ret: tgeompoint, sym: Temporal_start_instant}
+        - {sig: "startInstant(tgeogpoint)", ret: tgeogpoint, sym: Temporal_start_instant}
+      - lit: "\n"
+      - fns:
+        - {sig: "endInstant(tgeompoint)", ret: tgeompoint, sym: Temporal_end_instant}
+        - {sig: "endInstant(tgeogpoint)", ret: tgeogpoint, sym: Temporal_end_instant}
+      - lit: "\n"
+      - fns:
+        - {sig: "instantN(tgeompoint, integer)", ret: tgeompoint, sym: Temporal_instant_n}
+        - {sig: "instantN(tgeogpoint, integer)", ret: tgeogpoint, sym: Temporal_instant_n}
+      - lit: "\n"
+      - fns:
+        - {sig: "instants(tgeompoint)", ret: "tgeompoint[]", sym: Temporal_instants}
+        - {sig: "instants(tgeogpoint)", ret: "tgeogpoint[]", sym: Temporal_instants}
+      - lit: "\n"
+      - fns:
+        - {sig: "numTimestamps(tgeompoint)", ret: integer, sym: Temporal_num_timestamps}
+        - {sig: "numTimestamps(tgeogpoint)", ret: integer, sym: Temporal_num_timestamps}
+      - lit: "\n"
+      - fns:
+        - {sig: "startTimestamp(tgeompoint)", ret: timestamptz, sym: Temporal_start_timestamptz}
+        - {sig: "startTimestamp(tgeogpoint)", ret: timestamptz, sym: Temporal_start_timestamptz}
+      - lit: "\n"
+      - fns:
+        - {sig: "endTimestamp(tgeompoint)", ret: timestamptz, sym: Temporal_end_timestamptz}
+        - {sig: "endTimestamp(tgeogpoint)", ret: timestamptz, sym: Temporal_end_timestamptz}
+      - lit: "\n"
+      - fns:
+        - {sig: "timestampN(tgeompoint, integer)", ret: timestamptz, sym: Temporal_timestamptz_n}
+        - {sig: "timestampN(tgeogpoint, integer)", ret: timestamptz, sym: Temporal_timestamptz_n}
+      - lit: "\n"
+      - fns:
+        - {sig: "timestamps(tgeompoint)", ret: "timestamptz[]", sym: Temporal_timestamps}
+        - {sig: "timestamps(tgeogpoint)", ret: "timestamptz[]", sym: Temporal_timestamps}
+      - lit: "\n"
+      - fns:
+        - {sig: "numSequences(tgeompoint)", ret: integer, sym: Temporal_num_sequences}
+        - {sig: "numSequences(tgeogpoint)", ret: integer, sym: Temporal_num_sequences}
+      - lit: "\n"
+      - fns:
+        - {sig: "startSequence(tgeompoint)", ret: tgeompoint, sym: Temporal_start_sequence}
+        - {sig: "startSequence(tgeogpoint)", ret: tgeogpoint, sym: Temporal_start_sequence}
+      - lit: "\n"
+      - fns:
+        - {sig: "endSequence(tgeompoint)", ret: tgeompoint, sym: Temporal_end_sequence}
+        - {sig: "endSequence(tgeogpoint)", ret: tgeogpoint, sym: Temporal_end_sequence}
+      - lit: "\n"
+      - fns:
+        - {sig: "sequenceN(tgeompoint, integer)", ret: tgeompoint, sym: Temporal_sequence_n}
+        - {sig: "sequenceN(tgeogpoint, integer)", ret: tgeogpoint, sym: Temporal_sequence_n}
+      - lit: "\n"
+      - fns:
+        - {sig: "sequences(tgeompoint)", ret: "tgeompoint[]", sym: Temporal_sequences}
+        - {sig: "sequences(tgeogpoint)", ret: "tgeogpoint[]", sym: Temporal_sequences}
+      - lit: "\n"
+      - fns:
+        - {sig: "segments(tgeompoint)", ret: "tgeompoint[]", sym: Temporal_segments}
+        - {sig: "segments(tgeogpoint)", ret: "tgeogpoint[]", sym: Temporal_segments}
+      - lit: "\n"
+


### PR DESCRIPTION
Governs the accessor surface of tgeometry, tgeography, tgeompoint and tgeogpoint through the inherited SQL generator, as `blocks` sequences on the `geo` and `tpoint` entries of `accessor_families`.

The Accessor Functions section of these two families follows an order of its own rather than the shared `accessors.sql.tmpl` order: the value-domain accessor carries the name `valueSet`, `valueAtTimestamp` sits under Restriction Functions, and `timeSpan` is declared earlier as a cast target. The `blocks` sequence reproduces that layout with the same `lit`/`fns` architecture `restriction_families` uses for these families, rendered by `render_accessor_blocks`.

`extract_accessors` carries an anchor-based fallback so a reference-only `blocks` family validates against its bare hand text, leaving the `.in.sql` files free of markers. The `accessor_families` apply loop checks `reference` before bootstrap, matching every other axis's loop, which keeps a reference family out of the bootstrap-write path.

The change spans the generator and the manifest; the deployed SQL is untouched.