### PR TITLE
Define the destinations that the imported h3 bodies declare

### DIFF
--- a/meos/src/h3/h3_generated.c
+++ b/meos/src/h3/h3_generated.c
@@ -47,7 +47,7 @@
 /* Returns whether or not the provided H3 cell indexes are neighbors. */
 bool h3_are_neighbor_cells_meos(H3Index origin, H3Index destination)
 {
-  int neighboring;
+  int neighboring = {0};
 
   if ((areNeighborCells(origin, destination, &neighboring)) != E_SUCCESS)
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR, "h3 library error");
@@ -59,7 +59,7 @@ bool h3_are_neighbor_cells_meos(H3Index origin, H3Index destination)
 /* Returns a unidirectional edge H3 index based on the provided origin and destination. */
 H3Index h3_cells_to_directed_edge_meos(H3Index origin, H3Index destination)
 {
-  H3Index edge;
+  H3Index edge = {0};
 
   if ((cellsToDirectedEdge(origin, destination, &edge)) != E_SUCCESS)
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR, "h3 library error");
@@ -80,7 +80,7 @@ bool h3_is_valid_directed_edge_meos(H3Index edge)
 /* Returns the origin hexagon from the unidirectional edge H3Index. */
 H3Index h3_get_directed_edge_origin_meos(H3Index edge)
 {
-  H3Index origin;
+  H3Index origin = {0};
 
   if ((getDirectedEdgeOrigin(edge, &origin)) != E_SUCCESS)
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR, "h3 library error");
@@ -92,7 +92,7 @@ H3Index h3_get_directed_edge_origin_meos(H3Index edge)
 /* Returns the destination hexagon from the unidirectional edge H3Index. */
 H3Index h3_get_directed_edge_destination_meos(H3Index edge)
 {
-  H3Index destination;
+  H3Index destination = {0};
 
   if ((getDirectedEdgeDestination(edge, &destination)) != E_SUCCESS)
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR, "h3 library error");
@@ -104,7 +104,7 @@ H3Index h3_get_directed_edge_destination_meos(H3Index edge)
 /* Returns the parent (coarser) index containing given index */
 H3Index h3_cell_to_parent_meos(H3Index origin, int32 resolution)
 {
-  H3Index parent;
+  H3Index parent = {0};
 
   if ((cellToParent(origin, resolution, &parent)) != E_SUCCESS)
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR, "h3 library error");
@@ -116,7 +116,7 @@ H3Index h3_cell_to_parent_meos(H3Index origin, int32 resolution)
 /* Returns the center child (finer) index contained by input index at given resolution */
 H3Index h3_cell_to_center_child_meos(H3Index origin, int32 resolution)
 {
-  H3Index child;
+  H3Index child = {0};
 
   if ((cellToCenterChild(origin, resolution, &child)) != E_SUCCESS)
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR, "h3 library error");
@@ -127,7 +127,7 @@ H3Index h3_cell_to_center_child_meos(H3Index origin, int32 resolution)
 /* Extracted from h3-pg/h3/src/binding/hierarchy.c :: h3_cell_to_child_pos */
 int64 h3_cell_to_child_pos_meos(H3Index child, int32 parentRes)
 {
-  int64_t childPos;
+  int64_t childPos = {0};
 
   if ((cellToChildPos(child, parentRes, &childPos)) != E_SUCCESS)
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR, "h3 library error");
@@ -138,7 +138,7 @@ int64 h3_cell_to_child_pos_meos(H3Index child, int32 parentRes)
 /* Extracted from h3-pg/h3/src/binding/hierarchy.c :: h3_child_pos_to_cell */
 H3Index h3_child_pos_to_cell_meos(int64 childPos, H3Index parent, int32 childRes)
 {
-  H3Index child;
+  H3Index child = {0};
 
   if ((childPosToCell(childPos, parent, childRes, &child)) != E_SUCCESS)
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR, "h3 library error");
@@ -195,7 +195,7 @@ bool h3_is_pentagon_meos(H3Index hex)
 /* Number of unique H3 indexes at the given resolution */
 int64 h3_get_num_cells_meos(int32 resolution)
 {
-  int64_t cells;
+  int64_t cells = {0};
 
   if ((getNumCells(resolution, &cells)) != E_SUCCESS)
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR, "h3 library error");
@@ -215,7 +215,7 @@ int64 h3_get_num_cells_meos(int32 resolution)
  */
 int64 h3_grid_distance_meos(H3Index originIndex, H3Index h3Index)
 {
-  int64_t distance;
+  int64_t distance = {0};
 
   if ((gridDistance(originIndex, h3Index, &distance)) != E_SUCCESS)
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR, "h3 library error");
@@ -227,7 +227,7 @@ int64 h3_grid_distance_meos(H3Index originIndex, H3Index h3Index)
 /* Returns a single vertex for a given cell, as an H3 index */
 H3Index h3_cell_to_vertex_meos(H3Index cell, int32 vertexNum)
 {
-  H3Index vertex;
+  H3Index vertex = {0};
 
   if ((cellToVertex(cell, vertexNum, &vertex)) != E_SUCCESS)
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR, "h3 library error");

--- a/tools/codegen/h3pg_import/extract.py
+++ b/tools/codegen/h3pg_import/extract.py
@@ -43,11 +43,12 @@ except ImportError:
     sys.exit("pyyaml required: pip install pyyaml")
 
 
-ROOT = pathlib.Path(__file__).resolve().parents[2]
+HERE = pathlib.Path(__file__).resolve().parent
+ROOT = HERE.parents[2]
 H3PG_ROOT = ROOT / "h3-pg"
 OUT_C = ROOT / "meos" / "src" / "h3" / "h3_generated.c"
 OUT_H = ROOT / "meos" / "include" / "h3" / "h3_generated.h"
-REPORT = pathlib.Path(__file__).parent / "extraction_report.txt"
+REPORT = HERE / "extraction_report.txt"
 
 MDB_LICENSE = """\
 /*****************************************************************************
@@ -199,6 +200,33 @@ def find_pg_functions(text: str) -> Iterable[tuple[str, str, str]]:
         yield m["comment"], m["name"], m["body"]
 
 
+#: A local declaration carrying no initializer. A pointer is left alone: it
+#: is never the destination libh3 fills by address in these bindings.
+_BARE_DECL = re.compile(r"^(\s*[A-Za-z_][A-Za-z0-9_]*\s+[A-Za-z_]\w*)\s*;\s*$")
+
+
+def _initialized_decl(line: str) -> str:
+    """Give a local declaration an initializer.
+
+    A binding declares the destination of a libh3 call and passes its address.
+    libh3 leaves the destination untouched when it reports an error, and the
+    guard that follows is all that stands between that and the `return`. In
+    h3-pg the guard is `ereport(ERROR)`, which does not return, so the
+    destination is never read on the error path. Its MEOS translation is
+    `meos_error(ERROR, ...)`, which DOES return under the non-exiting error
+    handler that the language bindings install, and the function then returns
+    the destination: an uninitialized read, surfacing as a value built from
+    stack memory.
+
+    Initializing the declaration removes the undefined behaviour at its
+    source, so the error path returns 0 — the value h3 documents as the
+    invalid cell. `= {0}` initializes a scalar and a struct alike, so no
+    return type needs to be known here.
+    """
+    m = _BARE_DECL.match(line)
+    return "%s = {0};" % m.group(1) if m else line
+
+
 def try_transform(ruleset: RuleSet, rel_path: str, doc: str, name: str, body: str
                   ) -> tuple[Extracted | None, str | None]:
     """Return (extracted, None) on success, (None, reason) if a line
@@ -247,7 +275,7 @@ def try_transform(ruleset: RuleSet, rel_path: str, doc: str, name: str, body: st
                     stripped,
                 )
             ):
-                body_lines.append(stripped)
+                body_lines.append(_initialized_decl(stripped))
                 continue
             # Otherwise, we've left the prefix.
             consumed_arg_prefix = False
@@ -430,7 +458,13 @@ def main() -> int:
     skipped: list[Skipped] = []
     failed: list[Skipped] = []  # lines that didn't match and AREN'T opted out
 
-    for c_file in iter_binding_files():
+    binding_files = list(iter_binding_files())
+    if not binding_files:
+        sys.exit(
+            "no binding source under %s — the h3-pg subtree is absent or the "
+            "path is wrong. Refusing to write an empty result." % H3PG_ROOT)
+
+    for c_file in binding_files:
         rel = c_file.relative_to(ROOT).as_posix()
         skip_whole = optout.file_is_skipped(rel)
         if skip_whole:


### PR DESCRIPTION
An h3 binding declares the destination of a libh3 call and passes its address.
libh3 leaves the destination untouched when it reports an error, and the guard
that follows is all that stands between that and the `return`:

```c
H3Index h3_cell_to_parent_meos(H3Index origin, int32 resolution)
{
  H3Index parent;                                    /* uninitialized */
  if ((cellToParent(origin, resolution, &parent)) != E_SUCCESS)
    meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR, "h3 library error");
  return parent;                                     /* returned anyway */
}
```

In h3-pg that guard is `ereport(ERROR)`, which does not return, so the
destination is never read on the error path. Its MEOS translation is
`meos_error(ERROR, ...)`, which does return under the non-exiting error
handler that the language bindings install. Eleven of the imported bodies
carry this shape: `cell_to_parent`, `cell_to_center_child`,
`cell_to_child_pos`, `child_pos_to_cell`, `cell_to_vertex`,
`cells_to_directed_edge`, `get_directed_edge_origin`,
`get_directed_edge_destination`, `are_neighbor_cells`, `grid_distance`,
`get_num_cells`.

This change initializes every local declaration the generator emits. `= {0}`
initializes a scalar and a struct alike, so the generator needs to know no
return type.

PostgreSQL is not exposed: it routes errors through `ereport`, which longjmps,
so the SQL path never reaches the `return`.

### Effect

In a release build of the MEOS library, `th3index_cell_to_parent` asked for a
resolution finer than the cell's own:

```
cell 880326b885fffff (resolution 8), from the test fixtures

              before                    after
res 2         820327fffffffff  errno 0  820327fffffffff  errno 0
res 8         880326b885fffff  errno 0  880326b885fffff  errno 0
res 9         7ffe53db3b10     errno 2  0                errno 2
res 12        7ffd43aa7ec0     errno 2  0                errno 2
res 15        7ffc746308d0     errno 2  0                errno 2
res -1        7ffed8198cc0     errno 2  0                errno 2
res 16        7fff6f4f04c0     errno 2  0                errno 2
```

The values on the left are stack addresses, differing on every run. 0 is the
value h3 documents as the invalid cell, and the one that
`ensure_valid_th3index_h3index` already rejects as the invalid sentinel. The
resolutions that have a parent are unchanged.

### The generator root

The generator derives its root from the file rather than from the directory
holding it, so the root resolves to `tools` and the h3-pg subtree is sought
under `tools/h3-pg`. It reads no source, reports extracting nothing, and
writes its output beside that root, with a zero exit status.

This change derives the root as the two sibling generators under
`tools/codegen` derive theirs:

```python
HERE = pathlib.Path(__file__).resolve().parent
ROOT = HERE.parents[2]
```

and exits non-zero rather than write an empty result when no source is found.
With the root corrected and the initializer set aside, `--check` reports the
committed bodies as up to date, so the regenerated file differs only in the
eleven declarations.