### PR TITLE
Validate the pixel buffer length in raster_tile_value_quadbin

### DIFF
--- a/meos/include/meos_raster.h
+++ b/meos/include/meos_raster.h
@@ -149,8 +149,8 @@ extern int araster_value_gdal(const char *path, int band,
   const Temporal *traj, const Span *vspan);
 
 extern Temporal *raster_tile_value_quadbin(const uint8_t *pixels,
-  uint16_t width, uint16_t height, uint64 quadbin, MeosPixType pixtype,
-  double nodata, bool has_nodata, const Temporal *traj);
+  size_t pixels_size, uint16_t width, uint16_t height, uint64 quadbin,
+  MeosPixType pixtype, double nodata, bool has_nodata, const Temporal *traj);
 
 extern Temporal *raster_tile_value(const Raquet *rq, const Temporal *traj);
 extern Temporal *raster_tile_value_array(const Raquet **rqarr, int count,

--- a/meos/include/raster/raster_quadbin.h
+++ b/meos/include/raster/raster_quadbin.h
@@ -40,8 +40,8 @@
 #include <meos_raster.h>
 
 extern Temporal *raster_tile_value_quadbin(const uint8_t *pixels,
-  uint16_t width, uint16_t height, uint64 quadbin, MeosPixType pixtype,
-  double nodata, bool has_nodata, const Temporal *traj);
+  size_t pixels_size, uint16_t width, uint16_t height, uint64 quadbin,
+  MeosPixType pixtype, double nodata, bool has_nodata, const Temporal *traj);
 
 extern uint64 *trajectory_quadbins(const Temporal *traj, uint32_t zoom,
   int *count);

--- a/meos/src/raster/raquet.c
+++ b/meos/src/raster/raquet.c
@@ -513,8 +513,9 @@ Temporal *
 raster_tile_value(const Raquet *rq, const Temporal *traj)
 {
   VALIDATE_NOT_NULL(rq, NULL); VALIDATE_NOT_NULL(traj, NULL);
-  return raster_tile_value_quadbin(rq->pixels, rq->width, rq->height,
-    rq->quadbin, (MeosPixType) rq->pixtype, rq->nodata, rq->has_nodata, traj);
+  return raster_tile_value_quadbin(rq->pixels, raquet_pixels_size(rq),
+    rq->width, rq->height, rq->quadbin, (MeosPixType) rq->pixtype, rq->nodata,
+    rq->has_nodata, traj);
 }
 
 /**

--- a/meos/src/raster/raster_quadbin.c
+++ b/meos/src/raster/raster_quadbin.c
@@ -62,6 +62,7 @@
 #include "temporal/tinstant.h"
 #include "temporal/tsequence.h"
 /* Raster */
+#include "raster/raquet.h"
 #include "raster/raster_quadbin.h"
 
 /*****************************************************************************
@@ -314,6 +315,7 @@ read_pixel(const uint8_t *pixels, int col, int row, int width,
  * silently dropped; NULL is returned when no instants survive.
  * @param[in] pixels Row-major pixel bytes (all bands interleaved or
  * single-band depending on the Raquet producer)
+ * @param[in] pixels_size Number of bytes available at @p pixels
  * @param[in] width Tile width in pixels (typically 256)
  * @param[in] height Tile height in pixels (typically 256)
  * @param[in] quadbin CARTO QUADBIN cell identifier (uint64)
@@ -324,10 +326,20 @@ read_pixel(const uint8_t *pixels, int col, int row, int width,
  * @return tfloat instant set, or NULL
  */
 Temporal *
-raster_tile_value_quadbin(const uint8_t *pixels, uint16_t width,
-  uint16_t height, uint64 quadbin, MeosPixType pixtype, double nodata,
-  bool has_nodata, const Temporal *traj)
+raster_tile_value_quadbin(const uint8_t *pixels, size_t pixels_size,
+  uint16_t width, uint16_t height, uint64 quadbin, MeosPixType pixtype,
+  double nodata, bool has_nodata, const Temporal *traj)
 {
+  VALIDATE_NOT_NULL(pixels, NULL);
+  size_t need = (size_t) width * height * raquet_pixtype_size(pixtype);
+  if (pixels_size < need)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "The pixel array has %zu bytes but %zu are required for a %d x %d tile",
+      pixels_size, need, width, height);
+    return NULL;
+  }
+
   /* Decode QUADBIN → tile x, y, z → WGS84 bbox + Mercator top/bot */
   uint32_t tx, ty, tz;
   qb_to_xyz(quadbin, &tx, &ty, &tz);

--- a/mobilitydb/src/raster/temporal_raster.c
+++ b/mobilitydb/src/raster/temporal_raster.c
@@ -402,9 +402,10 @@ Raster_tile_value_quadbin(PG_FUNCTION_ARGS)
   Temporal  *traj      = PG_GETARG_TEMPORAL_P(7);
 
   const uint8_t *pixels = (const uint8_t *) VARDATA_ANY(pxbytea);
+  size_t pixels_size    = (size_t) VARSIZE_ANY_EXHDR(pxbytea);
   MeosPixType pixtype   = text_to_pixtype(pixtype_t);
 
-  Temporal *result = raster_tile_value_quadbin(pixels,
+  Temporal *result = raster_tile_value_quadbin(pixels, pixels_size,
     (uint16_t) width, (uint16_t) height, (uint64) quadbin,
     pixtype, nodata, has_nd, traj);
 

--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -219,6 +219,16 @@ SELECT raster_tile_value_quadbin(
  {1@2024-01-01 00:00:00+00, 2@2024-01-02 00:00:00+00, 3@2024-01-03 00:00:00+00}
 (1 row)
 
+SELECT raster_tile_value_quadbin(
+  '\x0102'::bytea,             -- 2 bytes, but a 2x2 UINT8 tile needs 4
+  2::integer,                  -- width
+  2::integer,                  -- height
+  5193776270265024512::bigint, -- quadbin_tile_to_cell(1,0,1)
+  'UINT8',
+  0.0, false,
+  tgeompointFromText('SRID=4326;{Point(45.0 10.0)@2024-01-01 00:00:00+00}')
+);
+ERROR:  The pixel array has 2 bytes but 4 are required for a 2 x 2 tile
 WITH t AS (
   SELECT tgeompointFromText('SRID=4326;{Point(45.0 75.0)@2024-01-01 00:00:00+00, Point(135.0 75.0)@2024-01-02 00:00:00+00, Point(45.0 10.0)@2024-01-03 00:00:00+00, Point(-45.0 75.0)@2024-01-04 00:00:00+00}') AS traj
 )

--- a/mobilitydb/test/raster/queries/500_raster.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster.test.sql
@@ -257,6 +257,19 @@ SELECT raster_tile_value_quadbin(
   tgeompointFromText('SRID=4326;{Point(45.0 75.0)@2024-01-01 00:00:00+00, Point(135.0 75.0)@2024-01-02 00:00:00+00, Point(45.0 10.0)@2024-01-03 00:00:00+00, Point(-45.0 75.0)@2024-01-04 00:00:00+00}')
 )::text AS result;
 
+-- A pixel array too small for the declared width/height raises an error
+-- rather than sampling past the end of the buffer. Point(45 10) maps to
+-- col=0, row=1 (byte offset 2), which is past the 2 bytes actually supplied.
+SELECT raster_tile_value_quadbin(
+  '\x0102'::bytea,             -- 2 bytes, but a 2x2 UINT8 tile needs 4
+  2::integer,                  -- width
+  2::integer,                  -- height
+  5193776270265024512::bigint, -- quadbin_tile_to_cell(1,0,1)
+  'UINT8',
+  0.0, false,
+  tgeompointFromText('SRID=4326;{Point(45.0 10.0)@2024-01-01 00:00:00+00}')
+);
+
 -------------------------------------------------------------------------------
 -- raquet type: construction, WKB round-trip, and typed sampling
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Validates the pixel buffer against the declared tile dimensions in `raster_tile_value_quadbin`, rejecting a buffer shorter than `width * height * raquet_pixtype_size(pixtype)`.

The function indexes its pixel buffer with caller-supplied width and height. Carrying the buffer length lets it establish, before the first pixel read, that the declared tile fits in the bytes supplied, so a short buffer paired with large dimensions raises an error instead of reading past the allocation.

The length reaches the check as a parameter, so every binding inherits the validation rather than restating it: the PostgreSQL wrapper passes `VARSIZE_ANY_EXHDR` of the bytea, and `raster_tile_value` passes `raquet_pixels_size`, the size `raquet_make` allocated. `Raquet_constructor` already validates this same shape before building a raquet.

A regression test covers a pixel array smaller than its declared tile.
