### PR TITLE
Pin the JSONPath datetime format cache in a persistent memory context

### DIFF
--- a/mobilitydb/test/json/expected/451_jsonbset_jsonfuncs.test.out
+++ b/mobilitydb/test/json/expected/451_jsonbset_jsonfuncs.test.out
@@ -414,6 +414,13 @@ SELECT jsonbsetPathMatchTz(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"unit
  {t,f}
 (1 row)
 
+/* .datetime() casts a JSON string to a date/time value for comparison */
+SELECT jsonbsetPathMatch(jsonbset '{"{\"d\": \"2001-01-01\"}", "{\"d\": \"1999-01-01\"}"}', '$.d.datetime() > "2000-06-01".datetime()');
+ jsonbsetpathmatch 
+-------------------
+ {t,f}
+(1 row)
+
 /* A path matching nothing is unknown, that is, false, for every element */
 SELECT jsonbsetPathMatch(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.xxx > 15', '{}', false);
  jsonbsetpathmatch 

--- a/mobilitydb/test/json/queries/451_jsonbset_jsonfuncs.test.sql
+++ b/mobilitydb/test/json/queries/451_jsonbset_jsonfuncs.test.sql
@@ -160,6 +160,9 @@ SELECT jsonbsetPathMatch(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\
 SELECT jsonbsetPathMatch(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.speed > $min', '{"min": 15}');
 SELECT jsonbsetPathMatchTz(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.speed > 15');
 
+/* .datetime() casts a JSON string to a date/time value for comparison */
+SELECT jsonbsetPathMatch(jsonbset '{"{\"d\": \"2001-01-01\"}", "{\"d\": \"1999-01-01\"}"}', '$.d.datetime() > "2000-06-01".datetime()');
+
 /* A path matching nothing is unknown, that is, false, for every element */
 SELECT jsonbsetPathMatch(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.xxx > 15', '{}', false);
 

--- a/pgtypes/utils/jsonpath_exec.c
+++ b/pgtypes/utils/jsonpath_exec.c
@@ -79,6 +79,12 @@
 #include "utils/timestamp.h"
 #include "utils/varlena.h"
 #include "utils/mb/pg_wchar.h"
+#include "utils/palloc.h"  /* MEOS: MemoryContext + MemoryContextSwitchTo (backend build) */
+
+/* MEOS: the vendored memutils.h omits this backend global; declare it locally,
+ * as dynahash.c and pg_locale.c do, so the extension can pin the static
+ * datetime format cache in a persistent context (see executeDateTimeMethod). */
+extern PGDLLIMPORT MemoryContext TopMemoryContext;
 
 #include "pgtypes.h"
 
@@ -2184,7 +2190,23 @@ executeDateTimeMethod(JsonPathExecContext *cxt, JsonPathItem *jsp,
     {
       if (!fmt_txt[i])
       {
+#if ! MEOS
+        /*
+         * In the PostgreSQL extension the first evaluation happens inside a
+         * query whose CurrentMemoryContext is short-lived (typically a
+         * per-tuple context). Allocate in TopMemoryContext so this
+         * function-static cache keeps pointing at live memory once that
+         * context resets; otherwise it dangles while staying non-NULL, and a
+         * later evaluation in the same backend reads a freed pointer as a
+         * text header. The standalone library never resets a context under
+         * the cache. Mirrors the PostgreSQL original.
+         */
+        MemoryContext oldcontext = MemoryContextSwitchTo(TopMemoryContext);
+#endif /* ! MEOS */
         fmt_txt[i] = pg_cstring_to_text(fmt_str[i]);
+#if ! MEOS
+        MemoryContextSwitchTo(oldcontext);
+#endif /* ! MEOS */
       }
       if (pg_parse_datetime(datetime, fmt_txt[i], collid, true, &typid,
         &typmod, &tz, &value))


### PR DESCRIPTION
`executeDateTimeMethod` keeps a function-static cache of the thirteen ISO
datetime format pictures it tries, filling each entry lazily with
`pg_cstring_to_text`. In the PostgreSQL extension that first fill runs inside
a query, where `CurrentMemoryContext` is short-lived, typically a per-tuple
context. The cache outlives that context, so once it resets every entry
dangles while staying non-NULL, and the next evaluation in the same backend
hands the freed pointer to `pg_parse_datetime`, which reads it as a text
header and memmoves a garbage length.

The effect is a segmentation fault in `pg_text_to_cstring`, reached through
`do_to_timestamp` and `pg_parse_datetime`, whenever a JSONPath `.datetime()`
method runs a second time in a backend whose earlier context is already
reset and reused. It is intermittent, since it depends on what overwrites
the freed chunk in the meantime. It shows up as a backend crash evaluating
`jsonbsetPathMatch(..., '$.d.datetime() > "2000-06-01".datetime()')`, with
this stack:

```
pg_text_to_cstring   (pgtypes/utils/varlena.c)
do_to_timestamp      (pgtypes/utils/formatting.c)
pg_parse_datetime    (pgtypes/utils/formatting.c)
executeDateTimeMethod(pgtypes/utils/jsonpath_exec.c)
...
pg_jsonb_path_match  (pgtypes/utils/jsonpath_exec.c)
jsonbset_path_match  (meos/src/json/jsonbset_jsonfuncs.c)
Jsonbset_path_match  (mobilitydb/src/json/jsonbset_jsonfuncs.c)
```

Allocates the cache entries in `TopMemoryContext`, as the PostgreSQL
original does, and as `meos_initialize_collation` already does for the
process-wide `default_locale`. The standalone library never resets a context
under the cache, so the switch is confined to the extension build.

Adds coverage for a `.datetime()` comparison evaluated through
`jsonbsetPathMatch`, which is unreachable while the crash stands.