### PR TITLE
Document the type catalog in the table of the template types

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -59,3 +59,11 @@ jobs:
         uses: actions/checkout@v4
       - name: Check spatial-relationship (geo x tgeo) grid completeness
         run: python3 tools/scripts/check_spatialrel_orthogonality.py
+
+  templatetypes_check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check that the templatetypes table documents the type catalog
+        run: python3 tools/scripts/check_templatetypes_doc.py

--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -39,17 +39,24 @@
 			<tbody>
 				<row>
 					<entry><emphasis role="bold"><varname>bool</varname></emphasis></entry>
-					<entry><varname></varname></entry>
-					<entry><varname></varname></entry>
-					<entry><varname></varname></entry>
+					<entry><varname/></entry>
+					<entry><varname/></entry>
+					<entry><varname/></entry>
 					<entry><varname>tbool</varname></entry>
 				</row>
 				<row>
 					<entry><emphasis role="bold"><varname>text</varname></emphasis></entry>
 					<entry><varname>textset</varname></entry>
-					<entry><varname></varname></entry>
-					<entry><varname></varname></entry>
+					<entry><varname/></entry>
+					<entry><varname/></entry>
 					<entry><varname>ttext</varname></entry>
+				</row>
+				<row>
+					<entry><emphasis role="bold"><varname>jsonb</varname></emphasis></entry>
+					<entry><varname>jsonbset</varname></entry>
+					<entry><varname/></entry>
+					<entry><varname/></entry>
+					<entry><varname>tjsonb</varname></entry>
 				</row>
 				<row>
 					<entry><emphasis role="bold"><varname>integer</varname></emphasis></entry>
@@ -77,48 +84,48 @@
 					<entry><varname>dateset</varname></entry>
 					<entry><varname>datespan</varname></entry>
 					<entry><varname>datespanset</varname></entry>
-					<entry><varname></varname></entry>
+					<entry><varname/></entry>
 				</row>
 				<row>
 					<entry><emphasis role="bold"><varname>timestamptz</varname></emphasis></entry>
 					<entry><varname>tstzset</varname></entry>
 					<entry><varname>tstzspan</varname></entry>
 					<entry><varname>tstzspanset</varname></entry>
-					<entry><varname></varname></entry>
+					<entry><varname/></entry>
 				</row>
 				<row>
 					<entry><emphasis role="bold"><varname>geometry</varname></emphasis></entry>
 					<entry><varname>geomset</varname></entry>
-					<entry><varname></varname></entry>
-					<entry><varname></varname></entry>
-					<entry><varname>tgeompoint</varname></entry>
+					<entry><varname/></entry>
+					<entry><varname/></entry>
+					<entry><varname>tgeompoint</varname>, <varname>tgeometry</varname></entry>
 				</row>
 				<row>
 					<entry><emphasis role="bold"><varname>geography</varname></emphasis></entry>
 					<entry><varname>geogset</varname></entry>
-					<entry><varname></varname></entry>
-					<entry><varname></varname></entry>
+					<entry><varname/></entry>
+					<entry><varname/></entry>
 					<entry><varname>tgeogpoint</varname>, <varname>tgeography</varname></entry>
 				</row>
 				<row>
 					<entry><emphasis role="bold"><varname>pose</varname></emphasis></entry>
 					<entry><varname>poseset</varname></entry>
-					<entry><varname></varname></entry>
-					<entry><varname></varname></entry>
-					<entry><varname>tpose</varname></entry>
+					<entry><varname/></entry>
+					<entry><varname/></entry>
+					<entry><varname>tpose</varname>, <varname>trgeometry</varname></entry>
 				</row>
 				<row>
 					<entry><emphasis role="bold"><varname>npoint</varname></emphasis></entry>
 					<entry><varname>npointset</varname></entry>
-					<entry><varname></varname></entry>
-					<entry><varname></varname></entry>
+					<entry><varname/></entry>
+					<entry><varname/></entry>
 					<entry><varname>tnpoint</varname></entry>
 				</row>
 				<row>
 					<entry><emphasis role="bold"><varname>cbuffer</varname></emphasis></entry>
 					<entry><varname>cbufferset</varname></entry>
-					<entry><varname></varname></entry>
-					<entry><varname></varname></entry>
+					<entry><varname/></entry>
+					<entry><varname/></entry>
 					<entry><varname>tcbuffer</varname></entry>
 				</row>
 				<row>

--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -293,7 +293,7 @@ SELECT asEWKT(setSRID(pose 'Pose(Point(0 0),1)', 4326));
 				</listitem>
 
 				<listitem xml:id="pose_transform">
-					<indexterm significance="normal"><primary><varname> </varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>transform</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>transformPipeline</varname></primary></indexterm>
 					<para>Transformar a un identificador de referencia espacial</para>
 					<para><varname>transform(pose,integer) → pose</varname></para>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -52,6 +52,13 @@
 					<entry><varname>ttext</varname></entry>
 				</row>
 				<row>
+					<entry><emphasis role="bold"><varname>jsonb</varname></emphasis></entry>
+					<entry><varname>jsonbset</varname></entry>
+					<entry><varname/></entry>
+					<entry><varname/></entry>
+					<entry><varname>tjsonb</varname></entry>
+				</row>
+				<row>
 					<entry><emphasis role="bold"><varname>integer</varname></emphasis></entry>
 					<entry><varname>intset</varname></entry>
 					<entry><varname>intspan</varname></entry>
@@ -105,7 +112,7 @@
 					<entry><varname>poseset</varname></entry>
 					<entry><varname/></entry>
 					<entry><varname/></entry>
-					<entry><varname>tpose</varname></entry>
+					<entry><varname>tpose</varname>, <varname>trgeometry</varname></entry>
 				</row>
 				<row>
 					<entry><emphasis role="bold"><varname>npoint</varname></emphasis></entry>

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -300,7 +300,7 @@ SELECT asEWKT(setSRID(pose 'Pose(Point(0 0),1)', 4326));
 				</listitem>
 
 				<listitem xml:id="pose_transform">
-					<indexterm significance="normal"><primary><varname> </varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>transform</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>transformPipeline</varname></primary></indexterm>
 					<para>Transform to a spatial reference identifier</para>
 					<para><varname>transform(pose,integer) → pose</varname></para>

--- a/tools/scripts/check_templatetypes_doc.py
+++ b/tools/scripts/check_templatetypes_doc.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+#
+# This MobilityDB code is provided under The PostgreSQL License.
+# Copyright (c) 2016-2025, Universite libre de Bruxelles and MobilityDB
+# contributors
+#
+"""Alignment lint for the `templatetypes` table of the manual.
+
+The manual documents, in the table `templatetypes` of `doc/reference.xml` (and
+of its Spanish translation), which instantiations of the four template types
+`set`, `span`, `spanset` and `temporal` exist for each base type.  The same
+information is what the array `MEOS_RELTYPE_CATALOG` of the file
+`meos/src/temporal/meos_catalog.c` keeps for the type lookups, so the table and
+the array are two representations of one thing:
+
+    row  float | floatset | floatspan | floatspanset | tfloat
+
+    [T_FLOAT8]      = { .basetype_settype = T_FLOATSET,
+                        .basetype_spantype = T_FLOATSPAN },
+    [T_FLOATSPAN]   = { .spantype_spansettype = T_FLOATSPANSET },
+    [T_TFLOAT]      = { .temptype_basetype = T_FLOAT8 },
+
+Nothing else compares them, so a type added to the array but not to the table
+leaves the manual silently wrong, and a cell of the table naming a type that
+was never registered leaves the manual promising a type that does not exist.
+This lint compares them cell by cell, in both directions and for every
+translation of the manual.
+
+Usage:
+  check_templatetypes_doc.py            compare every cell (CI guard)
+  check_templatetypes_doc.py --table    print the catalog table
+
+Exit status is non-zero when any cell of any translation disagrees with the
+array.
+"""
+
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+CATALOG = 'meos/src/temporal/meos_catalog.c'
+
+# Every translation of the manual carries the same table under the same id
+MANUALS = ['doc/reference.xml', 'doc/es/reference.xml']
+
+TABLE_ID = 'templatetypes'
+
+# The manual names a base type as PostgreSQL spells it in a type declaration,
+# the array names it as the MeosType enumeration spells it.  These are the
+# PostgreSQL aliases of one type, not two names of two types.
+DOC_BASETYPE_ALIAS = {
+    'integer': 'int4',
+    'bigint': 'int8',
+    'float': 'float8',
+}
+
+# A base type of the catalog for which no type is created in the SQL of the
+# extension, so that the manual, which documents the SQL types, does not list
+# it.  `tdouble2`, `tdouble3` and `tdouble4` carry the intermediate state of
+# the aggregations of a temporal number and are never seen by a user, as
+# `grep -r tdouble2 mobilitydb/sql` shows.  A type reachable from SQL does NOT
+# belong here: it belongs in the table.
+DOC_OMITTED_BASETYPES = {
+    'double2',
+    'double3',
+    'double4',
+}
+
+COLUMNS = ['set', 'span', 'spanset', 'temporal']
+
+
+def type_names(text):
+    """Return the name of every type of the MeosType enumeration, by token"""
+    block = re.search(r'MEOS_TYPE_NAMES\[\]\s*=\s*\{(.*?)\n\};', text, re.S)
+    if not block:
+        sys.exit('the array MEOS_TYPE_NAMES was not found in ' + CATALOG)
+    return dict(re.findall(r'\[(T_\w+)\]\s*=\s*"([^"]*)"', block.group(1)))
+
+
+def catalog_table(text, names):
+    """Return, for the name of every base type, the name of its set, span,
+    span set and temporal types, read from MEOS_RELTYPE_CATALOG"""
+    block = re.search(r'MEOS_RELTYPE_CATALOG\[\]\s*=\s*\{(.*?)\n\};', text, re.S)
+    if not block:
+        sys.exit('the array MEOS_RELTYPE_CATALOG was not found in ' + CATALOG)
+    entries = {}
+    for token, fields in re.findall(r'\[(T_\w+)\]\s*=\s*\{(.*?)\}', block.group(1), re.S):
+        entries[token] = dict(re.findall(r'\.(\w+)\s*=\s*(T_\w+)', fields))
+
+    table = {}
+
+    def row(base):
+        return table.setdefault(names[base], {c: set() for c in COLUMNS})
+
+    for token, fields in entries.items():
+        # A base type names its set and its span type
+        if 'basetype_settype' in fields:
+            row(token)['set'].add(names[fields['basetype_settype']])
+        if 'basetype_spantype' in fields:
+            row(token)['span'].add(names[fields['basetype_spantype']])
+        # A span type names its base type and its span set type
+        if 'spantype_spansettype' in fields:
+            base = entries[token]['spantype_basetype']
+            row(base)['spanset'].add(names[fields['spantype_spansettype']])
+        # A temporal type names its base type
+        if 'temptype_basetype' in fields:
+            row(fields['temptype_basetype'])['temporal'].add(names[token])
+    return table
+
+
+def names(cell):
+    """Return the type names of a cell of the table.  An instantiation that
+    does not exist is written `<varname/>` in one manual and `<varname></varname>`
+    in another, so an empty name is no name"""
+    return {n.strip() for n in re.findall(r'<varname\s*>(.*?)</varname\s*>', cell, re.S)
+        if n.strip()}
+
+
+def doc_table(text, path):
+    """Return, for the name of every base type, the name of its set, span,
+    span set and temporal types, read from the table of the manual"""
+    table = re.search(r'<table[^>]*xml:id="%s".*?</table>' % TABLE_ID, text, re.S)
+    if not table:
+        sys.exit('the table %s was not found in %s' % (TABLE_ID, path))
+    body = re.search(r'<tbody>(.*?)</tbody>', table.group(0), re.S)
+    if not body:
+        sys.exit('the table %s of %s has no body' % (TABLE_ID, path))
+    result = {}
+    for row in re.findall(r'<row>(.*?)</row>', body.group(1), re.S):
+        cells = re.findall(r'<entry>(.*?)</entry>', row, re.S)
+        if len(cells) != len(COLUMNS) + 1:
+            sys.exit('a row of the table %s of %s has %d cells, expected %d'
+                % (TABLE_ID, path, len(cells), len(COLUMNS) + 1))
+        cell = names(cells[0])
+        if len(cell) != 1:
+            sys.exit('a row of the table %s of %s names %d base types, expected one'
+                % (TABLE_ID, path, len(cell)))
+        base = cell.pop()
+        base = DOC_BASETYPE_ALIAS.get(base, base)
+        result[base] = {c: names(cells[i + 1]) for i, c in enumerate(COLUMNS)}
+    return result
+
+
+def compare(catalog, doc, path):
+    """Report every cell of the manual that disagrees with the array"""
+    problems = []
+    for base in sorted(set(catalog) | set(doc)):
+        if base in DOC_OMITTED_BASETYPES:
+            continue
+        if base not in doc:
+            if any(catalog[base][c] for c in COLUMNS):
+                problems.append('%s: base type %s is registered but the table '
+                    'has no row for it' % (path, base))
+            continue
+        if base not in catalog:
+            problems.append('%s: the table has a row for %s, which no type of '
+                'the catalog names as its base type' % (path, base))
+            continue
+        for c in COLUMNS:
+            if catalog[base][c] != doc[base][c]:
+                problems.append('%s: %s %s: the catalog has {%s}, the table has {%s}'
+                    % (path, base, c, ', '.join(sorted(catalog[base][c])) or '-',
+                       ', '.join(sorted(doc[base][c])) or '-'))
+    return problems
+
+
+def main():
+    with open(os.path.join(ROOT, CATALOG)) as f:
+        text = f.read()
+    catalog = catalog_table(text, type_names(text))
+
+    if '--table' in sys.argv:
+        width = max(len(b) for b in catalog)
+        print('%-*s  %s' % (width, 'base type', '  '.join('%-14s' % c for c in COLUMNS)))
+        for base in sorted(catalog):
+            print('%-*s  %s' % (width, base, '  '.join('%-14s'
+                % (', '.join(sorted(catalog[base][c])) or '-') for c in COLUMNS)))
+        return 0
+
+    problems = []
+    for manual in MANUALS:
+        path = os.path.join(ROOT, manual)
+        if not os.path.exists(path):
+            sys.exit('the manual %s was not found' % manual)
+        with open(path) as f:
+            problems += compare(catalog, doc_table(f.read(), manual), manual)
+
+    if problems:
+        print('The table %s does not agree with MEOS_RELTYPE_CATALOG:\n' % TABLE_ID)
+        for p in problems:
+            print('  ' + p)
+        print('\nA type is registered in %s and documented in %s.\nUpdate both, '
+            'or run this lint with --table to see what the catalog holds.'
+            % (CATALOG, ' and '.join(MANUALS)))
+        return 1
+    print('templatetypes: the table agrees with MEOS_RELTYPE_CATALOG in %d '
+        'translation(s) of the manual.' % len(MANUALS))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
The table `templatetypes` of the manual states, for each base type, which of the four template types are instantiated over it. That is the same information the array `MEOS_RELTYPE_CATALOG` holds for the type lookups, so the table and the array are two forms of one thing:

```
row  float | floatset | floatspan | floatspanset | tfloat

[T_FLOAT8]    = { .basetype_settype = T_FLOATSET, .basetype_spantype = T_FLOATSPAN },
[T_FLOATSPAN] = { .spantype_spansettype = T_FLOATSPANSET },
[T_TFLOAT]    = { .temptype_basetype = T_FLOAT8 },
```

Nothing compares them, and on master they disagree in both translations:

| | the array | the manual |
| --- | --- | --- |
| `jsonb` | `jsonbset`, `tjsonb` | no row at all |
| `pose` temporal | `tpose`, `trgeometry` | `tpose` |
| `geometry` temporal (Spanish only) | `tgeompoint`, `tgeometry` | `tgeompoint` |

The manual now states what the array holds.

## The lint

`tools/scripts/check_templatetypes_doc.py` reads the array and the table of every translation and compares them cell by cell, in both directions, so that a type registered in the catalog but absent from the manual, and a cell naming a type that no entry registers, are both an error. It runs as its own job of the code checks, and prints the array with `--table`.

Both shapes of drift make it exit non-zero: changing one cell of the table, and removing one row.

`double2`, `double3` and `double4` are exempted, and the exemption says why: they carry the intermediate state of the aggregations of a temporal number and of the temporal centroid, no `CREATE TYPE` is issued for them, and the manual documents the SQL types. A type reachable from SQL does not qualify.

## Also

An instantiation that does not exist is written `<varname/>`, the standard form of an empty element and what the rest of the manual spells, 25 times against 17. The Spanish table spells it as a pair of tags; this makes both tables use the empty element.

The index entry of the `transform` function of a pose carries an empty name, where five other chapters spell the name.
