### PR TITLE
Mark the SPTree argument of the box decomposition as unused

### DIFF
--- a/meos/src/temporal/temporal_sptree.c
+++ b/meos/src/temporal/temporal_sptree.c
@@ -681,7 +681,7 @@ sptree_search_temporal(const SPTree *sptree, RTreeSearchOp op,
  * @pre `temp` is compatible with `sptree` (verified by the callers)
  */
 static void *
-sptree_temporal_split_boxes(const SPTree *sptree, const Temporal *temp,
+sptree_temporal_split_boxes(const SPTree *sptree UNUSED, const Temporal *temp,
   int maxboxes, int *count)
 {
   assert(sptree); assert(temp); assert(count);


### PR DESCRIPTION
`sptree_temporal_split_boxes` states its precondition on the SPTree with an
assertion and reads nothing from it: the degenerate branch allocates for the
largest MEOS bounding box, because a temporal type's box may be larger than
the internal one, and the other branches delegate to the per-type splitters,
which take the temporal value alone.

The assertion is compiled out under `NDEBUG`, so the release build reports the
argument as unused:

```
meos/src/temporal/temporal_sptree.c:684:43: warning: unused parameter ‘sptree’ [-Wunused-parameter]
```

This change marks it with the `UNUSED` macro, as the other arguments kept for
the shape of their function are marked (`interp UNUSED` in `tcbuffer.c` and
`tgeo_meos.c`, `type UNUSED` in `tcellindex.c`, `np UNUSED` in `npoint.c`).
The attribute sits after the identifier, where it appertains to the parameter.

Compiling the translation unit with the flags the build generates for it:

```
before:  temporal_sptree.c:684:43: warning: unused parameter ‘sptree’
after:   no warning

full build: 0 warnings
```

The argument stays in the signature: it carries the precondition the assertion
checks in a debug build, and it keeps the function's shape aligned with the
callers that pass the SPTree they are decomposing for.