### PR TITLE
Titles the h3/quadbin conversion section Conversions, matching every sibling family

### DIFF
--- a/mobilitydb/sql/h3/253_th3index.in.sql
+++ b/mobilitydb/sql/h3/253_th3index.in.sql
@@ -149,7 +149,7 @@ CREATE CAST (th3index AS th3index) WITH FUNCTION th3index(th3index, integer)
   AS IMPLICIT;
 
 /******************************************************************************
- * Explicit assignment casts to / from tbigint
+ * Conversions
  *
  * The int64 payload is shared, but th3index sequences carry a geodetic
  * STBox bbox while tbigint sequences carry a TBox; a binary coercion

--- a/mobilitydb/sql/quadbin/353_tquadbin.in.sql
+++ b/mobilitydb/sql/quadbin/353_tquadbin.in.sql
@@ -149,7 +149,7 @@ CREATE CAST (tquadbin AS tquadbin) WITH FUNCTION tquadbin(tquadbin, integer)
   AS IMPLICIT;
 
 /******************************************************************************
- * Explicit assignment casts to / from tbigint
+ * Conversions
  *
  * The int64 payload is shared, but tquadbin sequences carry a planar
  * STBox bbox while tbigint sequences carry a TBox; a binary coercion

--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -2246,7 +2246,7 @@ def bootstrap_distance(filetext: str, fam: dict, rendered: str) -> str:
 # the next section), so the deployed .in.sql files are untouched while the template is
 # proven. th3index and tquadbin each carry a typmod self-cast in the I/O area and a
 # tstzspan cast buried in the Accessors section, both owned by other axes; between
-# them sits a single contiguous "Explicit assignment casts to / from tbigint" region
+# them sits a single contiguous "Conversions" region
 # (the tbigint cross-casts), which this axis slices like any other family. TWO
 # families remain intentionally absent from the manifest: tpcpoint/tpcpatch have no
 # contiguous conversion section (tpcpoint's lone tgeompoint cast trails the Accessors

--- a/tools/codegen/inherited/manifest.d/conversion_families.yaml
+++ b/tools/codegen/inherited/manifest.d/conversion_families.yaml
@@ -109,10 +109,10 @@ conversion_families:
 - family: h3
   file: mobilitydb/sql/h3/253_th3index.in.sql
   reference: true
-  begin: "\n * Explicit assignment casts to / from tbigint\n"
+  begin: "\n * Conversions\n"
   end: "\n * Constructors\n"
   blocks:
-  - lit: "/******************************************************************************\n * Explicit assignment casts to / from tbigint\n *\n * The int64 payload is shared, but th3index sequences carry a geodetic\n * STBox bbox while tbigint sequences carry a TBox; a binary coercion\n * would leave the wrong bbox shape in place and the wrong temptype byte\n * inside the Temporal header. The cast therefore goes through a real\n * function that lifts an identity Datum function so the result is\n * rebuilt at the correct shape. The cast is declared `AS ASSIGNMENT`\n * so the user must spell out `::th3index` or `::tbigint` — mistakes\n * surface as a clear binder error rather than silently reinterpreting\n * an arbitrary int64 trajectory as a stream of H3 cells.\n ******************************************************************************/\n\n"
+  - lit: "/******************************************************************************\n * Conversions\n *\n * The int64 payload is shared, but th3index sequences carry a geodetic\n * STBox bbox while tbigint sequences carry a TBox; a binary coercion\n * would leave the wrong bbox shape in place and the wrong temptype byte\n * inside the Temporal header. The cast therefore goes through a real\n * function that lifts an identity Datum function so the result is\n * rebuilt at the correct shape. The cast is declared `AS ASSIGNMENT`\n * so the user must spell out `::th3index` or `::tbigint` — mistakes\n * surface as a clear binder error rather than silently reinterpreting\n * an arbitrary int64 trajectory as a stream of H3 cells.\n ******************************************************************************/\n\n"
   - fns:
     - {sig: "th3index(tbigint)", ret: th3index, sym: Tbigint_to_th3index}
     - {sig: "tbigint(th3index)", ret: tbigint, sym: Th3index_to_tbigint}
@@ -120,10 +120,10 @@ conversion_families:
 - family: quadbin
   file: mobilitydb/sql/quadbin/353_tquadbin.in.sql
   reference: true
-  begin: "\n * Explicit assignment casts to / from tbigint\n"
+  begin: "\n * Conversions\n"
   end: "\n * Constructors\n"
   blocks:
-  - lit: "/******************************************************************************\n * Explicit assignment casts to / from tbigint\n *\n * The int64 payload is shared, but tquadbin sequences carry a planar\n * STBox bbox while tbigint sequences carry a TBox; a binary coercion\n * would leave the wrong bbox shape in place and the wrong temptype byte\n * inside the Temporal header. The cast therefore goes through a real\n * function that lifts an identity Datum function so the result is\n * rebuilt at the correct shape. The cast is declared `AS ASSIGNMENT`\n * so the user must spell out `::tquadbin` or `::tbigint` — mistakes\n * surface as a clear binder error rather than silently reinterpreting\n * an arbitrary int64 trajectory as a stream of quadbin cells.\n ******************************************************************************/\n\n"
+  - lit: "/******************************************************************************\n * Conversions\n *\n * The int64 payload is shared, but tquadbin sequences carry a planar\n * STBox bbox while tbigint sequences carry a TBox; a binary coercion\n * would leave the wrong bbox shape in place and the wrong temptype byte\n * inside the Temporal header. The cast therefore goes through a real\n * function that lifts an identity Datum function so the result is\n * rebuilt at the correct shape. The cast is declared `AS ASSIGNMENT`\n * so the user must spell out `::tquadbin` or `::tbigint` — mistakes\n * surface as a clear binder error rather than silently reinterpreting\n * an arbitrary int64 trajectory as a stream of quadbin cells.\n ******************************************************************************/\n\n"
   - fns:
     - {sig: "tquadbin(tbigint)", ret: tquadbin, sym: Tbigint_to_tquadbin}
     - {sig: "tbigint(tquadbin)", ret: tbigint, sym: Tquadbin_to_tbigint}


### PR DESCRIPTION
## Summary

Titles the tbigint cross-cast section of `th3index` and `tquadbin` with the canonical `Conversions` banner used by every sibling family (`cbuffer`, `tpose`, `tgeo`, `tpoint`, ...), replacing the divergent `Explicit assignment casts to / from tbigint` heading. Preserves the explanatory prose about the shared int64 payload, the differing bbox shapes, and the ASSIGNMENT-only casts as comment lines beneath the canonical heading.

Aligns the corresponding entries in `tools/codegen/inherited/manifest.d/conversion_families.yaml` — the `begin` anchor and `lit` block for both families — so `--validate` continues to reproduce the committed `.in.sql` files byte-for-byte. Updates the matching comment in `tools/codegen/inherited/generate.py` that names the section by its old banner text.

Comment-only change: no `CREATE FUNCTION`, `CREATE CAST`, or any other DDL line is touched.