### PR TITLE
Order two points by their coordinates rather than by a sortable hash

### DIFF
--- a/meos/src/temporal/type_util.c
+++ b/meos/src/temporal/type_util.c
@@ -145,7 +145,25 @@ datum_cmp(Datum l, Datum r, MeosType type)
       return text_cmp(DatumGetTextP(l), DatumGetTextP(r), DEFAULT_COLLATION_OID);
     case T_GEOMETRY:
     case T_GEOGRAPHY:
-      return gserialized_cmp(DatumGetGserializedP(l), DatumGetGserializedP(r));
+    {
+      const GSERIALIZED *gs1 = DatumGetGserializedP(l);
+      const GSERIALIZED *gs2 = DatumGetGserializedP(r);
+      /* Fast path: two points of the same SRID and dimension are ordered by
+       * their coordinates, as the centre of two circular buffers is. The
+       * general comparison builds a bounding box and a sortable hash for each
+       * operand, which is the dominant cost of sorting the values of a
+       * temporal point. A point precedes any other geometry, so that the
+       * order stays total on a value holding geometries of several types */
+      bool point1 = (gserialized_get_type(gs1) == POINTTYPE);
+      bool point2 = (gserialized_get_type(gs2) == POINTTYPE);
+      if (point1 && point2 &&
+          gserialized_get_srid(gs1) == gserialized_get_srid(gs2) &&
+          FLAGS_GET_Z(gs1->gflags) == FLAGS_GET_Z(gs2->gflags))
+        return geopoint_cmp(gs1, gs2);
+      if (point1 != point2)
+        return point1 ? -1 : 1;
+      return gserialized_cmp(gs1, gs2);
+    }
 #if CBUFFER
     case T_CBUFFER:
       return cbuffer_cmp(DatumGetCbufferP(l), DatumGetCbufferP(r));

--- a/mobilitydb/test/geo/expected/050_set_tbl.test.out
+++ b/mobilitydb/test/geo/expected/050_set_tbl.test.out
@@ -146,21 +146,21 @@ SELECT MIN(numValues(g)) FROM tbl_geomset;
 (1 row)
 
 SELECT MIN(round(ST_X(startValue(g)), 6)) FROM tbl_geomset;
-    min     
-------------
- -96.535171
+    min    
+-----------
+ -99.90013
 (1 row)
 
 SELECT MIN(round(ST_X(endValue(g)), 6)) FROM tbl_geomset;
     min     
 ------------
- -94.408967
+ -85.637205
 (1 row)
 
 SELECT MIN(round(ST_X(valueN(g, 1)), 6)) FROM tbl_geomset;
-    min     
-------------
- -96.535171
+    min    
+-----------
+ -99.90013
 (1 row)
 
 SELECT MIN(array_length(getValues(g), 1)) FROM tbl_geomset;
@@ -184,19 +184,19 @@ SELECT MIN(numValues(g)) FROM tbl_geogset;
 SELECT MIN(round(ST_X(startValue(g)::geometry), 6)) FROM tbl_geogset;
    min    
 ----------
- 0.432515
+ 0.027466
 (1 row)
 
 SELECT MIN(round(ST_X(endValue(g)::geometry), 6)) FROM tbl_geogset;
-   min    
-----------
- 0.806752
+   min   
+---------
+ 9.64211
 (1 row)
 
 SELECT MIN(round(ST_X(valueN(g, 1)::geometry), 6)) FROM tbl_geogset;
    min    
 ----------
- 0.432515
+ 0.027466
 (1 row)
 
 SELECT MIN(array_length(getValues(g), 1)) FROM tbl_geogset;
@@ -206,15 +206,15 @@ SELECT MIN(array_length(getValues(g), 1)) FROM tbl_geogset;
 (1 row)
 
 SELECT MIN(ST_X(startValue(round(g, 6)))) FROM tbl_geomset;
-    min     
-------------
- -96.535171
+    min    
+-----------
+ -99.90013
 (1 row)
 
 SELECT MIN(ST_X(startValue(round(g, 6))::geometry)) FROM tbl_geogset;
    min    
 ----------
- 0.432515
+ 0.027466
 (1 row)
 
 SELECT numValues(setUnion(g)) FROM tbl_geom_point3D WHERE NOT ST_IsEmpty(g);
@@ -336,13 +336,13 @@ SELECT COUNT(*) FROM tbl_geogset t1, tbl_geogset t2 WHERE t1.g >= t2.g;
 SELECT MAX(hash(g)) FROM tbl_geomset;
     max     
 ------------
- 2098051068
+ 2088610132
 (1 row)
 
 SELECT MAX(hash(g)) FROM tbl_geogset;
     max     
 ------------
- 2135464549
+ 2132910821
 (1 row)
 
 SELECT numValues(setUnion(g)) FROM tbl_geom_point WHERE NOT ST_IsEmpty(g);

--- a/mobilitydb/test/geo/expected/052_tgeo.test.out
+++ b/mobilitydb/test/geo/expected/052_tgeo.test.out
@@ -1906,7 +1906,7 @@ SELECT asEWKT(getValues(tgeography '[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2
 SELECT asEWKT(getValues(tgeography '{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03],[Point(3.5 3.5)@2000-01-04, Point(3.5 3.5)@2000-01-05]}'));
                               asewkt                              
 ------------------------------------------------------------------
- SRID=4326;{"POINT(1.5 1.5)", "POINT(3.5 3.5)", "POINT(2.5 2.5)"}
+ SRID=4326;{"POINT(1.5 1.5)", "POINT(2.5 2.5)", "POINT(3.5 3.5)"}
 (1 row)
 
 SELECT ST_AsEWKT(startValue(tgeometry 'Point(1 1)@2000-01-01'));

--- a/mobilitydb/test/geo/expected/052_tpoint.test.out
+++ b/mobilitydb/test/geo/expected/052_tpoint.test.out
@@ -1928,7 +1928,7 @@ SELECT asEWKT(getValues(tgeogpoint '[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2
 SELECT asEWKT(getValues(tgeogpoint '{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03],[Point(3.5 3.5)@2000-01-04, Point(3.5 3.5)@2000-01-05]}'));
                               asewkt                              
 ------------------------------------------------------------------
- SRID=4326;{"POINT(1.5 1.5)", "POINT(3.5 3.5)", "POINT(2.5 2.5)"}
+ SRID=4326;{"POINT(1.5 1.5)", "POINT(2.5 2.5)", "POINT(3.5 3.5)"}
 (1 row)
 
 SELECT ST_AsEWKT(startValue(tgeompoint 'Point(1 1)@2000-01-01'));

--- a/mobilitydb/test/geo/expected/056_tgeo_spatialfuncs.test.out
+++ b/mobilitydb/test/geo/expected/056_tgeo_spatialfuncs.test.out
@@ -1032,7 +1032,7 @@ SELECT ST_AsText(traversedArea(tgeography '[Point(1.5 1.5)@2000-01-01, Point(2.5
 SELECT ST_AsText(traversedArea(tgeography '{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03],[Point(3.5 3.5)@2000-01-04, Point(3.5 3.5)@2000-01-05]}'));
                  st_astext                 
 -------------------------------------------
- MULTIPOINT((1.5 1.5),(3.5 3.5),(2.5 2.5))
+ MULTIPOINT((1.5 1.5),(2.5 2.5),(3.5 3.5))
 (1 row)
 
 SELECT ST_AsText(traversedArea(tgeometry 'Point(1 1 1)@2000-01-01'));
@@ -1080,7 +1080,7 @@ SELECT ST_AsText(traversedArea(tgeography '[Point(1.5 1.5 1.5)@2000-01-01, Point
 SELECT ST_AsText(traversedArea(tgeography '{[Point(1.5 1.5 1.5)@2000-01-01, Point(2.5 2.5 2.5)@2000-01-02, Point(1.5 1.5 1.5)@2000-01-03],[Point(3.5 3.5 3.5)@2000-01-04, Point(3.5 3.5 3.5)@2000-01-05]}'));
                         st_astext                         
 ----------------------------------------------------------
- MULTIPOINT Z ((1.5 1.5 1.5),(3.5 3.5 3.5),(2.5 2.5 2.5))
+ MULTIPOINT Z ((1.5 1.5 1.5),(2.5 2.5 2.5),(3.5 3.5 3.5))
 (1 row)
 
 SELECT array_agg(ST_AsText((dp).geom)) FROM (SELECT ST_DumpPoints(traversedArea(tgeometry '{[Point(1 1)@2001-01-01], [Point(1 1)@2001-02-01], [Point(1 1)@2001-03-01]}'))) AS t(dp);

--- a/mobilitydb/test/geo/expected/056_tpoint_spatialfuncs.test.out
+++ b/mobilitydb/test/geo/expected/056_tpoint_spatialfuncs.test.out
@@ -1385,7 +1385,7 @@ SELECT array_agg(ST_AsText((dp).geom)) FROM (SELECT ST_DumpPoints(trajectory(tge
 SELECT array_agg(ST_AsText((dp).geom)) FROM (SELECT ST_DumpPoints(trajectory(tgeogpoint 'Interp=Step;{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03],[Point(3.5 3.5)@2000-01-04, Point(3.5 3.5)@2000-01-05]}')::geometry)) AS t(dp);
                       array_agg                       
 ------------------------------------------------------
- {"POINT(1.5 1.5)","POINT(3.5 3.5)","POINT(2.5 2.5)"}
+ {"POINT(1.5 1.5)","POINT(2.5 2.5)","POINT(3.5 3.5)"}
 (1 row)
 
 SELECT ST_AsText(trajectory(tgeompoint 'Point(1 1 1)@2000-01-01'));


### PR DESCRIPTION
Comparing two geometries builds a bounding box and a sortable hash for each operand and returns on the hashes. The equality shortcut inside that comparison answers only when the two values are byte-identical, so consecutive positions of a moving object never reach it, and the comparison dominates every operation that sorts the values of a temporal point.

Two points of the same SRID and dimension are now ordered by their coordinates in turn, as the centre of two circular buffers is. A point precedes any other geometry, so the order stays total on a value that holds geometries of several types.

## Measured
Over 60 real AIS trajectories of 500 instants:

| workload | before | after | |
| --- | ---: | ---: | ---: |
| sampling, restriction, distance, simplification, length | 609,336,386 | 445,127,937 | −26.9% |
| distinct values of a trajectory | 80,860,098 | 17,041,903 | −78.9% |

Every value of the operation mix is unchanged: a dump of every result hashes identically on both sides.

## The order of a geometry value set
The set of distinct values is the same set — sorting both dumps gives the same hash, over the same 15316 values — and what changes is the order in which a geometry value set is stored and printed: the coordinate order rather than the hash order.

A geometry has no semantic order. Its total order exists to support the B-tree opclass, the canonical storage of a set and the removal of duplicates, which is why `geomset` carries no position operators while `intset` and `tstzset` do. This replaces one such order with another.

Five expected outputs move, and the queries that move are the ones the order defines:

- `startValue`, `endValue`, `valueN` on a geometry set, which now report the coordinate-extreme values of the set: `MIN(ST_X(startValue(g)))` reads `-99.90013` where it read `-96.535171`, and `MIN(ST_X(endValue(g)))` reads `-85.637205` where it read `-94.408967`
- `hash` of a set, which reads its elements in stored order
- the point collections of `trajectory` and `traversedArea`, which are the same points in a different order: `MULTIPOINT((1.5 1.5),(3.5 3.5),(2.5 2.5))` becomes `MULTIPOINT((1.5 1.5),(2.5 2.5),(3.5 3.5))`

The counting queries over the same sets are untouched — `MIN(array_length(getValues(g), 1))` and `numValues(setUnion(g))` read the same values as before — so every set holds the same elements as it did.
