### PR TITLE
Restore the supported PostgreSQL range to 16-19 and make the range check effective

### DIFF
--- a/.github/workflows/pgversion.yml
+++ b/.github/workflows/pgversion.yml
@@ -1,8 +1,9 @@
 name: Main Build
 
 # Test for supported PostgreSQL/PostGIS versions.
-# Minimum supported PG is 16 (see mobilitydb/CMakeLists.txt PG_MIN_MAJOR_VERSION).
-# 3 (PostgreSQL) * 1 (PostGIS) * 1 (Linux) + 1 (coverage) = 4 jobs are triggered.
+# Supported PG range is 16 to 19 (see mobilitydb/CMakeLists.txt
+# PG_MIN_MAJOR_VERSION / PG_MAX_MAJOR_VERSION); the matrix below covers it.
+# 4 (PostgreSQL) * 1 (PostGIS) * 1 (Linux) + 1 (coverage) = 5 jobs are triggered.
 # Allow manual trigger
 
 on:

--- a/mobilitydb/CMakeLists.txt
+++ b/mobilitydb/CMakeLists.txt
@@ -42,11 +42,21 @@ endif()
 #-------------------------------------
 
 # Find PostgreSQL
-set(PG_MIN_MAJOR_VERSION "14")
-set(PG_MAX_MAJOR_VERSION "18")
+# Minimum supported version is 16. Older versions (14, 15) carry an
+# accumulating maintenance burden (per-version conditional code, allocator
+# differences exposed by the PG14/15 backend) that no longer pays off;
+# PostgreSQL 14 reaches end-of-life on 2026-11-12. The build fails clearly
+# here rather than letting the host pretend to be supported and crashing
+# later in fixtures.
+set(PG_MIN_MAJOR_VERSION "16")
+set(PG_MAX_MAJOR_VERSION "19")
 find_package(POSTGRESQL ${PG_MIN_MAJOR_VERSION} REQUIRED)
-if(NOT POSTGRES_VERSION VERSION_LESS PG_MAX_MAJOR_VERSION)
-  message(FATAL_ERROR "Not supporting PostgreSQL ${POSTGRESQL_VERSION}")
+if(POSTGRESQL_VERSION_MAJOR VERSION_LESS PG_MIN_MAJOR_VERSION OR
+   POSTGRESQL_VERSION_MAJOR VERSION_GREATER PG_MAX_MAJOR_VERSION)
+  message(FATAL_ERROR
+    "MobilityDB requires PostgreSQL ${PG_MIN_MAJOR_VERSION} to "
+    "${PG_MAX_MAJOR_VERSION}. Found ${POSTGRESQL_VERSION_STRING} at "
+    "${POSTGRESQL_PG_CONFIG}.")
 endif()
 
 include_directories(SYSTEM ${POSTGRESQL_INCLUDE_DIR})


### PR DESCRIPTION
## Summary

`mobilitydb/CMakeLists.txt` declares `PG_MIN_MAJOR_VERSION "14"`, yet the tree does not build on PostgreSQL 14 or 15:

- `mobilitydb/src/temporal/meos_catalog.c:205` calls `get_extension_schema`. `commands/extension.h` declares that symbol from PostgreSQL 16 on, and the file carries no fallback definition for earlier versions.
- The union aggregates reference `array_agg_combine`, `array_agg_serialize` and `array_agg_deserialize`. Those entries exist in `src/include/catalog/pg_proc.dat` from `REL_16_STABLE` on, and are absent in `REL_14_STABLE` and `REL_15_STABLE`.

The upper-bound guard is inert: it tests `POSTGRES_VERSION`, a variable no module defines, since `cmake/FindPOSTGRESQL.cmake` sets `POSTGRESQL_VERSION` and `POSTGRESQL_VERSION_MAJOR`. The condition is therefore always false and every version passes.

This PR makes the declared range match what the code supports, and makes the check enforce it.

## Changes

- `PG_MIN_MAJOR_VERSION` is 16 and `PG_MAX_MAJOR_VERSION` is 19, with a comment giving the reason for the floor.
- Both bounds test `POSTGRESQL_VERSION_MAJOR`. The error names the offending version and the `pg_config` path.
- The `pgversion.yml` header comment states the 16 to 19 range and the job count. The matrix already reads `[16, 17, 18, 19]`.

The range check accepts 16 through 19 and rejects 14, 15 and 20. A `cmake` configure of the tree against PostgreSQL 18.1 reaches `Generating done`.

Future: with the floor at 16, the 84 `#if POSTGRESQL_VERSION_NUMBER >= 160000` guards in the SQL sources, and the `130000` and `140000` substitution bands that expand them, are dead and can be removed separately.
