### PR TITLE
Name the GeoPose frame registry helpers in the pose chapters as the SQL does

### DIFF
--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -473,9 +473,9 @@ FROM geopose_frames ORDER BY frame_id;
 </programlisting>
 				<para>Tres funciones auxiliares SQL proporcionan una interfaz de consulta estable para el código que no quiere codificar de forma rígida la disposición de la tabla:</para>
 				<itemizedlist>
-					<listitem><para><varname>geopose_frame_srid(int) → int</varname> — el SRID de PostGIS de un marco, o <varname>NULL</varname> si el marco es paramétrico (LTP, BODY).</para></listitem>
-					<listitem><para><varname>geopose_frame_name(int) → text</varname> — el nombre legible del marco.</para></listitem>
-					<listitem><para><varname>geopose_frame_is_geographic(int) → boolean</varname> — <varname>true</varname> para los marcos lat/lon/h, <varname>false</varname> para los cartesianos o proyectados.</para></listitem>
+					<listitem><para><varname>geoPoseFrameSRID(int) → int</varname> — el SRID de PostGIS de un marco, o <varname>NULL</varname> si el marco es paramétrico (LTP, BODY).</para></listitem>
+					<listitem><para><varname>geoPoseFrameName(int) → text</varname> — el nombre legible del marco.</para></listitem>
+					<listitem><para><varname>geoPoseFrameIsGeographic(int) → boolean</varname> — <varname>true</varname> para los marcos lat/lon/h, <varname>false</varname> para los cartesianos o proyectados.</para></listitem>
 				</itemizedlist>
 				<para>Los usuarios pueden registrar marcos personalizados insertándolos en <varname>geopose_frames</varname>; el catálogo está marcado como una tabla de configuración, por lo que <varname>pg_dump</varname> preserva las filas del usuario.</para>
 			</sect3>

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -481,9 +481,9 @@ FROM geopose_frames ORDER BY frame_id;
 </programlisting>
 				<para>Three SQL helpers provide a stable lookup interface for code that doesn't want to hard-code the table layout:</para>
 				<itemizedlist>
-					<listitem><para><varname>geopose_frame_srid(int) → int</varname> — the PostGIS SRID for a frame, or <varname>NULL</varname> if the frame is parametric (LTP, BODY).</para></listitem>
-					<listitem><para><varname>geopose_frame_name(int) → text</varname> — the human-readable name of the frame.</para></listitem>
-					<listitem><para><varname>geopose_frame_is_geographic(int) → boolean</varname> — <varname>true</varname> for lat/lon/h frames, <varname>false</varname> for Cartesian or projected.</para></listitem>
+					<listitem><para><varname>geoPoseFrameSRID(int) → int</varname> — the PostGIS SRID for a frame, or <varname>NULL</varname> if the frame is parametric (LTP, BODY).</para></listitem>
+					<listitem><para><varname>geoPoseFrameName(int) → text</varname> — the human-readable name of the frame.</para></listitem>
+					<listitem><para><varname>geoPoseFrameIsGeographic(int) → boolean</varname> — <varname>true</varname> for lat/lon/h frames, <varname>false</varname> for Cartesian or projected.</para></listitem>
 				</itemizedlist>
 				<para>Users can register custom frames by inserting into <varname>geopose_frames</varname>; the catalog is marked as a configuration table so <varname>pg_dump</varname> preserves user rows.</para>
 			</sect3>


### PR DESCRIPTION
The registry helpers are `geoPoseFrameSRID`, `geoPoseFrameName` and `geoPoseFrameIsGeographic` in `mobilitydb/sql/pose/120_geopose_frames.in.sql`. Both pose chapters name them the same way, so the manual documents the functions the extension defines.

`generate_docs.yml` runs on a push to master whenever `doc/**` changes and is not exercised by pull-request checks, so its six steps ran locally on this commit: `xsltproc` HTML, `dblatex` PDF and `dbtoepub` EPUB, for the English and the Spanish manual.