### PR TITLE
Expose the temporal JSONB array-exists functions to MEOS and fix the all-keys operator tag

### DIFF
--- a/meos/include/meos_json.h
+++ b/meos/include/meos_json.h
@@ -349,6 +349,8 @@ extern Temporal *tjsonb_delete_array(const Temporal *temp, text **keys, int coun
 extern Temporal *tjsonb_delete_index(const Temporal *temp, int idx);
 extern Temporal *tjsonb_delete_path(const Temporal *temp, text **path_elems, int path_len);
 extern Temporal *tjsonb_exists(const Temporal *temp, const text *key);
+extern Temporal *tjsonb_exists_all(const Temporal *temp, text **keys, int count);
+extern Temporal *tjsonb_exists_any(const Temporal *temp, text **keys, int count);
 extern Temporal *tjsonb_exists_array(const Temporal *temp, text **keys, int count, bool any);
 extern Temporal *tjsonb_extract_path(const Temporal *temp, text **path_elems, int path_len, bool astext, nullHandleType null_handle);
 extern Temporal *tjsonb_insert(const Temporal *temp, text **keys, int count, const Jsonb *newjb, bool after);

--- a/meos/src/json/tjsonb_jsonfuncs.c
+++ b/meos/src/json/tjsonb_jsonfuncs.c
@@ -846,7 +846,8 @@ tjsonb_delete_array(const Temporal *temp, text **keys, int count)
 
 /**
  * @ingroup meos_json_json
- * @brief Delete a key from a temporal JSONB value
+ * @brief Return a temporal boolean that states if a key exists as a
+ * top-level key or array element within a temporal JSONB value
  * @param[in] temp Temporal JSONB value
  * @param[in] key Key
  * @csqlfn #Tjsonb_exists()
@@ -869,11 +870,15 @@ tjsonb_exists(const Temporal *temp, const text *key)
 
 /**
  * @ingroup meos_json_json
- * @brief Delete an array of keys from a temporal JSONB value
+ * @brief Return a temporal boolean that states if any or all of the keys in
+ * a text array exist as top-level keys or array elements within a temporal
+ * JSONB value, common to the #tjsonb_exists_any() and #tjsonb_exists_all()
+ * functions
  * @param[in] temp Temporal JSONB value
  * @param[in] keys Keys
  * @param[in] count Number of elements in the input array
  * @param[in] any True for the 'any' semantics, false for the 'all' semantics
+ * @csqlfn #Tjsonb_exists_any(), #Tjsonb_exists_all()
  */
 Temporal *
 tjsonb_exists_array(const Temporal *temp, text **keys, int count, bool any)
@@ -893,6 +898,38 @@ tjsonb_exists_array(const Temporal *temp, text **keys, int count, bool any)
   lfinfo.param[2] = BoolGetDatum(any);
   lfinfo.restype = T_TBOOL;
   return tfunc_temporal(temp, &lfinfo);
+}
+
+/**
+ * @ingroup meos_json_json
+ * @brief Return a temporal boolean that states if any of the keys in a text
+ * array exist as top-level keys or array elements within a temporal JSONB
+ * value
+ * @param[in] temp Temporal JSONB value
+ * @param[in] keys Keys
+ * @param[in] count Number of elements in the input array
+ * @csqlfn #Tjsonb_exists_any()
+ */
+Temporal *
+tjsonb_exists_any(const Temporal *temp, text **keys, int count)
+{
+  return tjsonb_exists_array(temp, keys, count, true);
+}
+
+/**
+ * @ingroup meos_json_json
+ * @brief Return a temporal boolean that states if all of the keys in a text
+ * array exist as top-level keys or array elements within a temporal JSONB
+ * value
+ * @param[in] temp Temporal JSONB value
+ * @param[in] keys Keys
+ * @param[in] count Number of elements in the input array
+ * @csqlfn #Tjsonb_exists_all()
+ */
+Temporal *
+tjsonb_exists_all(const Temporal *temp, text **keys, int count)
+{
+  return tjsonb_exists_array(temp, keys, count, false);
 }
 
 /**

--- a/mobilitydb/src/json/tjsonb_op.c
+++ b/mobilitydb/src/json/tjsonb_op.c
@@ -70,12 +70,10 @@ Tjsonb_exists(PG_FUNCTION_ARGS)
   PG_RETURN_TEMPORAL_P(result);
 }
 
-/**
- * @ingroup mobilitydb_temporal_jsonb
- * @brief Return a temporal boolean indicating if any/all of the given keys
- *        exist as top-level keys or array elements in a temporal JSONB value
- * @sqlfn tjsonbExistsAny()
- * @sqlfn tjsonbExistsAll()
+/*
+ * Shared implementation of Tjsonb_exists_any and Tjsonb_exists_all: return a
+ * temporal boolean indicating if any/all of the given keys exist as
+ * top-level keys or array elements in a temporal JSONB value
  */
 Datum
 Tjsonb_exists_array(FunctionCallInfo fcinfo, bool any)
@@ -126,7 +124,7 @@ Tjsonb_exists_any(PG_FUNCTION_ARGS)
  * @brief Return true if all of the strings in the text array exist as
  * top-level keys or array elements
  * @sqlfn tjsonbExistsAll()
- * @sqlop @p ?|
+ * @sqlop @p ?&
  */
 PGDLLEXPORT Datum Tjsonb_exists_all(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Tjsonb_exists_all);


### PR DESCRIPTION
The array forms of the temporal JSONB exists operator, `tjsonbExistsAny` and
`tjsonbExistsAll`, are backed by a single MEOS function, `tjsonb_exists_array`,
that carries no `@csqlfn` tag. The catalog that derives every non-PG binding
surface from these tags therefore carries no signature for either SQL
function, so PyMEOS, JMEOS, GoMEOS, MEOS.NET and MobilityDuck silently drop
both. Adds `tjsonb_exists_any` and `tjsonb_exists_all`, two thin MEOS
functions that forward to the existing `tjsonb_exists_array` with the
quantifier fixed, each carrying the `@csqlfn` tag of the wrapper it backs,
mirroring how every other any/all-style operator pair exposes its two
names. `tjsonb_exists_array` keeps its own signature and gains the combined
`@csqlfn` tag documenting both wrappers it implements, the same convention
the shared `ea_` kernels of the spatial relationships use.

Also corrects two copy-pasted `@brief` tags that describe `tjsonb_delete`
instead of the exists operators. The doxygen block sitting above the PG-side
shared helper `Tjsonb_exists_array` carries both operators' `@sqlfn` tags at
once; since the parser attaches a tag to the next matching definition, both
tags bind to `Tjsonb_exists_any`, leaving `Tjsonb_exists_all` unresolved
downstream and polluting `Tjsonb_exists_any`'s own operator tag. Replaces it
with a plain comment, since the two wrappers each already carry a correct
individual `@sqlfn`/`@sqlop` block of their own.

Finally, retags `Tjsonb_exists_all` with the `?&` operator it actually backs
per its `CREATE OPERATOR` statement, replacing the `?|` tag that duplicates
`Tjsonb_exists_any`'s operator.