### PR TITLE
Rename the GeoPose frame registry functions to camelCase

### DIFF
--- a/mobilitydb/sql/pose/120_geopose_frames.in.sql
+++ b/mobilitydb/sql/pose/120_geopose_frames.in.sql
@@ -81,15 +81,15 @@ INSERT INTO geopose_frames(frame_id, authority, code, name, srid, is_geographic,
 
 /* Helper SQL functions to query the registry without exposing the schema. */
 
-CREATE FUNCTION geopose_frame_srid(frame_id integer) RETURNS integer
+CREATE FUNCTION geoPoseFrameSRID(frame_id integer) RETURNS integer
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
   AS $$ SELECT srid FROM geopose_frames WHERE geopose_frames.frame_id = $1 $$;
 
-CREATE FUNCTION geopose_frame_name(frame_id integer) RETURNS text
+CREATE FUNCTION geoPoseFrameName(frame_id integer) RETURNS text
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
   AS $$ SELECT name FROM geopose_frames WHERE geopose_frames.frame_id = $1 $$;
 
-CREATE FUNCTION geopose_frame_is_geographic(frame_id integer) RETURNS boolean
+CREATE FUNCTION geoPoseFrameIsGeographic(frame_id integer) RETURNS boolean
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
   AS $$ SELECT is_geographic FROM geopose_frames WHERE geopose_frames.frame_id = $1 $$;
 

--- a/mobilitydb/test/pose/expected/107_geopose_frames.test.out
+++ b/mobilitydb/test/pose/expected/107_geopose_frames.test.out
@@ -4,26 +4,26 @@ SELECT count(*) FROM geopose_frames;
      4
 (1 row)
 
-SELECT geopose_frame_srid(1), geopose_frame_is_geographic(1);
- geopose_frame_srid | geopose_frame_is_geographic 
---------------------+-----------------------------
-               4326 | t
+SELECT geoPoseFrameSRID(1), geoPoseFrameIsGeographic(1);
+ geoposeframesrid | geoposeframeisgeographic 
+------------------+--------------------------
+             4326 | t
 (1 row)
 
-SELECT geopose_frame_name(2), geopose_frame_is_geographic(2);
-           geopose_frame_name            | geopose_frame_is_geographic 
------------------------------------------+-----------------------------
+SELECT geoPoseFrameName(2), geoPoseFrameIsGeographic(2);
+            geoposeframename             | geoposeframeisgeographic 
+-----------------------------------------+--------------------------
  WGS-84 ECEF (Earth-Centred Earth-Fixed) | f
 (1 row)
 
-SELECT geopose_frame_srid(3) IS NULL AS ltp_srid_null,
-       geopose_frame_srid(4) IS NULL AS body_srid_null;
+SELECT geoPoseFrameSRID(3) IS NULL AS ltp_srid_null,
+       geoPoseFrameSRID(4) IS NULL AS body_srid_null;
  ltp_srid_null | body_srid_null 
 ---------------+----------------
  t             | t
 (1 row)
 
-SELECT geopose_frame_srid(999) AS unknown_srid;
+SELECT geoPoseFrameSRID(999) AS unknown_srid;
  unknown_srid 
 --------------
              
@@ -33,10 +33,10 @@ INSERT INTO geopose_frames(frame_id, authority, code, name, srid, is_geographic,
 VALUES (1000, 'CUSTOM', 'EXAMPLE', 'Example custom outer frame', 3857, false,
         'Web Mercator projection used for tile-aligned visualisation.');
 INSERT 0 1
-SELECT geopose_frame_srid(1000), geopose_frame_name(1000);
- geopose_frame_srid |     geopose_frame_name     
---------------------+----------------------------
-               3857 | Example custom outer frame
+SELECT geoPoseFrameSRID(1000), geoPoseFrameName(1000);
+ geoposeframesrid |      geoposeframename      
+------------------+----------------------------
+             3857 | Example custom outer frame
 (1 row)
 
 DELETE FROM geopose_frames WHERE frame_id = 1000;

--- a/mobilitydb/test/pose/queries/107_geopose_frames.test.sql
+++ b/mobilitydb/test/pose/queries/107_geopose_frames.test.sql
@@ -13,24 +13,24 @@
 SELECT count(*) FROM geopose_frames;
 
 -- WGS-84 geographic is frame_id 1; SRID maps to PostGIS 4326.
-SELECT geopose_frame_srid(1), geopose_frame_is_geographic(1);
+SELECT geoPoseFrameSRID(1), geoPoseFrameIsGeographic(1);
 
 -- WGS-84 ECEF (frame_id 2) is Cartesian.
-SELECT geopose_frame_name(2), geopose_frame_is_geographic(2);
+SELECT geoPoseFrameName(2), geoPoseFrameIsGeographic(2);
 
 -- The parametric frames (LTP, BODY) have no static SRID.
-SELECT geopose_frame_srid(3) IS NULL AS ltp_srid_null,
-       geopose_frame_srid(4) IS NULL AS body_srid_null;
+SELECT geoPoseFrameSRID(3) IS NULL AS ltp_srid_null,
+       geoPoseFrameSRID(4) IS NULL AS body_srid_null;
 
 -- Lookup of an unknown frame_id returns NULL (helper functions are STRICT but
 -- the missing-row case yields NULL via the SQL body's empty result).
-SELECT geopose_frame_srid(999) AS unknown_srid;
+SELECT geoPoseFrameSRID(999) AS unknown_srid;
 
 -- A user can register a custom frame.
 INSERT INTO geopose_frames(frame_id, authority, code, name, srid, is_geographic, description)
 VALUES (1000, 'CUSTOM', 'EXAMPLE', 'Example custom outer frame', 3857, false,
         'Web Mercator projection used for tile-aligned visualisation.');
-SELECT geopose_frame_srid(1000), geopose_frame_name(1000);
+SELECT geoPoseFrameSRID(1000), geoPoseFrameName(1000);
 
 -- Cleanup the user-added row so the test doesn't leave state behind.
 DELETE FROM geopose_frames WHERE frame_id = 1000;


### PR DESCRIPTION
The SQL API names functions in camelCase, as in `expandSpace`, `setSRID` and
`isGeodetic`, while snake_case belongs to the MEOS C API. The three helper
functions over the GeoPose frame registry follow that convention:

| current | renamed |
| --- | --- |
| `geopose_frame_srid` | `geoPoseFrameSRID` |
| `geopose_frame_name` | `geoPoseFrameName` |
| `geopose_frame_is_geographic` | `geoPoseFrameIsGeographic` |

`SRID` stays fully capitalised, as in `setSRID`, and the predicate keeps the `is`
prefix, as in `isGeodetic`. The surrounding GeoPose surface already spells the
noun this way in `asGeoPose`, `poseFromGeoPose` and `tposeFromGeoPose`.

The `geopose_frames` catalog table and its columns keep their names: they are a
table, not part of the function API. These three are the only user-facing
snake_case functions in the pose family; the rest are internal I/O, aggregate
transition and GiST support functions.

The regression test calls these functions by name, so PostgreSQL derives the
result column labels from them and folds the labels to lowercase, and the column
widths shift with the new name lengths. The expected output is therefore
regenerated from the run rather than edited by hand. Normalising the function
spellings and the column padding makes the previous and regenerated expected
output identical, so the change carries no value difference.
