### PR TITLE
Index in both languages every function an entry documents

### DIFF
--- a/doc/box_types.xml
+++ b/doc/box_types.xml
@@ -889,10 +889,10 @@ SELECT stbox 'STBOX XT(((1,1),(2,2)),[2001-01-01,2001-01-02])' #&amp;&gt;
 				<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>cmp</varname></primary></indexterm>
 				<para>Traditional comparisons</para>
-				<para><varname>box {=, &lt;&gt;, &lt;, &lt;=, &gt;=} box → boolean</varname></para>
+				<para><varname>box {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} box → boolean</varname></para>
 				<para><varname>cmp(tbox,tbox) → int</varname></para>
 				<para><varname>cmp(stbox,stbox) → int</varname></para>
-				<para>Functions <varname>cmp</varname> and <varname>cmp</varname> returns -1, 0, or 1 depending on whether the first argument is, respectively, less than, equal to, or greater than the second one.</para>
+				<para>Function <varname>cmp</varname> returns -1, 0, or 1 depending on whether the first argument is, respectively, less than, equal to, or greater than the second one.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXINT XT([1,1],[2001-01-01,2001-01-04])' =
   tbox 'TBOXINT XT([2,2],[2001-01-03,2001-01-05])';

--- a/doc/es/box_types.xml
+++ b/doc/es/box_types.xml
@@ -891,6 +891,7 @@ SELECT stbox 'STBOX XT(((1,1),(2,2)),[2001-01-01,2001-01-02])' #&amp;&gt;
 				<indexterm significance="normal"><primary><varname>&gt;</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&lt;=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>cmp</varname></primary></indexterm>
 				<para>Comparaciones tradicionales</para>
 				<para><varname>box = box → boolean</varname></para>
 				<para><varname>box &lt;&gt; box → boolean</varname></para>
@@ -898,6 +899,9 @@ SELECT stbox 'STBOX XT(((1,1),(2,2)),[2001-01-01,2001-01-02])' #&amp;&gt;
 				<para><varname>box &gt; box → boolean</varname></para>
 				<para><varname>box &lt;= box → boolean</varname></para>
 				<para><varname>box &gt;= box → boolean</varname></para>
+				<para><varname>cmp(tbox,tbox) → int</varname></para>
+				<para><varname>cmp(stbox,stbox) → int</varname></para>
+				<para>La función <varname>cmp</varname> devuelve -1, 0 o 1 según que el primer argumento sea, respectivamente, menor que, igual a o mayor que el segundo.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tbox 'TBOXINT XT([1,1],[2001-01-01,2001-01-04])' =
   tbox 'TBOXINT XT([2,2],[2001-01-03,2001-01-05])';

--- a/doc/es/set_span_types.xml
+++ b/doc/es/set_span_types.xml
@@ -969,6 +969,8 @@ FROM test;
 		<itemizedlist>
 			<listitem xml:id="setspan_union">
 				<indexterm significance="normal"><primary><varname>+</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>-</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>*</varname></primary></indexterm>
 				<para>Unión, diferencia o intersección de conjuntos o de rangos</para>
 				<para><varname>set {+, - , *} set → set</varname></para>
 				<para><varname>spans {+, - , *} spans → spans</varname></para>
@@ -1266,6 +1268,7 @@ SELECT dateset '{2001-01-01, 2001-01-03, 2001-01-05}' &lt;-&gt;
 				<indexterm significance="normal"><primary><varname>&gt;</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&lt;=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>cmp</varname></primary></indexterm>
 				<para>Comparaciones tradicionales</para>
 				<para><varname>set {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} set → boolean</varname></para>
 				<para><varname>spans {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} spans → boolean</varname></para>
@@ -1340,6 +1343,7 @@ SELECT extent(ps) FROM periods;
 			<listitem xml:id="setspan_union_agg">
 				<indexterm significance="normal"><primary><varname>setUnion</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>spanUnion</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>spansetUnion</varname></primary></indexterm>
 				<para>Unión agregada</para>
 				<para><varname>setUnion({value,set}) → set</varname></para>
 				<para><varname>spanUnion(spans) → spanset</varname></para>

--- a/doc/es/temporal_circular_buffers.xml
+++ b/doc/es/temporal_circular_buffers.xml
@@ -998,6 +998,8 @@ SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>aIntersects</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>eTouches</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>aTouches</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>eCovers</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>aCovers</varname></primary></indexterm>
 				<para>TODO Relaciones alguna vez y siempre</para>
 				<para><varname>eContains(geometry,tcbuffer) → boolean</varname></para>
 				<para><varname>aContains(geometry,tcbuffer) → boolean</varname></para>

--- a/doc/es/temporal_network_points.xml
+++ b/doc/es/temporal_network_points.xml
@@ -324,6 +324,8 @@ SELECT tnpoint '[Npoint(1, 0.2)@2001-01-01 09:00:00, Npoint(2, 0.2)@2001-01-01 0
 			<itemizedlist>
 				<listitem xml:id="tnpoint_const">
 					<indexterm significance="normal"><primary><varname>tnpoint</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>tnpointSeq</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>tnpointSeqSet</varname></primary></indexterm>
 					<para>Constructor para puntos de red temporales con valor constante</para>
 					<para><varname>tnpoint(npoint,timestamptz) → tnpointInst</varname></para>
 					<para><varname>tnpoint(npoint,tstzset) → tnpointDiscSeq</varname></para>
@@ -825,7 +827,7 @@ SELECT tnpoint '[NPoint(1, 0.1)@2001-01-01, NPoint(1, 0.5)@2001-01-03]' &lt;
 
 			<listitem xml:id="tnpoint_ever_always">
 				<indexterm significance="normal"><primary><varname>?=</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>&amp;=</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>%=</varname></primary></indexterm>
 				<para>Comparaciones alguna vez y siempre</para>
 				<para><varname>{npoint,tnpoint} {?=, %=} {npoint,tnpoint} → boolean</varname></para>
 				<programlisting language="sql" xml:space="preserve">

--- a/doc/es/temporal_raster.xml
+++ b/doc/es/temporal_raster.xml
@@ -281,7 +281,13 @@ WHERE stbox(r.tile) &amp;&amp; stbox(t.trip);
 			</listitem>
 
 			<listitem xml:id="raquet_comparison">
-				<indexterm significance="normal"><primary><varname>comparación de raquet</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>=</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>&lt;&gt;</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>&lt;</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>&lt;=</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>&gt;</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>cmp</varname></primary></indexterm>
 				<para>Comparar dos teselas Raquet</para>
 				<para><varname>raquet = raquet → boolean</varname></para>
 				<para><varname>raquet &lt;&gt; raquet → boolean</varname></para>

--- a/doc/es/temporal_types_analytics.xml
+++ b/doc/es/temporal_types_analytics.xml
@@ -937,6 +937,7 @@ FROM (SELECT valueTimeSplit(tfloat '[1@2001-02-01, 10@2001-02-10)', 5.0, '5 days
 				<listitem xml:id="tspatial_spaceSplit">
 					<indexterm significance="normal"><primary><varname>spaceSplit</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>spaceTimeSplit</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>timeSplit</varname></primary></indexterm>
 					<para>Fragmentar un punto temporal con respecto a una malla espacial o espacio-temporal &SRF;</para>
 					<para><varname>spaceSplit(tgeompoint,xsize float,[ysize float,zsize float,]</varname></para>
 					<para><varname>  origin geompoint='Point(0 0 0)',bitmatrix boolean=true,borderInc bool=true) →</varname></para>

--- a/doc/es/temporal_types_p2.xml
+++ b/doc/es/temporal_types_p2.xml
@@ -485,6 +485,7 @@ SELECT tgeogpoint '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02]' =
 				<indexterm significance="normal"><primary><varname>&gt;</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&lt;=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>cmp</varname></primary></indexterm>
 					<para>Comparaciones tradicionales</para>
 					<para><varname>ttype {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} ttype → boolean</varname></para>
 					<programlisting language="sql" xml:space="preserve">

--- a/doc/temporal_network_points.xml
+++ b/doc/temporal_network_points.xml
@@ -359,7 +359,7 @@ SELECT tnpointSeqSet('Npoint(1, 0.2)', tstzspanset '{[2001-01-01, 2001-01-03]}',
 				</listitem>
 
 				<listitem xml:id="tnpointSeq">
-					<indexterm significance="normal"><primary><varname>=</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>tnpointSeq</varname></primary></indexterm>
 					<para>Constructor for temporal network points of sequence subtype</para>
 					<para><varname>tnpointSeq(tnpointInst[],interp={'step','linear'},leftInc bool=true,</varname></para>
 					<para><varname>  rightInc bool=true) →tnpointSeq</varname></para>

--- a/doc/temporal_raster.xml
+++ b/doc/temporal_raster.xml
@@ -279,7 +279,13 @@ WHERE stbox(r.tile) &amp;&amp; stbox(t.trip);
 			</listitem>
 
 			<listitem xml:id="raquet_comparison">
-				<indexterm significance="normal"><primary><varname>raquet comparison</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>=</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>&lt;&gt;</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>&lt;</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>&lt;=</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>&gt;</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>cmp</varname></primary></indexterm>
 				<para>Compare two Raquet tiles</para>
 				<para><varname>raquet = raquet → boolean</varname></para>
 				<para><varname>raquet &lt;&gt; raquet → boolean</varname></para>

--- a/doc/temporal_types_analytics.xml
+++ b/doc/temporal_types_analytics.xml
@@ -994,6 +994,7 @@ FROM (SELECT valueTimeSplit(tfloat '[1@2001-02-01, 10@2001-02-10)', 5.0, '5 days
 				<listitem xml:id="tspatial_spaceSplit">
 					<indexterm significance="normal"><primary><varname>spaceSplit</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>timeSplit</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>spaceTimeSplit</varname></primary></indexterm>
 					<para>Split a temporal point with respect to a spatial grid &Z_support;
  &SRF;
 </para>

--- a/tools/codegen/reference/fix_index_terms.py
+++ b/tools/codegen/reference/fix_index_terms.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Index in both languages every function and operator an entry documents.
+
+An entry indexes what its signatures declare, so the two languages carry the
+same index terms. Where they differ, the signatures decide: this adds the terms
+a language leaves out, corrects two that name something the entry does not
+document, and replaces a prose term by the operators the entry lists.
+
+Each edit names its entry and the term list that entry ends up with, so the
+result is checkable against the chapter it edits.
+"""
+import io
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__)))))
+
+TERM = ('<indexterm significance="normal"><primary><varname>%s</varname>'
+        "</primary></indexterm>")
+
+# (file, entry id, terms to add after the last term the entry already carries)
+ADD = [
+    # the comparison entries document cmp alongside the six operators
+    ("doc/es/box_types.xml", "box_eq", ["cmp"]),
+    ("doc/es/set_span_types.xml", "setspan_eq", ["cmp"]),
+    ("doc/es/temporal_types_p2.xml", "ttype_eq", ["cmp"]),
+    # the set operators the entry documents
+    ("doc/es/set_span_types.xml", "setspan_union", ["-", "*"]),
+    # the aggregate over span sets
+    ("doc/es/set_span_types.xml", "setspan_union_agg", ["spansetUnion"]),
+    # the cover predicates
+    ("doc/es/temporal_circular_buffers.xml", "tcbuffer_espatialrels",
+     ["eCovers", "aCovers"]),
+    # the sequence constructors the entry documents
+    ("doc/es/temporal_network_points.xml", "tnpoint_const",
+     ["tnpointSeq", "tnpointSeqSet"]),
+    # each language documents all three split functions
+    ("doc/temporal_types_analytics.xml", "tspatial_spaceSplit",
+     ["spaceTimeSplit"]),
+    ("doc/es/temporal_types_analytics.xml", "tspatial_spaceSplit",
+     ["timeSplit"]),
+]
+
+# (file, entry id, terms the entry ends up with) -- replaces every term it has
+REPLACE = [
+    # the entry documents the sequence constructor, not the equality operator
+    ("doc/temporal_network_points.xml", "tnpointSeq", ["tnpointSeq"]),
+    # the always-equal operator is %=
+    ("doc/es/temporal_network_points.xml", "tnpoint_ever_always",
+     ["?=", "%="]),
+    # a comparison entry indexes the operators it documents, as its siblings do
+    ("doc/temporal_raster.xml", "raquet_comparison",
+     ["=", "&lt;&gt;", "&lt;", "&lt;=", "&gt;=", "&gt;", "cmp"]),
+    ("doc/es/temporal_raster.xml", "raquet_comparison",
+     ["=", "&lt;&gt;", "&lt;", "&lt;=", "&gt;=", "&gt;", "cmp"]),
+]
+
+
+def entry_span(s, entry):
+    """(start, end) of an entry's markup."""
+    m = re.search(r'<listitem xml:id="%s">' % re.escape(entry), s)
+    assert m, entry
+    end = s.index("</listitem>", m.end())
+    return m.end(), end
+
+
+def indent_of(s, pos):
+    line = s.rfind("\n", 0, pos) + 1
+    return re.match(r"[\t ]*", s[line:]).group(0)
+
+
+def main():
+    check = "--check" in sys.argv
+    edits = 0
+    for rel, entry, terms in ADD:
+        path = os.path.join(ROOT, rel)
+        s = io.open(path, encoding="utf-8").read()
+        a, b = entry_span(s, entry)
+        blk = s[a:b]
+        last = blk.rindex("</indexterm>") + len("</indexterm>")
+        ind = indent_of(s, a + blk.rindex("<indexterm"))
+        ins = "".join("\n%s%s" % (ind, TERM % t) for t in terms)
+        s = s[:a + last] + ins + s[a + last:]
+        print("%-46s %-24s + %s" % (rel, entry, terms))
+        edits += 1
+        if not check:
+            io.open(path, "w", encoding="utf-8").write(s)
+    for rel, entry, terms in REPLACE:
+        path = os.path.join(ROOT, rel)
+        s = io.open(path, encoding="utf-8").read()
+        a, b = entry_span(s, entry)
+        blk = s[a:b]
+        first = blk.index("<indexterm")
+        last = blk.rindex("</indexterm>") + len("</indexterm>")
+        ind = indent_of(s, a + first)
+        new = ("\n%s" % ind).join(TERM % t for t in terms)
+        s = s[:a + first] + new + s[a + last:]
+        print("%-46s %-24s = %s" % (rel, entry, terms))
+        edits += 1
+        if not check:
+            io.open(path, "w", encoding="utf-8").write(s)
+    print("%s %d entries" % ("would edit" if check else "edited", edits))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/codegen/reference/index_terms.py
+++ b/tools/codegen/reference/index_terms.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Report the index terms an entry documents but does not index.
+
+An entry indexes every function and operator its signatures declare, in both
+languages. The signatures are the authority: a name that appears in a signature
+line belongs in the index, and the two languages document the same signatures,
+so their index terms agree.
+
+``--report`` prints, per entry, the terms the signatures call for against the
+terms each language carries.
+"""
+import io
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__)))))
+
+# an operator group -- "set {+, -, *} set" -- and a bare operator between two
+# operands, as the signature lines spell them
+GROUP = re.compile(r"\{([^{}]*?)\}")
+FN = re.compile(r"^([A-Za-z][A-Za-z0-9_]*)\(")
+
+
+def sql_names():
+    """Every function and aggregate the SQL declares."""
+    names = set()
+    for base, _dirs, fs in os.walk(os.path.join(ROOT, "mobilitydb/sql")):
+        for f in fs:
+            if f.endswith(".in.sql"):
+                s = io.open(os.path.join(base, f), encoding="utf-8").read()
+                names |= set(re.findall(
+                    r"CREATE (?:OR REPLACE )?(?:FUNCTION|AGGREGATE) "
+                    r"([A-Za-z][A-Za-z0-9_]*)\(", s))
+    return names
+
+
+def entries(path):
+    """id -> (indexed terms, signature lines) for every entry of a chapter."""
+    s = io.open(path, encoding="utf-8").read()
+    out = {}
+    for p in re.split(r'(?=<listitem xml:id=")', s)[1:]:
+        m = re.match(r'<listitem xml:id="([^"]+)"', p)
+        if not m:
+            continue
+        blk = re.split(r"</listitem>", p, 1)[0]
+        terms = re.findall(r"<primary><varname>([^<]+)</varname>", blk)
+        sigs = re.findall(r"<para><varname>(.+?)</varname></para>", blk, re.S)
+        out[m.group(1)] = (terms, sigs)
+    return out
+
+
+def wanted(sigs, declared):
+    """The terms the signature lines call for, in order of appearance."""
+    out = []
+    for sig in sigs:
+        fn = FN.match(sig.strip())
+        if fn and fn.group(1) in declared:
+            if fn.group(1) not in out:
+                out.append(fn.group(1))
+            continue
+        for grp in GROUP.findall(sig):
+            for op in (o.strip() for o in grp.split(",")):
+                # an operand placeholder is a word; an operator is punctuation
+                if op and not re.match(r"^[A-Za-z]", op) and op not in out:
+                    out.append(op)
+    return out
+
+
+def main():
+    declared = sql_names()
+    docs = os.path.join(ROOT, "doc")
+    for f in sorted(os.listdir(docs)):
+        if not f.endswith(".xml"):
+            continue
+        es = os.path.join(docs, "es", f)
+        if not os.path.exists(es):
+            continue
+        en_e, es_e = entries(os.path.join(docs, f)), entries(es)
+        for i, (terms, sigs) in en_e.items():
+            if i not in es_e:
+                continue
+            es_terms = es_e[i][0]
+            if set(terms) == set(es_terms):
+                continue
+            want = wanted(sigs, declared)
+            print("== %-30s %s" % (f, i))
+            print("   signatures call for : %s" % want)
+            print("   English indexes     : %s" % terms)
+            print("   Spanish indexes     : %s" % es_terms)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
An entry indexes the functions and operators its signatures declare, so the two languages carry the same index terms. Thirteen entries disagree, and in each the signatures decide.

The Spanish chapters leave out `cmp` on the three comparison entries, the difference and intersection operators on the set union entry, `spansetUnion` on the union aggregate, `eCovers` and `aCovers` among the circular-buffer predicates, and the sequence constructors of the network point. Each language documents the three splitting functions while indexing only two of them, so the English entry gains `spaceTimeSplit` and the Spanish one `timeSplit`.

Two terms name something their entry does not document: the network point sequence constructor is indexed under the equality operator, and the Spanish always-equal operator reads `&=` where the entry documents `%=`. The Raquet comparison entry is indexed under a prose phrase, translated in Spanish, rather than the operators it lists, as every other comparison entry is.

The box comparison entry documents five of the six operators it indexes, and the Spanish side documents all six but no `cmp`, although `cmp(tbox,tbox)` and `cmp(stbox,stbox)` exist; both sides now carry the six operators and the two signatures. Its English sentence also names the backing function twice.

Three entries are left alone because they diverge in what they document rather than in what they index, which is a separate matter: `setspan_FromBinary` documents six signatures in Spanish and three in English; the `set` constructor entry indexes four concrete constructors in Spanish that neither language documents there; and the number conversion entry documents `tnumber::tnumber` in English, for a type that does not exist, where Spanish documents `tint::tfloat` and `tfloat::tint`.

`tools/codegen/reference/index_terms.py` reports, per entry, the terms the signatures call for against the terms each language carries; `fix_index_terms.py` applies the edits above and names each one.

`generate_docs.yml` runs on a push to master rather than on a pull request, so its six steps ran locally: `dblatex`, `dbtoepub` and `xsltproc` over both manuals all return 0.