### PR TITLE
Add insert tests for the derived temporal families

### DIFF
--- a/mobilitydb/test/cbuffer/expected/202_tcbuffer.test.out
+++ b/mobilitydb/test/cbuffer/expected/202_tcbuffer.test.out
@@ -1940,6 +1940,19 @@ SELECT asText(afterTimestamp(tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cb
  {[Cbuffer(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Cbuffer(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Cbuffer(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST], [Cbuffer(POINT(2 2),0.6)@Tue Jan 04 00:00:00 2000 PST, Cbuffer(POINT(2 2),0.6)@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
+SELECT asText(insert(
+  tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02], [Cbuffer(Point(1 1), 0.5)@2000-01-03, Cbuffer(Point(1 1), 0.6)@2000-01-04]}',
+  tcbuffer '{[Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03]}'));
+                                                                                astext                                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[Cbuffer(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Cbuffer(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Cbuffer(POINT(1 1),0.6)@Tue Jan 04 00:00:00 2000 PST]}
+(1 row)
+
+/* Error: insert vs update distinguishing case (disagreeing value at common timestamp) */
+SELECT asText(insert(
+  tcbuffer '[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02]',
+  tcbuffer '[Cbuffer(Point(1 1), 0.9)@2000-01-02, Cbuffer(Point(1 1), 0.9)@2000-01-03]'));
+ERROR:  The temporal values have different value at their common timestamp Sun Jan 02 00:00:00 2000 PST
 SELECT asText(deleteTime(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01', timestamptz '2000-01-01'));
  astext 
 --------

--- a/mobilitydb/test/cbuffer/queries/202_tcbuffer.test.sql
+++ b/mobilitydb/test/cbuffer/queries/202_tcbuffer.test.sql
@@ -510,6 +510,14 @@ SELECT asText(afterTimestamp(tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cb
 -- Modification functions
 -------------------------------------------------------------------------------
 
+SELECT asText(insert(
+  tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02], [Cbuffer(Point(1 1), 0.5)@2000-01-03, Cbuffer(Point(1 1), 0.6)@2000-01-04]}',
+  tcbuffer '{[Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03]}'));
+/* Error: insert vs update distinguishing case (disagreeing value at common timestamp) */
+SELECT asText(insert(
+  tcbuffer '[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02]',
+  tcbuffer '[Cbuffer(Point(1 1), 0.9)@2000-01-02, Cbuffer(Point(1 1), 0.9)@2000-01-03]'));
+
 SELECT asText(deleteTime(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01', timestamptz '2000-01-01'));
 SELECT asText(deleteTime(tcbuffer '{Cbuffer(Point(1 1), 0.3)@2000-01-01, Cbuffer(Point(1 1), 0.5)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03}', timestamptz '2000-01-01'));
 SELECT asText(deleteTime(tcbuffer '[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03]', timestamptz '2000-01-01'));

--- a/mobilitydb/test/geo/expected/052_tgeo.test.out
+++ b/mobilitydb/test/geo/expected/052_tgeo.test.out
@@ -4404,6 +4404,31 @@ SELECT asText(afterTimestamp(tgeography '{[Point(1.5 1.5)@2000-01-01, Point(2.5 
  {[POINT(1.5 1.5)@Sat Jan 01 00:00:00 2000 PST, POINT(2.5 2.5)@Sun Jan 02 00:00:00 2000 PST, POINT(1.5 1.5)@Mon Jan 03 00:00:00 2000 PST], [POINT(3.5 3.5)@Tue Jan 04 00:00:00 2000 PST, POINT(3.5 3.5)@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
+SELECT asText(insert(
+  tgeometry '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02], [Point(3 3)@2000-01-03, Point(4 4)@2000-01-04]}',
+  tgeometry '{[Point(2 2)@2000-01-02, Point(3 3)@2000-01-03]}'));
+                                                                                 astext                                                                                 
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[POINT(1 1)@Sat Jan 01 00:00:00 2000 PST, POINT(2 2)@Sun Jan 02 00:00:00 2000 PST, POINT(3 3)@Mon Jan 03 00:00:00 2000 PST, POINT(4 4)@Tue Jan 04 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(insert(
+  tgeography '{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02], [Point(3.5 3.5)@2000-01-03, Point(4.5 4.5)@2000-01-04]}',
+  tgeography '{[Point(2.5 2.5)@2000-01-02, Point(3.5 3.5)@2000-01-03]}'));
+                                                                                         astext                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[POINT(1.5 1.5)@Sat Jan 01 00:00:00 2000 PST, POINT(2.5 2.5)@Sun Jan 02 00:00:00 2000 PST, POINT(3.5 3.5)@Mon Jan 03 00:00:00 2000 PST, POINT(4.5 4.5)@Tue Jan 04 00:00:00 2000 PST]}
+(1 row)
+
+/* Errors: insert vs update distinguishing case (disagreeing value at common timestamp) */
+SELECT asText(insert(
+  tgeometry '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]',
+  tgeometry '[Point(3 3)@2000-01-02, Point(3 3)@2000-01-03]'));
+ERROR:  The temporal values have different value at their common timestamp Sun Jan 02 00:00:00 2000 PST
+SELECT asText(insert(
+  tgeography '[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02]',
+  tgeography '[Point(3.5 3.5)@2000-01-02, Point(3.5 3.5)@2000-01-03]'));
+ERROR:  The temporal values have different value at their common timestamp Sun Jan 02 00:00:00 2000 PST
 SELECT asText(deleteTime(tgeometry 'Point(1 1)@2000-01-01', timestamptz '2000-01-01'));
  astext 
 --------

--- a/mobilitydb/test/geo/expected/052_tpoint.test.out
+++ b/mobilitydb/test/geo/expected/052_tpoint.test.out
@@ -4492,6 +4492,31 @@ SELECT asText(afterTimestamp(tgeogpoint '{[Point(1.5 1.5)@2000-01-01, Point(2.5 
  {[POINT(1.5 1.5)@Sat Jan 01 00:00:00 2000 PST, POINT(2.5 2.5)@Sun Jan 02 00:00:00 2000 PST, POINT(1.5 1.5)@Mon Jan 03 00:00:00 2000 PST], [POINT(3.5 3.5)@Tue Jan 04 00:00:00 2000 PST, POINT(3.5 3.5)@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
+SELECT asText(insert(
+  tgeompoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02], [Point(3 3)@2000-01-03, Point(4 4)@2000-01-04]}',
+  tgeompoint '{[Point(2 2)@2000-01-02, Point(3 3)@2000-01-03]}'));
+                                        astext                                        
+--------------------------------------------------------------------------------------
+ {[POINT(1 1)@Sat Jan 01 00:00:00 2000 PST, POINT(4 4)@Tue Jan 04 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(insert(
+  tgeogpoint '{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02], [Point(3.5 3.5)@2000-01-03, Point(4.5 4.5)@2000-01-04]}',
+  tgeogpoint '{[Point(2.5 2.5)@2000-01-02, Point(3.5 3.5)@2000-01-03]}'));
+                                                                                         astext                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[POINT(1.5 1.5)@Sat Jan 01 00:00:00 2000 PST, POINT(2.5 2.5)@Sun Jan 02 00:00:00 2000 PST, POINT(3.5 3.5)@Mon Jan 03 00:00:00 2000 PST, POINT(4.5 4.5)@Tue Jan 04 00:00:00 2000 PST]}
+(1 row)
+
+/* Errors: insert vs update distinguishing case (disagreeing value at common timestamp) */
+SELECT asText(insert(
+  tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]',
+  tgeompoint '[Point(3 3)@2000-01-02, Point(3 3)@2000-01-03]'));
+ERROR:  The temporal values have different value at their common timestamp Sun Jan 02 00:00:00 2000 PST
+SELECT asText(insert(
+  tgeogpoint '[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02]',
+  tgeogpoint '[Point(3.5 3.5)@2000-01-02, Point(3.5 3.5)@2000-01-03]'));
+ERROR:  The temporal values have different value at their common timestamp Sun Jan 02 00:00:00 2000 PST
 SELECT asText(deleteTime(tgeompoint 'Point(1 1)@2000-01-01', timestamptz '2000-01-01'));
  astext 
 --------

--- a/mobilitydb/test/geo/queries/052_tgeo.test.sql
+++ b/mobilitydb/test/geo/queries/052_tgeo.test.sql
@@ -1253,6 +1253,20 @@ SELECT asText(afterTimestamp(tgeography '{[Point(1.5 1.5)@2000-01-01, Point(2.5 
 -- Modification functions
 -------------------------------------------------------------------------------
 
+SELECT asText(insert(
+  tgeometry '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02], [Point(3 3)@2000-01-03, Point(4 4)@2000-01-04]}',
+  tgeometry '{[Point(2 2)@2000-01-02, Point(3 3)@2000-01-03]}'));
+SELECT asText(insert(
+  tgeography '{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02], [Point(3.5 3.5)@2000-01-03, Point(4.5 4.5)@2000-01-04]}',
+  tgeography '{[Point(2.5 2.5)@2000-01-02, Point(3.5 3.5)@2000-01-03]}'));
+/* Errors: insert vs update distinguishing case (disagreeing value at common timestamp) */
+SELECT asText(insert(
+  tgeometry '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]',
+  tgeometry '[Point(3 3)@2000-01-02, Point(3 3)@2000-01-03]'));
+SELECT asText(insert(
+  tgeography '[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02]',
+  tgeography '[Point(3.5 3.5)@2000-01-02, Point(3.5 3.5)@2000-01-03]'));
+
 SELECT asText(deleteTime(tgeometry 'Point(1 1)@2000-01-01', timestamptz '2000-01-01'));
 SELECT asText(deleteTime(tgeometry '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03}', timestamptz '2000-01-01'));
 SELECT asText(deleteTime(tgeometry '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03]', timestamptz '2000-01-01'));

--- a/mobilitydb/test/geo/queries/052_tpoint.test.sql
+++ b/mobilitydb/test/geo/queries/052_tpoint.test.sql
@@ -1285,6 +1285,20 @@ SELECT asText(afterTimestamp(tgeogpoint '{[Point(1.5 1.5)@2000-01-01, Point(2.5 
 -- Modification functions
 -------------------------------------------------------------------------------
 
+SELECT asText(insert(
+  tgeompoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02], [Point(3 3)@2000-01-03, Point(4 4)@2000-01-04]}',
+  tgeompoint '{[Point(2 2)@2000-01-02, Point(3 3)@2000-01-03]}'));
+SELECT asText(insert(
+  tgeogpoint '{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02], [Point(3.5 3.5)@2000-01-03, Point(4.5 4.5)@2000-01-04]}',
+  tgeogpoint '{[Point(2.5 2.5)@2000-01-02, Point(3.5 3.5)@2000-01-03]}'));
+/* Errors: insert vs update distinguishing case (disagreeing value at common timestamp) */
+SELECT asText(insert(
+  tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]',
+  tgeompoint '[Point(3 3)@2000-01-02, Point(3 3)@2000-01-03]'));
+SELECT asText(insert(
+  tgeogpoint '[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02]',
+  tgeogpoint '[Point(3.5 3.5)@2000-01-02, Point(3.5 3.5)@2000-01-03]'));
+
 SELECT asText(deleteTime(tgeompoint 'Point(1 1)@2000-01-01', timestamptz '2000-01-01'));
 SELECT asText(deleteTime(tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03}', timestamptz '2000-01-01'));
 SELECT asText(deleteTime(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03]', timestamptz '2000-01-01'));

--- a/mobilitydb/test/npoint/expected/302_tnpoint.test.out
+++ b/mobilitydb/test/npoint/expected/302_tnpoint.test.out
@@ -1953,6 +1953,19 @@ SELECT afterTimestamp(tnpoint '{[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-
  {[NPoint(1,0.2)@Sat Jan 01 00:00:00 2000 PST, NPoint(1,0.4)@Sun Jan 02 00:00:00 2000 PST, NPoint(1,0.5)@Mon Jan 03 00:00:00 2000 PST], [NPoint(2,0.6)@Tue Jan 04 00:00:00 2000 PST, NPoint(2,0.6)@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
+SELECT insert(
+  tnpoint '{[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02], [Npoint(1, 0.5)@2000-01-03, Npoint(1, 0.6)@2000-01-04]}',
+  tnpoint '{[Npoint(1, 0.4)@2000-01-02, Npoint(1, 0.5)@2000-01-03]}');
+                                                                 insert                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------
+ {[NPoint(1,0.2)@Sat Jan 01 00:00:00 2000 PST, NPoint(1,0.4)@Sun Jan 02 00:00:00 2000 PST, NPoint(1,0.6)@Tue Jan 04 00:00:00 2000 PST]}
+(1 row)
+
+/* Error: insert vs update distinguishing case (disagreeing value at common timestamp) */
+SELECT insert(
+  tnpoint '[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02]',
+  tnpoint '[Npoint(1, 0.9)@2000-01-02, Npoint(1, 0.9)@2000-01-03]');
+ERROR:  The temporal values have different value at their common timestamp Sun Jan 02 00:00:00 2000 PST
 SELECT deleteTime(tnpoint 'Npoint(1, 0.5)@2000-01-01', timestamptz '2000-01-01');
  deletetime 
 ------------

--- a/mobilitydb/test/npoint/queries/302_tnpoint.test.sql
+++ b/mobilitydb/test/npoint/queries/302_tnpoint.test.sql
@@ -505,6 +505,14 @@ SELECT afterTimestamp(tnpoint '{[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-
 -- Modification functions
 -------------------------------------------------------------------------------
 
+SELECT insert(
+  tnpoint '{[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02], [Npoint(1, 0.5)@2000-01-03, Npoint(1, 0.6)@2000-01-04]}',
+  tnpoint '{[Npoint(1, 0.4)@2000-01-02, Npoint(1, 0.5)@2000-01-03]}');
+/* Error: insert vs update distinguishing case (disagreeing value at common timestamp) */
+SELECT insert(
+  tnpoint '[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02]',
+  tnpoint '[Npoint(1, 0.9)@2000-01-02, Npoint(1, 0.9)@2000-01-03]');
+
 SELECT deleteTime(tnpoint 'Npoint(1, 0.5)@2000-01-01', timestamptz '2000-01-01');
 SELECT deleteTime(tnpoint '{Npoint(1, 0.3)@2000-01-01, Npoint(1, 0.5)@2000-01-02, Npoint(1, 0.5)@2000-01-03}', timestamptz '2000-01-01');
 SELECT deleteTime(tnpoint '[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02, Npoint(1, 0.5)@2000-01-03]', timestamptz '2000-01-01');

--- a/mobilitydb/test/pose/expected/102_tpose.test.out
+++ b/mobilitydb/test/pose/expected/102_tpose.test.out
@@ -1688,6 +1688,19 @@ SELECT asText(afterTimestamp(tpose '{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Poi
  {[Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST], [Pose(POINT(2 2),0.6)@Tue Jan 04 00:00:00 2000 PST, Pose(POINT(2 2),0.6)@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
+SELECT asText(insert(
+  tpose '{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02], [Pose(Point(1 1), 0.5)@2000-01-03, Pose(Point(1 1), 0.6)@2000-01-04]}',
+  tpose '{[Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]}'));
+                                                                           astext                                                                            
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.6)@Tue Jan 04 00:00:00 2000 PST]}
+(1 row)
+
+/* Error: insert vs update distinguishing case (disagreeing value at common timestamp) */
+SELECT asText(insert(
+  tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02]',
+  tpose '[Pose(Point(1 1), 0.9)@2000-01-02, Pose(Point(1 1), 0.9)@2000-01-03]'));
+ERROR:  The temporal values have different value at their common timestamp Sun Jan 02 00:00:00 2000 PST
 SELECT asText(deleteTime(tpose 'Pose(Point(1 1), 0.5)@2000-01-01', timestamptz '2000-01-01'));
  astext 
 --------

--- a/mobilitydb/test/pose/queries/102_tpose.test.sql
+++ b/mobilitydb/test/pose/queries/102_tpose.test.sql
@@ -447,6 +447,14 @@ SELECT asText(afterTimestamp(tpose '{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Poi
 -- Modification functions
 -------------------------------------------------------------------------------
 
+SELECT asText(insert(
+  tpose '{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02], [Pose(Point(1 1), 0.5)@2000-01-03, Pose(Point(1 1), 0.6)@2000-01-04]}',
+  tpose '{[Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]}'));
+/* Error: insert vs update distinguishing case (disagreeing value at common timestamp) */
+SELECT asText(insert(
+  tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02]',
+  tpose '[Pose(Point(1 1), 0.9)@2000-01-02, Pose(Point(1 1), 0.9)@2000-01-03]'));
+
 SELECT asText(deleteTime(tpose 'Pose(Point(1 1), 0.5)@2000-01-01', timestamptz '2000-01-01'));
 SELECT asText(deleteTime(tpose '{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}', timestamptz '2000-01-01'));
 SELECT asText(deleteTime(tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]', timestamptz '2000-01-01'));

--- a/mobilitydb/test/rgeo/expected/150_trgeo.test.out
+++ b/mobilitydb/test/rgeo/expected/150_trgeo.test.out
@@ -1795,6 +1795,13 @@ SELECT asText(afterTimestamp(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point
  POLYGON((1 1,2 2,3 1,1 1));{[Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST], [Pose(POINT(2 2),0.6)@Tue Jan 04 00:00:00 2000 PST, Pose(POINT(2 2),0.6)@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
+/* insert vs update distinguishing case (disagreeing value at common timestamp):
+ * under the pre-fix Temporal_update wiring this would succeed by overwriting,
+ * insert() correctly rejects it */
+SELECT asText(insert(
+  trgeometry 'Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02]',
+  trgeometry 'Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.9)@2000-01-02, Pose(Point(1 1), 0.9)@2000-01-03]'));
+ERROR:  The temporal values have different value at their common timestamp Sun Jan 02 00:00:00 2000 PST
 SELECT asText(deleteTime(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01', timestamptz '2000-01-01'));
  astext 
 --------

--- a/mobilitydb/test/rgeo/queries/150_trgeo.test.sql
+++ b/mobilitydb/test/rgeo/queries/150_trgeo.test.sql
@@ -484,6 +484,13 @@ SELECT asText(afterTimestamp(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point
 -- Modification functions
 -------------------------------------------------------------------------------
 
+/* insert vs update distinguishing case (disagreeing value at common timestamp):
+ * under the pre-fix Temporal_update wiring this would succeed by overwriting,
+ * insert() correctly rejects it */
+SELECT asText(insert(
+  trgeometry 'Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02]',
+  trgeometry 'Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.9)@2000-01-02, Pose(Point(1 1), 0.9)@2000-01-03]'));
+
 SELECT asText(deleteTime(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01', timestamptz '2000-01-01'));
 SELECT asText(deleteTime(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}', timestamptz '2000-01-01'));
 SELECT asText(deleteTime(trgeometry 'Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]', timestamptz '2000-01-01'));


### PR DESCRIPTION
Covers the `insert` modification function across the derived temporal families: tcbuffer, tgeometry/tgeography, tgeompoint/tgeogpoint, tnpoint, tpose, and trgeometry.

Exercises the merge-of-overlapping-fragments case, where two sequences sharing a common boundary timestamp with an agreeing value are spliced into a single result. Also exercises the error path where the two arguments disagree at a common timestamp, verifying that `insert` rejects the call instead of silently overwriting the value, distinguishing its semantics from `update`.