### PR TITLE
Add the SRID function for the pcpatch type

### DIFF
--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -231,6 +231,8 @@ SELECT getDim(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]), 'X');
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]));
 -- 0
+SELECT SRID(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]), PC_MakePoint(1, ARRAY[11.0, 21.0, 31.0])]));
+-- 0
 </programlisting>
 				</listitem>
 			</itemizedlist>

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -233,6 +233,8 @@ SELECT getDim(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]), 'X');
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]));
 -- 0
+SELECT SRID(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]), PC_MakePoint(1, ARRAY[11.0, 21.0, 31.0])]));
+-- 0
 </programlisting>
 				</listitem>
 			</itemizedlist>

--- a/meos/src/geo/tspatial_srid.c
+++ b/meos/src/geo/tspatial_srid.c
@@ -61,6 +61,7 @@
 #endif
 #if POINTCLOUD
   #include "pointcloud/pcpoint.h"
+  #include "pointcloud/pcpatch.h"
   #include "pointcloud/meos_schema_hook.h"
 #endif
 #if POSE
@@ -75,6 +76,7 @@
 #endif
 #if POINTCLOUD
   #include "pointcloud/pcpoint.h"
+  #include "pointcloud/pcpatch.h"
   #include "pointcloud/meos_schema_hook.h"
 #endif
 
@@ -94,12 +96,15 @@
 int32_t
 spatial_srid(Datum d, MeosType basetype)
 {
-  /* T_PCPOINT is deliberately outside spatial_basetype(): the other
-   * spatial_* dispatchers have no pgpointcloud case, and deriving a
-   * pcpoint's flags needs its schema. Only the SRID is available without
-   * one, so it is admitted here rather than catalog-wide. */
+  /* T_PCPOINT and T_PCPATCH are deliberately outside spatial_basetype():
+   * the other spatial_* dispatchers have no pgpointcloud case, and
+   * deriving a pcpoint's or pcpatch's flags needs its schema. Only the
+   * SRID is available without one, since both carry the same pcid and
+   * resolve it through the same schema lookup, so the two are admitted
+   * here rather than catalog-wide. */
 #if POINTCLOUD
-  assert(spatial_basetype(basetype) || basetype == T_PCPOINT);
+  assert(spatial_basetype(basetype) || basetype == T_PCPOINT ||
+    basetype == T_PCPATCH);
 #else
   assert(spatial_basetype(basetype));
 #endif
@@ -130,6 +135,10 @@ spatial_srid(Datum d, MeosType basetype)
     case T_PCPOINT: {
       const Pcpoint *pt = DatumGetPcpointP(d);
       return meos_pc_schema_get_srid(pcpoint_get_pcid(pt));
+    }
+    case T_PCPATCH: {
+      const Pcpatch *pa = DatumGetPcpatchP(d);
+      return meos_pc_schema_get_srid(pcpatch_get_pcid(pa));
     }
 #endif
 #if QUADBIN

--- a/mobilitydb/pg_include/pg_pointcloud/doxygen_mobilitydb_pointcloud.h
+++ b/mobilitydb/pg_include/pg_pointcloud/doxygen_mobilitydb_pointcloud.h
@@ -72,7 +72,7 @@
  *
  * @defgroup mobilitydb_pointcloud_base_srid Spatial reference system functions
  * @ingroup mobilitydb_pointcloud_base
- * @brief Spatial reference system functions for pcpoint
+ * @brief Spatial reference system functions for pcpoint / pcpatch
  *
  * @defgroup mobilitydb_pointcloud_base_comp Comparison functions
  * @ingroup mobilitydb_pointcloud_base

--- a/mobilitydb/sql/pointcloud/400_pcset.in.sql
+++ b/mobilitydb/sql/pointcloud/400_pcset.in.sql
@@ -93,14 +93,19 @@ CREATE FUNCTION getDim(pcpoint, text)
 /******************************************************************************
  * SRID functions
  *
- * pcpoint only: deriving a pcpatch's flags needs its schema and only the
- * SRID is available without one (see the T_PCPOINT relaxation in MEOS
- * spatial_srid), but the pcpatch dispatch case itself is not implemented.
+ * pcpoint and pcpatch: deriving either type's flags needs its schema and
+ * only the SRID is available without one (see the T_PCPOINT / T_PCPATCH
+ * relaxation in MEOS spatial_srid).
  ******************************************************************************/
 
 CREATE FUNCTION SRID(pcpoint)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Pcpoint_srid'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION SRID(pcpatch)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Pcpatch_srid'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /******************************************************************************

--- a/mobilitydb/src/pointcloud/pcset.c
+++ b/mobilitydb/src/pointcloud/pcset.c
@@ -200,6 +200,22 @@ Pcpoint_srid(PG_FUNCTION_ARGS)
   PG_RETURN_INT32(srid);
 }
 
+PGDLLEXPORT Datum Pcpatch_srid(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Pcpatch_srid);
+/**
+ * @ingroup mobilitydb_pointcloud_base_srid
+ * @brief Return the SRID of a pcpatch
+ * @sqlfn SRID()
+ */
+Datum
+Pcpatch_srid(PG_FUNCTION_ARGS)
+{
+  Pcpatch *pa = PG_GETARG_PCPATCH_P(0);
+  int32_t srid = meos_pc_schema_get_srid(pcpatch_get_pcid(pa));
+  PG_FREE_IF_COPY(pa, 0);
+  PG_RETURN_INT32(srid);
+}
+
 /*****************************************************************************
  * Comparison functions for pcpoint
  *****************************************************************************/

--- a/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
+++ b/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
@@ -13,6 +13,19 @@ SELECT numPoints(tpcpatch(
  t
 (1 row)
 
+SELECT SRID(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)));
+ srid 
+------
+    0
+(1 row)
+
+SELECT SRID(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))) =
+  SRID(pcpoint(1, 1.0, 1.0, 1.0));
+ ?column? 
+----------
+ t
+(1 row)
+
 SELECT asText(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz)) = format('%s', tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz));
  ?column? 
 ----------

--- a/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
+++ b/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
@@ -38,6 +38,17 @@ SELECT numPoints(tpcpatch(
   '2024-01-01'::timestamptz)) = 2;
 
 -------------------------------------------------------------------------------
+-- SRID
+-------------------------------------------------------------------------------
+
+-- pcid 1 is registered with SRID 0 in the test fixture.
+SELECT SRID(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)));
+-- A patch and a point sharing the same pcid resolve the same SRID: both
+-- go through the same schema lookup.
+SELECT SRID(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))) =
+  SRID(pcpoint(1, 1.0, 1.0, 1.0));
+
+-------------------------------------------------------------------------------
 -- Text output
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
The pcpatch type provides the SRID function. The value resolves through the pcid's registered schema exactly as for pcpoint, and the spatial dispatch admits the type for the SRID read only, keeping every other spatial accessor schema-gated.
