### PR TITLE
Test the arguments of the temporal cell index accessors

### DIFF
--- a/meos/include/meos_cellindex.h
+++ b/meos/include/meos_cellindex.h
@@ -45,6 +45,26 @@
 /* MEOS */
 #include <meos.h>
 
+/**
+ * @brief Ensure that the temporal value is a temporal cell index.
+ * Matches the pattern of `VALIDATE_TNUMBER`, the other macro stating a class
+ * of temporal types rather than a single one.
+ */
+#if MEOS
+  #define VALIDATE_TCELLINDEX(temp, ret) \
+    do { \
+      if (! ensure_not_null((void *) (temp)) || \
+          ! ensure_tcellindex_type(((Temporal *) (temp))->temptype) ) \
+        return (ret); \
+    } while (0)
+#else
+  #define VALIDATE_TCELLINDEX(temp, ret) \
+    do { \
+      assert(temp); \
+      assert(tcellindex_type(((Temporal *) (temp))->temptype)); \
+    } while (0)
+#endif /* MEOS */
+
 /*****************************************************************************
  * Accessor functions for temporal cell indices
  *****************************************************************************/

--- a/meos/include/temporal/tcellindex.h
+++ b/meos/include/temporal/tcellindex.h
@@ -126,6 +126,12 @@ typedef struct DggsCellOps
 extern bool tcellindex_type(MeosType type);
 
 /**
+ * @brief Ensure that @p type is a temporal DGGS cell-index type, or raise an
+ * error.
+ */
+extern bool ensure_tcellindex_type(MeosType type);
+
+/**
  * @brief Return the operations descriptor for a temporal cell-index type, or
  * raise an error if @p temptype is not a (compiled-in) DGGS type.
  */

--- a/meos/src/temporal/tcellindex.c
+++ b/meos/src/temporal/tcellindex.c
@@ -70,6 +70,19 @@ tcellindex_type(MeosType type UNUSED)
 }
 
 /**
+ * @brief Ensure that @p type is a temporal DGGS cell-index type.
+ */
+bool
+ensure_tcellindex_type(MeosType type)
+{
+  if (tcellindex_type(type))
+    return true;
+  meos_error(ERROR, MEOS_ERR_INVALID_ARG_TYPE,
+    "The temporal value must be a temporal cell index");
+  return false;
+}
+
+/**
  * @brief Return the operations descriptor for a temporal cell-index type.
  */
 const DggsCellOps *
@@ -156,7 +169,7 @@ tcellindex_lift_param1(const Temporal *temp, Datum (*func)(Datum, Datum),
 Temporal *
 tcellindex_get_resolution(const Temporal *temp)
 {
-  assert(temp); assert(tcellindex_type(temp->temptype));
+  VALIDATE_TCELLINDEX(temp, NULL);
   const DggsCellOps *ops = dggs_cellops(temp->temptype);
   if (! ops)
     return NULL;
@@ -173,7 +186,7 @@ tcellindex_get_resolution(const Temporal *temp)
 Temporal *
 tcellindex_is_valid_cell(const Temporal *temp)
 {
-  assert(temp); assert(tcellindex_type(temp->temptype));
+  VALIDATE_TCELLINDEX(temp, NULL);
   const DggsCellOps *ops = dggs_cellops(temp->temptype);
   if (! ops)
     return NULL;
@@ -189,7 +202,7 @@ tcellindex_is_valid_cell(const Temporal *temp)
 Temporal *
 tcellindex_cell_to_parent(const Temporal *temp, int32 resolution)
 {
-  assert(temp); assert(tcellindex_type(temp->temptype));
+  VALIDATE_TCELLINDEX(temp, NULL);
   const DggsCellOps *ops = dggs_cellops(temp->temptype);
   if (! ops)
     return NULL;
@@ -206,7 +219,7 @@ tcellindex_cell_to_parent(const Temporal *temp, int32 resolution)
 Temporal *
 tcellindex_cell_to_point(const Temporal *temp)
 {
-  assert(temp); assert(tcellindex_type(temp->temptype));
+  VALIDATE_TCELLINDEX(temp, NULL);
   const DggsCellOps *ops = dggs_cellops(temp->temptype);
   if (! ops)
     return NULL;
@@ -222,7 +235,7 @@ tcellindex_cell_to_point(const Temporal *temp)
 Temporal *
 tcellindex_cell_to_boundary(const Temporal *temp)
 {
-  assert(temp); assert(tcellindex_type(temp->temptype));
+  VALIDATE_TCELLINDEX(temp, NULL);
   const DggsCellOps *ops = dggs_cellops(temp->temptype);
   if (! ops)
     return NULL;
@@ -240,7 +253,7 @@ tcellindex_cell_to_boundary(const Temporal *temp)
 Temporal *
 tcellindex_cell_area(const Temporal *temp)
 {
-  assert(temp); assert(tcellindex_type(temp->temptype));
+  VALIDATE_TCELLINDEX(temp, NULL);
   const DggsCellOps *ops = dggs_cellops(temp->temptype);
   if (! ops)
     return NULL;


### PR DESCRIPTION
The generic accessors of the temporal cell index state their argument
contract with `assert` alone. An assertion is compiled out under `NDEBUG`, so
a release build performs no check and dereferences the argument, while the
concrete families below them, tquadbin and th3index, state the same contract
with the `VALIDATE_*` macros, which raise a MEOS error and return.

`tcellindex` states a class of temporal types rather than a single one, as
`tnumber` does, so the pair it needs is the one that class already has:

| tnumber | tcellindex |
| --- | --- |
| `tnumber_type` (`meos_catalog.c:1214`) | `tcellindex_type` |
| `ensure_tnumber_type` (`meos_catalog.c:1223`) | `ensure_tcellindex_type`, added beside it |
| `VALIDATE_TNUMBER` (`meos_internal.h:524`) | `VALIDATE_TCELLINDEX`, built on it |

The macro lives in `meos_cellindex.h`, the umbrella header that declares the
six accessors it guards, as the macro of each family lives in the header of
that family.

In the extension build the macro expands to the same two assertions that it
replaces, so the behaviour there is unchanged.

### Effect

Only the null argument changes behaviour. In a release build of the MEOS
library (`-O3 -DNDEBUG -O2`), with the non-exiting error handler installed as
the language bindings do:

```
before:  tcellindex_get_resolution(NULL)     -> SIGSEGV (exit 139)

after:   tcellindex_get_resolution(NULL)     -> NULL, errno 10
         tcellindex_is_valid_cell(NULL)      -> NULL, errno 10
         tcellindex_cell_to_parent(NULL, 3)  -> NULL, errno 10
         tcellindex_cell_to_point(NULL)      -> NULL, errno 10
         tcellindex_cell_to_boundary(NULL)   -> NULL, errno 10
         tcellindex_cell_area(NULL)          -> NULL, errno 10
```

A temporal value of another type is already rejected by `dggs_cellops`, which
returns NULL and sets `MEOS_ERR_INVALID_ARG_TYPE`. Probed separately against
both trees, that arm is unchanged:

```
before:  tcellindex_get_resolution(tint)     -> NULL, errno 11
after:   tcellindex_get_resolution(tint)     -> NULL, errno 11
```

The macro states that constraint in the accessor rather than in the
dispatcher, and rejects the null argument that the dispatcher never sees.

The regression tests are unaffected: the SQL functions are `STRICT`, so
PostgreSQL never passes a null argument, and the macro keeps asserting in the
extension build. The release-build comparison above is the evidence for this
change.