### PR TITLE
Add an accessor for the pixel bytes of a Raquet tile

### DIFF
--- a/meos/include/meos_raster.h
+++ b/meos/include/meos_raster.h
@@ -99,6 +99,7 @@ extern int raquet_width(const Raquet *rq);
 extern int raquet_height(const Raquet *rq);
 extern double raquet_nodata(const Raquet *rq);
 extern char *raquet_pixtype(const Raquet *rq);
+extern uint8_t *raquet_pixels(const Raquet *rq, size_t *size_out);
 extern uint32 raquet_hash(const Raquet *rq);
 extern uint64 raquet_hash_extended(const Raquet *rq, uint64 seed);
 

--- a/meos/src/raster/raquet.c
+++ b/meos/src/raster/raquet.c
@@ -376,6 +376,28 @@ raquet_pixtype(const Raquet *rq)
   }
 }
 
+/**
+ * @ingroup meos_raster_base_accessor
+ * @brief Return a copy of the pixel bytes of a Raquet tile
+ * @param[in] rq Raquet tile
+ * @param[out] size_out Number of bytes returned
+ * @return On error return @p NULL
+ * @note The bytes are row-major and packed, @p width * @p height pixels of
+ * @p raquet_pixtype_size() bytes each, which is the layout the tile
+ * constructors accept
+ */
+uint8_t *
+raquet_pixels(const Raquet *rq, size_t *size_out)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(rq, NULL); VALIDATE_NOT_NULL(size_out, NULL);
+  size_t size = raquet_pixels_size(rq);
+  uint8_t *result = palloc(size);
+  memcpy(result, rq->pixels, size);
+  *size_out = size;
+  return result;
+}
+
 /*****************************************************************************
  * Conversion functions
  *****************************************************************************/


### PR DESCRIPTION
The accessors of a Raquet tile reach its quadbin, width, height, nodata value and
pixel type, but not its pixels, and the size of the pixel buffer is computed by a
static inline function of the internal header. A caller holding a tile through
the public API can therefore read every field of it except the data, which is
what a binding marshalling a tile needs.

`raquet_pixels` returns a copy of the row-major packed bytes and reports how many
there are:

```c
extern uint8_t *raquet_pixels(const Raquet *rq, size_t *size_out);
```

That is the shape the other byte-buffer accessors already use, in `set_as_wkb`,
`span_as_wkb`, `tbox_as_wkb` and `raquet_as_hexwkb`: the buffer is the return
value and the size rides along in an auxiliary out-parameter.

It returns a copy rather than a pointer into the tile, as `raquet_pixtype`
already returns a copy of the type name. The caller is then free of the tile's
lifetime, and writing into the result leaves the tile's own bytes untouched.

A null tile or a null `size_out` yields `NULL`, the guard the public API carries
in place of the assertion an internal function would use.
