### PR TITLE
Count the subtype-generated surface when measuring behaviour coverage

### DIFF
--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -3482,6 +3482,38 @@ def rendered_temp_types(axis: str, entries: list, candidates: list) -> set:
     return out
 
 
+# The subtypes: mechanism (the module-level render(), used by --check/--validate
+# to emit per-subtype files) produces five of these axes' SQL straight from
+# templates/<behaviour>.sql.tmpl instead of a *_families entry, keyed by the
+# behaviour name in a subtypes: entry's `files` list (gist/spgist/indexes have no
+# *_families axis of their own to feed, so they stay unmeasured here). A type on
+# the subtypes track counts as covered on the axis its behaviour corresponds to,
+# the same way a *_families entry does.
+SUBTYPE_AXIS_BEHAVIOUR = {
+    "compops_families": "compops",
+    "topop_families": "topops",
+    "posop_families": "posops",
+    "spatialrel_families": "spatialrels",
+    "native_tempspatialrel_families": "tempspatialrels",
+}
+
+
+def rendered_subtype_types(axis: str, subtypes: list, candidates: list) -> set:
+    """The temporal types the subtypes: mechanism's rendered SQL declares a
+    surface for, on the behaviour (if any) that feeds this axis."""
+    behaviour = SUBTYPE_AXIS_BEHAVIOUR.get(axis)
+    if behaviour is None:
+        return set()
+    out = set()
+    for sub in subtypes:
+        if behaviour not in (sub.get("files") or []):
+            continue
+        for decl in DECLARATION.finditer(render(behaviour, sub)):
+            subject = RETURNS_CLAUSE.sub("", decl.group(0))
+            out.update(_decl_subject(subject, candidates))
+    return out
+
+
 def report_gaps(mf: dict) -> int:
     """Per behaviour, which members of its class its rendered SQL does not name.
 
@@ -3495,11 +3527,13 @@ def report_gaps(mf: dict) -> int:
     every = [m for m in classes["temporal"]["members"]
              if m not in INTERNAL_TEMP_TYPES]
     ranked = sorted(classes.items(), key=lambda kv: len(kv[1].get("members") or []))
+    subtypes = mf.get("subtypes") or []
     for axis in sorted(AXIS_RENDERERS):
         entries = mf.get(axis) or []
-        if not entries:
+        if not entries and axis not in SUBTYPE_AXIS_BEHAVIOUR:
             continue
-        have = rendered_temp_types(axis, entries, every)
+        have = (rendered_temp_types(axis, entries, every)
+                | rendered_subtype_types(axis, subtypes, every))
         if not have:
             print(f"[   ?] {axis:30} unmeasured - rendering named no type")
             continue


### PR DESCRIPTION
Counts the surface emitted by the `subtypes:` mechanism when `--gaps` measures behaviour coverage.

`report_gaps` walks the axes registered in `AXIS_RENDERERS`. The `subtypes:` mechanism emits per-family comparison, topological, positional and spatial-relationship files through its own templates, and those files carry the generator's do-not-edit banner, so the families they cover are machine-owned while reading as missing in the report. Counting both sources gives each behaviour row the full set of types its generated SQL declares.

The measurement reflects that on six rows:

| behaviour | before | after |
|---|---|---|
| `compops_families` | 10 of 18 | 18 of 18 |
| `native_tempspatialrel_families` | 1 of 10 | 5 of 10 |
| `posop_families` | unmeasured | 6 of 10 |
| `topop_families` | unmeasured | 6 of 10 |
| `spatialrel_families` | unmeasured | 2 of 10 |

No row loses a type. The four rows reading `unmeasured` name no temporal type in their `*_families` entries alone, and report a count once the subtype-emitted files join the same behaviour key.

The change spans the reporting path of `tools/codegen/inherited/generate.py`; the manifest, the templates and the deployed SQL are untouched, and each file keeps exactly one owning mechanism.
