### PR TITLE
Add the comparison operators for the pcpoint and pcpatch types

### DIFF
--- a/meos/src/pointcloud/pcpatch.c
+++ b/meos/src/pointcloud/pcpatch.c
@@ -292,6 +292,7 @@ uint32_t pcpatch_npoints(const Pcpatch *pa)
 /**
  * @ingroup meos_pointcloud_base_accessor
  * @brief Return the 32-bit hash of a pcpatch
+ * @csqlfn #Pcpatch_hash()
  */
 uint32
 pcpatch_hash(const Pcpatch *pa)
@@ -305,6 +306,7 @@ pcpatch_hash(const Pcpatch *pa)
 /**
  * @ingroup meos_pointcloud_base_accessor
  * @brief Return the 64-bit hash of a pcpatch with a seed
+ * @csqlfn #Pcpatch_hash_extended()
  */
 uint64
 pcpatch_hash_extended(const Pcpatch *pa, uint64 seed)
@@ -326,6 +328,7 @@ pcpatch_hash_extended(const Pcpatch *pa, uint64 seed)
  * @note Compares only the meaningful-prefix bytes — pgpointcloud's
  *   struct-tail padding is skipped so two pcpatches that disagree only
  *   on those padding bytes compare equal.
+ * @csqlfn #Pcpatch_cmp()
  */
 int
 pcpatch_cmp(const Pcpatch *pa1, const Pcpatch *pa2)

--- a/meos/src/pointcloud/pcpoint.c
+++ b/meos/src/pointcloud/pcpoint.c
@@ -318,6 +318,7 @@ pcpoint_get_pcid(const Pcpoint *pt)
  * @note Hashes only the meaningful-prefix bytes — pgpointcloud's
  *   struct-tail padding is skipped because it holds uninitialized heap
  *   bytes that differ between otherwise-identical values.
+ * @csqlfn #Pcpoint_hash()
  */
 uint32
 pcpoint_hash(const Pcpoint *pt)
@@ -331,6 +332,7 @@ pcpoint_hash(const Pcpoint *pt)
 /**
  * @ingroup meos_pointcloud_base_accessor
  * @brief Return the 64-bit seeded hash of a pcpoint
+ * @csqlfn #Pcpoint_hash_extended()
  */
 uint64
 pcpoint_hash_extended(const Pcpoint *pt, uint64 seed)
@@ -357,6 +359,7 @@ pcpoint_hash_extended(const Pcpoint *pt, uint64 seed)
  *   struct-tail padding is skipped (see the padding comment above).
  *   Two pcpoints that disagree only on those padding bytes now compare
  *   equal, making Set dedup and B-tree equality deterministic.
+ * @csqlfn #Pcpoint_cmp()
  */
 int
 pcpoint_cmp(const Pcpoint *pt1, const Pcpoint *pt2)

--- a/mobilitydb/pg_include/pg_pointcloud/doxygen_mobilitydb_pointcloud.h
+++ b/mobilitydb/pg_include/pg_pointcloud/doxygen_mobilitydb_pointcloud.h
@@ -69,6 +69,10 @@
  * @ingroup mobilitydb_pointcloud_base
  * @brief Schema-aware accessors (pcid, getX, getY, getZ, getDim) for
  *   pcpoint / pcpatch
+ *
+ * @defgroup mobilitydb_pointcloud_base_comp Comparison functions
+ * @ingroup mobilitydb_pointcloud_base
+ * @brief Comparison functions for pcpoint / pcpatch
  */
 
 /*****************************************************************************

--- a/mobilitydb/sql/pointcloud/400_pcset.in.sql
+++ b/mobilitydb/sql/pointcloud/400_pcset.in.sql
@@ -91,6 +91,198 @@ CREATE FUNCTION getDim(pcpoint, text)
   LANGUAGE C STABLE STRICT PARALLEL SAFE;
 
 /******************************************************************************
+ * pcpoint — Comparison / B-tree / hash
+ ******************************************************************************/
+
+CREATE FUNCTION eq(pcpoint, pcpoint)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Pcpoint_eq'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION ne(pcpoint, pcpoint)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Pcpoint_ne'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION lt(pcpoint, pcpoint)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Pcpoint_lt'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION le(pcpoint, pcpoint)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Pcpoint_le'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION ge(pcpoint, pcpoint)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Pcpoint_ge'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION gt(pcpoint, pcpoint)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Pcpoint_gt'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION cmp(pcpoint, pcpoint)
+  RETURNS int4
+  AS 'MODULE_PATHNAME', 'Pcpoint_cmp'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OPERATOR = (
+  PROCEDURE = eq,
+  LEFTARG = pcpoint, RIGHTARG = pcpoint,
+  COMMUTATOR = =, NEGATOR = <>,
+  RESTRICT = eqsel, JOIN = eqjoinsel
+);
+CREATE OPERATOR <> (
+  PROCEDURE = ne,
+  LEFTARG = pcpoint, RIGHTARG = pcpoint,
+  COMMUTATOR = <>, NEGATOR = =,
+  RESTRICT = neqsel, JOIN = neqjoinsel
+);
+CREATE OPERATOR < (
+  PROCEDURE = lt,
+  LEFTARG = pcpoint, RIGHTARG = pcpoint,
+  COMMUTATOR = >, NEGATOR = >=,
+  RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+CREATE OPERATOR <= (
+  PROCEDURE = le,
+  LEFTARG = pcpoint, RIGHTARG = pcpoint,
+  COMMUTATOR = >=, NEGATOR = >,
+  RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+CREATE OPERATOR >= (
+  PROCEDURE = ge,
+  LEFTARG = pcpoint, RIGHTARG = pcpoint,
+  COMMUTATOR = <=, NEGATOR = <,
+  RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+CREATE OPERATOR > (
+  PROCEDURE = gt,
+  LEFTARG = pcpoint, RIGHTARG = pcpoint,
+  COMMUTATOR = <, NEGATOR = <=,
+  RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR CLASS pcpoint_btree_ops
+  DEFAULT FOR TYPE pcpoint USING btree AS
+  OPERATOR  1 < ,
+  OPERATOR  2 <= ,
+  OPERATOR  3 = ,
+  OPERATOR  4 >= ,
+  OPERATOR  5 > ,
+  FUNCTION  1 cmp(pcpoint, pcpoint);
+
+/******************************************************************************/
+
+CREATE FUNCTION hash(pcpoint)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Pcpoint_hash'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION hashExtended(pcpoint, bigint)
+  RETURNS bigint
+  AS 'MODULE_PATHNAME', 'Pcpoint_hash_extended'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OPERATOR CLASS pcpoint_hash_ops
+  DEFAULT FOR TYPE pcpoint USING hash AS
+    OPERATOR    1   = ,
+    FUNCTION    1   hash(pcpoint),
+    FUNCTION    2   hashExtended(pcpoint, bigint);
+
+/******************************************************************************
+ * pcpatch — Comparison / B-tree / hash
+ ******************************************************************************/
+
+CREATE FUNCTION eq(pcpatch, pcpatch)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Pcpatch_eq'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION ne(pcpatch, pcpatch)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Pcpatch_ne'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION lt(pcpatch, pcpatch)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Pcpatch_lt'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION le(pcpatch, pcpatch)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Pcpatch_le'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION ge(pcpatch, pcpatch)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Pcpatch_ge'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION gt(pcpatch, pcpatch)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Pcpatch_gt'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION cmp(pcpatch, pcpatch)
+  RETURNS int4
+  AS 'MODULE_PATHNAME', 'Pcpatch_cmp'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OPERATOR = (
+  PROCEDURE = eq,
+  LEFTARG = pcpatch, RIGHTARG = pcpatch,
+  COMMUTATOR = =, NEGATOR = <>,
+  RESTRICT = eqsel, JOIN = eqjoinsel
+);
+CREATE OPERATOR <> (
+  PROCEDURE = ne,
+  LEFTARG = pcpatch, RIGHTARG = pcpatch,
+  COMMUTATOR = <>, NEGATOR = =,
+  RESTRICT = neqsel, JOIN = neqjoinsel
+);
+CREATE OPERATOR < (
+  PROCEDURE = lt,
+  LEFTARG = pcpatch, RIGHTARG = pcpatch,
+  COMMUTATOR = >, NEGATOR = >=,
+  RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+CREATE OPERATOR <= (
+  PROCEDURE = le,
+  LEFTARG = pcpatch, RIGHTARG = pcpatch,
+  COMMUTATOR = >=, NEGATOR = >,
+  RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+CREATE OPERATOR >= (
+  PROCEDURE = ge,
+  LEFTARG = pcpatch, RIGHTARG = pcpatch,
+  COMMUTATOR = <=, NEGATOR = <,
+  RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+CREATE OPERATOR > (
+  PROCEDURE = gt,
+  LEFTARG = pcpatch, RIGHTARG = pcpatch,
+  COMMUTATOR = <, NEGATOR = <=,
+  RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR CLASS pcpatch_btree_ops
+  DEFAULT FOR TYPE pcpatch USING btree AS
+  OPERATOR  1 < ,
+  OPERATOR  2 <= ,
+  OPERATOR  3 = ,
+  OPERATOR  4 >= ,
+  OPERATOR  5 > ,
+  FUNCTION  1 cmp(pcpatch, pcpatch);
+
+/******************************************************************************/
+
+CREATE FUNCTION hash(pcpatch)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Pcpatch_hash'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION hashExtended(pcpatch, bigint)
+  RETURNS bigint
+  AS 'MODULE_PATHNAME', 'Pcpatch_hash_extended'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OPERATOR CLASS pcpatch_hash_ops
+  DEFAULT FOR TYPE pcpatch USING hash AS
+    OPERATOR    1   = ,
+    FUNCTION    1   hash(pcpatch),
+    FUNCTION    2   hashExtended(pcpatch, bigint);
+
+/******************************************************************************
  * pcpointset — Input / output
  ******************************************************************************/
 

--- a/mobilitydb/src/pointcloud/pcset.c
+++ b/mobilitydb/src/pointcloud/pcset.c
@@ -179,4 +179,358 @@ Pcpoint_get_dim(PG_FUNCTION_ARGS)
   PG_RETURN_FLOAT8(v);
 }
 
+/*****************************************************************************
+ * Comparison functions for pcpoint
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Pcpoint_eq(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Pcpoint_eq);
+/**
+ * @ingroup mobilitydb_pointcloud_base_comp
+ * @brief Return true if the first pcpoint is equal to the second one
+ * @sqlfn eq()
+ * @sqlop @p =
+ */
+Datum
+Pcpoint_eq(PG_FUNCTION_ARGS)
+{
+  Pcpoint *pt1 = PG_GETARG_PCPOINT_P(0);
+  Pcpoint *pt2 = PG_GETARG_PCPOINT_P(1);
+  bool result = pcpoint_eq(pt1, pt2);
+  PG_FREE_IF_COPY(pt1, 0);
+  PG_FREE_IF_COPY(pt2, 1);
+  PG_RETURN_BOOL(result);
+}
+
+PGDLLEXPORT Datum Pcpoint_ne(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Pcpoint_ne);
+/**
+ * @ingroup mobilitydb_pointcloud_base_comp
+ * @brief Return true if the first pcpoint is different from the second one
+ * @sqlfn ne()
+ * @sqlop @p <>
+ */
+Datum
+Pcpoint_ne(PG_FUNCTION_ARGS)
+{
+  Pcpoint *pt1 = PG_GETARG_PCPOINT_P(0);
+  Pcpoint *pt2 = PG_GETARG_PCPOINT_P(1);
+  bool result = pcpoint_ne(pt1, pt2);
+  PG_FREE_IF_COPY(pt1, 0);
+  PG_FREE_IF_COPY(pt2, 1);
+  PG_RETURN_BOOL(result);
+}
+
+PGDLLEXPORT Datum Pcpoint_cmp(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Pcpoint_cmp);
+/**
+ * @ingroup mobilitydb_pointcloud_base_comp
+ * @brief Return -1, 0, or 1 depending on whether the first pcpoint is less
+ * than, equal to, or greater than the second one
+ * @note Function used for B-tree comparison
+ * @sqlfn cmp()
+ */
+Datum
+Pcpoint_cmp(PG_FUNCTION_ARGS)
+{
+  Pcpoint *pt1 = PG_GETARG_PCPOINT_P(0);
+  Pcpoint *pt2 = PG_GETARG_PCPOINT_P(1);
+  int result = pcpoint_cmp(pt1, pt2);
+  PG_FREE_IF_COPY(pt1, 0);
+  PG_FREE_IF_COPY(pt2, 1);
+  PG_RETURN_INT32(result);
+}
+
+PGDLLEXPORT Datum Pcpoint_lt(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Pcpoint_lt);
+/**
+ * @ingroup mobilitydb_pointcloud_base_comp
+ * @brief Return true if the first pcpoint is less than the second one
+ * @sqlfn lt()
+ * @sqlop @p <
+ */
+Datum
+Pcpoint_lt(PG_FUNCTION_ARGS)
+{
+  Pcpoint *pt1 = PG_GETARG_PCPOINT_P(0);
+  Pcpoint *pt2 = PG_GETARG_PCPOINT_P(1);
+  bool result = pcpoint_lt(pt1, pt2);
+  PG_FREE_IF_COPY(pt1, 0);
+  PG_FREE_IF_COPY(pt2, 1);
+  PG_RETURN_BOOL(result);
+}
+
+PGDLLEXPORT Datum Pcpoint_le(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Pcpoint_le);
+/**
+ * @ingroup mobilitydb_pointcloud_base_comp
+ * @brief Return true if the first pcpoint is less than or equal to the
+ * second one
+ * @sqlfn le()
+ * @sqlop @p <=
+ */
+Datum
+Pcpoint_le(PG_FUNCTION_ARGS)
+{
+  Pcpoint *pt1 = PG_GETARG_PCPOINT_P(0);
+  Pcpoint *pt2 = PG_GETARG_PCPOINT_P(1);
+  bool result = pcpoint_le(pt1, pt2);
+  PG_FREE_IF_COPY(pt1, 0);
+  PG_FREE_IF_COPY(pt2, 1);
+  PG_RETURN_BOOL(result);
+}
+
+PGDLLEXPORT Datum Pcpoint_ge(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Pcpoint_ge);
+/**
+ * @ingroup mobilitydb_pointcloud_base_comp
+ * @brief Return true if the first pcpoint is greater than or equal to the
+ * second one
+ * @sqlfn ge()
+ * @sqlop @p >=
+ */
+Datum
+Pcpoint_ge(PG_FUNCTION_ARGS)
+{
+  Pcpoint *pt1 = PG_GETARG_PCPOINT_P(0);
+  Pcpoint *pt2 = PG_GETARG_PCPOINT_P(1);
+  bool result = pcpoint_ge(pt1, pt2);
+  PG_FREE_IF_COPY(pt1, 0);
+  PG_FREE_IF_COPY(pt2, 1);
+  PG_RETURN_BOOL(result);
+}
+
+PGDLLEXPORT Datum Pcpoint_gt(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Pcpoint_gt);
+/**
+ * @ingroup mobilitydb_pointcloud_base_comp
+ * @brief Return true if the first pcpoint is greater than the second one
+ * @sqlfn gt()
+ * @sqlop @p >
+ */
+Datum
+Pcpoint_gt(PG_FUNCTION_ARGS)
+{
+  Pcpoint *pt1 = PG_GETARG_PCPOINT_P(0);
+  Pcpoint *pt2 = PG_GETARG_PCPOINT_P(1);
+  bool result = pcpoint_gt(pt1, pt2);
+  PG_FREE_IF_COPY(pt1, 0);
+  PG_FREE_IF_COPY(pt2, 1);
+  PG_RETURN_BOOL(result);
+}
+
+/*****************************************************************************
+ * Functions for defining hash indexes on pcpoint
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Pcpoint_hash(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Pcpoint_hash);
+/**
+ * @ingroup mobilitydb_pointcloud_base_comp
+ * @brief Return the 32-bit hash value of a pcpoint
+ * @sqlfn hash()
+ */
+Datum
+Pcpoint_hash(PG_FUNCTION_ARGS)
+{
+  Pcpoint *pt = PG_GETARG_PCPOINT_P(0);
+  uint32 result = pcpoint_hash(pt);
+  PG_FREE_IF_COPY(pt, 0);
+  PG_RETURN_UINT32(result);
+}
+
+PGDLLEXPORT Datum Pcpoint_hash_extended(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Pcpoint_hash_extended);
+/**
+ * @ingroup mobilitydb_pointcloud_base_comp
+ * @brief Return the 64-bit hash value of a pcpoint using a seed
+ * @sqlfn hashExtended()
+ */
+Datum
+Pcpoint_hash_extended(PG_FUNCTION_ARGS)
+{
+  Pcpoint *pt = PG_GETARG_PCPOINT_P(0);
+  uint64 seed = PG_GETARG_INT64(1);
+  uint64 result = pcpoint_hash_extended(pt, seed);
+  PG_FREE_IF_COPY(pt, 0);
+  PG_RETURN_UINT64(result);
+}
+
+/*****************************************************************************
+ * Comparison functions for pcpatch
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Pcpatch_eq(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Pcpatch_eq);
+/**
+ * @ingroup mobilitydb_pointcloud_base_comp
+ * @brief Return true if the first pcpatch is equal to the second one
+ * @sqlfn eq()
+ * @sqlop @p =
+ */
+Datum
+Pcpatch_eq(PG_FUNCTION_ARGS)
+{
+  Pcpatch *pa1 = PG_GETARG_PCPATCH_P(0);
+  Pcpatch *pa2 = PG_GETARG_PCPATCH_P(1);
+  bool result = pcpatch_eq(pa1, pa2);
+  PG_FREE_IF_COPY(pa1, 0);
+  PG_FREE_IF_COPY(pa2, 1);
+  PG_RETURN_BOOL(result);
+}
+
+PGDLLEXPORT Datum Pcpatch_ne(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Pcpatch_ne);
+/**
+ * @ingroup mobilitydb_pointcloud_base_comp
+ * @brief Return true if the first pcpatch is different from the second one
+ * @sqlfn ne()
+ * @sqlop @p <>
+ */
+Datum
+Pcpatch_ne(PG_FUNCTION_ARGS)
+{
+  Pcpatch *pa1 = PG_GETARG_PCPATCH_P(0);
+  Pcpatch *pa2 = PG_GETARG_PCPATCH_P(1);
+  bool result = pcpatch_ne(pa1, pa2);
+  PG_FREE_IF_COPY(pa1, 0);
+  PG_FREE_IF_COPY(pa2, 1);
+  PG_RETURN_BOOL(result);
+}
+
+PGDLLEXPORT Datum Pcpatch_cmp(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Pcpatch_cmp);
+/**
+ * @ingroup mobilitydb_pointcloud_base_comp
+ * @brief Return -1, 0, or 1 depending on whether the first pcpatch is less
+ * than, equal to, or greater than the second one
+ * @note Function used for B-tree comparison
+ * @sqlfn cmp()
+ */
+Datum
+Pcpatch_cmp(PG_FUNCTION_ARGS)
+{
+  Pcpatch *pa1 = PG_GETARG_PCPATCH_P(0);
+  Pcpatch *pa2 = PG_GETARG_PCPATCH_P(1);
+  int result = pcpatch_cmp(pa1, pa2);
+  PG_FREE_IF_COPY(pa1, 0);
+  PG_FREE_IF_COPY(pa2, 1);
+  PG_RETURN_INT32(result);
+}
+
+PGDLLEXPORT Datum Pcpatch_lt(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Pcpatch_lt);
+/**
+ * @ingroup mobilitydb_pointcloud_base_comp
+ * @brief Return true if the first pcpatch is less than the second one
+ * @sqlfn lt()
+ * @sqlop @p <
+ */
+Datum
+Pcpatch_lt(PG_FUNCTION_ARGS)
+{
+  Pcpatch *pa1 = PG_GETARG_PCPATCH_P(0);
+  Pcpatch *pa2 = PG_GETARG_PCPATCH_P(1);
+  bool result = pcpatch_lt(pa1, pa2);
+  PG_FREE_IF_COPY(pa1, 0);
+  PG_FREE_IF_COPY(pa2, 1);
+  PG_RETURN_BOOL(result);
+}
+
+PGDLLEXPORT Datum Pcpatch_le(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Pcpatch_le);
+/**
+ * @ingroup mobilitydb_pointcloud_base_comp
+ * @brief Return true if the first pcpatch is less than or equal to the
+ * second one
+ * @sqlfn le()
+ * @sqlop @p <=
+ */
+Datum
+Pcpatch_le(PG_FUNCTION_ARGS)
+{
+  Pcpatch *pa1 = PG_GETARG_PCPATCH_P(0);
+  Pcpatch *pa2 = PG_GETARG_PCPATCH_P(1);
+  bool result = pcpatch_le(pa1, pa2);
+  PG_FREE_IF_COPY(pa1, 0);
+  PG_FREE_IF_COPY(pa2, 1);
+  PG_RETURN_BOOL(result);
+}
+
+PGDLLEXPORT Datum Pcpatch_ge(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Pcpatch_ge);
+/**
+ * @ingroup mobilitydb_pointcloud_base_comp
+ * @brief Return true if the first pcpatch is greater than or equal to the
+ * second one
+ * @sqlfn ge()
+ * @sqlop @p >=
+ */
+Datum
+Pcpatch_ge(PG_FUNCTION_ARGS)
+{
+  Pcpatch *pa1 = PG_GETARG_PCPATCH_P(0);
+  Pcpatch *pa2 = PG_GETARG_PCPATCH_P(1);
+  bool result = pcpatch_ge(pa1, pa2);
+  PG_FREE_IF_COPY(pa1, 0);
+  PG_FREE_IF_COPY(pa2, 1);
+  PG_RETURN_BOOL(result);
+}
+
+PGDLLEXPORT Datum Pcpatch_gt(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Pcpatch_gt);
+/**
+ * @ingroup mobilitydb_pointcloud_base_comp
+ * @brief Return true if the first pcpatch is greater than the second one
+ * @sqlfn gt()
+ * @sqlop @p >
+ */
+Datum
+Pcpatch_gt(PG_FUNCTION_ARGS)
+{
+  Pcpatch *pa1 = PG_GETARG_PCPATCH_P(0);
+  Pcpatch *pa2 = PG_GETARG_PCPATCH_P(1);
+  bool result = pcpatch_gt(pa1, pa2);
+  PG_FREE_IF_COPY(pa1, 0);
+  PG_FREE_IF_COPY(pa2, 1);
+  PG_RETURN_BOOL(result);
+}
+
+/*****************************************************************************
+ * Functions for defining hash indexes on pcpatch
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Pcpatch_hash(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Pcpatch_hash);
+/**
+ * @ingroup mobilitydb_pointcloud_base_comp
+ * @brief Return the 32-bit hash value of a pcpatch
+ * @sqlfn hash()
+ */
+Datum
+Pcpatch_hash(PG_FUNCTION_ARGS)
+{
+  Pcpatch *pa = PG_GETARG_PCPATCH_P(0);
+  uint32 result = pcpatch_hash(pa);
+  PG_FREE_IF_COPY(pa, 0);
+  PG_RETURN_UINT32(result);
+}
+
+PGDLLEXPORT Datum Pcpatch_hash_extended(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Pcpatch_hash_extended);
+/**
+ * @ingroup mobilitydb_pointcloud_base_comp
+ * @brief Return the 64-bit hash value of a pcpatch using a seed
+ * @sqlfn hashExtended()
+ */
+Datum
+Pcpatch_hash_extended(PG_FUNCTION_ARGS)
+{
+  Pcpatch *pa = PG_GETARG_PCPATCH_P(0);
+  uint64 seed = PG_GETARG_INT64(1);
+  uint64 result = pcpatch_hash_extended(pa, seed);
+  PG_FREE_IF_COPY(pa, 0);
+  PG_RETURN_UINT64(result);
+}
+
 /*****************************************************************************/

--- a/mobilitydb/test/pointcloud/expected/400_pcpoint_compops.test.out
+++ b/mobilitydb/test/pointcloud/expected/400_pcpoint_compops.test.out
@@ -1,0 +1,208 @@
+SELECT pcpoint(1, 1.0, 1.0, 1.0) = pcpoint(1, 1.0, 1.0, 1.0);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT pcpoint(1, 1.0, 1.0, 1.0) = pcpoint(1, 2.0, 2.0, 2.0);
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT pcpoint(1, 1.0, 1.0, 1.0) <> pcpoint(1, 1.0, 1.0, 1.0);
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT pcpoint(1, 1.0, 1.0, 1.0) <> pcpoint(1, 2.0, 2.0, 2.0);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT cmp(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 1.0, 1.0, 1.0)) = 0;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT cmp(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <> 0;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT (pcpoint(1, 1.0, 1.0, 1.0) < pcpoint(1, 2.0, 2.0, 2.0)) =
+  (cmp(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) < 0);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT (pcpoint(1, 1.0, 1.0, 1.0) <= pcpoint(1, 2.0, 2.0, 2.0)) =
+  (cmp(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <= 0);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT (pcpoint(1, 1.0, 1.0, 1.0) > pcpoint(1, 2.0, 2.0, 2.0)) =
+  (cmp(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) > 0);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT (pcpoint(1, 1.0, 1.0, 1.0) >= pcpoint(1, 2.0, 2.0, 2.0)) =
+  (cmp(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) >= 0);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT (pcpoint(1, 1.0, 1.0, 1.0) < pcpoint(1, 2.0, 2.0, 2.0)) =
+  (pcpoint(1, 2.0, 2.0, 2.0) > pcpoint(1, 1.0, 1.0, 1.0));
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT pcpoint(1, 1.0, 1.0, 1.0) < pcpoint(1, 1.0, 1.0, 1.0);
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT pcpoint(1, 1.0, 1.0, 1.0) > pcpoint(1, 1.0, 1.0, 1.0);
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT pcpoint(1, 1.0, 1.0, 1.0) <= pcpoint(1, 1.0, 1.0, 1.0);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT pcpoint(1, 1.0, 1.0, 1.0) >= pcpoint(1, 1.0, 1.0, 1.0);
+ ?column? 
+----------
+ t
+(1 row)
+
+WITH v(pt) AS (
+  VALUES (pcpoint(1, 1.0, 1.0, 1.0)), (pcpoint(1, 2.0, 2.0, 2.0)),
+    (pcpoint(1, 3.0, 3.0, 3.0))
+), ordered AS (
+  SELECT pt, row_number() OVER (ORDER BY pt) AS rn FROM v
+)
+SELECT (SELECT count(*) FROM ordered) = 3
+  AND bool_and(a.pt <= b.pt)
+FROM ordered a JOIN ordered b ON b.rn = a.rn + 1;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) =
+  pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) =
+  pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0));
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <>
+  pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <>
+  pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0));
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT cmp(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
+  pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))) = 0;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT cmp(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
+  pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) <> 0;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <
+    pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) =
+  (cmp(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
+    pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) < 0);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) >
+    pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) =
+  (cmp(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
+    pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) > 0);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <
+    pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) =
+  (pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)) >
+    pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)));
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <
+  pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <=
+  pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
+ ?column? 
+----------
+ t
+(1 row)
+
+WITH v(pa) AS (
+  VALUES
+    (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))),
+    (pcpatch(1, pcpoint(1, 3.0, 3.0, 3.0), pcpoint(1, 4.0, 4.0, 4.0))),
+    (pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)))
+), ordered AS (
+  SELECT pa, row_number() OVER (ORDER BY pa) AS rn FROM v
+)
+SELECT (SELECT count(*) FROM ordered) = 3
+  AND bool_and(a.pa <= b.pa)
+FROM ordered a JOIN ordered b ON b.rn = a.rn + 1;
+ ?column? 
+----------
+ t
+(1 row)
+

--- a/mobilitydb/test/pointcloud/queries/400_pcpoint_compops.test.sql
+++ b/mobilitydb/test/pointcloud/queries/400_pcpoint_compops.test.sql
@@ -1,0 +1,135 @@
+-------------------------------------------------------------------------------
+--
+-- This MobilityDB code is provided under The PostgreSQL License.
+-- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+-- contributors
+--
+-- MobilityDB includes portions of PostGIS version 3 source code released
+-- under the GNU General Public License (GPLv2 or later).
+-- Copyright (c) 2001-2025, PostGIS contributors
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice and
+-- this paragraph and the following two paragraphs appear in all copies.
+--
+-- IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+-- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+-- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+-- EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+-- OF SUCH DAMAGE.
+--
+-- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+-- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+-- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+--
+-------------------------------------------------------------------------------
+
+-- Comparison operators (=, <>, <, <=, >=, >, cmp, B-tree opclass) for the
+-- static pcpoint / pcpatch base types. Uses the ergonomic pcpoint/pcpatch
+-- constructors (same pattern as 420_tpcpoint.test.sql / 430_tpcpatch.test.sql).
+
+-------------------------------------------------------------------------------
+-- pcpoint
+-------------------------------------------------------------------------------
+
+-- Equality of two identical points built independently.
+SELECT pcpoint(1, 1.0, 1.0, 1.0) = pcpoint(1, 1.0, 1.0, 1.0);
+SELECT pcpoint(1, 1.0, 1.0, 1.0) = pcpoint(1, 2.0, 2.0, 2.0);
+
+SELECT pcpoint(1, 1.0, 1.0, 1.0) <> pcpoint(1, 1.0, 1.0, 1.0);
+SELECT pcpoint(1, 1.0, 1.0, 1.0) <> pcpoint(1, 2.0, 2.0, 2.0);
+
+-- cmp() is reflexive and zero only for equal values.
+SELECT cmp(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 1.0, 1.0, 1.0)) = 0;
+SELECT cmp(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <> 0;
+
+-- The </<=/>/>= operators agree with the sign of cmp().
+SELECT (pcpoint(1, 1.0, 1.0, 1.0) < pcpoint(1, 2.0, 2.0, 2.0)) =
+  (cmp(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) < 0);
+SELECT (pcpoint(1, 1.0, 1.0, 1.0) <= pcpoint(1, 2.0, 2.0, 2.0)) =
+  (cmp(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <= 0);
+SELECT (pcpoint(1, 1.0, 1.0, 1.0) > pcpoint(1, 2.0, 2.0, 2.0)) =
+  (cmp(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) > 0);
+SELECT (pcpoint(1, 1.0, 1.0, 1.0) >= pcpoint(1, 2.0, 2.0, 2.0)) =
+  (cmp(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) >= 0);
+-- Antisymmetry.
+SELECT (pcpoint(1, 1.0, 1.0, 1.0) < pcpoint(1, 2.0, 2.0, 2.0)) =
+  (pcpoint(1, 2.0, 2.0, 2.0) > pcpoint(1, 1.0, 1.0, 1.0));
+-- Irreflexivity of the strict operators.
+SELECT pcpoint(1, 1.0, 1.0, 1.0) < pcpoint(1, 1.0, 1.0, 1.0);
+SELECT pcpoint(1, 1.0, 1.0, 1.0) > pcpoint(1, 1.0, 1.0, 1.0);
+SELECT pcpoint(1, 1.0, 1.0, 1.0) <= pcpoint(1, 1.0, 1.0, 1.0);
+SELECT pcpoint(1, 1.0, 1.0, 1.0) >= pcpoint(1, 1.0, 1.0, 1.0);
+
+-- ORDER BY over three distinct values produces a sequence that is
+-- non-decreasing with respect to the <= operator (a genuine B-tree total
+-- order, whatever its relationship to the coordinate magnitudes).
+WITH v(pt) AS (
+  VALUES (pcpoint(1, 1.0, 1.0, 1.0)), (pcpoint(1, 2.0, 2.0, 2.0)),
+    (pcpoint(1, 3.0, 3.0, 3.0))
+), ordered AS (
+  SELECT pt, row_number() OVER (ORDER BY pt) AS rn FROM v
+)
+SELECT (SELECT count(*) FROM ordered) = 3
+  AND bool_and(a.pt <= b.pt)
+FROM ordered a JOIN ordered b ON b.rn = a.rn + 1;
+
+-------------------------------------------------------------------------------
+-- pcpatch
+-------------------------------------------------------------------------------
+
+-- Equality of two identical patches built independently.
+SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) =
+  pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
+SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) =
+  pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0));
+
+SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <>
+  pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
+SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <>
+  pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0));
+
+-- cmp() is reflexive and zero only for equal values.
+SELECT cmp(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
+  pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))) = 0;
+SELECT cmp(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
+  pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) <> 0;
+
+-- The </<=/>/>= operators agree with the sign of cmp().
+SELECT (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <
+    pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) =
+  (cmp(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
+    pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) < 0);
+SELECT (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) >
+    pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) =
+  (cmp(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
+    pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) > 0);
+-- Antisymmetry.
+SELECT (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <
+    pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) =
+  (pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)) >
+    pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)));
+-- Irreflexivity of the strict operators.
+SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <
+  pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
+SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <=
+  pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
+
+-- ORDER BY over three distinct values produces a sequence that is
+-- non-decreasing with respect to the <= operator.
+WITH v(pa) AS (
+  VALUES
+    (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))),
+    (pcpatch(1, pcpoint(1, 3.0, 3.0, 3.0), pcpoint(1, 4.0, 4.0, 4.0))),
+    (pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)))
+), ordered AS (
+  SELECT pa, row_number() OVER (ORDER BY pa) AS rn FROM v
+)
+SELECT (SELECT count(*) FROM ordered) = 3
+  AND bool_and(a.pa <= b.pa)
+FROM ordered a JOIN ordered b ON b.rn = a.rn + 1;
+
+-------------------------------------------------------------------------------

--- a/tools/codegen/inherited/manifest.d/comparison_families.yaml
+++ b/tools/codegen/inherited/manifest.d/comparison_families.yaml
@@ -184,7 +184,7 @@ comparison_families:
   reference: true
   ops: set
   begin: "\n * pcpointset \u2014 Comparison / B-tree / hash\n"
-  end: "CREATE FUNCTION hash("
+  end: "CREATE FUNCTION hash(pcpointset"
   end_exact: true
   blocks:
   - lit: "/******************************************************************************\n * pcpointset \u2014 Comparison / B-tree / hash\n ******************************************************************************/\n\n"

--- a/tools/codegen/inherited/manifest.d/hash_families.yaml
+++ b/tools/codegen/inherited/manifest.d/hash_families.yaml
@@ -230,7 +230,7 @@ hash_families:
 - family: pcpointset
   file: mobilitydb/sql/pointcloud/400_pcset.in.sql
   reference: true
-  begin: "CREATE FUNCTION hash("
+  begin: "CREATE FUNCTION hash(pcpointset"
   begin_exact: true
   end: "\n * pcpointset \u2014 Set operations"
   blocks:


### PR DESCRIPTION
The base pointcloud types `pcpoint` and `pcpatch` provide the same comparison operators and B-tree operator class as the sibling base types (cbuffer, npoint, quadbin, h3index): `=`, `<>`, `<`, `<=`, `>=`, `>`, the underlying `eq`/`ne`/`lt`/`le`/`ge`/`gt`/`cmp` functions, and a default B-tree operator class, plus a hash operator class matching cbuffer's base type. The operators delegate to the exported `pcpoint_eq`/`pcpoint_cmp`/... and `pcpatch_eq`/`pcpatch_cmp`/... comparison functions in the MEOS pointcloud API. Tests cover equality, inequality, ordering consistency between the comparison operators and `cmp`, antisymmetry, irreflexivity of the strict operators, and sorting three distinct values with `ORDER BY`.
