### PR TITLE
Skip nodata pixels when sampling a PostGIS raster

### DIFF
--- a/mobilitydb/src/raster/temporal_raster.c
+++ b/mobilitydb/src/raster/temporal_raster.c
@@ -133,7 +133,7 @@ raster_st_value_sample(void *ctx, const GSERIALIZED *point, double *value)
   fcinfo_val->isnull         = false;   /* reset before every call */
   Datum pixval = FunctionCallInvoke(fcinfo_val);
   if (fcinfo_val->isnull)
-    return false;   /* nodata pixel or geometry outside the pixel grid */
+    return false;   /* nodata pixel, or point outside the raster or the band */
   *value = DatumGetFloat8(pixval);
   return true;
 }
@@ -177,9 +177,11 @@ raster_value_setup(Datum rast_datum, int32 band, STBox *box,
   fcinfo_val->args[0].isnull = false;
   fcinfo_val->args[1].value  = Int32GetDatum(band);
   fcinfo_val->args[1].isnull = false;
-  /* Arg 3 (exclude_nodata) = false — return the nodata sentinel as-is so we
-   * can detect a NULL and skip the instant, matching the SQL STRICT semantics */
-  fcinfo_val->args[3].value  = BoolGetDatum(false);
+  /* Arg 3 (exclude_nodata) = true — ST_Value reports a nodata pixel as NULL,
+   * which #raster_st_value_sample turns into "no value here", as the
+   * #raster_sample_fn contract requires. With false the sentinel comes back as
+   * an ordinary number and is sampled as though it were data */
+  fcinfo_val->args[3].value  = BoolGetDatum(true);
   fcinfo_val->args[3].isnull = false;
   /* Arg 4 (resample) = 'nearest' — PostGIS 3.6+ added this parameter */
   fcinfo_val->args[4].value  = PointerGetDatum(cstring_to_text("nearest"));

--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -48,6 +48,27 @@ WITH rast AS (
   SELECT ST_SetValues(
     ST_AddBand(
       ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+      '32BF'::text, 0.0::float8, -9999.0::float8
+    ),
+    1, 1, 1,
+    ARRAY[[10.0::float4, -9999.0::float4, 30.0::float4],
+          [40.0::float4, 50.0::float4, 60.0::float4],
+          [70.0::float4, 80.0::float4, 90.0::float4]]
+  ) AS r
+)
+SELECT raster_value(r,
+  tgeompoint 'SRID=4326;[POINT(0.5 2.5)@2000-01-01 00:00:00+00, POINT(1.5 2.5)@2000-01-02 00:00:00+00, POINT(0.5 0.5)@2000-01-03 00:00:00+00]'
+)::text AS result
+FROM rast;
+                         result                         
+--------------------------------------------------------
+ {10@2000-01-01 00:00:00+00, 70@2000-01-03 00:00:00+00}
+(1 row)
+
+WITH rast AS (
+  SELECT ST_SetValues(
+    ST_AddBand(
+      ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
       '32BF'::text, 0.0::float8, NULL::float8
     ),
     1, 1, 1,

--- a/mobilitydb/test/raster/queries/500_raster.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster.test.sql
@@ -81,6 +81,26 @@ SELECT raster_value(r,
 )::text AS result
 FROM rast;
 
+-- An instant on a nodata pixel is dropped, as one outside the extent is: the
+-- band declares -9999 as its nodata value and pixel(row=1,col=2) holds it.
+-- POINT(0.5 2.5) → 10; POINT(1.5 2.5) → nodata → dropped; POINT(0.5 0.5) → 70
+WITH rast AS (
+  SELECT ST_SetValues(
+    ST_AddBand(
+      ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+      '32BF'::text, 0.0::float8, -9999.0::float8
+    ),
+    1, 1, 1,
+    ARRAY[[10.0::float4, -9999.0::float4, 30.0::float4],
+          [40.0::float4, 50.0::float4, 60.0::float4],
+          [70.0::float4, 80.0::float4, 90.0::float4]]
+  ) AS r
+)
+SELECT raster_value(r,
+  tgeompoint 'SRID=4326;[POINT(0.5 2.5)@2000-01-01 00:00:00+00, POINT(1.5 2.5)@2000-01-02 00:00:00+00, POINT(0.5 0.5)@2000-01-03 00:00:00+00]'
+)::text AS result
+FROM rast;
+
 -- All instants outside the raster → NULL.
 WITH rast AS (
   SELECT ST_SetValues(


### PR DESCRIPTION
The `raster_sample_fn` contract is that the callback returns false when the point
lies outside the raster or on a nodata pixel:

```c
/**
 * @brief Callback returning the raster pixel value at a point: return true
 * and set @p value, or return false when the point lies outside the raster
 * or on a nodata pixel
 */
```

The GDAL-backed sampler follows it. The ST_Value-backed one passes
`exclude_nodata` as false, which makes ST_Value return the nodata sentinel as an
ordinary number rather than NULL, so the callback reports it as a value and the
sampling functions emit the sentinel as data. The same raster and trajectory
therefore give different results depending on which sampler runs.

Passing `exclude_nodata` as true lets ST_Value report a nodata pixel as NULL,
which the existing NULL branch already turns into no value. The comment on that
argument described the opposite of what the flag does, and now describes the
behaviour.

A test covers the effect of nodata on sampling, which none did: every existing
case passes NULL as the ST_AddBand nodata argument, so no pixel is ever nodata in
them. The new case declares -9999 as the band nodata value, places it at
pixel(row=1,col=2), and sends a trajectory across it, so the instant over that
pixel is dropped exactly as an instant outside the raster extent is.
