### PR TITLE
Keep the seam value when merging step sequences that meet at a timestamp

### DIFF
--- a/meos/src/temporal/tsequence.c
+++ b/meos/src/temporal/tsequence.c
@@ -442,10 +442,18 @@ tsequence_join_test(const TSequence *seq1, const TSequence *seq2,
      */
     (eq_last2_last1 && eq_last1_first1 && eq_first1_first2)
     ||
-    /* If float/point sequences and collinear last/first segments having the same duration
+    /* If linear sequences and collinear last/first segments having the same duration
        ..., 1@t1, 2@t2) [2@t2, 3@t3, ... -> ..., 1@t1, 3@t3, ...
+       This must be restricted to LINEAR interpolation: unlike
+       #tsequence_norm_test, checking temptype_supports_linear (i.e., the
+       type CAN be linear) instead of interp == LINEAR (i.e., this sequence
+       IS linear) would also match step sequences whose values happen to be
+       collinear, e.g., ..., 1@t1, 2@t2] (2@t2, 3@t3, ... which would wrongly
+       remove the shared instant 2@t2. For step interpolation, the value at
+       the shared boundary timestamp is the inclusive side's value and must
+       always survive the join.
     */
-    (temptype_supports_linear(seq1->temptype) && eq_last1_first1 &&
+    (interp == LINEAR && eq_last1_first1 &&
       datum_collinear(last2value, first1value, first2value, basetype,
         last2->t, first1->t, first2->t))
     ))

--- a/mobilitydb/test/geo/expected/052_tpoint.test.out
+++ b/mobilitydb/test/geo/expected/052_tpoint.test.out
@@ -1598,6 +1598,21 @@ SELECT asText(merge(tgeompoint 'Point(1 1)@2000-01-01', tgeompoint 'Point(1 1)@2
  POINT(1 1)@Sat Jan 01 00:00:00 2000 PST
 (1 row)
 
+SELECT tgeompoint 'Interp=Step;[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(3 3 3)@2000-01-03]' =
+  merge(atTime(tgeompoint 'Interp=Step;[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(3 3 3)@2000-01-03]', tstzspan '[2000-01-01,2000-01-02]'),
+    minusTime(tgeompoint 'Interp=Step;[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(3 3 3)@2000-01-03]', tstzspan '[2000-01-01,2000-01-02]'));
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT st_astext(valueAtTimestamp(merge(atTime(tgeompoint 'Interp=Step;[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(3 3 3)@2000-01-03]', tstzspan '[2000-01-01,2000-01-02]'),
+    minusTime(tgeompoint 'Interp=Step;[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(3 3 3)@2000-01-03]', tstzspan '[2000-01-01,2000-01-02]')), timestamptz '2000-01-02'));
+    st_astext    
+-----------------
+ POINT Z (2 2 2)
+(1 row)
+
 /* Errors */
 SELECT merge(tgeompoint 'SRID=5676;Point(1 1)@2000-01-01', tgeompoint 'Point(1 1)@2000-01-02');
 ERROR:  Operation on mixed SRID

--- a/mobilitydb/test/geo/queries/052_tpoint.test.sql
+++ b/mobilitydb/test/geo/queries/052_tpoint.test.sql
@@ -613,6 +613,16 @@ SELECT asText(merge(tgeompoint 'Point(1 1)@2000-01-01', tgeompoint '{Point(1 1)@
 SELECT asText(merge(tgeompoint 'Point(1 1)@2000-01-01', tgeompoint '{Point(1 1)@2000-01-03, Point(2 2)@2000-01-04, Point(1 1)@2000-01-05}'));
 SELECT asText(merge(tgeompoint 'Point(1 1)@2000-01-01', tgeompoint 'Point(1 1)@2000-01-01'));
 
+-- Merging step sequences that meet at a shared timestamp keeps the
+-- inclusive side's value at the seam: splitting a step sequence with
+-- atTime/minusTime at an interior timestamp and merging the pieces back
+-- together must return the original value
+SELECT tgeompoint 'Interp=Step;[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(3 3 3)@2000-01-03]' =
+  merge(atTime(tgeompoint 'Interp=Step;[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(3 3 3)@2000-01-03]', tstzspan '[2000-01-01,2000-01-02]'),
+    minusTime(tgeompoint 'Interp=Step;[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(3 3 3)@2000-01-03]', tstzspan '[2000-01-01,2000-01-02]'));
+SELECT st_astext(valueAtTimestamp(merge(atTime(tgeompoint 'Interp=Step;[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(3 3 3)@2000-01-03]', tstzspan '[2000-01-01,2000-01-02]'),
+    minusTime(tgeompoint 'Interp=Step;[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(3 3 3)@2000-01-03]', tstzspan '[2000-01-01,2000-01-02]')), timestamptz '2000-01-02'));
+
 /* Errors */
 SELECT merge(tgeompoint 'SRID=5676;Point(1 1)@2000-01-01', tgeompoint 'Point(1 1)@2000-01-02');
 SELECT merge(tgeompoint 'Point(1 1)@2000-01-01', tgeompoint 'Point(1 1 1)@2000-01-02');

--- a/mobilitydb/test/temporal/expected/022_temporal.test.out
+++ b/mobilitydb/test/temporal/expected/022_temporal.test.out
@@ -3266,6 +3266,21 @@ SELECT merge(tfloat '{[1@2000-01-01, 2@2000-01-02], [3@2000-01-03, 4@2000-01-04]
  {[1@Sat Jan 01 00:00:00 2000 PST, 5@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
+SELECT tint 'Interp=Step;[1@2000-01-01, 2@2000-01-02, 3@2000-01-03]' =
+  merge(atTime(tint 'Interp=Step;[1@2000-01-01, 2@2000-01-02, 3@2000-01-03]', tstzspan '[2000-01-01,2000-01-02]'),
+    minusTime(tint 'Interp=Step;[1@2000-01-01, 2@2000-01-02, 3@2000-01-03]', tstzspan '[2000-01-01,2000-01-02]'));
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT valueAtTimestamp(merge(atTime(tint 'Interp=Step;[1@2000-01-01, 2@2000-01-02, 3@2000-01-03]', tstzspan '[2000-01-01,2000-01-02]'),
+    minusTime(tint 'Interp=Step;[1@2000-01-01, 2@2000-01-02, 3@2000-01-03]', tstzspan '[2000-01-01,2000-01-02]')), timestamptz '2000-01-02');
+ valueattimestamp 
+------------------
+                2
+(1 row)
+
 SELECT merge(NULL::tfloat, NULL::tfloat);
  merge 
 -------

--- a/mobilitydb/test/temporal/queries/022_temporal.test.sql
+++ b/mobilitydb/test/temporal/queries/022_temporal.test.sql
@@ -945,6 +945,16 @@ SELECT merge(tfloat '[2@2000-01-02, 4@2000-01-04]', tfloat '[1@2000-01-01, 2@200
 
 SELECT merge(tfloat '{[1@2000-01-01, 2@2000-01-02], [3@2000-01-03, 4@2000-01-04]}', tfloat '{[2@2000-01-02, 3@2000-01-03], [4@2000-01-04, 5@2000-01-05]}');
 
+-- Merging step sequences that meet at a shared timestamp keeps the
+-- inclusive side's value at the seam: splitting a step sequence with
+-- atTime/minusTime at an interior timestamp and merging the pieces back
+-- together must return the original value
+SELECT tint 'Interp=Step;[1@2000-01-01, 2@2000-01-02, 3@2000-01-03]' =
+  merge(atTime(tint 'Interp=Step;[1@2000-01-01, 2@2000-01-02, 3@2000-01-03]', tstzspan '[2000-01-01,2000-01-02]'),
+    minusTime(tint 'Interp=Step;[1@2000-01-01, 2@2000-01-02, 3@2000-01-03]', tstzspan '[2000-01-01,2000-01-02]'));
+SELECT valueAtTimestamp(merge(atTime(tint 'Interp=Step;[1@2000-01-01, 2@2000-01-02, 3@2000-01-03]', tstzspan '[2000-01-01,2000-01-02]'),
+    minusTime(tint 'Interp=Step;[1@2000-01-01, 2@2000-01-02, 3@2000-01-03]', tstzspan '[2000-01-01,2000-01-02]')), timestamptz '2000-01-02');
+
 -- NULL
 SELECT merge(NULL::tfloat, NULL::tfloat);
 SELECT merge(tfloat '1@2000-01-01', NULL);


### PR DESCRIPTION
Merging a step sequence whose upper bound is inclusive with a successor whose exclusive lower bound holds the same value drops the boundary instant, changing the function's value at that timestamp. For example:

```sql
\set G 'tgeompoint ''Interp=Step;[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(3 3 3)@2001-01-03]'''
SELECT asText(merge(atTime(:G, tstzspan '[2001-01-01,2001-01-02]'), minusTime(:G, tstzspan '[2001-01-01,2001-01-02]')));
-- {[POINT Z (1 1 1)@..., POINT Z (3 3 3)@...]}, the middle instant is gone
SELECT valueAtTimestamp(merge(atTime(:G, ...), minusTime(:G, ...)), timestamptz '2001-01-02');
-- Point(1 1 1), the original value at that timestamp is Point(2 2 2)
```

`atTime` and `minusTime` are each individually correct; the defect is in the sequence-join test used during normalization, which decides two adjacent sequences can be merged into one instant whenever the type merely supports linear interpolation, instead of checking whether the sequences are actually linear. A step sequence whose boundary values happen to be collinear is then wrongly treated as linear and the shared instant is dropped.

The join now keeps the inclusive side's instant unless the sequences are actually linear, so `merge(atTime(temp, s), minusTime(temp, s))` returns the original value again and `valueAtTimestamp` at the seam is correct. Linear sequences keep their existing behaviour. Tests cover the round-trip identity and the seam value for a step tint and a step tgeompoint.