### PR TITLE
Keep the network point and cell index chapters a user reference

### DIFF
--- a/doc/contributing/th3index_design_notes.md
+++ b/doc/contributing/th3index_design_notes.md
@@ -1,0 +1,61 @@
+<!--
+  MobilityDB — Temporal H3 Cell Indexes: Design Notes
+  Copyright(c) MobilityDB Contributors
+
+  This documentation is licensed under a Creative Commons Attribution-Share
+  Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
+-->
+
+# Temporal H3 Cell Indexes — Design Notes
+
+An `h3index` is an opaque 64-bit cell identifier in a fixed hierarchy, so the type trades exact geometry for cell-level aggregation. The notes below record when the cell type fits a workload, the conventions the implementation enforces, and the numerical characteristics a production workload sees.
+
+> **Audience**: a contributor or binding author working at the MEOS C level.
+> This is design rationale, not user documentation — the user manual
+> (`doc/temporal_h3_index.xml`) intentionally does **not** carry these internals.
+
+---
+
+## When to use th3index
+
+Use `th3index` when the natural identifier for a discrete location at a given resolution is an H3 cell &#x2014; vehicle trips bucketed at H3 resolution 9, environmental sensor readings binned by H3 cell, geo-fenced events keyed by their containing cell. The type stores one H3 cell per instant; resolution may vary across instants in a single trajectory but most workloads pin one resolution per column.
+
+Choose `tgeompoint` / `tgeogpoint` over `th3index` when the actual geographic position (sub-cell precision) is the value of interest. Choose `tbigint` over `th3index` when the values happen to be 64-bit integers but carry no H3 semantics &#x2014; the binary representations are identical (they cast losslessly via `th3index :: tbigint` and back) but the SQL type system uses the distinction to reject h3index-agnostic functions on h3index-specific trajectories.
+
+## H3-specific hazards
+
+Five hazards reliably bite workloads using H3 cells. Each is a property of the H3 grid itself rather than a MobilityDB implementation choice; the mitigations below explain how to work with them.
+
+- **Int64 ordering is arbitrary with respect to grid geometry**. H3 cell identifiers are 64-bit unsigned integers whose bitpattern encodes resolution, base cell, and hierarchical position. The bitwise ordering of two cells carries no geographic meaning &#x2014; two cells that are bit-adjacent may be on opposite sides of the planet, and two cells that are spatially adjacent may have wildly different bitpatterns.
+
+  **Mitigation**: `th3index` deliberately has no `h3span` / `h3spanset` companion types (precedent: `geometry` has no `geometryspan`), and the bbox indexes capture the cells' spatiotemporal extent (`stbox`), not the cell-id value. Value-range filtering must go through `h3_*` inspection functions (resolution, base cell, hierarchy checks) or explicit set enumeration via `h3indexset`. Code that assumes `cell_a < cell_b` reflects spatial proximity will silently produce wrong results.
+
+- **Resolution mixing in operations**. H3 cells at different resolutions (0&#x2013;15) represent different coverage areas. Mixing resolutions in a single trajectory is valid but semantically requires explicit justification &#x2014; `th3CellToParent(cell, coarser_res)` coarsens, `h3CellToChildren(parent, finer_res)` refines, and `h3CompactCells` / `h3UncompactCells` round-trip correctly only when input resolutions are compatible.
+
+  **Mitigation**: consumers should document the resolution invariant per trajectory (e.g. "all cells are resolution 9") and validate inputs at the ingestion boundary. The `th3GetResolution` accessor lets a CHECK constraint enforce this.
+
+- **Pentagon cells**. The H3 grid has 12 pentagonal (instead of hexagonal) cells per resolution &#x2014; the Eisenstein duals of the icosahedron's 12 vertices. `h3GridRing` may fail near these pentagons; `h3GridPathCells` fails if the path crosses one. The error is loud (libh3 raises an explicit failure), but workloads that expect ring / path operations to always succeed need a guard.
+
+  **Mitigation**: defensive code should wrap pentagon-sensitive calls and check `h3_is_pentagon_cell` on inputs and key outputs. For trajectories that pass near a pentagon, fall back to `h3GridDisk` (which is pentagon-safe) or compute path segments in pieces around the pentagon.
+
+- **Compaction / decompaction round-trip**. `h3CompactCells` produces the most compact mixed-resolution representation of a set of cells; `h3UncompactCells` expands it back. The round-trip is lossless in spatial extent, but **cell ordering is not preserved** &#x2014; libh3 does not guarantee a sorted output. Queries that consume the output as if its order were stable will return different results before and after compaction even when the underlying spatial set is identical.
+
+  **Mitigation**: re-sort post-compaction if order matters (e.g. `ORDER BY cell` in SQL or `ARRAY_AGG ... ORDER BY 1` when materialising). For temporal sets, prefer the `h3indexset` set-equality semantics over array-equality semantics.
+
+- **Antimeridian and pole behaviour**. H3's base cells are positioned on an icosahedron; at high resolutions some cells near the antimeridian or poles can have counter-intuitive geometry. `th3CellToLatlng` / `h3_latlng_to_cell` round-trip correctly, but coordinates near &#xb1;180&#xb0; longitude or near the poles may resolve to cells in unexpected base-cell groups.
+
+  **Mitigation**: workloads at polar latitudes or that cross the antimeridian should validate representative cells against the libh3 reference implementation directly and add fixtures for the specific edge cases the workload encounters.
+
+## Durability and storage
+
+The on-disk representation of `th3index` is byte-identical to `tbigint` (each instant carries one 64-bit H3 cell ID plus a timestamp). Consequences for storage planning:
+
+- **WKT** via `th3_in` and `th3_out`. Cells render as canonical hex strings (e.g. `'8928308280fffff'`), which is also the form accepted on input. Round-trip is bit-stable.
+
+- **WKB / EWKB / HexWKB** via the standard PostGIS endian-flag-then-payload pattern. Stable across PostgreSQL major versions.
+
+- **MFJSON** via `asMFJSON(th3index)` and `th3indexFromMFJSON(text)`. The cell payload renders as the int64 cell identifier in the `values` array, the same representation carried by `tbigint`; consumers that need the canonical hex form apply `h3_cell_to_string`.
+
+- **pg_dump** uses WKT in plain mode and WKB under `--binary-upgrade`; both round-trip cleanly.
+
+- **Cross-cast with `tbigint`**: the bidirectional `th3index :: tbigint` casts are zero-cost bitwise reinterpretations. Use them when working with both type-safe (`th3index`) and arithmetic-friendly (`tbigint`) views of the same trajectory in a single query.

--- a/doc/contributing/tnpoint_design_notes.md
+++ b/doc/contributing/tnpoint_design_notes.md
@@ -1,0 +1,61 @@
+<!--
+  MobilityDB — Temporal Network Points: Design Notes
+  Copyright(c) MobilityDB Contributors
+
+  This documentation is licensed under a Creative Commons Attribution-Share
+  Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
+-->
+
+# Temporal Network Points — Design Notes
+
+A network point is a `(rid, pos)` pair whose position is relative to a route in a loaded network, so its behaviour follows from two decisions: the SRID comes from the route registry rather than the value, and network-relative semantics apply only within one connected component. The notes below record the conventions the implementation enforces and the numerical characteristics of the kernels.
+
+> **Audience**: a contributor or binding author working at the MEOS C level.
+> This is design rationale, not user documentation — the user manual
+> (`doc/temporal_network_points.xml`) intentionally does **not** carry these internals.
+
+---
+
+## When to use tnpoint vs tgeompoint
+
+A `tgeompoint` tracks a position in free space; a `tnpoint` tracks a position constrained to a known network of routes. Each network-point value is a pair `(rid, pos)` where `rid` is the route identifier and `pos` is the relative position along that route, normalised to `[0, 1]` (start of route to end of route).
+
+Use `tgeompoint` when the moving object is not constrained to a network, when the network topology is unknown, or when only the trajectory geometry matters &#x2014; vehicle GPS tracks at the raw-feed level, animal movement, AIS feeds.
+
+Use `tnpoint` when motion is on a known network and you want network-relative semantics: distances measured along the route, not in free space; aggregations grouped by route segment; spatial joins constrained to "same network". Canonical workloads are train-network and road-network tracking, where map-matched feeds become `tnpoint` values.
+
+The position component of a `tnpoint` is recoverable as a `tgeompoint` via the standard cast (or as a `geometry` via `geometry(npoint)`); a `geometry` can be projected back onto the loaded network with `npoint(geometry)`. Consequently a single `tnpoint` column subsumes a map-matched `tgeompoint` column when network-relative semantics are needed.
+
+## SRID inheritance from the network registry
+
+An `npoint` value does not carry its own SRID; it inherits the SRID of the route referenced by its `rid` field. The set of known routes &#x2014; the **ways** registry &#x2014; is loaded into a per-process cache (see `meos/src/npoint/ways_meos.c`) the first time a network function runs, and is keyed by route gid. Every `npoint` accessor that needs the route geometry (`npoint_to_geompoint`, `npoint_to_stbox`, all spatial predicates and distance functions) consults this cache.
+
+In the PostgreSQL extension the cache is populated automatically from the `public.ways` table. In standalone MEOS the application must call `meos_register_ways(...)` with the route table before any `npoint` operation; `meos_finalize_ways()` is idempotent and can be called multiple times safely. Cross-type operations between an `npoint` and a geometry validate that the route's SRID matches the geometry's SRID; mismatches raise an explicit error rather than silently re-projecting.
+
+## Numerical hazards
+
+Four hazards reliably bite real network-constrained tracking workloads. The implementation mitigates each as follows:
+
+- **Position-parameter clamping at [0, 1]**. A position outside `[0, 1]` has no meaning on a route that has not been extended.
+
+  **Mitigation**: `npoint_make` rejects `pos < 0` or `pos > 1` at construction with the message "The relative position must be a real number between 0 and 1", and the same check is applied at the WKT, WKB, and MFJSON parser entries. The endpoints `0.0` (start of route) and `1.0` (end of route) are valid and supported &#x2014; the test suite exercises both. Corrupt or unclipped feed data fails loudly rather than poisoning a downstream query.
+
+- **Mixed-SRID handling**. A `tnpoint` inherits its SRID from its route, while a `geometry` argument carries its SRID explicitly.
+
+  **Mitigation**: every cross-type operator (`tnpoint <-> geometry`, `tnpoint && geometry`, `distance(tnpoint, geometry)`) validates the two SRIDs match through `ensure_same_srid`; mismatches raise an explicit error rather than silently re-projecting one side onto the other.
+
+- **Route-not-registered**. An `npoint` referencing a route gid not present in the ways cache cannot resolve to a geometry.
+
+  **Mitigation**: `npoint_make` calls `ensure_route_exists` at construction; the WKT, WKB, MFJSON, and `npoint(...)` SQL constructors all flow through this check and raise "There is no route with gid value <n> in table ways" on miss. Standalone MEOS users who skip the `meos_register_ways(...)` bootstrap will see this error on the first network operation, not later as a silent zero-result query.
+
+- **Cross-network operations**. Two `tnpoint` values whose routes belong to different networks (or different connected components of the same network) cannot be related through network distance.
+
+  **Mitigation**: distance and spatial-relationship operators between two `tnpoint` values lower both sides to `tgeompoint` first and compute the result as free-space distance / topology. This is documented behaviour: callers who need true network distance must restrict their query to a single connected component upstream.
+
+## Durability and storage
+
+The on-disk representation of an `npoint` is a 16-byte tuple: an 8-byte route id followed by an 8-byte position. The byte layout is stable: `asBinary(tnpoint)` / `tnpointFromBinary(bytea)` round-trip preserves the value bit-for-bit, and the WKB / HexEWKB serialisations follow the standard temporal-types endian-flag-then-payload pattern. The `asMFJSON(tnpoint)` / `tnpointFromMFJSON(text)` pair is bidirectional, so MovingFeatures-JSON is a viable interchange format on equal footing with WKB. Each instant renders as `{"route":<route>,"position":<position>}`, with the field names matching the SQL accessor surface (`route`, `getPosition`) on the natural-language descriptor convention.
+
+The route id is emitted as a JSON number, which round-trips losslessly between MEOS encoders and decoders (both retain full `int64` precision via `INT64_FORMAT` / `strtoll`). It is not, however, lossless across JavaScript / ECMAScript consumers: the `Number` type has a 53-bit mantissa, so route ids beyond `2^53` (~9 × 10^15) lose precision when parsed by a generic browser-side `JSON.parse`. For OSM-derived networks this matters in practice — OSM way ids crossed `2^53` in 2025 — and the recommended mitigation on the JS side is to parse with a library that materialises numbers as `BigInt` (for example `json-bigint`) rather than rely on the default. This is a deliberate design choice, not an oversight: the alternative (emitting the route as a JSON string, as `th3index` does for its int64 cell payload) would diverge from the JSON shape that all numeric accessors return for this type and break the round-trip with naive int-parsing on every consumer that **does** handle 64-bit integers correctly.
+
+The `pg_dump` output of a table containing `npoint` or `tnpoint` columns uses the WKT representation by default; `pg_dump --binary-upgrade` uses the WKB representation. Both are round-trip-stable, but a dump is only restorable into a database whose `public.ways` table contains all referenced route ids: the route registry is logically a foreign key on every `npoint` column, even though it is not enforced as one.

--- a/doc/contributing/tquadbin_design_notes.md
+++ b/doc/contributing/tquadbin_design_notes.md
@@ -1,0 +1,55 @@
+<!--
+  MobilityDB — Temporal Quadbin Cell Indexes: Design Notes
+  Copyright(c) MobilityDB Contributors
+
+  This documentation is licensed under a Creative Commons Attribution-Share
+  Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
+-->
+
+# Temporal Quadbin Cell Indexes — Design Notes
+
+A `quadbin` packs a Web-Mercator tile into a 64-bit integer, so cells are square in the projected plane rather than on the sphere. The notes below record when the cell type fits a workload, the conventions the implementation enforces, and the numerical characteristics a production workload sees.
+
+> **Audience**: a contributor or binding author working at the MEOS C level.
+> This is design rationale, not user documentation — the user manual
+> (`doc/temporal_quadbin_index.xml`) intentionally does **not** carry these internals.
+
+---
+
+## When to use tquadbin
+
+Use `tquadbin` when the natural identifier for a discrete location at a given resolution is a QUADBIN tile &#x2014; vehicle trips bucketed at a fixed zoom level, sensor readings binned by tile, or events keyed by their containing cell, especially in pipelines that already speak the slippy-map / web-mercator tiling scheme. The type stores one QUADBIN cell per instant; resolution may vary across instants in a single trajectory but most workloads pin one resolution per column.
+
+Choose `tgeompoint` / `tgeogpoint` over `tquadbin` when the actual geographic position (sub-cell precision) is the value of interest. Choose `tbigint` over `tquadbin` when the values happen to be 64-bit integers but carry no QUADBIN semantics &#x2014; the binary representations are identical (they cast losslessly via `tquadbin :: tbigint` and back) but the SQL type system uses the distinction to reject quadbin-agnostic functions on quadbin-specific trajectories.
+
+## QUADBIN-specific hazards
+
+A few hazards reliably bite workloads using QUADBIN cells. Each is a property of the QUADBIN grid itself rather than a MobilityDB implementation choice; the mitigations below explain how to work with them.
+
+- **Int64 ordering is arbitrary with respect to grid geometry**. QUADBIN cell identifiers are 64-bit integers whose bitpattern encodes a header tag, resolution, and tile coordinates. The bitwise ordering of two cells carries no spatial-proximity meaning &#x2014; two cells that are bit-adjacent may be far apart, and two cells that are spatially adjacent may have different bitpatterns.
+
+  **Mitigation**: `tquadbin` deliberately has no `quadbinspan` / `quadbinspanset` companion types (precedent: `geometry` has no `geometryspan`). Value-range filtering must go through the `quadbin_*` inspection functions (resolution, validity, hierarchy) or explicit set enumeration via `quadbinset`. Code that assumes `cell_a < cell_b` reflects spatial proximity will silently produce wrong results.
+
+- **Resolution mixing in operations**. QUADBIN cells at different resolutions (0&#x2013;26) represent different coverage areas. Mixing resolutions in a single trajectory is valid but semantically requires explicit justification &#x2014; `quadbinCellToParent(cell, coarser_res)` coarsens and `quadbinCellToChildren(parent, finer_res)` refines.
+
+  **Mitigation**: consumers should document the resolution invariant per trajectory (e.g. "all cells are resolution 10") and validate inputs at the ingestion boundary. The `quadbinGetResolution` accessor lets a CHECK constraint enforce this.
+
+- **Web-mercator latitude limit**. QUADBIN inherits the web-mercator projection, which is defined only between approximately &#xb1;85.05&#xb0; latitude. Points outside this band have no QUADBIN cell, and cell area shrinks toward the poles &#x2014; `quadbinCellArea` returns progressively smaller values at higher latitudes for cells of the same resolution.
+
+  **Mitigation**: workloads near the poles should clamp or reject latitudes outside the web-mercator band at the ingestion boundary; do not rely on QUADBIN cells for polar coverage.
+
+- **Antimeridian behaviour**. Tile columns wrap at the antimeridian (&#xb1;180&#xb0; longitude). A trajectory crossing the antimeridian moves between cells whose tile `x` coordinates differ by the full width of the grid at that zoom, even though they are spatially adjacent.
+
+  **Mitigation**: workloads that cross the antimeridian should validate representative cells against the QUADBIN reference implementation and add fixtures for the specific edge cases the workload encounters.
+
+## Durability and storage
+
+The on-disk representation of `tquadbin` is byte-identical to `tbigint` (each instant carries one 64-bit QUADBIN cell ID plus a timestamp). Consequences for storage planning:
+
+- **WKT** via `tquadbin_in` and the temporal output function. Cells render as canonical hex strings (e.g. `'480fffffffffffff'`), which is also the form accepted on input. Round-trip is bit-stable.
+
+- **WKB / EWKB / HexWKB** via the standard PostGIS endian-flag-then-payload pattern. Stable across PostgreSQL major versions.
+
+- **pg_dump** uses WKT in plain mode and WKB under `--binary-upgrade`; both round-trip cleanly.
+
+- **Cross-cast with `tbigint`**: the bidirectional `tquadbin :: tbigint` casts are zero-cost bitwise reinterpretations. Use them when working with both type-safe (`tquadbin`) and arithmetic-friendly (`tbigint`) views of the same trajectory in a single query.

--- a/doc/es/temporal_h3_index.xml
+++ b/doc/es/temporal_h3_index.xml
@@ -17,7 +17,6 @@
 
 	<para>Como con otros tipos temporales, <varname>th3index</varname> tiene cuatro subtipos: <varname>Instant</varname>, secuencia discreta, secuencia continua con interpolación de pasos (las celdas H3 son discretas — la interpolación lineal carece de sentido), y <varname>SequenceSet</varname>.</para>
 
-	<para>La guía operativa sobre cuándo elegir <varname>th3index</varname> en lugar de <varname>tgeompoint</varname> o <varname>tgeogpoint</varname>; los peligros específicos de H3 que los consumidores deben anticipar (el orden int64 es arbitrario respecto a la geometría de la cuadrícula, la mezcla de resoluciones en las operaciones, las celdas pentagonales, la no preservación del orden de celdas en el ciclo de compactación, y el comportamiento en el antimeridiano y los polos a alta resolución); y las convenciones de durabilidad y almacenamiento se recogen en <xref linkend="h3_operational_notes"/>.</para>
 
 	<sect1 xml:id="th3_inout">
 		<title>Entrada y Salida</title>
@@ -893,53 +892,4 @@ CREATE INDEX ON trips USING spgist(cells th3_kdtree_ops);
 		</itemizedlist>
 	</sect1>
 
-	<sect1 xml:id="h3_operational_notes">
-		<title>Notas operativas</title>
-		<para>Esta sección recoge el conocimiento operativo que los consumidores necesitan además de la referencia de funciones: cuándo <varname>th3index</varname> es el tipo adecuado, las convenciones que asume la implementación y los peligros específicos de H3 que las cargas de trabajo reales deben tener en cuenta. La cuadrícula hexagonal jerárquica de H3 tiene algunas propiedades no evidentes que la codificación binaria <varname>int64</varname> oculta; esta sección las expone para que no sorprendan a los consumidores.</para>
-
-		<sect2 xml:id="h3_when_to_use">
-			<title>Cuándo usar th3index</title>
-			<para>Use <varname>th3index</varname> cuando el identificador natural de una ubicación discreta a una resolución dada sea una celda H3 &#x2014; viajes de vehículos agrupados a la resolución H3 9, lecturas de sensores ambientales agrupadas por celda H3, eventos geo-cercados identificados por su celda contenedora. El tipo almacena una celda H3 por instante; la resolución puede variar entre los instantes de una misma trayectoria, pero la mayoría de las cargas de trabajo fijan una resolución por columna.</para>
-			<para>Elija <varname>tgeompoint</varname> / <varname>tgeogpoint</varname> en lugar de <varname>th3index</varname> cuando el valor de interés sea la posición geográfica real (precisión subcelular). Elija <varname>tbigint</varname> en lugar de <varname>th3index</varname> cuando los valores resulten ser enteros de 64 bits pero no tengan semántica H3 &#x2014; las representaciones binarias son idénticas (se convierten sin pérdida mediante <varname>th3index :: tbigint</varname> y viceversa) pero el sistema de tipos SQL usa la distinción para rechazar funciones agnósticas a H3 sobre trayectorias específicas de H3.</para>
-		</sect2>
-
-		<sect2 xml:id="h3_hazards">
-			<title>Peligros específicos de H3</title>
-			<para>Cinco peligros afectan de forma fiable a las cargas de trabajo que usan celdas H3. Cada uno es una propiedad de la cuadrícula H3 en sí más que una decisión de implementación de MobilityDB; las mitigaciones siguientes explican cómo trabajar con ellos.</para>
-			<itemizedlist>
-				<listitem>
-					<para><emphasis>El orden int64 es arbitrario respecto a la geometría de la cuadrícula</emphasis>. Los identificadores de celda H3 son enteros sin signo de 64 bits cuyo patrón de bits codifica resolución, celda base y posición jerárquica. El orden binario de dos celdas no tiene significado geográfico &#x2014; dos celdas adyacentes en bits pueden estar en lados opuestos del planeta, y dos celdas espacialmente adyacentes pueden tener patrones de bits muy distintos.</para>
-					<para><emphasis>Mitigación</emphasis>: <varname>th3index</varname> deliberadamente no tiene tipos compañeros <varname>h3span</varname> / <varname>h3spanset</varname> (precedente: <varname>geometry</varname> no tiene <varname>geometryspan</varname>), y los índices de caja envolvente capturan la extensión espaciotemporal de las celdas (<varname>stbox</varname>), no el valor del identificador de celda. El filtrado por rango de valores debe pasar por funciones de inspección <varname>h3_*</varname> (resolución, celda base, comprobaciones de jerarquía) o la enumeración explícita de conjuntos mediante <varname>h3indexset</varname>. El código que asume que <varname>cell_a &lt; cell_b</varname> refleja proximidad espacial producirá resultados silenciosamente erróneos.</para>
-				</listitem>
-				<listitem>
-					<para><emphasis>Mezcla de resoluciones en las operaciones</emphasis>. Las celdas H3 a distintas resoluciones (0&#x2013;15) representan áreas de cobertura diferentes. Mezclar resoluciones en una misma trayectoria es válido pero semánticamente requiere justificación explícita &#x2014; <varname>th3CellToParent(cell, coarser_res)</varname> engrosa, <varname>h3CellToChildren(parent, finer_res)</varname> refina, y <varname>h3CompactCells</varname> / <varname>h3UncompactCells</varname> realizan el ciclo de ida y vuelta correctamente solo cuando las resoluciones de entrada son compatibles.</para>
-					<para><emphasis>Mitigación</emphasis>: los consumidores deberían documentar el invariante de resolución por trayectoria (p. ej. "todas las celdas son de resolución 9") y validar las entradas en el límite de ingesta. El accesor <varname>th3GetResolution</varname> permite que una restricción CHECK lo imponga.</para>
-				</listitem>
-				<listitem>
-					<para><emphasis>Celdas pentagonales</emphasis>. La cuadrícula H3 tiene 12 celdas pentagonales (en lugar de hexagonales) por resolución &#x2014; los duales de Eisenstein de los 12 vértices del icosaedro. <varname>h3GridRing</varname> puede fallar cerca de estos pentágonos; <varname>h3GridPathCells</varname> falla si el camino cruza uno. El error es explícito (libh3 lanza un fallo explícito), pero las cargas de trabajo que esperan que las operaciones de anillo / camino siempre tengan éxito necesitan una protección.</para>
-					<para><emphasis>Mitigación</emphasis>: el código defensivo debería envolver las llamadas sensibles a pentágonos y comprobar <varname>h3_is_pentagon_cell</varname> en las entradas y salidas clave. Para trayectorias que pasan cerca de un pentágono, recurra a <varname>h3GridDisk</varname> (que es seguro ante pentágonos) o calcule los segmentos del camino por partes alrededor del pentágono.</para>
-				</listitem>
-				<listitem>
-					<para><emphasis>Ciclo de compactación / descompactación</emphasis>. <varname>h3CompactCells</varname> produce la representación mixta de resoluciones más compacta de un conjunto de celdas; <varname>h3UncompactCells</varname> la expande de nuevo. El ciclo es sin pérdida en extensión espacial, pero <emphasis>el orden de las celdas no se preserva</emphasis> &#x2014; libh3 no garantiza una salida ordenada. Las consultas que consumen la salida como si su orden fuera estable devolverán resultados distintos antes y después de la compactación aunque el conjunto espacial subyacente sea idéntico.</para>
-					<para><emphasis>Mitigación</emphasis>: reordene tras la compactación si el orden importa (p. ej. <varname>ORDER BY cell</varname> en SQL o <varname>ARRAY_AGG ... ORDER BY 1</varname> al materializar). Para conjuntos temporales, prefiera la semántica de igualdad de conjuntos de <varname>h3indexset</varname> sobre la de igualdad de arreglos.</para>
-				</listitem>
-				<listitem>
-					<para><emphasis>Comportamiento en el antimeridiano y los polos</emphasis>. Las celdas base de H3 se posicionan sobre un icosaedro; a altas resoluciones algunas celdas cerca del antimeridiano o los polos pueden tener una geometría poco intuitiva. <varname>th3CellToLatlng</varname> / <varname>h3_latlng_to_cell</varname> realizan el ciclo de ida y vuelta correctamente, pero las coordenadas cerca de &#xb1;180&#xb0; de longitud o cerca de los polos pueden resolverse a celdas en grupos de celdas base inesperados.</para>
-					<para><emphasis>Mitigación</emphasis>: las cargas de trabajo en latitudes polares o que cruzan el antimeridiano deberían validar celdas representativas contra la implementación de referencia de libh3 directamente y añadir fixtures para los casos límite específicos que la carga de trabajo encuentre.</para>
-				</listitem>
-			</itemizedlist>
-		</sect2>
-
-		<sect2 xml:id="h3_durability">
-			<title>Durabilidad y almacenamiento</title>
-			<para>La representación en disco de <varname>th3index</varname> es byte a byte idéntica a la de <varname>tbigint</varname> (cada instante lleva un ID de celda H3 de 64 bits más una marca de tiempo). Consecuencias para la planificación del almacenamiento:</para>
-			<itemizedlist>
-				<listitem><para><emphasis>WKT</emphasis> mediante <varname>th3_in</varname> y <varname>th3_out</varname>. Las celdas se representan como cadenas hexadecimales canónicas (p. ej. <varname>'8928308280fffff'</varname>), que es también la forma aceptada en la entrada. El ciclo de ida y vuelta es estable a nivel de bits.</para></listitem>
-				<listitem><para><emphasis>WKB / EWKB / HexWKB</emphasis> mediante el patrón estándar de PostGIS de bandera de endianidad seguida de la carga útil. Estable entre versiones mayores de PostgreSQL.</para></listitem>
-				<listitem><para><emphasis>MFJSON</emphasis> mediante <varname>asMFJSON(th3index)</varname> y <varname>th3indexFromMFJSON(text)</varname>. La carga útil de la celda se representa como el identificador int64 de la celda en el arreglo <varname>values</varname>, la misma representación que utiliza <varname>tbigint</varname>; los consumidores que necesiten la forma hexadecimal canónica aplican <varname>h3_cell_to_string</varname>.</para></listitem>
-				<listitem><para><emphasis>pg_dump</emphasis> usa WKT en modo plano y WKB bajo <varname>--binary-upgrade</varname>; ambos realizan el ciclo de ida y vuelta limpiamente.</para></listitem>
-				<listitem><para><emphasis>Conversión cruzada con <varname>tbigint</varname></emphasis>: las conversiones bidireccionales <varname>th3index :: tbigint</varname> son reinterpretaciones binarias sin coste. Úselas al trabajar con vistas tanto seguras por tipo (<varname>th3index</varname>) como aptas para aritmética (<varname>tbigint</varname>) de la misma trayectoria en una sola consulta.</para></listitem>
-			</itemizedlist>
-		</sect2>
-	</sect1>
 </chapter>

--- a/doc/es/temporal_network_points.xml
+++ b/doc/es/temporal_network_points.xml
@@ -32,7 +32,6 @@
 
 	<para>El tipo <varname>npoint</varname> sirve como tipo base para definir el tipo punto de red temporal <varname>tnpoint</varname>. El tipo <varname>tnpoint</varname> tiene una funcionalidad similar al tipo de punto temporal <varname>tgeompoint</varname> con la excepción de que solo considera dos dimensiones. Por lo tanto, todas las funciones y operadores descritos anteriormente para el tipo <varname>tgeompoint</varname> también son aplicables para el tipo <varname>tnpoint</varname>. Además, hay funciones específicas definidas para el tipo <varname>tnpoint</varname>.</para>
 
-	<para>La guía operativa sobre cómo elegir entre <varname>tnpoint</varname> y <varname>tgeompoint</varname>; el contrato de herencia del SRID (el SRID se lee de la ruta registrada en <varname>ways</varname>, no se lleva explícitamente en el valor); los peligros numéricos que las cargas de trabajo de producción deben anticipar (la limitación del parámetro de posición a <varname>[0, 1]</varname>, el manejo de SRID mixtos, los errores de ruta no registrada, las operaciones entre redes); y las convenciones de durabilidad y almacenamiento se recogen en <xref linkend="tnpoint_production_guidance"/>.</para>
 
 	<sect1 xml:id="static_network_types">
 		<title>Tipos de red estáticos</title>
@@ -944,51 +943,4 @@ SELECT extent(temp) FROM tbl_tnpoint;
 		</itemizedlist>
 	</sect1>
 
-	<sect1 xml:id="tnpoint_production_guidance">
-		<title>Guía de producción</title>
-		<para>Esta sección recoge el conocimiento operativo que las cargas de trabajo de producción necesitan además de la referencia de funciones: cuándo <varname>npoint</varname> / <varname>tnpoint</varname> son el tipo adecuado, cómo fluyen los SRID desde el registro de la red, los peligros numéricos que afectan a las cargas de trabajo de seguimiento restringidas a una red, y la historia de durabilidad de los valores serializados. La mayoría de estos puntos aparecen por separado a lo largo del capítulo; el objetivo aquí es un único lugar que un nuevo contribuyente pueda leer de principio a fin antes de instrumentar una aplicación.</para>
-
-		<sect2 xml:id="tnpoint_when_to_use">
-			<title>Cuándo usar tnpoint frente a tgeompoint</title>
-			<para>Un <varname>tgeompoint</varname> rastrea una posición en el espacio libre; un <varname>tnpoint</varname> rastrea una posición restringida a una red conocida de rutas. Cada valor de punto de red es un par <varname>(rid, pos)</varname> donde <varname>rid</varname> es el identificador de ruta y <varname>pos</varname> es la posición relativa a lo largo de esa ruta, normalizada a <varname>[0, 1]</varname> (del inicio de la ruta al final de la ruta).</para>
-			<para>Use <varname>tgeompoint</varname> cuando el objeto en movimiento no esté restringido a una red, cuando la topología de la red sea desconocida, o cuando solo importe la geometría de la trayectoria &#x2014; trazas GPS de vehículos a nivel de datos crudos, movimiento de animales, flujos AIS.</para>
-			<para>Use <varname>tnpoint</varname> cuando el movimiento esté sobre una red conocida y se desee semántica relativa a la red: distancias medidas a lo largo de la ruta, no en el espacio libre; agregaciones agrupadas por segmento de ruta; uniones espaciales restringidas a la "misma red". Las cargas de trabajo canónicas son el seguimiento de redes ferroviarias y de carreteras, donde los flujos emparejados con el mapa se convierten en valores <varname>tnpoint</varname>.</para>
-			<para>La componente de posición de un <varname>tnpoint</varname> se puede recuperar como un <varname>tgeompoint</varname> mediante la conversión estándar (o como una <varname>geometry</varname> mediante <varname>geometry(npoint)</varname>); una <varname>geometry</varname> se puede proyectar de vuelta sobre la red cargada con <varname>npoint(geometry)</varname>. En consecuencia, una sola columna <varname>tnpoint</varname> subsume una columna <varname>tgeompoint</varname> emparejada con el mapa cuando se necesita semántica relativa a la red.</para>
-		</sect2>
-
-		<sect2 xml:id="tnpoint_srid_inheritance">
-			<title>Herencia del SRID desde el registro de la red</title>
-			<para>Un valor <varname>npoint</varname> no lleva su propio SRID; hereda el SRID de la ruta referenciada por su campo <varname>rid</varname>. El conjunto de rutas conocidas &#x2014; el registro <emphasis>ways</emphasis> &#x2014; se carga en una caché por proceso (véase <varname>meos/src/npoint/ways_meos.c</varname>) la primera vez que se ejecuta una función de red, y está indexado por el gid de ruta. Todo accesor de <varname>npoint</varname> que necesite la geometría de la ruta (<varname>npoint_to_geompoint</varname>, <varname>npoint_to_stbox</varname>, todos los predicados espaciales y funciones de distancia) consulta esta caché.</para>
-			<para>En la extensión de PostgreSQL la caché se rellena automáticamente desde la tabla <varname>public.ways</varname>. En MEOS independiente la aplicación debe llamar a <varname>meos_register_ways(...)</varname> con la tabla de rutas antes de cualquier operación <varname>npoint</varname>; <varname>meos_finalize_ways()</varname> es idempotente y se puede llamar varias veces de forma segura. Las operaciones entre tipos entre un <varname>npoint</varname> y una geometría validan que el SRID de la ruta coincida con el SRID de la geometría; las discrepancias generan un error explícito en lugar de reproyectar silenciosamente.</para>
-		</sect2>
-
-		<sect2 xml:id="tnpoint_hazards">
-			<title>Peligros numéricos</title>
-			<para>Cuatro peligros afectan de forma fiable a las cargas de trabajo reales de seguimiento restringidas a una red. La implementación mitiga cada uno como sigue:</para>
-			<itemizedlist>
-				<listitem>
-					<para><emphasis>Limitación del parámetro de posición a [0, 1]</emphasis>. Una posición fuera de <varname>[0, 1]</varname> no tiene significado en una ruta que no se ha extendido.</para>
-					<para><emphasis>Mitigación</emphasis>: <varname>npoint_make</varname> rechaza <varname>pos &lt; 0</varname> o <varname>pos &gt; 1</varname> en la construcción con el mensaje "The relative position must be a real number between 0 and 1", y la misma comprobación se aplica en las entradas de los analizadores WKT, WKB y MFJSON. Los extremos <varname>0.0</varname> (inicio de ruta) y <varname>1.0</varname> (fin de ruta) son válidos y admitidos &#x2014; el conjunto de pruebas ejercita ambos. Los datos de flujo corruptos o sin recortar fallan de forma explícita en lugar de contaminar una consulta posterior.</para>
-				</listitem>
-				<listitem>
-					<para><emphasis>Manejo de SRID mixtos</emphasis>. Un <varname>tnpoint</varname> hereda su SRID de su ruta, mientras que un argumento <varname>geometry</varname> lleva su SRID explícitamente.</para>
-					<para><emphasis>Mitigación</emphasis>: cada operador entre tipos (<varname>tnpoint &lt;-&gt; geometry</varname>, <varname>tnpoint &amp;&amp; geometry</varname>, <varname>distance(tnpoint, geometry)</varname>) valida que los dos SRID coincidan mediante <varname>ensure_same_srid</varname>; las discrepancias generan un error explícito en lugar de reproyectar silenciosamente un lado sobre el otro.</para>
-				</listitem>
-				<listitem>
-					<para><emphasis>Ruta no registrada</emphasis>. Un <varname>npoint</varname> que referencia un gid de ruta no presente en la caché de ways no puede resolverse a una geometría.</para>
-					<para><emphasis>Mitigación</emphasis>: <varname>npoint_make</varname> llama a <varname>ensure_route_exists</varname> en la construcción; los constructores SQL WKT, WKB, MFJSON y <varname>npoint(...)</varname> fluyen todos por esta comprobación y generan "There is no route with gid value &lt;n&gt; in table ways" si no se encuentra. Los usuarios de MEOS independiente que omitan el arranque <varname>meos_register_ways(...)</varname> verán este error en la primera operación de red, no más tarde como una consulta silenciosa de resultado cero.</para>
-				</listitem>
-				<listitem>
-					<para><emphasis>Operaciones entre redes</emphasis>. Dos valores <varname>tnpoint</varname> cuyas rutas pertenecen a redes diferentes (o a componentes conexas diferentes de la misma red) no pueden relacionarse mediante distancia de red.</para>
-					<para><emphasis>Mitigación</emphasis>: los operadores de distancia y de relación espacial entre dos valores <varname>tnpoint</varname> bajan primero ambos lados a <varname>tgeompoint</varname> y calculan el resultado como distancia / topología en el espacio libre. Este es un comportamiento documentado: quienes necesiten distancia de red verdadera deben restringir su consulta a una sola componente conexa aguas arriba.</para>
-				</listitem>
-			</itemizedlist>
-		</sect2>
-
-		<sect2 xml:id="tnpoint_durability">
-			<title>Durabilidad y almacenamiento</title>
-			<para>La representación en disco de un <varname>npoint</varname> es una tupla de 16 bytes: un id de ruta de 8 bytes seguido de una posición de 8 bytes. La disposición de bytes es estable: <varname>asBinary(tnpoint)</varname> / <varname>tnpointFromBinary(bytea)</varname> realizan un ciclo de ida y vuelta que preserva el valor bit a bit, y las serializaciones WKB / HexEWKB siguen el patrón estándar de los tipos temporales de bandera de endianidad seguida de la carga útil. El par <varname>asMFJSON(tnpoint)</varname> / <varname>tnpointFromMFJSON(text)</varname> es bidireccional, por lo que MovingFeatures-JSON es un formato de intercambio viable en igualdad de condiciones con WKB. Cada instante se representa como <varname>{"route":&lt;route&gt;,"position":&lt;position&gt;}</varname>, con los nombres de campo coincidiendo con la superficie de accesores SQL (<varname>route</varname>, <varname>getPosition</varname>) según la convención de descriptores en lenguaje natural.</para>
-			<para>El id de ruta se emite como un número JSON, que realiza un ciclo de ida y vuelta sin pérdida entre los codificadores y decodificadores de MEOS (ambos conservan la precisión completa de <varname>int64</varname> mediante <varname>INT64_FORMAT</varname> / <varname>strtoll</varname>). Sin embargo, no es sin pérdida en consumidores JavaScript / ECMAScript: el tipo <varname>Number</varname> tiene una mantisa de 53 bits, por lo que los ids de ruta más allá de <varname>2^53</varname> (~9 × 10^15) pierden precisión cuando los analiza un <varname>JSON.parse</varname> genérico del lado del navegador. Para redes derivadas de OSM esto importa en la práctica — los ids de vía de OSM cruzaron <varname>2^53</varname> en 2025 — y la mitigación recomendada del lado de JS es analizar con una biblioteca que materialice los números como <varname>BigInt</varname> (por ejemplo <varname>json-bigint</varname>) en lugar de confiar en el comportamiento por defecto. Esta es una decisión de diseño deliberada, no un descuido: la alternativa (emitir la ruta como una cadena JSON, como hace <varname>th3index</varname> para su carga útil de celda int64) divergiría de la forma JSON que devuelven todos los accesores numéricos de este tipo y rompería el ciclo de ida y vuelta con el análisis ingenuo de enteros en cada consumidor que <emphasis>sí</emphasis> maneja correctamente los enteros de 64 bits.</para>
-			<para>La salida de <varname>pg_dump</varname> de una tabla que contiene columnas <varname>npoint</varname> o <varname>tnpoint</varname> usa la representación WKT por defecto; <varname>pg_dump --binary-upgrade</varname> usa la representación WKB. Ambas son estables en el ciclo de ida y vuelta, pero un volcado solo se puede restaurar en una base de datos cuya tabla <varname>public.ways</varname> contenga todos los ids de ruta referenciados: el registro de rutas es lógicamente una clave foránea en cada columna <varname>npoint</varname>, aunque no se imponga como tal.</para>
-		</sect2>	</sect1>
 </chapter>

--- a/doc/es/temporal_quadbin_index.xml
+++ b/doc/es/temporal_quadbin_index.xml
@@ -17,7 +17,6 @@
 
 	<para>Como con otros tipos temporales, <varname>tquadbin</varname> tiene cuatro subtipos: <varname>Instant</varname>, secuencia discreta, secuencia continua con interpolación de pasos (las celdas QUADBIN son discretas — la interpolación lineal carece de sentido), y <varname>SequenceSet</varname>.</para>
 
-	<para>La guía operativa sobre cuándo elegir <varname>tquadbin</varname> en lugar de <varname>tgeompoint</varname> o <varname>tgeogpoint</varname>; los peligros específicos de QUADBIN que los consumidores deben anticipar (el orden int64 es arbitrario respecto a la geometría de la cuadrícula, la mezcla de resoluciones en las operaciones, el límite de latitud de web-mercator, y el comportamiento en el antimeridiano); y las convenciones de durabilidad y almacenamiento se recogen en <xref linkend="quadbin_operational_notes"/>.</para>
 
 	<sect1 xml:id="tquadbin_inout">
 		<title>Entrada y Salida</title>
@@ -367,7 +366,6 @@ SELECT round(quadbinCellArea(quadbin '48427fffffffffff')::numeric, 0);
 
 	<sect1 xml:id="tquadbin_comparisons">
 		<title>Comparaciones</title>
-		<para>Los operadores de comparación de árbol B (<varname>=</varname>, <varname>&lt;&gt;</varname>, <varname>&lt;</varname>, <varname>&lt;=</varname>, <varname>&gt;</varname>, <varname>&gt;=</varname>) y el operador hash están definidos sobre <varname>tquadbin</varname> a través de la maquinaria genérica de comparación temporal, ordenando por la secuencia de valores temporal subyacente. Soportan las clases de operadores <varname>tquadbin_btree_ops</varname> y <varname>tquadbin_hash_ops</varname> usadas por GROUP BY, DISTINCT, ORDER BY, y las uniones por mezcla / hash. Como con <varname>tbigint</varname>, el orden int64 de los identificadores QUADBIN no tiene significado geográfico — véase <xref linkend="quadbin_operational_notes"/>.</para>
 	</sect1>
 
 	<sect1 xml:id="tquadbin_aggregations">
@@ -430,48 +428,4 @@ CREATE INDEX ON trips USING hash(cells);        -- usa tquadbin_hash_ops por def
 		</itemizedlist>
 	</sect1>
 
-	<sect1 xml:id="quadbin_operational_notes">
-		<title>Notas operativas</title>
-		<para>Esta sección recoge el conocimiento operativo que los consumidores necesitan además de la referencia de funciones: cuándo <varname>tquadbin</varname> es el tipo adecuado, las convenciones que asume la implementación, y los peligros específicos de QUADBIN que las cargas de trabajo reales deben tener en cuenta. La cuadrícula cuadrada jerárquica QUADBIN tiene algunas propiedades no obvias que la codificación bit a bit en <varname>int64</varname> oculta; esta sección las expone para que no sorprendan a los consumidores.</para>
-
-		<sect2 xml:id="quadbin_when_to_use">
-			<title>Cuándo usar tquadbin</title>
-			<para>Use <varname>tquadbin</varname> cuando el identificador natural de una ubicación discreta a una resolución dada sea una tesela QUADBIN &#x2014; viajes de vehículos agrupados a un nivel de zoom fijo, lecturas de sensores agrupadas por tesela, o eventos asociados a su celda contenedora, especialmente en flujos de trabajo que ya hablan el esquema de teselado slippy-map / web-mercator. El tipo almacena una celda QUADBIN por instante; la resolución puede variar entre instantes de una misma trayectoria pero la mayoría de las cargas de trabajo fijan una resolución por columna.</para>
-			<para>Elija <varname>tgeompoint</varname> / <varname>tgeogpoint</varname> en lugar de <varname>tquadbin</varname> cuando la posición geográfica real (precisión sub-celda) sea el valor de interés. Elija <varname>tbigint</varname> en lugar de <varname>tquadbin</varname> cuando los valores resulten ser enteros de 64 bits pero no lleven semántica QUADBIN &#x2014; las representaciones binarias son idénticas (se convierten sin pérdidas vía <varname>tquadbin :: tbigint</varname> y de vuelta) pero el sistema de tipos SQL usa la distinción para rechazar funciones agnósticas a QUADBIN sobre trayectorias específicas de QUADBIN.</para>
-		</sect2>
-
-		<sect2 xml:id="quadbin_hazards">
-			<title>Peligros específicos de QUADBIN</title>
-			<para>Algunos peligros muerden de forma fiable a las cargas de trabajo que usan celdas QUADBIN. Cada uno es una propiedad de la propia cuadrícula QUADBIN y no una decisión de implementación de MobilityDB; las mitigaciones siguientes explican cómo trabajar con ellos.</para>
-			<itemizedlist>
-				<listitem>
-					<para><emphasis>El orden int64 es arbitrario respecto a la geometría de la cuadrícula</emphasis>. Los identificadores de celda QUADBIN son enteros de 64 bits cuyo patrón de bits codifica una etiqueta de cabecera, la resolución y las coordenadas de tesela. El orden bit a bit de dos celdas no tiene significado de proximidad espacial &#x2014; dos celdas adyacentes en bits pueden estar lejos, y dos celdas espacialmente adyacentes pueden tener patrones de bits diferentes.</para>
-					<para><emphasis>Mitigación</emphasis>: <varname>tquadbin</varname> deliberadamente no tiene tipos complementarios <varname>quadbinspan</varname> / <varname>quadbinspanset</varname> (precedente: <varname>geometry</varname> no tiene <varname>geometryspan</varname>). El filtrado por rango de valores debe pasar por las funciones de inspección <varname>quadbin_*</varname> (resolución, validez, jerarquía) o por la enumeración explícita de conjuntos vía <varname>quadbinset</varname>. El código que asume que <varname>cell_a &lt; cell_b</varname> refleja proximidad espacial producirá resultados erróneos silenciosamente.</para>
-				</listitem>
-				<listitem>
-					<para><emphasis>Mezcla de resoluciones en las operaciones</emphasis>. Las celdas QUADBIN a distintas resoluciones (0&#x2013;26) representan áreas de cobertura diferentes. Mezclar resoluciones en una misma trayectoria es válido pero semánticamente requiere una justificación explícita &#x2014; <varname>quadbinCellToParent(cell, res_mas_gruesa)</varname> engruesa y <varname>quadbinCellToChildren(parent, res_mas_fina)</varname> refina.</para>
-					<para><emphasis>Mitigación</emphasis>: los consumidores deben documentar la invariante de resolución por trayectoria (por ejemplo, "todas las celdas son de resolución 10") y validar las entradas en el límite de ingesta. El accesor <varname>quadbinGetResolution</varname> permite que una restricción CHECK lo imponga.</para>
-				</listitem>
-				<listitem>
-					<para><emphasis>Límite de latitud de web-mercator</emphasis>. QUADBIN hereda la proyección web-mercator, que está definida únicamente entre aproximadamente &#xb1;85,05&#xb0; de latitud. Los puntos fuera de esta banda no tienen celda QUADBIN, y el área de la celda se reduce hacia los polos &#x2014; <varname>quadbinCellArea</varname> devuelve valores progresivamente menores a latitudes más altas para celdas de la misma resolución.</para>
-					<para><emphasis>Mitigación</emphasis>: las cargas de trabajo cercanas a los polos deben recortar o rechazar las latitudes fuera de la banda web-mercator en el límite de ingesta; no confíe en las celdas QUADBIN para la cobertura polar.</para>
-				</listitem>
-				<listitem>
-					<para><emphasis>Comportamiento en el antimeridiano</emphasis>. Las columnas de tesela se envuelven en el antimeridiano (&#xb1;180&#xb0; de longitud). Una trayectoria que cruza el antimeridiano se mueve entre celdas cuyas coordenadas de tesela <varname>x</varname> difieren en el ancho completo de la cuadrícula a ese zoom, aunque sean espacialmente adyacentes.</para>
-					<para><emphasis>Mitigación</emphasis>: las cargas de trabajo que cruzan el antimeridiano deben validar celdas representativas contra la implementación de referencia de QUADBIN y añadir fixtures para los casos límite específicos que la carga de trabajo encuentre.</para>
-				</listitem>
-			</itemizedlist>
-		</sect2>
-
-		<sect2 xml:id="quadbin_durability">
-			<title>Durabilidad y almacenamiento</title>
-			<para>La representación en disco de <varname>tquadbin</varname> es idéntica byte a byte a la de <varname>tbigint</varname> (cada instante lleva un ID de celda QUADBIN de 64 bits más una marca de tiempo). Consecuencias para la planificación del almacenamiento:</para>
-			<itemizedlist>
-				<listitem><para><emphasis>WKT</emphasis> vía <varname>tquadbin_in</varname> y la función de salida temporal. Las celdas se representan como cadenas hexadecimales canónicas (por ejemplo, <varname>'480fffffffffffff'</varname>), que es también la forma aceptada en la entrada. El ciclo de ida y vuelta es estable a nivel de bits.</para></listitem>
-				<listitem><para><emphasis>WKB / EWKB / HexWKB</emphasis> vía el patrón estándar de PostGIS de bandera de endianness seguida de la carga útil. Estable entre versiones mayores de PostgreSQL.</para></listitem>
-				<listitem><para><emphasis>pg_dump</emphasis> usa WKT en modo plano y WKB bajo <varname>--binary-upgrade</varname>; ambos completan el ciclo de ida y vuelta limpiamente.</para></listitem>
-				<listitem><para><emphasis>Conversión cruzada con <varname>tbigint</varname></emphasis>: las conversiones bidireccionales <varname>tquadbin :: tbigint</varname> son reinterpretaciones bit a bit sin coste. Úselas cuando trabaje con vistas seguras por tipo (<varname>tquadbin</varname>) y aptas para aritmética (<varname>tbigint</varname>) de la misma trayectoria en una sola consulta.</para></listitem>
-			</itemizedlist>
-		</sect2>
-	</sect1>
 </chapter>

--- a/doc/temporal_h3_index.xml
+++ b/doc/temporal_h3_index.xml
@@ -17,7 +17,6 @@
 
 	<para>As with other temporal types, <varname>th3index</varname> has four subtypes: <varname>Instant</varname>, discrete-sequence, continuous-sequence with step interpolation (H3 cells are discrete — linear interpolation is meaningless), and <varname>SequenceSet</varname>.</para>
 
-	<para>Operational guidance on when to choose <varname>th3index</varname> over <varname>tgeompoint</varname> or <varname>tgeogpoint</varname>; the H3-specific hazards consumers should anticipate (int64 ordering arbitrary with respect to grid geometry, resolution mixing in operations, pentagon cells, compaction round-trip cell-order non-preservation, antimeridian and pole behaviour at high resolution); and the durability and storage conventions are collected in <xref linkend="h3_operational_notes"/>.</para>
 
 	<sect1 xml:id="th3_inout">
 		<title>Input and Output</title>
@@ -911,53 +910,4 @@ CREATE INDEX ON trips USING spgist(cells th3_kdtree_ops);
 		</itemizedlist>
 	</sect1>
 
-	<sect1 xml:id="h3_operational_notes">
-		<title>Operational notes</title>
-		<para>This section captures the operational knowledge consumers need on top of the function reference: when <varname>th3index</varname> is the right type, the conventions the implementation assumes, and the H3-specific hazards real workloads need to be aware of. The H3 hierarchical hexagonal grid has a few non-obvious properties that the bitwise <varname>int64</varname> encoding hides; this section surfaces them so they don't surprise consumers.</para>
-
-		<sect2 xml:id="h3_when_to_use">
-			<title>When to use th3index</title>
-			<para>Use <varname>th3index</varname> when the natural identifier for a discrete location at a given resolution is an H3 cell &#x2014; vehicle trips bucketed at H3 resolution 9, environmental sensor readings binned by H3 cell, geo-fenced events keyed by their containing cell. The type stores one H3 cell per instant; resolution may vary across instants in a single trajectory but most workloads pin one resolution per column.</para>
-			<para>Choose <varname>tgeompoint</varname> / <varname>tgeogpoint</varname> over <varname>th3index</varname> when the actual geographic position (sub-cell precision) is the value of interest. Choose <varname>tbigint</varname> over <varname>th3index</varname> when the values happen to be 64-bit integers but carry no H3 semantics &#x2014; the binary representations are identical (they cast losslessly via <varname>th3index :: tbigint</varname> and back) but the SQL type system uses the distinction to reject h3index-agnostic functions on h3index-specific trajectories.</para>
-		</sect2>
-
-		<sect2 xml:id="h3_hazards">
-			<title>H3-specific hazards</title>
-			<para>Five hazards reliably bite workloads using H3 cells. Each is a property of the H3 grid itself rather than a MobilityDB implementation choice; the mitigations below explain how to work with them.</para>
-			<itemizedlist>
-				<listitem>
-					<para><emphasis>Int64 ordering is arbitrary with respect to grid geometry</emphasis>. H3 cell identifiers are 64-bit unsigned integers whose bitpattern encodes resolution, base cell, and hierarchical position. The bitwise ordering of two cells carries no geographic meaning &#x2014; two cells that are bit-adjacent may be on opposite sides of the planet, and two cells that are spatially adjacent may have wildly different bitpatterns.</para>
-					<para><emphasis>Mitigation</emphasis>: <varname>th3index</varname> deliberately has no <varname>h3span</varname> / <varname>h3spanset</varname> companion types (precedent: <varname>geometry</varname> has no <varname>geometryspan</varname>), and the bbox indexes capture the cells' spatiotemporal extent (<varname>stbox</varname>), not the cell-id value. Value-range filtering must go through <varname>h3_*</varname> inspection functions (resolution, base cell, hierarchy checks) or explicit set enumeration via <varname>h3indexset</varname>. Code that assumes <varname>cell_a &lt; cell_b</varname> reflects spatial proximity will silently produce wrong results.</para>
-				</listitem>
-				<listitem>
-					<para><emphasis>Resolution mixing in operations</emphasis>. H3 cells at different resolutions (0&#x2013;15) represent different coverage areas. Mixing resolutions in a single trajectory is valid but semantically requires explicit justification &#x2014; <varname>th3CellToParent(cell, coarser_res)</varname> coarsens, <varname>h3CellToChildren(parent, finer_res)</varname> refines, and <varname>h3CompactCells</varname> / <varname>h3UncompactCells</varname> round-trip correctly only when input resolutions are compatible.</para>
-					<para><emphasis>Mitigation</emphasis>: consumers should document the resolution invariant per trajectory (e.g. "all cells are resolution 9") and validate inputs at the ingestion boundary. The <varname>th3GetResolution</varname> accessor lets a CHECK constraint enforce this.</para>
-				</listitem>
-				<listitem>
-					<para><emphasis>Pentagon cells</emphasis>. The H3 grid has 12 pentagonal (instead of hexagonal) cells per resolution &#x2014; the Eisenstein duals of the icosahedron's 12 vertices. <varname>h3GridRing</varname> may fail near these pentagons; <varname>h3GridPathCells</varname> fails if the path crosses one. The error is loud (libh3 raises an explicit failure), but workloads that expect ring / path operations to always succeed need a guard.</para>
-					<para><emphasis>Mitigation</emphasis>: defensive code should wrap pentagon-sensitive calls and check <varname>h3_is_pentagon_cell</varname> on inputs and key outputs. For trajectories that pass near a pentagon, fall back to <varname>h3GridDisk</varname> (which is pentagon-safe) or compute path segments in pieces around the pentagon.</para>
-				</listitem>
-				<listitem>
-					<para><emphasis>Compaction / decompaction round-trip</emphasis>. <varname>h3CompactCells</varname> produces the most compact mixed-resolution representation of a set of cells; <varname>h3UncompactCells</varname> expands it back. The round-trip is lossless in spatial extent, but <emphasis>cell ordering is not preserved</emphasis> &#x2014; libh3 does not guarantee a sorted output. Queries that consume the output as if its order were stable will return different results before and after compaction even when the underlying spatial set is identical.</para>
-					<para><emphasis>Mitigation</emphasis>: re-sort post-compaction if order matters (e.g. <varname>ORDER BY cell</varname> in SQL or <varname>ARRAY_AGG ... ORDER BY 1</varname> when materialising). For temporal sets, prefer the <varname>h3indexset</varname> set-equality semantics over array-equality semantics.</para>
-				</listitem>
-				<listitem>
-					<para><emphasis>Antimeridian and pole behaviour</emphasis>. H3's base cells are positioned on an icosahedron; at high resolutions some cells near the antimeridian or poles can have counter-intuitive geometry. <varname>th3CellToLatlng</varname> / <varname>h3_latlng_to_cell</varname> round-trip correctly, but coordinates near &#xb1;180&#xb0; longitude or near the poles may resolve to cells in unexpected base-cell groups.</para>
-					<para><emphasis>Mitigation</emphasis>: workloads at polar latitudes or that cross the antimeridian should validate representative cells against the libh3 reference implementation directly and add fixtures for the specific edge cases the workload encounters.</para>
-				</listitem>
-			</itemizedlist>
-		</sect2>
-
-		<sect2 xml:id="h3_durability">
-			<title>Durability and storage</title>
-			<para>The on-disk representation of <varname>th3index</varname> is byte-identical to <varname>tbigint</varname> (each instant carries one 64-bit H3 cell ID plus a timestamp). Consequences for storage planning:</para>
-			<itemizedlist>
-				<listitem><para><emphasis>WKT</emphasis> via <varname>th3_in</varname> and <varname>th3_out</varname>. Cells render as canonical hex strings (e.g. <varname>'8928308280fffff'</varname>), which is also the form accepted on input. Round-trip is bit-stable.</para></listitem>
-				<listitem><para><emphasis>WKB / EWKB / HexWKB</emphasis> via the standard PostGIS endian-flag-then-payload pattern. Stable across PostgreSQL major versions.</para></listitem>
-				<listitem><para><emphasis>MFJSON</emphasis> via <varname>asMFJSON(th3index)</varname> and <varname>th3indexFromMFJSON(text)</varname>. The cell payload renders as the int64 cell identifier in the <varname>values</varname> array, the same representation carried by <varname>tbigint</varname>; consumers that need the canonical hex form apply <varname>h3_cell_to_string</varname>.</para></listitem>
-				<listitem><para><emphasis>pg_dump</emphasis> uses WKT in plain mode and WKB under <varname>--binary-upgrade</varname>; both round-trip cleanly.</para></listitem>
-				<listitem><para><emphasis>Cross-cast with <varname>tbigint</varname></emphasis>: the bidirectional <varname>th3index :: tbigint</varname> casts are zero-cost bitwise reinterpretations. Use them when working with both type-safe (<varname>th3index</varname>) and arithmetic-friendly (<varname>tbigint</varname>) views of the same trajectory in a single query.</para></listitem>
-			</itemizedlist>
-		</sect2>
-	</sect1>
 </chapter>

--- a/doc/temporal_network_points.xml
+++ b/doc/temporal_network_points.xml
@@ -32,7 +32,6 @@
 
 	<para>The <varname>npoint</varname> type serves as base type for defining the temporal network point type <varname>tnpoint</varname>. The <varname>tnpoint</varname> type has similar functionality as the temporal point type <varname>tgeompoint</varname> with the exception that it only considers two dimensions. Thus, all functions and operators described before for the <varname>tgeompoint</varname> type are also applicable for the <varname>tnpoint</varname> type. In addition, there are specific functions defined for the <varname>tnpoint</varname> type.</para>
 
-	<para>Operational guidance on choosing between <varname>tnpoint</varname> and <varname>tgeompoint</varname>; the SRID-inheritance contract (the SRID is read from the route registered in <varname>ways</varname>, not carried explicitly on the value); the numerical hazards production workloads should anticipate (position-parameter clamping at <varname>[0, 1]</varname>, mixed-SRID handling, route-not-registered errors, cross-network operations); and the durability and storage conventions are collected in <xref linkend="tnpoint_production_guidance"/>.</para>
 
 	<sect1 xml:id="static_network_types">
 		<title>Static Network Types</title>
@@ -962,51 +961,4 @@ SELECT extent(temp) FROM tbl_tnpoint;
 		</itemizedlist>
 	</sect1>
 
-	<sect1 xml:id="tnpoint_production_guidance">
-		<title>Production guidance</title>
-		<para>This section captures the operational knowledge production workloads need on top of the function reference: when <varname>npoint</varname> / <varname>tnpoint</varname> are the right type, how SRIDs flow from the network registry, the numerical hazards that bite network-constrained tracking workloads, and the durability story for serialised values. Most of these points are surfaced separately throughout the chapter; the goal here is one place a new contributor can read end-to-end before instrumenting an application.</para>
-
-		<sect2 xml:id="tnpoint_when_to_use">
-			<title>When to use tnpoint vs tgeompoint</title>
-			<para>A <varname>tgeompoint</varname> tracks a position in free space; a <varname>tnpoint</varname> tracks a position constrained to a known network of routes. Each network-point value is a pair <varname>(rid, pos)</varname> where <varname>rid</varname> is the route identifier and <varname>pos</varname> is the relative position along that route, normalised to <varname>[0, 1]</varname> (start of route to end of route).</para>
-			<para>Use <varname>tgeompoint</varname> when the moving object is not constrained to a network, when the network topology is unknown, or when only the trajectory geometry matters &#x2014; vehicle GPS tracks at the raw-feed level, animal movement, AIS feeds.</para>
-			<para>Use <varname>tnpoint</varname> when motion is on a known network and you want network-relative semantics: distances measured along the route, not in free space; aggregations grouped by route segment; spatial joins constrained to "same network". Canonical workloads are train-network and road-network tracking, where map-matched feeds become <varname>tnpoint</varname> values.</para>
-			<para>The position component of a <varname>tnpoint</varname> is recoverable as a <varname>tgeompoint</varname> via the standard cast (or as a <varname>geometry</varname> via <varname>geometry(npoint)</varname>); a <varname>geometry</varname> can be projected back onto the loaded network with <varname>npoint(geometry)</varname>. Consequently a single <varname>tnpoint</varname> column subsumes a map-matched <varname>tgeompoint</varname> column when network-relative semantics are needed.</para>
-		</sect2>
-
-		<sect2 xml:id="tnpoint_srid_inheritance">
-			<title>SRID inheritance from the network registry</title>
-			<para>An <varname>npoint</varname> value does not carry its own SRID; it inherits the SRID of the route referenced by its <varname>rid</varname> field. The set of known routes &#x2014; the <emphasis>ways</emphasis> registry &#x2014; is loaded into a per-process cache (see <varname>meos/src/npoint/ways_meos.c</varname>) the first time a network function runs, and is keyed by route gid. Every <varname>npoint</varname> accessor that needs the route geometry (<varname>npoint_to_geompoint</varname>, <varname>npoint_to_stbox</varname>, all spatial predicates and distance functions) consults this cache.</para>
-			<para>In the PostgreSQL extension the cache is populated automatically from the <varname>public.ways</varname> table. In standalone MEOS the application must call <varname>meos_register_ways(...)</varname> with the route table before any <varname>npoint</varname> operation; <varname>meos_finalize_ways()</varname> is idempotent and can be called multiple times safely. Cross-type operations between an <varname>npoint</varname> and a geometry validate that the route's SRID matches the geometry's SRID; mismatches raise an explicit error rather than silently re-projecting.</para>
-		</sect2>
-
-		<sect2 xml:id="tnpoint_hazards">
-			<title>Numerical hazards</title>
-			<para>Four hazards reliably bite real network-constrained tracking workloads. The implementation mitigates each as follows:</para>
-			<itemizedlist>
-				<listitem>
-					<para><emphasis>Position-parameter clamping at [0, 1]</emphasis>. A position outside <varname>[0, 1]</varname> has no meaning on a route that has not been extended.</para>
-					<para><emphasis>Mitigation</emphasis>: <varname>npoint_make</varname> rejects <varname>pos &lt; 0</varname> or <varname>pos &gt; 1</varname> at construction with the message "The relative position must be a real number between 0 and 1", and the same check is applied at the WKT, WKB, and MFJSON parser entries. The endpoints <varname>0.0</varname> (start of route) and <varname>1.0</varname> (end of route) are valid and supported &#x2014; the test suite exercises both. Corrupt or unclipped feed data fails loudly rather than poisoning a downstream query.</para>
-				</listitem>
-				<listitem>
-					<para><emphasis>Mixed-SRID handling</emphasis>. A <varname>tnpoint</varname> inherits its SRID from its route, while a <varname>geometry</varname> argument carries its SRID explicitly.</para>
-					<para><emphasis>Mitigation</emphasis>: every cross-type operator (<varname>tnpoint &lt;-&gt; geometry</varname>, <varname>tnpoint &amp;&amp; geometry</varname>, <varname>distance(tnpoint, geometry)</varname>) validates the two SRIDs match through <varname>ensure_same_srid</varname>; mismatches raise an explicit error rather than silently re-projecting one side onto the other.</para>
-				</listitem>
-				<listitem>
-					<para><emphasis>Route-not-registered</emphasis>. An <varname>npoint</varname> referencing a route gid not present in the ways cache cannot resolve to a geometry.</para>
-					<para><emphasis>Mitigation</emphasis>: <varname>npoint_make</varname> calls <varname>ensure_route_exists</varname> at construction; the WKT, WKB, MFJSON, and <varname>npoint(...)</varname> SQL constructors all flow through this check and raise "There is no route with gid value &lt;n&gt; in table ways" on miss. Standalone MEOS users who skip the <varname>meos_register_ways(...)</varname> bootstrap will see this error on the first network operation, not later as a silent zero-result query.</para>
-				</listitem>
-				<listitem>
-					<para><emphasis>Cross-network operations</emphasis>. Two <varname>tnpoint</varname> values whose routes belong to different networks (or different connected components of the same network) cannot be related through network distance.</para>
-					<para><emphasis>Mitigation</emphasis>: distance and spatial-relationship operators between two <varname>tnpoint</varname> values lower both sides to <varname>tgeompoint</varname> first and compute the result as free-space distance / topology. This is documented behaviour: callers who need true network distance must restrict their query to a single connected component upstream.</para>
-				</listitem>
-			</itemizedlist>
-		</sect2>
-
-		<sect2 xml:id="tnpoint_durability">
-			<title>Durability and storage</title>
-			<para>The on-disk representation of an <varname>npoint</varname> is a 16-byte tuple: an 8-byte route id followed by an 8-byte position. The byte layout is stable: <varname>asBinary(tnpoint)</varname> / <varname>tnpointFromBinary(bytea)</varname> round-trip preserves the value bit-for-bit, and the WKB / HexEWKB serialisations follow the standard temporal-types endian-flag-then-payload pattern. The <varname>asMFJSON(tnpoint)</varname> / <varname>tnpointFromMFJSON(text)</varname> pair is bidirectional, so MovingFeatures-JSON is a viable interchange format on equal footing with WKB. Each instant renders as <varname>{"route":&lt;route&gt;,"position":&lt;position&gt;}</varname>, with the field names matching the SQL accessor surface (<varname>route</varname>, <varname>getPosition</varname>) on the natural-language descriptor convention.</para>
-			<para>The route id is emitted as a JSON number, which round-trips losslessly between MEOS encoders and decoders (both retain full <varname>int64</varname> precision via <varname>INT64_FORMAT</varname> / <varname>strtoll</varname>). It is not, however, lossless across JavaScript / ECMAScript consumers: the <varname>Number</varname> type has a 53-bit mantissa, so route ids beyond <varname>2^53</varname> (~9 × 10^15) lose precision when parsed by a generic browser-side <varname>JSON.parse</varname>. For OSM-derived networks this matters in practice — OSM way ids crossed <varname>2^53</varname> in 2025 — and the recommended mitigation on the JS side is to parse with a library that materialises numbers as <varname>BigInt</varname> (for example <varname>json-bigint</varname>) rather than rely on the default. This is a deliberate design choice, not an oversight: the alternative (emitting the route as a JSON string, as <varname>th3index</varname> does for its int64 cell payload) would diverge from the JSON shape that all numeric accessors return for this type and break the round-trip with naive int-parsing on every consumer that <emphasis>does</emphasis> handle 64-bit integers correctly.</para>
-			<para>The <varname>pg_dump</varname> output of a table containing <varname>npoint</varname> or <varname>tnpoint</varname> columns uses the WKT representation by default; <varname>pg_dump --binary-upgrade</varname> uses the WKB representation. Both are round-trip-stable, but a dump is only restorable into a database whose <varname>public.ways</varname> table contains all referenced route ids: the route registry is logically a foreign key on every <varname>npoint</varname> column, even though it is not enforced as one.</para>
-		</sect2>	</sect1>
 </chapter>

--- a/doc/temporal_quadbin_index.xml
+++ b/doc/temporal_quadbin_index.xml
@@ -17,7 +17,6 @@
 
 	<para>As with other temporal types, <varname>tquadbin</varname> has four subtypes: <varname>Instant</varname>, discrete-sequence, continuous-sequence with step interpolation (QUADBIN cells are discrete — linear interpolation is meaningless), and <varname>SequenceSet</varname>.</para>
 
-	<para>Operational guidance on when to choose <varname>tquadbin</varname> over <varname>tgeompoint</varname> or <varname>tgeogpoint</varname>; the quadbin-specific hazards consumers should anticipate (int64 ordering arbitrary with respect to grid geometry, resolution mixing in operations, web-mercator latitude limit, antimeridian behaviour); and the durability and storage conventions are collected in <xref linkend="quadbin_operational_notes"/>.</para>
 
 	<sect1 xml:id="tquadbin_inout">
 		<title>Input and Output</title>
@@ -367,7 +366,6 @@ SELECT round(quadbinCellArea(quadbin '48427fffffffffff')::numeric, 0);
 
 	<sect1 xml:id="tquadbin_comparisons">
 		<title>Comparisons</title>
-		<para>The B-tree comparison operators (<varname>=</varname>, <varname>&lt;&gt;</varname>, <varname>&lt;</varname>, <varname>&lt;=</varname>, <varname>&gt;</varname>, <varname>&gt;=</varname>) and the hash operator are defined on <varname>tquadbin</varname> through the generic temporal comparison machinery, ordering by the underlying temporal-value sequence. They support the <varname>tquadbin_btree_ops</varname> and <varname>tquadbin_hash_ops</varname> operator classes used by GROUP BY, DISTINCT, ORDER BY, and merge / hash joins. As with <varname>tbigint</varname>, the int64 ordering of QUADBIN identifiers carries no geographic meaning — see <xref linkend="quadbin_operational_notes"/>.</para>
 	</sect1>
 
 	<sect1 xml:id="tquadbin_aggregations">
@@ -430,48 +428,4 @@ CREATE INDEX ON trips USING hash(cells);        -- uses tquadbin_hash_ops by def
 		</itemizedlist>
 	</sect1>
 
-	<sect1 xml:id="quadbin_operational_notes">
-		<title>Operational notes</title>
-		<para>This section captures the operational knowledge consumers need on top of the function reference: when <varname>tquadbin</varname> is the right type, the conventions the implementation assumes, and the QUADBIN-specific hazards real workloads need to be aware of. The QUADBIN hierarchical square grid has a few non-obvious properties that the bitwise <varname>int64</varname> encoding hides; this section surfaces them so they don't surprise consumers.</para>
-
-		<sect2 xml:id="quadbin_when_to_use">
-			<title>When to use tquadbin</title>
-			<para>Use <varname>tquadbin</varname> when the natural identifier for a discrete location at a given resolution is a QUADBIN tile &#x2014; vehicle trips bucketed at a fixed zoom level, sensor readings binned by tile, or events keyed by their containing cell, especially in pipelines that already speak the slippy-map / web-mercator tiling scheme. The type stores one QUADBIN cell per instant; resolution may vary across instants in a single trajectory but most workloads pin one resolution per column.</para>
-			<para>Choose <varname>tgeompoint</varname> / <varname>tgeogpoint</varname> over <varname>tquadbin</varname> when the actual geographic position (sub-cell precision) is the value of interest. Choose <varname>tbigint</varname> over <varname>tquadbin</varname> when the values happen to be 64-bit integers but carry no QUADBIN semantics &#x2014; the binary representations are identical (they cast losslessly via <varname>tquadbin :: tbigint</varname> and back) but the SQL type system uses the distinction to reject quadbin-agnostic functions on quadbin-specific trajectories.</para>
-		</sect2>
-
-		<sect2 xml:id="quadbin_hazards">
-			<title>QUADBIN-specific hazards</title>
-			<para>A few hazards reliably bite workloads using QUADBIN cells. Each is a property of the QUADBIN grid itself rather than a MobilityDB implementation choice; the mitigations below explain how to work with them.</para>
-			<itemizedlist>
-				<listitem>
-					<para><emphasis>Int64 ordering is arbitrary with respect to grid geometry</emphasis>. QUADBIN cell identifiers are 64-bit integers whose bitpattern encodes a header tag, resolution, and tile coordinates. The bitwise ordering of two cells carries no spatial-proximity meaning &#x2014; two cells that are bit-adjacent may be far apart, and two cells that are spatially adjacent may have different bitpatterns.</para>
-					<para><emphasis>Mitigation</emphasis>: <varname>tquadbin</varname> deliberately has no <varname>quadbinspan</varname> / <varname>quadbinspanset</varname> companion types (precedent: <varname>geometry</varname> has no <varname>geometryspan</varname>). Value-range filtering must go through the <varname>quadbin_*</varname> inspection functions (resolution, validity, hierarchy) or explicit set enumeration via <varname>quadbinset</varname>. Code that assumes <varname>cell_a &lt; cell_b</varname> reflects spatial proximity will silently produce wrong results.</para>
-				</listitem>
-				<listitem>
-					<para><emphasis>Resolution mixing in operations</emphasis>. QUADBIN cells at different resolutions (0&#x2013;26) represent different coverage areas. Mixing resolutions in a single trajectory is valid but semantically requires explicit justification &#x2014; <varname>quadbinCellToParent(cell, coarser_res)</varname> coarsens and <varname>quadbinCellToChildren(parent, finer_res)</varname> refines.</para>
-					<para><emphasis>Mitigation</emphasis>: consumers should document the resolution invariant per trajectory (e.g. "all cells are resolution 10") and validate inputs at the ingestion boundary. The <varname>quadbinGetResolution</varname> accessor lets a CHECK constraint enforce this.</para>
-				</listitem>
-				<listitem>
-					<para><emphasis>Web-mercator latitude limit</emphasis>. QUADBIN inherits the web-mercator projection, which is defined only between approximately &#xb1;85.05&#xb0; latitude. Points outside this band have no QUADBIN cell, and cell area shrinks toward the poles &#x2014; <varname>quadbinCellArea</varname> returns progressively smaller values at higher latitudes for cells of the same resolution.</para>
-					<para><emphasis>Mitigation</emphasis>: workloads near the poles should clamp or reject latitudes outside the web-mercator band at the ingestion boundary; do not rely on QUADBIN cells for polar coverage.</para>
-				</listitem>
-				<listitem>
-					<para><emphasis>Antimeridian behaviour</emphasis>. Tile columns wrap at the antimeridian (&#xb1;180&#xb0; longitude). A trajectory crossing the antimeridian moves between cells whose tile <varname>x</varname> coordinates differ by the full width of the grid at that zoom, even though they are spatially adjacent.</para>
-					<para><emphasis>Mitigation</emphasis>: workloads that cross the antimeridian should validate representative cells against the QUADBIN reference implementation and add fixtures for the specific edge cases the workload encounters.</para>
-				</listitem>
-			</itemizedlist>
-		</sect2>
-
-		<sect2 xml:id="quadbin_durability">
-			<title>Durability and storage</title>
-			<para>The on-disk representation of <varname>tquadbin</varname> is byte-identical to <varname>tbigint</varname> (each instant carries one 64-bit QUADBIN cell ID plus a timestamp). Consequences for storage planning:</para>
-			<itemizedlist>
-				<listitem><para><emphasis>WKT</emphasis> via <varname>tquadbin_in</varname> and the temporal output function. Cells render as canonical hex strings (e.g. <varname>'480fffffffffffff'</varname>), which is also the form accepted on input. Round-trip is bit-stable.</para></listitem>
-				<listitem><para><emphasis>WKB / EWKB / HexWKB</emphasis> via the standard PostGIS endian-flag-then-payload pattern. Stable across PostgreSQL major versions.</para></listitem>
-				<listitem><para><emphasis>pg_dump</emphasis> uses WKT in plain mode and WKB under <varname>--binary-upgrade</varname>; both round-trip cleanly.</para></listitem>
-				<listitem><para><emphasis>Cross-cast with <varname>tbigint</varname></emphasis>: the bidirectional <varname>tquadbin :: tbigint</varname> casts are zero-cost bitwise reinterpretations. Use them when working with both type-safe (<varname>tquadbin</varname>) and arithmetic-friendly (<varname>tbigint</varname>) views of the same trajectory in a single query.</para></listitem>
-			</itemizedlist>
-		</sect2>
-	</sect1>
 </chapter>


### PR DESCRIPTION
The manual is the function reference a SQL user reads. The operational knowledge for `tnpoint`, `th3index` and `tquadbin` — when the type fits a workload against its neighbours, the frame and encoding conventions the implementation enforces, the numerical characteristics of the kernels, and the durability conventions — moves to `doc/contributing`, beside `talpha_design_notes.md` and `distance_design_notes.md`, giving three new notes: `tnpoint_design_notes.md`, `th3index_design_notes.md`, `tquadbin_design_notes.md`.

Both language chapters drop the section and the paragraph that cross-referenced it, so the two manuals stay symmetric: 48 lines from each network-point chapter, 50 from each h3 chapter, 46 from each quadbin chapter.

The conversion is mechanical rather than retyped, and the word count is preserved across it (1097 → 1083, 894 → 891, 701 → 698, the deltas being tag names and anchors).

`generate_docs.yml` runs on a push to master whenever `doc/**` changes and pull-request checks never exercise it, so its six steps ran locally on this commit: `xsltproc` HTML, `dblatex` PDF and `dbtoepub` EPUB, for the English and the Spanish manual.