### PR TITLE
Compute the pointcloud nearest-approach distance on synchronized values

### DIFF
--- a/meos/include/meos_pointcloud.h
+++ b/meos/include/meos_pointcloud.h
@@ -438,6 +438,10 @@ extern bool ensure_same_pcid_tpcbox(const TPCBox *box1, const TPCBox *box2);
       assert(((Temporal *) (temp))->temptype == T_TPCPATCH); } while (0)
 #endif
 
+/* Conversion */
+
+extern Temporal *tpointcloud_to_tgeompoint(const Temporal *temp);
+
 extern TInstant *tpcpointinst_make(const Pcpoint *pt, TimestampTz t);
 extern TSequence *tpcpointseq_from_base_tstzset(const Pcpoint *pt, const Set *s);
 extern TSequence *tpcpointseq_from_base_tstzspan(const Pcpoint *pt, const Span *sp);

--- a/meos/include/pointcloud/doxygen_meos_pointcloud.h
+++ b/meos/include/pointcloud/doxygen_meos_pointcloud.h
@@ -158,6 +158,10 @@
  * @ingroup meos_pointcloud
  * @brief Constructor functions for temporal pgpointcloud types
  *
+ * @defgroup meos_pointcloud_conversion Conversion functions
+ * @ingroup meos_pointcloud
+ * @brief Conversion functions for temporal pgpointcloud types
+ *
  * @defgroup meos_pointcloud_accessor Accessor functions
  * @ingroup meos_pointcloud
  * @brief Accessor functions for temporal pgpointcloud types

--- a/meos/src/pointcloud/tpc_boxops.c
+++ b/meos/src/pointcloud/tpc_boxops.c
@@ -32,6 +32,7 @@
 #include <meos_internal.h>
 #include "temporal/span.h"
 #include "temporal/temporal.h"
+#include "temporal/meos_catalog.h"  /* T_TPCPOINT */
 #include <utils/timestamp.h>   /* TimestampTzGetDatum */
 #include "pointcloud/meos_schema_hook.h"
 #include "pointcloud/pcpoint.h"
@@ -367,10 +368,40 @@ nad_tpointcloud_tpcbox(const Temporal *temp, const TPCBox *box)
 double
 nad_tpointcloud_tpointcloud(const Temporal *temp1, const Temporal *temp2)
 {
-  TPCBox tmp1, tmp2;
-  temporal_set_bbox(temp1, &tmp1);
-  temporal_set_bbox(temp2, &tmp2);
-  return nad_tpcbox_tpcbox(&tmp1, &tmp2);
+  /* Patches are not point trajectories: they have no single-point
+   * projection to a tgeompoint, so their nearest-approach distance stays
+   * the distance between their bounding boxes, exactly as before. */
+  if (temp1->temptype != T_TPCPOINT || temp2->temptype != T_TPCPOINT)
+  {
+    TPCBox tmp1, tmp2;
+    temporal_set_bbox(temp1, &tmp1);
+    temporal_set_bbox(temp2, &tmp2);
+    return nad_tpcbox_tpcbox(&tmp1, &tmp2);
+  }
+
+  /* PCID mismatch: the two values live in unrelated coordinate systems */
+  const Pcpoint *first1 =
+    (const Pcpoint *) DatumGetPointer(temporal_start_value(temp1));
+  const Pcpoint *first2 =
+    (const Pcpoint *) DatumGetPointer(temporal_start_value(temp2));
+  if (first1->pcid != first2->pcid)
+    return DBL_MAX;
+
+  /* Project both values onto their point trajectories and return the
+   * minimum of their synchronized distance, as the sibling spatiotemporal
+   * types do. This is finer than the bounding-box distance computed by
+   * nad_tpcbox_tpcbox: it can only be equal to or larger. */
+  Temporal *proj1 = tpointcloud_to_tgeompoint(temp1);
+  Temporal *proj2 = tpointcloud_to_tgeompoint(temp2);
+  if (! proj1 || ! proj2)
+  {
+    if (proj1) pfree(proj1);
+    if (proj2) pfree(proj2);
+    return DBL_MAX;
+  }
+  double result = nad_tgeo_tgeo(proj1, proj2);
+  pfree(proj1); pfree(proj2);
+  return result;
 }
 
 /*****************************************************************************/

--- a/meos/src/pointcloud/tpcpoint_spatialfuncs.c
+++ b/meos/src/pointcloud/tpcpoint_spatialfuncs.c
@@ -33,6 +33,7 @@
                                    meos_pc_schema, pcpoint_get_x/y */
 #include "temporal/temporal.h"  /* Temporal, TInstant */
 #include "temporal/meos_catalog.h"  /* T_TPCPOINT */
+#include "geo/tgeo_spatialfuncs.h"  /* geopoint_make */
 #include "pointcloud/pcpoint.h" /* struct Pcpoint body (.pcid field) */
 
 /*****************************************************************************
@@ -64,6 +65,114 @@ tpointcloudinst_pcpoint(const Temporal *temp)
   assert(temp->temptype == T_TPCPOINT);
   return (const Pcpoint *) DatumGetPointer(
     tinstant_value_p((const TInstant *) temp));
+}
+
+/*****************************************************************************
+ * Projection to tgeompoint
+ *
+ * Per-instant mapper: pcpoint -> POINT gserialized with the schema's SRID
+ * and Z-presence, read through the schema-aware public accessors
+ * (pcpoint_get_x/y/z). The schema is resolved once from the value's
+ * common pcid (enforced at construction time by set_make_exp's
+ * same-pcid check) and shared across every instant.
+ *****************************************************************************/
+
+/**
+ * @brief Return the temporal geometry point instant equivalent to a
+ *   temporal pointcloud instant
+ */
+static TInstant *
+tpointcloudinst_to_tgeompointinst(const TInstant *inst, PCSCHEMA *schema)
+{
+  const Pcpoint *pt =
+    (const Pcpoint *) DatumGetPointer(tinstant_value_p(inst));
+  double x, y, z = 0.0;
+  if (! pcpoint_get_x(pt, schema, &x) || ! pcpoint_get_y(pt, schema, &y))
+    return NULL;
+  bool hasz = (schema->zdim != NULL);
+  if (hasz && ! pcpoint_get_z(pt, schema, &z))
+    return NULL;
+  GSERIALIZED *gs = geopoint_make(x, y, z, hasz, /* geodetic */ false,
+    (int32_t) schema->srid);
+  TInstant *result = tinstant_make(PointerGetDatum(gs), T_TGEOMPOINT, inst->t);
+  pfree(gs);
+  return result;
+}
+
+/**
+ * @brief Return the temporal geometry point sequence equivalent to a
+ *   temporal pointcloud sequence
+ */
+static TSequence *
+tpointcloudseq_to_tgeompointseq(const TSequence *seq, PCSCHEMA *schema)
+{
+  TInstant **insts = palloc(sizeof(TInstant *) * seq->count);
+  int n = 0;
+  for (int i = 0; i < seq->count; i++)
+  {
+    TInstant *out = tpointcloudinst_to_tgeompointinst(
+      TSEQUENCE_INST_N(seq, i), schema);
+    if (! out) continue;
+    insts[n++] = out;
+  }
+  /* Step-interpolated in; linear is semantically meaningful for the
+   * projected XY path (the sensor physically moved), so we promote. */
+  interpType interp = MEOS_FLAGS_GET_INTERP(seq->flags);
+  if (interp == STEP) interp = LINEAR;
+  return tsequence_make_free(insts, n, seq->period.lower_inc,
+    seq->period.upper_inc, interp, NORMALIZE);
+}
+
+/**
+ * @brief Return the temporal geometry point sequence set equivalent to a
+ *   temporal pointcloud sequence set
+ */
+static TSequenceSet *
+tpointcloudseqset_to_tgeompointseqset(const TSequenceSet *ss,
+  PCSCHEMA *schema)
+{
+  TSequence **seqs = palloc(sizeof(TSequence *) * ss->count);
+  int n = 0;
+  for (int i = 0; i < ss->count; i++)
+  {
+    TSequence *out = tpointcloudseq_to_tgeompointseq(
+      TSEQUENCESET_SEQ_N(ss, i), schema);
+    if (! out) continue;
+    seqs[n++] = out;
+  }
+  return tsequenceset_make_free(seqs, n, NORMALIZE);
+}
+
+/**
+ * @ingroup meos_pointcloud_conversion
+ * @brief Return a temporal pointcloud value projected onto a temporal
+ *   geometry point by extracting X/Y/[Z] from each instant's pcpoint via
+ *   the schema cache
+ * @param[in] temp Temporal pointcloud value
+ * @return NULL if the pcid schema cannot be resolved
+ * @csqlfn #Tpcpoint_to_tgeompoint()
+ */
+Temporal *
+tpointcloud_to_tgeompoint(const Temporal *temp)
+{
+  VALIDATE_TPCPOINT(temp, NULL);
+  const Pcpoint *first =
+    (const Pcpoint *) DatumGetPointer(temporal_start_value(temp));
+  PCSCHEMA *schema = meos_pc_schema(first->pcid);
+  if (! schema)
+    return NULL;
+  switch (temp->subtype)
+  {
+    case TINSTANT:
+      return (Temporal *) tpointcloudinst_to_tgeompointinst(
+        (const TInstant *) temp, schema);
+    case TSEQUENCE:
+      return (Temporal *) tpointcloudseq_to_tgeompointseq(
+        (const TSequence *) temp, schema);
+    default: /* TSEQUENCESET */
+      return (Temporal *) tpointcloudseqset_to_tgeompointseqset(
+        (const TSequenceSet *) temp, schema);
+  }
 }
 
 /*****************************************************************************

--- a/mobilitydb/src/pointcloud/tpcpoint.c
+++ b/mobilitydb/src/pointcloud/tpcpoint.c
@@ -64,7 +64,6 @@
 #include "temporal/tinstant.h"
 #include "temporal/tsequence.h"
 #include "temporal/tsequenceset.h"
-#include "geo/tgeo_spatialfuncs.h"  /* geopoint_make */
 #include "pointcloud/pcpoint.h"
 #include "pointcloud/tpcbox.h"     /* PG_GETARG_TPCBOX_P */
 /* MobilityDB */
@@ -257,90 +256,11 @@ TPCPOINT_PROJ(Tpcpoint_get_z, dim_get_z)
 /*****************************************************************************
  * Projection to tgeompoint
  *
- * Per-instant mapper: pcpoint → POINT gserialized with the schema's
- * SRID and Z-presence. Reuses the schema cache on the first instant;
- * the same-pcid invariant (enforced at construction by set_make_exp)
- * lets us cache schema + z-flag once per sequence.
+ * The per-instant schema-aware projection (pcpoint -> POINT gserialized)
+ * lives in the MEOS function @c tpointcloud_to_tgeompoint, shared by this
+ * wrapper, the bbox-based restrictions below, and the spatial
+ * relationships / nearest-approach distance.
  *****************************************************************************/
-
-static TInstant *
-tpcpointinst_tgeompointinst(const TInstant *inst, const PCSCHEMA *schema)
-{
-  const Pcpoint *pt =
-    (const Pcpoint *) DatumGetPointer(tinstant_value_p(inst));
-  PCPOINT pcpt;
-  pcpt.readonly = 1;
-  pcpt.schema = schema;
-  pcpt.data = (uint8_t *) pt->data;
-  double x, y, z = 0.0;
-  if (! pc_point_get_x(&pcpt, &x) || ! pc_point_get_y(&pcpt, &y))
-    return NULL;
-  bool hasz = (schema->zdim != NULL);
-  if (hasz && ! pc_point_get_z(&pcpt, &z))
-    return NULL;
-  GSERIALIZED *gs = geopoint_make(x, y, z, hasz, /* geodetic */ false,
-    (int32_t) schema->srid);
-  TInstant *result = tinstant_make(PointerGetDatum(gs), T_TGEOMPOINT, inst->t);
-  pfree(gs);
-  return result;
-}
-
-static TSequence *
-tpcpointseq_tgeompointseq(const TSequence *seq, const PCSCHEMA *schema)
-{
-  TInstant **insts = palloc(sizeof(TInstant *) * seq->count);
-  int n = 0;
-  for (int i = 0; i < seq->count; i++)
-  {
-    TInstant *out = tpcpointinst_tgeompointinst(TSEQUENCE_INST_N(seq, i),
-      schema);
-    if (! out) continue;
-    insts[n++] = out;
-  }
-  /* Step-interpolated in; linear is semantically meaningful for the
-   * projected XY path (the sensor physically moved), so we promote. */
-  interpType interp = MEOS_FLAGS_GET_INTERP(seq->flags);
-  if (interp == STEP) interp = LINEAR;
-  return tsequence_make_free(insts, n, seq->period.lower_inc,
-    seq->period.upper_inc, interp, NORMALIZE);
-}
-
-static TSequenceSet *
-tpcpointseqset_tgeompointseqset(const TSequenceSet *ss, const PCSCHEMA *schema)
-{
-  TSequence **seqs = palloc(sizeof(TSequence *) * ss->count);
-  int n = 0;
-  for (int i = 0; i < ss->count; i++)
-  {
-    TSequence *out = tpcpointseq_tgeompointseq(TSEQUENCESET_SEQ_N(ss, i),
-      schema);
-    if (! out) continue;
-    seqs[n++] = out;
-  }
-  return tsequenceset_make_free(seqs, n, NORMALIZE);
-}
-
-/* Project a tpcpoint Temporal* to a fresh tgeompoint Temporal* by
- * dispatching to the per-subtype static helpers. The schema must be
- * resolved by the caller (typically via tpcpoint_schema). Returns
- * NULL on dispatch error. Reusable from spatialrels and restriction
- * code paths. */
-static Temporal *
-tpcpoint_project_tgeompoint(const Temporal *temp, const PCSCHEMA *schema)
-{
-  switch (temp->subtype)
-  {
-    case TINSTANT:
-      return (Temporal *) tpcpointinst_tgeompointinst((TInstant *) temp,
-        schema);
-    case TSEQUENCE:
-      return (Temporal *) tpcpointseq_tgeompointseq((TSequence *) temp,
-        schema);
-    default: /* TSEQUENCESET */
-      return (Temporal *) tpcpointseqset_tgeompointseqset(
-        (TSequenceSet *) temp, schema);
-  }
-}
 
 PGDLLEXPORT Datum Tpcpoint_to_tgeompoint(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Tpcpoint_to_tgeompoint);
@@ -354,8 +274,7 @@ Datum
 Tpcpoint_to_tgeompoint(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
-  PCSCHEMA *schema = tpcpoint_schema(temp);
-  Temporal *result = tpcpoint_project_tgeompoint(temp, schema);
+  Temporal *result = tpointcloud_to_tgeompoint(temp);
   PG_FREE_IF_COPY(temp, 0);
   if (! result) PG_RETURN_NULL();
   PG_RETURN_POINTER(result);
@@ -388,23 +307,8 @@ tpcpoint_restrict_tpcbox(const Temporal *temp, const TPCBox *box,
   if (first->pcid != box->pcid)
     return atfunc ? NULL : temporal_copy(temp);
 
-  /* Project tpcpoint -> tgeompoint via the existing static helper. */
-  PCSCHEMA *schema = tpcpoint_schema(temp);
-  Temporal *tpoint;
-  switch (temp->subtype)
-  {
-    case TINSTANT:
-      tpoint = (Temporal *)
-        tpcpointinst_tgeompointinst((TInstant *) temp, schema);
-      break;
-    case TSEQUENCE:
-      tpoint = (Temporal *)
-        tpcpointseq_tgeompointseq((TSequence *) temp, schema);
-      break;
-    default: /* TSEQUENCESET */
-      tpoint = (Temporal *)
-        tpcpointseqset_tgeompointseqset((TSequenceSet *) temp, schema);
-  }
+  /* Project tpcpoint -> tgeompoint via the shared MEOS conversion. */
+  Temporal *tpoint = tpointcloud_to_tgeompoint(temp);
   if (! tpoint)
     return atfunc ? NULL : temporal_copy(temp);
 
@@ -525,8 +429,7 @@ Tpcpoint_get_dim(PG_FUNCTION_ARGS)
 static Temporal *
 tpcpoint_to_tgeompoint_temp(const Temporal *temp)
 {
-  PCSCHEMA *schema = tpcpoint_schema(temp);
-  return tpcpoint_project_tgeompoint(temp, schema);
+  return tpointcloud_to_tgeompoint(temp);
 }
 
 #define EA_INTERSECTS_TPC_GEO(NAME, EVER)                                      \

--- a/mobilitydb/test/pointcloud/expected/439_tpc_distance.test.out
+++ b/mobilitydb/test/pointcloud/expected/439_tpc_distance.test.out
@@ -44,3 +44,39 @@ SELECT (tpcpoint(PC_MakePoint(1, ARRAY[0.0, 0.0, 0.0]::float[]), '2024-01-01'::t
  t
 (1 row)
 
+SELECT round((tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01 00:00:00'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-01 00:30:00'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-02 00:00:00'::timestamptz)]) |=| tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[10.0, 10.0, 10.0]::float[]), '2024-01-01 00:00:00'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[12.0, 12.0, 12.0]::float[]), '2024-01-02 00:00:00'::timestamptz)]))::numeric, 4);
+  round  
+---------
+ 13.9286
+(1 row)
+
+SELECT round((tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[10.0, 10.0, 10.0]::float[]), '2024-01-01 00:00:00'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[12.0, 12.0, 12.0]::float[]), '2024-01-02 00:00:00'::timestamptz)]) |=| tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01 00:00:00'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-01 00:30:00'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-02 00:00:00'::timestamptz)]))::numeric, 4);
+  round  
+---------
+ 13.9286
+(1 row)
+
+SELECT (tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01 00:00:00'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-01 00:30:00'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-02 00:00:00'::timestamptz)]) |=| tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[10.0, 10.0, 10.0]::float[]), '2024-01-01 00:00:00'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[12.0, 12.0, 12.0]::float[]), '2024-01-02 00:00:00'::timestamptz)])) > 12.1244;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT (tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01 00:00:00'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-01 00:30:00'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-02 00:00:00'::timestamptz)])) |=| (tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01 00:00:00'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-01 00:30:00'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-02 00:00:00'::timestamptz)]));
+ ?column? 
+----------
+        0
+(1 row)
+
+SELECT eDwithin(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01 00:00:00'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-01 00:30:00'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-02 00:00:00'::timestamptz)]), tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[10.0, 10.0, 10.0]::float[]), '2024-01-01 00:00:00'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[12.0, 12.0, 12.0]::float[]), '2024-01-02 00:00:00'::timestamptz)]), 13);
+ edwithin 
+----------
+ f
+(1 row)
+
+SELECT eDwithin(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01 00:00:00'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-01 00:30:00'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-02 00:00:00'::timestamptz)]), tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[10.0, 10.0, 10.0]::float[]), '2024-01-01 00:00:00'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[12.0, 12.0, 12.0]::float[]), '2024-01-02 00:00:00'::timestamptz)]), 14);
+ edwithin 
+----------
+ t
+(1 row)
+

--- a/mobilitydb/test/pointcloud/queries/439_tpc_distance.test.sql
+++ b/mobilitydb/test/pointcloud/queries/439_tpc_distance.test.sql
@@ -46,3 +46,32 @@ SELECT (:p1) |=| (tpcbox_zt(0, 0, 0, 0, 0, 0,
   tstzspan '[2024-01-01, 2024-01-02]', 999, 0)) > 1e10;
 
 -------------------------------------------------------------------------------
+-- Temporal-temporal nearest-approach distance is the minimum of the
+-- SYNCHRONIZED distance between the two values, not the distance between
+-- their bounding boxes: the box-corner value is only reachable when the
+-- two values are simultaneously at their extreme positions, which need
+-- not happen.
+-------------------------------------------------------------------------------
+
+\set d1 '''2024-01-01 00:00:00''::timestamptz'
+\set d2 '''2024-01-01 00:30:00''::timestamptz'
+\set d3 '''2024-01-02 00:00:00''::timestamptz'
+\set s1 'tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), :d1), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), :d2), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), :d3)])'
+\set s2 'tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[10.0, 10.0, 10.0]::float[]), :d1), tpcpoint(PC_MakePoint(1, ARRAY[12.0, 12.0, 12.0]::float[]), :d3)])'
+
+-- Synchronized minimum, symmetric in both argument orders. It is strictly
+-- greater than the bounding-box distance between [1,3] and [10,12] on
+-- each axis (7 * sqrt(3) ~ 12.1244): the values never simultaneously
+-- reach their closest box corners.
+SELECT round((:s1 |=| :s2)::numeric, 4);
+SELECT round((:s2 |=| :s1)::numeric, 4);
+SELECT (:s1 |=| :s2) > 12.1244;
+
+-- Nearest-approach distance of a value with itself is zero.
+SELECT (:s1) |=| (:s1);
+
+-- Consistency with eDwithin on both sides of the synchronized minimum.
+SELECT eDwithin(:s1, :s2, 13);
+SELECT eDwithin(:s1, :s2, 14);
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
The nearest-approach distance between two temporal pointclouds is the distance between their bounding boxes, which understates the true value and contradicts `eDwithin`: a pair whose synchronized minimum is 13.8564 reports 12.1244, so `nearestApproachDistance(a, b) < d` and `eDwithin(a, b, d)` disagree.

This change computes the distance as the minimum of the synchronized distance between the projected point trajectories, as the sibling spatiotemporal types do, keeping the DBL_MAX sentinel for pcid mismatch and no temporal overlap. The projection of a temporal pointcloud to a temporal point lives in the MEOS function `tpointcloud_to_tgeompoint`, shared by the restriction wrapper and the distance path. Tests cover the synchronized minimum, self-distance, and agreement with `eDwithin` on both sides of the threshold.