### PR TITLE
Bring the cell-index conversion sections under the inherited SQL generator

### DIFF
--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -2270,13 +2270,14 @@ def bootstrap_distance(filetext: str, fam: dict, rendered: str) -> str:
 # (marker-aware, mirroring extract_constructors: sliced by GENERATED-CONVERSIONS
 # markers once they exist, else by the Conversions banner header down to the `/*` of
 # the next section), so the deployed .in.sql files are untouched while the template is
-# proven. FOUR families are intentionally absent from the manifest: th3index and
-# tquadbin scatter their casts across three non-contiguous locations (the typmod
-# self-cast in the I/O area, the tbigint assignment casts, and the tstzspan cast
-# buried in the Accessors section — there is no single Conversions section to slice),
-# and tpcpoint/tpcpatch likewise have no contiguous conversion section (tpcpoint's
-# lone tgeompoint cast trails the Accessors block; tpcpatch has none). They are
-# classified out by omission from the data, never by a code-level skip.
+# proven. th3index and tquadbin each carry a typmod self-cast in the I/O area and a
+# tstzspan cast buried in the Accessors section, both owned by other axes; between
+# them sits a single contiguous "Explicit assignment casts to / from tbigint" region
+# (the tbigint cross-casts), which this axis slices like any other family. TWO
+# families remain intentionally absent from the manifest: tpcpoint/tpcpatch have no
+# contiguous conversion section (tpcpoint's lone tgeompoint cast trails the Accessors
+# block; tpcpatch has none). They are classified out by omission from the data, never
+# by a code-level skip.
 def _conversions_markers(family: str):
     begin = (f"-- GENERATED-CONVERSIONS-BEGIN {family} — "
              "tools/codegen/inherited/generate.py from templates/conversions.sql.tmpl;\n"

--- a/tools/codegen/inherited/manifest.d/conversion_families.yaml
+++ b/tools/codegen/inherited/manifest.d/conversion_families.yaml
@@ -4,12 +4,12 @@
 # the same chunks). tfloat and ttext are not named here — tfloat already surfaces
 # through these shared numeric chunks and ttext through the json family's ttext<->
 # tjsonb casts — so they are not missing from the class, just covered elsewhere.
-# th3index and tquadbin are NOT modeled: their casts scatter across three
-# non-contiguous locations (the typmod self-cast in the I/O area, the tbigint
-# assignment casts, and the tstzspan cast buried in the Accessors section), so
-# there is no single Conversions section to slice with the begin/end-anchor model
-# every other family here uses. tpcpoint/tpcpatch are reserved for a separate
-# pointcloud session and are likewise absent.
+# th3index and tquadbin each carry a typmod self-cast in the I/O area and a
+# tstzspan cast buried in the Accessors section (both owned by other axes, left
+# alone here); the dedicated conversion region between them — the "Explicit
+# assignment casts to / from tbigint" banner down to the Constructors banner —
+# is the single contiguous slice this axis governs. tpcpoint/tpcpatch are
+# reserved for a separate pointcloud session and are likewise absent.
 conversion_families:
 - family: temporal
   file: mobilitydb/sql/temporal/022_temporal.in.sql
@@ -128,3 +128,25 @@ conversion_families:
   - fns:
     - {sig: "geometry(trgeometry)", ret: geometry, sym: Trgeometry_to_geom}
   - lit: "\nCREATE CAST (trgeometry AS geometry) WITH FUNCTION geometry(trgeometry);\n\n"
+- family: h3
+  file: mobilitydb/sql/h3/253_th3index.in.sql
+  reference: true
+  begin: "\n * Explicit assignment casts to / from tbigint\n"
+  end: "\n * Constructors\n"
+  blocks:
+  - lit: "/******************************************************************************\n * Explicit assignment casts to / from tbigint\n *\n * The int64 payload is shared, but th3index sequences carry a geodetic\n * STBox bbox while tbigint sequences carry a TBox; a binary coercion\n * would leave the wrong bbox shape in place and the wrong temptype byte\n * inside the Temporal header. The cast therefore goes through a real\n * function that lifts an identity Datum function so the result is\n * rebuilt at the correct shape. The cast is declared `AS ASSIGNMENT`\n * so the user must spell out `::th3index` or `::tbigint` — mistakes\n * surface as a clear binder error rather than silently reinterpreting\n * an arbitrary int64 trajectory as a stream of H3 cells.\n ******************************************************************************/\n\n"
+  - fns:
+    - {sig: "th3index(tbigint)", ret: th3index, sym: Tbigint_to_th3index}
+    - {sig: "tbigint(th3index)", ret: tbigint, sym: Th3index_to_tbigint}
+  - lit: "\nCREATE CAST (tbigint AS th3index) WITH FUNCTION th3index(tbigint) AS ASSIGNMENT;\nCREATE CAST (th3index AS tbigint) WITH FUNCTION tbigint(th3index) AS ASSIGNMENT;\n\n"
+- family: quadbin
+  file: mobilitydb/sql/quadbin/353_tquadbin.in.sql
+  reference: true
+  begin: "\n * Explicit assignment casts to / from tbigint\n"
+  end: "\n * Constructors\n"
+  blocks:
+  - lit: "/******************************************************************************\n * Explicit assignment casts to / from tbigint\n *\n * The int64 payload is shared, but tquadbin sequences carry a planar\n * STBox bbox while tbigint sequences carry a TBox; a binary coercion\n * would leave the wrong bbox shape in place and the wrong temptype byte\n * inside the Temporal header. The cast therefore goes through a real\n * function that lifts an identity Datum function so the result is\n * rebuilt at the correct shape. The cast is declared `AS ASSIGNMENT`\n * so the user must spell out `::tquadbin` or `::tbigint` — mistakes\n * surface as a clear binder error rather than silently reinterpreting\n * an arbitrary int64 trajectory as a stream of quadbin cells.\n ******************************************************************************/\n\n"
+  - fns:
+    - {sig: "tquadbin(tbigint)", ret: tquadbin, sym: Tbigint_to_tquadbin}
+    - {sig: "tbigint(tquadbin)", ret: tbigint, sym: Tquadbin_to_tbigint}
+  - lit: "\nCREATE CAST (tbigint AS tquadbin) WITH FUNCTION tquadbin(tbigint) AS ASSIGNMENT;\nCREATE CAST (tquadbin AS tbigint) WITH FUNCTION tbigint(tquadbin) AS ASSIGNMENT;\n\n"


### PR DESCRIPTION
## Summary

Governs the th3index and tquadbin conversion regions with the same begin/end-anchor model every other conversion family already uses. Each type carries a single contiguous slice between its typmod self-cast (I/O area) and its tstzspan cast (Accessors) — the "Explicit assignment casts to / from tbigint" banner down to the Constructors banner — reproduced byte-exact via lit/fns blocks in `manifest.d/conversion_families.yaml`, mirroring the cbuffer/npoint/pose entries.

Corrects the generator's comment describing th3index/tquadbin as structurally ungovernable; the live layout carries one contiguous region, not three scattered locations.

Advances `conversion_families` from 14/18 to 16/18. tpcpoint/tpcpatch stay excluded, reserved for a dedicated pointcloud session.