### PR TITLE
Index every function a chapter entry documents

### DIFF
--- a/doc/box_types.xml
+++ b/doc/box_types.xml
@@ -170,6 +170,7 @@ SELECT tbox(tstzspan '[2001-01-01,2001-01-02)');
 				<indexterm significance="normal"><primary><varname>geodstboxZ</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>geodstboxT</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>geodstboxZT</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
 				<para>Constructor for <varname>stbox</varname></para>
 				<para><varname>stboxX(float,float,float,float,srid=0) → stbox</varname></para>
 				<para><varname>stboxZ(float,float,float,float,float,float,srid=0) → stbox</varname></para>
@@ -216,6 +217,9 @@ SELECT stbox(geography 'Linestring(1 1 1,2 2 2)', tstzspan '[2001-01-03,2001-01-
 		<itemizedlist>
 			<listitem xml:id="tbox_convert_to">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>intspan</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>floatspan</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tstzspan</varname></primary></indexterm>
 				<para>Convert a <varname>tbox</varname> to another type</para>
 				<para><varname>tbox::{intspan,floatspan,tstzspan}</varname></para>
 				<para><varname>intspan(tbox) → tbox</varname></para>
@@ -233,6 +237,7 @@ SELECT tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-02))'::tstzspan;
 
 			<listitem xml:id="tbox_convert_from">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tbox</varname></primary></indexterm>
 				<para>Convert another type to a <varname>tbox</varname></para>
 				<para><varname>{numbers,times,tnumber}::tbox</varname></para>
 				<para><varname>tbox({numbers,times,tnumber}) → tbox</varname></para>
@@ -250,6 +255,11 @@ SELECT tstzspanset '{(2001-01-01,2001-01-02),(2001-01-03,2001-01-04)}'::tbox;
 
 			<listitem xml:id="stbox_convert_to">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>box2d</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>box3d</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>geometry</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>geography</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tstzspan</varname></primary></indexterm>
 				<para>Convert an <varname>stbox</varname> to a another type</para>
 				<para><varname>stbox::{box2d,box3d,geo,tstzspan}</varname></para>
 				<para><varname>box2d(stbox) → box2d</varname></para>
@@ -280,6 +290,7 @@ SELECT stbox 'STBOX XT(((1.0,2.0),(3.0,4.0)),[2001-01-01,2001-01-03])'::tstzspan
 
 			<listitem xml:id="stbox_convert_from">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
 				<para>Convert another type to an <varname>stbox</varname></para>
 				<para><varname>{box2d,box3d,geo,time,tgeo}::stbox</varname></para>
 				<para><varname>stbox({box2d,box3d,geo,time,tgeo}) → stbox</varname></para>
@@ -410,6 +421,7 @@ SELECT tMaxInc(stbox 'GEODSTBOX T([2001-01-01,2001-01-03))');
 			<listitem xml:id="area">
 				<indexterm significance="normal"><primary><varname>area</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>perimeter</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>volume</varname></primary></indexterm>
 				<para>Area, volume, perimeter</para>
 				<para><varname>area(stbox, spheroid bool=true) → float</varname></para>
 				<para><varname>volume(stbox) → float</varname></para>
@@ -875,7 +887,6 @@ SELECT stbox 'STBOX XT(((1,1),(2,2)),[2001-01-01,2001-01-02])' #&amp;&gt;
 				<indexterm significance="normal"><primary><varname>&gt;</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&lt;=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>cmp</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>cmp</varname></primary></indexterm>
 				<para>Traditional comparisons</para>
 				<para><varname>box {=, &lt;&gt;, &lt;, &lt;=, &gt;=} box → boolean</varname></para>

--- a/doc/es/box_types.xml
+++ b/doc/es/box_types.xml
@@ -168,6 +168,7 @@ SELECT tbox(tstzspan '[2001-01-01,2001-01-02)');
 				<indexterm significance="normal"><primary><varname>geodstboxZ</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>geodstboxT</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>geodstboxZT</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
 				<para>Constructor para <varname>stbox</varname></para>
 				<para><varname>stboxX(float,float,float,float,srid=0) → stbox</varname></para>
 				<para><varname>stboxZ(float,float,float,float,float,float,srid=0) → stbox</varname></para>
@@ -214,6 +215,9 @@ SELECT stbox(geography 'Linestring(1 1 1,2 2 2)', tstzspan '[2001-01-03, 2001-01
 		<itemizedlist>
 			<listitem xml:id="tbox_convert_to">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>intspan</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>floatspan</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tstzspan</varname></primary></indexterm>
 				<para>Convertir un <varname>tbox</varname> a otro tipo</para>
 				<para><varname>tbox::{intspan,floatspan,tstzspan}</varname></para>
 				<para><varname>intspan(tbox) → tbox</varname></para>
@@ -231,6 +235,7 @@ SELECT tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-02))'::tstzspan;
 
 			<listitem xml:id="tbox_convert_from">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tbox</varname></primary></indexterm>
 				<para>Convertir otro tipo a un <varname>tbox</varname></para>
 				<para><varname>{numbers,times,tnumber}::tbox</varname></para>
 				<para><varname>tbox({numbers,times,tnumber}) → tbox</varname></para>
@@ -248,6 +253,11 @@ SELECT tstzspanset '{(2001-01-01,2001-01-02),(2001-01-03,2001-01-04)}'::tbox;
 
 			<listitem xml:id="stbox_convert_to">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>box2d</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>box3d</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>geometry</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>geography</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tstzspan</varname></primary></indexterm>
 				<para>Convertir un <varname>stbox</varname> a otro tipo</para>
 				<para><varname>stbox::{box2d,box2d,geo,tstzspan}</varname></para>
 				<para><varname>box2d(stbox) → box2d</varname></para>
@@ -278,6 +288,7 @@ SELECT stbox 'STBOX XT(((1.0,2.0),(3.0,4.0)),[2001-01-01,2001-01-03])'::tstzspan
 
 			<listitem xml:id="stbox_convert_from">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
 				<para>Convertir otro tipo a un <varname>stbox</varname></para>
 				<para><varname>{box2d,box3d,geo,times,tgeo}::stbox</varname></para>
 				<para><varname>stbox({box2d,box3d,geo,times,tgeo}) → stbox</varname></para>
@@ -406,6 +417,7 @@ SELECT tMaxInc(stbox 'GEODSTBOX T([2001-01-01,2001-01-03))');
 			<listitem xml:id="box_area">
 				<indexterm significance="normal"><primary><varname>area</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>perimeter</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>volume</varname></primary></indexterm>
 				<para>Área, volumen, perímetro</para>
 				<para><varname>area(stbox, spheroid bool=true) → float</varname></para>
 				<para><varname>volume(stbox) → float</varname></para>

--- a/doc/es/set_span_types.xml
+++ b/doc/es/set_span_types.xml
@@ -275,6 +275,7 @@ SELECT floatspansetFromHexWKB(
 				<indexterm significance="normal"><primary><varname>floatset</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>textset</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tstzset</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>set</varname></primary></indexterm>
 				<para>Constructor para tipos de conjunto</para>
 				<para><varname>set(base[]) → set</varname></para>
 				<programlisting language="sql" xml:space="preserve">
@@ -352,6 +353,7 @@ SELECT spanset(timestamptz '2001-01-01 08:00:00');
 
 			<listitem xml:id="set_convert">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>spanset</varname></primary></indexterm>
 				<para>Convertir un valor de conjunto en un valor de conjunto de rangos</para>
 				<para><varname>set::spanset</varname></para>
 				<para><varname>spanset(set) → spanset</varname></para>
@@ -366,6 +368,7 @@ SELECT spanset(tstzset '{2001-01-01 08:00:00, 2001-01-01 08:15:00,
 
 			<listitem xml:id="span_convert">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>spanset</varname></primary></indexterm>
 				<para>Convertir un valor de rango a un valor de conjunto de rangos</para>
 				<para><varname>span::spanset</varname></para>
 				<para><varname>spanset(span) → spanset</varname></para>

--- a/doc/es/temporal_alpha.xml
+++ b/doc/es/temporal_alpha.xml
@@ -47,6 +47,9 @@
 				<indexterm significance="normal"><primary><varname>valueSpan(tnumber)</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>timeSpan(tnumber)</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tbox(tnumber)</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>valueSpan</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>timeSpan</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tbox</varname></primary></indexterm>
 				<para>Convertir un número temporal en un rango o un cuadro delimitador temporal</para>
 				<para><varname>tnumber::{span,tbox}</varname></para>
 				<para><varname>valueSpan(tnumber) → numspan</varname></para>
@@ -73,6 +76,7 @@ SELECT tfloat '(1@2001-01-01, 3@2001-01-03, 2@2001-01-05]'::tbox;
 			<listitem xml:id="tbool_tint">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tint(tbool)</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tint</varname></primary></indexterm>
 				<para>Convertir entre un booleano temporal y un entero temporal</para>
 				<para><varname>tbool::tint</varname></para>
 				<para><varname>tint(tbool) → tint</varname></para>

--- a/doc/es/temporal_circular_buffers.xml
+++ b/doc/es/temporal_circular_buffers.xml
@@ -439,6 +439,7 @@ SELECT asText(tcbufferSeq(ARRAY[tcbuffer 'Cbuffer(Point(1 1), 0.2)@2001-01-01',
 
 			<listitem xml:id="tcbufferSeqSet">
 				<indexterm significance="normal"><primary><varname>tcbufferSeqSet</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tcbufferSeqSetGaps</varname></primary></indexterm>
 				<para>Constructor para búferes circulares temporales de subtipo conjunto de secuencias</para>
 				<para><varname>tcbufferSeqSet(tcbuffer[]) → tcbufferSeqSet</varname></para>
 				<para><varname>tcbufferSeqSetGaps(tcbufferInst[],maxt=NULL,maxdist=NULL,interp='linear') →</varname></para>
@@ -613,6 +614,7 @@ SELECT asText(appendSequence(tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01]', '
 
 			<listitem xml:id="tcbuffer_merge">
 				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>mergeAgg</varname></primary></indexterm>
 				<para>Fusionar los búferes circulares temporales</para>
 				<para><varname>merge(tcbuffer,tcbuffer) → tcbuffer</varname></para>
 				<para><varname>merge(tcbuffer[]) → tcbuffer</varname></para>

--- a/doc/es/temporal_h3_index.xml
+++ b/doc/es/temporal_h3_index.xml
@@ -296,6 +296,7 @@ SELECT th3GetResolution(th3index(
 
 			<listitem xml:id="th3_h3_cell_to_latlng">
 				<indexterm significance="normal"><primary><varname>th3CellToLatlng</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>th3CellToLatlngTgeompoint</varname></primary></indexterm>
 				<para>Devolver el centroide geodésico temporal de cada celda en una trayectoria. Una sobrecarga planar (SRID 4326) está disponible bajo el nombre <varname>th3CellToLatlngTgeompoint</varname>.</para>
 				<para><varname>th3CellToLatlng(th3index) → tgeogpoint</varname></para>
 				<para><varname>th3CellToLatlngTgeompoint(th3index) → tgeompoint</varname></para>

--- a/doc/es/temporal_jsonb.xml
+++ b/doc/es/temporal_jsonb.xml
@@ -584,7 +584,7 @@ SELECT tjsonbSeq(ARRAY[tjsonb
 			<listitem xml:id="tjsonbSeqSet">
 				<indexterm significance="normal"><primary><varname>tjsonbSeqSet</varname></primary></indexterm>
 				<para>Constructor de valores JSONB temporales del subtipo conjunto de secuencias</para>
-				<para><varname>tjsonbSeqset(tjsonb[]) → tjsonbSeqSet</varname></para>
+				<para><varname>tjsonbSeqSet(tjsonb[]) → tjsonbSeqSet</varname></para>
 				<para><varname>tjsonbSeqSetGaps(tjsonbInst[],maxt=NULL,maxdist=NULL) → tjsonbSeqSet</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonbSeqSet(ARRAY[tjsonb

--- a/doc/es/temporal_jsonb.xml
+++ b/doc/es/temporal_jsonb.xml
@@ -85,6 +85,8 @@ SELECT jsonbset_object_field(textset '{[{"unit": "km", "speed": 10},
 			<listitem xml:id="jsonbset_extract_path">
 				<indexterm significance="normal"><primary><varname>-></varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>->></varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>jsonbset_extract_path</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>jsonbset_extract_path_text</varname></primary></indexterm>
 				<para>Extraer un campo de objeto JSON especificado por una ruta</para>
 				<para><varname>{textset,jsonbset} #> text[] → {textset,jsonbset}</varname></para>
 				<para><varname>jsonbset_extract_path(jsonbset,text[],null_handle text='use_json_null') → jsonbset</varname></para>
@@ -583,6 +585,7 @@ SELECT tjsonbSeq(ARRAY[tjsonb
 
 			<listitem xml:id="tjsonbSeqSet">
 				<indexterm significance="normal"><primary><varname>tjsonbSeqSet</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tjsonbSeqSetGaps</varname></primary></indexterm>
 				<para>Constructor de valores JSONB temporales del subtipo conjunto de secuencias</para>
 				<para><varname>tjsonbSeqSet(tjsonb[]) → tjsonbSeqSet</varname></para>
 				<para><varname>tjsonbSeqSetGaps(tjsonbInst[],maxt=NULL,maxdist=NULL) → tjsonbSeqSet</varname></para>
@@ -795,6 +798,9 @@ SELECT tjson_object_field(ttext '{[{"unit": "km", "speed": 10}@2001-01-01,
 			<listitem xml:id="tjson_extract_path">
 				<indexterm significance="normal"><primary><varname>-></varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>->></varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tjson_extract_path</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tjsonb_extract_path</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tjsonb_extract_path_text</varname></primary></indexterm>
 				<para>Extraer un campo de objeto JSON temporal especificado por una ruta</para>
 				<para><varname>{ttext,tjsonb} #> text[] → {ttext,tjsonb}</varname></para>
 				<para><varname>tjson_extract_path(ttext,text[],null_handle text='use_json_null') → ttext</varname></para>

--- a/doc/es/temporal_network_points.xml
+++ b/doc/es/temporal_network_points.xml
@@ -358,6 +358,7 @@ SELECT tnpointSeq(ARRAY[tnpoint 'Npoint(1, 0.2)@2001-01-01',
 
 				<listitem xml:id="tnpointSeqSet">
 					<indexterm significance="normal"><primary><varname>tnpointSeqSet</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>tnpointSeqSetGaps</varname></primary></indexterm>
 					<para>Constructor para puntos de red temporal de subtipo conjunto de secuencias</para>
 					<para><varname>tnpointSeqSet(tnpoint[]) → tnpointSeqSet</varname></para>
 					<para><varname>tnpointSeqSetGaps(tnpointInst[],maxt=NULL,maxdist=NULL,interp='linear') →</varname></para>
@@ -558,6 +559,7 @@ SELECT asText(appendSequence(tnpoint '[Npoint(1, 0.1)@2001-01-01]', '[Npoint(1, 
 
 			<listitem xml:id="tnpoint_merge">
 				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>mergeAgg</varname></primary></indexterm>
 				<para>Fusionar los puntos de red temporales</para>
 				<para><varname>merge(tnpoint,tnpoint) → tnpoint</varname></para>
 				<para><varname>merge(tnpoint[]) → tnpoint</varname></para>

--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -1782,6 +1782,7 @@ SELECT tdensity(v) FROM (VALUES
 
 			<listitem xml:id="tpcpoint_merge">
 				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>mergeAgg</varname></primary></indexterm>
 				<para>Combina múltiples valores temporales en uno solo con todos los instantes de entrada fusionados en orden temporal. Todas las entradas deben compartir el mismo pcid y subtipo.</para>
 				<para><varname>merge(tpcpoint) → tpcpoint</varname>, <varname>merge(tpcpatch) → tpcpatch</varname></para>
 				<para><varname>mergeAgg(tpcpoint) → tpcpoint</varname>, <varname>mergeAgg(tpcpatch) → tpcpatch</varname></para>
@@ -1796,6 +1797,8 @@ SELECT numInstants(mergeAgg(v)) FROM (VALUES
 			<listitem xml:id="tpcpoint_append">
 				<indexterm significance="normal"><primary><varname>appendInstant</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>appendInstantAgg</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>appendSequenceAgg</varname></primary></indexterm>
 				<para>Agregados de construcción en flujo: <varname>appendInstant</varname> ensambla instantes en una secuencia; <varname>appendSequence</varname> ensambla secuencias en un conjunto de secuencias. Útil para cargadores de trayectorias que consumen filas en orden temporal.</para>
 				<para><varname>appendInstant(tpcpoint[,interp,maxt]) → tpcpoint</varname>, <varname>appendInstant(tpcpatch) → tpcpatch</varname></para>
 				<para><varname>appendInstantAgg(tpcpoint[,interp,maxt]) → tpcpoint</varname>, <varname>appendInstantAgg(tpcpatch) → tpcpatch</varname></para>

--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -282,7 +282,7 @@ SELECT asText(round(pose(ST_Point(1.123456789,1.123456789), 0.123456789), 6));
 					<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>setSRID</varname></primary></indexterm>
 					<para>Devuelve o establece el identificador de referencia espacial</para>
-					<para><varname>srid(pose) → integer</varname></para>
+					<para><varname>SRID(pose) → integer</varname></para>
 					<para><varname>setSRID(pose) → pose</varname></para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(pose 'Pose(SRID=5676;Point(1 1), 0.3)');
@@ -849,7 +849,7 @@ SELECT asEWKT(points(tpose 'SRID=5676;{Pose(Point(3 3), 0.3)@2001-01-01,
 			</listitem>
 
 			<listitem xml:id="tpose_rotation">
-				<indexterm significance="normal"><primary><varname>points</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>rotation</varname></primary></indexterm>
 				<para>Devuelve la rotación</para>
 				<para><varname>rotation(tpose2d) → tfloat</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">

--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -756,6 +756,7 @@ SELECT asText(tposeSeq(ARRAY[tpose 'Pose(Point(1 1), 0.2)@2001-01-01',
 
 			<listitem xml:id="tposeSeqSet">
 				<indexterm significance="normal"><primary><varname>tposeSeqSet</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tposeSeqSetGaps</varname></primary></indexterm>
 				<para>Constructor para poses temporales de subtipo conjunto de secuencias</para>
 				<para><varname>tposeSeqSet(tpose[]) → tposeSeqSet</varname></para>
 				<para><varname>tposeSeqSetGaps(tposeInst[],maxt=NULL,maxdist=NULL,interp='linear') → tposeSeqSet</varname></para>
@@ -966,6 +967,7 @@ SELECT asText(appendSequence(tpose '[Pose(Point(1 1), 0.5)@2001-01-01]', '[Pose(
 
 			<listitem xml:id="tpose_merge">
 				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>mergeAgg</varname></primary></indexterm>
 				<para>Fusionar las poses temporales</para>
 				<para><varname>merge(tpose,tpose) → tpose</varname></para>
 				<para><varname>merge(tpose[]) → tpose</varname></para>

--- a/doc/es/temporal_quadbin_index.xml
+++ b/doc/es/temporal_quadbin_index.xml
@@ -178,6 +178,7 @@ SELECT valueAtTimestamp(tquadbin
 		<itemizedlist>
 			<listitem xml:id="tquadbin_quadbin_get_resolution">
 				<indexterm significance="normal"><primary><varname>quadbinGetResolution</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tquadbinGetResolution</varname></primary></indexterm>
 				<para>Devuelve el nivel de resolución (zoom) (0–26) de una celda. La forma estática devuelve un <varname>integer</varname>; la forma temporal devuelve la resolución de cada celda de una trayectoria como un <varname>tint</varname>.</para>
 				<para><varname>quadbinGetResolution(quadbin) → integer</varname></para>
 				<para><varname>tquadbinGetResolution(tquadbin) → tint</varname></para>
@@ -206,6 +207,7 @@ SELECT isValidCell(tquadbin '480fffffffffffff@2001-01-01');
 		<itemizedlist>
 			<listitem xml:id="tquadbin_quadbin_cell_to_parent">
 				<indexterm significance="normal"><primary><varname>quadbinCellToParent</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tquadbinCellToParent</varname></primary></indexterm>
 				<para>Devuelve la celda padre en la resolución más gruesa dada. La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el padre de cada celda de una trayectoria.</para>
 				<para><varname>quadbinCellToParent(quadbin,integer) → quadbin</varname></para>
 				<para><varname>tquadbinCellToParent(tquadbin,integer) → tquadbin</varname></para>
@@ -269,6 +271,7 @@ SELECT geoToQuadbinCell(geometry 'SRID=4326;POINT(4.35 50.85)', 10)
 
 			<listitem xml:id="tquadbin_quadbin_cell_to_point">
 				<indexterm significance="normal"><primary><varname>quadbinCellToPoint</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tquadbinCellToPoint</varname></primary></indexterm>
 				<para>Devuelve el centroide de una celda como un punto SRID 4326. La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el centroide de cada celda de una trayectoria como un <varname>tgeompoint</varname>.</para>
 				<para><varname>quadbinCellToPoint(quadbin) → geometry</varname></para>
 				<para><varname>tquadbinCellToPoint(tquadbin) → tgeompoint</varname></para>
@@ -284,6 +287,7 @@ SELECT asText(tquadbinCellToPoint(tquadbin
 
 			<listitem xml:id="tquadbin_quadbin_cell_to_boundary">
 				<indexterm significance="normal"><primary><varname>quadbinCellToBoundary</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tquadbinCellToBoundary</varname></primary></indexterm>
 				<para>Devuelve el contorno poligonal cuadrado de una celda como una geometría SRID 4326. La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el contorno de cada celda de una trayectoria como un <varname>tgeometry</varname>.</para>
 				<para><varname>quadbinCellToBoundary(quadbin) → geometry</varname></para>
 				<para><varname>tquadbinCellToBoundary(tquadbin) → tgeometry</varname></para>
@@ -331,6 +335,7 @@ SELECT quadbinCellToTile(quadbin '48a6227affffffff');
 
 			<listitem xml:id="tquadbin_quadbin_cell_to_quadkey">
 				<indexterm significance="normal"><primary><varname>quadbinCellToQuadkey</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tquadbinCellToQuadkey</varname></primary></indexterm>
 				<para>Emite la cadena quadkey en base 4 de una celda (un dígito por nivel de zoom, primero el más significativo; la celda mundial de resolución 0 se corresponde con la cadena vacía). La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el quadkey de cada celda de una trayectoria como un <varname>ttext</varname>.</para>
 				<para><varname>quadbinCellToQuadkey(quadbin) → text</varname></para>
 				<para><varname>tquadbinCellToQuadkey(tquadbin) → ttext</varname></para>
@@ -351,6 +356,7 @@ SELECT quadbinCellToQuadkey(quadbin '48a6227affffffff');
 		<itemizedlist>
 			<listitem xml:id="tquadbin_quadbin_cell_area">
 				<indexterm significance="normal"><primary><varname>quadbinCellArea</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tquadbinCellArea</varname></primary></indexterm>
 				<para>Devuelve el área de una celda sobre la esfera, en metros cuadrados. La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el área de cada celda de una trayectoria como un <varname>tfloat</varname>. El área de la celda se reduce hacia los polos, ya que los cuadrados web-mercator cubren progresivamente menos terreno a latitudes más altas.</para>
 				<para><varname>quadbinCellArea(quadbin) → float8</varname></para>
 				<para><varname>tquadbinCellArea(tquadbin) → tfloat</varname></para>

--- a/doc/es/temporal_rigid_geometries.xml
+++ b/doc/es/temporal_rigid_geometries.xml
@@ -94,6 +94,8 @@ SELECT asText(trgeometryFromHexEWKB(asHexEWKB(trgeometry 'Polygon((0 0,1 0,1 1,0
 				<indexterm significance="normal"><primary><varname>trgeometryFromText</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>trgeometryFromMFJSON</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>trgeometryFromEWKB</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>trgeometryFromEWKT</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>trgeometryFromHexEWKB</varname></primary></indexterm>
 				<para>Cada formato de salida tiene un analizador complementario:</para>
 				<para><varname>trgeometryFromText(text) → trgeometry</varname></para>
 				<para><varname>trgeometryFromEWKT(text) → trgeometry</varname></para>
@@ -790,6 +792,7 @@ SELECT extent(temp) FROM tbl_trgeometry;
 
 			<listitem xml:id="trgeometry_merge">
 				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>mergeAgg</varname></primary></indexterm>
 				<para>Combinar dos trgeometries con la misma geometría de referencia en un único conjunto de secuencias</para>
 				<para><varname>merge(trgeometry, trgeometry) → trgeometry</varname></para>
 				<para><varname>mergeAgg(trgeometry) → trgeometry</varname></para>

--- a/doc/es/temporal_spatial_p1.xml
+++ b/doc/es/temporal_spatial_p1.xml
@@ -221,7 +221,7 @@ SELECT asEWKT(tgeographyFromMFJSON(text '{"type":"MovingGeometry",
 				<indexterm significance="normal"><primary><varname>tspatialFromEWKB</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tspatialFromHexEWKB</varname></primary></indexterm>
 				<para>Entrar a partir de su representación binaria conocida (WKB), de la representación extendida binaria conocida (EWKB), o de la representación hexadecimal extendida binaria conocida (HexEWKB) &Z_support; &geography_support;</para>
-				<para><varname>tspatialBinary(bytea) → tspatial</varname></para>
+				<para><varname>tspatialFromBinary(bytea) → tspatial</varname></para>
 				<para><varname>tspatialFromEWKB(bytea) → tspatial</varname></para>
 				<para><varname>tspatialFromHexEWKB(text) → tspatial</varname></para>
 				<para>En las funciones anteriores, <varname>tspatial</varname> reemplaza cualquier tipo espacial, como <varname>tgeompoint</varname>, <varname>tgeometry</varname> o <varname>tpose</varname></para>

--- a/doc/es/temporal_types_p1.xml
+++ b/doc/es/temporal_types_p1.xml
@@ -899,6 +899,7 @@ SELECT getTimestamp(tfloat '1@2001-01-01');
 
 			<listitem xml:id="ttype_getValues">
 				<indexterm significance="normal"><primary><varname>getValues</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>getTime</varname></primary></indexterm>
 				<para>Devuelve los valores o el tiempo en el que se define el valor temporal</para>
 				<para><varname>getValues(talpha) → {bool[],spanset,textset}</varname></para>
 				<para><varname>getTime(ttype) → tstzspanset</varname></para>

--- a/doc/es/temporal_types_p2.xml
+++ b/doc/es/temporal_types_p2.xml
@@ -314,6 +314,10 @@ SELECT merge(inst) FROM temp;
 				<indexterm significance="normal"><primary><varname>minusValue</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>atValues</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusValues</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>atSpan</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>minusSpan</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>atSpanset</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>minusSpanset</varname></primary></indexterm>
 				<para>Restringir a (al complemento de) un valor o un conjunto de valores o, para un número temporal, un span o un conjunto de spans de valores</para>
 				<para><varname>atValue(ttype,value) → ttype</varname></para>
 				<para><varname>minusValue(ttype,value) → ttype</varname></para>

--- a/doc/set_span_types.xml
+++ b/doc/set_span_types.xml
@@ -351,6 +351,7 @@ SELECT spanset(timestamptz '2001-01-01 08:00:00');
 
 			<listitem xml:id="set_convert">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>spanset</varname></primary></indexterm>
 				<para>Convert a set value to a span set value</para>
 				<para><varname>set::spanset</varname></para>
 				<para><varname>spanset(set) → spanset</varname></para>
@@ -595,6 +596,7 @@ SELECT spans(tstzspanset '{[2001-01-01, 2001-01-03), [2001-01-04, 2001-01-04],
 			<listitem xml:id="setspan_startSpan">
 				<indexterm significance="normal"><primary><varname>startSpan</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>endSpan</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>spanN</varname></primary></indexterm>
 				<para>Return the start, end, or n-th span</para>
 				<para><varname>startSpan(spanset) → span</varname></para>
 				<para><varname>endSpan(spanset) → span</varname></para>
@@ -1261,8 +1263,6 @@ SELECT dateset '{2001-01-01, 2001-01-03, 2001-01-05}' &lt;-&gt;
 				<indexterm significance="normal"><primary><varname>&lt;=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>cmp</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>cmp</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>cmp</varname></primary></indexterm>
 				<para>Traditional comparisons</para>
 				<para><varname>set {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} set → boolean</varname></para>
 				<para><varname>spans {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} spans → boolean</varname></para>
@@ -1343,6 +1343,7 @@ SELECT extent(ps) FROM periods;
 			<listitem xml:id="setspan_union_agg">
 				<indexterm significance="normal"><primary><varname>setUnion</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>spanUnion</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>spansetUnion</varname></primary></indexterm>
 				<para>Aggregate union</para>
 				<para><varname>setUnion({value,set}) → set</varname></para>
 				<para><varname>spanUnion(spans) → spanset</varname></para>

--- a/doc/temporal_alpha.xml
+++ b/doc/temporal_alpha.xml
@@ -46,6 +46,9 @@
 				<indexterm significance="normal"><primary><varname>valueSpan(tnumber)</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>timeSpan(tnumber)</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tbox(tnumber)</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>valueSpan</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>timeSpan</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tbox</varname></primary></indexterm>
 				<para>Convert a temporal number to a span or to a temporal bounding box</para>
 				<para><varname>tnumber::{span,tbox}</varname></para>
 				<para><varname>valueSpan(tnumber) → numspan</varname></para>
@@ -72,6 +75,7 @@ SELECT tfloat '(1@2001-01-01, 3@2001-01-03, 2@2001-01-05]'::tbox;
 			<listitem xml:id="tbool_tint">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tint(tbool)</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tint</varname></primary></indexterm>
 				<para>Convert between a temporal Boolean and a temporal integer</para>
 				<para><varname>tbool::tint</varname></para>
 				<para><varname>tint(tbool) → tint</varname></para>

--- a/doc/temporal_circular_buffers.xml
+++ b/doc/temporal_circular_buffers.xml
@@ -439,6 +439,7 @@ SELECT asText(tcbufferSeq(ARRAY[tcbuffer 'Cbuffer(Point(1 1), 0.2)@2001-01-01',
 
 			<listitem xml:id="tcbufferSeqSet">
 				<indexterm significance="normal"><primary><varname>tcbufferSeqSet</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tcbufferSeqSetGaps</varname></primary></indexterm>
 				<para>Constructor for temporal circular buffers of sequence set subtype</para>
 				<para><varname>tcbufferSeqSet(tcbuffer[]) → tcbufferSeqSet</varname></para>
 				<para><varname>tcbufferSeqSetGaps(tcbufferInst[],maxt=NULL,maxdist=NULL,interp='linear') →</varname></para>
@@ -613,6 +614,7 @@ SELECT asText(appendSequence(tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01]', '
 
 			<listitem xml:id="tcbuffer_merge">
 				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>mergeAgg</varname></primary></indexterm>
 				<para>Merge the temporal circular buffers</para>
 				<para><varname>merge(tcbuffer,tcbuffer) → tcbuffer</varname></para>
 				<para><varname>merge(tcbuffer[]) → tcbuffer</varname></para>

--- a/doc/temporal_h3_index.xml
+++ b/doc/temporal_h3_index.xml
@@ -306,6 +306,7 @@ SELECT th3GetResolution(th3index(
 
 			<listitem xml:id="th3_h3_cell_to_latlng">
 				<indexterm significance="normal"><primary><varname>th3CellToLatlng</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>th3CellToLatlngTgeompoint</varname></primary></indexterm>
 				<para>Return the temporal geodetic centroid of each cell in a trajectory. A planar (SRID 4326) overload is available under the name <varname>th3CellToLatlngTgeompoint</varname>.</para>
 				<para><varname>th3CellToLatlng(th3index) → tgeogpoint</varname></para>
 				<para><varname>th3CellToLatlngTgeompoint(th3index) → tgeompoint</varname></para>

--- a/doc/temporal_jsonb.xml
+++ b/doc/temporal_jsonb.xml
@@ -584,7 +584,7 @@ SELECT tjsonbSeq(ARRAY[tjsonb
 			<listitem xml:id="tjsonbSeqSet">
 				<indexterm significance="normal"><primary><varname>tjsonbSeqSet</varname></primary></indexterm>
 				<para>Constructor for temporal JSONB values of sequence set subtype</para>
-				<para><varname>tjsonbSeqset(tjsonb[]) → tjsonbSeqSet</varname></para>
+				<para><varname>tjsonbSeqSet(tjsonb[]) → tjsonbSeqSet</varname></para>
 				<para><varname>tjsonbSeqSetGaps(tjsonbInst[],maxt=NULL,maxdist=NULL) → tjsonbSeqSet</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonbSeqSet(ARRAY[tjsonb

--- a/doc/temporal_jsonb.xml
+++ b/doc/temporal_jsonb.xml
@@ -85,6 +85,8 @@ SELECT jsonbset_object_field(textset '{[{"unit": "km", "speed": 10},
 			<listitem xml:id="jsonbset_extract_path">
 				<indexterm significance="normal"><primary><varname>-></varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>->></varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>jsonbset_extract_path</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>jsonbset_extract_path_text</varname></primary></indexterm>
 				<para>Extract a JSON object field specified by a path</para>
 				<para><varname>{textset,jsonbset} #> text[] → {textset,jsonbset}</varname></para>
 				<para><varname>jsonbset_extract_path(jsonbset,text[],null_handle text='use_json_null') → jsonbset</varname></para>
@@ -583,6 +585,7 @@ SELECT tjsonbSeq(ARRAY[tjsonb
 
 			<listitem xml:id="tjsonbSeqSet">
 				<indexterm significance="normal"><primary><varname>tjsonbSeqSet</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tjsonbSeqSetGaps</varname></primary></indexterm>
 				<para>Constructor for temporal JSONB values of sequence set subtype</para>
 				<para><varname>tjsonbSeqSet(tjsonb[]) → tjsonbSeqSet</varname></para>
 				<para><varname>tjsonbSeqSetGaps(tjsonbInst[],maxt=NULL,maxdist=NULL) → tjsonbSeqSet</varname></para>
@@ -795,6 +798,9 @@ SELECT tjson_object_field(ttext '{[{"unit": "km", "speed": 10}@2001-01-01,
 			<listitem xml:id="tjson_extract_path">
 				<indexterm significance="normal"><primary><varname>-></varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>->></varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tjson_extract_path</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tjsonb_extract_path</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tjsonb_extract_path_text</varname></primary></indexterm>
 				<para>Extract a temporal JSON object field specified by a path</para>
 				<para><varname>{ttext,tjsonb} #> text[] → {ttext,tjsonb}</varname></para>
 				<para><varname>tjson_extract_path(ttext,text[],null_handle text='use_json_null') → ttext</varname></para>

--- a/doc/temporal_network_points.xml
+++ b/doc/temporal_network_points.xml
@@ -375,6 +375,7 @@ SELECT tnpointSeq(ARRAY[tnpoint 'Npoint(1, 0.2)@2001-01-01',
 
 				<listitem xml:id="tnpointSeqSet">
 					<indexterm significance="normal"><primary><varname>tnpointSeqSet</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>tnpointSeqSetGaps</varname></primary></indexterm>
 					<para>Constructor for temporal network points of sequence set subtype</para>
 					<para><varname>tnpointSeqSet(tnpoint[]) → tnpointSeqSet</varname></para>
 					<para><varname>tnpointSeqSetGaps(tnpointInst[],maxt=NULL,maxdist=NULL,interp='linear') →</varname></para>
@@ -576,6 +577,7 @@ SELECT asText(appendSequence(tnpoint '[Npoint(1, 0.1)@2001-01-01]', '[Npoint(1, 
 
 			<listitem xml:id="tnpoint_merge">
 				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>mergeAgg</varname></primary></indexterm>
 				<para>Merge the temporal network points</para>
 				<para><varname>merge(tnpoint,tnpoint) → tnpoint</varname></para>
 				<para><varname>merge(tnpoint[]) → tnpoint</varname></para>

--- a/doc/temporal_network_points.xml
+++ b/doc/temporal_network_points.xml
@@ -376,7 +376,7 @@ SELECT tnpointSeq(ARRAY[tnpoint 'Npoint(1, 0.2)@2001-01-01',
 				<listitem xml:id="tnpointSeqSet">
 					<indexterm significance="normal"><primary><varname>tnpointSeqSet</varname></primary></indexterm>
 					<para>Constructor for temporal network points of sequence set subtype</para>
-					<para><varname>tnpointSeqset(tnpoint[]) → tnpointSeqSet</varname></para>
+					<para><varname>tnpointSeqSet(tnpoint[]) → tnpointSeqSet</varname></para>
 					<para><varname>tnpointSeqSetGaps(tnpointInst[],maxt=NULL,maxdist=NULL,interp='linear') →</varname></para>
 					<para><varname>  tnpointSeqSet</varname></para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -1789,6 +1789,7 @@ SELECT tdensity(v) FROM (VALUES
 
 			<listitem xml:id="tpcpoint_merge">
 				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>mergeAgg</varname></primary></indexterm>
 				<para>Combine multiple temporal values into a single one with all input instants merged in temporal order. All inputs must share the same pcid and subtype.</para>
 				<para><varname>merge(tpcpoint) → tpcpoint</varname>, <varname>merge(tpcpatch) → tpcpatch</varname></para>
 				<para><varname>mergeAgg(tpcpoint) → tpcpoint</varname>, <varname>mergeAgg(tpcpatch) → tpcpatch</varname></para>
@@ -1803,6 +1804,8 @@ SELECT numInstants(mergeAgg(v)) FROM (VALUES
 			<listitem xml:id="tpcpoint_append">
 				<indexterm significance="normal"><primary><varname>appendInstant</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>appendInstantAgg</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>appendSequenceAgg</varname></primary></indexterm>
 				<para>Streaming construction aggregates: <varname>appendInstant</varname> assembles instants into a sequence; <varname>appendSequence</varname> assembles sequences into a sequence set. Useful for trajectory loaders that consume rows in time order.</para>
 				<para><varname>appendInstant(tpcpoint[,interp,maxt]) → tpcpoint</varname>, <varname>appendInstant(tpcpatch) → tpcpatch</varname></para>
 				<para><varname>appendInstantAgg(tpcpoint[,interp,maxt]) → tpcpoint</varname>, <varname>appendInstantAgg(tpcpatch) → tpcpatch</varname></para>

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -289,7 +289,7 @@ SELECT asText(round(pose(ST_Point(1.123456789,1.123456789), 0.123456789), 6));
 					<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>setSRID</varname></primary></indexterm>
 					<para>Return or set the spatial reference identifier</para>
-					<para><varname>srid(pose) → integer</varname></para>
+					<para><varname>SRID(pose) → integer</varname></para>
 					<para><varname>setSRID(pose) → pose</varname></para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(pose 'Pose(SRID=5676;Point(1 1), 0.3)');
@@ -856,7 +856,7 @@ SELECT asEWKT(points(tpose 'SRID=5676;{Pose(Point(3 3), 0.3)@2001-01-01,
 			</listitem>
 
 			<listitem xml:id="tpose_rotation">
-				<indexterm significance="normal"><primary><varname>points</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>rotation</varname></primary></indexterm>
 				<para>Return the rotation</para>
 				<para><varname>rotation(tpose2d) → tfloat</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -763,6 +763,7 @@ SELECT asText(tposeSeq(ARRAY[tpose 'Pose(Point(1 1), 0.2)@2001-01-01',
 
 			<listitem xml:id="tposeSeqSet">
 				<indexterm significance="normal"><primary><varname>tposeSeqSet</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tposeSeqSetGaps</varname></primary></indexterm>
 				<para>Constructor for temporal poses of sequence set subtype</para>
 				<para><varname>tposeSeqSet(tpose[]) → tposeSeqSet</varname></para>
 				<para><varname>tposeSeqSetGaps(tposeInst[],maxt=NULL,maxdist=NULL,interp='linear') → tposeSeqSet</varname></para>
@@ -973,6 +974,7 @@ SELECT asText(appendSequence(tpose '[Pose(Point(1 1), 0.5)@2001-01-01]', '[Pose(
 
 			<listitem xml:id="tpose_merge">
 				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>mergeAgg</varname></primary></indexterm>
 				<para>Merge the temporal poses</para>
 				<para><varname>merge(tpose,tpose) → tpose</varname></para>
 				<para><varname>merge(tpose[]) → tpose</varname></para>

--- a/doc/temporal_quadbin_index.xml
+++ b/doc/temporal_quadbin_index.xml
@@ -178,6 +178,7 @@ SELECT valueAtTimestamp(tquadbin
 		<itemizedlist>
 			<listitem xml:id="tquadbin_quadbin_get_resolution">
 				<indexterm significance="normal"><primary><varname>quadbinGetResolution</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tquadbinGetResolution</varname></primary></indexterm>
 				<para>Return the resolution (zoom) level (0–26) of a cell. The static form returns an <varname>integer</varname>; the temporal form returns the resolution of each cell in a trajectory as a <varname>tint</varname>.</para>
 				<para><varname>quadbinGetResolution(quadbin) → integer</varname></para>
 				<para><varname>tquadbinGetResolution(tquadbin) → tint</varname></para>
@@ -206,6 +207,7 @@ SELECT isValidCell(tquadbin '480fffffffffffff@2001-01-01');
 		<itemizedlist>
 			<listitem xml:id="tquadbin_quadbin_cell_to_parent">
 				<indexterm significance="normal"><primary><varname>quadbinCellToParent</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tquadbinCellToParent</varname></primary></indexterm>
 				<para>Return the parent cell at the given coarser resolution. The static form takes a single <varname>quadbin</varname>; the temporal form returns the parent of each cell in a trajectory.</para>
 				<para><varname>quadbinCellToParent(quadbin,integer) → quadbin</varname></para>
 				<para><varname>tquadbinCellToParent(tquadbin,integer) → tquadbin</varname></para>
@@ -269,6 +271,7 @@ SELECT geoToQuadbinCell(geometry 'SRID=4326;POINT(4.35 50.85)', 10)
 
 			<listitem xml:id="tquadbin_quadbin_cell_to_point">
 				<indexterm significance="normal"><primary><varname>quadbinCellToPoint</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tquadbinCellToPoint</varname></primary></indexterm>
 				<para>Return the centroid of a cell as an SRID-4326 point. The static form takes a single <varname>quadbin</varname>; the temporal form returns the centroid of each cell in a trajectory as a <varname>tgeompoint</varname>.</para>
 				<para><varname>quadbinCellToPoint(quadbin) → geometry</varname></para>
 				<para><varname>tquadbinCellToPoint(tquadbin) → tgeompoint</varname></para>
@@ -284,6 +287,7 @@ SELECT asText(tquadbinCellToPoint(tquadbin
 
 			<listitem xml:id="tquadbin_quadbin_cell_to_boundary">
 				<indexterm significance="normal"><primary><varname>quadbinCellToBoundary</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tquadbinCellToBoundary</varname></primary></indexterm>
 				<para>Return the square polygon boundary of a cell as an SRID-4326 geometry. The static form takes a single <varname>quadbin</varname>; the temporal form returns the boundary of each cell in a trajectory as a <varname>tgeometry</varname>.</para>
 				<para><varname>quadbinCellToBoundary(quadbin) → geometry</varname></para>
 				<para><varname>tquadbinCellToBoundary(tquadbin) → tgeometry</varname></para>
@@ -331,6 +335,7 @@ SELECT quadbinCellToTile(quadbin '48a6227affffffff');
 
 			<listitem xml:id="tquadbin_quadbin_cell_to_quadkey">
 				<indexterm significance="normal"><primary><varname>quadbinCellToQuadkey</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tquadbinCellToQuadkey</varname></primary></indexterm>
 				<para>Emit the base-4 slippy-tile quadkey string of a cell (one digit per zoom level, MSB-first; the resolution-0 world cell maps to the empty string). The static form takes a single <varname>quadbin</varname>; the temporal form returns the quadkey of each cell in a trajectory as a <varname>ttext</varname>.</para>
 				<para><varname>quadbinCellToQuadkey(quadbin) → text</varname></para>
 				<para><varname>tquadbinCellToQuadkey(tquadbin) → ttext</varname></para>
@@ -351,6 +356,7 @@ SELECT quadbinCellToQuadkey(quadbin '48a6227affffffff');
 		<itemizedlist>
 			<listitem xml:id="tquadbin_quadbin_cell_area">
 				<indexterm significance="normal"><primary><varname>quadbinCellArea</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tquadbinCellArea</varname></primary></indexterm>
 				<para>Return the area of a cell on the sphere, in square metres. The static form takes a single <varname>quadbin</varname>; the temporal form returns the area of each cell in a trajectory as a <varname>tfloat</varname>. Cell area shrinks toward the poles, as web-mercator squares cover progressively less ground at higher latitudes.</para>
 				<para><varname>quadbinCellArea(quadbin) → float8</varname></para>
 				<para><varname>tquadbinCellArea(tquadbin) → tfloat</varname></para>

--- a/doc/temporal_rigid_geometries.xml
+++ b/doc/temporal_rigid_geometries.xml
@@ -94,6 +94,8 @@ SELECT asText(trgeometryFromHexEWKB(asHexEWKB(trgeometry 'Polygon((0 0,1 0,1 1,0
 				<indexterm significance="normal"><primary><varname>trgeometryFromText</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>trgeometryFromMFJSON</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>trgeometryFromEWKB</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>trgeometryFromEWKT</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>trgeometryFromHexEWKB</varname></primary></indexterm>
 				<para>Each output format has a companion parser:</para>
 				<para><varname>trgeometryFromText(text) → trgeometry</varname></para>
 				<para><varname>trgeometryFromEWKT(text) → trgeometry</varname></para>
@@ -790,6 +792,7 @@ SELECT extent(temp) FROM tbl_trgeometry;
 
 			<listitem xml:id="trgeometry_merge">
 				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>mergeAgg</varname></primary></indexterm>
 				<para>Combine two trgeometries with the same reference geometry into a single sequence-set</para>
 				<para><varname>merge(trgeometry, trgeometry) → trgeometry</varname></para>
 				<para><varname>mergeAgg(trgeometry) → trgeometry</varname></para>

--- a/doc/temporal_types_analytics.xml
+++ b/doc/temporal_types_analytics.xml
@@ -993,6 +993,7 @@ FROM (SELECT valueTimeSplit(tfloat '[1@2001-02-01, 10@2001-02-10)', 5.0, '5 days
 
 				<listitem xml:id="spaceSplit">
 					<indexterm significance="normal"><primary><varname>spaceSplit</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>timeSplit</varname></primary></indexterm>
 					<para>Split a temporal point with respect to a spatial grid &Z_support;
  &SRF;
 </para>

--- a/doc/temporal_types_p1.xml
+++ b/doc/temporal_types_p1.xml
@@ -852,7 +852,7 @@ SELECT tempBasetype(tgeompoint 'Point(1 1)@2001-01-01');
 			</listitem>
 
 			<listitem xml:id="ttype_interp">
-				<indexterm significance="normal"><primary><varname>interpolation</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>interp</varname></primary></indexterm>
 				<para>Return the interpolation</para>
 				<para><varname>interp(ttype) → {'None','Discrete','Step','Linear'}</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">

--- a/doc/temporal_types_p1.xml
+++ b/doc/temporal_types_p1.xml
@@ -891,6 +891,7 @@ SELECT getTimestamp(tfloat '1@2001-01-01');
 
 			<listitem xml:id="ttype_getValues">
 				<indexterm significance="normal"><primary><varname>getValues</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>getTime</varname></primary></indexterm>
 				<para>Return the values or the time on which a temporal value is defined</para>
 				<para><varname>getValues(ttype) → baseset</varname></para>
 				<para><varname>getTime(ttype) → tstzspanset</varname></para>

--- a/doc/temporal_types_p2.xml
+++ b/doc/temporal_types_p2.xml
@@ -317,6 +317,10 @@ SELECT merge(inst) FROM temp;
 				<indexterm significance="normal"><primary><varname>minusValue</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>atValues</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusValues</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>atSpan</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>minusSpan</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>atSpanset</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>minusSpanset</varname></primary></indexterm>
 				<para>Restrict to (the complement of) a value or a set of values, or, for a temporal number, a span or a span set of values</para>
 				<para><varname>atValue(ttype,value) → ttype</varname></para>
 				<para><varname>minusValue(ttype,value) → ttype</varname></para>

--- a/tools/codegen/reference/add_index_gaps.py
+++ b/tools/codegen/reference/add_index_gaps.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Add the index terms that find_index_gaps.py reports as missing.
+
+A term is added only when the extension's SQL defines the name, with CREATE
+FUNCTION or CREATE AGGREGATE: the SQL is the authority for a name, and the
+manual's generic placeholders (ttype, tnumber) name no function, so they are
+left alone. The new term goes after the entry's existing ones.
+
+    python3 tools/codegen/reference/add_index_gaps.py
+"""
+import io
+import os
+import re
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import docbook as db
+import find_index_gaps as gaps
+
+TERM = '<indexterm significance="normal"><primary><varname>%s</varname></primary></indexterm>'
+
+
+def sql_names():
+    out = set()
+    for pat in (r"^CREATE FUNCTION\s+([A-Za-z_][A-Za-z0-9_]*)",
+                r"^CREATE AGGREGATE\s+([A-Za-z_][A-Za-z0-9_]*)"):
+        r = subprocess.run(["grep", "-rhoE", pat, os.path.join(db.ROOT, "mobilitydb", "sql")],
+                           capture_output=True, text=True)
+        out.update(line.split()[-1] for line in r.stdout.splitlines())
+    return out
+
+
+def main():
+    known = sql_names()
+    print("the SQL defines %d distinct names" % len(known))
+    added = skipped = 0
+    for lang in ("en", "es"):
+        d = db.CHAPTER_DIR[lang]
+        for fname, anchor, terms, missing in gaps.gaps(lang):
+            real = [m for m in missing if m in known]
+            skipped += len(missing) - len(real)
+            if not real:
+                continue
+            path = os.path.join(db.ROOT, d, fname)
+            s = io.open(path, encoding="utf-8").read()
+            m = re.search(r'(<listitem xml:id="%s">\n)((?:[^\n]*<indexterm[^\n]*\n)+)'
+                          % re.escape(anchor), s)
+            if not m:
+                print("  ! %s :: %s has no index term block" % (fname, anchor))
+                continue
+            indent = re.match(r'\s*', m.group(2)).group(0)
+            s = s[:m.end(2)] + "".join(indent + (TERM % n) + "\n" for n in real) + s[m.end(2):]
+            io.open(path, "w", encoding="utf-8").write(s)
+            added += len(real)
+            print("  %-30s %-32s + %s" % (fname, anchor, ", ".join(real)))
+    print("added %d index terms; left %d names the SQL does not define" % (added, skipped))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/codegen/reference/docbook.py
+++ b/tools/codegen/reference/docbook.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Read the manual's DocBook chapters.
+
+The chapters are XML fragments without a DTD, and the manual keeps its chapter
+order and its shared entities (&Z_support;, &SRF; …) in the book file's internal
+subset, so a tool that walks the chapters resolves both from there. The five XML
+built-ins survive untouched: an operator name is written &amp;&amp; in a chapter,
+and dropping it yields an empty name.
+"""
+import io
+import os
+import re
+import xml.etree.ElementTree as ET
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", ".."))
+MANUAL = {"en": "doc/mobilitydb-manual.xml", "es": "doc/es/mobilitydb-manual.xml"}
+CHAPTER_DIR = {"en": "doc", "es": "doc/es"}
+# chapters that carry no function reference surface
+SKIP = {"introduction", "reference", "portable_sql", "data_generator"}
+BUILTIN = {"amp", "lt", "gt", "apos", "quot"}
+
+
+def read(path):
+    return io.open(os.path.join(ROOT, path), encoding="utf-8").read()
+
+
+def entity_map(manual_text):
+    """{name: replacement} for every <!ENTITY name "..."> in the internal subset."""
+    return {m.group(1): m.group(2) for m in
+            re.finditer(r'<!ENTITY\s+(\S+)\s+"((?:[^"]|\n)*)"\s*>', manual_text)}
+
+
+def chapter_order(manual_text):
+    """Chapter entity names, in the order the manual references them."""
+    body = manual_text.split("]>", 1)[-1]
+    seen, order = set(), []
+    for m in re.finditer(r"&([A-Za-z_][A-Za-z0-9_]*);", body):
+        n = m.group(1)
+        if n not in seen and n not in SKIP:
+            seen.add(n)
+            order.append(n)
+    return order
+
+
+def parse_chapter(text, ents):
+    """Parse one chapter, resolving the manual's named entities."""
+    def sub(m):
+        name = m.group(1)
+        return m.group(0) if name in BUILTIN else ents.get(name, "")
+    return ET.fromstring(re.sub(r"&([A-Za-z_][A-Za-z0-9_]*);", sub, text))
+
+
+def chapters(lang):
+    """Yield (relative path, parsed root) for every reference-carrying chapter."""
+    manual = read(MANUAL[lang])
+    ents = entity_map(manual)
+    d = CHAPTER_DIR[lang]
+    for name in chapter_order(manual):
+        p = os.path.join(d, "%s.xml" % name)
+        if os.path.exists(os.path.join(ROOT, p)):
+            yield p, parse_chapter(read(p), ents)
+
+
+def inline(el):
+    """The element's text content, markup removed."""
+    out = [el.text or ""]
+    for ch in el:
+        out.append(inline(ch))
+        out.append(ch.tail or "")
+    return "".join(out)
+
+
+def norm(s):
+    return re.sub(r"\s+", " ", s).strip()
+
+
+def anchor(el):
+    return el.get("{http://www.w3.org/XML/1998/namespace}id")
+
+
+def index_terms(listitem):
+    """The function names a documented entry declares."""
+    return [norm(inline(v)) for it in listitem.findall("indexterm")
+            for pr in it.findall("primary") for v in pr.findall("varname")]

--- a/tools/codegen/reference/find_index_gaps.py
+++ b/tools/codegen/reference/find_index_gaps.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Report chapter entries whose index terms miss a function they document.
+
+A documented entry carries one index term per function it documents, so the
+manual's index and the reference summary name the whole surface. The callee of a
+signature is the identifier before the first '(' and before the arrow: what
+follows the arrow is a return type, and a bare cast form (`tbox::{intspan,…}`)
+names no callee.
+
+    python3 tools/codegen/reference/find_index_gaps.py
+"""
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import docbook as db
+
+
+def callees(listitem):
+    out = []
+    for para in listitem.findall("para"):
+        t = db.inline(para)
+        if "→" not in t:
+            continue
+        m = re.match(r'\s*([A-Za-z_][A-Za-z0-9_]*)\s*\(', t.split("→")[0])
+        if m:
+            out.append(m.group(1))
+    return list(dict.fromkeys(out))
+
+
+def gaps(lang):
+    found = []
+    for path, root in db.chapters(lang):
+        for li in root.iter("listitem"):
+            if not db.anchor(li):
+                continue
+            terms = db.index_terms(li)
+            if not terms:
+                continue
+            missing = [c for c in callees(li) if c not in terms]
+            if missing:
+                found.append((os.path.basename(path), db.anchor(li), terms, missing))
+    return found
+
+
+if __name__ == "__main__":
+    for lang in ("en", "es"):
+        rows = gaps(lang)
+        print("=== %s: %d entries whose index terms miss a documented function ===" %
+              (lang.upper(), len(rows)))
+        for f, a, terms, missing in rows:
+            print("  %-30s %-34s indexed=%-28s missing=%s" %
+                  (f, a, ",".join(terms)[:28], ",".join(missing)))


### PR DESCRIPTION
A chapter entry documents one or more functions and carries an index term for each, so the manual index and the reference summary name the whole surface. Two commits:

**Names the extension defines.** Six entries name something absent from the SQL, and now read the name the function has: the interpolation accessor is indexed as `interp`, the temporal pose rotation accessor as `rotation` rather than `points`, the pose accessor signature reads `SRID`, the sequence set constructors read `tnpointSeqSet` and `tjsonbSeqSet`, and the Spanish binary parser reads `tspatialFromBinary`. Each name comes from `mobilitydb/sql`.

**Index terms for the rest.** 99 terms across both languages: the `*SeqSetGaps` constructors, the `mergeAgg` / `appendInstantAgg` / `appendSequenceAgg` aggregate forms, `spansetUnion`, `getTime`, `interp`, `timeSplit`, `atSpan` / `atSpanset` / `minusSpan` / `minusSpanset`, `volume`, the named cast constructors beside the `::` operator, the six `tquadbin*` temporal cell functions, `th3CellToLatlngTgeompoint`, and the rigid geometry EWKT and HexEWKB parsers. The `cmp` term appears once per entry rather than once per signature line.

A term exists only for a name `CREATE FUNCTION` or `CREATE AGGREGATE` declares, so the manual generic placeholders (`ttype`, `tnumber`) stay unindexed: one entry, `tint_tfloat`, reports `tnumber` as unindexed and that is the correct outcome.

Two tools under `tools/codegen/reference/` keep this checkable: `find_index_gaps.py` reports an entry whose index terms miss a function its signatures document, and `add_index_gaps.py` applies the ones the SQL declares. Both read the chapters through `docbook.py` beside them, which resolves the manual entity subset and preserves the XML built-ins so an operator name such as `&&` keeps its text.

`generate_docs.yml` runs on a push to master whenever `doc/**` changes and pull-request checks never exercise it, so its six steps run locally on this commit: `xsltproc` HTML, `dblatex` PDF and `dbtoepub` EPUB, for the English and the Spanish manual. Every link in both reference chapters resolves and both manuals validate under `xmllint --xinclude`.