### PR TITLE
Give the h3, quadbin and json families a boxops file

### DIFF
--- a/mobilitydb/sql/h3/253_th3index.in.sql
+++ b/mobilitydb/sql/h3/253_th3index.in.sql
@@ -574,26 +574,6 @@ CREATE FUNCTION timeSplit(th3index, bin_width interval,
   AS 'MODULE_PATHNAME', 'Temporal_time_split'
   LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
 
-/******************************************************************************/
-
--- spans()
-CREATE FUNCTION spans(th3index)
-  RETURNS tstzspan[]
-  AS 'MODULE_PATHNAME', 'Temporal_spans'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
--- splitNSpans()
-CREATE FUNCTION splitNSpans(th3index, integer)
-  RETURNS tstzspan[]
-  AS 'MODULE_PATHNAME', 'Temporal_split_n_spans'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
--- splitEachNSpans()
-CREATE FUNCTION splitEachNSpans(th3index, integer)
-  RETURNS tstzspan[]
-  AS 'MODULE_PATHNAME', 'Temporal_split_each_n_spans'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
 /******************************************************************************
  * Comparison functions and B-tree / hash indexing
  *

--- a/mobilitydb/sql/h3/257_th3index_boxops.in.sql
+++ b/mobilitydb/sql/h3/257_th3index_boxops.in.sql
@@ -1,0 +1,53 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Bounding box operations for temporal H3 cells
+ */
+
+-- spans()
+CREATE FUNCTION spans(th3index)
+  RETURNS tstzspan[]
+  AS 'MODULE_PATHNAME', 'Temporal_spans'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- splitNSpans()
+CREATE FUNCTION splitNSpans(th3index, integer)
+  RETURNS tstzspan[]
+  AS 'MODULE_PATHNAME', 'Temporal_split_n_spans'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- splitEachNSpans()
+CREATE FUNCTION splitEachNSpans(th3index, integer)
+  RETURNS tstzspan[]
+  AS 'MODULE_PATHNAME', 'Temporal_split_each_n_spans'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/*****************************************************************************/

--- a/mobilitydb/sql/h3/CMakeLists.txt
+++ b/mobilitydb/sql/h3/CMakeLists.txt
@@ -5,6 +5,7 @@ SET(LOCAL_FILES
   253_th3index
   254_th3index_compops
   255_th3index_spatialfuncs
+  257_th3index_boxops
   258_th3index_topops
   259_th3index_posops
   262_th3index_spatialrels

--- a/mobilitydb/sql/json/452_tjsonb.in.sql
+++ b/mobilitydb/sql/json/452_tjsonb.in.sql
@@ -609,26 +609,6 @@ CREATE FUNCTION timeSplit(tjsonb, bin_width interval,
   AS 'MODULE_PATHNAME', 'Temporal_time_split'
   LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
 
-/*****************************************************************************/
-
--- spans()
-CREATE FUNCTION spans(tjsonb)
-  RETURNS tstzspan[]
-  AS 'MODULE_PATHNAME', 'Temporal_spans'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
--- splitNSpans()
-CREATE FUNCTION splitNSpans(tjsonb, integer)
-  RETURNS tstzspan[]
-  AS 'MODULE_PATHNAME', 'Temporal_split_n_spans'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
--- splitEachNSpans()
-CREATE FUNCTION splitEachNSpans(tjsonb, integer)
-  RETURNS tstzspan[]
-  AS 'MODULE_PATHNAME', 'Temporal_split_each_n_spans'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
 /*****************************************************************************
  * Comparison functions and B-tree indexing
  *****************************************************************************/

--- a/mobilitydb/sql/json/459_tjsonb_boxops.in.sql
+++ b/mobilitydb/sql/json/459_tjsonb_boxops.in.sql
@@ -1,0 +1,53 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Bounding box operations for temporal JSONB values
+ */
+
+-- spans()
+CREATE FUNCTION spans(tjsonb)
+  RETURNS tstzspan[]
+  AS 'MODULE_PATHNAME', 'Temporal_spans'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- splitNSpans()
+CREATE FUNCTION splitNSpans(tjsonb, integer)
+  RETURNS tstzspan[]
+  AS 'MODULE_PATHNAME', 'Temporal_split_n_spans'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- splitEachNSpans()
+CREATE FUNCTION splitEachNSpans(tjsonb, integer)
+  RETURNS tstzspan[]
+  AS 'MODULE_PATHNAME', 'Temporal_split_each_n_spans'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/*****************************************************************************/

--- a/mobilitydb/sql/json/CMakeLists.txt
+++ b/mobilitydb/sql/json/CMakeLists.txt
@@ -5,6 +5,7 @@ SET(LOCAL_FILES
   454_tjsonb_jsonfuncs
   456_tjsonb_op
   458_tjsonb_compops
+  459_tjsonb_boxops
   460_tjsonb_topops
   462_tjsonb_posops
   464_tjsonb_aggfuncs

--- a/mobilitydb/sql/quadbin/353_tquadbin.in.sql
+++ b/mobilitydb/sql/quadbin/353_tquadbin.in.sql
@@ -576,26 +576,6 @@ CREATE FUNCTION timeSplit(tquadbin, bin_width interval,
   AS 'MODULE_PATHNAME', 'Temporal_time_split'
   LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
 
-/******************************************************************************/
-
--- spans()
-CREATE FUNCTION spans(tquadbin)
-  RETURNS tstzspan[]
-  AS 'MODULE_PATHNAME', 'Temporal_spans'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
--- splitNSpans()
-CREATE FUNCTION splitNSpans(tquadbin, integer)
-  RETURNS tstzspan[]
-  AS 'MODULE_PATHNAME', 'Temporal_split_n_spans'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
--- splitEachNSpans()
-CREATE FUNCTION splitEachNSpans(tquadbin, integer)
-  RETURNS tstzspan[]
-  AS 'MODULE_PATHNAME', 'Temporal_split_each_n_spans'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
 /******************************************************************************
  * Comparison functions and B-tree / hash indexing
  *

--- a/mobilitydb/sql/quadbin/357_tquadbin_boxops.in.sql
+++ b/mobilitydb/sql/quadbin/357_tquadbin_boxops.in.sql
@@ -1,0 +1,53 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Bounding box operations for temporal QUADBIN cells
+ */
+
+-- spans()
+CREATE FUNCTION spans(tquadbin)
+  RETURNS tstzspan[]
+  AS 'MODULE_PATHNAME', 'Temporal_spans'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- splitNSpans()
+CREATE FUNCTION splitNSpans(tquadbin, integer)
+  RETURNS tstzspan[]
+  AS 'MODULE_PATHNAME', 'Temporal_split_n_spans'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- splitEachNSpans()
+CREATE FUNCTION splitEachNSpans(tquadbin, integer)
+  RETURNS tstzspan[]
+  AS 'MODULE_PATHNAME', 'Temporal_split_each_n_spans'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/*****************************************************************************/

--- a/mobilitydb/sql/quadbin/CMakeLists.txt
+++ b/mobilitydb/sql/quadbin/CMakeLists.txt
@@ -5,6 +5,7 @@ SET(LOCAL_FILES
   353_tquadbin
   354_tquadbin_compops
   355_tquadbin_spatialfuncs
+  357_tquadbin_boxops
   358_tquadbin_topops
   359_tquadbin_posops
   362_tquadbin_spatialrels

--- a/tools/codegen/inherited/manifest.d/tiling_families.yaml
+++ b/tools/codegen/inherited/manifest.d/tiling_families.yaml
@@ -41,7 +41,14 @@ tiling_families:
   - lit: "/*****************************************************************************\n * Multidimensional tiling\n *****************************************************************************/\n\nCREATE TYPE time_tjsonb AS (\n  time timestamptz,\n  temp tjsonb\n);\n\n"
   - fns:
     - {sig: "timeSplit(tjsonb, bin_width interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tjsonb", sym: "Temporal_time_split"}
-  - lit: "\n/*****************************************************************************/\n\n-- spans()\nCREATE FUNCTION spans(tjsonb)\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Temporal_spans'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- splitNSpans()\nCREATE FUNCTION splitNSpans(tjsonb, integer)\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Temporal_split_n_spans'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- splitEachNSpans()\nCREATE FUNCTION splitEachNSpans(tjsonb, integer)\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Temporal_split_each_n_spans'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n"
+  - lit: "\n"
+- family: json_boxops
+  file: mobilitydb/sql/json/459_tjsonb_boxops.in.sql
+  reference: true
+  begin: "@brief Bounding box operations for temporal JSONB values"
+  end: ""
+  blocks:
+  - lit: "/**\n * @file\n * @brief Bounding box operations for temporal JSONB values\n */\n\n-- spans()\nCREATE FUNCTION spans(tjsonb)\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Temporal_spans'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- splitNSpans()\nCREATE FUNCTION splitNSpans(tjsonb, integer)\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Temporal_split_n_spans'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- splitEachNSpans()\nCREATE FUNCTION splitEachNSpans(tjsonb, integer)\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Temporal_split_each_n_spans'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n/*****************************************************************************/"
 - family: npoint
   file: mobilitydb/sql/npoint/302_tnpoint.in.sql
   reference: true
@@ -312,7 +319,14 @@ tiling_families:
   - lit: "CREATE TYPE time_th3index AS (\n  time timestamptz,\n  temp th3index\n);\n\n"
   - fns:
     - {sig: "timeSplit(th3index, bin_width interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_th3index", sym: "Temporal_time_split"}
-  - lit: "\n/******************************************************************************/\n\n-- spans()\nCREATE FUNCTION spans(th3index)\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Temporal_spans'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- splitNSpans()\nCREATE FUNCTION splitNSpans(th3index, integer)\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Temporal_split_n_spans'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- splitEachNSpans()\nCREATE FUNCTION splitEachNSpans(th3index, integer)\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Temporal_split_each_n_spans'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n"
+  - lit: "\n"
+- family: th3index_boxops
+  file: mobilitydb/sql/h3/257_th3index_boxops.in.sql
+  reference: true
+  begin: "@brief Bounding box operations for temporal H3 cells"
+  end: ""
+  blocks:
+  - lit: "/**\n * @file\n * @brief Bounding box operations for temporal H3 cells\n */\n\n-- spans()\nCREATE FUNCTION spans(th3index)\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Temporal_spans'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- splitNSpans()\nCREATE FUNCTION splitNSpans(th3index, integer)\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Temporal_split_n_spans'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- splitEachNSpans()\nCREATE FUNCTION splitEachNSpans(th3index, integer)\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Temporal_split_each_n_spans'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n/*****************************************************************************/"
 
 - family: quadbin
   file: mobilitydb/sql/quadbin/353_tquadbin.in.sql
@@ -324,4 +338,11 @@ tiling_families:
   - lit: "CREATE TYPE time_tquadbin AS (\n  time timestamptz,\n  temp tquadbin\n);\n\n"
   - fns:
     - {sig: "timeSplit(tquadbin, bin_width interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tquadbin", sym: "Temporal_time_split"}
-  - lit: "\n/******************************************************************************/\n\n-- spans()\nCREATE FUNCTION spans(tquadbin)\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Temporal_spans'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- splitNSpans()\nCREATE FUNCTION splitNSpans(tquadbin, integer)\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Temporal_split_n_spans'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- splitEachNSpans()\nCREATE FUNCTION splitEachNSpans(tquadbin, integer)\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Temporal_split_each_n_spans'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n"
+  - lit: "\n"
+- family: quadbin_boxops
+  file: mobilitydb/sql/quadbin/357_tquadbin_boxops.in.sql
+  reference: true
+  begin: "@brief Bounding box operations for temporal QUADBIN cells"
+  end: ""
+  blocks:
+  - lit: "/**\n * @file\n * @brief Bounding box operations for temporal QUADBIN cells\n */\n\n-- spans()\nCREATE FUNCTION spans(tquadbin)\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Temporal_spans'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- splitNSpans()\nCREATE FUNCTION splitNSpans(tquadbin, integer)\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Temporal_split_n_spans'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- splitEachNSpans()\nCREATE FUNCTION splitEachNSpans(tquadbin, integer)\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Temporal_split_each_n_spans'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n/*****************************************************************************/"


### PR DESCRIPTION
Gives the h3, quadbin and json families a boxops file holding their box-extraction surface, the arrangement the cbuffer, geo, npoint, pose, rgeo and temporal families carry.

`257_th3index_boxops.in.sql`, `357_tquadbin_boxops.in.sql` and `459_tjsonb_boxops.in.sql` each hold that family's `spans`, `splitNSpans` and `splitEachNSpans` declarations. Each file number places extraction immediately ahead of its family's topological-operator file, matching the 207-before-208 ordering of the cbuffer family, and each `CMakeLists.txt` loads it in that position.

The declarations stay generated: the manifest entry that emits them names the boxops file as its target, so the surface remains a projection of the generator. The set of declarations across `mobilitydb/sql` is identical, backing symbols included.

Without a boxops file: pointcloud.
