### PR TITLE
Let the vendored strerror name the function of the platform

### DIFF
--- a/pgtypes/port/strerror.c
+++ b/pgtypes/port/strerror.c
@@ -18,9 +18,8 @@
  * Within this file, "strerror" means the platform's function not pg_strerror,
  * and likewise for "strerror_r"
  */
-// MEOS
-// #undef strerror
-// #undef strerror_r
+#undef strerror
+#undef strerror_r
 
 static char *gnuish_strerror_r(int errnum, char *buf, size_t buflen);
 static char *get_errno_symbol(int errnum);


### PR DESCRIPTION
`pgtypes/port/strerror.c` defines `pg_strerror`, and `pgtypes/port.h:253` makes `strerror` mean `pg_strerror` for every file that includes it. Inside this one file the name must keep its original meaning, which is what the two directives undefining `strerror` and `strerror_r` are for — the comment above them says so:

```c
/*
 * Within this file, "strerror" means the platform's function not pg_strerror,
 * and likewise for "strerror_r"
 */
// MEOS
// #undef strerror
// #undef strerror_r
```

They are commented out, and `HAVE_STRERROR_R` is defined nowhere under `pgtypes/`, so the fallback branch of `gnuish_strerror_r` compiles and calls `strerror`, which is `pg_strerror`, which calls `pg_strerror_r`, which calls `gnuish_strerror_r`. Formatting the message of any errno recurses until the stack is exhausted.

The backtrace of the crash is that cycle repeated to the frame limit:

```
#0  pg_strerror_r (errnum=<error reading variable: Cannot access memory at 0x7fffff7feffc>) at pgtypes/port/strerror.c:48
#1  pg_strerror (errnum=22) at pgtypes/port/strerror.c:40
#2  gnuish_strerror_r (errnum=22, ...) at pgtypes/port/strerror.c:99
#3  pg_strerror_r (errnum=22, ...) at pgtypes/port/strerror.c:59
#4  pg_strerror (errnum=22) at pgtypes/port/strerror.c:40
...
```

## Measured

A JSONB value and a JSON path comparing datetimes reach the message of an errno:

| | result |
| --- | --- |
| before | `Segmentation fault` |
| after | `could not create locale "(null)": Invalid argument` |

In the extension the same path takes down the backend: a `SELECT` over a JSONB set returns `server closed the connection unexpectedly`.

Restoring the two directives makes the name mean the function of the platform here, as it does in the file this one is vendored from.

No test accompanies this: the message that triggers it depends on the locales of the machine, and the file exports nothing a test can call directly. The evidence is the pair of runs above.
