### PR TITLE
Read the distinct values of a temporal geo without sorting them twice

### DIFF
--- a/meos/src/geo/tgeo_meos.c
+++ b/meos/src/geo/tgeo_meos.c
@@ -764,11 +764,7 @@ tgeo_values(const Temporal *temp, int *count)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TGEO(temp, NULL); VALIDATE_NOT_NULL(count, NULL);
-  int count1;
-  Datum *datumarr = temporal_values_p(temp, &count1);
-  MeosType basetype = temptype_basetype(temp->temptype);
-  datumarr_sort(datumarr, count1, basetype);
-  *count = datumarr_remove_duplicates(datumarr, count1, basetype);
+  Datum *datumarr = temporal_values_p(temp, count);
   GSERIALIZED **result = palloc(sizeof(GSERIALIZED *) * *count);
   for (int i = 0; i < *count; i++)
     result[i] = geo_copy(DatumGetGserializedP(datumarr[i]));


### PR DESCRIPTION
`tgeo_values` reads the distinct values of a temporal geo from `temporal_values_p`, which returns them already sorted and free of duplicates: `tsequence_values_p` and `tsequenceset_values_p` both sort the array and call `datumarr_remove_duplicates` before returning it. The accessor sorted and deduplicated that array a second time.

The repeated pass is the expensive one for a geometry, whose comparison builds a bounding box and a sortable hash for each operand.

## Measured
Over 40 real AIS trajectories of 300 instants, reading the distinct values:

```
80,860,098 -> 72,681,284 instructions   (-10.1%)
```

The values are the same: 15316 distinct values on both sides, and a dump of every value hashes identically.

## Shape
The sibling accessors of the other families read the array of `temporal_values_p` directly, among them `tbool_values` and `tnpoint_values`, which is what this accessor now does.
