### PR TITLE
Export the pixel type size and add a pixel type name parser

### DIFF
--- a/meos/include/meos_raster.h
+++ b/meos/include/meos_raster.h
@@ -65,6 +65,11 @@ typedef enum
   MEOS_PT_FLOAT64 = 4,   /**< 64-bit IEEE double      */
 } MeosPixType;
 
+/* Pixel type utility functions */
+
+extern size_t raquet_pixtype_size(MeosPixType pixtype);
+extern MeosPixType raquet_pixtype_from_string(const char *str);
+
 /* Opaque structure to represent a Raquet raster tile */
 
 typedef struct Raquet Raquet;

--- a/meos/include/raster/raquet.h
+++ b/meos/include/raster/raquet.h
@@ -94,23 +94,6 @@ extern void raquet_set_stbox(const Raquet *rq, STBox *box);
  *****************************************************************************/
 
 /**
- * @brief Return the size in bytes of a single pixel of the given type
- */
-static inline size_t
-raquet_pixtype_size(MeosPixType pixtype)
-{
-  switch (pixtype)
-  {
-    case MEOS_PT_UINT8:   return 1;
-    case MEOS_PT_INT16:   return 2;
-    case MEOS_PT_INT32:   return 4;
-    case MEOS_PT_FLOAT32: return 4;
-    case MEOS_PT_FLOAT64: return 8;
-    default:              return 0;
-  }
-}
-
-/**
  * @brief Return the number of pixel bytes of a Raquet tile
  */
 static inline size_t

--- a/meos/src/raster/raquet.c
+++ b/meos/src/raster/raquet.c
@@ -81,6 +81,50 @@ ensure_valid_pixtype(uint8 pixtype)
 }
 
 /*****************************************************************************
+ * Pixel type functions
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_raster_base_accessor
+ * @brief Return the size in bytes of a single pixel of the given type
+ * @param[in] pixtype Pixel data type
+ */
+size_t
+raquet_pixtype_size(MeosPixType pixtype)
+{
+  switch (pixtype)
+  {
+    case MEOS_PT_UINT8:   return 1;
+    case MEOS_PT_INT16:   return 2;
+    case MEOS_PT_INT32:   return 4;
+    case MEOS_PT_FLOAT32: return 4;
+    case MEOS_PT_FLOAT64: return 8;
+    default:              return 0;
+  }
+}
+
+/**
+ * @ingroup meos_raster_base_accessor
+ * @brief Return the pixel data type corresponding to a name
+ * @param[in] str Pixel type name: UINT8, INT16, INT32, FLOAT32, or FLOAT64
+ * @note This is the parser counterpart of #raquet_pixtype()
+ */
+MeosPixType
+raquet_pixtype_from_string(const char *str)
+{
+  VALIDATE_NOT_NULL(str, MEOS_PT_UINT8);
+  if (strcmp(str, "UINT8") == 0)   return MEOS_PT_UINT8;
+  if (strcmp(str, "INT16") == 0)   return MEOS_PT_INT16;
+  if (strcmp(str, "INT32") == 0)   return MEOS_PT_INT32;
+  if (strcmp(str, "FLOAT32") == 0) return MEOS_PT_FLOAT32;
+  if (strcmp(str, "FLOAT64") == 0) return MEOS_PT_FLOAT64;
+  meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+    "Unknown pixel type \"%s\": use UINT8, INT16, INT32, FLOAT32, or FLOAT64",
+    str);
+  return MEOS_PT_UINT8; /* make compiler quiet */
+}
+
+/*****************************************************************************
  * Input/output functions
  *****************************************************************************/
 

--- a/mobilitydb/src/raster/temporal_raster.c
+++ b/mobilitydb/src/raster/temporal_raster.c
@@ -58,6 +58,7 @@
  */
 extern Datum regprocedurein(PG_FUNCTION_ARGS);
 extern text *cstring_to_text(const char *s);
+extern char *text_to_cstring(const text *t);
 /* PostgreSQL array support (does not pull in fmgrprotos.h) */
 #include <utils/array.h>
 /* PostGIS liblwgeom (vendored) */
@@ -360,18 +361,10 @@ Araster_value(PG_FUNCTION_ARGS)
 static MeosPixType
 text_to_pixtype(const text *pt)
 {
-  const char *s   = VARDATA_ANY(pt);
-  int         len = (int) VARSIZE_ANY_EXHDR(pt);
-  if (len == 5 && strncmp(s, "UINT8",   5) == 0) return MEOS_PT_UINT8;
-  if (len == 5 && strncmp(s, "INT16",   5) == 0) return MEOS_PT_INT16;
-  if (len == 5 && strncmp(s, "INT32",   5) == 0) return MEOS_PT_INT32;
-  if (len == 7 && strncmp(s, "FLOAT32", 7) == 0) return MEOS_PT_FLOAT32;
-  if (len == 7 && strncmp(s, "FLOAT64", 7) == 0) return MEOS_PT_FLOAT64;
-  ereport(ERROR,
-    (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-     errmsg("unknown pixel type \"%.*s\": use UINT8, INT16, INT32, FLOAT32, "
-            "or FLOAT64", len, s)));
-  return MEOS_PT_UINT8; /* unreachable */
+  char *s = text_to_cstring(pt);
+  MeosPixType result = raquet_pixtype_from_string(s);
+  pfree(s);
+  return result;
 }
 
 PGDLLEXPORT Datum Raster_tile_value_quadbin(PG_FUNCTION_ARGS);


### PR DESCRIPTION
Exports `raquet_pixtype_size` and adds `raquet_pixtype_from_string`, so a consumer of the raster family reaches the pixel type size and the pixel type name through MEOS.

`raquet_pixtype_size` returns the byte size of a single pixel of a given type and lives in an internal header, so a binding that sizes a pixel band restates its switch. Declaring it in `meos_raster.h` puts it beside the raquet accessors that consumers already reach.

MEOS renders a pixel type as its name and, until now, reads none back, so a caller holding the name of a pixel type has no way to obtain the enumerator. `raquet_pixtype_from_string` reads the name, following the `interptype_from_string` and `tempsubtype_from_string` spelling of the other enumeration parsers.

The PostgreSQL wrapper takes its pixel type through the parser rather than carrying a second copy of the name table.
