### PR TITLE
Test the arguments of the h3 temporal functions as their siblings do

### DIFF
--- a/meos/src/h3/th3index_edges.c
+++ b/meos/src/h3/th3index_edges.c
@@ -89,9 +89,8 @@ h3_directed_edge_to_gs_boundary(H3Index edge)
 Temporal *
 th3index_are_neighbor_cells(const Temporal *origin, const Temporal *dest)
 {
-  assert(origin); assert(dest);
-  assert(origin->temptype == T_TH3INDEX);
-  assert(dest->temptype == T_TH3INDEX);
+  VALIDATE_TH3INDEX(origin, NULL);
+  VALIDATE_TH3INDEX(dest, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
@@ -118,9 +117,8 @@ th3index_are_neighbor_cells(const Temporal *origin, const Temporal *dest)
 Temporal *
 th3index_cells_to_directed_edge(const Temporal *origin, const Temporal *dest)
 {
-  assert(origin); assert(dest);
-  assert(origin->temptype == T_TH3INDEX);
-  assert(dest->temptype == T_TH3INDEX);
+  VALIDATE_TH3INDEX(origin, NULL);
+  VALIDATE_TH3INDEX(dest, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
@@ -148,7 +146,7 @@ th3index_cells_to_directed_edge(const Temporal *origin, const Temporal *dest)
 Temporal *
 th3index_is_valid_directed_edge(const Temporal *edge)
 {
-  assert(edge); assert(edge->temptype == T_TH3INDEX);
+  VALIDATE_TH3INDEX(edge, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
@@ -174,7 +172,7 @@ th3index_is_valid_directed_edge(const Temporal *edge)
 Temporal *
 th3index_get_directed_edge_origin(const Temporal *edge)
 {
-  assert(edge); assert(edge->temptype == T_TH3INDEX);
+  VALIDATE_TH3INDEX(edge, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
@@ -200,7 +198,7 @@ th3index_get_directed_edge_origin(const Temporal *edge)
 Temporal *
 th3index_get_directed_edge_destination(const Temporal *edge)
 {
-  assert(edge); assert(edge->temptype == T_TH3INDEX);
+  VALIDATE_TH3INDEX(edge, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
@@ -229,7 +227,7 @@ th3index_get_directed_edge_destination(const Temporal *edge)
 Temporal *
 th3index_directed_edge_to_boundary(const Temporal *edge)
 {
-  assert(edge); assert(edge->temptype == T_TH3INDEX);
+  VALIDATE_TH3INDEX(edge, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));

--- a/meos/src/h3/th3index_hierarchy.c
+++ b/meos/src/h3/th3index_hierarchy.c
@@ -101,7 +101,7 @@ h3_cell_to_center_child_next_meos(H3Index cell)
 Temporal *
 th3index_cell_to_parent(const Temporal *temp, int32 resolution)
 {
-  assert(temp); assert(temp->temptype == T_TH3INDEX);
+  VALIDATE_TH3INDEX(temp, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
@@ -128,7 +128,7 @@ th3index_cell_to_parent(const Temporal *temp, int32 resolution)
 Temporal *
 th3index_cell_to_parent_next(const Temporal *temp)
 {
-  assert(temp); assert(temp->temptype == T_TH3INDEX);
+  VALIDATE_TH3INDEX(temp, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
@@ -154,7 +154,7 @@ th3index_cell_to_parent_next(const Temporal *temp)
 Temporal *
 th3index_cell_to_center_child(const Temporal *temp, int32 resolution)
 {
-  assert(temp); assert(temp->temptype == T_TH3INDEX);
+  VALIDATE_TH3INDEX(temp, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
@@ -181,7 +181,7 @@ th3index_cell_to_center_child(const Temporal *temp, int32 resolution)
 Temporal *
 th3index_cell_to_center_child_next(const Temporal *temp)
 {
-  assert(temp); assert(temp->temptype == T_TH3INDEX);
+  VALIDATE_TH3INDEX(temp, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
@@ -208,7 +208,7 @@ th3index_cell_to_center_child_next(const Temporal *temp)
 Temporal *
 th3index_cell_to_child_pos(const Temporal *temp, int32 parent_res)
 {
-  assert(temp); assert(temp->temptype == T_TH3INDEX);
+  VALIDATE_TH3INDEX(temp, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
@@ -240,9 +240,8 @@ Temporal *
 th3index_child_pos_to_cell(const Temporal *child_pos, const Temporal *parent,
   int32 child_res)
 {
-  assert(child_pos); assert(parent);
-  assert(child_pos->temptype == T_TBIGINT);
-  assert(parent->temptype == T_TH3INDEX);
+  VALIDATE_TBIGINT(child_pos, NULL);
+  VALIDATE_TH3INDEX(parent, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));

--- a/meos/src/h3/th3index_inspection.c
+++ b/meos/src/h3/th3index_inspection.c
@@ -60,7 +60,7 @@
 Temporal *
 th3index_get_resolution(const Temporal *temp)
 {
-  assert(temp); assert(temp->temptype == T_TH3INDEX);
+  VALIDATE_TH3INDEX(temp, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
@@ -86,7 +86,7 @@ th3index_get_resolution(const Temporal *temp)
 Temporal *
 th3index_get_base_cell_number(const Temporal *temp)
 {
-  assert(temp); assert(temp->temptype == T_TH3INDEX);
+  VALIDATE_TH3INDEX(temp, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
@@ -113,7 +113,7 @@ th3index_get_base_cell_number(const Temporal *temp)
 Temporal *
 th3index_is_valid_cell(const Temporal *temp)
 {
-  assert(temp); assert(temp->temptype == T_TH3INDEX);
+  VALIDATE_TH3INDEX(temp, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
@@ -140,7 +140,7 @@ th3index_is_valid_cell(const Temporal *temp)
 Temporal *
 th3index_is_res_class_iii(const Temporal *temp)
 {
-  assert(temp); assert(temp->temptype == T_TH3INDEX);
+  VALIDATE_TH3INDEX(temp, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
@@ -167,7 +167,7 @@ th3index_is_res_class_iii(const Temporal *temp)
 Temporal *
 th3index_is_pentagon(const Temporal *temp)
 {
-  assert(temp); assert(temp->temptype == T_TH3INDEX);
+  VALIDATE_TH3INDEX(temp, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));

--- a/meos/src/h3/th3index_latlng.c
+++ b/meos/src/h3/th3index_latlng.c
@@ -376,7 +376,7 @@ tpoint_to_th3index_dense(const Temporal *temp, int32 resolution)
 Temporal *
 tgeompoint_to_th3index(const Temporal *temp, int32 resolution)
 {
-  assert(temp); assert(temp->temptype == T_TGEOMPOINT);
+  VALIDATE_TGEOMPOINT(temp, NULL);
   return tpoint_to_th3index_dense(temp, resolution);
 }
 
@@ -394,7 +394,7 @@ tgeompoint_to_th3index(const Temporal *temp, int32 resolution)
 Temporal *
 tgeogpoint_to_th3index(const Temporal *temp, int32 resolution)
 {
-  assert(temp); assert(temp->temptype == T_TGEOGPOINT);
+  VALIDATE_TGEOGPOINT(temp, NULL);
   return tpoint_to_th3index_dense(temp, resolution);
 }
 
@@ -410,7 +410,7 @@ tgeogpoint_to_th3index(const Temporal *temp, int32 resolution)
 Temporal *
 th3index_to_tgeogpoint(const Temporal *temp)
 {
-  assert(temp); assert(temp->temptype == T_TH3INDEX);
+  VALIDATE_TH3INDEX(temp, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
@@ -442,7 +442,7 @@ th3index_to_tgeogpoint(const Temporal *temp)
 Temporal *
 th3index_to_tgeompoint(const Temporal *temp)
 {
-  assert(temp); assert(temp->temptype == T_TH3INDEX);
+  VALIDATE_TH3INDEX(temp, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
@@ -469,7 +469,7 @@ th3index_to_tgeompoint(const Temporal *temp)
 Temporal *
 th3index_cell_to_boundary(const Temporal *temp)
 {
-  assert(temp); assert(temp->temptype == T_TH3INDEX);
+  VALIDATE_TH3INDEX(temp, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));

--- a/meos/src/h3/th3index_metrics.c
+++ b/meos/src/h3/th3index_metrics.c
@@ -178,7 +178,8 @@ h3_gs_great_circle_distance_meos(const GSERIALIZED *a, const GSERIALIZED *b,
 Temporal *
 th3index_cell_area(const Temporal *temp, const char *unit)
 {
-  assert(temp); assert(temp->temptype == T_TH3INDEX);
+  VALIDATE_TH3INDEX(temp, NULL);
+  VALIDATE_NOT_NULL(unit, NULL);
 
   H3Unit u = h3_unit_from_cstring(unit);
 
@@ -208,7 +209,8 @@ th3index_cell_area(const Temporal *temp, const char *unit)
 Temporal *
 th3index_edge_length(const Temporal *temp, const char *unit)
 {
-  assert(temp); assert(temp->temptype == T_TH3INDEX);
+  VALIDATE_TH3INDEX(temp, NULL);
+  VALIDATE_NOT_NULL(unit, NULL);
 
   H3Unit u = h3_unit_from_cstring(unit);
 
@@ -245,9 +247,9 @@ Temporal *
 tgeogpoint_great_circle_distance(const Temporal *a, const Temporal *b,
   const char *unit)
 {
-  assert(a); assert(b);
-  assert(a->temptype == T_TGEOGPOINT);
-  assert(b->temptype == T_TGEOGPOINT);
+  VALIDATE_TGEOGPOINT(a, NULL);
+  VALIDATE_TGEOGPOINT(b, NULL);
+  VALIDATE_NOT_NULL(unit, NULL);
 
   H3Unit u = h3_unit_from_cstring(unit);
 

--- a/meos/src/h3/th3index_traversal.c
+++ b/meos/src/h3/th3index_traversal.c
@@ -109,9 +109,8 @@ h3_local_ij_to_cell_meos(H3Index origin, const GSERIALIZED *coord)
 Temporal *
 th3index_grid_distance(const Temporal *origin, const Temporal *dest)
 {
-  assert(origin); assert(dest);
-  assert(origin->temptype == T_TH3INDEX);
-  assert(dest->temptype == T_TH3INDEX);
+  VALIDATE_TH3INDEX(origin, NULL);
+  VALIDATE_TH3INDEX(dest, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
@@ -139,9 +138,8 @@ th3index_grid_distance(const Temporal *origin, const Temporal *dest)
 Temporal *
 th3index_cell_to_local_ij(const Temporal *origin, const Temporal *cell)
 {
-  assert(origin); assert(cell);
-  assert(origin->temptype == T_TH3INDEX);
-  assert(cell->temptype == T_TH3INDEX);
+  VALIDATE_TH3INDEX(origin, NULL);
+  VALIDATE_TH3INDEX(cell, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
@@ -169,9 +167,8 @@ th3index_cell_to_local_ij(const Temporal *origin, const Temporal *cell)
 Temporal *
 th3index_local_ij_to_cell(const Temporal *origin, const Temporal *coord)
 {
-  assert(origin); assert(coord);
-  assert(origin->temptype == T_TH3INDEX);
-  assert(coord->temptype == T_TGEOMPOINT);
+  VALIDATE_TH3INDEX(origin, NULL);
+  VALIDATE_TGEOMPOINT(coord, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));

--- a/meos/src/h3/th3index_vertices.c
+++ b/meos/src/h3/th3index_vertices.c
@@ -83,7 +83,7 @@ h3_vertex_to_gs_point(H3Index vertex)
 Temporal *
 th3index_cell_to_vertex(const Temporal *temp, int32 vertex_num)
 {
-  assert(temp); assert(temp->temptype == T_TH3INDEX);
+  VALIDATE_TH3INDEX(temp, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
@@ -111,7 +111,7 @@ th3index_cell_to_vertex(const Temporal *temp, int32 vertex_num)
 Temporal *
 th3index_vertex_to_latlng(const Temporal *temp)
 {
-  assert(temp); assert(temp->temptype == T_TH3INDEX);
+  VALIDATE_TH3INDEX(temp, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
@@ -138,7 +138,7 @@ th3index_vertex_to_latlng(const Temporal *temp)
 Temporal *
 th3index_is_valid_vertex(const Temporal *temp)
 {
-  assert(temp); assert(temp->temptype == T_TH3INDEX);
+  VALIDATE_TH3INDEX(temp, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));


### PR DESCRIPTION
The public functions of the h3 family state their argument contract with
`assert` alone. An assertion is compiled out under `NDEBUG`, so a release
build performs no check and dereferences the argument. The sibling
families, and `th3index.c` itself, state the same contract with the
`VALIDATE_*` macros, which raise a MEOS error and return.

`meos/src/h3` splits cleanly along that line:

| file | `VALIDATE_*` | `assert` |
| --- | --- | --- |
| `th3index.c` | 10 | 3 |
| `th3index_edges.c` | 0 | 10 |
| `th3index_traversal.c` | 0 | 9 |
| `th3index_hierarchy.c` | 0 | 8 |
| `th3index_inspection.c` | 0 | 5 |
| `th3index_latlng.c` | 0 | 5 |
| `th3index_metrics.c` | 0 | 5 |
| `th3index_vertices.c` | 0 | 3 |

This change gives the 31 public functions in the seven satellite files the
matching macro: `VALIDATE_TH3INDEX`, and `VALIDATE_TBIGINT`,
`VALIDATE_TGEOMPOINT` or `VALIDATE_TGEOGPOINT` where the argument is of
another temporal type.

It also validates the `unit` argument of the metric functions, as
`th3index_in` validates its string argument. A null unit is otherwise
reported only from `h3_unit_from_cstring`, which continues with a default
unit once the error handler returns.

The internal functions of `th3index_boxops.c` keep their assertions, as
their counterparts in the sibling families do.

In the extension build the macros expand to the same two assertions that
they replace, so the behaviour there is unchanged. In the MEOS build they
raise `MEOS_ERR_INVALID_ARG_VALUE` and return NULL.

### Effect

In a release build of the MEOS library (`-O3 -DNDEBUG -O2`), with the
non-exiting error handler installed as the language bindings do:

```
before:  th3index_cell_area(NULL, "km")             -> SIGSEGV (exit 139)

after:   th3index_cell_area(NULL, "km")             -> NULL, errno 10
         th3index_cell_area(NULL, NULL)             -> NULL, errno 10
         th3index_get_resolution(NULL)              -> NULL, errno 10
         th3index_grid_distance(NULL, NULL)         -> NULL, errno 10
         th3index_child_pos_to_cell(NULL, NULL, 3)  -> NULL, errno 10
```

The regression tests are unaffected: the SQL functions are `STRICT`, so
PostgreSQL never passes a null argument, and the macros keep asserting in
the extension build. The release-build comparison above is the evidence
for this change.