### PR TITLE
Register h3 in the temporal cell index registry

### DIFF
--- a/meos/src/h3/CMakeLists.txt
+++ b/meos/src/h3/CMakeLists.txt
@@ -10,6 +10,11 @@ set(H3_SRCS
   # Static set-returning h3-pg ports.
   h3index_sets.c
 
+  # The h3_cellops descriptor that plugs the kernel into the shared temporal
+  # cell-index machinery (meos/src/temporal/tcellindex.c), with the square-metre
+  # adapter its area slot takes. The quadbin analogue is tquadbin_ops.c.
+  th3index_ops.c
+
   # Public inheritance boilerplate: inout, constructors,
   # conversions, accessors, validators.
   th3index.c

--- a/meos/src/h3/th3index_ops.c
+++ b/meos/src/h3/th3index_ops.c
@@ -1,0 +1,96 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief The `h3_cellops` descriptor that plugs h3 into the shared temporal
+ * cell-index machinery (meos/src/temporal/tcellindex.c).
+ *
+ * The Datum-convention wrappers of the h3 kernel live alongside the base type
+ * in h3index.c, so this file holds the descriptor and the single adapter the
+ * descriptor needs: the shared `cell_area` slot is a one-argument function
+ * returning square metres, whereas the h3 kernel takes the unit as a second
+ * argument.
+ *
+ * An h3 cell is geodetic, so the descriptor emits a tgeogpoint centroid and,
+ * through it, a tgeography boundary. The static adapter behind the centroid
+ * builds an SRID-4326 point; geography and geometry are distinguished at the
+ * lifting layer by `point_temptype`, exactly as the typed th3index conversions
+ * distinguish them by their `restype`.
+ */
+
+#include "h3/th3index_internal.h"
+
+/* PostgreSQL */
+#include <postgres.h>
+/* MEOS */
+#include <meos.h>
+#include <meos_h3.h>
+#include "temporal/meos_catalog.h"
+#include "temporal/tcellindex.h"
+
+/*****************************************************************************
+ * Datum-convention adapter
+ *****************************************************************************/
+
+/**
+ * @brief Return the area of an h3 cell in square metres, the unit the shared
+ * `cell_area` slot is defined in.
+ */
+static Datum
+datum_h3_cell_area_m2(Datum cell_d)
+{
+  return datum_h3_cell_area(cell_d, Int32GetDatum((int32) H3_UNIT_M2));
+}
+
+/*****************************************************************************
+ * Descriptor
+ *****************************************************************************/
+
+/**
+ * @brief H3 operations descriptor consumed by `dggs_cellops()`.
+ */
+const DggsCellOps h3_cellops =
+{
+  .celltype        = T_H3INDEX,
+  .settype         = T_H3INDEXSET,
+  .temptype        = T_TH3INDEX,
+  .min_resolution  = 0,
+  .max_resolution  = 15,
+  .point_temptype  = T_TGEOGPOINT,
+  .point_srid      = 4326,
+  .get_resolution  = &datum_h3_get_resolution,
+  .is_valid_cell   = &datum_h3_is_valid_cell,
+  .cell_to_parent  = &datum_h3_cell_to_parent,
+  .cell_to_point   = &datum_h3_cell_to_latlng,
+  .cell_to_boundary = &datum_h3_cell_to_boundary,
+  .cell_area       = &datum_h3_cell_area_m2
+};
+
+/*****************************************************************************/

--- a/meos/src/temporal/tcellindex.c
+++ b/meos/src/temporal/tcellindex.c
@@ -48,6 +48,9 @@
 
 /* Per-DGGS descriptors, defined in each family and referenced here under the
  * same build-flag guard that compiles the family. */
+#if H3
+extern const DggsCellOps h3_cellops;
+#endif
 #if QUADBIN
 extern const DggsCellOps quadbin_cellops;
 #endif
@@ -63,6 +66,9 @@ bool
 tcellindex_type(MeosType type UNUSED)
 {
   return
+#if H3
+    type == T_TH3INDEX ||
+#endif
 #if QUADBIN
     type == T_TQUADBIN ||
 #endif
@@ -90,6 +96,10 @@ dggs_cellops(MeosType temptype)
 {
   switch (temptype)
   {
+#if H3
+    case T_TH3INDEX:
+      return &h3_cellops;
+#endif
 #if QUADBIN
     case T_TQUADBIN:
       return &quadbin_cellops;

--- a/tools/codegen/inherited/manifest.d/classes.yaml
+++ b/tools/codegen/inherited/manifest.d/classes.yaml
@@ -28,7 +28,7 @@ classes:
     members: [tgeompoint, tgeogpoint]
   tcellindex:
     predicate: tcellindex_type
-    members: [tquadbin]
+    members: [th3index, tquadbin]
   tpointcloud:
     predicate: tpointcloud_temptype
     members: [tpcpoint, tpcpatch]


### PR DESCRIPTION
The shared cell-index scaffolding is written for the DGGS families th3index,
tquadbin and a future ts2cell, and `meos/include/temporal/tcellindex.h` states
the four steps that plug a family into it: the catalog entry, the static
kernel, a `DggsCellOps` descriptor, and one line in `dggs_cellops()`.

h3 carries the first two and not the last two. `tcellindex_type()` therefore
answers false for `T_TH3INDEX` and the generic accessors reject it, although
the comment above the predicate lists it first.

### The descriptor

The kernel is already there. Five of the six slots take the `datum_h3_*`
wrapper of the same shape:

| slot | h3 kernel |
| --- | --- |
| `get_resolution(Datum)` | `datum_h3_get_resolution` |
| `is_valid_cell(Datum)` | `datum_h3_is_valid_cell` |
| `cell_to_parent(Datum, Datum)` | `datum_h3_cell_to_parent` |
| `cell_to_point(Datum)` | `datum_h3_cell_to_latlng` |
| `cell_to_boundary(Datum)` | `datum_h3_cell_to_boundary` |
| `cell_area(Datum)` | `datum_h3_cell_area(Datum, Datum)` |

The last one is the single adapter this adds: the shared slot is defined in
square metres, while the h3 kernel takes the unit as a second argument.

An h3 cell is geodetic, so the descriptor emits a tgeogpoint centroid and
through it a tgeography boundary. The static adapter behind the centroid
builds an SRID-4326 point either way; geography and geometry are distinguished
at the lifting layer by `point_temptype`, exactly as the typed th3index
conversions distinguish them by their `restype`.

### Effect

The typed th3index functions are untouched, and the two paths agree on every
slot of the descriptor:

```
input: {8928308280fffff@2000-01-01, 8928308280bffff@2000-01-02}

  getResolution    AGREE   {9@2000-01-01, 9@2000-01-02}
  isValidCell      AGREE   {t@2000-01-01, t@2000-01-02}
  cellToParent     AGREE   {85283083fffffff@2000-01-01, ...}
  cellToPoint      AGREE   {0101000020E6100000C5F19C09C89A5EC0...}
  cellToBoundary   AGREE   {0103000020E61000000100000007000000...}
  cellArea         AGREE   {109398.188647@2000-01-01, ...}
```

`tcellindex_type` is a class predicate of the inherited SQL generator, so
`manifest.d/classes.yaml` records the new member, as its header requires. The
emitted SQL is unchanged: `generate.py --check` writes the same 35 files
before and after.