### PR TITLE
Name the raster QUADBIN cell function after what it returns

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3871,7 +3871,7 @@
 			<title>Muestreo Raquet / QUADBIN</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="trajectory_quadbins"><varname>quadbins</varname></link>: Devolver las celdas QUADBIN distintas en un nivel de zoom cubiertas por una trayectoria</para>
+					<para><link linkend="raster_quadbins"><varname>quadbins</varname></link>: Devolver las celdas QUADBIN distintas en un nivel de zoom cubiertas por una trayectoria</para>
 				</listitem>
 
 				<listitem>

--- a/doc/es/temporal_raster.xml
+++ b/doc/es/temporal_raster.xml
@@ -75,29 +75,29 @@ WHERE atSpan(rasterValue(trip, elev), floatspan '[200, 9999]') IS NOT NULL;
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Step 1: identify which tiles the trajectory overlaps
 SELECT DISTINCT q
-FROM unnest(trajectoryQuadbins(traj, 8)) AS q;
+FROM unnest(quadbins(traj, 8)) AS q;
 
 -- Step 2: sample each matching tile
 SELECT rasterTileValueQuadbin(traj,
     band_data, width, height, quadbin, 'FLOAT32', nodata, true)
 FROM elevation_raquet
-WHERE quadbin = ANY(trajectoryQuadbins(traj, 8));
+WHERE quadbin = ANY(quadbins(traj, 8));
 </programlisting>
 
 		<itemizedlist>
-			<listitem xml:id="trajectory_quadbins">
+			<listitem xml:id="raster_quadbins">
 				<indexterm significance="normal"><primary><varname>quadbins</varname></primary></indexterm>
 				<para>Devolver las celdas QUADBIN distintas en un nivel de zoom cubiertas por una trayectoria</para>
-				<para><varname>trajectoryQuadbins(tgeompoint,integer) → bigint[]</varname></para>
+				<para><varname>quadbins(tgeompoint,integer) → bigint[]</varname></para>
 				<para>Devuelve el conjunto de celdas QUADBIN únicas (deduplicadas) cuyas envolventes de tesela Web-Mercator contienen al menos un instante de <varname>traj</varname>. El resultado es adecuado como clave de unión en la cláusula WHERE contra una tabla Raquet. El parámetro <varname>zoom</varname> debe estar en [0, 15].</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Three instants spanning three tiles at zoom 3
-SELECT trajectoryQuadbins(tgeompoint 'SRID=4326;{Point(-60 45)@2024-01-01,
+SELECT quadbins(tgeompoint 'SRID=4326;{Point(-60 45)@2024-01-01,
   Point(0 45)@2024-01-02, Point(60 45)@2024-01-03}', 3);
 -- {5202501994543054848,5203346419473186816,5203416788217364480}
 
 -- Count of Raquet tiles a ship trajectory overlaps at zoom 8
-SELECT array_length(trajectoryQuadbins(trip, 8), 1) AS tile_count
+SELECT array_length(quadbins(trip, 8), 1) AS tile_count
 FROM trips
 ORDER BY tile_count DESC;
 </programlisting>
@@ -114,13 +114,13 @@ ORDER BY tile_count DESC;
 SELECT t.tripid, rasterTileValueQuadbin(t.trip
   r.band_data, r.width, r.height, r.quadbin, 'FLOAT32', r.nodata, true)
 FROM trips t
-JOIN elevation_raquet r ON r.quadbin = ANY(trajectoryQuadbins(t.trip, 8));
+JOIN elevation_raquet r ON r.quadbin = ANY(quadbins(t.trip, 8));
 
 -- Average sea-surface temperature per trajectory
 SELECT t.tripid, avgValue(rasterTileValueQuadbin(t.trip, 
   r.band_data, 256, 256, r.quadbin, 'INT16', -9999, true)) AS mean_sst
 FROM trips t
-JOIN sst_raquet r ON r.quadbin = ANY(trajectoryQuadbins(t.trip, 6));
+JOIN sst_raquet r ON r.quadbin = ANY(quadbins(t.trip, 6));
 </programlisting>
 			</listitem>
 
@@ -164,7 +164,7 @@ FROM elevation_files;
 -- Muestrear teselas raquet preempaquetadas a lo largo de trayectorias de barcos
 SELECT t.tripid, rasterTileValue(t.trip, r.tile)
 FROM trips t
-JOIN elevation_tiles r ON r.quadbin = ANY(trajectoryQuadbins(t.trip, 8));
+JOIN elevation_tiles r ON r.quadbin = ANY(quadbins(t.trip, 8));
 </programlisting>
 			</listitem>
 
@@ -177,7 +177,7 @@ JOIN elevation_tiles r ON r.quadbin = ANY(trajectoryQuadbins(t.trip, 8));
 -- Muestrear una trayectoria en todas las teselas que cruza, en un solo valor
 SELECT t.tripid, rasterTileValue(t.trip, array_agg(r.tile))
 FROM trips t
-JOIN elevation_tiles r ON r.quadbin = ANY(trajectoryQuadbins(t.trip, 8))
+JOIN elevation_tiles r ON r.quadbin = ANY(quadbins(t.trip, 8))
 GROUP BY t.tripid, t.trip;
 </programlisting>
 			</listitem>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3931,7 +3931,7 @@
 			<title>Raquet / QUADBIN Sampling</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="trajectory_quadbins"><varname>quadbins</varname></link>: Return the distinct QUADBIN cells at a zoom level covered by a trajectory</para>
+					<para><link linkend="raster_quadbins"><varname>quadbins</varname></link>: Return the distinct QUADBIN cells at a zoom level covered by a trajectory</para>
 				</listitem>
 
 				<listitem>

--- a/doc/temporal_raster.xml
+++ b/doc/temporal_raster.xml
@@ -74,29 +74,29 @@ WHERE atSpan(rasterValue(trip, elev), floatspan '[200, 9999]') IS NOT NULL;
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Step 1: identify which tiles the trajectory overlaps
 SELECT DISTINCT q
-FROM unnest(trajectoryQuadbins(traj, 8)) AS q;
+FROM unnest(quadbins(traj, 8)) AS q;
 
 -- Step 2: sample each matching tile
 SELECT raster_tileValueQuadbin(traj, band_data, width, height, quadbin, 'FLOAT32',
   nodata, true)
 FROM elevation_raquet
-WHERE quadbin = ANY(trajectoryQuadbins(traj, 8));
+WHERE quadbin = ANY(quadbins(traj, 8));
 </programlisting>
 
 		<itemizedlist>
-			<listitem xml:id="trajectory_quadbins">
+			<listitem xml:id="raster_quadbins">
 				<indexterm significance="normal"><primary><varname>quadbins</varname></primary></indexterm>
 				<para>Return the distinct QUADBIN cells at a zoom level covered by a trajectory</para>
-				<para><varname>trajectoryQuadbins(tgeompoint,integer) → bigint[]</varname></para>
+				<para><varname>quadbins(tgeompoint,integer) → bigint[]</varname></para>
 				<para>Returns the set of unique QUADBIN cells (deduplicated) whose Web-Mercator tile envelopes contain at least one instant of <varname>traj</varname>. The result is suitable as a WHERE-clause join key against a Raquet table. <varname>zoom</varname> must be in [0, 15].</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Three instants spanning three tiles at zoom 3
-SELECT trajectoryQuadbins(tgeompoint 'SRID=4326;{Point(-60 45)@2024-01-01,
+SELECT quadbins(tgeompoint 'SRID=4326;{Point(-60 45)@2024-01-01,
   Point(0 45)@2024-01-02, Point(60 45)@2024-01-03}', 3);
 -- {5202501994543054848,5203346419473186816,5203416788217364480}
 
 -- Count of Raquet tiles a ship trajectory overlaps at zoom 8
-SELECT array_length(trajectoryQuadbins(trip, 8), 1) AS tile_count
+SELECT array_length(quadbins(trip, 8), 1) AS tile_count
 FROM trips
 ORDER BY tile_count DESC;
 </programlisting>
@@ -113,13 +113,13 @@ ORDER BY tile_count DESC;
 SELECT t.tripid, rasterTileValueQuadbin(t.trip, r.band_data, r.width, r.height,
   r.quadbin, 'FLOAT32', r.nodata, true)
 FROM trips t
-JOIN elevation_raquet r ON r.quadbin = ANY(trajectoryQuadbins(t.trip, 8));
+JOIN elevation_raquet r ON r.quadbin = ANY(quadbins(t.trip, 8));
 
 -- Average sea-surface temperature per trajectory
 SELECT t.tripid, avgValue(rasterTileValueQuadbin(t.trip, 
   r.band_data, 256, 256, r.quadbin, 'INT16', -9999, true)) AS mean_sst
 FROM trips t
-JOIN sst_raquet r ON r.quadbin = ANY(trajectoryQuadbins(t.trip, 6));
+JOIN sst_raquet r ON r.quadbin = ANY(quadbins(t.trip, 6));
 </programlisting>
 			</listitem>
 
@@ -162,7 +162,7 @@ FROM elevation_files;
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Sample pre-packaged raquet tiles along ship trajectories
 SELECT t.tripid, rasterTileValue(t.trip, r.tile)
-FROM trips t JOIN elevation_tiles r ON r.quadbin = ANY(trajectoryQuadbins(t.trip, 8));
+FROM trips t JOIN elevation_tiles r ON r.quadbin = ANY(quadbins(t.trip, 8));
 </programlisting>
 			</listitem>
 
@@ -175,7 +175,7 @@ FROM trips t JOIN elevation_tiles r ON r.quadbin = ANY(trajectoryQuadbins(t.trip
 -- Sample a trajectory across every tile it crosses, in one value
 SELECT t.tripid, rasterTileValue(t.trip, array_agg(r.tile))
 FROM trips t
-JOIN elevation_tiles r ON r.quadbin = ANY(trajectoryQuadbins(t.trip, 8))
+JOIN elevation_tiles r ON r.quadbin = ANY(quadbins(t.trip, 8))
 GROUP BY t.tripid, t.trip;
 </programlisting>
 			</listitem>

--- a/mobilitydb/sql/raster/500_raster.in.sql
+++ b/mobilitydb/sql/raster/500_raster.in.sql
@@ -35,7 +35,7 @@
  * Sampling functions:
  *   rasterValue(tgeompoint, raster, band integer DEFAULT 1) → tfloat
  *   rasterTileValueQuadbin(tgeompoint, bytea, ...) → tfloat
- *   trajectoryQuadbins(tgeompoint, integer) → bigint[]
+ *   quadbins(tgeompoint, integer) → bigint[]
  *
  * Restriction functions (SQL-defined, compose the sampling operators):
  *   atRasterValue(tgeompoint, raster, floatspan, band DEFAULT 1) → tgeompoint
@@ -201,7 +201,7 @@ CREATE FUNCTION rasterTileValue(
   LANGUAGE C STRICT;
 
 /******************************************************************************
- * trajectoryQuadbins
+ * quadbins
  *****************************************************************************/
 
 /**
@@ -212,7 +212,7 @@ CREATE FUNCTION rasterTileValue(
  * @param[in] zoom  QUADBIN zoom level (0–15)
  * @csqlfn #Trajectory_quadbins()
  */
-CREATE OR REPLACE FUNCTION trajectoryQuadbins(
+CREATE OR REPLACE FUNCTION quadbins(
     traj  tgeompoint,
     zoom  integer
 ) RETURNS bigint[]

--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -189,7 +189,7 @@ FROM rast;
  f       | t
 (1 row)
 
-SELECT array_length(trajectoryQuadbins(
+SELECT array_length(quadbins(
   tgeompoint 'SRID=4326;{Point(-60.0 45.0)@2024-01-01,
   Point(0.0 45.0)@2024-01-02, Point(60.0 45.0)@2024-01-03}', 3), 1) AS num_distinct_tiles;
  num_distinct_tiles 
@@ -197,7 +197,7 @@ SELECT array_length(trajectoryQuadbins(
                   3
 (1 row)
 
-SELECT array_length(trajectoryQuadbins(
+SELECT array_length(quadbins(
   tgeompoint 'SRID=4326;{Point(-60.0 45.0)@2024-01-01,
     Point(-61.0 44.0)@2024-01-02}', 3), 1) AS num_distinct_tiles;
  num_distinct_tiles 
@@ -205,7 +205,7 @@ SELECT array_length(trajectoryQuadbins(
                   1
 (1 row)
 
-SELECT trajectoryQuadbins(tgeompoint 'SRID=4326;{Point(0.0 0.0)@2024-01-01}', 16);
+SELECT quadbins(tgeompoint 'SRID=4326;{Point(0.0 0.0)@2024-01-01}', 16);
 ERROR:  zoom level must be between 0 and 15
 SELECT rasterTileValueQuadbin(tgeompoint 'SRID=4326;{Point(45.0 75.0)@2024-01-01,
   Point(135.0 75.0)@2024-01-02, Point(45.0 10.0)@2024-01-03, Point(-45.0 75.0)@2024-01-04}',

--- a/mobilitydb/test/raster/queries/500_raster.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster.test.sql
@@ -220,21 +220,21 @@ SELECT
 FROM rast;
 
 -------------------------------------------------------------------------------
--- trajectoryQuadbins
+-- quadbins
 -------------------------------------------------------------------------------
 
 -- Three distinct longitudes at zoom 3 produce three distinct QUADBIN cells.
-SELECT array_length(trajectoryQuadbins(
+SELECT array_length(quadbins(
   tgeompoint 'SRID=4326;{Point(-60.0 45.0)@2024-01-01,
   Point(0.0 45.0)@2024-01-02, Point(60.0 45.0)@2024-01-03}', 3), 1) AS num_distinct_tiles;
 
 -- Two instants in the same tile → deduplicated to 1 cell.
-SELECT array_length(trajectoryQuadbins(
+SELECT array_length(quadbins(
   tgeompoint 'SRID=4326;{Point(-60.0 45.0)@2024-01-01,
     Point(-61.0 44.0)@2024-01-02}', 3), 1) AS num_distinct_tiles;
 
 -- Invalid zoom level raises an error.
-SELECT trajectoryQuadbins(tgeompoint 'SRID=4326;{Point(0.0 0.0)@2024-01-01}', 16);
+SELECT quadbins(tgeompoint 'SRID=4326;{Point(0.0 0.0)@2024-01-01}', 16);
 
 -------------------------------------------------------------------------------
 -- rasterTileValueQuadbin


### PR DESCRIPTION
`quadbins(tgeompoint, integer)` returns the distinct QUADBIN cells a trajectory covers.

The SQL API names a collection-returning function after what it returns and carries the argument in the signature: `instants(tgeompoint)`, `points(tgeompoint)`, `timestamps(temporal)`, `getValues(tbigint)`, `traversedArea(trgeometry)`, `trajectory(tgeompoint)`. Renaming `trajectoryQuadbins` to `quadbins` brings the one function named after the kind of its argument, rather than what it returns, in line with that pattern. The `raquet` accessors keep their receiver, so `quadbin(raquet)` singular and `quadbins(tgeompoint, integer)` plural read as the pair they are, and the PG wrapper's `@sqlfn` tag already reads `#quadbins()`.

The manual's entry anchor renames `trajectory_quadbins` to `raster_quadbins`, matching the `raster_<functionName>` convention the raster chapter's other entries use, and updates both reference-index links.
