### PR TITLE
Derive the WKB pixel size from raquet_pixtype_size

### DIFF
--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -1972,18 +1972,13 @@ raquet_from_wkb_state(meos_wkb_parse_state *s)
   uint16_t height = (uint16_t) int32_from_wkb_state(s);
   bool has_nodata = (bool) byte_from_wkb_state(s);
   double nodata = double_from_wkb_state(s);
-  size_t pixsize;
-  switch (pixtype)
+  /* A zero size is the unknown-pixel-type signal of #raquet_pixtype_size */
+  size_t pixsize = raquet_pixtype_size((MeosPixType) pixtype);
+  if (pixsize == 0)
   {
-    case MEOS_PT_UINT8:   pixsize = 1; break;
-    case MEOS_PT_INT16:   pixsize = 2; break;
-    case MEOS_PT_INT32:   pixsize = 4; break;
-    case MEOS_PT_FLOAT32: pixsize = 4; break;
-    case MEOS_PT_FLOAT64: pixsize = 8; break;
-    default:
-      meos_error(ERROR, MEOS_ERR_WKB_INPUT,
-        "Unknown raquet pixel type in WKB: %u", pixtype);
-      return (Datum) 0;
+    meos_error(ERROR, MEOS_ERR_WKB_INPUT,
+      "Unknown raquet pixel type in WKB: %u", pixtype);
+    return (Datum) 0;
   }
   size_t npixels = (size_t) width * height * pixsize;
   /* Check that there is enough data to read the pixel payload */


### PR DESCRIPTION
The raquet WKB reader carries its own switch over the pixel type to obtain the
pixel size in bytes, duplicating `raquet_pixtype_size`. The reader calls that
function instead.

`raquet_pixtype_size` returns 0 for a type it does not know, so that value is the
unknown-type case at the call site, which keeps the WKB-specific error code and
message. `meos_raster.h` is already included under the same `RASTER` guard as the
reader, so no further include is needed.

The two tables agree on every entry (UINT8 1, INT16 2, INT32 4, FLOAT32 4,
FLOAT64 8), so the payload length the reader computes is unchanged and the WKB
wire format is untouched.
