### PR TITLE
Test the arguments of the pointcloud base types as their siblings do

### DIFF
--- a/meos/src/pointcloud/pcpatch.c
+++ b/meos/src/pointcloud/pcpatch.c
@@ -21,6 +21,7 @@
 
 /* C */
 #include <assert.h>
+#include <limits.h>
 #include <string.h>
 #include <stddef.h>          /* offsetof */
 /* PostgreSQL */
@@ -33,6 +34,8 @@
 #include <liblwgeom.h>       /* parse_hex, deparse_hex */
 /* MEOS */
 #include <meos.h>
+#include <meos_internal.h>
+#include "temporal/temporal.h"
 
 /*****************************************************************************
  * Reserved tail
@@ -209,7 +212,8 @@ char *
 pcpatch_hex_out(const Pcpatch *pa, int maxdd)
 {
   (void) maxdd;
-  assert(pa);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pa, NULL);
   size_t byte_len = VARSIZE(pa);
   size_t meaningful = pcpatch_meaningful_size(pa);
   size_t hex_len = byte_len * 2;
@@ -254,7 +258,8 @@ pcpatch_as_hexwkb(const Pcpatch *pa)
 Pcpatch *
 pcpatch_copy(const Pcpatch *pa)
 {
-  assert(pa);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pa, NULL);
   size_t sz = VARSIZE(pa);
   Pcpatch *result = palloc(sz);
   memcpy(result, pa, sz);
@@ -268,7 +273,9 @@ pcpatch_copy(const Pcpatch *pa)
  */
 uint32_t pcpatch_get_pcid(const Pcpatch *pa)
 {
-  assert(pa); return pa->pcid;
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pa, INT_MAX);
+  return pa->pcid;
 }
 
 /**
@@ -277,7 +284,9 @@ uint32_t pcpatch_get_pcid(const Pcpatch *pa)
  */
 uint32_t pcpatch_npoints(const Pcpatch *pa)
 {
-  assert(pa); return pa->npoints;
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pa, INT_MAX);
+  return pa->npoints;
 }
 
 /**
@@ -287,7 +296,8 @@ uint32_t pcpatch_npoints(const Pcpatch *pa)
 uint32
 pcpatch_hash(const Pcpatch *pa)
 {
-  assert(pa);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pa, INT_MAX);
   return hash_any((const unsigned char *) pa,
     (int) pcpatch_meaningful_size(pa));
 }
@@ -299,7 +309,8 @@ pcpatch_hash(const Pcpatch *pa)
 uint64
 pcpatch_hash_extended(const Pcpatch *pa, uint64 seed)
 {
-  assert(pa);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pa, LONG_MAX);
   return hash_any_extended((const unsigned char *) pa,
     (int) pcpatch_meaningful_size(pa), seed);
 }
@@ -319,7 +330,8 @@ pcpatch_hash_extended(const Pcpatch *pa, uint64 seed)
 int
 pcpatch_cmp(const Pcpatch *pa1, const Pcpatch *pa2)
 {
-  assert(pa1); assert(pa2);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pa1, false); VALIDATE_NOT_NULL(pa2, false);
   size_t sz1 = pcpatch_meaningful_size(pa1);
   size_t sz2 = pcpatch_meaningful_size(pa2);
   size_t minsz = (sz1 < sz2) ? sz1 : sz2;

--- a/meos/src/pointcloud/pcpoint.c
+++ b/meos/src/pointcloud/pcpoint.c
@@ -27,6 +27,7 @@
 
 /* C */
 #include <assert.h>
+#include <limits.h>
 #include <string.h>
 /* PostgreSQL */
 #include <postgres.h>
@@ -40,6 +41,8 @@
 #include "pc_api.h"
 /* MEOS */
 #include <meos.h>
+#include <meos_internal.h>
+#include "temporal/temporal.h"
 #include <meos_pointcloud.h>
 #include "pointcloud/meos_schema_hook.h"
 
@@ -238,7 +241,8 @@ char *
 pcpoint_hex_out(const Pcpoint *pt, int maxdd)
 {
   (void) maxdd;
-  assert(pt);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pt, NULL);
   size_t byte_len = VARSIZE(pt);
   size_t meaningful = pcpoint_meaningful_size(pt);
   size_t hex_len = byte_len * 2;
@@ -283,7 +287,8 @@ pcpoint_as_hexwkb(const Pcpoint *pt)
 Pcpoint *
 pcpoint_copy(const Pcpoint *pt)
 {
-  assert(pt);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pt, NULL);
   size_t sz = VARSIZE(pt);
   Pcpoint *result = palloc(sz);
   memcpy(result, pt, sz);
@@ -302,7 +307,8 @@ pcpoint_copy(const Pcpoint *pt)
 uint32_t
 pcpoint_get_pcid(const Pcpoint *pt)
 {
-  assert(pt);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pt, INT_MAX);
   return pt->pcid;
 }
 
@@ -316,7 +322,8 @@ pcpoint_get_pcid(const Pcpoint *pt)
 uint32
 pcpoint_hash(const Pcpoint *pt)
 {
-  assert(pt);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pt, INT_MAX);
   return hash_any((const unsigned char *) pt,
     (int) pcpoint_meaningful_size(pt));
 }
@@ -328,7 +335,8 @@ pcpoint_hash(const Pcpoint *pt)
 uint64
 pcpoint_hash_extended(const Pcpoint *pt, uint64 seed)
 {
-  assert(pt);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pt, LONG_MAX);
   return hash_any_extended((const unsigned char *) pt,
     (int) pcpoint_meaningful_size(pt), seed);
 }
@@ -353,7 +361,8 @@ pcpoint_hash_extended(const Pcpoint *pt, uint64 seed)
 int
 pcpoint_cmp(const Pcpoint *pt1, const Pcpoint *pt2)
 {
-  assert(pt1); assert(pt2);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pt1, false); VALIDATE_NOT_NULL(pt2, false);
   size_t sz1 = pcpoint_meaningful_size(pt1);
   size_t sz2 = pcpoint_meaningful_size(pt2);
   size_t minsz = (sz1 < sz2) ? sz1 : sz2;
@@ -444,7 +453,9 @@ pcpoint_as_pcpt(const Pcpoint *pt, PCSCHEMA *schema, PCPOINT *out)
 bool
 pcpoint_get_x(const Pcpoint *pt, PCSCHEMA *schema, double *out)
 {
-  assert(pt); assert(schema); assert(out);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pt, false); VALIDATE_NOT_NULL(schema, false);
+  VALIDATE_NOT_NULL(out, false);
   if (! schema->xdim)
     return false;
   PCPOINT pcpt;
@@ -463,7 +474,9 @@ pcpoint_get_x(const Pcpoint *pt, PCSCHEMA *schema, double *out)
 bool
 pcpoint_get_y(const Pcpoint *pt, PCSCHEMA *schema, double *out)
 {
-  assert(pt); assert(schema); assert(out);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pt, false); VALIDATE_NOT_NULL(schema, false);
+  VALIDATE_NOT_NULL(out, false);
   if (! schema->ydim)
     return false;
   PCPOINT pcpt;
@@ -482,7 +495,9 @@ pcpoint_get_y(const Pcpoint *pt, PCSCHEMA *schema, double *out)
 bool
 pcpoint_get_z(const Pcpoint *pt, PCSCHEMA *schema, double *out)
 {
-  assert(pt); assert(schema); assert(out);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pt, false); VALIDATE_NOT_NULL(schema, false);
+  VALIDATE_NOT_NULL(out, false);
   if (! schema->zdim)
     return false;
   PCPOINT pcpt;
@@ -503,7 +518,9 @@ bool
 pcpoint_get_dim(const Pcpoint *pt, PCSCHEMA *schema,
   const char *name, double *out)
 {
-  assert(pt); assert(schema); assert(name); assert(out);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pt, false); VALIDATE_NOT_NULL(schema, false);
+  VALIDATE_NOT_NULL(name, false); VALIDATE_NOT_NULL(out, false);
   PCPOINT pcpt;
   pcpoint_as_pcpt(pt, schema, &pcpt);
   return pc_point_get_double_by_name(&pcpt, name, out) != 0;
@@ -519,7 +536,8 @@ pcpoint_get_dim(const Pcpoint *pt, PCSCHEMA *schema,
 TPCBox *
 pcpoint_to_tpcbox(const Pcpoint *pt, PCSCHEMA *schema)
 {
-  assert(pt); assert(schema);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pt, NULL); VALIDATE_NOT_NULL(schema, NULL);
   if (! schema->xdim || ! schema->ydim)
     return NULL;
   PCPOINT pcpt;


### PR DESCRIPTION
A public MEOS function tests its arguments and returns an error; an internal one asserts the precondition and trusts its caller. Eighteen public functions of the `pcpoint` and `pcpatch` base types state that test with `assert` alone. `assert` is a no-op under `NDEBUG`, so a Release build carries no check and the argument reaches the dereference.

In a Release build, `pcpoint_cmp(NULL, NULL)` returns `0` and reports `Null pointer not allowed` with the guard in place. With the guard absent, the same call dereferences the null argument through `pcpoint_meaningful_size` and the process takes SIGSEGV.

## The guards
Each function uses `VALIDATE_NOT_NULL` with the return value of its counterpart in the sibling families:

| construct | return | sibling |
| --- | --- | --- |
| `_copy`, `_hex_out`, `pcpoint_to_tpcbox` | `NULL` | `cbuffer_copy` |
| 32-bit accessors and `_hash` | `INT_MAX` | `cbuffer_hash` |
| `_hash_extended` | `LONG_MAX` | `cbuffer_hash_extended` |
| `_cmp`, dimension accessors | `false` | `cbuffer_cmp`, `raquet_cmp` |

`pcpoint_to_tpcbox` carries `_to_` in its name, which marks the public cast and requires the guard.

The two files gain `<limits.h>` for the sentinels, `<meos_internal.h>` for the macro, and `temporal/temporal.h` for `ensure_not_null`, which the macro expands to under `-DMEOS=ON`. Four files in the same directory already include the last two.

## Two constructs keep their assert
`tpcbox_expand` agrees with `stbox_expand` and `tbox_expand`, which assert as well. `nad_tpcbox_tpcbox` has siblings that disagree with each other: `nad_stbox_stbox` validates and `nad_tbox_tbox` asserts. Neither is drift against its own family, so both stay as they are.

## Coverage
No automated test exercises this class. The SQL functions are `LANGUAGE C ... STRICT`, so PostgreSQL never passes a null argument to them, and a test written at the SQL level never reaches the guard. The Release-build behaviour above is the evidence.
