### PR TITLE
Document the timestamp restrictions in the Spanish chapter

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -875,6 +875,10 @@
 				<listitem>
 					<para><link linkend="ttype_atTime"><varname>atTime</varname>, <varname>minusTime</varname></link>: Restringir a (al complemento de) un valor de tiempo</para>
 				</listitem>
+
+				<listitem>
+					<para><link linkend="beforeTimestamp"><varname>beforeTimestamp</varname>, <varname>afterTimestamp</varname></link>: Mantener los instantes de un valor temporal que son anteriores o posteriores a una marca de tiempo, o iguales a ella</para>
+				</listitem>
 			</itemizedlist>
 		</sect2>
 

--- a/doc/es/temporal_types_p2.xml
+++ b/doc/es/temporal_types_p2.xml
@@ -408,6 +408,30 @@ SELECT minusTime(tint '[1@2001-01-01, 1@2001-01-15)',
    [1@2001-01-05, 1@2001-01-15)} */
 </programlisting>
 			</listitem>
+
+			<listitem xml:id="beforeTimestamp">
+				<indexterm significance="normal"><primary><varname>beforeTimestamp</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>afterTimestamp</varname></primary></indexterm>
+				<para>Mantener los instantes de un valor temporal que son anteriores o posteriores a una marca de tiempo, o iguales a ella</para>
+				<para><varname>beforeTimestamp(ttype,timestamptz,strict bool=TRUE) → ttype</varname></para>
+				<para><varname>afterTimestamp(ttype,timestamptz,strict bool=TRUE) → ttype</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT beforeTimestamp(tint '[1@2001-01-01, 1@2001-01-03]', timestamptz '2001-01-02');
+-- [1@2001-01-01, 1@2001-01-02)
+SELECT beforeTimestamp(tint '[1@2001-01-01, 1@2001-01-03]', timestamptz '2001-01-01');
+-- NULL
+SELECT beforeTimestamp(tbigint '[1@2001-01-01, 1@2001-01-03]', timestamptz '2001-01-01',
+  false);
+-- [1@2001-01-01]
+SELECT afterTimestamp(tfloat '[1@2001-01-01, 3@2001-01-03]', timestamptz '2001-01-02',
+  false);
+-- [2@2001-01-02, 3@2001-01-03]
+SELECT asText(afterTimestamp(tgeompoint '{[Point(1 1 1)@2001-01-01,
+  Point(2 2 2)@2001-01-02], [Point(3 3 3)@2001-01-04, Point(3 3 3)@2001-01-05]}',
+  timestamptz '2001-01-03'));
+/* {[POINT Z (3 3 3)@2001-01-04, POINT Z (3 3 3)@2001-01-05]} */
+</programlisting>
+			</listitem>
 		</itemizedlist>
 	</sect1>
 

--- a/doc/temporal_types_p2.xml
+++ b/doc/temporal_types_p2.xml
@@ -426,7 +426,7 @@ SELECT beforeTimestamp(tint '[1@2001-01-01, 1@2001-01-03]', timestamptz '2001-01
 SELECT beforeTimestamp(tbigint '[1@2001-01-01, 1@2001-01-03]', timestamptz '2001-01-01',
   false);
 -- [1@2001-01-01]
-SELECT afterTimestamp(tfloat '[1@2001-01-01, 3@2001-01-03]', timestamptz '2001-01-02]',
+SELECT afterTimestamp(tfloat '[1@2001-01-01, 3@2001-01-03]', timestamptz '2001-01-02',
   false);
 -- [2@2001-01-02, 3@2001-01-03]
 SELECT asText(afterTimestamp(tgeompoint '{[Point(1 1 1)@2001-01-01,


### PR DESCRIPTION
The Spanish temporal-types chapter closes its restriction section at `minusTime`, while the English one documents `beforeTimestamp` and `afterTimestamp` there as well. The Spanish manual and its reference index therefore carry no entry for the two functions, although the Spanish pointcloud chapter documents the same pair for `tpcpoint` and `tpcpatch`. This adds the entry and its index row, with the examples of the English entry and the wording the pointcloud entry already uses.

The English entry passes `timestamptz '2001-01-02]'`, a literal with a trailing bracket that no timestamp parses, so the example errors out where it is meant to illustrate the third argument. Dropping the bracket makes it run. All five examples of the entry produce exactly the results the entry documents:

```
SELECT beforeTimestamp(tint '[1@2001-01-01, 1@2001-01-03]', timestamptz '2001-01-02');
 [1@Mon Jan 01 00:00:00 2001 PST, 1@Tue Jan 02 00:00:00 2001 PST)
SELECT afterTimestamp(tfloat '[1@2001-01-01, 3@2001-01-03]', timestamptz '2001-01-02', false);
 [2@Tue Jan 02 00:00:00 2001 PST, 3@Wed Jan 03 00:00:00 2001 PST]
```

`generate_docs.yml` runs on a push to master rather than on a pull request, so its six steps ran locally instead: `dblatex`, `dbtoepub` and `xsltproc` over both the English and the Spanish manual all return 0, and every link resolves within its own language with the reference index and the chapters symmetric between the two.