### PR TITLE
Emit Doxygen stubs for the SQL declaration forms the parser skips

### DIFF
--- a/tools/codegen/sql_to_doxygen_stubs/sql_to_doxygen_stubs.py
+++ b/tools/codegen/sql_to_doxygen_stubs/sql_to_doxygen_stubs.py
@@ -34,16 +34,19 @@ from dataclasses import dataclass, field
 # A CREATE FUNCTION header can span multiple lines. We only need the name,
 # the parenthesised argument list, and the RETURNS clause — the body (AS ...)
 # is parsed separately to extract the C backing function name.
+# The OR REPLACE form declares a function exactly as the plain form does, so it
+# is matched too. Without it a function written that way gets no phantom, and
+# every @sqlfn reference to it renders as plain text rather than a link.
 CREATE_FN_RE = re.compile(
     r"""
-    ^CREATE\s+FUNCTION\s+
+    ^CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+
     (?P<name>[A-Za-z_][A-Za-z0-9_]*)   # SQL function name (unquoted)
     \s*\(                              # opening paren
     (?P<args>[^)]*(?:\([^)]*\)[^)]*)*) # arg list, allows one nested paren pair
     \)                                 # closing paren
     \s*
     (?:RETURNS\s+(?P<ret>[A-Za-z0-9_\[\]\s]+?))?  # optional RETURNS clause
-    (?:\s+(?:AS\s+['"]MODULE_PATHNAME['"]\s*,\s*['"](?P<cfn>[A-Za-z_][A-Za-z0-9_]*)['"])|\s+AS\s+\$|\s*;|\s+LANGUAGE)
+    (?:\s+(?:AS\s+['"]MODULE_PATHNAME['"]\s*,\s*['"](?P<cfn>[A-Za-z_][A-Za-z0-9_]*)['"])|\s+AS\s+\$|\s+AS\s+'|\s*;|\s+LANGUAGE)
     """,
     re.VERBOSE | re.IGNORECASE | re.MULTILINE | re.DOTALL,
 )


### PR DESCRIPTION
Doxygen has no SQL lexer, so the stub generator emits a phantom C declaration for
every SQL function, which is what a `@sqlfn` reference in a C comment autolinks
to. Two declaration forms it does not read leave their functions without a
phantom, and a reference to one of those renders as plain text:

`CREATE OR REPLACE FUNCTION` declares a function exactly as the plain form does,
and is not matched at all.

A single-quoted SQL body, as in `AS 'SELECT @extschema@.affine(...)'`, is neither
`AS 'MODULE_PATHNAME'` nor `AS $`, and it sits between the `RETURNS` clause and
`LANGUAGE`, so the header ends in none of the ways the pattern accepts.

Reading both forms covers 16 further functions:

| | |
| --- | --- |
| affine transformations | `affine`, `rotate`, `rotateX`, `rotateY`, `rotateZ`, `translate`, `transscale` |
| raster sampling | `rasterValue`, `atRasterValue`, `minusRasterValue`, `eRasterValue`, `aRasterValue`, `rasterTileValueQuadbin`, `trajectoryQuadbins` |
| selectivity | `_mobdb_span_sel`, `_mobdb_span_joinsel` |

Over `mobilitydb/sql` the generator goes from 1255 phantoms covering 7970 SQL
declarations across 1282 unique names, to 1271 phantoms covering 8089
declarations across 1298 names. Every name it already emits it still emits; the
16 are additions.

The last two are internal. Whether the manual lists names beginning with an
underscore is a separate question about what it documents, and a filter for them
belongs with that answer rather than with the parser.
