### PR TITLE
Validate the arguments of the temporal pointcloud nearest-approach distance

### DIFF
--- a/meos/include/meos_pointcloud.h
+++ b/meos/include/meos_pointcloud.h
@@ -428,6 +428,12 @@ extern bool ensure_same_pcid_tpcbox(const TPCBox *box1, const TPCBox *box2);
               ! ensure_temporal_isof_type((Temporal *) (temp), T_TPCPATCH) ) \
            return (ret); \
     } while (0)
+  #define VALIDATE_TPOINTCLOUD(temp, ret) \
+    do { \
+          if (! ensure_not_null((void *) (temp)) || \
+              ! ensure_tpointcloud_temptype(((Temporal *) (temp))->temptype) ) \
+           return (ret); \
+    } while (0)
 #else
   #define VALIDATE_TPCPOINT(temp, ret) \
     do { assert(temp); \
@@ -435,6 +441,9 @@ extern bool ensure_same_pcid_tpcbox(const TPCBox *box1, const TPCBox *box2);
   #define VALIDATE_TPCPATCH(temp, ret) \
     do { assert(temp); \
       assert(((Temporal *) (temp))->temptype == T_TPCPATCH); } while (0)
+  #define VALIDATE_TPOINTCLOUD(temp, ret) \
+    do { assert(temp); \
+      assert(tpointcloud_temptype(((Temporal *) (temp))->temptype)); } while (0)
 #endif
 
 /* Conversion */

--- a/meos/include/temporal/meos_catalog.h
+++ b/meos/include/temporal/meos_catalog.h
@@ -258,6 +258,7 @@ extern bool ensure_spatialset_type(MeosType type);
 extern bool pointcloud_basetype(MeosType type);
 extern bool pointcloudset_type(MeosType type);
 extern bool tpointcloud_temptype(MeosType type);
+extern bool ensure_tpointcloud_temptype(MeosType type);
 #endif /* POINTCLOUD */
 
 extern bool span_basetype(MeosType type);

--- a/meos/src/pointcloud/tpc_boxops.c
+++ b/meos/src/pointcloud/tpc_boxops.c
@@ -353,11 +353,14 @@ nad_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
  *   value and a TPCBox
  * @param[in] temp Temporal pointcloud value
  * @param[in] box Bounding box
+ * @return On error or if the time frames do not intersect return infinity
  * @csqlfn #NAD_tpointcloud_tpcbox()
  */
 double
 nad_tpointcloud_tpcbox(const Temporal *temp, const TPCBox *box)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_TPOINTCLOUD(temp, DBL_MAX); VALIDATE_TPCBOX(box, DBL_MAX);
   TPCBox tmp;
   temporal_set_bbox(temp, &tmp);
   return nad_tpcbox_tpcbox(&tmp, box);
@@ -368,11 +371,15 @@ nad_tpointcloud_tpcbox(const Temporal *temp, const TPCBox *box)
  * @brief Return the nearest-approach distance between two temporal
  *   pointcloud values
  * @param[in] temp1,temp2 Temporal pointcloud values
+ * @return On error or if the time frames do not intersect return infinity
  * @csqlfn #NAD_tpointcloud_tpointcloud()
  */
 double
 nad_tpointcloud_tpointcloud(const Temporal *temp1, const Temporal *temp2)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_TPOINTCLOUD(temp1, DBL_MAX); VALIDATE_TPOINTCLOUD(temp2, DBL_MAX);
+
   /* Patches are not point trajectories: they have no single-point
    * projection to a tgeompoint, so their nearest-approach distance stays
    * the distance between their bounding boxes, exactly as before. */

--- a/meos/src/temporal/meos_catalog.c
+++ b/meos/src/temporal/meos_catalog.c
@@ -1193,6 +1193,19 @@ tpointcloud_temptype(MeosType type)
 {
   return (type == T_TPCPOINT || type == T_TPCPATCH);
 }
+
+/**
+ * @brief Ensure that a type is a temporal pgpointcloud type
+ */
+bool
+ensure_tpointcloud_temptype(MeosType type)
+{
+  if (tpointcloud_temptype(type))
+    return true;
+  meos_error(ERROR, MEOS_ERR_INVALID_ARG_TYPE,
+    "The temporal value must be a temporal pgpointcloud type");
+  return false;
+}
 #endif
 
 /**


### PR DESCRIPTION
The two temporal pointcloud nearest-approach distance functions read their
temporal argument before any validity test. `nad_tpointcloud_tpcbox` hands it
straight to `temporal_set_bbox`, and `nad_tpointcloud_tpointcloud` reads
`temp1->temptype`. The sibling `nad_tgeo_stbox` opens with
`VALIDATE_TGEO(temp, DBL_MAX); VALIDATE_NOT_NULL(box, DBL_MAX);`.

Both functions accept either temporal pointcloud type, so neither
`VALIDATE_TPCPOINT` nor `VALIDATE_TPCPATCH` fits. The catalog carries the
`tpointcloud_temptype` predicate without the `ensure_` counterpart its sibling
predicates have, so it gains `ensure_tpointcloud_temptype`, and
`meos_pointcloud.h` gains `VALIDATE_TPOINTCLOUD`, in the shape `VALIDATE_TGEO`
has over `ensure_tgeo_type_all`.

Both functions also state the infinity they return on error, as
`nad_tpcbox_tpcbox` does.

The SQL surface is unchanged: the argument type is already fixed by the SQL
signature, so this is a MEOS-side guard.
