### PR TITLE
Order two points by comparing their coordinates in turn

### DIFF
--- a/meos/src/geo/tgeo_spatialfuncs.c
+++ b/meos/src/geo/tgeo_spatialfuncs.c
@@ -142,11 +142,17 @@ geopoint_cmp(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   {
     const POINT3DZ *point1 = GSERIALIZED_POINT3DZ_P(gs1);
     const POINT3DZ *point2 = GSERIALIZED_POINT3DZ_P(gs2);
-    if (float8_lt(point1->x, point2->x) || float8_lt(point1->y, point2->y) || 
-        float8_lt(point1->z, point2->z))
+    if (float8_lt(point1->x, point2->x))
       return -1;
-    if (float8_gt(point1->x, point2->x) || float8_gt(point1->y, point2->y) || 
-        float8_gt(point1->z, point2->z))
+    if (float8_gt(point1->x, point2->x))
+      return 1;
+    if (float8_lt(point1->y, point2->y))
+      return -1;
+    if (float8_gt(point1->y, point2->y))
+      return 1;
+    if (float8_lt(point1->z, point2->z))
+      return -1;
+    if (float8_gt(point1->z, point2->z))
       return 1;
     return 0;
   }
@@ -154,9 +160,13 @@ geopoint_cmp(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   {
     const POINT2D *point1 = GSERIALIZED_POINT2D_P(gs1);
     const POINT2D *point2 = GSERIALIZED_POINT2D_P(gs2);
-    if (float8_lt(point1->x, point2->x) || float8_lt(point1->y, point2->y))
+    if (float8_lt(point1->x, point2->x))
       return -1;
-    if (float8_gt(point1->x, point2->x) || float8_gt(point1->y, point2->y))
+    if (float8_gt(point1->x, point2->x))
+      return 1;
+    if (float8_lt(point1->y, point2->y))
+      return -1;
+    if (float8_gt(point1->y, point2->y))
       return 1;
     return 0;
   }


### PR DESCRIPTION
`geopoint_cmp` answers `-1` as soon as either coordinate of the first point is smaller, and `1` as soon as either is greater. For `(1 5)` and `(2 3)` the first test succeeds in both directions:

- comparing `(1 5)` with `(2 3)` gives `-1`, because `1 < 2`
- comparing `(2 3)` with `(1 5)` gives `-1`, because `3 < 5`

A comparison that holds in both directions is not an order, and a sort reading it has no defined result.

Each coordinate now settles the comparison before the next one is read, which is how `cbuffer_cmp` orders the centre of two buffers.

The function has no caller today, so the behaviour of the tree is unchanged. It is declared in `tgeo_spatialfuncs.h` and is the natural comparison to reach for when ordering points.
