### PR TITLE
Initialize the lc_monetary/lc_numeric/lc_time GUC mirrors so JSONPath datetime comparisons work

### DIFF
--- a/mobilitydb/test/json/expected/451_jsonbset_jsonfuncs.test.out
+++ b/mobilitydb/test/json/expected/451_jsonbset_jsonfuncs.test.out
@@ -377,6 +377,13 @@ SELECT jsonbsetPathExistsTz(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"uni
  {t,f}
 (1 row)
 
+/* .datetime() casts a JSON string to a date/time value for comparison */
+SELECT jsonbsetPathExistsTz(jsonbset '{"{\"d\": \"2001-01-01\"}", "{\"d\": \"1999-01-01\"}"}', '$.d.datetime() > "2000-06-01".datetime()');
+ jsonbsetpathexiststz 
+----------------------
+ {t,t}
+(1 row)
+
 SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' @@ '$.speed > 15';
  ?column? 
 ----------

--- a/mobilitydb/test/json/queries/451_jsonbset_jsonfuncs.test.sql
+++ b/mobilitydb/test/json/queries/451_jsonbset_jsonfuncs.test.sql
@@ -150,6 +150,9 @@ SELECT jsonbsetPathExists(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units
 SELECT jsonbsetPathExists(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.speed ? (@ > $min)', '{"min": 15}');
 SELECT jsonbsetPathExistsTz(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.units');
 
+/* .datetime() casts a JSON string to a date/time value for comparison */
+SELECT jsonbsetPathExistsTz(jsonbset '{"{\"d\": \"2001-01-01\"}", "{\"d\": \"1999-01-01\"}"}', '$.d.datetime() > "2000-06-01".datetime()');
+
 SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' @@ '$.speed > 15';
 SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' @@ '$.speed == 10';
 

--- a/pgtypes/utils/pg_locale.c
+++ b/pgtypes/utils/pg_locale.c
@@ -129,11 +129,22 @@ extern size_t strtitle_libc(char *dst, size_t dstsize, const char *src,
 extern size_t strupper_libc(char *dst, size_t dstsize, const char *src,
   ssize_t srclen, pg_locale_t locale);
 
-/* GUC settings */
+/*
+ * GUC settings.
+ *
+ * In PostgreSQL these are initialized by the GUC machinery from their boot
+ * value ("C" for lc_monetary/lc_numeric/lc_time) before any SQL executes.
+ * MEOS never runs that machinery, so without an explicit initializer here
+ * these stay NULL and the first newlocale()/_create_locale() call that
+ * consults them (e.g. cache_locale_time(), reached from jsonpath's
+ * .datetime() methods through pg_parse_datetime) fails with
+ * "could not create locale "(null)"". Match the PostgreSQL boot value so
+ * MEOS behaves like a freshly initialized backend.
+ */
 char *locale_messages;
-char *locale_monetary;
-char *locale_numeric;
-char *locale_time;
+char *locale_monetary = "C";
+char *locale_numeric = "C";
+char *locale_time = "C";
 
 int icu_validation_level = WARNING;
 


### PR DESCRIPTION
A JSONPath expression that calls `.datetime()`, such as
`'$.d.datetime() > "2000-06-01".datetime()'`, fails with
`could not create locale "(null)": Invalid argument`, in MEOS and in SQL
alike, for the base, set and temporal JSONB forms. The comparison goes
through `pg_parse_datetime` -> `do_to_timestamp` -> `DCH_from_char`, which
calls `cache_locale_time()` to load the localized day and month names; that
function passes the global `lc_time` GUC mirror to `newlocale()`, and since
this vendored `pgtypes` tree never runs PostgreSQL's GUC machinery, the
variable is simply never initialized and holds NULL. `lc_monetary` and
`lc_numeric` sit next to it and are read the same way, so they are exposed
to the same failure the first time something consults them.

Initializes the three to `"C"`, the boot value PostgreSQL's own GUC
machinery assigns them before any SQL executes (confirmed against a live
PostgreSQL instance: `select name, boot_val from pg_settings where name in
('lc_time', 'lc_monetary', 'lc_numeric')`). MEOS then behaves like a freshly
initialized backend rather than one whose locale GUCs are unset.
`lc_messages` stays untouched, since PostgreSQL boots it to an empty string
and nothing in `pgtypes` dereferences that global directly.

Adds a regression case exercising `.datetime()` in a path comparison, which
is currently untested because it cannot run.