### PR TITLE
Check the assertions in the build that runs the whole test surface

### DIFF
--- a/.github/workflows/pgversion.yml
+++ b/.github/workflows/pgversion.yml
@@ -132,13 +132,18 @@ jobs:
           mkdir build
           cd build
           # The coverage/test build enables ALL present families so the suite
-          # exercises cross-family behaviour. Families are plug&play 
+          # exercises cross-family behaviour. Families are plug&play
           # independent in code; only the test build turns them all on.
           # H3 depends on libh3, POINTCLOUD on pgPointCloud's libpc.a, and RASTER
           # on PostGIS raster — all installed/built/located above only on coverage builds.
+          # The same build checks the assertions (CASSERT=ON), so that the
+          # preconditions the internal functions trust are verified over the
+          # whole surface. It is the only job that both compiles every family
+          # and runs the regression suite; the others keep a release build,
+          # where the assertions are compiled out.
           cmake -DCMAKE_BUILD_TYPE=Release -DWITH_COVERAGE=${{ matrix.coverage }} \
             -DCBUFFER=ON -DNPOINT=ON -DPOSE=ON -DRGEO=ON -DQUADBIN=ON \
-            ${{ matrix.coverage == '1' && '-DPOINTCLOUD=ON' || '' }} \
+            ${{ matrix.coverage == '1' && '-DPOINTCLOUD=ON -DCASSERT=ON' || '' }} \
             ${{ matrix.coverage == '1' && format('-DH3=ON -DH3_INCLUDE_DIR={0} -DH3_LIBRARY={1} -DRASTER=ON', env.H3_INCLUDE_DIR, env.H3_LIBRARY) || '' }} \
             ..
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -389,6 +389,32 @@ set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O2")
 # Disable compiler optimizations for debugging
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0")
 
+# Assertion checking, the counterpart of PostgreSQL's --enable-cassert.
+#
+# An assertion states a precondition that an internal function trusts, the
+# public function above it having already tested the same constraint with the
+# VALIDATE_* macros. A production build compiles the assertions out, since
+# re-testing a precondition in the loops over the instants of a sequence or the
+# elements of a set would pay for it a second time. The option is therefore OFF
+# by default and a release keeps its current flags.
+#
+# cmake defines NDEBUG in every configuration except Debug, which ties whether
+# the assertions are checked to the optimization level. CASSERT separates the
+# two: a build can be optimized and still check its preconditions, and a
+# session under a debugger can keep them without giving up -O2.
+option(CASSERT
+  "Set ON|OFF (default=OFF) to check the assertions stating the preconditions \
+of the internal functions. A production build compiles them out." OFF)
+if(CASSERT)
+  message(STATUS "Assertion checking enabled")
+  foreach(config "" _DEBUG _RELEASE _RELWITHDEBINFO _MINSIZEREL)
+    string(REPLACE "-DNDEBUG" "" CMAKE_C_FLAGS${config}
+      "${CMAKE_C_FLAGS${config}}")
+    string(REPLACE "-DNDEBUG" "" CMAKE_CXX_FLAGS${config}
+      "${CMAKE_CXX_FLAGS${config}}")
+  endforeach()
+endif()
+
 # Check machine architecture: big endian vs. little endian
 # Needed for WKB support in MobilityDB and PostGIS (file postgis_config.h.in)
 include(TestBigEndian)


### PR DESCRIPTION
An assertion states a precondition that an internal function trusts, the
public function above it having already tested the same constraint with the
`VALIDATE_*` macros. A production build compiles the assertions out, since
re-testing a precondition in the loops over the instants of a sequence or the
elements of a set pays for it a second time.

`cmake` defines `NDEBUG` in every configuration except `Debug`, which ties
whether the assertions are checked to the optimization level. The two are
independent concerns, and tying them leaves a gap:

| workflow | build type | assertions | surface |
| --- | --- | --- | --- |
| `meos.yml` | `Debug` | checked | `MEOS CBUFFER JSON`, the programs of `meos/test` |
| `meos.yml` (TSan) | `Debug` | checked | `MEOS` |
| `meos-smoke.yml` | `Debug` | checked | `MEOS RGEO POSE CBUFFER NPOINT`, valgrind |
| `pgversion.yml` | `Release` | compiled out | every family, the regression suite |
| `clang`, `codeql`, `cppcheck`, `macos`, `windows`, … | `Release` | compiled out | |

The jobs that check the assertions compile a subset of the families and run the
programs of `meos/test`; the job that compiles every family and runs the
regression suite is the one that compiles them out. Neither
`.github/workflows/meos.yml` nor `.github/workflows/meos-smoke.yml` mentions
`H3`, so for the h3, quadbin, pointcloud and raster families no assertion is
evaluated anywhere.

### The option

`CASSERT` is the counterpart of PostgreSQL's `--enable-cassert`, which
likewise ships a production build without the assertions and keeps dedicated
buildfarm members that check them. It removes `NDEBUG` independently of the
build type, and is OFF by default, so a release keeps its current flags. It
appears in `cmake -L`, the listing that `doc/introduction.xml` points to.

Removing the flag rather than appending `-UNDEBUG` keeps the build tree
directly verifiable, and reaches the vendored C++ targets as well:

```
$ cmake -B build -DALL=ON -DCMAKE_BUILD_TYPE=Release
  C_FLAGS = -O3 -DNDEBUG -O2 ...

$ cmake -B build -DALL=ON -DCMAKE_BUILD_TYPE=Release -DCASSERT=ON
  -- Assertion checking enabled
  C_FLAGS = -O3 -O2 ...
  $ grep -rl NDEBUG build --include=flags.make
  (no match)

$ cmake -B build -DALL=ON -DCMAKE_BUILD_TYPE=Release -DWITH_COVERAGE=1 -DCASSERT=ON
  C_FLAGS = -fprofile-arcs -ftest-coverage -O3 -O2 ...
```

The optimization level and the coverage instrumentation are both kept, so the
job it is set in stays the job it is today.

The separation also serves a session under a debugger, where checking a
precondition is independent of the optimization level.

### The job it is set in

The coverage variant of `pgversion.yml`, which is the only job that both
compiles every family and runs the regression suite. Every other job, and
every release, keeps `NDEBUG`.

That suite passes with the assertions live: **288 of 288 tests, no assertion
failure**, and the build reports no warning. Enabling the option therefore
reports nothing today; it reports the violations that follow.