### PR TITLE
Describe the accepted input form of the cell index types

### DIFF
--- a/doc/es/temporal_h3_index.xml
+++ b/doc/es/temporal_h3_index.xml
@@ -21,7 +21,7 @@
 
 	<sect1 xml:id="th3_inout">
 		<title>Entrada y Salida</title>
-		<para>Un valor <varname>th3index</varname> se introduce utilizando la sintaxis temporal estándar con el identificador de celda H3 de 64 bits subyacente. El analizador acepta tanto la forma hexadecimal canónica (la que produce la CLI de H3 y <varname>h3_cell_to_string</varname> en el proyecto original) como el equivalente en decimal sin signo. El hexadecimal es idiomático en el ecosistema H3 y es lo que emite la función de salida — todos los ejemplos siguientes lo usan. Como referencia, el valor hexadecimal <varname>831c02fffffffff</varname> empleado en los ejemplos corresponde al valor decimal <varname>590464338553208831</varname>.</para>
+		<para>Un valor <varname>th3index</varname> se introduce utilizando la sintaxis temporal estándar con el identificador de celda H3 de 64 bits subyacente. El analizador acepta la forma hexadecimal canónica (la que produce la CLI de H3 y <varname>h3_cell_to_string</varname> en el proyecto original), con un prefijo <varname>0x</varname> opcional, tal como la lee la propia biblioteca H3. El hexadecimal es idiomático en el ecosistema H3 y es lo que emite la función de salida — todos los ejemplos siguientes lo usan.</para>
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3index '831c02fffffffff@2001-01-01';
 SELECT th3index '{831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02}';
@@ -897,7 +897,7 @@ CREATE INDEX ON trips USING spgist(cells th3_kdtree_ops);
 			<title>Durabilidad y almacenamiento</title>
 			<para>La representación en disco de <varname>th3index</varname> es byte a byte idéntica a la de <varname>tbigint</varname> (cada instante lleva un ID de celda H3 de 64 bits más una marca de tiempo). Consecuencias para la planificación del almacenamiento:</para>
 			<itemizedlist>
-				<listitem><para><emphasis>WKT</emphasis> mediante <varname>th3_in</varname> y <varname>th3_out</varname>. Las celdas se representan como cadenas hexadecimales canónicas (p. ej. <varname>'8928308280fffff'</varname>); se aceptan tanto decimal como hexadecimal en la entrada. El ciclo de ida y vuelta es estable a nivel de bits.</para></listitem>
+				<listitem><para><emphasis>WKT</emphasis> mediante <varname>th3_in</varname> y <varname>th3_out</varname>. Las celdas se representan como cadenas hexadecimales canónicas (p. ej. <varname>'8928308280fffff'</varname>), que es también la forma aceptada en la entrada. El ciclo de ida y vuelta es estable a nivel de bits.</para></listitem>
 				<listitem><para><emphasis>WKB / EWKB / HexWKB</emphasis> mediante el patrón estándar de PostGIS de bandera de endianidad seguida de la carga útil. Estable entre versiones mayores de PostgreSQL.</para></listitem>
 				<listitem><para><emphasis>MFJSON</emphasis> mediante <varname>asMFJSON(th3index)</varname> y <varname>th3indexFromMFJSON(text)</varname>. La carga útil de la celda se representa como el identificador int64 de la celda en el arreglo <varname>values</varname>, la misma representación que utiliza <varname>tbigint</varname>; los consumidores que necesiten la forma hexadecimal canónica aplican <varname>h3_cell_to_string</varname>.</para></listitem>
 				<listitem><para><emphasis>pg_dump</emphasis> usa WKT en modo plano y WKB bajo <varname>--binary-upgrade</varname>; ambos realizan el ciclo de ida y vuelta limpiamente.</para></listitem>

--- a/doc/es/temporal_quadbin_index.xml
+++ b/doc/es/temporal_quadbin_index.xml
@@ -21,7 +21,7 @@
 
 	<sect1 xml:id="tquadbin_inout">
 		<title>Entrada y Salida</title>
-		<para>Un valor <varname>tquadbin</varname> se introduce utilizando la sintaxis temporal estándar con el identificador de celda QUADBIN de 64 bits subyacente. El analizador acepta tanto la forma hexadecimal canónica como el equivalente en decimal sin signo. El hexadecimal es idiomático en el ecosistema QUADBIN y es lo que emite la función de salida — todos los ejemplos siguientes lo usan. Como referencia, el valor hexadecimal <varname>480fffffffffffff</varname> empleado en los ejemplos es la celda mundial de resolución 0, igual al valor decimal <varname>5192650370358181887</varname>.</para>
+		<para>Un valor <varname>tquadbin</varname> se introduce utilizando la sintaxis temporal estándar con el identificador de celda QUADBIN de 64 bits subyacente. El analizador acepta la forma hexadecimal canónica, con un prefijo <varname>0x</varname> opcional, en cualquiera de las dos cajas de letra, tal como la lee la implementación de referencia de CARTO. El hexadecimal es idiomático en el ecosistema QUADBIN y es lo que emite la función de salida — todos los ejemplos siguientes lo usan. Como referencia, el valor hexadecimal <varname>480fffffffffffff</varname> empleado en los ejemplos es la celda mundial de resolución 0, igual al valor decimal <varname>5192650370358181887</varname>.</para>
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tquadbin '480fffffffffffff@2001-01-01';
 SELECT tquadbin '{480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02}';
@@ -430,7 +430,7 @@ CREATE INDEX ON trips USING hash(cells);        -- usa tquadbin_hash_ops por def
 			<title>Durabilidad y almacenamiento</title>
 			<para>La representación en disco de <varname>tquadbin</varname> es idéntica byte a byte a la de <varname>tbigint</varname> (cada instante lleva un ID de celda QUADBIN de 64 bits más una marca de tiempo). Consecuencias para la planificación del almacenamiento:</para>
 			<itemizedlist>
-				<listitem><para><emphasis>WKT</emphasis> vía <varname>tquadbin_in</varname> y la función de salida temporal. Las celdas se representan como cadenas hexadecimales canónicas (por ejemplo, <varname>'480fffffffffffff'</varname>); se aceptan tanto decimal como hexadecimal en la entrada. El ciclo de ida y vuelta es estable a nivel de bits.</para></listitem>
+				<listitem><para><emphasis>WKT</emphasis> vía <varname>tquadbin_in</varname> y la función de salida temporal. Las celdas se representan como cadenas hexadecimales canónicas (por ejemplo, <varname>'480fffffffffffff'</varname>), que es también la forma aceptada en la entrada. El ciclo de ida y vuelta es estable a nivel de bits.</para></listitem>
 				<listitem><para><emphasis>WKB / EWKB / HexWKB</emphasis> vía el patrón estándar de PostGIS de bandera de endianness seguida de la carga útil. Estable entre versiones mayores de PostgreSQL.</para></listitem>
 				<listitem><para><emphasis>pg_dump</emphasis> usa WKT en modo plano y WKB bajo <varname>--binary-upgrade</varname>; ambos completan el ciclo de ida y vuelta limpiamente.</para></listitem>
 				<listitem><para><emphasis>Conversión cruzada con <varname>tbigint</varname></emphasis>: las conversiones bidireccionales <varname>tquadbin :: tbigint</varname> son reinterpretaciones bit a bit sin coste. Úselas cuando trabaje con vistas seguras por tipo (<varname>tquadbin</varname>) y aptas para aritmética (<varname>tbigint</varname>) de la misma trayectoria en una sola consulta.</para></listitem>

--- a/doc/temporal_h3_index.xml
+++ b/doc/temporal_h3_index.xml
@@ -21,7 +21,7 @@
 
 	<sect1 xml:id="th3_inout">
 		<title>Input and Output</title>
-		<para>A <varname>th3index</varname> value is entered using the standard temporal syntax with the underlying 64-bit H3 cell identifier. The input parser accepts both the canonical hexadecimal form (as produced by the H3 CLI and by <varname>h3_cell_to_string</varname> upstream) and the equivalent unsigned decimal. Hexadecimal is idiomatic in the H3 ecosystem and is what the output function emits — all examples below use it. For reference, the hex value <varname>831c02fffffffff</varname> used in the examples corresponds to the decimal value <varname>590464338553208831</varname>.</para>
+		<para>A <varname>th3index</varname> value is entered using the standard temporal syntax with the underlying 64-bit H3 cell identifier. The input parser accepts the canonical hexadecimal form (as produced by the H3 CLI and by <varname>h3_cell_to_string</varname> upstream), with an optional <varname>0x</varname> prefix, as the H3 library itself reads it. Hexadecimal is idiomatic in the H3 ecosystem and is what the output function emits — all examples below use it.</para>
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3index '831c02fffffffff@2001-01-01';
 SELECT th3index '{831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02}';
@@ -915,7 +915,7 @@ CREATE INDEX ON trips USING spgist(cells th3_kdtree_ops);
 			<title>Durability and storage</title>
 			<para>The on-disk representation of <varname>th3index</varname> is byte-identical to <varname>tbigint</varname> (each instant carries one 64-bit H3 cell ID plus a timestamp). Consequences for storage planning:</para>
 			<itemizedlist>
-				<listitem><para><emphasis>WKT</emphasis> via <varname>th3_in</varname> and <varname>th3_out</varname>. Cells render as canonical hex strings (e.g. <varname>'8928308280fffff'</varname>); both decimal and hex are accepted on input. Round-trip is bit-stable.</para></listitem>
+				<listitem><para><emphasis>WKT</emphasis> via <varname>th3_in</varname> and <varname>th3_out</varname>. Cells render as canonical hex strings (e.g. <varname>'8928308280fffff'</varname>), which is also the form accepted on input. Round-trip is bit-stable.</para></listitem>
 				<listitem><para><emphasis>WKB / EWKB / HexWKB</emphasis> via the standard PostGIS endian-flag-then-payload pattern. Stable across PostgreSQL major versions.</para></listitem>
 				<listitem><para><emphasis>MFJSON</emphasis> via <varname>asMFJSON(th3index)</varname> and <varname>th3indexFromMFJSON(text)</varname>. The cell payload renders as the int64 cell identifier in the <varname>values</varname> array, the same representation carried by <varname>tbigint</varname>; consumers that need the canonical hex form apply <varname>h3_cell_to_string</varname>.</para></listitem>
 				<listitem><para><emphasis>pg_dump</emphasis> uses WKT in plain mode and WKB under <varname>--binary-upgrade</varname>; both round-trip cleanly.</para></listitem>

--- a/doc/temporal_quadbin_index.xml
+++ b/doc/temporal_quadbin_index.xml
@@ -21,7 +21,7 @@
 
 	<sect1 xml:id="tquadbin_inout">
 		<title>Input and Output</title>
-		<para>A <varname>tquadbin</varname> value is entered using the standard temporal syntax with the underlying 64-bit QUADBIN cell identifier. The input parser accepts both the canonical hexadecimal form and the equivalent unsigned decimal. Hexadecimal is idiomatic in the QUADBIN ecosystem and is what the output function emits — all examples below use it. For reference, the hex value <varname>480fffffffffffff</varname> used in the examples is the resolution-0 world cell, equal to the decimal value <varname>5192650370358181887</varname>.</para>
+		<para>A <varname>tquadbin</varname> value is entered using the standard temporal syntax with the underlying 64-bit QUADBIN cell identifier. The input parser accepts the canonical hexadecimal form, with an optional <varname>0x</varname> prefix, in either letter case, as the CARTO reference implementation reads it. Hexadecimal is idiomatic in the QUADBIN ecosystem and is what the output function emits — all examples below use it. For reference, the hex value <varname>480fffffffffffff</varname> used in the examples is the resolution-0 world cell, equal to the decimal value <varname>5192650370358181887</varname>.</para>
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tquadbin '480fffffffffffff@2001-01-01';
 SELECT tquadbin '{480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02}';
@@ -430,7 +430,7 @@ CREATE INDEX ON trips USING hash(cells);        -- uses tquadbin_hash_ops by def
 			<title>Durability and storage</title>
 			<para>The on-disk representation of <varname>tquadbin</varname> is byte-identical to <varname>tbigint</varname> (each instant carries one 64-bit QUADBIN cell ID plus a timestamp). Consequences for storage planning:</para>
 			<itemizedlist>
-				<listitem><para><emphasis>WKT</emphasis> via <varname>tquadbin_in</varname> and the temporal output function. Cells render as canonical hex strings (e.g. <varname>'480fffffffffffff'</varname>); both decimal and hex are accepted on input. Round-trip is bit-stable.</para></listitem>
+				<listitem><para><emphasis>WKT</emphasis> via <varname>tquadbin_in</varname> and the temporal output function. Cells render as canonical hex strings (e.g. <varname>'480fffffffffffff'</varname>), which is also the form accepted on input. Round-trip is bit-stable.</para></listitem>
 				<listitem><para><emphasis>WKB / EWKB / HexWKB</emphasis> via the standard PostGIS endian-flag-then-payload pattern. Stable across PostgreSQL major versions.</para></listitem>
 				<listitem><para><emphasis>pg_dump</emphasis> uses WKT in plain mode and WKB under <varname>--binary-upgrade</varname>; both round-trip cleanly.</para></listitem>
 				<listitem><para><emphasis>Cross-cast with <varname>tbigint</varname></emphasis>: the bidirectional <varname>tquadbin :: tbigint</varname> casts are zero-cost bitwise reinterpretations. Use them when working with both type-safe (<varname>tquadbin</varname>) and arithmetic-friendly (<varname>tbigint</varname>) views of the same trajectory in a single query.</para></listitem>

--- a/meos/include/h3/h3index.h
+++ b/meos/include/h3/h3index.h
@@ -37,7 +37,8 @@
  * compound payload (it is a 64-bit integer cell identifier), so
  * the helpers here are minimal:
  *
- *   * an input parser that accepts both decimal and hex strings,
+ *   * an input parser that delegates to the h3 library, which reads the
+ *     canonical hexadecimal cell literal with an optional "0x" prefix,
  *   * an output formatter (canonical form is hex, matching h3-pg),
  *   * comparison / ordering / hashing helpers — exposed at the MEOS
  *     layer so MobilityDuck and other consumers can reuse them

--- a/mobilitydb/sql/h3/251_h3indexset.in.sql
+++ b/mobilitydb/sql/h3/251_h3indexset.in.sql
@@ -35,7 +35,7 @@
  * Every C call routes to a generic `Set_*` symbol. The dispatch
  * arms in `type_in.c` / `type_out.c` (basetype_in / basetype_out
  * cases for T_H3INDEX) make the generic Set parser and formatter
- * use h3index_parse / h3index_to_string for elements.
+ * use h3index_in / h3index_out for elements.
  */
 
 /******************************************************************************

--- a/mobilitydb/test/h3/queries/251_h3indexset.test.sql
+++ b/mobilitydb/test/h3/queries/251_h3indexset.test.sql
@@ -9,7 +9,7 @@
 -- h3indexset — set of h3 cells. All operations delegate to
 -- the generic Set_* C symbols; the dispatch arms in basetype_in /
 -- basetype_out (catalog work) make the per-element parser
--- and formatter route through h3index_parse / h3index_to_string.
+-- and formatter route through h3index_in / h3index_out.
 
 -------------------------------------------------------------------------------
 -- Input / Output
@@ -20,7 +20,9 @@ SELECT h3indexset '{8a2a1072b59ffff, 831c02fffffffff, 880326b885fffff}';
 -- Singleton
 SELECT h3indexset '{8a2a1072b59ffff}';
 
--- Decimal element form is also accepted (h3index_parse handles both)
+-- The h3 library reads a cell literal as hexadecimal, so the decimal
+-- spelling of a cell is read as hex, exceeds 64 bits, and reaches the
+-- cell lookup as the saturated value
 SELECT h3indexset '{622236750694711295}';
 
 /* Errors */


### PR DESCRIPTION
Describes the input form that the h3index and quadbin parsers accept.

Both types read a hexadecimal cell literal, with an optional `0x` prefix. The h3index parser delegates to the h3 library, whose `stringToH3` converts the canonical string format, and the quadbin parser reads base 16, as the CARTO reference implementation `quadbin-py` does with `int(index, base=16)`. An unsigned decimal spelling is not an accepted input form for either.

The English and Spanish chapters of both types state that the parser also accepts the decimal form, wording that describes an input parser reading both bases which the delegation to the h3 library replaced. The `h3indexset` file and its test name that parser as `h3index_parse` and `h3index_to_string`, which are now `h3index_in` and `h3index_out`.

The parsers themselves are unchanged: the accepted input stays what the h3 library and the CARTO reference implementation define.
