### PR TITLE
Route the shared h3 cell operations through the shared implementation

### DIFF
--- a/meos/src/h3/th3index_hierarchy.c
+++ b/meos/src/h3/th3index_hierarchy.c
@@ -43,6 +43,7 @@
 #include <string.h>
 
 #include <meos.h>
+#include <meos_cellindex.h>
 #include <meos_h3.h>
 #include <h3api.h>
 
@@ -102,18 +103,7 @@ Temporal *
 th3index_cell_to_parent(const Temporal *temp, int32 resolution)
 {
   VALIDATE_TH3INDEX(temp, NULL);
-
-  LiftedFunctionInfo lfinfo;
-  memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
-  lfinfo.func = (varfunc) &datum_h3_cell_to_parent;
-  lfinfo.numparam = 1;
-  lfinfo.param[0] = Int32GetDatum(resolution);
-  lfinfo.argtype[0] = T_TH3INDEX;
-  lfinfo.restype = T_TH3INDEX;
-  lfinfo.reslinear = false;
-  lfinfo.invert = INVERT_NO;
-  lfinfo.discont = CONTINUOUS;
-  return tfunc_temporal(temp, &lfinfo);
+  return tcellindex_cell_to_parent(temp, resolution);
 }
 
 /*****************************************************************************

--- a/meos/src/h3/th3index_inspection.c
+++ b/meos/src/h3/th3index_inspection.c
@@ -40,6 +40,7 @@
 #include <string.h>
 
 #include <meos.h>
+#include <meos_cellindex.h>
 #include <meos_h3.h>
 
 #include "temporal/temporal.h"
@@ -61,17 +62,7 @@ Temporal *
 th3index_get_resolution(const Temporal *temp)
 {
   VALIDATE_TH3INDEX(temp, NULL);
-
-  LiftedFunctionInfo lfinfo;
-  memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
-  lfinfo.func = (varfunc) &datum_h3_get_resolution;
-  lfinfo.numparam = 0;
-  lfinfo.argtype[0] = T_TH3INDEX;
-  lfinfo.restype = T_TINT;
-  lfinfo.reslinear = false;
-  lfinfo.invert = INVERT_NO;
-  lfinfo.discont = CONTINUOUS;
-  return tfunc_temporal(temp, &lfinfo);
+  return tcellindex_get_resolution(temp);
 }
 
 /*****************************************************************************
@@ -114,17 +105,7 @@ Temporal *
 th3index_is_valid_cell(const Temporal *temp)
 {
   VALIDATE_TH3INDEX(temp, NULL);
-
-  LiftedFunctionInfo lfinfo;
-  memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
-  lfinfo.func = (varfunc) &datum_h3_is_valid_cell;
-  lfinfo.numparam = 0;
-  lfinfo.argtype[0] = T_TH3INDEX;
-  lfinfo.restype = T_TBOOL;
-  lfinfo.reslinear = false;
-  lfinfo.invert = INVERT_NO;
-  lfinfo.discont = CONTINUOUS;
-  return tfunc_temporal(temp, &lfinfo);
+  return tcellindex_is_valid_cell(temp);
 }
 
 /*****************************************************************************

--- a/meos/src/h3/th3index_latlng.c
+++ b/meos/src/h3/th3index_latlng.c
@@ -49,6 +49,7 @@
 #include <liblwgeom.h>
 
 #include <meos.h>
+#include <meos_cellindex.h>
 #include <meos_h3.h>
 
 #include "geo/tgeo_spatialfuncs.h"
@@ -411,17 +412,7 @@ Temporal *
 th3index_to_tgeogpoint(const Temporal *temp)
 {
   VALIDATE_TH3INDEX(temp, NULL);
-
-  LiftedFunctionInfo lfinfo;
-  memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
-  lfinfo.func = (varfunc) &datum_h3_cell_to_latlng;
-  lfinfo.numparam = 0;
-  lfinfo.argtype[0] = T_TH3INDEX;
-  lfinfo.restype = T_TGEOGPOINT;
-  lfinfo.reslinear = false;
-  lfinfo.invert = INVERT_NO;
-  lfinfo.discont = CONTINUOUS;
-  return tfunc_temporal(temp, &lfinfo);
+  return tcellindex_cell_to_point(temp);
 }
 
 /*****************************************************************************
@@ -470,17 +461,7 @@ Temporal *
 th3index_cell_to_boundary(const Temporal *temp)
 {
   VALIDATE_TH3INDEX(temp, NULL);
-
-  LiftedFunctionInfo lfinfo;
-  memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
-  lfinfo.func = (varfunc) &datum_h3_cell_to_boundary;
-  lfinfo.numparam = 0;
-  lfinfo.argtype[0] = T_TH3INDEX;
-  lfinfo.restype = T_TGEOGRAPHY;
-  lfinfo.reslinear = false;
-  lfinfo.invert = INVERT_NO;
-  lfinfo.discont = CONTINUOUS;
-  return tfunc_temporal(temp, &lfinfo);
+  return tcellindex_cell_to_boundary(temp);
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
The temporal cell index carries one implementation of the operations every
DGGS shares: each lifts the descriptor's kernel over the temporal value. h3
supplies that descriptor, and five of its typed functions build the same
lifting a second time.

This change delegates them:

| typed function | delegates to |
| --- | --- |
| `th3index_get_resolution` | `tcellindex_get_resolution` |
| `th3index_is_valid_cell` | `tcellindex_is_valid_cell` |
| `th3index_cell_to_parent` | `tcellindex_cell_to_parent` |
| `th3index_to_tgeogpoint` | `tcellindex_cell_to_point` |
| `th3index_cell_to_boundary` | `tcellindex_cell_to_boundary` |

```c
 th3index_cell_to_parent(const Temporal *temp, int32 resolution)
 {
   VALIDATE_TH3INDEX(temp, NULL);
-  LiftedFunctionInfo lfinfo;
-  memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
-  lfinfo.func = (varfunc) &datum_h3_cell_to_parent;
-  lfinfo.numparam = 1;
-  lfinfo.param[0] = Int32GetDatum(resolution);
-  lfinfo.argtype[0] = T_TH3INDEX;
-  lfinfo.restype = T_TH3INDEX;
-  lfinfo.reslinear = false;
-  lfinfo.invert = INVERT_NO;
-  lfinfo.discont = CONTINUOUS;
-  return tfunc_temporal(temp, &lfinfo);
+  return tcellindex_cell_to_parent(temp, resolution);
 }
```

The functions, their doxygen groups, their SQL names and their exports are
unchanged, and each keeps its own `VALIDATE_TH3INDEX`, which states a stricter
contract than the shared entry point.

### What stays typed

Two of the h3 operations keep their own lifting, the shared slot being
narrower than the function:

- `th3index_to_tgeompoint` emits a planar point, whereas the descriptor
  carries a single centroid slot whose type is geodetic for h3.
- `th3index_cell_area` takes the unit as an argument, whereas the shared slot
  is defined in square metres.

The quadbin descriptor states the same principle for its quadkey, which has no
h3 analogue: the descriptor exposes the operations shared by every DGGS, and a
family is free to expose more.

### Effect

The generic and the typed path return the same value on every slot of the
descriptor, over a discrete set, a sequence, an instant, the resolutions 0 and
15, a pentagon cell and a value mixing resolutions — 63 comparisons, no
difference.

The SQL functions keep their names and their results, so the regression
outputs are unchanged.