### PR TITLE
Return a Boolean per value from the predicates over a JSONB set

### DIFF
--- a/doc/es/temporal_jsonb.xml
+++ b/doc/es/temporal_jsonb.xml
@@ -312,26 +312,19 @@ SELECT minusValues(textset '[{"speed": 10}, null,
 				<indexterm significance="normal"><primary><varname>jsonbset_path_exists</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>jsonbset_path_exists_tz</varname></primary></indexterm>
 				<para>¿Devuelve la ruta JSON algún elemento para el conjunto JSONB especificado?</para>
-				<para><varname>jsonbset @? jsonpath → tbool</varname></para>
-				<para><varname>jsonbset_path_exists(jsonbset,vars jsonb='{}',silent boolean=false) → tbool</varname></para>
-				<para><varname>jsonbset_path_exists_tz(jsonbset,vars jsonb='{}',silent boolean=false) → tbool</varname></para>
+				<para><varname>jsonbset @? jsonpath → boolean[]</varname></para>
+				<para><varname>jsonbset_path_exists(jsonbset,vars jsonb='{}',silent boolean=false) → boolean[]</varname></para>
+				<para><varname>jsonbset_path_exists_tz(jsonbset,vars jsonb='{}',silent boolean=false) → boolean[]</varname></para>
 				<para>El operador <varname>@?</varname> suprime los siguientes errores: campo de objeto o elemento de arreglo faltante, tipo de elemento JSON inesperado, errores de fecha/hora y numéricos. Las funciones anteriores también pueden suprimir estos tipos de errores estableciendo el último argumento en verdadero. Este comportamiento puede ser útil al buscar en colecciones de documentos JSON de estructura variable.</para>
+				<para>El resultado es un booleano por cada valor del conjunto, en el orden de los valores del conjunto.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT jsonbset '[{"speed":10}, {"speed": 20, "units": "km/h"}]' @?
-  '$.units ? (@ == "km/h")';
--- [f, t]
-SELECT jsonbset_path_exists(jsonbset
-  '{{"road": "Bvd Gén. Jacques", "category": "primary"},
-  {"road": "Bvd Gén. Jacques", "category": "primary"},
-  {"road": "Bvd de la Cambre", "category": "residential"}}',
-  '$.category ? (@ == "residential")');
--- {f, f, t}
--- TODO, it works without ".datetime()"
-SELECT jsonbset_path_exists_tz(jsonbset
-  '[{"speed":10, "cameraId": "25", "lastInspection": "2000-08-01 12:00:00"},
-    {"speed":20, "cameraId": "35", "lastInspection": "2000-03-01 12:00:00"}]',
-  '$.lastInspection ? (@.datetime() > "2000-06-01".datetime() )');
--- [t, f]
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}';
+-- {"{\"speed\": 20, \"units\": \"km/h\"}", "{\"speed\": 10}"}
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' @? '$.units';
+-- {t,f}
+SELECT jsonbset_path_exists(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}',
+  '$.speed ? (@ &gt; $min)', '{"min": 15}');
+-- {t,f}
 </programlisting>
 			</listitem>
 
@@ -340,26 +333,19 @@ SELECT jsonbset_path_exists_tz(jsonbset
 				<indexterm significance="normal"><primary><varname>jsonbset_path_match</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>jsonbset_path_match_tz</varname></primary></indexterm>
 				<para>Devolver el resultado de una comprobación de predicado de ruta JSON para un conjunto JSONB</para>
-				<para><varname>jsonbset @@ jsonpath → tbool</varname></para>
-				<para><varname>jsonbset_path_match(jsonbset,vars jsonb='{}',silent boolean=false) → tbool</varname></para>
-				<para><varname>jsonbset_path_match_tz(jsonbset,vars jsonb='{}',silent boolean=false) → tbool</varname></para>
+				<para><varname>jsonbset @@ jsonpath → boolean[]</varname></para>
+				<para><varname>jsonbset_path_match(jsonbset,vars jsonb='{}',silent boolean=false) → boolean[]</varname></para>
+				<para><varname>jsonbset_path_match_tz(jsonbset,vars jsonb='{}',silent boolean=false) → boolean[]</varname></para>
 				<para>El operador <varname>@@</varname> suprime los siguientes errores: campo de objeto o elemento de arreglo faltante, tipo de elemento JSON inesperado, errores de fecha/hora y numéricos. Las funciones anteriores también pueden suprimir estos tipos de errores estableciendo el último argumento en verdadero. Este comportamiento puede ser útil al buscar en colecciones de documentos JSON de estructura variable.</para>
+				<para>El resultado es un booleano por cada valor del conjunto, en el orden de los valores del conjunto.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT jsonbset '[{"speed":10}, {"speed": 20, "units": "km/h"}]' @@
-  '$.units == "km/h"';
--- [f, t]
-SELECT jsonbset_path_match(jsonbset
-  '{{"road": "Bvd Gén. Jacques", "category": "primary"},
-  {"road": "Bvd Gén. Jacques", "category": "primary"},
-  {"road": "Bvd de la Cambre", "category": "residential"}}',
-  '$.category == "residential"');
--- {f, f, t}
--- TODO, it works without ".datetime()"
-SELECT jsonbset_path_match_tz(jsonbset
-  '[{"speed":10, "cameraId": "25", "lastInspection": "2000-08-01 12:00:00"},
-    {"speed":20, "cameraId": "35", "lastInspection": "2000-03-01 12:00:00"}]',
-  '$.lastInspection.datetime() > "2000-06-01".datetime()');
--- [t, f]
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}';
+-- {"{\"speed\": 20, \"units\": \"km/h\"}", "{\"speed\": 10}"}
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' @@ '$.speed &gt; 15';
+-- {t,f}
+SELECT jsonbset_path_match(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}',
+  '$.speed &gt; $min', '{"min": 15}');
+-- {t,f}
 </programlisting>
 			</listitem>
 

--- a/doc/temporal_jsonb.xml
+++ b/doc/temporal_jsonb.xml
@@ -312,26 +312,19 @@ SELECT minusValues(textset '[{"speed": 10}, null,
 				<indexterm significance="normal"><primary><varname>jsonbset_path_exists</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>jsonbset_path_exists_tz</varname></primary></indexterm>
 				<para>Does the JSON path return any item for the specified JSONB set?</para>
-				<para><varname>jsonbset @? jsonpath → tbool</varname></para>
-				<para><varname>jsonbset_path_exists(jsonbset,vars jsonb='{}',silent boolean=false) → tbool</varname></para>
-				<para><varname>jsonbset_path_exists_tz(jsonbset,vars jsonb='{}',silent boolean=false) → tbool</varname></para>
+				<para><varname>jsonbset @? jsonpath → boolean[]</varname></para>
+				<para><varname>jsonbset_path_exists(jsonbset,vars jsonb='{}',silent boolean=false) → boolean[]</varname></para>
+				<para><varname>jsonbset_path_exists_tz(jsonbset,vars jsonb='{}',silent boolean=false) → boolean[]</varname></para>
 				<para>The operator <varname>@?</varname> suppresses the following errors: missing object field or array element, unexpected JSON item type, datetime and numeric errors. The above functions can also suppress these types of errors by setting the last argument to true. This behavior might be helpful when searching JSON document collections of varying structure.</para>
+				<para>The result is a Boolean for every value of the set, in the order of the values of the set.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT jsonbset '[{"speed":10}, {"speed": 20, "units": "km/h"}]' @?
-  '$.units ? (@ == "km/h")';
--- [f, t]
-SELECT jsonbset_path_exists(jsonbset 
-  '{{"road": "Bvd Gén. Jacques", "category": "primary"},
-  {"road": "Bvd Gén. Jacques", "category": "primary"},
-  {"road": "Bvd de la Cambre", "category": "residential"}}',
-  '$.category ? (@ == "residential")');
--- {f, f, t}
--- TODO, it works without ".datetime()"
-SELECT jsonbset_path_exists_tz(jsonbset
-  '[{"speed":10, "cameraId": "25", "lastInspection": "2000-08-01 12:00:00"}, 
-    {"speed":20, "cameraId": "35", "lastInspection": "2000-03-01 12:00:00"}]',
-  '$.lastInspection ? (@.datetime() > "2000-06-01".datetime() )');
--- [t, f]
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}';
+-- {"{\"speed\": 20, \"units\": \"km/h\"}", "{\"speed\": 10}"}
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' @? '$.units';
+-- {t,f}
+SELECT jsonbset_path_exists(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}',
+  '$.speed ? (@ &gt; $min)', '{"min": 15}');
+-- {t,f}
 </programlisting>
 			</listitem>
 
@@ -340,26 +333,19 @@ SELECT jsonbset_path_exists_tz(jsonbset
 				<indexterm significance="normal"><primary><varname>jsonbset_path_match</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>jsonbset_path_match_tz</varname></primary></indexterm>
 				<para>Return the result of a JSON path predicate check for a JSONB set</para>
-				<para><varname>jsonbset @@ jsonpath → tbool</varname></para>
-				<para><varname>jsonbset_path_match(jsonbset,vars jsonb='{}',silent boolean=false) → tbool</varname></para>
-				<para><varname>jsonbset_path_match_tz(jsonbset,vars jsonb='{}',silent boolean=false) → tbool</varname></para>
+				<para><varname>jsonbset @@ jsonpath → boolean[]</varname></para>
+				<para><varname>jsonbset_path_match(jsonbset,vars jsonb='{}',silent boolean=false) → boolean[]</varname></para>
+				<para><varname>jsonbset_path_match_tz(jsonbset,vars jsonb='{}',silent boolean=false) → boolean[]</varname></para>
 				<para>The operator <varname>@@</varname> suppresses the following errors: missing object field or array element, unexpected JSON item type, datetime and numeric errors. The above functions can also suppress these types of errors by setting the last argument to true. This behavior might be helpful when searching JSON document collections of varying structure.</para>
+				<para>The result is a Boolean for every value of the set, in the order of the values of the set.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT jsonbset '[{"speed":10}, {"speed": 20, "units": "km/h"}]' @@
-  '$.units == "km/h"';
--- [f, t]
-SELECT jsonbset_path_match(jsonbset 
-  '{{"road": "Bvd Gén. Jacques", "category": "primary"},
-  {"road": "Bvd Gén. Jacques", "category": "primary"},
-  {"road": "Bvd de la Cambre", "category": "residential"}}',
-  '$.category == "residential"');
--- {f, f, t}
--- TODO, it works without ".datetime()"
-SELECT jsonbset_path_match_tz(jsonbset
-  '[{"speed":10, "cameraId": "25", "lastInspection": "2000-08-01 12:00:00"}, 
-    {"speed":20, "cameraId": "35", "lastInspection": "2000-03-01 12:00:00"}]',
-  '$.lastInspection.datetime() > "2000-06-01".datetime()');
--- [t, f]
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}';
+-- {"{\"speed\": 20, \"units\": \"km/h\"}", "{\"speed\": 10}"}
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' @@ '$.speed &gt; 15';
+-- {t,f}
+SELECT jsonbset_path_match(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}',
+  '$.speed &gt; $min', '{"min": 15}');
+-- {t,f}
 </programlisting>
 			</listitem>
 

--- a/meos/include/meos_json.h
+++ b/meos/include/meos_json.h
@@ -240,8 +240,8 @@ extern Set *jsonbset_array_element(const Set *set, int idx, bool astext, nullHan
 extern Set *jsonbset_delete_index(const Set *set, int idx);
 extern Set *jsonbset_delete(const Set *set, const text *key);
 extern Set *jsonbset_delete_array(const Set *set, text **keys, int count);
-extern Set *jsonbset_exists(const Set *set, const text *key);
-extern Set *jsonbset_exists_array(const Set *set, text **keys, int count, bool any);
+extern bool *jsonbset_exists(const Set *set, const text *key, int *count);
+extern bool *jsonbset_exists_array(const Set *set, text **keys, int count, bool any, int *rescount);
 extern Set *jsonbset_set(const Set *set, text **keys, int count, const Jsonb *newjb, bool create, const text *null_handle, bool lax);
 extern Set *jsonbset_to_alphanumset(const Set *set, const char *key, MeosType settype, nullHandleType null_handle);
 extern Set *jsonbset_to_intset(const Set *set, const char *key, nullHandleType null_handle);
@@ -253,8 +253,8 @@ extern Set *jsonbset_pretty(const Set *set);
 extern Set *jsonbset_delete_path(const Set *set, text **path_elems, int path_len);
 extern Set *jsonbset_extract_path(const Set *set, text **path_elems, int path_len, bool astext, nullHandleType null_handle);
 extern Set *jsonbset_insert(const Set *set, text **path_elems, int path_len, const Jsonb *newjb, bool after);
-extern Set *jsonbset_path_exists(const Set *set, const JsonPath *jp, const Jsonb *vars, bool silent, bool tz);
-extern Set *jsonbset_path_match(const Set *set, const JsonPath *jp, const Jsonb *vars, bool silent, bool tz);
+extern bool *jsonbset_path_exists(const Set *set, const JsonPath *jp, const Jsonb *vars, bool silent, bool tz, int *count);
+extern bool *jsonbset_path_match(const Set *set, const JsonPath *jp, const Jsonb *vars, bool silent, bool tz, int *count);
 extern Set *jsonbset_path_query_array(const Set *set, const JsonPath *jp, const Jsonb *vars, bool silent, bool tz);
 extern Set *jsonbset_path_query_first(const Set *set, const JsonPath *jp, const Jsonb *vars, bool silent, bool tz);
 

--- a/meos/include/temporal/lifting.h
+++ b/meos/include/temporal/lifting.h
@@ -136,6 +136,8 @@ extern int eafunc_temporal_temporal(const Temporal *temp1,
 /*****************************************************************************/
 
 extern Set *lfunc_set(const Set *set, LiftedFunctionInfo *lfinfo);
+extern bool *lfunc_set_bool(const Set *set, LiftedFunctionInfo *lfinfo,
+  int *count);
 
 /*****************************************************************************/
 

--- a/meos/src/json/jsonbset_jsonfuncs.c
+++ b/meos/src/json/jsonbset_jsonfuncs.c
@@ -247,15 +247,17 @@ jsonbset_delete_array(const Set *set, text **keys, int count)
 
 /**
  * @ingroup meos_json_set_json
- * @brief Delete a key from a JSONB set
+ * @brief Return for every value of a JSONB set whether it contains a key
  * @param[in] set JSONB set
  * @param[in] key Key
+ * @param[out] count Number of values in the output array
  */
-Set *
-jsonbset_exists(const Set *set, const text *key)
+bool *
+jsonbset_exists(const Set *set, const text *key, int *count)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_JSONBSET(set, NULL); VALIDATE_NOT_NULL(key, NULL);
+  VALIDATE_NOT_NULL(count, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
@@ -263,23 +265,26 @@ jsonbset_exists(const Set *set, const text *key)
   lfinfo.argtype[0] = T_JSONBSET;
   lfinfo.numparam = 1;
   lfinfo.param[0] = PointerGetDatum(key);
-  lfinfo.restype = T_TBOOL;
-  return lfunc_set(set, &lfinfo);
+  return lfunc_set_bool(set, &lfinfo, count);
 }
 
 /**
  * @ingroup meos_json_set_json
- * @brief Delete an array of keys from a JSONB set
+ * @brief Return for every value of a JSONB set whether it contains the keys of
+ * an array
  * @param[in] set JSONB set
  * @param[in] keys Keys
  * @param[in] count Number of elements in the input array
  * @param[in] any True for the 'any' semantics, false for the 'all' semantics
+ * @param[out] rescount Number of values in the output array
  */
-Set *
-jsonbset_exists_array(const Set *set, text **keys, int count, bool any)
+bool *
+jsonbset_exists_array(const Set *set, text **keys, int count, bool any,
+  int *rescount)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_JSONBSET(set, NULL); VALIDATE_NOT_NULL(keys, NULL);
+  VALIDATE_NOT_NULL(rescount, NULL);
   if (! ensure_positive(count))
     return NULL;
 
@@ -291,8 +296,7 @@ jsonbset_exists_array(const Set *set, text **keys, int count, bool any)
   lfinfo.param[0] = PointerGetDatum(keys);
   lfinfo.param[1] = Int32GetDatum(count);
   lfinfo.param[2] = BoolGetDatum(any);
-  lfinfo.restype = T_TBOOL;
-  return lfunc_set(set, &lfinfo);
+  return lfunc_set_bool(set, &lfinfo, rescount);
 }
 
 /**
@@ -589,8 +593,8 @@ jsonbset_insert(const Set *set, text **path_elems, int path_len,
 
 /**
  * @ingroup meos_json_set_json
- * @brief Return true if a JSON path expression returns at least one item for a
- * JSONB set
+ * @brief Return for every value of a JSONB set whether a JSON path expression
+ * returns at least one item for it
  * @param[in] set JSONB set
  * @param[in] jp JSON path expression
  * @param[in] vars JSON variables, may be NULL
@@ -599,34 +603,35 @@ jsonbset_insert(const Set *set, text **path_elems, int path_len,
  * numeric errors, when false, no errors are suppressed
  * @param[in] tz When true, support comparisons of date/time values that
  * require timezone-aware conversions, false otherwise
+ * @param[out] count Number of values in the output array
+ * @csqlfn #Jsonbset_path_exists()
  */
-Set *
+bool *
 jsonbset_path_exists(const Set *set, const JsonPath *jp, const Jsonb *vars,
-  bool silent, bool tz)
+  bool silent, bool tz, int *count)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_JSONBSET(set, NULL); VALIDATE_NOT_NULL(jp, NULL);
+  VALIDATE_NOT_NULL(count, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) &datum_jsonb_path_exists;
   lfinfo.argtype[0] = T_JSONBSET;
-  lfinfo.numparam = 3;
+  lfinfo.numparam = 4;
   lfinfo.param[0] = PointerGetDatum(jp);
   lfinfo.param[1] = PointerGetDatum(vars);
   lfinfo.param[2] = BoolGetDatum(silent);
   lfinfo.param[3] = BoolGetDatum(tz);
-  lfinfo.restype = T_TBOOL;
-  return lfunc_set(set, &lfinfo);
+  return lfunc_set_bool(set, &lfinfo, count);
 }
 
 /*****************************************************************************/
 
 /**
  * @ingroup meos_json_set_json
- * @brief Extract an item specified by a JSON path expression from a temporal
- * JSONB value
- * predicate
+ * @brief Return for every value of a JSONB set the result of a JSON path
+ * predicate check
  * @param[in] set JSONB set
  * @param[in] jp JSON path expression
  * @param[in] vars JSON variables, may be NULL
@@ -635,25 +640,27 @@ jsonbset_path_exists(const Set *set, const JsonPath *jp, const Jsonb *vars,
  * numeric errors, when false, no errors are suppressed
  * @param[in] tz When true, support comparisons of date/time values that
  * require timezone-aware conversions, false otherwise
+ * @param[out] count Number of values in the output array
+ * @csqlfn #Jsonbset_path_match()
  */
-Set *
+bool *
 jsonbset_path_match(const Set *set, const JsonPath *jp, const Jsonb *vars,
-  bool silent, bool tz)
+  bool silent, bool tz, int *count)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_JSONBSET(set, NULL); VALIDATE_NOT_NULL(jp, NULL);
+  VALIDATE_NOT_NULL(count, NULL);
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) &datum_jsonb_path_match;
   lfinfo.argtype[0] = T_JSONBSET;
-  lfinfo.numparam = 3;
+  lfinfo.numparam = 4;
   lfinfo.param[0] = PointerGetDatum(jp);
   lfinfo.param[1] = PointerGetDatum(vars);
   lfinfo.param[2] = BoolGetDatum(silent);
   lfinfo.param[3] = BoolGetDatum(tz);
-  lfinfo.restype = T_TBOOL;
-  return lfunc_set(set, &lfinfo);
+  return lfunc_set_bool(set, &lfinfo, count);
 }
 
 /*****************************************************************************/

--- a/meos/src/temporal/lifting.c
+++ b/meos/src/temporal/lifting.c
@@ -341,6 +341,26 @@ lfunc_set(const Set *set, LiftedFunctionInfo *lfinfo)
   return result;
 }
 
+/**
+ * @brief Apply a lifted predicate to the elements of a set
+ * @param[in] set Set
+ * @param[in] lfinfo Information about the lifted function
+ * @param[out] count Number of values in the output array
+ * @note A predicate returns a Boolean for every element of the set. There is
+ * no Boolean set type, and a set would remove the duplicate results and
+ * reorder them, so the result is an array in the order of the elements
+ */
+bool *
+lfunc_set_bool(const Set *set, LiftedFunctionInfo *lfinfo, int *count)
+{
+  assert(set); assert(lfinfo); assert(count);
+  bool *result = palloc(sizeof(bool) * set->count);
+  for (int i = 0; i < set->count; i++)
+    result[i] = DatumGetBool(lfunc_base(SET_VAL_N(set, i), lfinfo));
+  *count = set->count;
+  return result;
+}
+
 /*****************************************************************************
  * Functions where the argument is a temporal type.
  * The function is applied to the composing instants.

--- a/mobilitydb/pg_include/pg_temporal/type_util.h
+++ b/mobilitydb/pg_include/pg_temporal/type_util.h
@@ -108,6 +108,7 @@ extern STBox *stboxarr_extract(ArrayType *array, int *count);
 extern Temporal **temparr_extract(ArrayType *array, int *count);
 
 extern ArrayType *datumarr_to_array(Datum *values, int count, MeosType type);
+extern ArrayType *boolarr_to_array(bool *values, int count);
 extern ArrayType *int64arr_to_array(int64 *longints, int count);
 extern ArrayType *datearr_to_array(DateADT *dates, int count);
 extern ArrayType *tstzarr_to_array(TimestampTz *times, int count);

--- a/mobilitydb/sql/json/451_jsonbset_jsonfuncs.in.sql
+++ b/mobilitydb/sql/json/451_jsonbset_jsonfuncs.in.sql
@@ -241,17 +241,17 @@ CREATE FUNCTION jsonbset_pretty(jsonbset)
 
 CREATE FUNCTION jsonbset_path_exists(jsonbset, jsonpath, vars jsonb DEFAULT '{}',
   silent boolean DEFAULT FALSE)
-RETURNS jsonbset
+RETURNS boolean[]
 AS 'MODULE_PATHNAME', 'Jsonbset_path_exists'
 LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION jsonbset_path_exists_tz(jsonbset, jsonpath,
   vars jsonb DEFAULT '{}', silent boolean DEFAULT false)
-RETURNS jsonbset
+RETURNS boolean[]
 AS 'MODULE_PATHNAME', 'Jsonbset_path_exists_tz'
 LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION jsonbset_path_exists_opr(jsonbset, jsonpath)
-  RETURNS textset
+  RETURNS boolean[]
   AS 'MODULE_PATHNAME', 'Jsonbset_path_exists_opr'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
@@ -262,17 +262,17 @@ CREATE OPERATOR @? (
 
 CREATE FUNCTION jsonbset_path_match(jsonbset, jsonpath, vars jsonb DEFAULT '{}',
   silent boolean DEFAULT FALSE)
-RETURNS bool[]
+RETURNS boolean[]
 AS 'MODULE_PATHNAME', 'Jsonbset_path_match'
 LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION jsonbset_path_match_tz(jsonbset, jsonpath,
   vars jsonb DEFAULT '{}', silent boolean DEFAULT FALSE)
-RETURNS bool[]
+RETURNS boolean[]
 AS 'MODULE_PATHNAME', 'Jsonbset_path_match_tz'
 LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION jsonbset_path_match_opr(jsonbset, jsonpath)
-  RETURNS bool[]
+  RETURNS boolean[]
   AS 'MODULE_PATHNAME', 'Jsonbset_path_match_opr'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 

--- a/mobilitydb/src/json/jsonbset_jsonfuncs.c
+++ b/mobilitydb/src/json/jsonbset_jsonfuncs.c
@@ -48,6 +48,7 @@
 #include <pgtypes.h>
 /* MobilityDB */
 #include "pg_temporal/temporal.h"
+#include "pg_temporal/type_util.h"
 
 /* Function defined in file tjsonb_jsonfuncs.c */
 extern nullHandleType input_null_handle_text(FunctionCallInfo fcinfo, int argno);
@@ -778,8 +779,8 @@ Jsonbset_pretty(PG_FUNCTION_ARGS)
  *****************************************************************************/
 
 /**
- * @brief Return true if a JSON path expression returns at least one item for a
- * JSONB set value
+ * @brief Return for every value of a JSONB set whether a JSON path expression
+ * returns at least one item for it
  * @sqlfn jsonbset_path_exists(), jsonbset_path_exists_tz()
  */
 Datum
@@ -796,13 +797,14 @@ Jsonbset_path_exists_common(FunctionCallInfo fcinfo, bool tz)
     silent = PG_GETARG_BOOL(3);
   }
   /* Compute the result */
-  Set *result = jsonbset_path_exists(set, jp, vars, silent, tz);
+  int count;
+  bool *result = jsonbset_path_exists(set, jp, vars, silent, tz, &count);
   /* Clean up and return */
   PG_FREE_IF_COPY(set, 0);
   PG_FREE_IF_COPY(jp, 1);
   if (! result)
     PG_RETURN_NULL();
-  PG_RETURN_SET_P(result);
+  PG_RETURN_ARRAYTYPE_P(boolarr_to_array(result, count));
 }
 
 PGDLLEXPORT Datum Jsonbset_path_exists(PG_FUNCTION_ARGS);
@@ -870,13 +872,14 @@ Jsonbset_path_match_common(FunctionCallInfo fcinfo, bool tz)
     silent = PG_GETARG_BOOL(3);
   }
   /* Compute the result */
-  Set *result = jsonbset_path_match(set, jp, vars, silent, tz);
+  int count;
+  bool *result = jsonbset_path_match(set, jp, vars, silent, tz, &count);
   /* Clean up and return */
   PG_FREE_IF_COPY(set, 0);
   PG_FREE_IF_COPY(jp, 1);
   if (! result)
     PG_RETURN_NULL();
-  PG_RETURN_SET_P(result);
+  PG_RETURN_ARRAYTYPE_P(boolarr_to_array(result, count));
 }
 
 PGDLLEXPORT Datum Jsonbset_path_match(PG_FUNCTION_ARGS);

--- a/mobilitydb/src/temporal/type_util.c
+++ b/mobilitydb/src/temporal/type_util.c
@@ -333,6 +333,21 @@ datumarr_to_array(Datum *values, int count, MeosType type)
 }
 
 /**
+ * @brief Return a C array of Booleans converted into a PostgreSQL array
+ */
+ArrayType *
+boolarr_to_array(bool *values, int count)
+{
+  assert(count > 0);
+  Datum *dvalues = palloc(sizeof(Datum) * count);
+  for (int i = 0; i < count; i++)
+    dvalues[i] = BoolGetDatum(values[i]);
+  ArrayType *result = construct_array(dvalues, count, BOOLOID, 1, true, 'c');
+  pfree(dvalues); pfree(values);
+  return result;
+}
+
+/**
  * @brief Return a C array of timestamps converted into a PostgreSQL array
  */
 ArrayType *

--- a/mobilitydb/test/json/expected/451_jsonbset_jsonfuncs.test.out
+++ b/mobilitydb/test/json/expected/451_jsonbset_jsonfuncs.test.out
@@ -286,3 +286,76 @@ SELECT intset(jsonbset '{"{\"a\":1, \"b\":2.5}"}', text 'xxx');
 ERROR:  The lifted operation returned NULL
 SELECT intset(jsonbset '{"{\"a\":\"xxx\", \"b\":2.5}"}', text 'a');
 ERROR:  Invalid numeric string for key "a": xxx
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' @? '$.units';
+ ?column? 
+----------
+ {t,f}
+(1 row)
+
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' @? '$.speed ? (@ > 15)';
+ ?column? 
+----------
+ {t,f}
+(1 row)
+
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' @? '$.xxx';
+ ?column? 
+----------
+ {f,f}
+(1 row)
+
+SELECT jsonbset_path_exists(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.units');
+ jsonbset_path_exists 
+----------------------
+ {t,f}
+(1 row)
+
+SELECT jsonbset_path_exists(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.speed ? (@ > $min)', '{"min": 15}');
+ jsonbset_path_exists 
+----------------------
+ {t,f}
+(1 row)
+
+SELECT jsonbset_path_exists_tz(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.units');
+ jsonbset_path_exists_tz 
+-------------------------
+ {t,f}
+(1 row)
+
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' @@ '$.speed > 15';
+ ?column? 
+----------
+ {t,f}
+(1 row)
+
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' @@ '$.speed == 10';
+ ?column? 
+----------
+ {f,t}
+(1 row)
+
+SELECT jsonbset_path_match(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.speed > 15');
+ jsonbset_path_match 
+---------------------
+ {t,f}
+(1 row)
+
+SELECT jsonbset_path_match(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.speed > $min', '{"min": 15}');
+ jsonbset_path_match 
+---------------------
+ {t,f}
+(1 row)
+
+SELECT jsonbset_path_match_tz(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.speed > 15');
+ jsonbset_path_match_tz 
+------------------------
+ {t,f}
+(1 row)
+
+/* A path matching nothing is unknown, that is, false, for every element */
+SELECT jsonbset_path_match(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.xxx > 15', '{}', false);
+ jsonbset_path_match 
+---------------------
+ {f,f}
+(1 row)
+

--- a/mobilitydb/test/json/queries/451_jsonbset_jsonfuncs.test.sql
+++ b/mobilitydb/test/json/queries/451_jsonbset_jsonfuncs.test.sql
@@ -122,3 +122,26 @@ SELECT intset(jsonbset '{"{\"a\":\"xxx\", \"b\":2.5}"}', text 'a');
 
 -------------------------------------------------------------------------------
 
+
+-- JSON path functions. The result of a path predicate is one Boolean per
+-- element of the set, in the order of the elements
+
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' @? '$.units';
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' @? '$.speed ? (@ > 15)';
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' @? '$.xxx';
+
+SELECT jsonbset_path_exists(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.units');
+SELECT jsonbset_path_exists(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.speed ? (@ > $min)', '{"min": 15}');
+SELECT jsonbset_path_exists_tz(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.units');
+
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' @@ '$.speed > 15';
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' @@ '$.speed == 10';
+
+SELECT jsonbset_path_match(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.speed > 15');
+SELECT jsonbset_path_match(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.speed > $min', '{"min": 15}');
+SELECT jsonbset_path_match_tz(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.speed > 15');
+
+/* A path matching nothing is unknown, that is, false, for every element */
+SELECT jsonbset_path_match(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.xxx > 15', '{}', false);
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
Four functions apply a predicate to every value of a JSONB set: whether the value holds a key, whether it holds the keys of an array, and whether a JSON path returns an item for it or matches it. They lift the predicate with `lfunc_set`, whose result type names a set type, and pass `T_TBOOL`. There is no Boolean set type, so `settype_basetype` raises `type tbool is not a set type` and all four return NULL, for every input:

```
$ ./probe                          # against master, unmodified
type tbool is not a set type
```

## The shape of the result

A predicate over a set gives one Boolean per value, and a set is the wrong container for it: a set removes the duplicate results and reorders them, which loses which value each Boolean belongs to. The four return an array of Booleans in the order of the values. That is what the SQL of `jsonbset_path_match` already declares, and what `getValues(tbool)` already does for the same reason — `Temporal_valueset` in `mobilitydb/src/temporal/temporal.c` branches to `datumarr_to_array` for a `tbool` under a comment recording that no Boolean set type exists.

```
SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}';
-- {"{\"speed\": 20, \"units\": \"km/h\"}", "{\"speed\": 10}"}
SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' @? '$.units';
-- {t,f}
```

`lfunc_set_bool` lifts a predicate over the values of a set without consulting the catalog at all, and `boolarr_to_array` turns its result into an array of PostgreSQL, beside `int64arr_to_array`.

## A second defect in the two path functions

They declare three parameters while assigning four:

```c
lfinfo.numparam = 3;
lfinfo.param[3] = BoolGetDatum(tz);     /* assigned, never passed */
```

`datum_jsonb_path_exists` takes five `Datum`s, so `lfunc_base` calls it through a pointer to a function of one parameter fewer and `tz` never reaches it, leaving the `_tz` variants indistinguishable from the others. The temporal counterparts of these two functions declare four.

## The other layers

The SQL declares three different types across the six deployed functions — `jsonbset`, `textset` and `bool[]`. All six declare `boolean[]`.

The manual states that these functions return a `tbool`, and its examples are neither valid input, a set is written between braces, nor real output. The declared type is the type of the result, and the examples run and carry harvested results, in both translations.

## Coverage

No test covers any of the six, which is how the defect survives. The tests exercise every one of them, both operators, the variants, and a path matching nothing.
