### PR TITLE
Document the temporal pose speed accessors with the other accessors

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1664,6 +1664,14 @@
 					<listitem>
 						<para><link linkend="tpose_valueAtTimestamp"><varname>valueAtTimestamp</varname></link>: Devuelve el valor en una marca de tiempo</para>
 					</listitem>
+
+					<listitem>
+						<para><link linkend="tpose_speed"><varname>speed</varname></link>: Devuelve la velocidad de una pose temporal como un flotante temporal, la magnitud de la velocidad de la componente de posición (distancia recorrida por unidad de tiempo)</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tpose_angular_speed"><varname>angularSpeed</varname></link>: Devuelve la velocidad angular de una pose temporal como un flotante temporal con interpolación escalonada (radianes por unidad de tiempo)</para>
+					</listitem>
 				</itemizedlist>
 			</sect3>
 

--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -539,34 +539,6 @@ SELECT asGeoPose(tpose '[Pose(Point(8 47), 0)@2026-01-01,
 				</itemizedlist>
 			</sect3>
 
-			<sect3 xml:id="pose_geopose_speed">
-				<title>Velocidad y velocidad angular</title>
-				<itemizedlist>
-					<listitem xml:id="tpose_speed">
-						<indexterm significance="normal"><primary><varname>speed</varname></primary></indexterm>
-						<para>Devuelve la velocidad de una pose temporal como un flotante temporal: la magnitud de la velocidad de la componente de posición (distancia recorrida por unidad de tiempo). La orientación no forma parte de este escalar; para la velocidad angular véase <varname>angularSpeed</varname>.</para>
-						<para><varname>speed(tpose) → tfloat</varname></para>
-						<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT asText(speed(tpose '[Pose(Point(0 0), 0)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02]'));
--- Interp=Step;[1.6368e-5@2000-01-01, 1.6368e-5@2000-01-02]
--- (sqrt(2) units / 86400 seconds — units depend on the SRID's CRS)
-</programlisting>
-					</listitem>
-
-					<listitem xml:id="tpose_angular_speed">
-						<indexterm significance="normal"><primary><varname>angularSpeed</varname></primary></indexterm>
-						<para>Devuelve la velocidad angular de una pose temporal como un flotante temporal con interpolación por pasos (radianes por unidad de tiempo). Para las poses 2D es el delta theta del arco más corto por segmento dividido por la duración del segmento; para las poses 3D es el ángulo de arco de SLERP <varname>2 · acos(|q1 · q2|)</varname> dividido por la duración del segmento. SLERP tiene por construcción velocidad angular constante a lo largo de un segmento, por lo que el resultado es constante a trozos.</para>
-						<para><varname>angularSpeed(tpose) → tfloat</varname></para>
-						<programlisting language="sql" xml:space="preserve" format="linespecific">
--- 90-degree yaw rotation over one day -> pi/2 rad / 86400 s
-SELECT asText(angularSpeed(tpose
-  '[Pose(Point(0 0 0), 1, 0, 0, 0)@2000-01-01,
-    Pose(Point(0 0 0), 0.7071067811865476, 0, 0, 0.7071067811865475)@2000-01-02]'));
--- Interp=Step;[1.8181e-5@2000-01-01, 1.8181e-5@2000-01-02]
-</programlisting>
-					</listitem>
-				</itemizedlist>
-			</sect3>
 		</sect2>
 
 	</sect1>
@@ -899,6 +871,30 @@ SELECT asText(valueAtTimestamp(tpose
   '[Pose(Point Z(1 1 1), 0.5, 0.5, 0.5, 0.5)@2001-01-01,
     Pose(Point Z(3 3 3), 1, 0, 0, 0)@2001-01-03)', timestamptz '2001-01-02'), 6);
 -- Pose(POINT Z (2 2 2),0.866025,0.288675,0.288675,0.288675)
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="tpose_speed">
+				<indexterm significance="normal"><primary><varname>speed</varname></primary></indexterm>
+				<para>Devuelve la velocidad de una pose temporal como un flotante temporal: la magnitud de la velocidad de la componente de posición (distancia recorrida por unidad de tiempo). La orientación no forma parte de este escalar; para la velocidad angular véase <varname>angularSpeed</varname>.</para>
+				<para><varname>speed(tpose) → tfloat</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(speed(tpose '[Pose(Point(0 0), 0)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02]'));
+-- Interp=Step;[1.6368e-5@2000-01-01, 1.6368e-5@2000-01-02]
+-- (sqrt(2) units / 86400 seconds — units depend on the SRID's CRS)
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="tpose_angular_speed">
+				<indexterm significance="normal"><primary><varname>angularSpeed</varname></primary></indexterm>
+				<para>Devuelve la velocidad angular de una pose temporal como un flotante temporal con interpolación por pasos (radianes por unidad de tiempo). Para las poses 2D es el delta theta del arco más corto por segmento dividido por la duración del segmento; para las poses 3D es el ángulo de arco de SLERP <varname>2 · acos(|q1 · q2|)</varname> dividido por la duración del segmento. SLERP tiene por construcción velocidad angular constante a lo largo de un segmento, por lo que el resultado es constante a trozos.</para>
+				<para><varname>angularSpeed(tpose) → tfloat</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- 90-degree yaw rotation over one day -> pi/2 rad / 86400 s
+SELECT asText(angularSpeed(tpose
+  '[Pose(Point(0 0 0), 1, 0, 0, 0)@2000-01-01,
+    Pose(Point(0 0 0), 0.7071067811865476, 0, 0, 0.7071067811865475)@2000-01-02]'));
+-- Interp=Step;[1.8181e-5@2000-01-01, 1.8181e-5@2000-01-02]
 </programlisting>
 			</listitem>
 		</itemizedlist>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1650,6 +1650,14 @@
 					<listitem>
 						<para><link linkend="tpose_valueAtTimestamp"><varname>valueAtTimestamp</varname></link>: Return the value at a timestamp</para>
 					</listitem>
+
+					<listitem>
+						<para><link linkend="tpose_speed"><varname>speed</varname></link>: Return the speed of a temporal pose as a temporal float, the magnitude of the position-component velocity (distance travelled per unit time)</para>
+					</listitem>
+
+					<listitem>
+						<para><link linkend="tpose_angular_speed"><varname>angularSpeed</varname></link>: Return the angular speed of a temporal pose as a step-interpolated temporal float (radians per unit time)</para>
+					</listitem>
 				</itemizedlist>
 			</sect3>
 

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -547,34 +547,6 @@ SELECT asGeoPose(tpose '[Pose(Point(8 47), 0)@2026-01-01,
 				</itemizedlist>
 			</sect3>
 
-			<sect3 xml:id="pose_geopose_speed">
-				<title>Speed and angular speed</title>
-				<itemizedlist>
-					<listitem xml:id="tpose_speed">
-						<indexterm significance="normal"><primary><varname>speed</varname></primary></indexterm>
-						<para>Return the speed of a temporal pose as a temporal float — the magnitude of the position-component velocity (distance travelled per unit time). The orientation is not part of this scalar; for angular velocity see <varname>angularSpeed</varname>.</para>
-						<para><varname>speed(tpose) → tfloat</varname></para>
-						<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT asText(speed(tpose '[Pose(Point(0 0), 0)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02]'));
--- Interp=Step;[1.6368e-5@2000-01-01, 1.6368e-5@2000-01-02]
--- (sqrt(2) units / 86400 seconds — units depend on the SRID's CRS)
-</programlisting>
-					</listitem>
-
-					<listitem xml:id="tpose_angular_speed">
-						<indexterm significance="normal"><primary><varname>angularSpeed</varname></primary></indexterm>
-						<para>Return the angular speed of a temporal pose as a step-interpolated temporal float (radians per unit time). For 2D poses this is the per-segment shortest-arc theta delta divided by the segment duration; for 3D poses it is the SLERP arc angle <varname>2 · acos(|q1 · q2|)</varname> divided by the segment duration. SLERP is by construction constant-angular-velocity along a segment, so the result is piecewise-constant.</para>
-						<para><varname>angularSpeed(tpose) → tfloat</varname></para>
-						<programlisting language="sql" xml:space="preserve" format="linespecific">
--- 90-degree yaw rotation over one day -> pi/2 rad / 86400 s
-SELECT asText(angularSpeed(tpose
-  '[Pose(Point(0 0 0), 1, 0, 0, 0)@2000-01-01,
-    Pose(Point(0 0 0), 0.7071067811865476, 0, 0, 0.7071067811865475)@2000-01-02]'));
--- Interp=Step;[1.8181e-5@2000-01-01, 1.8181e-5@2000-01-02]
-</programlisting>
-					</listitem>
-				</itemizedlist>
-			</sect3>
 		</sect2>
 	</sect1>
 
@@ -906,6 +878,30 @@ SELECT asText(valueAtTimestamp(tpose
   '[Pose(Point Z(1 1 1), 0.5, 0.5, 0.5, 0.5)@2001-01-01,
     Pose(Point Z(3 3 3), 1, 0, 0, 0)@2001-01-03)', timestamptz '2001-01-02'), 6);
 -- Pose(POINT Z (2 2 2),0.866025,0.288675,0.288675,0.288675)
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="tpose_speed">
+				<indexterm significance="normal"><primary><varname>speed</varname></primary></indexterm>
+				<para>Return the speed of a temporal pose as a temporal float — the magnitude of the position-component velocity (distance travelled per unit time). The orientation is not part of this scalar; for angular velocity see <varname>angularSpeed</varname>.</para>
+				<para><varname>speed(tpose) → tfloat</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(speed(tpose '[Pose(Point(0 0), 0)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02]'));
+-- Interp=Step;[1.6368e-5@2000-01-01, 1.6368e-5@2000-01-02]
+-- (sqrt(2) units / 86400 seconds — units depend on the SRID's CRS)
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="tpose_angular_speed">
+				<indexterm significance="normal"><primary><varname>angularSpeed</varname></primary></indexterm>
+				<para>Return the angular speed of a temporal pose as a step-interpolated temporal float (radians per unit time). For 2D poses this is the per-segment shortest-arc theta delta divided by the segment duration; for 3D poses it is the SLERP arc angle <varname>2 · acos(|q1 · q2|)</varname> divided by the segment duration. SLERP is by construction constant-angular-velocity along a segment, so the result is piecewise-constant.</para>
+				<para><varname>angularSpeed(tpose) → tfloat</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- 90-degree yaw rotation over one day -> pi/2 rad / 86400 s
+SELECT asText(angularSpeed(tpose
+  '[Pose(Point(0 0 0), 1, 0, 0, 0)@2000-01-01,
+    Pose(Point(0 0 0), 0.7071067811865476, 0, 0, 0.7071067811865475)@2000-01-02]'));
+-- Interp=Step;[1.8181e-5@2000-01-01, 1.8181e-5@2000-01-02]
 </programlisting>
 			</listitem>
 		</itemizedlist>


### PR DESCRIPTION
`speed` and `angularSpeed` are accessors of a temporal pose: they read a derived quantity out of the value and return a `tfloat`. Both chapters document them in the Accessors section beside `getValues`, `points`, `rotation` and `valueAtTimestamp`, which is where the sibling families keep `speed` as well (`tgeo_speed` sits in `tgeo_accessors`, and `tnpoint_speed` and `trgeometry_speed` follow the same pattern). Neither function is part of the OGC GeoPose surface.

The reference index of both languages carries a row for each, with the same one-liner as the chapter entry.

`generate_docs.yml` runs on a push to master whenever `doc/**` changes and pull-request checks never exercise it, so its six steps ran locally on this commit: `xsltproc` HTML, `dblatex` PDF and `dbtoepub` EPUB, for the English and the Spanish manual.