### PR TITLE
Deploy the exists predicates of a JSONB set in SQL

### DIFF
--- a/doc/es/temporal_jsonb.xml
+++ b/doc/es/temporal_jsonb.xml
@@ -192,41 +192,26 @@ SELECT minusValues(jsonbset '[["Grand Place", "La Bourse"],
 
 			<listitem xml:id="jsonbset_exists">
 				<indexterm significance="normal"><primary><varname>?</varname></primary></indexterm>
-				<para>Existencia JSONB temporal</para>
-				<para><varname>jsonbset ? jsonb → tbool</varname></para>
-				<para><varname>jsonbset ?| jsonb[] → tbool</varname></para>
-				<para><varname>jsonbset ?&amp; jsonb[] → tbool</varname></para>
+				<para>Existencia en un conjunto JSONB</para>
+				<para><varname>jsonbset ? text → boolean[]</varname></para>
+				<para><varname>jsonbset ?| text[] → boolean[]</varname></para>
+				<para><varname>jsonbset ?&amp; text[] → boolean[]</varname></para>
 				<para>Como en PostgreSQL, los operadores <varname>?|</varname> y <varname>?&amp;</varname> comprueban, respectivamente, si <emphasis>alguna</emphasis> o <emphasis>todas</emphasis> las cadenas del arreglo de texto existen como claves de nivel superior o elementos de arreglo.</para>
+				<para>El resultado es un booleano por cada valor del conjunto, en el orden de los valores del conjunto.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT jsonbset '"{\"geom\": \"Point(1 1)\"}"' ? text 'geom';
--- t
-SELECT jsonbset '{{"geom": "Point(1 1)"}, {"geom": "Point(2 2)"},
-  {"geom": "Point(1 1)"}}' ?| ARRAY[text 'geom'];
--- {t, t, t}
-SELECT jsonbset '[{"speed": 10, "units": "km/h"},
-  {"speed": 20, "units": "km/h"}]' ?&amp; ARRAY['speed', 'units'];
--- {[t, t]}
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}';
+-- {"{\"speed\": 20, \"units\": \"km/h\"}", "{\"speed\": 10}"}
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' ? text 'units';
+-- {t,f}
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}'
+  ?| ARRAY[text 'units', text 'lights'];
+-- {t,f}
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}'
+  ?&amp; ARRAY[text 'speed', text 'units'];
+-- {t,f}
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="jsonbset_contains">
-				<indexterm significance="normal"><primary><varname>@&gt;</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>&lt;@</varname></primary></indexterm>
-				<para>Contiene/contenido JSONB temporal</para>
-				<para><varname>{jsonbset,jsonb} @&gt; {jsonbset,jsonb} → tbool</varname></para>
-				<para><varname>{jsonbset,jsonb} &lt;@ {jsonbset,jsonb} → tbool</varname></para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT jsonbset '"{\"geom\": \"Point(1 1)\"}"' @&gt; jsonb '{"geom": "Point(1 1)"}';
--- t
-SELECT jsonbset '{{"geom": "Point(1 1)"}, {"geom": "Point(2 2)"},
-  {"geom": "Point(1 1)"}}' @&gt; jsonb '{"geom": "Point(1 1)"}';
--- {t, f, t}
-SELECT jsonb '{"geom": "Point(1 1)"}' &lt;@ jsonbset '{[{"geom": "Point(1 1)"},
-  {"geom": "Point(1 1)"}, {"geom": "Point(1 1)"}],
-  [{"geom": "Point(2 2)"}, {"geom": "Point(2 2)"}]}';
--- {[t, t], [f, f]}
-</programlisting>
-			</listitem>
 
 			<listitem xml:id="jsonbset_set">
 				<indexterm significance="normal"><primary><varname>jsonbset_set</varname></primary></indexterm>

--- a/doc/temporal_jsonb.xml
+++ b/doc/temporal_jsonb.xml
@@ -192,41 +192,26 @@ SELECT minusValues(jsonbset '[["Grand Place", "La Bourse"],
 
 			<listitem xml:id="jsonbset_exists">
 				<indexterm significance="normal"><primary><varname>?</varname></primary></indexterm>
-				<para>Temporal JSONB exists</para>
-				<para><varname>jsonbset ? jsonb → tbool</varname></para>
-				<para><varname>jsonbset ?| jsonb[] → tbool</varname></para>
-				<para><varname>jsonbset ?&amp; jsonb[] → tbool</varname></para>
+				<para>JSONB set exists</para>
+				<para><varname>jsonbset ? text → boolean[]</varname></para>
+				<para><varname>jsonbset ?| text[] → boolean[]</varname></para>
+				<para><varname>jsonbset ?&amp; text[] → boolean[]</varname></para>
 				<para>As in PostgreSQL, the operators <varname>?|</varname> and <varname>?&amp;</varname> test, respectively, whether <emphasis>any</emphasis> or <emphasis>all</emphasis> of the strings in the text array exist as top-level keys or array elements.</para>
+				<para>The result is a Boolean for every value of the set, in the order of the values of the set.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT jsonbset '"{\"geom\": \"Point(1 1)\"}"' ? text 'geom';
--- t
-SELECT jsonbset '{{"geom": "Point(1 1)"}, {"geom": "Point(2 2)"},
-  {"geom": "Point(1 1)"}}' ?| ARRAY[text 'geom'];
--- {t, t, t}
-SELECT jsonbset '[{"speed": 10, "units": "km/h"},
-  {"speed": 20, "units": "km/h"}]' ?&amp; ARRAY['speed', 'units'];
--- {[t, t]}
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}';
+-- {"{\"speed\": 20, \"units\": \"km/h\"}", "{\"speed\": 10}"}
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' ? text 'units';
+-- {t,f}
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}'
+  ?| ARRAY[text 'units', text 'lights'];
+-- {t,f}
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}'
+  ?&amp; ARRAY[text 'speed', text 'units'];
+-- {t,f}
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="jsonbset_contains">
-				<indexterm significance="normal"><primary><varname>@&gt;</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>&lt;@</varname></primary></indexterm>
-				<para>Temporal JSONB contains/contained</para>
-				<para><varname>{jsonbset,jsonb} @&gt; {jsonbset,jsonb} → tbool</varname></para>
-				<para><varname>{jsonbset,jsonb} &lt;@ {jsonbset,jsonb} → tbool</varname></para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT jsonbset '"{\"geom\": \"Point(1 1)\"}"' @&gt; jsonb '{"geom": "Point(1 1)"}';
--- t
-SELECT jsonbset '{{"geom": "Point(1 1)"}, {"geom": "Point(2 2)"},
-  {"geom": "Point(1 1)"}}' @&gt; jsonb '{"geom": "Point(1 1)"}';
--- {t, f, t}
-SELECT jsonb '{"geom": "Point(1 1)"}' &lt;@ jsonbset '{[{"geom": "Point(1 1)"},
-  {"geom": "Point(1 1)"}, {"geom": "Point(1 1)"}],
-  [{"geom": "Point(2 2)"}, {"geom": "Point(2 2)"}]}';
--- {[t, t], [f, f]}
-</programlisting>
-			</listitem>
 
 			<listitem xml:id="jsonbset_set">
 				<indexterm significance="normal"><primary><varname>jsonbset_set</varname></primary></indexterm>

--- a/meos/src/json/jsonbset_jsonfuncs.c
+++ b/meos/src/json/jsonbset_jsonfuncs.c
@@ -251,6 +251,7 @@ jsonbset_delete_array(const Set *set, text **keys, int count)
  * @param[in] set JSONB set
  * @param[in] key Key
  * @param[out] count Number of values in the output array
+ * @csqlfn #Jsonbset_exists()
  */
 bool *
 jsonbset_exists(const Set *set, const text *key, int *count)
@@ -277,6 +278,7 @@ jsonbset_exists(const Set *set, const text *key, int *count)
  * @param[in] count Number of elements in the input array
  * @param[in] any True for the 'any' semantics, false for the 'all' semantics
  * @param[out] rescount Number of values in the output array
+ * @csqlfn #Jsonbset_exists_any(), #Jsonbset_exists_all()
  */
 bool *
 jsonbset_exists_array(const Set *set, text **keys, int count, bool any,

--- a/mobilitydb/sql/json/451_jsonbset_jsonfuncs.in.sql
+++ b/mobilitydb/sql/json/451_jsonbset_jsonfuncs.in.sql
@@ -208,6 +208,36 @@ CREATE OPERATOR #- (
   LEFTARG   = jsonbset, RIGHTARG = text[]
 );
 
+/*****************************************************************************
+ * Exists
+ *****************************************************************************/
+
+CREATE FUNCTION jsonbset_exists(jsonbset, text)
+  RETURNS boolean[]
+  AS 'MODULE_PATHNAME', 'Jsonbset_exists'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION jsonbset_exists_any(jsonbset, text[])
+  RETURNS boolean[]
+  AS 'MODULE_PATHNAME', 'Jsonbset_exists_any'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION jsonbset_exists_all(jsonbset, text[])
+  RETURNS boolean[]
+  AS 'MODULE_PATHNAME', 'Jsonbset_exists_all'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OPERATOR ? (
+  PROCEDURE = jsonbset_exists,
+  LEFTARG   = jsonbset, RIGHTARG = text
+);
+CREATE OPERATOR ?| (
+  PROCEDURE = jsonbset_exists_any,
+  LEFTARG   = jsonbset, RIGHTARG = text[]
+);
+CREATE OPERATOR ?& (
+  PROCEDURE = jsonbset_exists_all,
+  LEFTARG   = jsonbset, RIGHTARG = text[]
+);
+
 /*****************************************************************************/
 
 CREATE FUNCTION jsonbset_set(jsonbset, path text[], val jsonb,

--- a/mobilitydb/src/json/jsonbset_jsonfuncs.c
+++ b/mobilitydb/src/json/jsonbset_jsonfuncs.c
@@ -281,6 +281,109 @@ Jsonbset_delete_array(PG_FUNCTION_ARGS)
   PG_RETURN_SET_P(result);
 }
 
+/*****************************************************************************/
+
+PGDLLEXPORT Datum Jsonbset_exists(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Jsonbset_exists);
+/**
+ * @ingroup mobilitydb_json_json
+ * @brief Return for every value of a JSONB set whether the text string exists
+ * as a top-level key or array element within it
+ * @sqlfn jsonbset_exists()
+ * @sqlop @p ?
+ */
+Datum
+Jsonbset_exists(PG_FUNCTION_ARGS)
+{
+  /* Input arguments */
+  Set *set = PG_GETARG_SET_P(0);
+  text *key = PG_GETARG_TEXT_P(1);
+  /* Compute the result */
+  int count;
+  bool *result = jsonbset_exists(set, key, &count);
+  /* Clean up and return */
+  PG_FREE_IF_COPY(set, 0);
+  PG_FREE_IF_COPY(key, 1);
+  if (! result)
+    PG_RETURN_NULL();
+  PG_RETURN_ARRAYTYPE_P(boolarr_to_array(result, count));
+}
+
+/**
+ * @brief Return for every value of a JSONB set whether any or all of the text
+ * strings of an array exist as top-level keys or array elements within it
+ * @sqlfn jsonbset_exists_any(), jsonbset_exists_all()
+ */
+Datum
+Jsonbset_exists_array(FunctionCallInfo fcinfo, bool any)
+{
+  /* Input arguments */
+  Set *set = PG_GETARG_SET_P(0);
+  ArrayType *keys = PG_GETARG_ARRAYTYPE_P(1);
+  if (ARR_NDIM(keys) > 1)
+    ereport(ERROR, (errcode(ERRCODE_ARRAY_SUBSCRIPT_ERROR),
+       errmsg("wrong number of array subscripts")));
+
+  /* Extract the keys from the array */
+  int keys_len;
+  Datum *keys_elems;
+  bool *keys_nulls;
+  deconstruct_array(keys, TEXTOID, -1, false, 'i', &keys_elems, &keys_nulls,
+    &keys_len);
+  if (keys_len == 0)
+  {
+    pfree(keys_elems); pfree(keys_nulls);
+    PG_FREE_IF_COPY(set, 0);
+    PG_FREE_IF_COPY(keys, 1);
+    PG_RETURN_NULL();
+  }
+
+  /* Compute the result */
+  int count;
+  bool *result = jsonbset_exists_array(set, (text **) keys_elems, keys_len,
+    any, &count);
+
+  /* Clean up and return */
+  pfree(keys_elems); pfree(keys_nulls);
+  PG_FREE_IF_COPY(set, 0);
+  PG_FREE_IF_COPY(keys, 1);
+  if (! result)
+    PG_RETURN_NULL();
+  PG_RETURN_ARRAYTYPE_P(boolarr_to_array(result, count));
+}
+
+PGDLLEXPORT Datum Jsonbset_exists_any(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Jsonbset_exists_any);
+/**
+ * @ingroup mobilitydb_json_json
+ * @brief Return for every value of a JSONB set whether any of the text strings
+ * of an array exist as top-level keys or array elements within it
+ * @sqlfn jsonbset_exists_any()
+ * @sqlop @p ?|
+ */
+Datum
+Jsonbset_exists_any(PG_FUNCTION_ARGS)
+{
+  return Jsonbset_exists_array(fcinfo, true);
+}
+
+PGDLLEXPORT Datum Jsonbset_exists_all(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Jsonbset_exists_all);
+/**
+ * @ingroup mobilitydb_json_json
+ * @brief Return for every value of a JSONB set whether all of the text strings
+ * of an array exist as top-level keys or array elements within it
+ * @sqlfn jsonbset_exists_all()
+ * @sqlop @p ?&
+ */
+Datum
+Jsonbset_exists_all(PG_FUNCTION_ARGS)
+{
+  return Jsonbset_exists_array(fcinfo, false);
+}
+
+/*****************************************************************************/
+
 PGDLLEXPORT Datum Jsonbset_delete_index(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Jsonbset_delete_index);
 /**

--- a/mobilitydb/test/json/expected/451_jsonbset_jsonfuncs.test.out
+++ b/mobilitydb/test/json/expected/451_jsonbset_jsonfuncs.test.out
@@ -286,6 +286,61 @@ SELECT intset(jsonbset '{"{\"a\":1, \"b\":2.5}"}', text 'xxx');
 ERROR:  The lifted operation returned NULL
 SELECT intset(jsonbset '{"{\"a\":\"xxx\", \"b\":2.5}"}', text 'a');
 ERROR:  Invalid numeric string for key "a": xxx
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' ? text 'units';
+ ?column? 
+----------
+ {t,f}
+(1 row)
+
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' ? text 'speed';
+ ?column? 
+----------
+ {t,t}
+(1 row)
+
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' ? text 'xxx';
+ ?column? 
+----------
+ {f,f}
+(1 row)
+
+SELECT jsonbset_exists(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', text 'speed');
+ jsonbset_exists 
+-----------------
+ {t,t}
+(1 row)
+
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' ?| ARRAY[text 'units', text 'lights'];
+ ?column? 
+----------
+ {t,f}
+(1 row)
+
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' ?& ARRAY[text 'speed', text 'units'];
+ ?column? 
+----------
+ {t,f}
+(1 row)
+
+SELECT jsonbset_exists_any(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', ARRAY[text 'speed']);
+ jsonbset_exists_any 
+---------------------
+ {t,t}
+(1 row)
+
+SELECT jsonbset_exists_all(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', ARRAY[text 'speed']);
+ jsonbset_exists_all 
+---------------------
+ {t,t}
+(1 row)
+
+/* An empty array of keys has no result */
+SELECT jsonbset '{"{\"speed\": 10}"}' ?| ARRAY[]::text[];
+ ?column? 
+----------
+ 
+(1 row)
+
 SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' @? '$.units';
  ?column? 
 ----------

--- a/mobilitydb/test/json/queries/451_jsonbset_jsonfuncs.test.sql
+++ b/mobilitydb/test/json/queries/451_jsonbset_jsonfuncs.test.sql
@@ -123,6 +123,22 @@ SELECT intset(jsonbset '{"{\"a\":\"xxx\", \"b\":2.5}"}', text 'a');
 -------------------------------------------------------------------------------
 
 
+-- Exists. The result is one Boolean per value of the set, in the order of the
+-- values of the set
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' ? text 'units';
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' ? text 'speed';
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' ? text 'xxx';
+SELECT jsonbset_exists(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', text 'speed');
+
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' ?| ARRAY[text 'units', text 'lights'];
+SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' ?& ARRAY[text 'speed', text 'units'];
+SELECT jsonbset_exists_any(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', ARRAY[text 'speed']);
+SELECT jsonbset_exists_all(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', ARRAY[text 'speed']);
+/* An empty array of keys has no result */
+SELECT jsonbset '{"{\"speed\": 10}"}' ?| ARRAY[]::text[];
+
+-------------------------------------------------------------------------------
+
 -- JSON path functions. The result of a path predicate is one Boolean per
 -- element of the set, in the order of the elements
 


### PR DESCRIPTION
MEOS applies the exists predicate to the values of a JSONB set with `jsonbset_exists` and `jsonbset_exists_array`, and the manual documents the three operators of PostgreSQL that name them, but no function of the extension reaches them: the SQL of the JSONB set deploys `->`, `->>`, `#>`, `#>>`, `||`, `-`, `#-`, `@?` and `@@`, and not `?`, `?|` and `?&`. The three are deployed here, as `456_tjsonb_op.in.sql` deploys them for the temporal JSONB type, and return an array of Booleans in the order of the values of the set, as the path predicates of a set do.

```
SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}';
-- {"{\"speed\": 20, \"units\": \"km/h\"}", "{\"speed\": 10}"}
SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' ? text 'units';
-- {t,f}
SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}'
  ?| ARRAY[text 'units', text 'lights'];
-- {t,f}
SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}'
  ?& ARRAY[text 'speed', text 'units'];
-- {t,f}
```

The two MEOS functions carry the `@csqlfn` tag of their wrapper, so the catalog holds the signatures and every binding derives them.

The manual states the operand of the three as a JSONB and an array of JSONB. The operand is a text and an array of texts — both here and for the temporal JSONB type — which is what a top-level key is.

## The containment of a JSONB set

The manual also states that a JSONB set contains and is contained in a JSONB with `@>` and `<@` returning a `tbool`, which describes the containment of one document in another applied to every value. Those two operators exist for a JSONB set with another meaning, the one every set type gives them:

```sql
CREATE FUNCTION contains(jsonbset, jsonb) RETURNS boolean AS ... 'Contains_set_value'
CREATE OPERATOR @> (PROCEDURE = contains, LEFTARG = jsonbset, RIGHTARG = jsonb, COMMUTATOR = <@);
```

`@>` states whether a value belongs to the set and returns a Boolean, and `doc/set_span_types.xml` documents it for every set type as `set @> {set,base} → boolean`. The documented signature has the same operand types as the deployed one, so it cannot be added beside it, and taking the name would give one set type a meaning the other fifteen do not have. The two entries are removed from the chapter on the JSONB types, which leaves the operators documented once, where they belong. Nothing links to the removed entry.
