### PR TITLE
Transform temporal poses and pose sets to another SRID

### DIFF
--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -299,12 +299,26 @@ SELECT asEWKT(setSRID(pose 'Pose(Point(0 0),1)', 4326));
 					<para><varname>transform(pose,integer) → pose</varname></para>
 					<para><varname>transformPipeline(pose,pipeline text,to_srid integer,is_forward bool=true) → pose</varname></para>
 					<para>La función <varname>transform</varname> especifica la transformación con un SRID de destino. Se genera un error cuando la pose de entrada tiene un SRID desconocido (representado por 0).</para>
+					<para>En una pose 3D, la orientación se reexpresa en la base del marco de destino en el punto de la pose. La corrección está definida para el par canónico de OGC GeoPose, WGS-84 geográfico (EPSG:4326) ↔ WGS-84 ECEF (EPSG:4978), y toma la base estándar Este-Norte-Arriba en el punto geográfico como pivote de rotación. Para cualquier otro par de SRID, <varname>transform</varname> emite un <varname>NOTICE</varname> y deja pasar la orientación sin cambios. En una pose 2D, el ángulo es intrínseco a la proyección de origen y se deja pasar sin cambios.</para>
 					<para>La función <varname>transformPipeline</varname> especifica la transformación con una canalización de transformación de coordenadas definida representada con el siguiente formato de cadena:</para>
 				<para><varname>urn:ogc:def:coordinateOperation:AUTHORITY::CODE</varname></para>
 				<para>El SRID de la pose de entrada se ignora y el SRID de la pose de salida se establecerá en cero a menos que se proporcione un valor a través del parámetro opcional <varname>to_srid</varname>. Como se indica en el último parámetro, la canalización se ejecuta de forma predeterminada en dirección hacia adelante; al establecer el parámetro en falso, la canalización se ejecuta en la dirección inversa.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(transform(pose 'SRID=4326;Pose(Point(4.35 50.85),1)', 3812), 6);
--- SRID=4326;Pose(POINT(648679.018035 671067.055638),1)
+-- SRID=3812;Pose(POINT(648679.018035 671067.055638),1)
+</programlisting>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Un viaje de ida y vuelta de una pose 3D por ECEF aterriza en la pose de entrada
+SELECT asEWKT(round(
+  transform(transform(pose 'SRID=4326;Pose(Point(8 47 0), 1, 0, 0, 0)', 4978),
+            4326), 6));
+-- SRID=4326;Pose(POINT Z (8 47 0),1,0,0,0)
+
+-- En el cruce del ecuador y el meridiano (lat=lon=0), el cuaternión identidad
+-- del cuerpo en la base ECEF es la rotación canónica Este-Norte-Arriba a ECEF
+SELECT asEWKT(round(
+  transform(pose 'SRID=4326;Pose(Point(0 0 0), 1, 0, 0, 0)', 4978), 6));
+-- SRID=4978;Pose(POINT Z (6378137 0 0),0.5,-0.5,-0.5,-0.5)
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH test(pose, pipeline) AS (
@@ -483,25 +497,6 @@ SELECT asText(applyPose(ST_Point(1,0),
           Pose(Point(10 20), 1.5707963267948966)@2026-01-02]'));
 -- [POINT(1 0)@2026-01-01, POINT(10 21)@2026-01-02]
 </programlisting>
-			</sect3>
-
-			<sect3 xml:id="pose_geopose_transform">
-				<title>Transformaciones de marco entre SRID</title>
-				<para>La función <varname>transform(pose, srid)</varname> lleva los valores de pose de un SRID a otro. El flujo de trabajo n.º 6 del plan de GeoPose temporal amplía el comportamiento preexistente de <emphasis>solo posición</emphasis> con la corrección de orientación necesaria cuando el marco de origen y el de destino tienen bases distintas en el punto de la pose. La versión v1 implementa el caso canónico de OGC GeoPose —WGS-84 geográfico (EPSG:4326) ↔ WGS-84 ECEF (EPSG:4978)— utilizando la base estándar Este-Norte-Arriba en el punto geográfico como pivote de rotación. Para los pares de SRID cuya corrección de orientación aún no está definida, <varname>transform</varname> emite un <varname>NOTICE</varname> y deja pasar la orientación sin cambios.</para>
-				<para>Un viaje de ida y vuelta a través de ECEF y de regreso aterriza exactamente en la pose de entrada:</para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT asEWKT(round(
-  transform(transform(pose 'SRID=4326;Pose(Point(8 47 0), 1, 0, 0, 0)', 4978),
-            4326), 6));
--- SRID=4326;Pose(POINT Z (8 47 0),1,0,0,0)
-
--- At the equator-meridian (lat=lon=0), the body identity quaternion in
--- the ECEF basis becomes the canonical ENU->ECEF rotation:
-SELECT asEWKT(round(
-  transform(pose 'SRID=4326;Pose(Point(0 0 0), 1, 0, 0, 0)', 4978), 6));
--- SRID=4978;Pose(POINT Z (6378137 0 0),0.5,-0.5,-0.5,-0.5)
-</programlisting>
-				<para>La implementación también corrige un error preexistente de solo posición en el que <varname>transform</varname> no actualizaba el campo SRID del resultado, de modo que la pose devuelta ahora lleva el SRID de destino como se espera.</para>
 			</sect3>
 
 			<sect3 xml:id="pose_geopose_temporal_io">
@@ -1073,6 +1068,7 @@ SELECT asEWKT(setSRID(tpose '[Pose(Point(0 0),1)@2001-01-01,
 				<para>Transformar a un identificador de referencia espacial</para>
 				<para><varname>transform(tpose,integer) → tpose</varname></para>
 				<para><varname>transformPipeline(tpose,pipeline text,to_srid integer,is_forward bool=true) → tpose</varname></para>
+				<para>La pose de cada instante se transforma igual que la pose estática correspondiente, con la corrección de orientación incluida, como se describe en <xref linkend="pose_transform"/>. Lo mismo ocurre con un <varname>poseset</varname>. Una <varname>trgeometry</varname> asocia sus poses con una geometría de referencia que comparte su marco, y la transformación a otro SRID no está admitida para ese tipo.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(transform(tpose 'SRID=4326;Pose(Point(4.35 50.85),1)@2001-01-01', 
   3812));

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -306,12 +306,26 @@ SELECT asEWKT(setSRID(pose 'Pose(Point(0 0),1)', 4326));
 					<para><varname>transform(pose,integer) → pose</varname></para>
 					<para><varname>transformPipeline(pose,pipeline text,to_srid integer,is_forward bool=true) → pose</varname></para>
 					<para>The <varname>transform</varname> function specifies the transformation with a target SRID. An error is raised when the input pose has an unknown SRID (represented by 0).</para>
+					<para>For a 3D pose the orientation is re-expressed in the basis of the target frame at the pose's point. The correction is defined for the canonical OGC GeoPose pair, WGS-84 geographic (EPSG:4326) ↔ WGS-84 ECEF (EPSG:4978), and takes the standard East-North-Up basis at the geographic point as the rotation pivot. For any other pair of SRIDs, <varname>transform</varname> emits a <varname>NOTICE</varname> and passes the orientation through unchanged. For a 2D pose the angle is intrinsic to the source projection and is passed through unchanged.</para>
 					<para>The <varname>transformPipeline</varname> function specifies the transformation with a defined coordinate transformation pipeline represented with the following string format:</para>
 				<para><varname>urn:ogc:def:coordinateOperation:AUTHORITY::CODE</varname></para>
 				<para>The SRID of the input pose is ignored, and the SRID of the output pose will be set to zero unless a value is provided via the optional <varname>to_srid</varname> parameter. As stated by the last parameter, the pipeline is executed by default in a forward direction; by setting the parameter to false, the pipeline is executed in the inverse direction.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(transform(pose 'SRID=4326;Pose(Point(4.35 50.85),1)', 3812), 6);
--- SRID=4326;Pose(POINT(648679.018035 671067.055638),1)
+-- SRID=3812;Pose(POINT(648679.018035 671067.055638),1)
+</programlisting>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Round-tripping a 3D pose through ECEF and back lands at the input pose
+SELECT asEWKT(round(
+  transform(transform(pose 'SRID=4326;Pose(Point(8 47 0), 1, 0, 0, 0)', 4978),
+            4326), 6));
+-- SRID=4326;Pose(POINT Z (8 47 0),1,0,0,0)
+
+-- At the equator-meridian (lat=lon=0), the body identity quaternion in the
+-- ECEF basis is the canonical East-North-Up to ECEF rotation
+SELECT asEWKT(round(
+  transform(pose 'SRID=4326;Pose(Point(0 0 0), 1, 0, 0, 0)', 4978), 6));
+-- SRID=4978;Pose(POINT Z (6378137 0 0),0.5,-0.5,-0.5,-0.5)
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH test(pose, pipeline) AS (
@@ -491,25 +505,6 @@ SELECT asText(applyPose(ST_Point(1,0),
           Pose(Point(10 20), 1.5707963267948966)@2026-01-02]'));
 -- [POINT(1 0)@2026-01-01, POINT(10 21)@2026-01-02]
 </programlisting>
-			</sect3>
-
-			<sect3 xml:id="pose_geopose_transform">
-				<title>Cross-SRID frame transforms</title>
-				<para>The <varname>transform(pose, srid)</varname> function carries pose values across SRIDs. Workstream #6 of the temporal-GeoPose plan extends the pre-existing <emphasis>position-only</emphasis> behaviour with the orientation correction required when the source and target frames have different bases at the pose's point. v1 implements the canonical OGC GeoPose case — WGS-84 geographic (EPSG:4326) ↔ WGS-84 ECEF (EPSG:4978) — using the standard East-North-Up basis at the geographic point as the rotation pivot. For SRID pairs whose orientation correction is not yet defined, <varname>transform</varname> emits a <varname>NOTICE</varname> and passes the orientation through unchanged.</para>
-				<para>Round-tripping through ECEF and back lands exactly at the input pose:</para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT asEWKT(round(
-  transform(transform(pose 'SRID=4326;Pose(Point(8 47 0), 1, 0, 0, 0)', 4978),
-            4326), 6));
--- SRID=4326;Pose(POINT Z (8 47 0),1,0,0,0)
-
--- At the equator-meridian (lat=lon=0), the body identity quaternion in
--- the ECEF basis becomes the canonical ENU->ECEF rotation:
-SELECT asEWKT(round(
-  transform(pose 'SRID=4326;Pose(Point(0 0 0), 1, 0, 0, 0)', 4978), 6));
--- SRID=4978;Pose(POINT Z (6378137 0 0),0.5,-0.5,-0.5,-0.5)
-</programlisting>
-				<para>The implementation also fixes a pre-existing position-only bug where <varname>transform</varname> did not update the result's SRID field, so the returned pose now carries the target SRID as expected.</para>
 			</sect3>
 
 			<sect3 xml:id="pose_geopose_temporal_io">
@@ -1080,6 +1075,7 @@ SELECT asEWKT(setSRID(tpose '[Pose(Point(0 0),1)@2001-01-01,
 				<para>Transform to a spatial reference identifier</para>
 				<para><varname>transform(tpose,integer) → tpose</varname></para>
 				<para><varname>transformPipeline(tpose,pipeline text,to_srid integer,is_forward bool=true) → tpose</varname></para>
+				<para>Each instant's pose is transformed as the corresponding static pose is, orientation correction included, as described in <xref linkend="pose_transform"/>. The same holds for a <varname>poseset</varname>. A <varname>trgeometry</varname> pairs its poses with a reference geometry that shares their frame, and transformation to another SRID is not supported for it.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(transform(tpose 'SRID=4326;Pose(Point(4.35 50.85),1)@2001-01-01', 
   3812));

--- a/meos/include/pose/pose.h
+++ b/meos/include/pose/pose.h
@@ -36,6 +36,8 @@
 
 /* PostgreSQL */
 #include <postgres.h>
+/* PostGIS */
+#include <liblwgeom.h>
 /* MEOS */
 #include <meos.h>
 #include <meos_pose.h>
@@ -104,6 +106,8 @@ extern Datum datum_pose_apply_geo(Datum pose, Datum body);
 /* Transformation functions */
 
 extern Datum datum_pose_round(Datum pose, Datum size);
+extern Pose *pose_transf_pj(const Pose *pose, int32_t srid_to,
+  const LWPROJ *pj);
 
 /* Distance */
 

--- a/meos/src/geo/tspatial_srid.c
+++ b/meos/src/geo/tspatial_srid.c
@@ -518,13 +518,13 @@ point_transf_pj(GSERIALIZED *gs, int32_t srid_to, const LWPROJ *pj)
  * to another SRID
  */
 Datum
-#if CBUFFER
+#if CBUFFER || POSE || RGEO
   datum_transf_pj(Datum d, MeosType basetype, int32_t srid_to,
     const LWPROJ *pj)
 #else
   datum_transf_pj(Datum d, MeosType basetype, int32_t srid_to UNUSED,
     const LWPROJ *pj)
-#endif /* CBUFFER */
+#endif /* CBUFFER || POSE || RGEO */
 {
   assert(spatial_basetype(basetype));
   switch (basetype)
@@ -547,6 +547,10 @@ Datum
     case T_CBUFFER:
       return PointerGetDatum(cbuffer_transf_pj(DatumGetCbufferP(d), srid_to,
         pj));
+#endif
+#if POSE || RGEO
+    case T_POSE:
+      return PointerGetDatum(pose_transf_pj(DatumGetPoseP(d), srid_to, pj));
 #endif
     default: /* Error! */
       meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
@@ -750,6 +754,29 @@ tspatial_transf_pj(const Temporal *temp, int32_t srid_to, const LWPROJ *pj)
   }
 }
 
+#if RGEO
+/**
+ * @brief Ensure that a spatiotemporal value is not a temporal rigid geometry
+ * @details A transformation rebuilds the value from its transformed instants,
+ * while a temporal rigid geometry also carries a reference geometry beside
+ * them, whose frame must agree with that of the poses
+ * @param[in] temp Spatiotemporal value
+ */
+static bool
+ensure_not_trgeometry(const Temporal *temp)
+{
+  assert(temp);
+  if (temp->temptype == T_TRGEOMETRY)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_TYPE,
+      "Transformation to another SRID is not supported for type %s",
+      meostype_name(temp->temptype));
+    return false;
+  }
+  return true;
+}
+#endif /* RGEO */
+
 /**
  * @ingroup meos_geo_srid
  * @brief Return a spatiotemporal value transformed to another SRID
@@ -762,6 +789,10 @@ tspatial_transform(const Temporal *temp, int32_t srid_to)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TSPATIAL(temp, NULL);
+#if RGEO
+  if (! ensure_not_trgeometry(temp))
+    return NULL;
+#endif /* RGEO */
   int32_t srid_from = tspatial_srid(temp);
   if (! ensure_srid_known(srid_from) || ! ensure_srid_known(srid_to))
     return NULL;
@@ -799,6 +830,10 @@ tspatial_transform_pipeline(const Temporal *temp, const char *pipeline,
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TSPATIAL(temp, NULL); VALIDATE_NOT_NULL(pipeline, NULL);
+#if RGEO
+  if (! ensure_not_trgeometry(temp))
+    return NULL;
+#endif /* RGEO */
   /* srid_to may legitimately be SRID_UNKNOWN for pipeline transformations:
    * the pipeline string itself encodes the destination CRS. So unlike the
    * sibling tspatial_transform path, we do NOT call ensure_srid_known here. */

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -1463,8 +1463,7 @@ pose_set_srid(Pose *pose, int32_t srid)
  * @param[in] pj Information about the transformation
  */
 /* SRIDs whose orientation correction is implemented by
- * pose_orientation_apply_frame_change. Cf. workstream #6 of the
- * temporal-GeoPose plan. */
+ * pose_orientation_apply_frame_change. */
 #define POSE_SRID_WGS84_GEOGRAPHIC 4326   /* lat/lon/h, ENU local frame */
 #define POSE_SRID_WGS84_ECEF       4978   /* X/Y/Z geocentric Cartesian */
 
@@ -1541,11 +1540,9 @@ pose_enu_to_ecef_quaternion(double lat_rad, double lon_rad,
  * @brief Apply the orientation correction for a frame change between two
  * SRIDs. The new orientation @p (q_new) re-expresses the same physical
  * body→world rotation in the *target* frame's basis at the (transformed)
- * point. v1 implements the canonical OGC GeoPose case
- * (WGS-84 geographic ↔ ECEF); for other SRID pairs the orientation is
- * passed through unchanged with a NOTICE — explicit cross-frame
- * orientation maths can land on top of this kernel without changing
- * the call sites.
+ * point. The correction is defined for the canonical OGC GeoPose case
+ * (WGS-84 geographic ↔ ECEF); for any other SRID pair the orientation is
+ * passed through unchanged with a NOTICE.
  */
 static void
 pose_orientation_apply_frame_change(int32_t srid_from, int32_t srid_to,
@@ -1624,7 +1621,7 @@ pose_transf_pj(const Pose *pose, int32_t srid_to, const LWPROJ *pj)
    * source/target SRID pair) sees the right value. */
   pose_set_srid(result, srid_to);
 
-  /* Apply the orientation correction (workstream #6). For the
+  /* Apply the orientation correction. For the
    * geographic ↔ ECEF case the rotation depends on the lat/lon of the
    * source point — compute that from the *input* pose's coordinates,
    * which were lon/lat (degrees) when the source SRID is 4326, or

--- a/mobilitydb/test/pose/expected/105_tpose_spatialfuncs.test.out
+++ b/mobilitydb/test/pose/expected/105_tpose_spatialfuncs.test.out
@@ -16,6 +16,53 @@ SELECT asEWKT(setSRID(tpose 'Pose(Point(1 2),0.5)@2000-01-01', 5676));
  SRID=5676;Pose(POINT(1 2),0.5)@Sat Jan 01 00:00:00 2000 PST
 (1 row)
 
+SELECT asEWKT(round(transform(transform(tpose
+  'SRID=4326;Pose(Point(8 47 0), 1, 0, 0, 0)@2000-01-01', 4978), 4326), 6));
+                                asewkt                                 
+-----------------------------------------------------------------------
+ SRID=4326;Pose(POINT Z (8 47 0),1,0,0,0)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asEWKT(round(transform(transform(tpose
+  'SRID=4326;{Pose(Point(8 47 0), 1, 0, 0, 0)@2000-01-01,
+    Pose(Point(9 48 0), 1, 0, 0, 0)@2000-01-02}', 4978), 4326), 6));
+                                                                asewkt                                                                
+--------------------------------------------------------------------------------------------------------------------------------------
+ SRID=4326;{Pose(POINT Z (8 47 0),1,0,0,0)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT Z (9 48 0),1,0,0,0)@Sun Jan 02 00:00:00 2000 PST}
+(1 row)
+
+SELECT asEWKT(round(transform(transform(tpose
+  'SRID=4326;[Pose(Point(8 47 0), 1, 0, 0, 0)@2000-01-01,
+    Pose(Point(9 48 0), 1, 0, 0, 0)@2000-01-02]', 4978), 4326), 6));
+                                                                asewkt                                                                
+--------------------------------------------------------------------------------------------------------------------------------------
+ SRID=4326;[Pose(POINT Z (8 47 0),1,0,0,0)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT Z (9 48 0),1,0,0,0)@Sun Jan 02 00:00:00 2000 PST]
+(1 row)
+
+SELECT asEWKT(round(transform(tpose
+  'SRID=4326;Pose(Point(0 0 0), 1, 0, 0, 0)@2000-01-01', 4978), 6));
+                                        asewkt                                         
+---------------------------------------------------------------------------------------
+ SRID=4978;Pose(POINT Z (6378137 0 0),0.5,-0.5,-0.5,-0.5)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asEWKT(transform(tpose
+  'SRID=4326;Pose(Point(8 47 0), 1, 0, 0, 0)@2000-01-01', 4326));
+                                asewkt                                 
+-----------------------------------------------------------------------
+ SRID=4326;Pose(POINT Z (8 47 0),1,0,0,0)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asEWKT(round(transform(tpose
+  'SRID=4326;Pose(Point(4.35 50.85), 1)@2000-01-01', 3812), 6));
+                                      asewkt                                       
+-----------------------------------------------------------------------------------
+ SRID=3812;Pose(POINT(648679.018035 671067.055638),1)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asEWKT(transform(tpose 'Pose(Point(8 47 0), 1, 0, 0, 0)@2000-01-01',
+  4978));
+ERROR:  The SRID cannot be unknown
 SELECT asText(atGeometry(
   tpose 'Pose(Point(0 0),0)@2000-01-01',
   'Polygon((-1 -1,1 -1,1 1,-1 1,-1 -1))'::geometry));

--- a/mobilitydb/test/pose/queries/100_pose.test.sql
+++ b/mobilitydb/test/pose/queries/100_pose.test.sql
@@ -141,7 +141,7 @@ SELECT pose 'Pose(Point(1 1),0.5)' >= pose 'Pose(Point(2 2),0.5)';
 
 -------------------------------------------------------------------------------/
 
--- Cross-SRID frame transforms (workstream #6). The orientation correction
+-- Cross-SRID frame transforms. The orientation correction
 -- between WGS-84 geographic (4326) and WGS-84 ECEF (4978) is the local
 -- East-North-Up basis change at the point. Round-trip lands at the input.
 SELECT asEWKT(round(transform(transform(pose 'SRID=4326;Pose(Point(8 47 0), 1, 0, 0, 0)', 4978), 4326), 6));

--- a/mobilitydb/test/pose/queries/105_tpose_spatialfuncs.test.sql
+++ b/mobilitydb/test/pose/queries/105_tpose_spatialfuncs.test.sql
@@ -33,6 +33,31 @@ SELECT SRID(tpose 'SRID=5676;Pose(Point(1 2),0.5)@2000-01-01');
 
 SELECT asEWKT(setSRID(tpose 'Pose(Point(1 2),0.5)@2000-01-01', 5676));
 
+-- Frame transformation. Each instant's pose is transformed as the static pose
+-- is, orientation correction included, so a round trip through WGS-84 ECEF
+-- (4978) returns the input.
+SELECT asEWKT(round(transform(transform(tpose
+  'SRID=4326;Pose(Point(8 47 0), 1, 0, 0, 0)@2000-01-01', 4978), 4326), 6));
+SELECT asEWKT(round(transform(transform(tpose
+  'SRID=4326;{Pose(Point(8 47 0), 1, 0, 0, 0)@2000-01-01,
+    Pose(Point(9 48 0), 1, 0, 0, 0)@2000-01-02}', 4978), 4326), 6));
+SELECT asEWKT(round(transform(transform(tpose
+  'SRID=4326;[Pose(Point(8 47 0), 1, 0, 0, 0)@2000-01-01,
+    Pose(Point(9 48 0), 1, 0, 0, 0)@2000-01-02]', 4978), 4326), 6));
+-- At the equator-meridian the body identity quaternion expressed in the ECEF
+-- basis is the canonical East-North-Up to ECEF rotation
+SELECT asEWKT(round(transform(tpose
+  'SRID=4326;Pose(Point(0 0 0), 1, 0, 0, 0)@2000-01-01', 4978), 6));
+-- A same-SRID transformation is a no-op
+SELECT asEWKT(transform(tpose
+  'SRID=4326;Pose(Point(8 47 0), 1, 0, 0, 0)@2000-01-01', 4326));
+-- A 2D pose angle is intrinsic to its projection and is passed through
+SELECT asEWKT(round(transform(tpose
+  'SRID=4326;Pose(Point(4.35 50.85), 1)@2000-01-01', 3812), 6));
+-- An unknown source SRID is an error
+SELECT asEWKT(transform(tpose 'Pose(Point(8 47 0), 1, 0, 0, 0)@2000-01-01',
+  4978));
+
 -------------------------------------------------------------------------------
 -- atGeometry / minusGeometry — instant
 

--- a/mobilitydb/test/rgeo/expected/153_trgeo_spatialfuncs.test.out
+++ b/mobilitydb/test/rgeo/expected/153_trgeo_spatialfuncs.test.out
@@ -1,3 +1,18 @@
+SELECT SRID(trgeometry
+  'SRID=4326;Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01');
+ srid 
+------
+ 4326
+(1 row)
+
+SELECT transform(trgeometry
+  'SRID=4326;Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01',
+  3812);
+ERROR:  Transformation to another SRID is not supported for type trgeometry
+SELECT transformPipeline(trgeometry
+  'SRID=4326;Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01',
+  'urn:ogc:def:coordinateOperation:EPSG::16031', 4326);
+ERROR:  Transformation to another SRID is not supported for type trgeometry
 SELECT asText(atGeometry(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(2 0), 0.0)@2001-01-01',
   geometry 'Polygon((1 -1,3 -1,3 1,1 1,1 -1))'));

--- a/mobilitydb/test/rgeo/queries/153_trgeo_spatialfuncs.test.sql
+++ b/mobilitydb/test/rgeo/queries/153_trgeo_spatialfuncs.test.sql
@@ -26,6 +26,20 @@
 -- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 --
 -------------------------------------------------------------------------------
+-- SRID functions
+-------------------------------------------------------------------------------
+
+SELECT SRID(trgeometry
+  'SRID=4326;Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01');
+
+-- A reference geometry accompanies the poses and shares their frame, so a
+-- transformation to another SRID is not supported
+SELECT transform(trgeometry
+  'SRID=4326;Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01',
+  3812);
+SELECT transformPipeline(trgeometry
+  'SRID=4326;Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01',
+  'urn:ogc:def:coordinateOperation:EPSG::16031', 4326);
 
 -------------------------------------------------------------------------------
 -- atGeometry / minusGeometry — restriction by a geometry on the centroid path


### PR DESCRIPTION
The generic value dispatcher `datum_transf_pj` covers geometry, geography and circular buffers. `transform` and `transformPipeline` on a `poseset`, a `tpose` or a `trgeometry` reach its default branch and raise `Unknown transformation function for type: pose`, although the SQL functions exist for all three and the pose chapter documents an example for `transform(tpose, integer)`.

`pose_transf_pj` gains a declaration in `pose/pose.h`, next to where the `cbuffer` sibling declares `cbuffer_transf_pj`, and `T_POSE` dispatches to it. Each instant of a temporal pose and each element of a pose set then receives the position reprojection plus the WGS-84 geographic to ECEF orientation correction that a static pose receives, so `transform(tpose, srid)` agrees instant by instant with `transform(pose, srid)`.

A `trgeometry` carries a reference geometry beside its poses that shares their frame. The rebuild from transformed instants does not carry it over, so `ensure_not_trgeometry` rejects that type with an explicit message.

The pose chapter documents the frame correction with the SRID surface of the type, beside the signatures and the pipeline form, rather than in the OGC GeoPose section; the reference chapter already points there. The `transform(pose, 3812)` example carries the target SRID that the function returns.

Regression queries cover the instant, discrete-sequence, continuous-sequence, same-SRID, 2D and unknown-SRID paths for `tpose`, and the rejected `trgeometry` transformation. Every value they print is exact or bounded to six decimals: `round` on a 3D pose renormalises the quaternion it just rounded, so a general orientation would print full double precision and drift across platforms.