### PR TITLE
Anchor every function entry of the manual under its type

### DIFF
--- a/doc/box_types.xml
+++ b/doc/box_types.xml
@@ -310,7 +310,7 @@ SELECT tstzspanset '{(2001-01-01,2001-01-02),(2001-01-03,2001-01-04)}'::stbox;
 		<title>Accessors</title>
 
 		<itemizedlist>
-			<listitem xml:id="hasX">
+			<listitem xml:id="box_hasX">
 				<indexterm significance="normal"><primary><varname>hasX</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>hasZ</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>hasT</varname></primary></indexterm>
@@ -332,7 +332,7 @@ SELECT hasT(stbox 'STBOX X((1.0,2.0),(3.0,4.0))');
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="isGeodetic">
+			<listitem xml:id="stbox_isGeodetic">
 				<indexterm significance="normal"><primary><varname>isGeodetic</varname></primary></indexterm>
 				<para>Is geodetic?</para>
 				<para><varname>isGeodetic(stbox) → boolean</varname></para>
@@ -344,7 +344,7 @@ SELECT isGeodetic(stbox 'STBOX XT(((1.0,2.0),(3.0,4.0)),[2001-01-01,2001-01-02])
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="xMin">
+			<listitem xml:id="box_xMin">
 				<indexterm significance="normal"><primary><varname>xMin</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>yMin</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>zMin</varname></primary></indexterm>
@@ -367,7 +367,7 @@ SELECT tMin(stbox 'GEODSTBOX T([2001-01-01,2001-01-03))');
 				<para>Notice that for <varname>tbox</varname> the result value for <varname>xMin</varname> and <varname>xMin</varname> is converted to a <varname>float</varname> for the temporal boxes with an integer span.</para>
 			</listitem>
 
-			<listitem xml:id="xMax">
+			<listitem xml:id="box_xMax">
 				<indexterm significance="normal"><primary><varname>xMax</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>yMax</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>zMax</varname></primary></indexterm>
@@ -390,7 +390,7 @@ SELECT tMax(stbox 'GEODSTBOX T([2001-01-01,2001-01-03))');
 				<para>Notice that for <varname>tbox</varname> the result value for <varname>xMin</varname> and <varname>xMin</varname> is converted to a <varname>float</varname> for the temporal boxes with an integer span.</para>
 			</listitem>
 
-			<listitem xml:id="xMinInc">
+			<listitem xml:id="tbox_xMinInc">
 				<indexterm significance="normal"><primary><varname>xMinInc</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tMinInc</varname></primary></indexterm>
 				<para>Is the minimum X/T value inclusive?</para>
@@ -404,7 +404,7 @@ SELECT tMinInc(stbox 'GEODSTBOX T([2001-01-01,2001-01-03))');
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="xMaxInc">
+			<listitem xml:id="tbox_xMaxInc">
 				<indexterm significance="normal"><primary><varname>xMaxInc</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tMaxInc</varname></primary></indexterm>
 				<para>Is the maximum X/T value inclusive?</para>
@@ -418,7 +418,7 @@ SELECT tMaxInc(stbox 'GEODSTBOX T([2001-01-01,2001-01-03))');
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="area">
+			<listitem xml:id="stbox_area">
 				<indexterm significance="normal"><primary><varname>area</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>perimeter</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>volume</varname></primary></indexterm>
@@ -623,7 +623,7 @@ FROM test;
 		<title>Splitting Operations</title>
 
 		<itemizedlist>
-			<listitem xml:id="quadSplit">
+			<listitem xml:id="stbox_quadSplit">
 				<indexterm significance="normal"><primary><varname>quadSplit</varname></primary></indexterm>
 				<para>Split the bounding box in quadrants or octants &SRF;
 </para>

--- a/doc/es/box_types.xml
+++ b/doc/es/box_types.xml
@@ -330,7 +330,7 @@ SELECT hasT(stbox 'STBOX X((1.0,2.0),(3.0,4.0))');
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="box_isGeodetic">
+			<listitem xml:id="stbox_isGeodetic">
 				<indexterm significance="normal"><primary><varname>isGeodetic</varname></primary></indexterm>
 				<para>¿Es geodética?</para>
 				<para><varname>isGeodetic(stbox) → boolean</varname></para>
@@ -386,7 +386,7 @@ SELECT tMax(stbox 'GEODSTBOX T([2001-01-01,2001-01-03))');
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="box_xMinInc">
+			<listitem xml:id="tbox_xMinInc">
 				<indexterm significance="normal"><primary><varname>xMinInc</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tMinInc</varname></primary></indexterm>
 				<para>Es el mínimo valor X/T inclusivo?</para>
@@ -400,7 +400,7 @@ SELECT tMinInc(stbox 'GEODSTBOX T([2001-01-01,2001-01-03))');
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="box_xMaxInc">
+			<listitem xml:id="tbox_xMaxInc">
 				<indexterm significance="normal"><primary><varname>xMaxInc</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tMaxInc</varname></primary></indexterm>
 				<para>Es el máximo valor X/T inclusivo?</para>
@@ -414,7 +414,7 @@ SELECT tMaxInc(stbox 'GEODSTBOX T([2001-01-01,2001-01-03))');
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="box_area">
+			<listitem xml:id="stbox_area">
 				<indexterm significance="normal"><primary><varname>area</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>perimeter</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>volume</varname></primary></indexterm>
@@ -621,7 +621,7 @@ FROM test;
 		<title>Operaciones de división</title>
 
 		<itemizedlist>
-			<listitem xml:id="box_quadSplit">
+			<listitem xml:id="stbox_quadSplit">
 				<indexterm significance="normal"><primary><varname>quadSplit</varname></primary></indexterm>
 				<para>Dividir el cuadro delimitador en cuadrantes u octantes &SRF;</para>
 				<para><varname>quadSplit(stbox) → {stbox}</varname></para>

--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -404,11 +404,11 @@
 				<title>Operaciones de división</title>
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="splitNSpans"><varname>splitNSpans</varname></link>: Devuelve una matriz de N rangos obtenida fusionando los elementos de un conjunto o los rangos de un conjunto de rangos</para>
+						<para><link linkend="setspan_splitNSpans"><varname>splitNSpans</varname></link>: Devuelve una matriz de N rangos obtenida fusionando los elementos de un conjunto o los rangos de un conjunto de rangos</para>
 					</listitem>
 
 					<listitem>
-						<para><link linkend="splitNSpans"><varname>splitEachNSpans</varname></link>: Devuelve una matriz de rangos obtenida fusionando N elementos consecutivos de un conjunto o N rangos consecutivos de un conjunto de rangos</para>
+						<para><link linkend="setspan_splitNSpans"><varname>splitEachNSpans</varname></link>: Devuelve una matriz de rangos obtenida fusionando N elementos consecutivos de un conjunto o N rangos consecutivos de un conjunto de rangos</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -516,7 +516,7 @@
 				</listitem>
 
 				<listitem>
-					<para><link linkend="box_isGeodetic"><varname>isGeodetic</varname></link>: ¿Es geodética?</para>
+					<para><link linkend="stbox_isGeodetic"><varname>isGeodetic</varname></link>: ¿Es geodética?</para>
 				</listitem>
 
 				<listitem>
@@ -528,15 +528,15 @@
 				</listitem>
 
 				<listitem>
-					<para><link linkend="box_xMinInc"><varname>xMinInc</varname>, <varname>tMinInc</varname></link>: Es el mínimo valor X/T inclusivo?</para>
+					<para><link linkend="tbox_xMinInc"><varname>xMinInc</varname>, <varname>tMinInc</varname></link>: Es el mínimo valor X/T inclusivo?</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="box_xMaxInc"><varname>xMaxInc</varname>, <varname>tMaxInc</varname></link>: Es el máximo valor X/T inclusivo?</para>
+					<para><link linkend="tbox_xMaxInc"><varname>xMaxInc</varname>, <varname>tMaxInc</varname></link>: Es el máximo valor X/T inclusivo?</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="box_area"><varname>area</varname>, <varname>volume</varname>, <varname>perimeter</varname></link>: Área, volumen, perímetro</para>
+					<para><link linkend="stbox_area"><varname>area</varname>, <varname>volume</varname>, <varname>perimeter</varname></link>: Área, volumen, perímetro</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -584,7 +584,7 @@
 			<title>Operaciones de división</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="box_quadSplit"><varname>quadSplit</varname></link>: Dividir un cuadro delimitador en cuadrantes u octantes </para>
+					<para><link linkend="stbox_quadSplit"><varname>quadSplit</varname></link>: Dividir un cuadro delimitador en cuadrantes u octantes </para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -839,27 +839,27 @@
 			<title>Modificaciones</title>
 			<itemizedlist>
 				<listitem>
-				<para><link linkend="insert"><varname>insert</varname></link>: Insertar un valor temporal en otro</para>
+				<para><link linkend="ttype_insert"><varname>insert</varname></link>: Insertar un valor temporal en otro</para>
 				</listitem>
 
 				<listitem>
-				<para><link linkend="update"><varname>update</varname></link>: Actualizar un valor temporal con otro</para>
+				<para><link linkend="ttype_update"><varname>update</varname></link>: Actualizar un valor temporal con otro</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="deleteTime"><varname>deleteTime</varname></link>: Eliminar de un valor temporal los instantes que intersectan un valor de tiempo</para>
+					<para><link linkend="ttype_deleteTime"><varname>deleteTime</varname></link>: Eliminar de un valor temporal los instantes que intersectan un valor de tiempo</para>
 				</listitem>
 
 				<listitem>
-				<para><link linkend="appendInstant"><varname>appendInstant</varname>, <varname>appendInstantAgg</varname></link>: Anexar un instante temporal a un valor temporal</para>
+				<para><link linkend="ttype_appendInstant"><varname>appendInstant</varname>, <varname>appendInstantAgg</varname></link>: Anexar un instante temporal a un valor temporal</para>
 				</listitem>
 
 				<listitem>
-				<para><link linkend="appendSequence"><varname>appendSequence</varname>, <varname>appendSequenceAgg</varname></link>: Anexar una secuencia temporal a un valor temporal</para>
+				<para><link linkend="ttype_appendSequence"><varname>appendSequence</varname>, <varname>appendSequenceAgg</varname></link>: Anexar una secuencia temporal a un valor temporal</para>
 				</listitem>
 
 				<listitem>
-				<para><link linkend="merge"><varname>merge</varname>, <varname>mergeAgg</varname></link>: Fusionar los valores temporales</para>
+				<para><link linkend="ttype_merge"><varname>merge</varname>, <varname>mergeAgg</varname></link>: Fusionar los valores temporales</para>
 				</listitem>
 
 			</itemizedlist>
@@ -877,7 +877,7 @@
 				</listitem>
 
 				<listitem>
-					<para><link linkend="beforeTimestamp"><varname>beforeTimestamp</varname>, <varname>afterTimestamp</varname></link>: Mantener los instantes de un valor temporal que son anteriores o posteriores a una marca de tiempo, o iguales a ella</para>
+					<para><link linkend="ttype_beforeTimestamp"><varname>beforeTimestamp</varname>, <varname>afterTimestamp</varname></link>: Mantener los instantes de un valor temporal que son anteriores o posteriores a una marca de tiempo, o iguales a ella</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -997,7 +997,7 @@
 			<title>Operaciones matemáticas</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="tAdd"><varname>+</varname>, <varname>-</varname>, <varname>*</varname>, <varname>/</varname></link>: Adición, resta, multiplicación y división temporal</para>
+					<para><link linkend="tnumber_tAdd"><varname>+</varname>, <varname>-</varname>, <varname>*</varname>, <varname>/</varname></link>: Adición, resta, multiplicación y división temporal</para>
 				</listitem>
 
 				<listitem>
@@ -1389,11 +1389,11 @@
 
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="bins"><varname>bins</varname></link>: Devuelve un conjunto de intervalos que cubre un rango de valores o de tiempo con intervalos de la misma amplitud or duración</para>
+						<para><link linkend="setspan_bins"><varname>bins</varname></link>: Devuelve un conjunto de intervalos que cubre un rango de valores o de tiempo con intervalos de la misma amplitud or duración</para>
 					</listitem>
 
 					<listitem>
-						<para><link linkend="getBin"><varname>getBin</varname></link>: Devuelve el intervalo que contiene un número o una marca de tiempo</para>
+						<para><link linkend="setspan_getBin"><varname>getBin</varname></link>: Devuelve el intervalo que contiene un número o una marca de tiempo</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -1403,16 +1403,16 @@
 
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="valueTimeTiles"><varname>valueTiles</varname>, <varname>timeTiles</varname>, <varname>valueTimeTiles</varname></link>: Devuelve el conjunto de mosaicos que cubre un cuadro delimitador temporal con mosaicos del mismo tamaño y/o duración</para>
+						<para><link linkend="tbox_valueTimeTiles"><varname>valueTiles</varname>, <varname>timeTiles</varname>, <varname>valueTimeTiles</varname></link>: Devuelve el conjunto de mosaicos que cubre un cuadro delimitador temporal con mosaicos del mismo tamaño y/o duración</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="spaceTimeTiles"><varname>spaceTiles</varname>, <varname>timeTiles</varname>, <varname>spaceTimeTiles</varname></link>: Devuelve el conjunto de mosaicos que cubre un cuadro delimitador espaciotemporal con mosaicos del mismo tamaño y/o duración</para>
+						<para><link linkend="stbox_spaceTimeTiles"><varname>spaceTiles</varname>, <varname>timeTiles</varname>, <varname>spaceTimeTiles</varname></link>: Devuelve el conjunto de mosaicos que cubre un cuadro delimitador espaciotemporal con mosaicos del mismo tamaño y/o duración</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="getValueTimeTile"><varname>getValueTile</varname>, <varname>getTboxTimeTile</varname>, <varname>getValueTimeTile</varname></link>: Devuelve el mosaico temporal que cubre un valor y/o una marca de tiempo</para>
+						<para><link linkend="tbox_getValueTimeTile"><varname>getValueTile</varname>, <varname>getTboxTimeTile</varname>, <varname>getValueTimeTile</varname></link>: Devuelve el mosaico temporal que cubre un valor y/o una marca de tiempo</para>
 						</listitem>
 					<listitem>
-						<para><link linkend="getSpaceTimeTile"><varname>getSpaceTile</varname>, <varname>getStboxTimeTile</varname>, <varname>getSpaceTimeTile</varname></link>: Devuelve el mosaico espaciotemporal que cubre un punto y/o una marca de tiempo</para>
+						<para><link linkend="stbox_getSpaceTimeTile"><varname>getSpaceTile</varname>, <varname>getStboxTimeTile</varname>, <varname>getSpaceTimeTile</varname></link>: Devuelve el mosaico espaciotemporal que cubre un punto y/o una marca de tiempo</para>
 						</listitem>
 				</itemizedlist>
 			</sect3>
@@ -1422,15 +1422,15 @@
 
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="valueTimeBins"><varname>valueBins</varname>, <varname>timeBins</varname></link>: Devuelve una matriz de intervalos de valores or de tiempo obtenidos a partir de los instantes o segmentos de un número temporal con respecto a un mosaico de valores o de tiempo</para>
+						<para><link linkend="tnumber_valueTimeBins"><varname>valueBins</varname>, <varname>timeBins</varname></link>: Devuelve una matriz de intervalos de valores or de tiempo obtenidos a partir de los instantes o segmentos de un número temporal con respecto a un mosaico de valores o de tiempo</para>
 					</listitem>
 
 					<listitem>
-						<para><link linkend="valueTimeBoxes"><varname>valueBoxes</varname>, <varname>timeBoxes</varname>, <varname>valueTimeBoxes</varname></link>: Devuelve una matriz de cuadros temporales obtenidos a partir de los instantes o segmentos de un número temporal con respecto a un mosaico de valores y/o tiempo</para>
+						<para><link linkend="tnumber_valueTimeBoxes"><varname>valueBoxes</varname>, <varname>timeBoxes</varname>, <varname>valueTimeBoxes</varname></link>: Devuelve una matriz de cuadros temporales obtenidos a partir de los instantes o segmentos de un número temporal con respecto a un mosaico de valores y/o tiempo</para>
 					</listitem>
 
 					<listitem>
-						<para><link linkend="spaceTimeBoxes"><varname>spaceBoxes</varname>, <varname>timeBoxes</varname>, <varname>spaceTimeBoxes</varname></link>: Devuelve una matriz de cuadros espaciotemporales obtenidos a partir de los instantes o segmentos de un punto temporal con respecto a un mosaico espacial y/o temporal</para>
+						<para><link linkend="tspatial_spaceTimeBoxes"><varname>spaceBoxes</varname>, <varname>timeBoxes</varname>, <varname>spaceTimeBoxes</varname></link>: Devuelve una matriz de cuadros espaciotemporales obtenidos a partir de los instantes o segmentos de un punto temporal con respecto a un mosaico espacial y/o temporal</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -1440,11 +1440,11 @@
 
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="valueSplit"><varname>valueSplit</varname>, <varname>timeSplit</varname>, <varname>valueTimeSplit</varname></link>: Fragmentar un número temporal con respecto a intervalos de valores y/o de tiempo</para>
+						<para><link linkend="tnumber_valueSplit"><varname>valueSplit</varname>, <varname>timeSplit</varname>, <varname>valueTimeSplit</varname></link>: Fragmentar un número temporal con respecto a intervalos de valores y/o de tiempo</para>
 					</listitem>
 
 					<listitem>
-						<para><link linkend="spaceSplit"><varname>spaceSplit</varname>, <varname>spaceTimeSplit</varname></link>: Fragmentar un punto temporal con respecto a los mosaicos de una malla espacial o espacio-temporal</para>
+						<para><link linkend="tspatial_spaceSplit"><varname>spaceSplit</varname>, <varname>spaceTimeSplit</varname></link>: Fragmentar un punto temporal con respecto a los mosaicos de una malla espacial o espacio-temporal</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -1455,31 +1455,31 @@
 
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="tCount"><varname>tCount</varname></link>: Conteo temporal</para>
+					<para><link linkend="ttype_tCount"><varname>tCount</varname></link>: Conteo temporal</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="extent"><varname>extent</varname></link>: Extensión del cuadro delimitador </para>
+					<para><link linkend="ttype_extent"><varname>extent</varname></link>: Extensión del cuadro delimitador </para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="tAnd"><varname>tAnd</varname>, <varname>tOr</varname></link>: Y, o temporal</para>
+					<para><link linkend="tbool_tAnd"><varname>tAnd</varname>, <varname>tOr</varname></link>: Y, o temporal</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="tMin"><varname>tMin</varname>, <varname>tMinAgg</varname>, <varname>tMax</varname>, <varname>tMaxAgg</varname>, <varname>tSum</varname>, <varname>tAvg</varname></link>: Mínimo, máximo, suma y promedio temporal</para>
+					<para><link linkend="ttype_tMin"><varname>tMin</varname>, <varname>tMinAgg</varname>, <varname>tMax</varname>, <varname>tMaxAgg</varname>, <varname>tSum</varname>, <varname>tAvg</varname></link>: Mínimo, máximo, suma y promedio temporal</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="wCount"><varname>wCount</varname></link>: Conteo de ventana</para>
+					<para><link linkend="ttype_wCount"><varname>wCount</varname></link>: Conteo de ventana</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="wMin"><varname>wMin</varname>, <varname>wMax</varname>, <varname>wSum</varname>, <varname>wAvg</varname></link>: Mínimo, máximo, suma y promedio de ventana</para>
+					<para><link linkend="tnumber_wMin"><varname>wMin</varname>, <varname>wMax</varname>, <varname>wSum</varname>, <varname>wAvg</varname></link>: Mínimo, máximo, suma y promedio de ventana</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="tCentroid"><varname>tCentroid</varname></link>: Centroide temporal</para>
+					<para><link linkend="tpoint_tCentroid"><varname>tCentroid</varname></link>: Centroide temporal</para>
 				</listitem>
 
 			</itemizedlist>
@@ -1830,15 +1830,15 @@
 				<title>Accesores</title>
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="route"><varname>route</varname></link>: Devuelve el identificador de ruta</para>
+						<para><link linkend="npoint_route"><varname>route</varname></link>: Devuelve el identificador de ruta</para>
 					</listitem>
 
 					<listitem>
-						<para><link linkend="getPosition"><varname>getPosition</varname></link>: Devuelve la fracción de posición</para>
+						<para><link linkend="npoint_getPosition"><varname>getPosition</varname></link>: Devuelve la fracción de posición</para>
 					</listitem>
 
 					<listitem>
-						<para><link linkend="startPosition"><varname>startPosition</varname>, <varname>endPosition</varname></link>: Devuelve la posición inicial o final</para>
+						<para><link linkend="npoint_startPosition"><varname>startPosition</varname>, <varname>endPosition</varname></link>: Devuelve la posición inicial o final</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -3862,7 +3862,7 @@
 			<title>Operador de Muestreo</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="rasterValue"><varname>rasterValue</varname></link>: Muestrear una banda de ráster en cada instante de una trayectoria</para>
+					<para><link linkend="raster_rasterValue"><varname>rasterValue</varname></link>: Muestrear una banda de ráster en cada instante de una trayectoria</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3875,7 +3875,7 @@
 				</listitem>
 
 				<listitem>
-					<para><link linkend="rasterTileValueQuadbin"><varname>rasterTileValueQuadbin</varname></link>: Muestrear un chip ráster de Raquet a lo largo de una trayectoria usando una celda QUADBIN para la georreferenciación</para>
+					<para><link linkend="raster_rasterTileValueQuadbin"><varname>rasterTileValueQuadbin</varname></link>: Muestrear un chip ráster de Raquet a lo largo de una trayectoria usando una celda QUADBIN para la georreferenciación</para>
 				</listitem>
 
 				<listitem>
@@ -3887,11 +3887,11 @@
 				</listitem>
 
 				<listitem>
-					<para><link linkend="rasterTileValue"><varname>rasterTileValue</varname></link>: Muestrear una tesela ráster raquet a lo largo de una trayectoria</para>
+					<para><link linkend="raster_rasterTileValue"><varname>rasterTileValue</varname></link>: Muestrear una tesela ráster raquet a lo largo de una trayectoria</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="rasterTileValueArray"><varname>rasterTileValue</varname></link>: Muestrear un arreglo de teselas ráster raquet a lo largo de una trayectoria, conservando la resolución más fina donde se solapan</para>
+					<para><link linkend="raster_rasterTileValueArray"><varname>rasterTileValue</varname></link>: Muestrear un arreglo de teselas ráster raquet a lo largo de una trayectoria, conservando la resolución más fina donde se solapan</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3933,19 +3933,19 @@
 			<title>Operadores de Restricción y Predicado</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="atRasterValue"><varname>atRasterValue</varname></link>: Devolver los instantes de una trayectoria donde el valor ráster muestreado cae dentro de un rango de flotante</para>
+					<para><link linkend="raster_atRasterValue"><varname>atRasterValue</varname></link>: Devolver los instantes de una trayectoria donde el valor ráster muestreado cae dentro de un rango de flotante</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="minusRasterValue"><varname>minusRasterValue</varname></link>: Devolver los instantes de una trayectoria donde el valor ráster muestreado cae fuera de un rango de flotante</para>
+					<para><link linkend="raster_minusRasterValue"><varname>minusRasterValue</varname></link>: Devolver los instantes de una trayectoria donde el valor ráster muestreado cae fuera de un rango de flotante</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="eRasterValue"><varname>eRasterValue</varname></link>: Devolver verdadero si la trayectoria alguna vez muestrea un valor de píxel ráster dentro de un rango de flotante</para>
+					<para><link linkend="raster_eRasterValue"><varname>eRasterValue</varname></link>: Devolver verdadero si la trayectoria alguna vez muestrea un valor de píxel ráster dentro de un rango de flotante</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="aRasterValue"><varname>aRasterValue</varname></link>: Devolver verdadero si cada instante de la trayectoria dentro de la extensión del ráster muestrea un valor de píxel dentro de un rango de flotante</para>
+					<para><link linkend="raster_aRasterValue"><varname>aRasterValue</varname></link>: Devolver verdadero si cada instante de la trayectoria dentro de la extensión del ráster muestrea un valor de píxel dentro de un rango de flotante</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/es/set_span_types.xml
+++ b/doc/es/set_span_types.xml
@@ -1173,7 +1173,7 @@ SELECT timestamp '2001-01-01' #&amp;&gt; tstzspan '[2001-01-01, 2001-01-05)';
 			<para>Sin embargo, cuando los cuadros delimitadores tienen un gran espacio vacío no cubierto por los valores reales, el índice generará muchos valores candidatos que no satisfacen el predicado de la consulta, lo que reduce la eficiencia del índice. En estas situaciones, puede ser mejor representar un valor no con un cuadro delimitador <emphasis>único</emphasis>, sino con <emphasis>múltiples</emphasis> cuadros delimitadores. Esto aumenta considerablemente la eficiencia del índice, siempre que el índice sea capaz de gestionar múltiples cuadros delimitadores por valor. Las siguientes funciones se utilizan para generar múltiples rangos a partir de un único valor de conjunto o conjunto de rangos.</para>
 
 			<itemizedlist>
-				<listitem xml:id="splitNSpans">
+				<listitem xml:id="setspan_splitNSpans">
 					<indexterm significance="normal"><primary><varname>splitNSpans</varname></primary></indexterm>
 					<para>Devuelve una matriz de N rangos obtenida fusionando los elementos de un conjunto o los rangos de un conjunto de rangos</para>
 					<para><varname>splitNSpans(set, integer) → span[]</varname></para>
@@ -1200,12 +1200,12 @@ SELECT splitNSpans(datespanset '{[2000-01-01, 2000-01-04), [2000-01-05, 2000-01-
 </programlisting>
 				</listitem>
 
-				<listitem xml:id="splitEachNSpans">
+				<listitem xml:id="setspan_splitEachNSpans">
 					<indexterm significance="normal"><primary><varname>splitEachNSpans</varname></primary></indexterm>
 					<para>Devuelve una matriz de rangos obtenida fusionando N elementos consecutivos de un conjunto o N rangos consecutivos de un conjunto de rangos</para>
 					<para><varname>splitEachNSpans(set, integer) → span[]</varname></para>
 					<para><varname>splitEachNSpans(spanset, integer) → span[]</varname></para>
-					<para>El último argumento especifica el número de elementos de entrada que se fusionan para producir un rango de salida. Si la cantidad de elementos de entrada es menor que el número especificado, la matriz resultante tendrá un rango de salida por elemento. De lo contrario, la cantidad especificada de elementos de entrada consecutivos se fusionará en un único rango de salida en la respuesta. Observe que, a diferencia de la función <link linkend="splitNSpans"><varname>splitNSpans</varname></link>, el número de rangos en el resultado depende del número de elementos o de rangos de entrada.</para>
+					<para>El último argumento especifica el número de elementos de entrada que se fusionan para producir un rango de salida. Si la cantidad de elementos de entrada es menor que el número especificado, la matriz resultante tendrá un rango de salida por elemento. De lo contrario, la cantidad especificada de elementos de entrada consecutivos se fusionará en un único rango de salida en la respuesta. Observe que, a diferencia de la función <link linkend="setspan_splitNSpans"><varname>splitNSpans</varname></link>, el número de rangos en el resultado depende del número de elementos o de rangos de entrada.</para>
 					<programlisting language="sql" xml:space="preserve">
 SELECT splitEachNSpans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 1);
 /* {"[1, 2)","[2, 3)","[3, 4)","[4, 5)","[5, 6)","[6, 7)","[7, 8)","[8, 9)",

--- a/doc/es/temporal_alpha.xml
+++ b/doc/es/temporal_alpha.xml
@@ -357,7 +357,7 @@ SELECT whenTrue(tdwithin(tgeompoint '[Point(1 1)@2001-01-01, Point(4 4)@2001-01-
 		<title>Operaciones matemáticas</title>
 
 		<itemizedlist>
-			<listitem xml:id="tAdd">
+			<listitem xml:id="tnumber_tAdd">
 				<indexterm significance="normal"><primary><varname>+</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>-</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>*</varname></primary></indexterm>

--- a/doc/es/temporal_network_points.xml
+++ b/doc/es/temporal_network_points.xml
@@ -140,7 +140,7 @@ SELECT geometry 'SRID=5676;LINESTRING(406.7 702.6,383.6 845.1)'::nsegment;
 			<title>Accesores</title>
 
 			<itemizedlist>
-				<listitem xml:id="route">
+				<listitem xml:id="npoint_route">
 					<indexterm significance="normal"><primary><varname>route</varname></primary></indexterm>
 					<para>Devuelve el identificador de ruta</para>
 					<para><varname>route({npoint,nsegment}) → bigint</varname></para>
@@ -152,7 +152,7 @@ SELECT route(nsegment 'Nsegment(76, 0.3, 0.3)');
 </programlisting>
 				</listitem>
 
-				<listitem xml:id="getPosition">
+				<listitem xml:id="npoint_getPosition">
 					<indexterm significance="normal"><primary><varname>getPosition</varname></primary></indexterm>
 					<para>Devuelve la posición</para>
 					<para><varname>getPosition(npoint) → float</varname></para>
@@ -162,7 +162,7 @@ SELECT getPosition(npoint 'Npoint(63, 0.3)');
 </programlisting>
 				</listitem>
 
-				<listitem xml:id="startPosition">
+				<listitem xml:id="npoint_startPosition">
 					<indexterm significance="normal"><primary><varname>startPosition</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>endPosition</varname></primary></indexterm>
 					<para>Devuelve la posición inicial/final</para>

--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -903,7 +903,7 @@ SELECT asEWKT(setSRID(tpose '[Pose(Point(0 0),1)@2001-01-01,
 				<para>Transformar a un identificador de referencia espacial</para>
 				<para><varname>transform(tpose,integer) → tpose</varname></para>
 				<para><varname>transformPipeline(tpose,pipeline text,to_srid integer,is_forward bool=true) → tpose</varname></para>
-				<para>La pose de cada instante se transforma igual que la pose estática correspondiente, con la corrección de orientación incluida, como se describe en <xref linkend="pose_transform"/>. Lo mismo ocurre con un <varname>poseset</varname>. Una <varname>trgeometry</varname> asocia sus poses con una geometría de referencia que comparte su marco, y la transformación a otro SRID no está admitida para ese tipo.</para>
+				<para>La pose de cada instante se transforma igual que la pose estática correspondiente, con la corrección de orientación incluida, como se describe para <link linkend="pose_transform"><varname>transform</varname></link>. Lo mismo ocurre con un <varname>poseset</varname>. Una <varname>trgeometry</varname> asocia sus poses con una geometría de referencia que comparte su marco, y la transformación a otro SRID no está admitida para ese tipo.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(transform(tpose 'SRID=4326;Pose(Point(4.35 50.85),1)@2001-01-01', 
   3812));

--- a/doc/es/temporal_raster.xml
+++ b/doc/es/temporal_raster.xml
@@ -26,7 +26,7 @@ CREATE EXTENSION mobilitydb CASCADE;
 		<title>Operador de Muestreo</title>
 
 		<itemizedlist>
-			<listitem xml:id="rasterValue">
+			<listitem xml:id="raster_rasterValue">
 				<indexterm significance="normal"><primary><varname>rasterValue</varname></primary></indexterm>
 				<para>Muestrear una banda de ráster en cada instante de una trayectoria</para>
 				<para><varname>rasterValue(tgeompoint,raster,band integer DEFAULT 1) → tfloat</varname></para>
@@ -103,7 +103,7 @@ ORDER BY tile_count DESC;
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="rasterTileValueQuadbin">
+			<listitem xml:id="raster_rasterTileValueQuadbin">
 				<indexterm significance="normal"><primary><varname>rasterTileValueQuadbin</varname></primary></indexterm>
 				<para>Muestrear un chip ráster de Raquet a lo largo de una trayectoria usando una celda QUADBIN para la georreferenciación</para>
 				<para><varname>rasterTileValueQuadbin(tgeompoint,bytea,integer,integer,bigint,text,float8,boolean) → tfloat</varname></para>
@@ -128,7 +128,7 @@ JOIN sst_raquet r ON r.quadbin = ANY(trajectoryQuadbins(t.trip, 6));
 				<indexterm significance="normal"><primary><varname>raquet</varname></primary></indexterm>
 				<para>Construir una tesela ráster Raquet a partir de sus bytes de píxeles, dimensiones, celda QUADBIN y tipo de píxel</para>
 				<para><varname>raquet(bytea,integer,integer,bigint,text,float8) → raquet</varname></para>
-				<para>Empaqueta un arreglo de píxeles <varname>pixels</varname> de banda única en orden de fila mayor de <varname>width</varname> × <varname>height</varname> píxeles de tipo <varname>pixtype</varname> (uno de <varname>UINT8</varname>, <varname>INT16</varname>, <varname>INT32</varname>, <varname>FLOAT32</varname> o <varname>FLOAT64</varname>), georreferenciado por la celda <varname>quadbin</varname>, en un único valor <varname>raquet</varname> autodescriptivo. El argumento <varname>nodata</varname> es opcional; cuando se omite (<varname>NULL</varname>) la tesela no lleva valor centinela de nodata. Se genera un error cuando el arreglo <varname>pixels</varname> es menor que <varname>width</varname> × <varname>height</varname> × el tamaño del píxel. Un <varname>raquet</varname> es un valor de longitud variable, libre de GDAL, con una representación portátil en texto Hex-WKB y binaria, distinto de y coexistente con el tipo <varname>raster</varname> de PostGIS usado por <link linkend="rasterValue"><varname>rasterValue</varname></link>.</para>
+				<para>Empaqueta un arreglo de píxeles <varname>pixels</varname> de banda única en orden de fila mayor de <varname>width</varname> × <varname>height</varname> píxeles de tipo <varname>pixtype</varname> (uno de <varname>UINT8</varname>, <varname>INT16</varname>, <varname>INT32</varname>, <varname>FLOAT32</varname> o <varname>FLOAT64</varname>), georreferenciado por la celda <varname>quadbin</varname>, en un único valor <varname>raquet</varname> autodescriptivo. El argumento <varname>nodata</varname> es opcional; cuando se omite (<varname>NULL</varname>) la tesela no lleva valor centinela de nodata. Se genera un error cuando el arreglo <varname>pixels</varname> es menor que <varname>width</varname> × <varname>height</varname> × el tamaño del píxel. Un <varname>raquet</varname> es un valor de longitud variable, libre de GDAL, con una representación portátil en texto Hex-WKB y binaria, distinto de y coexistente con el tipo <varname>raster</varname> de PostGIS usado por <link linkend="raster_rasterValue"><varname>rasterValue</varname></link>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Empaquetar las columnas sueltas de una tabla Raquet en valores raquet
 SELECT raquet(band_data, width, height, quadbin, 'FLOAT32', nodata) AS tile
@@ -155,11 +155,11 @@ FROM elevation_files;
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="rasterTileValue">
+			<listitem xml:id="raster_rasterTileValue">
 				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
 				<para>Muestrear una tesela ráster <varname>raquet</varname> a lo largo de una trayectoria</para>
 				<para><varname>rasterTileValue(tgeompoint,raquet) → tfloat</varname></para>
-				<para>Evalúa la tesela en cada instante de <varname>traj</varname> (SRID 4326), devolviendo los valores de píxel muestreados como un <varname>tfloat</varname>. Es el equivalente tipado de <link linkend="rasterTileValueQuadbin"><varname>rasterTileValueQuadbin</varname></link>: las dimensiones, la celda QUADBIN, el tipo de píxel y el tratamiento de nodata se toman del valor <varname>raquet</varname> en lugar de argumentos separados. Devuelve <varname>NULL</varname> cuando ningún instante cae dentro de la tesela o sobrevive al filtrado de nodata.</para>
+				<para>Evalúa la tesela en cada instante de <varname>traj</varname> (SRID 4326), devolviendo los valores de píxel muestreados como un <varname>tfloat</varname>. Es el equivalente tipado de <link linkend="raster_rasterTileValueQuadbin"><varname>rasterTileValueQuadbin</varname></link>: las dimensiones, la celda QUADBIN, el tipo de píxel y el tratamiento de nodata se toman del valor <varname>raquet</varname> en lugar de argumentos separados. Devuelve <varname>NULL</varname> cuando ningún instante cae dentro de la tesela o sobrevive al filtrado de nodata.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Muestrear teselas raquet preempaquetadas a lo largo de trayectorias de barcos
 SELECT t.tripid, rasterTileValue(t.trip, r.tile)
@@ -168,7 +168,7 @@ JOIN elevation_tiles r ON r.quadbin = ANY(trajectoryQuadbins(t.trip, 8));
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="rasterTileValueArray">
+			<listitem xml:id="raster_rasterTileValueArray">
 				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
 				<para>Muestrear un arreglo de teselas ráster <varname>raquet</varname> a lo largo de una trayectoria</para>
 				<para><varname>rasterTileValue(tgeompoint,raquet[]) → tfloat</varname></para>
@@ -309,7 +309,7 @@ SELECT DISTINCT tile FROM elevation_tiles;
 		<para>Los siguientes operadores definidos en SQL componen <varname>rasterValue</varname> con las funciones estándar de restricción temporal y predicado de MobilityDB. Aceptan un argumento opcional <varname>band</varname> (por defecto 1) e invocan <varname>rasterValue</varname> exactamente una vez por invocación.</para>
 
 		<itemizedlist>
-			<listitem xml:id="atRasterValue">
+			<listitem xml:id="raster_atRasterValue">
 				<indexterm significance="normal"><primary><varname>atRasterValue</varname></primary></indexterm>
 				<para>Devolver los instantes de una trayectoria donde el valor ráster muestreado cae dentro de un rango de flotante</para>
 				<para><varname>atRasterValue(tgeompoint,raster,floatspan,band integer DEFAULT 1) → tgeompoint</varname></para>
@@ -331,7 +331,7 @@ FROM rast;
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="minusRasterValue">
+			<listitem xml:id="raster_minusRasterValue">
 				<indexterm significance="normal"><primary><varname>minusRasterValue</varname></primary></indexterm>
 				<para>Devolver los instantes de una trayectoria donde el valor ráster muestreado cae fuera de un rango de flotante</para>
 				<para><varname>minusRasterValue(tgeompoint,raster,floatspan,band integer DEFAULT 1) → tgeompoint</varname></para>
@@ -343,7 +343,7 @@ FROM trips, elevation_raster;
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="eRasterValue">
+			<listitem xml:id="raster_eRasterValue">
 				<indexterm significance="normal"><primary><varname>eRasterValue</varname></primary></indexterm>
 				<para>Devolver verdadero si la trayectoria alguna vez muestrea un valor de píxel ráster dentro de un rango de flotante</para>
 				<para><varname>eRasterValue(tgeompoint,raster,floatspan,band integer DEFAULT 1) → boolean</varname></para>
@@ -356,7 +356,7 @@ WHERE eRasterValue(trip, elev_raster, floatspan '[200, 9999]');
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="aRasterValue">
+			<listitem xml:id="raster_aRasterValue">
 				<indexterm significance="normal"><primary><varname>aRasterValue</varname></primary></indexterm>
 				<para>Devolver verdadero si cada instante de la trayectoria dentro de la extensión del ráster muestrea un valor de píxel dentro de un rango de flotante</para>
 				<para><varname>aRasterValue(tgeompoint,raster,floatspan,band integer DEFAULT 1) → boolean</varname></para>

--- a/doc/es/temporal_types_aggregation.xml
+++ b/doc/es/temporal_types_aggregation.xml
@@ -32,7 +32,7 @@
 
 		<para>En los ejemplos que siguen, suponemos que las tablas <varname>Department</varname> y <varname>Trip</varname> contienen las dos tuplas introducidas en la <xref linkend="ttype_examples" />.</para>
 		<itemizedlist>
-			<listitem xml:id="tCount">
+			<listitem xml:id="ttype_tCount">
 				<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
 				<para>Conteo temporal</para>
 				<para><varname>tCount(ttype) → {tintSeq,tintSeqSet}</varname></para>
@@ -42,7 +42,7 @@ SELECT tCount(NoEmps) FROM Department;
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="extent">
+			<listitem xml:id="ttype_extent">
 				<indexterm significance="normal"><primary><varname>extent</varname></primary></indexterm>
 				<para>Extensión del cuadro delimitador</para>
 				<para><varname>extent(temp) → {tstzspan,tbox,stbox}</varname></para>
@@ -54,7 +54,7 @@ SELECT extent(Trip) FROM Trips;
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="tAnd">
+			<listitem xml:id="tbool_tAnd">
 				<indexterm significance="normal"><primary><varname>tAnd</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tOr</varname></primary></indexterm>
 				<para>Y, o temporal</para>
@@ -68,7 +68,7 @@ SELECT tOr(NoEmps #&gt; 6) FROM Department;
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="tMin">
+			<listitem xml:id="ttype_tMin">
 				<indexterm significance="normal"><primary><varname>tMin</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tMax</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tSum</varname></primary></indexterm>
@@ -93,7 +93,7 @@ SELECT tAvg(NoEmps) FROM Department;
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="wCount">
+			<listitem xml:id="ttype_wCount">
 				<indexterm significance="normal"><primary><varname>wCount</varname></primary></indexterm>
 				<para>Conteo de ventana</para>
 				<para><varname>wCount(tnumber,interval) → {tintSeq,tintSeqSet}</varname></para>
@@ -104,7 +104,7 @@ SELECT wCount(NoEmps, interval '2 days') FROM Department;
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="wMin">
+			<listitem xml:id="tnumber_wMin">
 				<indexterm significance="normal"><primary><varname>wMin</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>wMax</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>wSum</varname></primary></indexterm>
@@ -128,7 +128,7 @@ SELECT round(wAvg(NoEmps, interval '2 days'), 3) FROM Department;
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="tCentroid">
+			<listitem xml:id="tpoint_tCentroid">
 				<indexterm significance="normal"><primary><varname>tCentroid</varname></primary></indexterm>
 				<para>Centroide temporal</para>
 				<para><varname>tCentroid(tgeompoint) → tgeompoint</varname></para>

--- a/doc/es/temporal_types_analytics.xml
+++ b/doc/es/temporal_types_analytics.xml
@@ -543,7 +543,7 @@ SELECT splitEachNStboxes(tgeogpoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01
 			<title>Operaciones de intervalos</title>
 
 			<itemizedlist>
-				<listitem xml:id="bins">
+				<listitem xml:id="setspan_bins">
 					<indexterm significance="normal"><primary><varname>bins</varname></primary></indexterm>
 					<para>Devuelve una matriz de intervalos que cubre el rango de valores o de tiempo con intervalos de la misma amplitud o duración</para>
 					<para><varname>bins(numspans,width number,origin number=0) → span[]</varname></para>
@@ -572,7 +572,7 @@ FROM unnest(bins(tstzspanset '{[2001-01-15, 2001-01-17],[2001-01-22, 2001-01-25]
 </programlisting>
 				</listitem>
 
-				<listitem xml:id="getBin">
+				<listitem xml:id="setspan_getBin">
 					<indexterm significance="normal"><primary><varname>getBin</varname></primary></indexterm>
 					<para>Devuelve el rango que contiene un número o una marca de tiempo</para>
 					<para><varname>getBin(number,size number,origin number=0) → span</varname></para>
@@ -597,7 +597,7 @@ SELECT getBin('2001-01-04', interval '1 week', '2001-01-07');
 			<title>Operaciones de mosaicos</title>
 
 			<itemizedlist>
-				<listitem xml:id="valueTimeTiles">
+				<listitem xml:id="tbox_valueTimeTiles">
 					<indexterm significance="normal"><primary><varname>valueTiles</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>timeTiles</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>valueTimeTiles</varname></primary></indexterm>
@@ -636,7 +636,7 @@ SELECT valueTimeTiles(tfloat '[15@2001-01-15, 25@2001-01-25]'::tbox, 2.0, '2 day
 </programlisting>
 				</listitem>
 
-				<listitem xml:id="spaceTimeTiles">
+				<listitem xml:id="stbox_spaceTimeTiles">
 					<indexterm significance="normal"><primary><varname>spaceTiles</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>timeTiles</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>spaceTimeTiles</varname></primary></indexterm>
@@ -691,7 +691,7 @@ SELECT spaceTimeTiles(tgeompoint '[Point(3 3 3)@2001-01-15,
 </programlisting>
 				</listitem>
 
-				<listitem xml:id="getValueTimeTile">
+				<listitem xml:id="tbox_getValueTimeTile">
 					<indexterm significance="normal"><primary><varname>getValueTile</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>getTboxTimeTile</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>getValueTimeTile</varname></primary></indexterm>
@@ -714,7 +714,7 @@ SELECT getValueTimeTile(15, '2001-01-15', 2, interval '2 days', 1, '2001-01-02')
 </programlisting>
 				</listitem>
 
-				<listitem xml:id="getSpaceTimeTile">
+				<listitem xml:id="stbox_getSpaceTimeTile">
 					<indexterm significance="normal"><primary><varname>getSpaceTile</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>getStboxTimeTile</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>getSpaceTimeTile</varname></primary></indexterm>
@@ -747,7 +747,7 @@ SELECT getSspaceTimeTile(geometry 'Point(1 1)', '2001-01-01', 2.0, interval '2 d
 			<title>Operaciones de cuadro delimitador</title>
 			<para>Estas operaciones fragmentan el cuadro delimitador de un valor temporal con respecto a un mosaico multidimensional. Ofrecen una alternativa a las operaciones de la <xref linkend="ttype_splitting" /> para dividir los cuadros delimitadores especificando el tamaño máximo de los cuadros en las distintas dimensiones.</para>
 			<itemizedlist>
-				<listitem xml:id="valueTimeBins">
+				<listitem xml:id="tnumber_valueTimeBins">
 					<indexterm significance="normal"><primary><varname>valueBins</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>timeBins</varname></primary></indexterm>
 					<para>Devuelve una matriz de rangos de valores o de tiempo obtenidos a partir de los instantes o segmentos de un número temporal con respecto a un mosaico de valores o de tiempo</para>
@@ -772,7 +772,7 @@ SELECT timeBins(tfloat '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
 </programlisting>
 				</listitem>
 
-				<listitem xml:id="valueTimeBoxes">
+				<listitem xml:id="tnumber_valueTimeBoxes">
 					<indexterm significance="normal"><primary><varname>valueBoxes</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>timeBoxes</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>valueTimeBoxes</varname></primary></indexterm>
@@ -804,7 +804,7 @@ SELECT valueTimeBoxes(tfloat '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-
 </programlisting>
 				</listitem>
 
-				<listitem xml:id="spaceTimeBoxes">
+				<listitem xml:id="tspatial_spaceTimeBoxes">
 					<indexterm significance="normal"><primary><varname>spaceBoxes</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>timeBoxes</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>spaceTimeBoxes</varname></primary></indexterm>
@@ -848,7 +848,7 @@ SELECT spaceTimeBoxes(tgeompoint '[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01
 			<title>Operaciones de división</title>
 			<para>Estas funciones fragmentan un valor temporal con respecto a una secuencia de intervalos (ver la <xref linkend="bin_functions" />) o un mosaico multidimensional (ver la <xref linkend="tile_functions" />).</para>
 			<itemizedlist>
-				<listitem xml:id="valueSplit">
+				<listitem xml:id="tnumber_valueSplit">
 					<indexterm significance="normal"><primary><varname>valueSplit</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>timeSplit</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>valueTimeSplit</varname></primary></indexterm>
@@ -934,7 +934,7 @@ FROM (SELECT valueTimeSplit(tfloat '[1@2001-02-01, 10@2001-02-10)', 5.0, '5 days
 </programlisting>
 				</listitem>
 
-				<listitem xml:id="spaceSplit">
+				<listitem xml:id="tspatial_spaceSplit">
 					<indexterm significance="normal"><primary><varname>spaceSplit</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>spaceTimeSplit</varname></primary></indexterm>
 					<para>Fragmentar un punto temporal con respecto a una malla espacial o espacio-temporal &SRF;</para>

--- a/doc/es/temporal_types_p1.xml
+++ b/doc/es/temporal_types_p1.xml
@@ -703,6 +703,7 @@ SELECT ttextFromHexWKB('01290001040000000000000041414100009C57D3C11C0000');
 
 		<itemizedlist>
 			<listitem xml:id="ttype_const">
+				<indexterm significance="normal"><primary><varname>ttype</varname></primary></indexterm>
 				<para>Constructores para tipos temporales que tienen un valor constante</para>
 				<para>Estos constructores tienen dos argumentos, un tipo base y un tipo de tiempo, donde el último es un valor de <varname>timestamptz</varname>, <varname>tstzset</varname>, <varname>tstzspan</varname> o <varname>tstzspanset</varname> para construir, respectivamente, un valor de subtipo instante, una secuencia con interpolación discreta, una secuencia con interpolación linear o escalonada o un conjunto de secuencias. Las funciones para valores de secuencia o de conjunto de secuencias con tipo de base continuo tienen además un tercer argumento opcional que indica si el valor temporal resultante tiene interpolación lineal o escalonada. Se asume por defecto una interpolación lineal si el argumento no se especifica.</para>
 				<para><varname>ttype(base,timestamptz) → ttypeInst</varname></para>

--- a/doc/es/temporal_types_p2.xml
+++ b/doc/es/temporal_types_p2.xml
@@ -79,7 +79,8 @@
 		</figure>
 
 		<itemizedlist>
-			<listitem xml:id="insert">
+			<listitem xml:id="ttype_insert">
+				<indexterm significance="normal"><primary><varname>insert</varname></primary></indexterm>
 				<para>Insertar un valor temporal en otro</para>
 				<para><varname>insert(ttype,ttype,connect=true) → ttype</varname></para>
 				<programlisting language="sql" xml:space="preserve">
@@ -103,7 +104,8 @@ SELECT asText(insert(tgeompoint '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="update">
+			<listitem xml:id="ttype_update">
+				<indexterm significance="normal"><primary><varname>update</varname></primary></indexterm>
 				<para>Actualizar un valor temporal con otro</para>
 				<para><varname>update(ttype,ttype,connect=true) → ttype</varname></para>
 				<programlisting language="sql" xml:space="preserve">
@@ -126,7 +128,8 @@ SELECT asText(update(
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="deleteTime">
+			<listitem xml:id="ttype_deleteTime">
+				<indexterm significance="normal"><primary><varname>deleteTime</varname></primary></indexterm>
 				<para>Eliminar de un valor temporal un valor de tiempo</para>
 				<para><varname>deleteTime(ttype,time,connect=true) → ttype</varname></para>
 				<programlisting language="sql" xml:space="preserve">
@@ -145,7 +148,7 @@ SELECT asText(deleteTime(tgeompoint '{[Point(1 1 1)@2001-01-01,
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="appendInstant">
+			<listitem xml:id="ttype_appendInstant">
 				<indexterm significance="normal"><primary><varname>appendInstant</varname></primary></indexterm>
 				<para>Anexar un instante temporal a un valor temporal</para>
 				<para><varname>appendInstant(ttype,ttypeInst,interp=NULL) → ttype</varname></para>
@@ -214,7 +217,7 @@ SELECT asText(appendInstant(inst, NULL, sqrt(2), '1 day' ORDER BY inst)) FROM te
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="appendSequence">
+			<listitem xml:id="ttype_appendSequence">
 				<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
 				<para>Anexar una secuencia temporal a un valor temporal</para>
 				<para><varname>appendSequence(ttype,ttypeSeq) → {ttypeSeq, ttypeSeqSet}</varname></para>
@@ -241,7 +244,7 @@ SELECT asText(appendSequence(tgeometry '{[Point(1 1)@2001-01-01, Point(2 2)@2001
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="merge">
+			<listitem xml:id="ttype_merge">
 				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
 				<para>Fusionar los valores temporales</para>
 				<para><varname>merge(ttype,ttype) → ttype</varname></para>
@@ -409,7 +412,7 @@ SELECT minusTime(tint '[1@2001-01-01, 1@2001-01-15)',
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="beforeTimestamp">
+			<listitem xml:id="ttype_beforeTimestamp">
 				<indexterm significance="normal"><primary><varname>beforeTimestamp</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>afterTimestamp</varname></primary></indexterm>
 				<para>Mantener los instantes de un valor temporal que son anteriores o posteriores a una marca de tiempo, o iguales a ella</para>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -399,10 +399,10 @@
 				<title>Splitting Operations</title>
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="splitNSpans"><varname>splitNSpans</varname></link>: Return an array of N spans obtained by merging the elements of a set or the spans of a spanset</para>
+						<para><link linkend="setspan_splitNSpans"><varname>splitNSpans</varname></link>: Return an array of N spans obtained by merging the elements of a set or the spans of a spanset</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="splitEachNSpans"><varname>splitEachNSpans</varname></link>: Return an array of spans obtained by merging N consecutive elements of a set or N consecutive spans of a spanset</para>
+						<para><link linkend="setspan_splitEachNSpans"><varname>splitEachNSpans</varname></link>: Return an array of spans obtained by merging N consecutive elements of a set or N consecutive spans of a spanset</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -508,31 +508,31 @@
 
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="hasX"><varname>hasX</varname>, <varname>hasZ</varname>, <varname>hasT</varname></link>: Has X/Z/T dimension?</para>
+					<para><link linkend="box_hasX"><varname>hasX</varname>, <varname>hasZ</varname>, <varname>hasT</varname></link>: Has X/Z/T dimension?</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="isGeodetic"><varname>isGeodetic</varname></link>: Is geodetic?</para>
+					<para><link linkend="stbox_isGeodetic"><varname>isGeodetic</varname></link>: Is geodetic?</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="xMin"><varname>xMin</varname>, <varname>yMin</varname>, <varname>zMin</varname>, <varname>tMin</varname></link>: Return the minimum X/Y/Z/T value</para>
+					<para><link linkend="box_xMin"><varname>xMin</varname>, <varname>yMin</varname>, <varname>zMin</varname>, <varname>tMin</varname></link>: Return the minimum X/Y/Z/T value</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="xMax"><varname>xMax</varname>, <varname>yMax</varname>, <varname>zMax</varname>, <varname>tMax</varname></link>: Return the maximum X/Y/Z/T value</para>
+					<para><link linkend="box_xMax"><varname>xMax</varname>, <varname>yMax</varname>, <varname>zMax</varname>, <varname>tMax</varname></link>: Return the maximum X/Y/Z/T value</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="xMinInc"><varname>xMinInc</varname>, <varname>tMinInc</varname></link>: Is the minimum X/T value inclusive?</para>
+					<para><link linkend="tbox_xMinInc"><varname>xMinInc</varname>, <varname>tMinInc</varname></link>: Is the minimum X/T value inclusive?</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="xMaxInc"><varname>xMaxInc</varname>, <varname>tMaxInc</varname></link>: Is the maximum X/T value inclusive?</para>
+					<para><link linkend="tbox_xMaxInc"><varname>xMaxInc</varname>, <varname>tMaxInc</varname></link>: Is the maximum X/T value inclusive?</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="area"><varname>area</varname>, <varname>volume</varname>, <varname>perimeter</varname></link>: Area, volume, perimeter</para>
+					<para><link linkend="stbox_area"><varname>area</varname>, <varname>volume</varname>, <varname>perimeter</varname></link>: Area, volume, perimeter</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -581,7 +581,7 @@
 			<title>Splitting Operations</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="quadSplit"><varname>quadSplit</varname></link>: Split a bounding box in quadrants or octants</para>
+					<para><link linkend="stbox_quadSplit"><varname>quadSplit</varname></link>: Split a bounding box in quadrants or octants</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -818,31 +818,31 @@
 			<title>Modifications</title>
 			<itemizedlist>
 				<listitem>
-				<para><link linkend="insert"><varname>insert</varname></link>: Insert a temporal value into another one</para>
+				<para><link linkend="ttype_insert"><varname>insert</varname></link>: Insert a temporal value into another one</para>
 				</listitem>
 
 				<listitem>
-				<para><link linkend="update"><varname>update</varname></link>: Update a temporal value with another one</para>
+				<para><link linkend="ttype_update"><varname>update</varname></link>: Update a temporal value with another one</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="deleteTime"><varname>deleteTime</varname></link>: Delete the instants of a temporal value that intersect a time value</para>
+					<para><link linkend="ttype_deleteTime"><varname>deleteTime</varname></link>: Delete the instants of a temporal value that intersect a time value</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="beforeTimestamp"><varname>beforeTimestamp</varname>, <varname>afterTimestamp</varname></link>: Keep the instants of a temporal value that are before/after or equal a timestamp</para>
+					<para><link linkend="ttype_beforeTimestamp"><varname>beforeTimestamp</varname>, <varname>afterTimestamp</varname></link>: Keep the instants of a temporal value that are before/after or equal a timestamp</para>
 				</listitem>
 
 				<listitem>
-				<para><link linkend="appendInstant"><varname>appendInstant</varname>, <varname>appendInstantAgg</varname></link>: Append a temporal instant to a temporal value</para>
+				<para><link linkend="ttype_appendInstant"><varname>appendInstant</varname>, <varname>appendInstantAgg</varname></link>: Append a temporal instant to a temporal value</para>
 				</listitem>
 
 				<listitem>
-				<para><link linkend="appendSequence"><varname>appendSequence</varname>, <varname>appendSequenceAgg</varname></link>: Append a temporal sequence to a temporal value</para>
+				<para><link linkend="ttype_appendSequence"><varname>appendSequence</varname>, <varname>appendSequenceAgg</varname></link>: Append a temporal sequence to a temporal value</para>
 				</listitem>
 
 				<listitem>
-				<para><link linkend="merge"><varname>merge</varname>, <varname>mergeAgg</varname></link>: Merge temporal values</para>
+				<para><link linkend="ttype_merge"><varname>merge</varname>, <varname>mergeAgg</varname></link>: Merge temporal values</para>
 				</listitem>
 
 			</itemizedlist>
@@ -977,7 +977,7 @@
 			<title>Mathematical Operations</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="tAdd"><varname>+</varname>, <varname>-</varname>, <varname>*</varname>, <varname>/</varname></link>: Temporal addition, subtraction, multiplication, and division</para>
+					<para><link linkend="tnumber_tAdd"><varname>+</varname>, <varname>-</varname>, <varname>*</varname>, <varname>/</varname></link>: Temporal addition, subtraction, multiplication, and division</para>
 				</listitem>
 
 				<listitem>
@@ -1368,11 +1368,11 @@
 
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="bins"><varname>bins</varname></link>: Return a set of bins that cover a value or time span with bins of the same width or duration</para>
+						<para><link linkend="setspan_bins"><varname>bins</varname></link>: Return a set of bins that cover a value or time span with bins of the same width or duration</para>
 					</listitem>
 
 					<listitem>
-						<para><link linkend="getBin"><varname>getBin</varname></link>: Return the bin that contains a number or a timestamp</para>
+						<para><link linkend="setspan_getBin"><varname>getBin</varname></link>: Return the bin that contains a number or a timestamp</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -1382,19 +1382,19 @@
 
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="valueTimeTiles"><varname>valueTiles</varname>, <varname>timeTiles</varname>, <varname>valueTimeTiles</varname></link>: Return the set of tiles that cover a temporal box with tiles of the same size and/or duration</para>
+						<para><link linkend="tbox_valueTimeTiles"><varname>valueTiles</varname>, <varname>timeTiles</varname>, <varname>valueTimeTiles</varname></link>: Return the set of tiles that cover a temporal box with tiles of the same size and/or duration</para>
 					</listitem>
 
 					<listitem>
-						<para><link linkend="spaceTimeTiles"><varname>spaceTiles</varname>, <varname>timeTiles</varname>, <varname>spaceTimeTiles</varname></link>: Return the set of tiles that cover a spatiotemporal box with tiles of the same size and/or duration</para>
+						<para><link linkend="stbox_spaceTimeTiles"><varname>spaceTiles</varname>, <varname>timeTiles</varname>, <varname>spaceTimeTiles</varname></link>: Return the set of tiles that cover a spatiotemporal box with tiles of the same size and/or duration</para>
 					</listitem>
 
 					<listitem>
-						<para><link linkend="getValueTimeTile"><varname>getValueTile</varname>, <varname>getTboxTimeTile</varname>, <varname>getValueTimeTile</varname></link>: Return the temporal tile that covers a value and/or a timestamp</para>
+						<para><link linkend="tbox_getValueTimeTile"><varname>getValueTile</varname>, <varname>getTboxTimeTile</varname>, <varname>getValueTimeTile</varname></link>: Return the temporal tile that covers a value and/or a timestamp</para>
 						</listitem>
 
 					<listitem>
-						<para><link linkend="getSpaceTimeTile"><varname>getSpaceTile</varname>, <varname>getStboxTimeTile</varname>, <varname>getSpaceTimeTile</varname></link>: Return the spatiotemporal tile that covers a point and/or a timestamp</para>
+						<para><link linkend="stbox_getSpaceTimeTile"><varname>getSpaceTile</varname>, <varname>getStboxTimeTile</varname>, <varname>getSpaceTimeTile</varname></link>: Return the spatiotemporal tile that covers a point and/or a timestamp</para>
 						</listitem>
 				</itemizedlist>
 			</sect3>
@@ -1404,15 +1404,15 @@
 
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="valueTimeBins"><varname>valueBins</varname>, <varname>timeBins</varname></link>: Return an array of value or times spans obtained from the instants or segments of a temporal number with respect to a value or time grid</para>
+						<para><link linkend="tnumber_valueTimeBins"><varname>valueBins</varname>, <varname>timeBins</varname></link>: Return an array of value or times spans obtained from the instants or segments of a temporal number with respect to a value or time grid</para>
 					</listitem>
 
 					<listitem>
-						<para><link linkend="valueTimeBoxes"><varname>valueBoxes</varname>, <varname>timeBoxes</varname>, <varname>valueTimeBoxes</varname></link>: Return an array of temporal boxes obtained from the instants or segments of a temporal number with respect to a value and/or time grid</para>
+						<para><link linkend="tnumber_valueTimeBoxes"><varname>valueBoxes</varname>, <varname>timeBoxes</varname>, <varname>valueTimeBoxes</varname></link>: Return an array of temporal boxes obtained from the instants or segments of a temporal number with respect to a value and/or time grid</para>
 					</listitem>
 
 					<listitem>
-						<para><link linkend="spaceTimeBoxes"><varname>spaceBoxes</varname>, <varname>timeBoxes</varname>, <varname>spaceTimeBoxes</varname></link>: Return an array of spatiotemporal boxes obtained from the instants or segments of a temporal point with respect to a space and/or time grid</para>
+						<para><link linkend="tspatial_spaceTimeBoxes"><varname>spaceBoxes</varname>, <varname>timeBoxes</varname>, <varname>spaceTimeBoxes</varname></link>: Return an array of spatiotemporal boxes obtained from the instants or segments of a temporal point with respect to a space and/or time grid</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -1422,11 +1422,11 @@
 
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="valueSplit"><varname>valueSplit</varname>, <varname>timeSplit</varname>, <varname>valueTimeSplit</varname></link>: Split a temporal number with respect to value and/or time bins</para>
+						<para><link linkend="tnumber_valueSplit"><varname>valueSplit</varname>, <varname>timeSplit</varname>, <varname>valueTimeSplit</varname></link>: Split a temporal number with respect to value and/or time bins</para>
 					</listitem>
 
 					<listitem>
-						<para><link linkend="spaceSplit"><varname>spaceSplit</varname>, <varname>spaceTimeSplit</varname></link>: Split a temporal point with respect to a spatial or spatiotemporal grid</para>
+						<para><link linkend="tspatial_spaceSplit"><varname>spaceSplit</varname>, <varname>spaceTimeSplit</varname></link>: Split a temporal point with respect to a spatial or spatiotemporal grid</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -1437,31 +1437,31 @@
 
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="tCount"><varname>tCount</varname></link>: Temporal count</para>
+					<para><link linkend="ttype_tCount"><varname>tCount</varname></link>: Temporal count</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="extent"><varname>extent</varname></link>: Bounding box extent</para>
+					<para><link linkend="ttype_extent"><varname>extent</varname></link>: Bounding box extent</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="tAnd"><varname>tAnd</varname>, <varname>tOr</varname></link>: Temporal and, temporal or</para>
+					<para><link linkend="tbool_tAnd"><varname>tAnd</varname>, <varname>tOr</varname></link>: Temporal and, temporal or</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="tMin"><varname>tMin</varname>, <varname>tMinAgg</varname>, <varname>tMax</varname>, <varname>tMaxAgg</varname>, <varname>tSum</varname>, <varname>tAvg</varname></link>: Temporal minimum, maximum, sum, and average</para>
+					<para><link linkend="ttype_tMin"><varname>tMin</varname>, <varname>tMinAgg</varname>, <varname>tMax</varname>, <varname>tMaxAgg</varname>, <varname>tSum</varname>, <varname>tAvg</varname></link>: Temporal minimum, maximum, sum, and average</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="wCount"><varname>wCount</varname></link>: Window count</para>
+					<para><link linkend="ttype_wCount"><varname>wCount</varname></link>: Window count</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="wMin"><varname>wMin</varname>, <varname>wMax</varname>, <varname>wSum</varname>, <varname>wAvg</varname></link>: Window minimum, maximum, sum, and average</para>
+					<para><link linkend="tnumber_wMin"><varname>wMin</varname>, <varname>wMax</varname>, <varname>wSum</varname>, <varname>wAvg</varname></link>: Window minimum, maximum, sum, and average</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="tCentroid"><varname>tCentroid</varname></link>: Temporal centroid</para>
+					<para><link linkend="tpoint_tCentroid"><varname>tCentroid</varname></link>: Temporal centroid</para>
 				</listitem>
 
 			</itemizedlist>
@@ -1812,15 +1812,15 @@
 				<title>Accessors</title>
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="route"><varname>route</varname></link>: Return the route identifier</para>
+						<para><link linkend="npoint_route"><varname>route</varname></link>: Return the route identifier</para>
 					</listitem>
 
 					<listitem>
-						<para><link linkend="getPosition"><varname>getPosition</varname></link>: Return the position fraction</para>
+						<para><link linkend="npoint_getPosition"><varname>getPosition</varname></link>: Return the position fraction</para>
 					</listitem>
 
 					<listitem>
-						<para><link linkend="startPosition"><varname>startPosition</varname>, <varname>endPosition</varname></link>: Return the start or end position</para>
+						<para><link linkend="npoint_startPosition"><varname>startPosition</varname>, <varname>endPosition</varname></link>: Return the start or end position</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -3922,7 +3922,7 @@
 			<title>Sampling Operator</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="rasterValue"><varname>rasterValue</varname></link>: Sample a raster band at each instant of a trajectory</para>
+					<para><link linkend="raster_rasterValue"><varname>rasterValue</varname></link>: Sample a raster band at each instant of a trajectory</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3935,7 +3935,7 @@
 				</listitem>
 
 				<listitem>
-					<para><link linkend="rasterTileValueQuadbin"><varname>rasterTileValueQuadbin</varname></link>: Sample a Raquet raster chip along a trajectory using a QUADBIN cell for georeferencing</para>
+					<para><link linkend="raster_rasterTileValueQuadbin"><varname>rasterTileValueQuadbin</varname></link>: Sample a Raquet raster chip along a trajectory using a QUADBIN cell for georeferencing</para>
 				</listitem>
 
 				<listitem>
@@ -3947,11 +3947,11 @@
 				</listitem>
 
 				<listitem>
-					<para><link linkend="rasterTileValue"><varname>rasterTileValue</varname></link>: Sample a Raquet raster tile along a trajectory</para>
+					<para><link linkend="raster_rasterTileValue"><varname>rasterTileValue</varname></link>: Sample a Raquet raster tile along a trajectory</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="rasterTileValueArray"><varname>rasterTileValue</varname></link>: Sample an array of Raquet raster tiles along a trajectory, keeping the finer resolution where tiles overlap</para>
+					<para><link linkend="raster_rasterTileValueArray"><varname>rasterTileValue</varname></link>: Sample an array of Raquet raster tiles along a trajectory, keeping the finer resolution where tiles overlap</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3993,19 +3993,19 @@
 			<title>Restriction and Predicate Operators</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="atRasterValue"><varname>atRasterValue</varname></link>: Return the instants of a trajectory where the sampled raster value falls inside a float range</para>
+					<para><link linkend="raster_atRasterValue"><varname>atRasterValue</varname></link>: Return the instants of a trajectory where the sampled raster value falls inside a float range</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="minusRasterValue"><varname>minusRasterValue</varname></link>: Return the instants of a trajectory where the sampled raster value falls outside a float range</para>
+					<para><link linkend="raster_minusRasterValue"><varname>minusRasterValue</varname></link>: Return the instants of a trajectory where the sampled raster value falls outside a float range</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="eRasterValue"><varname>eRasterValue</varname></link>: Return true if the trajectory ever samples a raster pixel value inside a float range</para>
+					<para><link linkend="raster_eRasterValue"><varname>eRasterValue</varname></link>: Return true if the trajectory ever samples a raster pixel value inside a float range</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="aRasterValue"><varname>aRasterValue</varname></link>: Return true if every in-raster-extent instant of the trajectory samples a pixel value inside a float range</para>
+					<para><link linkend="raster_aRasterValue"><varname>aRasterValue</varname></link>: Return true if every in-raster-extent instant of the trajectory samples a pixel value inside a float range</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/set_span_types.xml
+++ b/doc/set_span_types.xml
@@ -1169,7 +1169,7 @@ SELECT timestamp '2001-01-01' #&amp;&gt; tstzspan '[2001-01-01, 2001-01-05)';
 			<para>However, when the bounding boxes have a large empty space not covered by the actual values, the index will generate many candidate values that do not satisfy the query predicate, which reduces the efficiency of the index. In these situations, it may be better to represent a value not with a <emphasis>single</emphasis> bounding box, but instead with <emphasis>multiple</emphasis> bounding boxes. This increases considerably the efficiency of the index, provided that the index is able to manage multiple bounding boxes per value. The following functions are used for generating multiple spans from a single set or span set value.</para>
 
 			<itemizedlist>
-				<listitem xml:id="splitNSpans">
+				<listitem xml:id="setspan_splitNSpans">
 					<indexterm significance="normal"><primary><varname>splitNSpans</varname></primary></indexterm>
 					<para>Return an array of N spans obtained by merging the elements of a set or the spans of a spanset</para>
 					<para><varname>splitNSpans(set, integer) → span[]</varname></para>
@@ -1196,12 +1196,12 @@ SELECT splitNSpans(datespanset '{[2000-01-01, 2000-01-04), [2000-01-05, 2000-01-
 </programlisting>
 				</listitem>
 
-				<listitem xml:id="splitEachNSpans">
+				<listitem xml:id="setspan_splitEachNSpans">
 					<indexterm significance="normal"><primary><varname>splitEachNSpans</varname></primary></indexterm>
 					<para>Return an array of spans obtained by merging N consecutive elements of a set or N consecutive spans of a spanset</para>
 					<para><varname>splitEachNSpans(set, integer) → span[]</varname></para>
 					<para><varname>splitEachNSpans(spanset, integer) → span[]</varname></para>
-					<para>The last argument specifies the number of input elements that are merged to produce an output span. If the number of input elements is less than the given number, the resulting array will have one output span per element. Otherwise, the given number of consecutive input elements will be merged into a single output span in the answer. Notice that, contrary to the <link linkend="splitNSpans"><varname>splitNSpans</varname></link> function, the number of spans in the result depends on the number of input elements or spans.</para>
+					<para>The last argument specifies the number of input elements that are merged to produce an output span. If the number of input elements is less than the given number, the resulting array will have one output span per element. Otherwise, the given number of consecutive input elements will be merged into a single output span in the answer. Notice that, contrary to the <link linkend="setspan_splitNSpans"><varname>splitNSpans</varname></link> function, the number of spans in the result depends on the number of input elements or spans.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitEachNSpans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 1);
 /* {"[1, 2)","[2, 3)","[3, 4)","[4, 5)","[5, 6)","[6, 7)","[7, 8)","[8, 9)",

--- a/doc/temporal_alpha.xml
+++ b/doc/temporal_alpha.xml
@@ -340,7 +340,7 @@ SELECT whenTrue(tdwithin(tgeompoint '[Point(1 1)@2001-01-01, Point(4 4)@2001-01-
 		<title>Mathematical Operations</title>
 
 		<itemizedlist>
-			<listitem xml:id="tAdd">
+			<listitem xml:id="tnumber_tAdd">
 				<indexterm significance="normal"><primary><varname>+</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>-</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>*</varname></primary></indexterm>

--- a/doc/temporal_network_points.xml
+++ b/doc/temporal_network_points.xml
@@ -154,7 +154,7 @@ SELECT stbox(npoint 'NPoint(1,0.3)', tstzspan '[2001-01-01,2001-01-02]');
 		<sect2 xml:id="npoint_accessor_functions">
 			<title>Accessors</title>
 			<itemizedlist>
-				<listitem xml:id="route">
+				<listitem xml:id="npoint_route">
 					<indexterm significance="normal"><primary><varname>route</varname></primary></indexterm>
 					<para>Return the route identifier</para>
 					<para><varname>route({npoint,nsegment}) → bigint</varname></para>
@@ -166,7 +166,7 @@ SELECT route(nsegment 'Nsegment(76, 0.3, 0.3)');
 </programlisting>
 				</listitem>
 
-				<listitem xml:id="getPosition">
+				<listitem xml:id="npoint_getPosition">
 					<indexterm significance="normal"><primary><varname>getPosition</varname></primary></indexterm>
 					<para>Return the position</para>
 					<para><varname>getPosition(npoint) → float</varname></para>
@@ -176,7 +176,7 @@ SELECT getPosition(npoint 'Npoint(63, 0.3)');
 </programlisting>
 				</listitem>
 
-				<listitem xml:id="startPosition">
+				<listitem xml:id="npoint_startPosition">
 					<indexterm significance="normal"><primary><varname>startPosition</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>endPosition</varname></primary></indexterm>
 					<para>Return the start/end position</para>

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -912,7 +912,7 @@ SELECT asEWKT(setSRID(tpose '[Pose(Point(0 0),1)@2001-01-01,
 				<para>Transform to a spatial reference identifier</para>
 				<para><varname>transform(tpose,integer) → tpose</varname></para>
 				<para><varname>transformPipeline(tpose,pipeline text,to_srid integer,is_forward bool=true) → tpose</varname></para>
-				<para>Each instant's pose is transformed as the corresponding static pose is, orientation correction included, as described in <xref linkend="pose_transform"/>. The same holds for a <varname>poseset</varname>. A <varname>trgeometry</varname> pairs its poses with a reference geometry that shares their frame, and transformation to another SRID is not supported for it.</para>
+				<para>Each instant's pose is transformed as the corresponding static pose is, orientation correction included, as described for <link linkend="pose_transform"><varname>transform</varname></link>. The same holds for a <varname>poseset</varname>. A <varname>trgeometry</varname> pairs its poses with a reference geometry that shares their frame, and transformation to another SRID is not supported for it.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(transform(tpose 'SRID=4326;Pose(Point(4.35 50.85),1)@2001-01-01', 
   3812));

--- a/doc/temporal_raster.xml
+++ b/doc/temporal_raster.xml
@@ -26,7 +26,7 @@ CREATE EXTENSION mobilitydb CASCADE;
 		<title>Sampling Operator</title>
 
 		<itemizedlist>
-			<listitem xml:id="rasterValue">
+			<listitem xml:id="raster_rasterValue">
 				<indexterm significance="normal"><primary><varname>rasterValue</varname></primary></indexterm>
 				<para>Sample a raster band at each instant of a trajectory</para>
 				<para><varname>rasterValue(tgeompoint,raster,band integer DEFAULT 1) → tfloat</varname></para>
@@ -102,7 +102,7 @@ ORDER BY tile_count DESC;
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="rasterTileValueQuadbin">
+			<listitem xml:id="raster_rasterTileValueQuadbin">
 				<indexterm significance="normal"><primary><varname>rasterTileValueQuadbin</varname></primary></indexterm>
 				<para>Sample a Raquet raster chip along a trajectory using a QUADBIN cell for georeferencing</para>
 				<para><varname>rasterTileValueQuadbin(tgeompoint,bytea,integer,integer,bigint,text,float8,boolean) → tfloat</varname></para>
@@ -127,7 +127,7 @@ JOIN sst_raquet r ON r.quadbin = ANY(trajectoryQuadbins(t.trip, 6));
 				<indexterm significance="normal"><primary><varname>raquet</varname></primary></indexterm>
 				<para>Construct a Raquet raster tile from its pixel bytes, dimensions, QUADBIN cell and pixel type</para>
 				<para><varname>raquet(bytea,integer,integer,bigint,text,float8) → raquet</varname></para>
-				<para>Packages a row-major single-band <varname>pixels</varname> array of <varname>width</varname> × <varname>height</varname> pixels of type <varname>pixtype</varname> (one of <varname>UINT8</varname>, <varname>INT16</varname>, <varname>INT32</varname>, <varname>FLOAT32</varname>, or <varname>FLOAT64</varname>), georeferenced by the <varname>quadbin</varname> cell, into a single self-describing <varname>raquet</varname> value. The <varname>nodata</varname> argument is optional; when omitted (<varname>NULL</varname>) the tile carries no nodata sentinel. An error is raised when the <varname>pixels</varname> array is smaller than <varname>width</varname> × <varname>height</varname> × the pixel size. A <varname>raquet</varname> is a GDAL-free, variable-length value with a portable Hex-WKB text and binary representation, distinct from and coexisting with the PostGIS <varname>raster</varname> type used by <link linkend="rasterValue"><varname>rasterValue</varname></link>.</para>
+				<para>Packages a row-major single-band <varname>pixels</varname> array of <varname>width</varname> × <varname>height</varname> pixels of type <varname>pixtype</varname> (one of <varname>UINT8</varname>, <varname>INT16</varname>, <varname>INT32</varname>, <varname>FLOAT32</varname>, or <varname>FLOAT64</varname>), georeferenced by the <varname>quadbin</varname> cell, into a single self-describing <varname>raquet</varname> value. The <varname>nodata</varname> argument is optional; when omitted (<varname>NULL</varname>) the tile carries no nodata sentinel. An error is raised when the <varname>pixels</varname> array is smaller than <varname>width</varname> × <varname>height</varname> × the pixel size. A <varname>raquet</varname> is a GDAL-free, variable-length value with a portable Hex-WKB text and binary representation, distinct from and coexisting with the PostGIS <varname>raster</varname> type used by <link linkend="raster_rasterValue"><varname>rasterValue</varname></link>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Package the loose tile columns of a Raquet table into raquet values
 SELECT raquet(band_data, width, height, quadbin, 'FLOAT32', nodata) AS tile
@@ -154,11 +154,11 @@ FROM elevation_files;
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="rasterTileValue">
+			<listitem xml:id="raster_rasterTileValue">
 				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
 				<para>Sample a <varname>raquet</varname> raster tile along a trajectory</para>
 				<para><varname>rasterTileValue(tgeompoint,raquet) → tfloat</varname></para>
-				<para>Evaluates the tile at each instant of <varname>traj</varname> (SRID 4326), returning the sampled pixel values as a <varname>tfloat</varname>. This is the typed equivalent of <link linkend="rasterTileValueQuadbin"><varname>rasterTileValueQuadbin</varname></link>: the dimensions, QUADBIN cell, pixel type and nodata handling are taken from the <varname>raquet</varname> value instead of from separate arguments. Returns <varname>NULL</varname> when no instant falls inside the tile or survives nodata filtering.</para>
+				<para>Evaluates the tile at each instant of <varname>traj</varname> (SRID 4326), returning the sampled pixel values as a <varname>tfloat</varname>. This is the typed equivalent of <link linkend="raster_rasterTileValueQuadbin"><varname>rasterTileValueQuadbin</varname></link>: the dimensions, QUADBIN cell, pixel type and nodata handling are taken from the <varname>raquet</varname> value instead of from separate arguments. Returns <varname>NULL</varname> when no instant falls inside the tile or survives nodata filtering.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Sample pre-packaged raquet tiles along ship trajectories
 SELECT t.tripid, rasterTileValue(t.trip, r.tile)
@@ -166,7 +166,7 @@ FROM trips t JOIN elevation_tiles r ON r.quadbin = ANY(trajectoryQuadbins(t.trip
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="rasterTileValueArray">
+			<listitem xml:id="raster_rasterTileValueArray">
 				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
 				<para>Sample an array of <varname>raquet</varname> raster tiles along a trajectory</para>
 				<para><varname>rasterTileValue(tgeompoint,raquet[]) → tfloat</varname></para>
@@ -307,7 +307,7 @@ SELECT DISTINCT tile FROM elevation_tiles;
 		<para>The following SQL-defined operators compose <varname>rasterValue</varname> with the standard MobilityDB temporal restriction and predicate functions. They accept an optional <varname>band</varname> argument (default 1) and call <varname>rasterValue</varname> exactly once per invocation.</para>
 
 		<itemizedlist>
-			<listitem xml:id="atRasterValue">
+			<listitem xml:id="raster_atRasterValue">
 				<indexterm significance="normal"><primary><varname>atRasterValue</varname></primary></indexterm>
 				<para>Return the instants of a trajectory where the sampled raster value falls inside a float range</para>
 				<para><varname>atRasterValue(tgeompoint,raster,floatspan,band integer DEFAULT 1) → tgeompoint</varname></para>
@@ -330,7 +330,7 @@ FROM rast;
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="minusRasterValue">
+			<listitem xml:id="raster_minusRasterValue">
 				<indexterm significance="normal"><primary><varname>minusRasterValue</varname></primary></indexterm>
 				<para>Return the instants of a trajectory where the sampled raster value falls outside a float range</para>
 				<para><varname>minusRasterValue(tgeompoint,raster,floatspan,band integer DEFAULT 1) → tgeompoint</varname></para>
@@ -342,7 +342,7 @@ FROM trips, elevation_raster;
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="eRasterValue">
+			<listitem xml:id="raster_eRasterValue">
 				<indexterm significance="normal"><primary><varname>eRasterValue</varname></primary></indexterm>
 				<para>Return true if the trajectory ever samples a raster pixel value inside a float range</para>
 				<para><varname>eRasterValue(tgeompoint,raster,floatspan,band integer DEFAULT 1) → boolean</varname></para>
@@ -355,7 +355,7 @@ WHERE eRasterValue(trip, elev_raster, floatspan '[200, 9999]');
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="aRasterValue">
+			<listitem xml:id="raster_aRasterValue">
 				<indexterm significance="normal"><primary><varname>aRasterValue</varname></primary></indexterm>
 				<para>Return true if every in-raster-extent instant of the trajectory samples a pixel value inside a float range</para>
 				<para><varname>aRasterValue(tgeompoint,raster,floatspan,band integer DEFAULT 1) → boolean</varname></para>

--- a/doc/temporal_types_aggregation.xml
+++ b/doc/temporal_types_aggregation.xml
@@ -32,7 +32,7 @@
 
 		<para>In the examples that follow, we suppose the tables <varname>Department</varname> and <varname>Trip</varname> contain the two tuples introduced in <xref linkend="ttype_examples"/>.</para>
 		<itemizedlist>
-			<listitem xml:id="tCount">
+			<listitem xml:id="ttype_tCount">
 				<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
 				<para>Temporal count</para>
 				<para><varname>tCount(ttype) → {tintSeq,tintSeqSet}</varname></para>
@@ -42,7 +42,7 @@ SELECT tCount(NoEmps) FROM Department;
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="extent">
+			<listitem xml:id="ttype_extent">
 				<indexterm significance="normal"><primary><varname>extent</varname></primary></indexterm>
 				<para>Bounding box extent</para>
 				<para><varname>extent(temp) → {tstzspan,tbox,stbox}</varname></para>
@@ -54,7 +54,7 @@ SELECT extent(Trip) FROM Trips;
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="tAnd">
+			<listitem xml:id="tbool_tAnd">
 				<indexterm significance="normal"><primary><varname>tAnd</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tOr</varname></primary></indexterm>
 				<para>Temporal and, temporal or</para>
@@ -68,7 +68,7 @@ SELECT tOr(NoEmps #&gt; 6) FROM Department;
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="tMin">
+			<listitem xml:id="ttype_tMin">
 				<indexterm significance="normal"><primary><varname>tMin</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tMax</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tSum</varname></primary></indexterm>
@@ -93,7 +93,7 @@ SELECT tAvg(NoEmps) FROM Department;
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="wCount">
+			<listitem xml:id="ttype_wCount">
 				<indexterm significance="normal"><primary><varname>wCount</varname></primary></indexterm>
 				<para>Window count</para>
 				<para><varname>wCount(tnumber,interval) → {tintSeq,tintSeqSet}</varname></para>
@@ -104,7 +104,7 @@ SELECT wCount(NoEmps, interval '2 days') FROM Department;
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="wMin">
+			<listitem xml:id="tnumber_wMin">
 				<indexterm significance="normal"><primary><varname>wMin</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>wMax</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>wSum</varname></primary></indexterm>
@@ -128,7 +128,7 @@ SELECT round(wAvg(NoEmps, interval '2 days'), 3) FROM Department;
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="tCentroid">
+			<listitem xml:id="tpoint_tCentroid">
 				<indexterm significance="normal"><primary><varname>tCentroid</varname></primary></indexterm>
 				<para>Temporal centroid</para>
 				<para><varname>tCentroid(tgeompoint) → tgeompoint</varname></para>

--- a/doc/temporal_types_analytics.xml
+++ b/doc/temporal_types_analytics.xml
@@ -593,7 +593,7 @@ SELECT splitEachNStboxes(tgeogpoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01
 			<title>Bin Operations</title>
 
 			<itemizedlist>
-				<listitem xml:id="bins">
+				<listitem xml:id="setspan_bins">
 					<indexterm significance="normal"><primary><varname>bins</varname></primary></indexterm>
 					<para>Return an array of bins that cover a value or time span with bins of the same size or duration
 </para>
@@ -623,7 +623,7 @@ FROM unnest(bins(tstzspanset '{[2001-01-15, 2001-01-17],[2001-01-22, 2001-01-25]
 </programlisting>
 				</listitem>
 
-				<listitem xml:id="getBin">
+				<listitem xml:id="setspan_getBin">
 					<indexterm significance="normal"><primary><varname>getBin</varname></primary></indexterm>
 					<para>Return the bin that contains a number or a timestamp</para>
 					<para><varname>getBin(number,size number,origin number=0) → span</varname></para>
@@ -648,7 +648,7 @@ SELECT getBin('2001-01-04', interval '1 week', '2001-01-07');
 			<title>Tile Operations</title>
 
 			<itemizedlist>
-				<listitem xml:id="valueTimeTiles">
+				<listitem xml:id="tbox_valueTimeTiles">
 					<indexterm significance="normal"><primary><varname>valueTiles</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>timeTiles</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>valueTimeTiles</varname></primary></indexterm>
@@ -688,7 +688,7 @@ SELECT valueTimeTiles(tfloat '[15@2001-01-15,25@2001-01-25]'::tbox, 2.0, '2 days
 </programlisting>
 				</listitem>
 
-				<listitem xml:id="spaceTimeTiles">
+				<listitem xml:id="stbox_spaceTimeTiles">
 					<indexterm significance="normal"><primary><varname>spaceTiles</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>timeTiles</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>spaceTimeTiles</varname></primary></indexterm>
@@ -745,7 +745,7 @@ SELECT spaceTimeTiles(tgeompoint '[Point(3 3 3)@2001-01-15,
 </programlisting>
 				</listitem>
 
-				<listitem xml:id="getValueTimeTile">
+				<listitem xml:id="tbox_getValueTimeTile">
 					<indexterm significance="normal"><primary><varname>getValueTile</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>getTboxTimeTile</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>getValueTimeTile</varname></primary></indexterm>
@@ -769,7 +769,7 @@ SELECT getValueTimeTile(15, '2001-01-15', 2, interval '2 days', 1, '2001-01-02')
 </programlisting>
 				</listitem>
 
-				<listitem xml:id="getSpaceTimeTile">
+				<listitem xml:id="stbox_getSpaceTimeTile">
 					<indexterm significance="normal"><primary><varname>getSpaceTile</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>getStboxTimeTile</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>getSpaceTimeTile</varname></primary></indexterm>
@@ -803,7 +803,7 @@ SELECT getSpaceTimeTile(geometry 'Point(1 1)', '2001-01-01', 2.0, interval '2 da
 			<title>Bounding Box Operations</title>
 			<para>These functions fragment the bounding box of a temporal value with respect to a multidimensional grid. They provide an alternative to the functions in <xref linkend="ttype_splitting" /> to split the bounding boxes by specifying the maximum size of the boxes in the various dimensions.</para>
 			<itemizedlist>
-				<listitem xml:id="valueTimeBins">
+				<listitem xml:id="tnumber_valueTimeBins">
 					<indexterm significance="normal"><primary><varname>valueBins</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>timeBins</varname></primary></indexterm>
 					<para>Return an array of value or time spans obtained from the instants or segments of a temporal number with respect to a value or time grid</para>
@@ -828,7 +828,7 @@ SELECT timeBins(tfloat '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
 </programlisting>
 				</listitem>
 
-				<listitem xml:id="valueTimeBoxes">
+				<listitem xml:id="tnumber_valueTimeBoxes">
 					<indexterm significance="normal"><primary><varname>valueBoxes</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>timeBoxes</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>valueTimeBoxes</varname></primary></indexterm>
@@ -860,7 +860,7 @@ SELECT valueTimeBoxes(tfloat '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-
 </programlisting>
 				</listitem>
 
-				<listitem xml:id="spaceTimeBoxes">
+				<listitem xml:id="tspatial_spaceTimeBoxes">
 					<indexterm significance="normal"><primary><varname>spaceBoxes</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>timeBoxes</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>spaceTimeBoxes</varname></primary></indexterm>
@@ -905,7 +905,7 @@ SELECT spaceTimeBoxes(tgeompoint '[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01
 			<title>Splitting Operations</title>
 			<para>These functions split a temporal value with respect to a sequence of bins (see <xref linkend="bin_functions" />) or tiles (see <xref linkend="tile_functions" />).</para>
 			<itemizedlist>
-				<listitem xml:id="valueSplit">
+				<listitem xml:id="tnumber_valueSplit">
 					<indexterm significance="normal"><primary><varname>valueSplit</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>timeSplit</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>valueTimeSplit</varname></primary></indexterm>
@@ -991,7 +991,7 @@ FROM (SELECT valueTimeSplit(tfloat '[1@2001-02-01, 10@2001-02-10)', 5.0, '5 days
 </programlisting>
 				</listitem>
 
-				<listitem xml:id="spaceSplit">
+				<listitem xml:id="tspatial_spaceSplit">
 					<indexterm significance="normal"><primary><varname>spaceSplit</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>timeSplit</varname></primary></indexterm>
 					<para>Split a temporal point with respect to a spatial grid &Z_support;

--- a/doc/temporal_types_p2.xml
+++ b/doc/temporal_types_p2.xml
@@ -79,7 +79,7 @@
 		</para>
 
 		<itemizedlist>
-			<listitem xml:id="insert">
+			<listitem xml:id="ttype_insert">
 				<indexterm significance="normal"><primary><varname>insert</varname></primary></indexterm>
 				<para>Insert a temporal value into another one</para>
 				<para><varname>insert(ttype,ttype,connect=true) → ttype</varname></para>
@@ -104,7 +104,7 @@ SELECT asText(insert(tgeompoint '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01
 </programlisting>
 				</listitem>
 
-			<listitem xml:id="update">
+			<listitem xml:id="ttype_update">
 				<indexterm significance="normal"><primary><varname>update</varname></primary></indexterm>
 				<para>Update a temporal value with another one</para>
 				<para><varname>update(ttype,ttype,connect=true) → ttype</varname></para>
@@ -128,7 +128,7 @@ SELECT asText(update(
 </programlisting>
 				</listitem>
 
-			<listitem xml:id="deleteTime">
+			<listitem xml:id="ttype_deleteTime">
 				<indexterm significance="normal"><primary><varname>deleteTime</varname></primary></indexterm>
 				<para>Delete the instants of a temporal value that intersect a time value</para>
 				<para><varname>deleteTime(ttype,time,connect=true) → ttype</varname></para>
@@ -148,7 +148,7 @@ SELECT asText(deleteTime(tgeompoint '{[Point(1 1 1)@2001-01-01,
 </programlisting>
 				</listitem>
 
-			<listitem xml:id="appendInstant">
+			<listitem xml:id="ttype_appendInstant">
 				<indexterm significance="normal"><primary><varname>appendInstant</varname></primary></indexterm>
 				<para>Append a temporal instant to a temporal value</para>
 				<para><varname>appendInstant(ttype,ttypeInst,interp=NULL) → ttype</varname></para>
@@ -217,7 +217,7 @@ SELECT asText(appendInstant(inst, NULL, sqrt(2), '1 day' ORDER BY inst)) FROM te
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="appendSequence">
+			<listitem xml:id="ttype_appendSequence">
 				<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
 				<para>Append a temporal sequence to a temporal value</para>
 				<para><varname>appendSequence(ttype,ttypeSeq) → {ttypeSeq,ttypeSeqSet}</varname></para>
@@ -244,7 +244,7 @@ SELECT asText(appendSequence(tgeometry '{[Point(1 1)@2001-01-01, Point(2 2)@2001
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="merge">
+			<listitem xml:id="ttype_merge">
 				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
 				<para>Merge the temporal values</para>
 				<para><varname>merge(ttype,ttype) → ttype</varname></para>
@@ -412,7 +412,7 @@ SELECT minusTime(tint '[1@2001-01-01, 1@2001-01-15)',
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="beforeTimestamp">
+			<listitem xml:id="ttype_beforeTimestamp">
 				<indexterm significance="normal"><primary><varname>beforeTimestamp</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>afterTimestamp</varname></primary></indexterm>
 				<para>Keep the instants of a temporal value that are before/after or equal a timestamp</para>

--- a/tools/codegen/reference/prefix_anchors.py
+++ b/tools/codegen/reference/prefix_anchors.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Give every function entry of the manual an anchor that names its type.
+
+A function entry is anchored as ``<type>_<entryName>``, where the type token
+names the set of types the SQL declares the entry's functions for. The token is
+what lets a name that several families share reach the entry the reader means:
+``transform`` exists for every spatial type, and ``SRID`` for both ``cbuffer``
+and ``tcbuffer`` inside one chapter.
+
+Most entries already follow the rule, and they fix the token vocabulary
+(``ttype``, ``setspan``, ``box``, ``tnumber``, ``tspatial``, ...). Of the 84
+entries anchored under a bare name, 36 already carry a type token as the first
+word of the name itself -- ``tposeSeq``, ``tcbufferFromText``, ``tjsonbFromText``
+-- and are left alone, since a prefix would only repeat what the name says. The
+other 48 get the token.
+
+The anchor derives from the entry name rather than from the function name it
+documents, which keeps it unique: ``rasterTileValueArray`` documents
+``rasterTileValue``, so two entries would otherwise claim one anchor.
+
+An anchor is language-independent -- it derives from the English entry -- so each
+rename applies to the Spanish chapters and to the reference index as well.
+
+``--check`` reports without writing.
+"""
+import io
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__)))))
+
+# entry -> type token. Every token is the set of types the CREATE FUNCTION and
+# CREATE AGGREGATE statements declare the entry's functions for, never the
+# section the entry sits in. Where an entry documents two functions of different
+# scope (valueBins with timeBins, valueSplit with timeSplit), the token follows
+# the first function, which is the one the entry is named after.
+RENAMES = {
+    # box_types.xml — hasX, xMin and xMax are declared for stbox, tbox and
+    # tpcbox, so they take the box umbrella; the inclusive-bound accessors are
+    # declared for tbox alone, and area, isGeodetic and quadSplit for stbox
+    "hasX": "box",
+    "xMin": "box",
+    "xMax": "box",
+    "xMinInc": "tbox",
+    "xMaxInc": "tbox",
+    "isGeodetic": "stbox",
+    "area": "stbox",
+    "quadSplit": "stbox",
+    # set_span_types.xml — declared for the sets and the span sets alike
+    "splitNSpans": "setspan",
+    "splitEachNSpans": "setspan",
+    # temporal_alpha.xml — the arithmetic operators over numbers and temporal
+    # numbers
+    "tAdd": "tnumber",
+    # temporal_network_points.xml — route for npoint, nsegment and tnpoint,
+    # getPosition for npoint, startPosition for nsegment
+    "route": "npoint",
+    "getPosition": "npoint",
+    "startPosition": "npoint",
+    # temporal_raster.xml — a temporal point restricted or tested against a
+    # raster
+    "rasterValue": "raster",
+    "rasterTileValue": "raster",
+    "rasterTileValueArray": "raster",
+    "rasterTileValueQuadbin": "raster",
+    "atRasterValue": "raster",
+    "minusRasterValue": "raster",
+    "eRasterValue": "raster",
+    "aRasterValue": "raster",
+    # temporal_types_aggregation.xml
+    "tCount": "ttype",
+    "extent": "ttype",
+    "tMin": "ttype",
+    "tAnd": "tbool",
+    "wCount": "ttype",
+    "wMin": "tnumber",
+    "tCentroid": "tpoint",
+    # temporal_types_analytics.xml — spaceBoxes and spaceSplit are declared for
+    # tgeometry, tgeompoint, tpcpoint, tpose and trgeometry, hence tspatial
+    "bins": "setspan",
+    "getBin": "setspan",
+    "valueTimeTiles": "tbox",
+    "getValueTimeTile": "tbox",
+    "spaceTimeTiles": "stbox",
+    "getSpaceTimeTile": "stbox",
+    "valueTimeBins": "tnumber",
+    "valueTimeBoxes": "tnumber",
+    "valueSplit": "tnumber",
+    "spaceTimeBoxes": "tspatial",
+    "spaceSplit": "tspatial",
+    # temporal_types_p2.xml — declared for every temporal type
+    "insert": "ttype",
+    "update": "ttype",
+    "deleteTime": "ttype",
+    "appendInstant": "ttype",
+    "appendSequence": "ttype",
+    "merge": "ttype",
+    "beforeTimestamp": "ttype",
+}
+
+# The Spanish chapter anchors these three under a token the declarations
+# contradict: area, isGeodetic and quadSplit are declared for stbox alone.
+ES_LAGGARDS = {
+    "box_area": "stbox_area",
+    "box_isGeodetic": "stbox_isGeodetic",
+    "box_quadSplit": "stbox_quadSplit",
+    "box_xMinInc": "tbox_xMinInc",
+    "box_xMaxInc": "tbox_xMaxInc",
+}
+
+
+def files():
+    out = []
+    for d in ("doc", "doc/es"):
+        p = os.path.join(ROOT, d)
+        out += [os.path.join(p, f) for f in sorted(os.listdir(p))
+                if f.endswith(".xml")]
+    return out
+
+
+def main():
+    check = "--check" in sys.argv
+    targets = {old: "%s_%s" % (tok, old) for old, tok in RENAMES.items()}
+    taken = {}
+    for old, new in targets.items():
+        assert new not in taken, "%s and %s both become %s" % (
+            old, taken[new], new)
+        taken[new] = old
+
+    # an entry anchor is unique within a language: assert it, so a bare name that
+    # is also a per-family entry in another chapter is never caught by mistake
+    anchor_of = {}
+    for path in files():
+        s = io.open(path, encoding="utf-8").read()
+        for i in re.findall(r'<listitem xml:id="([^"]+)"', s):
+            if i in targets or i in ES_LAGGARDS:
+                anchor_of.setdefault(i, []).append(path)
+    for i, paths in sorted(anchor_of.items()):
+        langs = [("es" if "/es/" in p else "en") for p in paths]
+        assert len(langs) == len(set(langs)), "%s: %s" % (i, paths)
+
+    mapping = dict(targets)
+    mapping.update(ES_LAGGARDS)
+    anchors = links = 0
+    touched = []
+    for path in files():
+        s = io.open(path, encoding="utf-8").read()
+        orig = s
+        for src, target in mapping.items():
+            s, n = re.subn(r'(<listitem xml:id=")%s(">)' % re.escape(src),
+                           r"\g<1>%s\g<2>" % target, s)
+            anchors += n
+            s, n = re.subn(r'(linkend=")%s(["#])' % re.escape(src),
+                           r"\g<1>%s\g<2>" % target, s)
+            links += n
+        if s != orig:
+            touched.append(os.path.relpath(path, ROOT))
+            if not check:
+                io.open(path, "w", encoding="utf-8").write(s)
+
+    print("%s %d anchors and %d references in %d files"
+          % ("would rewrite" if check else "rewrote", anchors, links,
+             len(touched)))
+    for t in touched:
+        print("   ", t)
+    # report an entry a language does not carry at all, under either spelling,
+    # so a converted tree reports nothing
+    present = {}
+    for path in files():
+        s = io.open(path, encoding="utf-8").read()
+        lang = "es" if "/es/" in path else "en"
+        for i in re.findall(r'<listitem xml:id="([^"]+)"', s):
+            present.setdefault(i, set()).add(lang)
+    for name, target in sorted(targets.items()):
+        have = present.get(name, set()) | present.get(target, set())
+        missing = {"en", "es"} - have
+        if missing:
+            print("    %s is not anchored in %s -- the chapters are not in step"
+                  % (name, ", ".join(sorted(missing))))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
A function entry is anchored as `<type>_<entryName>`, where the type token names the set of types the SQL declares the entry's functions for. The token is what lets a name several families share reach the entry the reader means: `transform` exists for every spatial type, and `SRID` for both `cbuffer` and `tcbuffer` inside one chapter.

Most entries already follow the rule and fix the token vocabulary (`ttype`, `setspan`, `box`, `tnumber`, `tspatial`, ...). Of the 84 entries anchored under a bare name, 36 already carry a type token as the first word of the name itself — `tposeSeq`, `tcbufferFromText`, `tjsonbFromText` — so a prefix would only repeat what the name says, and they stay as they are. The other 48 get the token, in both languages and in the reference index, since an anchor derives from the English entry and is therefore language-independent.

Each token comes from the declarations rather than from the containing section:

| entry | declared for | token |
|---|---|---|
| `hasX`, `xMin`, `xMax` | `stbox`, `tbox`, `tpcbox` | `box` |
| `xMinInc`, `xMaxInc` | `tbox` | `tbox` |
| `area`, `isGeodetic`, `quadSplit` | `stbox` | `stbox` |
| `spaceTimeBoxes`, `spaceSplit` | `tgeometry`, `tgeompoint`, `tpcpoint`, `tpose`, `trgeometry` | `tspatial` |
| `tCentroid` | `tgeompoint`, `tnpoint` | `tpoint` |
| `wMin`, `valueSplit`, `valueTimeBins` | the temporal numbers | `tnumber` |

Five Spanish anchors carry a token the declarations contradict — `box_area`, `box_isGeodetic`, `box_quadSplit`, `box_xMinInc` and `box_xMaxInc` — and join their English counterparts.

The anchor derives from the entry name rather than from the function name the entry documents, which keeps it unique: `rasterTileValueArray` documents `rasterTileValue`, so two entries would otherwise claim one anchor.

Two defects the same pass turns up. The Spanish chapters leave four entries out of the index — `insert`, `update` and `deleteTime` among the modifications, and the constant-value constructors — while the English ones index them. And a cross-reference in the pose chapters points at an entry of an itemized list, which DocBook cannot label, so the manual builds with `Don't know what gentext to create for xref to: listitem` and the sentence renders without a target; it becomes a link carrying the function name, as the other references to entries do.

Every linkend resolves within its own language, and the reference index and the chapters stay symmetric between the two. `generate_docs.yml` runs on a push to master rather than on a pull request, so its six steps ran locally: `dblatex`, `dbtoepub` and `xsltproc` over both manuals all return 0, with no `gentext` warning left.

`tools/codegen/reference/prefix_anchors.py` records the token per entry and applies the rename; `--check` reports without writing and prints nothing to do once the manual is converted.