### PR TITLE
Share the temporal-to-bbox split and bbox-type compatibility helpers between the RTree and SPTree in-memory indexes

### DIFF
--- a/meos/include/meos_internal.h
+++ b/meos/include/meos_internal.h
@@ -945,6 +945,10 @@ extern bool temporal_bbox_eq(const void *box1, const void *box2,
   MeosType temptype);
 extern int temporal_bbox_cmp(const void *box1, const void *box2,
   MeosType temptype);
+extern bool ensure_bbox_temporal_compatible(MeosType bboxtype,
+  const Temporal *temp);
+extern void *bbox_temporal_split_boxes(MeosType bboxtype, size_t boxsize,
+  const Temporal *temp, int maxboxes, int *count);
 
 /* Set functions for set and span types */
 

--- a/meos/src/temporal/temporal_boxops.c
+++ b/meos/src/temporal/temporal_boxops.c
@@ -176,6 +176,100 @@ temporal_bbox_cmp(const void *box1, const void *box2, MeosType temptype)
     return stbox_cmp((STBox *) box1, (STBox *) box2);
 }
 
+/**
+ * @brief Return true if the bounding box type is compatible with the
+ * temporal type, report an error otherwise
+ * @details Shared by the in-memory RTree and SPTree indexes: temporal alphas
+ * (tbool, ttext) require a span bounding box, temporal numbers (tint,
+ * tfloat) require a TBox, spatiotemporal types (tgeompoint, tgeogpoint,
+ * etc.) require an STBox, and, when POINTCLOUD is enabled, temporal point
+ * clouds (tpcpoint, tpcpatch) require a TPCBox.
+ * @param[in] bboxtype Bounding box type of the index
+ * @param[in] temp Temporal value
+ */
+bool
+ensure_bbox_temporal_compatible(MeosType bboxtype, const Temporal *temp)
+{
+  assert(temp);
+  MeosType temptype = temp->temptype;
+  bool compatible =
+    (talpha_type(temptype) && bboxtype == T_TSTZSPAN) ||
+    (tnumber_type(temptype) && bboxtype == T_TBOX) ||
+    (tspatial_type(temptype) && bboxtype == T_STBOX)
+#if POINTCLOUD
+    || (tpointcloud_temptype(temptype) && bboxtype == T_TPCBOX)
+#endif
+    ;
+  if (! compatible)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_TYPE,
+      "Bounding box type (%s) is not compatible with temporal type (%s)",
+      meostype_name(bboxtype), meostype_name(temptype));
+    return false;
+  }
+  return true;
+}
+
+/**
+ * @brief Decompose a temporal value into an array of tight per-segment
+ * bounding boxes whose element type matches the given bounding box type
+ * @details Shared by the in-memory RTree and SPTree indexes. The
+ * decomposition reuses the same per-segment bounding box machinery as the
+ * single-box path: temporal alphas are split with #temporal_split_n_spans,
+ * temporal numbers with #tnumber_split_n_tboxes, and temporal geos with
+ * #tgeo_split_n_stboxes. These already handle the TINSTANT, TSEQUENCE and
+ * TSEQUENCESET subtypes, the discrete, step and linear interpolations, and
+ * the Z, geodetic and SRID flags, and coarsen by merging adjacent segment
+ * boxes (deterministic chunking) down to at most `maxboxes` boxes. When
+ * `maxboxes <= 1`, the temporal value is an instant, or the temporal type
+ * has no per-segment splitter (e.g. tcbuffer, tnpoint, tpose, tpcpoint,
+ * tpcpatch), the function degenerates to the single minimum bounding box,
+ * byte-identical to the result of #temporal_set_bbox.
+ * @param[in] bboxtype Bounding box type of the index (unused for the
+ * multi-box decomposition, kept for symmetry with the compatibility check
+ * and for the assertion below)
+ * @param[in] boxsize Size in bytes of a single bounding box allocated for
+ * the degenerate/fallback single-box result; the caller passes a size large
+ * enough to hold #temporal_set_bbox's output for `temp`, which may differ
+ * from the index's own per-entry box size (e.g. an index that internally
+ * projects a larger box type onto a smaller one)
+ * @param[in] temp Temporal value to decompose
+ * @param[in] maxboxes Maximum number of boxes produced for `temp`
+ * @param[out] count Number of boxes in the returned array
+ * @return Allocated array of `*count` bounding boxes, or @p NULL on error
+ * @pre `temp` is compatible with `bboxtype` (verified by the callers)
+ */
+void *
+bbox_temporal_split_boxes(MeosType bboxtype UNUSED, size_t boxsize,
+  const Temporal *temp, int maxboxes, int *count)
+{
+  assert(bbox_type(bboxtype)); assert(temp); assert(count);
+
+  /* Degenerate single minimum bounding box */
+  if (maxboxes <= 1 || temp->subtype == TINSTANT)
+  {
+    void *result = palloc0(boxsize);
+    temporal_set_bbox(temp, result);
+    *count = 1;
+    return result;
+  }
+
+  /* Multi-box decomposition reusing the existing per-type splitters */
+  MeosType temptype = temp->temptype;
+  if (talpha_type(temptype))
+    return temporal_split_n_spans(temp, maxboxes, count);
+  if (tnumber_type(temptype))
+    return tnumber_split_n_tboxes(temp, maxboxes, count);
+  if (tgeo_type_all(temptype))
+    return tgeo_split_n_stboxes(temp, maxboxes, count);
+
+  /* No per-segment splitter: fall back to the single minimum bounding box */
+  void *result = palloc0(boxsize);
+  temporal_set_bbox(temp, result);
+  *count = 1;
+  return result;
+}
+
 /*****************************************************************************
  * Compute the bounding box at the creation of temporal values
  *****************************************************************************/

--- a/meos/src/temporal/temporal_rtree.c
+++ b/meos/src/temporal/temporal_rtree.c
@@ -1066,34 +1066,6 @@ rtree_search(const RTree *rtree, RTreeSearchOp op, const void *query,
 }
 
 /**
- * @brief Return true if the RTree's bounding box type is compatible with the
- * temporal type, report an error otherwise
- * @param[in] rtree Pointer to the RTree structure
- * @param[in] temp Temporal value
- */
-static bool
-ensure_rtree_temporal_compatible(const RTree *rtree, const Temporal *temp)
-{
-  MeosType temptype = temp->temptype;
-  bool compatible =
-    (talpha_type(temptype) && rtree->bboxtype == T_TSTZSPAN) ||
-    (tnumber_type(temptype) && rtree->bboxtype == T_TBOX) ||
-    (tspatial_type(temptype) && rtree->bboxtype == T_STBOX)
-#if POINTCLOUD
-    || (tpointcloud_temptype(temptype) && rtree->bboxtype == T_TPCBOX)
-#endif
-    ;
-  if (! compatible)
-  {
-    meos_error(ERROR, MEOS_ERR_INVALID_ARG_TYPE,
-      "RTree bounding box type (%s) is not compatible with temporal type (%s)",
-      meostype_name(rtree->bboxtype), meostype_name(temptype));
-    return false;
-  }
-  return true;
-}
-
-/**
  * @ingroup meos_temporal_box_index
  * @brief Insert a temporal value into the RTree index
  * @details The bounding box is automatically extracted from the temporal value.
@@ -1108,7 +1080,7 @@ ensure_rtree_temporal_compatible(const RTree *rtree, const Temporal *temp)
 void
 rtree_insert_temporal(RTree *rtree, const Temporal *temp, int id)
 {
-  if (! ensure_rtree_temporal_compatible(rtree, temp))
+  if (! ensure_bbox_temporal_compatible(rtree->bboxtype, temp))
     return;
   /* Use a stack buffer large enough for any MEOS bounding box type */
   bboxunion buf;
@@ -1134,7 +1106,7 @@ int
 rtree_search_temporal(const RTree *rtree, RTreeSearchOp op,
   const Temporal *temp, MeosArray *result)
 {
-  if (! ensure_rtree_temporal_compatible(rtree, temp))
+  if (! ensure_bbox_temporal_compatible(rtree->bboxtype, temp))
   {
     meos_array_reset(result);
     return 0;
@@ -1157,63 +1129,6 @@ rtree_search_temporal(const RTree *rtree, RTreeSearchOp op,
  * additive: #rtree_insert, #rtree_insert_temporal, #rtree_search and
  * #rtree_search_temporal keep their exact semantics.
  *****************************************************************************/
-
-/**
- * @brief Decompose a temporal value into an array of tight per-segment
- * bounding boxes whose element type matches the RTree's bounding box type
- * @details The decomposition reuses the same per-segment bounding box
- * machinery as the single-box path: temporal alphas are split with
- * #temporal_split_n_spans, temporal numbers with #tnumber_split_n_tboxes, and
- * temporal geos with #tgeo_split_n_stboxes. These already handle the TINSTANT,
- * TSEQUENCE and TSEQUENCESET subtypes, the discrete, step and linear
- * interpolations, and the Z, geodetic and SRID flags through the same
- * `tspatialinst_set_stbox` / `tnumberinst_set_tbox` / span machinery used by
- * #temporal_set_bbox, and coarsen by merging adjacent segment boxes
- * (deterministic chunking) down to at most `maxboxes` boxes. When
- * `maxboxes <= 1`, the temporal value is an instant, or the spatial type is
- * not a temporal geo (e.g. tcbuffer, tnpoint, tpose), the function degenerates
- * to the single minimum bounding box, byte-identical to the result of
- * #temporal_set_bbox used by #rtree_insert_temporal.
- * @param[in] rtree The RTree whose bounding box type drives the element type
- * @param[in] temp The temporal value to decompose
- * @param[in] maxboxes Maximum number of boxes produced for `temp`
- * @param[out] count Number of boxes in the returned array
- * @return Newly allocated array of `*count` bounding boxes, each of
- * `rtree->bboxsize` bytes, or @p NULL on error
- * @pre `temp` is compatible with `rtree` (verified by the callers)
- */
-static void *
-rtree_temporal_split_boxes(const RTree *rtree, const Temporal *temp,
-  int maxboxes, int *count)
-{
-  assert(rtree); assert(temp); assert(count);
-
-  /* Degenerate single minimum bounding box: identical to the behaviour of
-   * rtree_insert_temporal / rtree_search_temporal */
-  if (maxboxes <= 1 || temp->subtype == TINSTANT)
-  {
-    void *result = palloc0(rtree->bboxsize);
-    temporal_set_bbox(temp, result);
-    *count = 1;
-    return result;
-  }
-
-  /* Multi-box decomposition reusing the existing per-type splitters */
-  MeosType temptype = temp->temptype;
-  if (talpha_type(temptype))
-    return temporal_split_n_spans(temp, maxboxes, count);
-  if (tnumber_type(temptype))
-    return tnumber_split_n_tboxes(temp, maxboxes, count);
-  if (tgeo_type_all(temptype))
-    return tgeo_split_n_stboxes(temp, maxboxes, count);
-
-  /* Spatial types without a per-segment STBox splitter (e.g. tcbuffer,
-   * tnpoint, tpose): fall back to the single minimum bounding box */
-  void *result = palloc0(rtree->bboxsize);
-  temporal_set_bbox(temp, result);
-  *count = 1;
-  return result;
-}
 
 /**
  * @ingroup meos_temporal_box_index
@@ -1245,10 +1160,10 @@ void
 rtree_insert_temporal_split(RTree *rtree, const Temporal *temp, int id,
   int maxboxes)
 {
-  if (! ensure_rtree_temporal_compatible(rtree, temp))
+  if (! ensure_bbox_temporal_compatible(rtree->bboxtype, temp))
     return;
   int count;
-  void *boxes = rtree_temporal_split_boxes(rtree, temp, maxboxes, &count);
+  void *boxes = bbox_temporal_split_boxes(rtree->bboxtype, rtree->bboxsize, temp, maxboxes, &count);
   if (! boxes)
     return;
   for (int i = 0; i < count; i++)
@@ -1284,11 +1199,11 @@ rtree_search_temporal_dedup(const RTree *rtree, RTreeSearchOp op,
   const Temporal *temp, int maxboxes, MeosArray *result)
 {
   meos_array_reset(result);
-  if (! ensure_rtree_temporal_compatible(rtree, temp))
+  if (! ensure_bbox_temporal_compatible(rtree->bboxtype, temp))
     return 0;
 
   int count;
-  void *boxes = rtree_temporal_split_boxes(rtree, temp, maxboxes, &count);
+  void *boxes = bbox_temporal_split_boxes(rtree->bboxtype, rtree->bboxsize, temp, maxboxes, &count);
   if (! boxes)
     return 0;
 

--- a/meos/src/temporal/temporal_sptree.c
+++ b/meos/src/temporal/temporal_sptree.c
@@ -584,34 +584,6 @@ sptree_search(const SPTree *sptree, RTreeSearchOp op, const void *query,
  *****************************************************************************/
 
 /**
- * @brief Return true if the SPTree's bounding box type is compatible with the
- * temporal type, report an error otherwise
- * @param[in] sptree Pointer to the SPTree structure
- * @param[in] temp Temporal value
- */
-static bool
-ensure_sptree_temporal_compatible(const SPTree *sptree, const Temporal *temp)
-{
-  MeosType temptype = temp->temptype;
-  bool compatible =
-    (talpha_type(temptype) && sptree->bboxtype == T_TSTZSPAN) ||
-    (tnumber_type(temptype) && sptree->bboxtype == T_TBOX) ||
-    (tspatial_type(temptype) && sptree->bboxtype == T_STBOX)
-#if POINTCLOUD
-    || (tpointcloud_temptype(temptype) && sptree->bboxtype == T_TPCBOX)
-#endif
-    ;
-  if (! compatible)
-  {
-    meos_error(ERROR, MEOS_ERR_INVALID_ARG_TYPE,
-      "SPTree bounding box type (%s) is not compatible with temporal type (%s)",
-      meostype_name(sptree->bboxtype), meostype_name(temptype));
-    return false;
-  }
-  return true;
-}
-
-/**
  * @ingroup meos_temporal_box_index
  * @brief Insert a temporal value into an in-memory space-partitioning index
  * @details The bounding box is automatically extracted from the temporal value.
@@ -625,7 +597,7 @@ ensure_sptree_temporal_compatible(const SPTree *sptree, const Temporal *temp)
 void
 sptree_insert_temporal(SPTree *sptree, const Temporal *temp, int id)
 {
-  if (! ensure_sptree_temporal_compatible(sptree, temp))
+  if (! ensure_bbox_temporal_compatible(sptree->bboxtype, temp))
     return;
   /* Use a stack buffer large enough for any MEOS bounding box type */
   bboxunion buf;
@@ -651,7 +623,7 @@ int
 sptree_search_temporal(const SPTree *sptree, RTreeSearchOp op,
   const Temporal *temp, MeosArray *result)
 {
-  if (! ensure_sptree_temporal_compatible(sptree, temp))
+  if (! ensure_bbox_temporal_compatible(sptree->bboxtype, temp))
   {
     meos_array_reset(result);
     return 0;
@@ -661,57 +633,6 @@ sptree_search_temporal(const SPTree *sptree, RTreeSearchOp op,
   memset(&buf, 0, sizeof(buf));
   temporal_set_bbox(temp, &buf);
   return sptree_search(sptree, op, &buf, result);
-}
-
-/**
- * @brief Decompose a temporal value into an array of tight per-segment
- * bounding boxes whose element type matches the SPTree's bounding box type
- * @details The decomposition reuses the same per-segment machinery as the
- * single-box path: temporal alphas are split with #temporal_split_n_spans and
- * temporal numbers with #tnumber_split_n_tboxes. When `maxboxes <= 1` or the
- * temporal value is an instant, the function degenerates to the single minimum
- * bounding box, byte-identical to the result of #temporal_set_bbox used by
- * #sptree_insert_temporal.
- * @param[in] sptree The SPTree whose bounding box type drives the element type
- * @param[in] temp The temporal value to decompose
- * @param[in] maxboxes Maximum number of boxes produced for `temp`
- * @param[out] count Number of boxes in the returned array
- * @return Allocated array of `*count` bounding boxes, each of `sptree->boxsize`
- * bytes
- * @pre `temp` is compatible with `sptree` (verified by the callers)
- */
-static void *
-sptree_temporal_split_boxes(const SPTree *sptree UNUSED, const Temporal *temp,
-  int maxboxes, int *count)
-{
-  assert(sptree); assert(temp); assert(count);
-
-  /* Degenerate single minimum bounding box. The allocation is sized for any
-   * MEOS bounding box type because the temporal type's box may be larger than
-   * the internal one (a TPCBox is projected to an STBox at insertion) */
-  if (maxboxes <= 1 || temp->subtype == TINSTANT)
-  {
-    void *result = palloc0(sizeof(bboxunion));
-    temporal_set_bbox(temp, result);
-    *count = 1;
-    return result;
-  }
-
-  /* Multi-box decomposition reusing the existing per-type splitters */
-  MeosType temptype = temp->temptype;
-  if (talpha_type(temptype))
-    return temporal_split_n_spans(temp, maxboxes, count);
-  if (tnumber_type(temptype))
-    return tnumber_split_n_tboxes(temp, maxboxes, count);
-  if (tgeo_type_all(temptype))
-    return tgeo_split_n_stboxes(temp, maxboxes, count);
-
-  /* No per-segment splitter (e.g. tcbuffer, tnpoint, tpose, tpcpoint,
-   * tpcpatch): fall back to the single minimum bounding box */
-  void *result = palloc0(sizeof(bboxunion));
-  temporal_set_bbox(temp, result);
-  *count = 1;
-  return result;
 }
 
 /**
@@ -735,10 +656,10 @@ void
 sptree_insert_temporal_split(SPTree *sptree, const Temporal *temp, int id,
   int maxboxes)
 {
-  if (! ensure_sptree_temporal_compatible(sptree, temp))
+  if (! ensure_bbox_temporal_compatible(sptree->bboxtype, temp))
     return;
   int count;
-  void *boxes = sptree_temporal_split_boxes(sptree, temp, maxboxes, &count);
+  void *boxes = bbox_temporal_split_boxes(sptree->bboxtype, sizeof(bboxunion), temp, maxboxes, &count);
   if (! boxes)
     return;
   for (int i = 0; i < count; i++)
@@ -771,11 +692,11 @@ sptree_search_temporal_dedup(const SPTree *sptree, RTreeSearchOp op,
   const Temporal *temp, int maxboxes, MeosArray *result)
 {
   meos_array_reset(result);
-  if (! ensure_sptree_temporal_compatible(sptree, temp))
+  if (! ensure_bbox_temporal_compatible(sptree->bboxtype, temp))
     return 0;
 
   int count;
-  void *boxes = sptree_temporal_split_boxes(sptree, temp, maxboxes, &count);
+  void *boxes = bbox_temporal_split_boxes(sptree->bboxtype, sizeof(bboxunion), temp, maxboxes, &count);
   if (! boxes)
     return 0;
 


### PR DESCRIPTION
The in-memory RTree and SPTree indexes each carried a near-identical pair of static helpers: one that decomposes a temporal value into per-segment bounding boxes (with a single-MBR fallback), and one that checks the temporal type against the index's bounding box type. This factors both into internal functions in `temporal_boxops.c`, declared in `meos_internal.h`:

- `bbox_temporal_split_boxes(bboxtype, boxsize, temp, maxboxes, count)` - the union of the two split helpers (tstzspan to `temporal_split_n_spans`, tbox to `tnumber_split_n_tboxes`, stbox to `tgeo_split_n_stboxes`, otherwise a single MBR via `temporal_set_bbox`). Each caller passes its own box size, so the SPTree keeps allocating `sizeof(bboxunion)` for its projected (TPCBox to STBox) path.
- `ensure_bbox_temporal_compatible(bboxtype, temp)` - the union compatibility check (talpha/T_TSTZSPAN, tnumber/T_TBOX, tspatial/T_STBOX, and tpointcloud/T_TPCBOX under POINTCLOUD).

Both indexes now call the shared functions and the four statics are removed. Behavior is unchanged: `rtree_mest_test` and `sptree_test` (including the POINTCLOUD TPCBox sections) stay green.