### PR TITLE
Allow building a self-contained static libmeos

### DIFF
--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -8,6 +8,7 @@ on:
       - 'cmake/**'
       - 'meos/**'
       - 'mobilitydb/**'
+      - 'pgtypes/**'
       - 'postgis/**'
       - 'CMakeLists.txt'
     branches-ignore:
@@ -18,6 +19,7 @@ on:
       - 'cmake/**'
       - 'meos/**'
       - 'mobilitydb/**'
+      - 'pgtypes/**'
       - 'postgis/**'
       - 'CMakeLists.txt'
     branches-ignore:
@@ -165,3 +167,82 @@ jobs:
           export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
           export TSAN_OPTIONS="halt_on_error=1 second_deadlock_stack=1"
           ./threaded_test 8 5000
+
+  static:
+    name: Self-contained static library
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgeos-dev \
+            libproj-dev \
+            libjson-c-dev \
+            libgsl-dev
+
+      # Install into a local prefix rather than /usr/local, so the link test
+      # below cannot silently resolve against a system-installed libmeos.
+      - name: Build the static library
+        run: |
+          cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DMEOS=on -DCBUFFER=on -DJSON=on \
+            -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX="$PWD/prefix"
+          cmake --build build -j $(nproc)
+          cmake --install build
+
+      - name: Check that the archive, and only the archive, is installed
+        run: |
+          test -f prefix/lib/libmeos.a || { echo "libmeos.a was not installed"; exit 1; }
+          if ls prefix/lib/libmeos.so* prefix/lib/libmeos.dylib 2>/dev/null | grep -q .; then
+            echo "a shared libmeos was installed by a BUILD_SHARED_LIBS=OFF build"
+            exit 1
+          fi
+
+      # The invariant this job exists to protect: a downstream module that links
+      # the archive must be self-contained. A consumer that ships one loadable
+      # file (a DuckDB extension, a Python wheel) has nowhere to put a sidecar
+      # libmeos, so any residual dependency on one makes the artifact unloadable
+      # on every machine except the one that built it.
+      - name: Link a shared module against the archive and run it
+        run: |
+          cat > module.c <<'EOF'
+          #include <stdio.h>
+          #include <stdlib.h>
+          #include <meos.h>
+          int mod_entry(void);
+          int mod_entry(void)
+          {
+            meos_initialize();
+            Temporal *temp = tint_in("[1@2000-01-01, 3@2000-01-03]");
+            if (! temp) { printf("parse failed\n"); return 1; }
+            char *str = tint_out(temp);
+            printf("%s\n", str);
+            free(str); free(temp);
+            meos_finalize();
+            return 0;
+          }
+          EOF
+          cat > loader.c <<'EOF'
+          #include <stdio.h>
+          #include <dlfcn.h>
+          int main(int argc, char **argv)
+          {
+            void *handle = dlopen(argv[1], RTLD_NOW);
+            if (! handle) { printf("dlopen failed: %s\n", dlerror()); return 1; }
+            int (*entry)(void) = dlsym(handle, "mod_entry");
+            if (! entry) { printf("dlsym failed: %s\n", dlerror()); return 1; }
+            return entry();
+          }
+          EOF
+          export PKG_CONFIG_PATH="$PWD/prefix/lib/pkgconfig"
+          gcc -shared -fPIC -Wall -Werror -o module.so module.c \
+            $(pkg-config --cflags meos) $(pkg-config --static --libs meos)
+          gcc -o loader loader.c -ldl
+          if readelf -d module.so | grep libmeos; then
+            echo "the module still depends on a shared libmeos"
+            exit 1
+          fi
+          ./loader ./module.so

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,26 @@ if(MEOS)
   if(WIN32)
     add_definitions(-DWIN32)
   endif()
+
+  # Linkage of the standalone library. ON (the default) keeps the historical
+  # behaviour: a shared libmeos.so/.dylib that consumers resolve at load time.
+  # OFF builds a self-contained static libmeos.a instead, for consumers that
+  # embed MEOS in a single relocatable module and therefore cannot ship a
+  # sidecar shared library next to it — a DuckDB extension, a Python wheel, or
+  # any other plugin distributed as one file. BUILD_SHARED_LIBS is the standard
+  # CMake spelling, so package managers that already drive it (vcpkg maps the
+  # triplet's VCPKG_LIBRARY_LINKAGE onto it) select the right linkage with no
+  # project-specific option. Every add_library() in this tree names its type
+  # explicitly, so this variable only ever reaches the libmeos target below.
+  option(BUILD_SHARED_LIBS "Set ON|OFF (default=ON) to build libmeos as a shared library; OFF builds a self-contained static libmeos" ON)
+  if(NOT BUILD_SHARED_LIBS)
+    # The static libmeos exists to be linked into someone else's shared module,
+    # so every object it carries must be position-independent. The individual
+    # object libraries set this only case by case (liblwgeom, ryu, clipper2,
+    # geo), which is enough for a shared build that links them directly but not
+    # for an archive that is relocated into a downstream .so/.dylib.
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+  endif()
 else()
   message(STATUS "MEOS=0: Building MEOS core for MobilityDB (internal API only)")
   add_definitions(-DMEOS=0)

--- a/meos/CMakeLists.txt
+++ b/meos/CMakeLists.txt
@@ -188,7 +188,7 @@ if(RGEO)
   set(MEOS_OBJECTS ${MEOS_OBJECTS} "$<TARGET_OBJECTS:rgeo>")
 endif()
 
-if(MEOS)
+if(MEOS AND BUILD_SHARED_LIBS)
   # Build as SHARED library for standalone use
   add_library(${MEOS_LIB_NAME} SHARED ${MEOS_OBJECTS})
   message(STATUS "Building MEOS as SHARED library")
@@ -199,6 +199,34 @@ if(MEOS)
       LINK_FLAGS "-Wl,-undefined,dynamic_lookup"
     )
   endif()
+elseif(MEOS)
+  # Build as a SELF-CONTAINED STATIC library for standalone use. A consumer
+  # that embeds MEOS in a single relocatable module cannot ship a sidecar
+  # libmeos next to it, so the archive must carry every in-tree object the
+  # shared library resolves through its own link line — otherwise the consumer
+  # inherits a dangling dependency on a libpgtypes.a/libpostgis.a/libpc.a that
+  # `make install` never installs. Fold those objects in here, exactly as the
+  # optional families above are folded in, so the install produces one archive
+  # and consumers link one library.
+  set(MEOS_STATIC_OBJECTS ${MEOS_OBJECTS})
+  set(MEOS_STATIC_OBJECTS ${MEOS_STATIC_OBJECTS} "$<TARGET_OBJECTS:pgtypes_objects>")
+  set(MEOS_STATIC_OBJECTS ${MEOS_STATIC_OBJECTS} "$<TARGET_OBJECTS:liblwgeom>")
+  set(MEOS_STATIC_OBJECTS ${MEOS_STATIC_OBJECTS} "$<TARGET_OBJECTS:ryu>")
+  if(RASTER)
+    set(MEOS_STATIC_OBJECTS ${MEOS_STATIC_OBJECTS} "$<TARGET_OBJECTS:librtcore>")
+  endif()
+  if(POINTCLOUD)
+    set(MEOS_STATIC_OBJECTS ${MEOS_STATIC_OBJECTS} "$<TARGET_OBJECTS:pointcloud_libpc_objects>")
+  endif()
+  add_library(${MEOS_LIB_NAME} STATIC ${MEOS_STATIC_OBJECTS})
+  message(STATUS "Building MEOS as self-contained STATIC library")
+
+  # The archive is meant to be linked into a downstream shared module. Place it
+  # where the shared library would land (CMAKE_LIBRARY_OUTPUT_DIRECTORY governs
+  # shared libraries only) so the build tree looks the same under either linkage.
+  set_target_properties(${MEOS_LIB_NAME} PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+    ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 else()
   # Build as STATIC library for linking into MobilityDB
   add_library(${MEOS_LIB_NAME} STATIC ${MEOS_OBJECTS})
@@ -463,6 +491,33 @@ if(MEOS)
     set(libdir "$\{exec_prefix\}/${CMAKE_INSTALL_LIBDIR}")
   endif()
   set(VERSION ${MEOS_LIB_VERSION})
+
+  # A shared libmeos records its own dependencies, so `pkg-config --libs meos`
+  # is enough to link against it. A static libmeos cannot: the archive carries
+  # only MEOS's own objects, so every external library it calls into has to
+  # reach the consumer's link line. Publish them as Libs.private, which is what
+  # `pkg-config --static --libs meos` appends. These are spelled as link flags
+  # rather than reused from the find_package results, because those results are
+  # CMake imported target names (GEOS::geos_c) or absolute paths into the build
+  # machine's /usr/lib — neither belongs in an installed .pc file. The enabled
+  # families decide which entries apply, mirroring target_link_libraries above.
+  set(MEOS_PC_LIBS_PRIVATE "")
+  if(NOT BUILD_SHARED_LIBS)
+    set(_meos_pc_libs -lgeos_c -lproj -lgsl -lgslcblas -ljson-c)
+    if(H3)
+      list(APPEND _meos_pc_libs -lh3)
+    endif()
+    if(RASTER)
+      list(APPEND _meos_pc_libs -lgdal)
+    endif()
+    if(POINTCLOUD)
+      list(APPEND _meos_pc_libs -lxml2 -lz)
+    endif()
+    # The clipper2 polygon engine is C++, so a C consumer linking the archive
+    # needs the C++ runtime that a shared libmeos would have pulled in itself.
+    list(APPEND _meos_pc_libs -lstdc++ -lm)
+    string(REPLACE ";" " " MEOS_PC_LIBS_PRIVATE "${_meos_pc_libs}")
+  endif()
 
   configure_file(
     ${CMAKE_SOURCE_DIR}/tools/meos.pc.in

--- a/meos/src/pointcloud/CMakeLists.txt
+++ b/meos/src/pointcloud/CMakeLists.txt
@@ -178,16 +178,31 @@ if(POINTCLOUD)
   # each, so no linker hack is required on any platform.
   list(APPEND POINTCLOUD_LIBPC_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/pc_stringbuffer_shim.c)
-  add_library(pointcloud_libpc STATIC ${POINTCLOUD_LIBPC_SRCS})
-  set_target_properties(pointcloud_libpc PROPERTIES
-    POSITION_INDEPENDENT_CODE ON OUTPUT_NAME pc)
-  target_include_directories(pointcloud_libpc PRIVATE
+  # Compile libpc once as an object library, then assemble the archive from it —
+  # SIBLING-FROM postgis/CMakeLists.txt (liblwgeom/ryu/librtcore OBJECT libraries
+  # collected into POSTGIS_OBJECTS, then `add_library(postgis STATIC …)`). The
+  # object library is what lets a self-contained static libmeos fold these
+  # objects in (meos/CMakeLists.txt): $<TARGET_OBJECTS:…> reads an OBJECT library
+  # from any directory scope, so meos/ reaches them from two levels up.
+  add_library(pointcloud_libpc_objects OBJECT ${POINTCLOUD_LIBPC_SRCS})
+  set_target_properties(pointcloud_libpc_objects PROPERTIES
+    POSITION_INDEPENDENT_CODE ON)
+  target_include_directories(pointcloud_libpc_objects PRIVATE
     ${CMAKE_SOURCE_DIR}/pointcloud-pg/lib)   # holds sources + generated pc_config.h
-  target_link_libraries(pointcloud_libpc PUBLIC LibXml2::LibXml2 ZLIB::ZLIB)
+  # libxml2 and zlib carry the include directories the libpc sources compile
+  # against (pc_schema.c includes <libxml/parser.h>), so the object library needs
+  # them as well as the archive: linking an imported target is how those usage
+  # requirements reach the compile line.
+  target_link_libraries(pointcloud_libpc_objects PUBLIC LibXml2::LibXml2 ZLIB::ZLIB)
   # Vendored upstream pgPointCloud sources that MobilityDB does not maintain or
   # lint; suppress their compiler warnings on this target only, as done for the
   # other vendored libraries (liblwgeom, ryu, libpgcommon).
-  target_compile_options(pointcloud_libpc PRIVATE "-w")
+  target_compile_options(pointcloud_libpc_objects PRIVATE "-w")
+
+  add_library(pointcloud_libpc STATIC $<TARGET_OBJECTS:pointcloud_libpc_objects>)
+  set_target_properties(pointcloud_libpc PROPERTIES
+    POSITION_INDEPENDENT_CODE ON OUTPUT_NAME pc)
+  target_link_libraries(pointcloud_libpc PUBLIC LibXml2::LibXml2 ZLIB::ZLIB)
 
   # Link the core into the MEOS-layer pointcloud shim. lazperf (the PC_LAZPERF
   # / `laz` scheme) stays optional: pc_patch_lazperf.c is compiled into libpc

--- a/pgtypes/CMakeLists.txt
+++ b/pgtypes/CMakeLists.txt
@@ -182,20 +182,29 @@ add_subdirectory(utils)
 # Uncomment the following line to see all source files included
 # message(STATUS "PGTYPES_SOURCES ${PGTYPES_SOURCES}")
 
-# Compile the source files
-add_library(pgtypes STATIC ${PGTYPES_SOURCES})
+# Compile the source files once, as an object library, so that the archive
+# below and a self-contained static libmeos (meos/CMakeLists.txt) can both
+# consume the same objects without compiling them twice. The archive keeps the
+# name and the contents it has always had, so every existing consumer — the
+# MobilityDB extension and the shared libmeos — links exactly as before.
+add_library(pgtypes_objects OBJECT ${PGTYPES_SOURCES})
 
 # Create the list of object files
-# set(PGTYPES_OBJECTS "$<TARGET_OBJECTS:pgtypes>")
+set(PGTYPES_OBJECTS "$<TARGET_OBJECTS:pgtypes_objects>")
 
 # Define a static library for pgtypes
-# add_library(pgtypes STATIC ${PGTYPES_OBJECTS})
+add_library(pgtypes STATIC ${PGTYPES_OBJECTS})
 
-target_include_directories(pgtypes PUBLIC "${CMAKE_SOURCE_DIR}/pgtypes")
-target_include_directories(pgtypes PUBLIC "${CMAKE_BINARY_DIR}/pgtypes")
-# The pgtypes sources include the MEOS public headers (meos.h, meos_error.h,
-# meos_tls.h); expose meos/include on the target so they resolve from any
-# pgtypes subdirectory depth (a relative ../../meos/include path only resolved
-# for the depth-2 files and broke the standalone -DMEOS build of the others).
-target_include_directories(pgtypes PUBLIC "${CMAKE_SOURCE_DIR}/meos/include")
+# The include directories go on both targets: the object library needs them to
+# compile the sources, and the archive needs them to carry the same usage
+# requirements to its consumers as it did when it owned the sources.
+foreach(_pgtypes_target pgtypes_objects pgtypes)
+  target_include_directories(${_pgtypes_target} PUBLIC "${CMAKE_SOURCE_DIR}/pgtypes")
+  target_include_directories(${_pgtypes_target} PUBLIC "${CMAKE_BINARY_DIR}/pgtypes")
+  # The pgtypes sources include the MEOS public headers (meos.h, meos_error.h,
+  # meos_tls.h); expose meos/include on the target so they resolve from any
+  # pgtypes subdirectory depth (a relative ../../meos/include path only resolved
+  # for the depth-2 files and broke the standalone -DMEOS build of the others).
+  target_include_directories(${_pgtypes_target} PUBLIC "${CMAKE_SOURCE_DIR}/meos/include")
+endforeach()
 

--- a/tools/meos.pc.in
+++ b/tools/meos.pc.in
@@ -9,3 +9,4 @@ Requires:
 Version: @VERSION@
 Cflags: -I${includedir}
 Libs: -L${libdir} -lmeos
+Libs.private: @MEOS_PC_LIBS_PRIVATE@


### PR DESCRIPTION
A consumer that embeds MEOS in a single relocatable module — a DuckDB extension, a Python wheel, any plugin distributed as one file — has nowhere to put a sidecar libmeos next to it. `-DMEOS=ON` always produces a shared library, so such a consumer ships an artifact that keeps a dependency on a `libmeos.so`/`.dylib` resolved through an rpath baked to the build machine, and fails to load anywhere else.

This is what MobilityDuck's published extension hits; a user reports:

```
IO Error: Extension "mobilityduck.duckdb_extension" could not be loaded:
Library not loaded: @rpath/libmeos.dylib
  tried: '/Users/runner/work/MobilityDuck/MobilityDuck/build/release/
          vcpkg_installed/arm64-osx-release/share/meos/../../lib/libmeos.dylib'
```

### What this adds

`meos/CMakeLists.txt` honours `BUILD_SHARED_LIBS`, defaulting to ON, so the standalone build keeps its current behaviour. `BUILD_SHARED_LIBS` is the standard CMake spelling, so package managers that already drive it (vcpkg maps the triplet's `VCPKG_LIBRARY_LINKAGE` onto it) select the right linkage with no project-specific option. Every `add_library()` in this tree names its type explicitly, so the variable only ever reaches the libmeos target.

Setting it OFF builds a static libmeos and makes that archive **self-contained**: `pgtypes`, `liblwgeom`, `ryu`, and per family `librtcore` and the pgPointCloud core are folded in, exactly as the optional families already are. These are separate archives that the shared library resolves through its own link line but that no `install()` rule ships, so otherwise they remain dangling dependencies on libraries a consumer cannot obtain. `pgtypes` and the pgPointCloud core use the object-library-plus-archive split `postgis` already uses, so their objects are reachable while both archives keep exactly the contents they carry today.

The pkg-config file carries a `Libs.private` listing the external libraries a static consumer links, since only a shared library records its own dependencies.

The PostgreSQL extension is unaffected: its exported and undefined symbol sets are identical either way.

### Guard

A new CI job in `meos.yml` links a shared module against the archive, fails if the module still references a shared libmeos, and runs it. `pgtypes/**` joins the workflow's trigger paths, since pgtypes objects are part of libmeos under this option.