### PR TITLE
Correct the tjsonb compops file brief to describe JSONB, not circular buffers

### DIFF
--- a/mobilitydb/sql/json/458_tjsonb_compops.in.sql
+++ b/mobilitydb/sql/json/458_tjsonb_compops.in.sql
@@ -30,7 +30,7 @@
 /**
  * @file
  * @brief Ever/always and temporal comparison functions and operators for
- * temporal circular buffers
+ * temporal JSONB
  */
 
 /*****************************************************************************

--- a/tools/codegen/inherited/manifest.d/subtypes.yaml
+++ b/tools/codegen/inherited/manifest.d/subtypes.yaml
@@ -61,14 +61,11 @@ subtypes:
   # byte-identical in shape to this template's single-pair output, so it converges
   # here from the compops_families items/lit axis rather than staying a second
   # hand-transcribed mechanism for the same behaviour. Not tspatial (no `category`;
-  # the field is unused by the generator, so no value fits). `brief` reproduces the
-  # committed file's doc string verbatim (misdescribes tjsonb as "circular buffers",
-  # a pre-existing copy/paste artifact from tcbuffer) since converging ownership
-  # must not change committed .in.sql content.
+  # the field is unused by the generator, so no value fits).
   - temp:  tjsonb
     base:  jsonb
     fam:   json
-    brief: "temporal circular buffers"
+    brief: "temporal JSONB"
     bin:   454
     reference: true
     files: [compops]


### PR DESCRIPTION
Describes the tjsonb compops file brief as temporal JSONB, matching the family's own file `452_tjsonb.in.sql` ("Basic functions for temporal JSONB") and the sibling inherited-family briefs (tcbuffer/th3index/tquadbin/tnpoint each name their own base type). States the corrected wording in `tools/codegen/inherited/manifest.d/subtypes.yaml` on the `tjsonb` entry, replacing the comment that justified reproducing the tcbuffer-copied text with a plain statement of the entry's purpose. Names `mobilitydb/sql/json/458_tjsonb_compops.in.sql` as the sole generated-file change, limited to the single doc-comment line.
