### PR TITLE
Document the spans and splitting functions of the pointcloud types

### DIFF
--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -1041,6 +1041,34 @@ FROM (SELECT timeSplit(tpcpointSeq(ARRAY[
 -- 2024-01-03 | 1
 </programlisting>
 				</listitem>
+
+				<listitem xml:id="tpcpoint_spans">
+					<indexterm significance="normal"><primary><varname>spans</varname></primary></indexterm>
+					<para>Devuelve el arreglo de lapsos de tiempo de los segmentos de un tpcpoint</para>
+					<para><varname>spans(tpcpoint) → tstzspan[]</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT spans(tpcpointSeq(ARRAY[
+  tpcpoint(pcpoint(1, 1, 1, 1), '2024-01-01'::timestamptz),
+  tpcpoint(pcpoint(1, 2, 2, 2), '2024-01-02'::timestamptz),
+  tpcpoint(pcpoint(1, 3, 3, 3), '2024-01-03'::timestamptz)]));
+-- {"[2024-01-01, 2024-01-02]","[2024-01-02, 2024-01-03]"}
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="tpcpoint_split_spans">
+					<indexterm significance="normal"><primary><varname>splitNSpans</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>splitEachNSpans</varname></primary></indexterm>
+					<para>Devuelve los lapsos de tiempo de un tpcpoint dividido en un número dado de contenedores, o con un número dado de segmentos por contenedor</para>
+					<para><varname>splitNSpans(tpcpoint, integer) → tstzspan[]</varname></para>
+					<para><varname>splitEachNSpans(tpcpoint, integer) → tstzspan[]</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT splitNSpans(tpcpointSeq(ARRAY[
+  tpcpoint(pcpoint(1, 1, 1, 1), '2024-01-01'::timestamptz),
+  tpcpoint(pcpoint(1, 2, 2, 2), '2024-01-02'::timestamptz),
+  tpcpoint(pcpoint(1, 3, 3, 3), '2024-01-03'::timestamptz)]), 2);
+-- {"[2024-01-01, 2024-01-02]","[2024-01-02, 2024-01-03]"}
+</programlisting>
+				</listitem>
 			</itemizedlist>
 		</sect2>
 
@@ -1507,6 +1535,34 @@ FROM (SELECT timeSplit(tpcpatchSeq(ARRAY[
 -- 2024-01-01 | 2
 -- 2024-01-02 | 2
 -- 2024-01-03 | 1
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="tpcpatch_spans">
+					<indexterm significance="normal"><primary><varname>spans</varname></primary></indexterm>
+					<para>Devuelve el arreglo de lapsos de tiempo de los segmentos de un tpcpatch</para>
+					<para><varname>spans(tpcpatch) → tstzspan[]</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT spans(tpcpatchSeq(ARRAY[
+  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)), '2024-01-01'::timestamptz),
+  tpcpatch(pcpatch(1, pcpoint(1, 5, 5, 5), pcpoint(1, 6, 6, 6)), '2024-01-02'::timestamptz),
+  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)), '2024-01-03'::timestamptz)]));
+-- {"[2024-01-01, 2024-01-02]","[2024-01-02, 2024-01-03]"}
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="tpcpatch_split_spans">
+					<indexterm significance="normal"><primary><varname>splitNSpans</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>splitEachNSpans</varname></primary></indexterm>
+					<para>Devuelve los lapsos de tiempo de un tpcpatch dividido en un número dado de contenedores, o con un número dado de segmentos por contenedor</para>
+					<para><varname>splitNSpans(tpcpatch, integer) → tstzspan[]</varname></para>
+					<para><varname>splitEachNSpans(tpcpatch, integer) → tstzspan[]</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT splitNSpans(tpcpatchSeq(ARRAY[
+  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)), '2024-01-01'::timestamptz),
+  tpcpatch(pcpatch(1, pcpoint(1, 5, 5, 5), pcpoint(1, 6, 6, 6)), '2024-01-02'::timestamptz),
+  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)), '2024-01-03'::timestamptz)]), 2);
+-- {"[2024-01-01, 2024-01-02]","[2024-01-02, 2024-01-03]"}
 </programlisting>
 				</listitem>
 			</itemizedlist>

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -1046,6 +1046,34 @@ FROM (SELECT timeSplit(tpcpointSeq(ARRAY[
 -- 2024-01-03 | 1
 </programlisting>
 				</listitem>
+
+				<listitem xml:id="tpcpoint_spans">
+					<indexterm significance="normal"><primary><varname>spans</varname></primary></indexterm>
+					<para>Return the array of time spans of a tpcpoint's segments</para>
+					<para><varname>spans(tpcpoint) → tstzspan[]</varname></para>
+									<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT spans(tpcpointSeq(ARRAY[
+  tpcpoint(pcpoint(1, 1, 1, 1), '2024-01-01'::timestamptz),
+  tpcpoint(pcpoint(1, 2, 2, 2), '2024-01-02'::timestamptz),
+  tpcpoint(pcpoint(1, 3, 3, 3), '2024-01-03'::timestamptz)]));
+-- {"[2024-01-01, 2024-01-02]","[2024-01-02, 2024-01-03]"}
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="tpcpoint_split_spans">
+					<indexterm significance="normal"><primary><varname>splitNSpans</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>splitEachNSpans</varname></primary></indexterm>
+					<para>Return the time spans of a tpcpoint split into a given number of bins, or with a given number of segments per bin</para>
+					<para><varname>splitNSpans(tpcpoint, integer) → tstzspan[]</varname></para>
+					<para><varname>splitEachNSpans(tpcpoint, integer) → tstzspan[]</varname></para>
+									<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT splitNSpans(tpcpointSeq(ARRAY[
+  tpcpoint(pcpoint(1, 1, 1, 1), '2024-01-01'::timestamptz),
+  tpcpoint(pcpoint(1, 2, 2, 2), '2024-01-02'::timestamptz),
+  tpcpoint(pcpoint(1, 3, 3, 3), '2024-01-03'::timestamptz)]), 2);
+-- {"[2024-01-01, 2024-01-02]","[2024-01-02, 2024-01-03]"}
+</programlisting>
+				</listitem>
 			</itemizedlist>
 		</sect2>
 
@@ -1513,6 +1541,34 @@ FROM (SELECT timeSplit(tpcpatchSeq(ARRAY[
 -- 2024-01-01 | 2
 -- 2024-01-02 | 2
 -- 2024-01-03 | 1
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="tpcpatch_spans">
+					<indexterm significance="normal"><primary><varname>spans</varname></primary></indexterm>
+					<para>Return the array of time spans of a tpcpatch's segments</para>
+					<para><varname>spans(tpcpatch) → tstzspan[]</varname></para>
+									<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT spans(tpcpatchSeq(ARRAY[
+  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)), '2024-01-01'::timestamptz),
+  tpcpatch(pcpatch(1, pcpoint(1, 5, 5, 5), pcpoint(1, 6, 6, 6)), '2024-01-02'::timestamptz),
+  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)), '2024-01-03'::timestamptz)]));
+-- {"[2024-01-01, 2024-01-02]","[2024-01-02, 2024-01-03]"}
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="tpcpatch_split_spans">
+					<indexterm significance="normal"><primary><varname>splitNSpans</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>splitEachNSpans</varname></primary></indexterm>
+					<para>Return the time spans of a tpcpatch split into a given number of bins, or with a given number of segments per bin</para>
+					<para><varname>splitNSpans(tpcpatch, integer) → tstzspan[]</varname></para>
+					<para><varname>splitEachNSpans(tpcpatch, integer) → tstzspan[]</varname></para>
+									<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT splitNSpans(tpcpatchSeq(ARRAY[
+  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)), '2024-01-01'::timestamptz),
+  tpcpatch(pcpatch(1, pcpoint(1, 5, 5, 5), pcpoint(1, 6, 6, 6)), '2024-01-02'::timestamptz),
+  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)), '2024-01-03'::timestamptz)]), 2);
+-- {"[2024-01-01, 2024-01-02]","[2024-01-02, 2024-01-03]"}
 </programlisting>
 				</listitem>
 			</itemizedlist>


### PR DESCRIPTION
## Summary
The temporal pointcloud types (`tpcpoint`, `tpcpatch`) expose `spans`, `splitNSpans` and `splitEachNSpans`, mirroring every other temporal family's time-span extraction surface. This PR documents those three functions in the pointcloud chapter of both the English and Spanish manuals, alongside the existing `unnest`/`timeSplit` entries, each with a live-harvested example.
