### PR TITLE
Document the same signatures in both chapters of three entries

### DIFF
--- a/doc/es/set_span_types.xml
+++ b/doc/es/set_span_types.xml
@@ -232,16 +232,10 @@ SELECT asHexWKB(floatspanset '{[1, 2], [4, 5]}', 'XDR');
 				<indexterm significance="normal"><primary><varname>settypeFromBinary</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>spantypeFromBinary</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>spansettypeFromBinary</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>settypeFromHexWKB</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>spantypeFromHexWKB</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>spansettypeFromHexWKB</varname></primary></indexterm>
-				<para>Entrar a partir de la representación binaria conocida (WKB) o a partir de la representación hexadecimal binaria conocida (HexWKB)</para>
+				<para>Entrar a partir de la representación binaria conocida (WKB)</para>
 				<para><varname>settypeFromBinary(bytea) → set</varname></para>
 				<para><varname>spantypeFromBinary(bytea) → span</varname></para>
 				<para><varname>spansettypeFromBinary(bytea) → spanset</varname></para>
-				<para><varname>settypeFromHexWKB(text) → set</varname></para>
-				<para><varname>spantypeFromHexWKB(text) → span</varname></para>
-				<para><varname>spansettypeFromHexWKB(text) → spanset</varname></para>
 				<para>Hay una función por tipo de conjunto o de rango, el nombre de la función tiene como prefijo el nombre del tipo.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT datesetFromBinary('\x01050001020000006e01000070010000');
@@ -251,10 +245,25 @@ SELECT intspanFromBinary('\x011300010100000003000000');
 SELECT floatspansetFromBinary(
   '\x00000e00000002033ff000000000000040000000000000000340100000000000004014000000000000');
 -- {[1, 2], [4, 5]}
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="setspan_FromHexWKB">
+				<indexterm significance="normal"><primary><varname>settypeFromHexWKB</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>spantypeFromHexWKB</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>spansettypeFromHexWKB</varname></primary></indexterm>
+				<para>Entrar a partir de la representación hexadecimal binaria conocida (HexWKB)</para>
+				<para><varname>settypeFromHexWKB(text) → set</varname></para>
+				<para><varname>spantypeFromHexWKB(text) → span</varname></para>
+				<para><varname>spansettypeFromHexWKB(text) → spanset</varname></para>
+				<para>Hay una función por tipo de conjunto o de rango, el nombre de la función tiene como prefijo el nombre del tipo.</para>
+				<programlisting language="sql" xml:space="preserve">
 SELECT datesetFromHexWKB('01050001020000006E01000070010000');
 -- {2001-01-01, 2001-01-03}
 SELECT intspanFromHexWKB('011300010100000003000000');
 -- [1, 3)
+SELECT floatspanFromHexWKB('01060001000000000000F83F0000000000000440');
+-- [1.5, 2.5)
 SELECT floatspansetFromHexWKB(
   '00000E00000002033FF000000000000040000000000000000340100000000000004014000000000000');
 -- {[1, 2], [4, 5]}
@@ -271,10 +280,6 @@ SELECT floatspansetFromHexWKB(
 		</para>
 		<itemizedlist>
 			<listitem xml:id="set">
-				<indexterm significance="normal"><primary><varname>intset</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>floatset</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>textset</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>tstzset</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>set</varname></primary></indexterm>
 				<para>Constructor para tipos de conjunto</para>
 				<para><varname>set(base[]) → set</varname></para>

--- a/doc/es/temporal_alpha.xml
+++ b/doc/es/temporal_alpha.xml
@@ -88,13 +88,10 @@ SELECT tbool '[true@2001-01-01, false@2001-01-03]'::tint;
 
 			<listitem xml:id="tint_tfloat">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>tfloat(tint)</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>tint(tfloat)</varname></primary></indexterm>
-				<para>Convertir entre un entero integer y un número flotante temporal</para>
-				<para><varname>tint::tfloat</varname></para>
-				<para><varname>tfloat::tint</varname></para>
-				<para><varname>tfloat(tint)</varname></para>
-				<para><varname>tint(tfloat)</varname></para>
+				<indexterm significance="normal"><primary><varname>tnumber(tnumber)</varname></primary></indexterm>
+				<para>Convertir entre enteros temporales, enteros grandes temporales y flotantes temporales</para>
+				<para><varname>tnumber::tnumber</varname></para>
+				<para><varname>tnumber(tnumber) → tnumber</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tint '[1@2001-01-01, 2@2001-01-03]'::tfloat;
 -- Interp=Step;[1@2001-01-01, 2@2001-01-03]
@@ -102,7 +99,7 @@ SELECT tbigint '[1@2001-01-01, 2@2001-01-03, 3@2001-01-05]'::tfloat;
 -- Interp=Step;[1@2001-01-01, 2@2001-01-03, 3@2001-01-05]
 SELECT tfloat 'Interp=Step;[1.5@2001-01-01, 2.5@2001-01-03]'::tint;
 -- [1@2001-01-01, 2@2001-01-03]
-SELECT tfloat '[1.5@2001-01-01, 2.5@2001-01-03]'::tint;
+SELECT tint(tfloat '[1.5@2001-01-01, 2.5@2001-01-03]');
 -- ERROR:  Cannot cast temporal float with linear interpolation to temporal integer
 </programlisting>
 			</listitem>


### PR DESCRIPTION
Three entries document a different surface in each language, so a reader of one manual sees functions the other does not.

The English chapter documents the binary and the hexadecimal input in two entries, `setspan_FromBinary` and `setspan_FromHexWKB`, while the Spanish one merges both into the entry for the binary input — which leaves the hexadecimal anchor with no Spanish counterpart. The Spanish chapter gains the second entry, with the examples that belong to it.

The Spanish constructor entry for set types indexes `intset`, `floatset`, `textset` and `tstzset` — four of the concrete constructors, and not the complete list — while the entry documents the generic `set(base[])` and the manual indexes the generic name. The four terms go.

The Spanish conversion entry for temporal numbers documents the conversions between temporal integers and temporal floats only, although its own examples convert a temporal big integer, and it names the argument types where the manual writes `tnumber` for any temporal number, as the arithmetic entry does. The declarations cover all six conversions among `tint`, `tbigint` and `tfloat`, which the generic form states, so the entry documents `tnumber::tnumber` and `tnumber(tnumber) → tnumber` as the English entry does, and closes with the same example, which calls the function rather than the cast so that the error it illustrates comes from the function.

Both manuals keep every link resolving within their own language, the index terms of the two languages agree for every entry, and `generate_docs.yml` — which runs on a push to master rather than on a pull request — has its six steps green locally: `dblatex`, `dbtoepub` and `xsltproc` over both manuals all return 0.