### PR TITLE
Ship the figures in the Spanish EPUB

### DIFF
--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -43,7 +43,17 @@ jobs:
         run: |
           cd doc
           dblatex -s texstyle.sty -o es/mobilitydb-manual.pdf es/mobilitydb-manual.xml
-          dbtoepub -o es/mobilitydb-manual.epub es/mobilitydb-manual.xml
+          # The Spanish chapters reach the figures as ../images, which an .epub
+          # container has no way to express, so the packager drops every figure.
+          # Build the .epub from a tree where the figures sit beside the
+          # chapters, as they do for English.
+          rm -rf epub-es
+          mkdir epub-es
+          cp es/*.xml epub-es/
+          cp -r images epub-es/images
+          sed -i 's|\.\./images/|images/|g' epub-es/*.xml
+          dbtoepub -o es/mobilitydb-manual.epub epub-es/mobilitydb-manual.xml
+          rm -rf epub-es
           xsltproc --stringparam html.stylesheet "docbook.css" --stringparam chunker.output.encoding "UTF-8" --xinclude -o es/index.html /usr/share/xml/docbook/stylesheet/docbook-xsl/html/chunk.xsl es/mobilitydb-manual.xml
           cp docbook.css es/
 

--- a/doc/es/temporal_types_analytics.xml
+++ b/doc/es/temporal_types_analytics.xml
@@ -527,9 +527,9 @@ SELECT splitEachNStboxes(tgeogpoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01
 		<figure xml:id="tiling" float="start">
 			<title>Mosaicos multidimensionales para números flotantes temporales.</title>
 			<mediaobject>
-				<imageobject role="html"><imagedata format="SVG" fileref='../images/tiling.svg'/></imageobject>
-				<imageobject role="dblatex"><imagedata scale='75' format="PDF" fileref='../images/tiling.pdf'/></imageobject>
-				<imageobject role="dbtoepub"><imagedata scale='75' format="PDF" fileref='../images/tiling.pdf'/></imageobject>
+				<imageobject><imagedata format="PDF" scale='75' fileref='../images/tiling.pdf'/></imageobject>
+				<imageobject><imagedata format="SVG" scale='75' fileref='../images/tiling.svg'/></imageobject>
+				<imageobject><imagedata format="PNG" scale='75' fileref='../images/tiling.png'/></imageobject>
 			</mediaobject>
 		</figure>
 


### PR DESCRIPTION
The Spanish EPUB carries no figure at all. It weighs 419 kB against the 8.7 MB of the English one, and holds 0 image files against 31:

```
en.epub  8732599 bytes   31 image files
es.epub   418903 bytes    0 image files
```

The Spanish chapters reach the figures as `../images/tiling.svg`, and an EPUB is a container whose entries cannot leave its root, so the packager silently drops every one of them. The Spanish PDF and HTML are unaffected, because `dblatex` and `xsltproc` resolve a relative reference against the directory of the chapter that makes it, where `../images` is correct — which is why the loss shows up in one artifact only, and why re-running the step from another directory does not help. Building the EPUB from a directory where the figures sit beside the chapters, as they already do for English, gives a container that can hold them: 8.75 MB and 31 image files.

The tiling figure offers the EPUB a PDF, which a reader cannot display, and declares its HTML and PDF forms through `role` attributes that the other eleven figures of the Spanish manual do not use. It now offers the same three formats as its English counterpart, which is what brings the count to 31 rather than 30.

`generate_docs.yml` runs on a push to master rather than on a pull request, so its steps ran locally: the three Spanish steps return 0, and the English ones are untouched.