### PR TITLE
Return the canonical error sentinel from the double-returning functions

### DIFF
--- a/meos/src/cbuffer/cbuffer.c
+++ b/meos/src/cbuffer/cbuffer.c
@@ -971,7 +971,7 @@ cbuffer_distance(const Cbuffer *cb1, const Cbuffer *cb2)
 /**
  * @ingroup meos_cbuffer_base_dist
  * @brief Return the distance between two circular buffers
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn #Distance_cbuffer_cbuffer()
  */
 double
@@ -979,7 +979,7 @@ distance_cbuffer_cbuffer(const Cbuffer *cb1, const Cbuffer *cb2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_cbuffer_cbuffer(cb1, cb2))
-    return -1.0;
+    return DBL_MAX;
   /* The following function assumes that all validity tests have been done */
   return cbuffer_distance(cb1, cb2);
 }
@@ -1001,7 +1001,7 @@ datum_cbuffer_distance(Datum cb1, Datum cb2)
 /**
  * @ingroup meos_cbuffer_base_dist
  * @brief Return the distance between a circular buffer and a geometry
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn #Distance_cbuffer_geo()
  */
 double
@@ -1009,7 +1009,7 @@ distance_cbuffer_geo(const Cbuffer *cb, const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_cbuffer_geo(cb, gs) || gserialized_is_empty(gs))
-    return -1.0;
+    return DBL_MAX;
 
   GSERIALIZED *geo = cbuffer_to_geom(cb);
   double result = geom_distance2d(geo, gs);
@@ -1020,7 +1020,7 @@ distance_cbuffer_geo(const Cbuffer *cb, const GSERIALIZED *gs)
 /**
  * @ingroup meos_cbuffer_base_dist
  * @brief Return the distance between a circular buffer and a spatiotemporal box
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn #Distance_cbuffer_stbox()
  */
 double
@@ -1028,7 +1028,7 @@ distance_cbuffer_stbox(const Cbuffer *cb, const STBox *box)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_cbuffer_stbox(cb, box))
-    return -1.0;
+    return DBL_MAX;
 
   GSERIALIZED *geo1 = cbuffer_to_geom(cb);
   GSERIALIZED *geo2 = stbox_geo(box);

--- a/meos/src/geo/stbox.c
+++ b/meos/src/geo/stbox.c
@@ -1335,16 +1335,16 @@ stbox_tmax_inc(const STBox *box, bool *result)
  * @param[in] box Spatiotemporal box
  * @param[in] spheroid When true, the calculation uses the WGS 84 spheroid,
  * otherwise it uses a faster spherical calculation
- * @return On error, return -1.0
+ * @return On error, return @p DBL_MAX
  * @csqlfn #Stbox_area()
  */
 double
 stbox_area(const STBox *box, bool spheroid)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(box, -1.0); 
+  VALIDATE_NOT_NULL(box, DBL_MAX); 
   if (! ensure_has_X(T_STBOX, box->flags))
-    return -1.0;
+    return DBL_MAX;
 
   if (! MEOS_FLAGS_GET_GEODETIC(box->flags))
     return (box->xmax - box->xmin) * (box->ymax - box->ymin);
@@ -1359,17 +1359,17 @@ stbox_area(const STBox *box, bool spheroid)
  * @ingroup meos_geo_box_accessor
  * @brief Return the volume of a 3D spatiotemporal box
  * @param[in] box Spatiotemporal box
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn #Stbox_volume()
  */
 double
 stbox_volume(const STBox *box)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(box, -1.0); 
+  VALIDATE_NOT_NULL(box, DBL_MAX); 
   if (! ensure_has_X(T_STBOX, box->flags) ||
       ! ensure_has_Z(T_STBOX, box->flags) || ! ensure_not_geodetic(box->flags))
-    return -1.0;
+    return DBL_MAX;
   return (box->xmax - box->xmin) * (box->ymax - box->ymin) * 
     (box->zmax - box->zmin);
 }
@@ -1380,16 +1380,16 @@ stbox_volume(const STBox *box)
  * @param[in] box Spatiotemporal box
  * @param[in] spheroid When true, the calculation uses the WGS 84 spheroid,
  * otherwise it uses a faster spherical calculation
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn #Stbox_perimeter()
  */
 double
 stbox_perimeter(const STBox *box, bool spheroid)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(box, -1.0); 
+  VALIDATE_NOT_NULL(box, DBL_MAX); 
   if (! ensure_has_X(T_STBOX, box->flags))
-    return -1.0;
+    return DBL_MAX;
 
   GSERIALIZED *geo = stbox_geo(box);
   double result = MEOS_FLAGS_GET_GEODETIC(box->flags) ?

--- a/meos/src/geo/tpoint_spatialfuncs.c
+++ b/meos/src/geo/tpoint_spatialfuncs.c
@@ -2377,14 +2377,14 @@ tpointseqset_length(const TSequenceSet *ss)
  * @ingroup meos_geo_accessor
  * @brief Return the length traversed by a temporal point sequence (set)
  * @param[in] temp Temporal point
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn #Tpoint_length()
  */
 double
 tpoint_length(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TPOINT(temp, -1.0);
+  VALIDATE_TPOINT(temp, DBL_MAX);
 
   assert(temptype_subtype(temp->subtype));
   if (! MEOS_FLAGS_LINEAR_INTERP(temp->flags))
@@ -2399,7 +2399,7 @@ tpoint_length(const Temporal *temp)
  * @ingroup meos_geo_accessor
  * @brief Return the speed of a temporal point sequence (set)
  * @param[in] temp Temporal point
- * @return On error return -1.0
+ * @return On error return @p NULL
  * @csqlfn #Tpoint_speed()
  */
 Temporal *
@@ -3248,7 +3248,7 @@ geog_distance_geos(const GEOSGeometry *pt1, const GEOSGeometry *pt2)
 /**
  * @brief Calculate the length of the diagonal of the minimum rotated rectangle
  * of the input GEOS geometry
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @note The computation is always done in 2D
  */
 static double
@@ -3301,7 +3301,7 @@ mrr_distance_geos(GEOSGeometry *geom, bool geodetic)
         GEOSGeom_destroy(mrr_geom);
         meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
           "Invalid geometry type for Minimum Rotated Rectangle");
-        return -1.0;
+        return DBL_MAX;
     }
     GEOSGeom_destroy(mrr_geom);
   }

--- a/meos/src/npoint/npoint.c
+++ b/meos/src/npoint/npoint.c
@@ -1077,14 +1077,14 @@ npoint_route(const Npoint *np)
  * @ingroup meos_npoint_base_accessor
  * @brief Return the position of a network point
  * @param[in] np Network point
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn #Npoint_position()
  */
 double
 npoint_position(const Npoint *np)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(np, -1.0);
+  VALIDATE_NOT_NULL(np, DBL_MAX);
   return np->pos;
 }
 
@@ -1106,13 +1106,14 @@ nsegment_route(const Nsegment *ns)
  * @ingroup meos_npoint_base_accessor
  * @brief Return the start position of a network segment
  * @param[in] ns Network segment
+ * @return On error return @p DBL_MAX
  * @csqlfn #Nsegment_start_position()
  */
 double
 nsegment_start_position(const Nsegment *ns)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(ns, -1.0);
+  VALIDATE_NOT_NULL(ns, DBL_MAX);
   return ns->pos1;
 }
 
@@ -1120,13 +1121,14 @@ nsegment_start_position(const Nsegment *ns)
  * @ingroup meos_npoint_base_accessor
  * @brief Return the end position of a network segment
  * @param[in] ns Network segment
+ * @return On error return @p DBL_MAX
  * @csqlfn #Nsegment_end_position()
  */
 double
 nsegment_end_position(const Nsegment *ns)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(ns, -1.0);
+  VALIDATE_NOT_NULL(ns, DBL_MAX);
   return ns->pos2;
 }
 

--- a/meos/src/npoint/tnpoint_spatialfuncs.c
+++ b/meos/src/npoint/tnpoint_spatialfuncs.c
@@ -36,6 +36,7 @@
 
 /* C */
 #include <assert.h>
+#include <float.h>
 #include <math.h>
 /* MEOS */
 #include <meos.h>
@@ -259,13 +260,14 @@ tnpointseqset_length(const TSequenceSet *ss)
  * @ingroup meos_npoint_accessor
  * @brief Length traversed by a temporal network point
  * @param[in] temp Temporal point
+ * @return On error return @p DBL_MAX
  * @csqlfn #Tnpoint_length()
  */
 double
 tnpoint_length(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TNPOINT(temp, -1.0);
+  VALIDATE_TNPOINT(temp, DBL_MAX);
 
   assert(temptype_subtype(temp->subtype));
   if (! MEOS_FLAGS_LINEAR_INTERP(temp->flags))

--- a/meos/src/npoint/ways.c
+++ b/meos/src/npoint/ways.c
@@ -135,7 +135,7 @@ route_exists(int64 rid)
  * @brief Access the edge table to return the route length from the
  * corresponding route identifier
  * @param[in] rid Route identifier
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  */
 double
 route_length(int64 rid)
@@ -160,7 +160,7 @@ route_length(int64 rid)
   {
     meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
       "Cannot get the length for route " INT64_FORMAT, rid);
-    return -1.0;
+    return DBL_MAX;
   }
   return result;
 }

--- a/meos/src/npoint/ways_meos.c
+++ b/meos/src/npoint/ways_meos.c
@@ -371,14 +371,14 @@ route_geom(int64 rid)
  * @brief Access the edge table to return the route length from the
  * corresponding route identifier
  * @param[in] rid Route identifier
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  */
 double
 route_length(int64 rid)
 {
   ways_record rec;
   if (route_lookup(rid, false, &rec) == LW_FAILURE)
-    return -1.0;
+    return DBL_MAX;
   return rec.length;
 }
 

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -1775,7 +1775,7 @@ pose_distance(Datum pose1, Datum pose2)
 /**
  * @ingroup meos_pose_base_dist
  * @brief Return the distance between two poses
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn Distance_pose_pose()
  */
 double
@@ -1783,7 +1783,7 @@ distance_pose_pose(const Pose *pose1, const Pose *pose2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_pose_pose(pose1, pose2))
-    return -1.0;
+    return DBL_MAX;
   /* The following function assumes that all validity tests have been done */
   return pose_distance(PointerGetDatum(pose1), PointerGetDatum(pose2));
 }
@@ -1805,7 +1805,7 @@ datum_pose_distance(Datum pose1, Datum pose2)
 /**
  * @ingroup meos_pose_base_dist
  * @brief Return the distance between a pose and a geometry
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn Distance_pose_geo()
  */
 double
@@ -1813,7 +1813,7 @@ distance_pose_geo(const Pose *pose, const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_pose_geo(pose, gs) || gserialized_is_empty(gs))
-    return -1.0;
+    return DBL_MAX;
 
   GSERIALIZED *geo = pose_to_point(pose);
   double result = geom_distance2d(geo, gs);
@@ -1824,7 +1824,7 @@ distance_pose_geo(const Pose *pose, const GSERIALIZED *gs)
 /**
  * @ingroup meos_pose_base_dist
  * @brief Return the distance between a pose and a spatiotemporal box
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn Distance_pose_stbox()
  */
 double
@@ -1832,7 +1832,7 @@ distance_pose_stbox(const Pose *pose, const STBox *box)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_pose_stbox(pose, box))
-    return -1.0;
+    return DBL_MAX;
 
   GSERIALIZED *geo1 = pose_to_point(pose);
   GSERIALIZED *geo2 = stbox_geo(box);

--- a/meos/src/rgeo/trgeo_spatialfuncs.c
+++ b/meos/src/rgeo/trgeo_spatialfuncs.c
@@ -872,13 +872,14 @@ trgeometry_dyntimewarp_path(const Temporal *temp1, const Temporal *temp2,
  * @brief Return the length traversed by the centroid of a temporal rigid
  * geometry
  * @param[in] temp Temporal rigid geometry
+ * @return On error return @p DBL_MAX
  * @csqlfn #Trgeometry_length()
  */
 double
 trgeometry_length(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TRGEOMETRY(temp, -1.0);
+  VALIDATE_TRGEOMETRY(temp, DBL_MAX);
 
   Temporal *tpoint = trgeometry_to_tgeompoint(temp);
   double result = tpoint_length(tpoint);

--- a/meos/src/temporal/set_ops_meos.c
+++ b/meos/src/temporal/set_ops_meos.c
@@ -34,6 +34,7 @@
 
 /* C */
 #include <assert.h>
+#include <float.h>
 /* PostgreSQL */
 #include <postgres.h>
 #include <utils/timestamp.h>
@@ -1562,14 +1563,14 @@ distance_set_bigint(const Set *s, int64 i)
  * @brief Return the distance between a set and a float
  * @param[in] s Set
  * @param[in] d Value
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn #Distance_set_value()
  */
 double
 distance_set_float(const Set *s, double d)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_FLOATSET(s, -1.0);
+  VALIDATE_FLOATSET(s, DBL_MAX);
   return DatumGetFloat8(distance_set_value(s, Float8GetDatum(d)));
 }
 
@@ -1595,14 +1596,14 @@ distance_set_date(const Set *s, DateADT d)
  * double
  * @param[in] s Set
  * @param[in] t Value
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn #Distance_set_value()
  */
 double
 distance_set_timestamptz(const Set *s, TimestampTz t)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TSTZSET(s, -1.0);
+  VALIDATE_TSTZSET(s, DBL_MAX);
   return DatumGetFloat8(distance_set_value(s, TimestampTzGetDatum(t)));
 }
 
@@ -1644,7 +1645,7 @@ distance_bigintset_bigintset(const Set *s1, const Set *s2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two float sets
  * @param[in] s1,s2 Sets
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn #Distance_set_set()
  */
 double
@@ -1652,7 +1653,7 @@ distance_floatset_floatset(const Set *s1, const Set *s2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_set_set(s1, s2) || ! ensure_set_isof_type(s1, T_FLOATSET))
-    return -1.0;
+    return DBL_MAX;
   return DatumGetFloat8(distance_set_set(s1, s2));
 }
 
@@ -1676,7 +1677,7 @@ distance_dateset_dateset(const Set *s1, const Set *s2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance in seconds between two timestamptz sets
  * @param[in] s1,s2 Sets
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn #Distance_set_set()
  */
 double
@@ -1684,7 +1685,7 @@ distance_tstzset_tstzset(const Set *s1, const Set *s2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_set_set(s1, s2) || ! ensure_set_isof_type(s1, T_TSTZSET))
-    return -1.0;
+    return DBL_MAX;
   return DatumGetFloat8(distance_set_set(s1, s2));
 }
 

--- a/meos/src/temporal/span_meos.c
+++ b/meos/src/temporal/span_meos.c
@@ -600,14 +600,14 @@ bigintspan_width(const Span *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the width of a float span
  * @param[in] s Span
- * @return On error return -1
+ * @return On error return @p DBL_MAX
  * @csqlfn #Numspan_width()
  */
 double
 floatspan_width(const Span *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_FLOATSPAN(s, -1.0);
+  VALIDATE_FLOATSPAN(s, DBL_MAX);
   return DatumGetFloat8(numspan_width(s));
 }
 

--- a/meos/src/temporal/span_ops.c
+++ b/meos/src/temporal/span_ops.c
@@ -876,7 +876,7 @@ minus_span_span(const Span *s1, const Span *s2)
  * @brief Return the distance between two values as a double for the indexes
  * @param[in] l,r Values
  * @param[in] type Type of the values
- * @return On error return -1
+ * @return On error return @p DBL_MAX
  */
 double
 dist_double_value_value(Datum l, Datum r, MeosType type)
@@ -901,7 +901,7 @@ dist_double_value_value(Datum l, Datum r, MeosType type)
       meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
         "Unknown types for distance between values: %s",
         meostype_name(type));
-      return -1;
+      return DBL_MAX;
   }
 }
 

--- a/meos/src/temporal/span_ops_meos.c
+++ b/meos/src/temporal/span_ops_meos.c
@@ -1386,14 +1386,14 @@ distance_span_bigint(const Span *s, int64 i)
  * @brief Return the distance between a span and a float
  * @param[in] s Span
  * @param[in] d Value
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn #Distance_span_value()
  */
 double
 distance_span_float(const Span *s, double d)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_FLOATSPAN(s, -1.0);
+  VALIDATE_FLOATSPAN(s, DBL_MAX);
   return distance_span_value(s, Float8GetDatum(d));
 }
 
@@ -1419,14 +1419,14 @@ distance_span_date(const Span *s, DateADT d)
  * double
  * @param[in] s Span
  * @param[in] t Value
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn #Distance_span_value()
  */
 double
 distance_span_timestamptz(const Span *s, TimestampTz t)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TSTZSPAN(s, -1.0);
+  VALIDATE_TSTZSPAN(s, DBL_MAX);
   return distance_span_value(s, TimestampTzGetDatum(t));
 }
 
@@ -1466,14 +1466,14 @@ distance_bigintspan_bigintspan(const Span *s1, const Span *s2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two float spans
  * @param[in] s1,s2 Spans
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn #Distance_span_span()
  */
 double
 distance_floatspan_floatspan(const Span *s1, const Span *s2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_FLOATSPAN(s1, -1.0); VALIDATE_FLOATSPAN(s2, -1.0);
+  VALIDATE_FLOATSPAN(s1, DBL_MAX); VALIDATE_FLOATSPAN(s2, DBL_MAX);
   return DatumGetFloat8(distance_span_span(s1, s2));
 }
 
@@ -1496,14 +1496,14 @@ distance_datespan_datespan(const Span *s1, const Span *s2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance in seconds between two timestamptz spans
  * @param[in] s1,s2 Spans
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn #Distance_span_span()
  */
 double
 distance_tstzspan_tstzspan(const Span *s1, const Span *s2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TSTZSPAN(s1, -1.0); VALIDATE_TSTZSPAN(s2, -1.0);
+  VALIDATE_TSTZSPAN(s1, DBL_MAX); VALIDATE_TSTZSPAN(s2, DBL_MAX);
   return DatumGetFloat8(distance_span_span(s1, s2));
 }
 

--- a/meos/src/temporal/spanset_meos.c
+++ b/meos/src/temporal/spanset_meos.c
@@ -547,14 +547,14 @@ bigintspanset_width(const SpanSet *ss, bool boundspan)
  * @brief Return the width of a float span set
  * @param[in] ss Span
  * @param[in] boundspan True when the potential time gaps are ignored
- * @return On error return -1
+ * @return On error return @p DBL_MAX
  * @csqlfn #Numspanset_width(()
  */
 double
 floatspanset_width(const SpanSet *ss, bool boundspan)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_FLOATSPANSET(ss, -1.0);
+  VALIDATE_FLOATSPANSET(ss, DBL_MAX);
   return DatumGetFloat8(numspanset_width(ss, boundspan));
 }
 

--- a/meos/src/temporal/spanset_ops_meos.c
+++ b/meos/src/temporal/spanset_ops_meos.c
@@ -34,6 +34,7 @@
 
 /* C */
 #include <assert.h>
+#include <float.h>
 /* PostgreSQL */
 #include <postgres.h>
 #include <utils/timestamp.h>
@@ -1304,14 +1305,14 @@ distance_spanset_bigint(const SpanSet *ss, int64 i)
  * @brief Return the distance between a span set and a float
  * @param[in] ss Span set
  * @param[in] d Value
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn #Distance_spanset_value()
  */
 double
 distance_spanset_float(const SpanSet *ss, double d)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_FLOATSPANSET(ss, -1.0);
+  VALIDATE_FLOATSPANSET(ss, DBL_MAX);
   return DatumGetFloat8(distance_spanset_value(ss, Float8GetDatum(d)));
 }
 
@@ -1337,14 +1338,14 @@ distance_spanset_date(const SpanSet *ss, DateADT d)
  * @brief Return the distance in seconds between a span set and a timestamptz
  * @param[in] ss Span set
  * @param[in] t Value
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn #Distance_spanset_value()
  */
 double
 distance_spanset_timestamptz(const SpanSet *ss, TimestampTz t)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TSTZSPANSET(ss, -1.0);
+  VALIDATE_TSTZSPANSET(ss, DBL_MAX);
   return DatumGetFloat8(distance_spanset_value(ss, TimestampTzGetDatum(t)));
 }
 
@@ -1387,14 +1388,14 @@ distance_bigintspanset_bigintspan(const SpanSet *ss, const Span *s)
  * @brief Return the distance between a float span set and a span
  * @param[in] ss Spanset
  * @param[in] s Span
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn #Distance_spanset_span()
  */
 double
 distance_floatspanset_floatspan(const SpanSet *ss, const Span *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_FLOATSPANSET(ss, -1.0); VALIDATE_FLOATSPAN(s, -1.0);
+  VALIDATE_FLOATSPANSET(ss, DBL_MAX); VALIDATE_FLOATSPAN(s, DBL_MAX);
   return DatumGetFloat8(distance_spanset_span(ss, s));
 }
 
@@ -1420,14 +1421,14 @@ distance_datespanset_datespan(const SpanSet *ss, const Span *s)
  * span
  * @param[in] ss Spanset
  * @param[in] s Span
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn #Distance_spanset_span()
  */
 double
 distance_tstzspanset_tstzspan(const SpanSet *ss, const Span *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TSTZSPANSET(ss, -1.0); VALIDATE_TSTZSPAN(s, -1.0);
+  VALIDATE_TSTZSPANSET(ss, DBL_MAX); VALIDATE_TSTZSPAN(s, DBL_MAX);
   return DatumGetFloat8(distance_spanset_span(ss, s));
 }
 
@@ -1467,14 +1468,14 @@ distance_bigintspanset_bigintspanset(const SpanSet *ss1, const SpanSet *ss2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two float span sets
  * @param[in] ss1,ss2 Spanset
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn #Distance_spanset_spanset()
  */
 double
 distance_floatspanset_floatspanset(const SpanSet *ss1, const SpanSet *ss2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_FLOATSPANSET(ss1, -1.0); VALIDATE_FLOATSPANSET(ss2, -1.0);
+  VALIDATE_FLOATSPANSET(ss1, DBL_MAX); VALIDATE_FLOATSPANSET(ss2, DBL_MAX);
   return DatumGetFloat8(distance_spanset_spanset(ss1, ss2));
 }
 
@@ -1497,13 +1498,13 @@ distance_datespanset_datespanset(const SpanSet *ss1, const SpanSet *ss2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance in seconds between two timestamptz span sets
  * @param[in] ss1,ss2 Spanset
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn #Distance_spanset_spanset()
  */
 double
 distance_tstzspanset_tstzspanset(const SpanSet *ss1, const SpanSet *ss2)
 {
-  VALIDATE_TSTZSPANSET(ss1, -1.0); VALIDATE_TSTZSPANSET(ss2, -1.0);
+  VALIDATE_TSTZSPANSET(ss1, DBL_MAX); VALIDATE_TSTZSPANSET(ss2, DBL_MAX);
   return DatumGetFloat8(distance_spanset_spanset(ss1, ss2));
 }
 

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -3416,14 +3416,14 @@ temporal_stops(const Temporal *temp, double maxdist,
  * @ingroup meos_temporal_accessor
  * @brief Return the integral (area under the curve) of a temporal number
  * @param[in] temp Temporal value
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn #Tnumber_integral()
  */
 double
 tnumber_integral(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TNUMBER(temp, -1.0);
+  VALIDATE_TNUMBER(temp, DBL_MAX);
 
   assert(temptype_subtype(temp->subtype));
    switch (temp->subtype)

--- a/meos/src/temporal/temporal_analytics.c
+++ b/meos/src/temporal/temporal_analytics.c
@@ -2530,7 +2530,7 @@ tinstarr_average_hausdorff_distance(const TInstant **instants1, int count1,
  * @ingroup meos_temporal_analytics_similarity
  * @brief Return the average Hausdorff distance between two temporal values
  * @param[in] temp1,temp2 Temporal values
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn #Temporal_average_hausdorff_distance()
  */
 double
@@ -2539,7 +2539,7 @@ temporal_average_hausdorff_distance(const Temporal *temp1,
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_temporal_temporal(temp1, temp2))
-    return -1.0;
+    return DBL_MAX;
 
   int count1, count2;
   const TInstant **instants1 = temporal_insts_p(temp1, &count1);
@@ -2597,7 +2597,7 @@ tinstarr_lcss_distance(const TInstant **instants1, int count1,
  * temporal values
  * @param[in] temp1,temp2 Temporal values
  * @param[in] epsilon Maximum distance for two instants to match
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  * @csqlfn #Temporal_lcss_distance()
  */
 double
@@ -2606,7 +2606,7 @@ temporal_lcss_distance(const Temporal *temp1, const Temporal *temp2,
 {
   /* Ensure the validity of the arguments */
   if (epsilon < 0 || ! ensure_valid_temporal_temporal(temp1, temp2))
-    return -1.0;
+    return DBL_MAX;
 
   int count1, count2;
   const TInstant **instants1 = temporal_insts_p(temp1, &count1);

--- a/meos/src/temporal/tsequenceset.c
+++ b/meos/src/temporal/tsequenceset.c
@@ -36,6 +36,7 @@
 
 /* C */
 #include <assert.h>
+#include <float.h>
 /* PostgreSQL */
 #include <postgres.h>
 #include <varatt.h>
@@ -169,7 +170,7 @@ tseqarr_normalize(TSequence **sequences, int count, int *newcount)
  * @param[in] value1,value2 Values
  * @param[in] type Type of the values
  * @param[in] flags Flags
- * @return On error return -1.0
+ * @return On error return @p DBL_MAX
  */
 double
 datum_distance(Datum value1, Datum value2, MeosType type, int16 flags)
@@ -187,7 +188,7 @@ datum_distance(Datum value1, Datum value2, MeosType type, int16 flags)
 #endif
   meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
     "Unknown types for distance between values: %s", meostype_name(type));
-  return -1;
+  return DBL_MAX;
 }
 
 /*****************************************************************************

--- a/mobilitydb/src/cbuffer/tcbuffer_distance.c
+++ b/mobilitydb/src/cbuffer/tcbuffer_distance.c
@@ -62,6 +62,8 @@ Distance_cbuffer_geo(PG_FUNCTION_ARGS)
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(1);
   double result = distance_cbuffer_geo(cb, gs);
   PG_FREE_IF_COPY(gs, 1);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 
@@ -80,6 +82,8 @@ Distance_geo_cbuffer(PG_FUNCTION_ARGS)
   Cbuffer *cb = PG_GETARG_CBUFFER_P(1);
   double result = distance_cbuffer_geo(cb, gs);
   PG_FREE_IF_COPY(gs, 0);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 
@@ -100,6 +104,8 @@ Distance_cbuffer_stbox(PG_FUNCTION_ARGS)
   Cbuffer *cb = PG_GETARG_CBUFFER_P(0);
   STBox *box = PG_GETARG_STBOX_P(1);
   double result = distance_cbuffer_stbox(cb, box);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 
@@ -118,6 +124,8 @@ Distance_stbox_cbuffer(PG_FUNCTION_ARGS)
   STBox *box = PG_GETARG_STBOX_P(0);
   Cbuffer *cb = PG_GETARG_CBUFFER_P(1);
   double result = distance_cbuffer_stbox(cb, box);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 
@@ -135,6 +143,8 @@ Distance_cbuffer_cbuffer(PG_FUNCTION_ARGS)
   Cbuffer *cb1 = PG_GETARG_CBUFFER_P(0);
   Cbuffer *cb2 = PG_GETARG_CBUFFER_P(1);
   double result = distance_cbuffer_cbuffer(cb1, cb2);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 

--- a/mobilitydb/src/geo/tgeo_spatialfuncs.c
+++ b/mobilitydb/src/geo/tgeo_spatialfuncs.c
@@ -34,6 +34,7 @@
 
 /* C */
 #include <assert.h>
+#include <float.h>
 /* PostgreSQL */
 #include <postgres.h>
 #include <funcapi.h>
@@ -451,6 +452,8 @@ Tpoint_length(PG_FUNCTION_ARGS)
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   double result = tpoint_length(temp);
   PG_FREE_IF_COPY(temp, 0);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 

--- a/mobilitydb/src/npoint/npoint.c
+++ b/mobilitydb/src/npoint/npoint.c
@@ -37,6 +37,8 @@
 
 #include "npoint/tnpoint.h"
 
+/* C */
+#include <float.h>
 /* PostgreSQL */
 #include <postgres.h>
 #include <pgtypes.h>
@@ -565,7 +567,10 @@ Datum
 Npoint_position(PG_FUNCTION_ARGS)
 {
   Npoint *np = PG_GETARG_NPOINT_P(0);
-  PG_RETURN_FLOAT8(npoint_position(np));
+  double result = npoint_position(np);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
+  PG_RETURN_FLOAT8(result);
 }
 
 PGDLLEXPORT Datum Nsegment_route(PG_FUNCTION_ARGS);
@@ -593,7 +598,10 @@ Datum
 Nsegment_start_position(PG_FUNCTION_ARGS)
 {
   Nsegment *ns = PG_GETARG_NSEGMENT_P(0);
-  PG_RETURN_FLOAT8(nsegment_start_position(ns));
+  double result = nsegment_start_position(ns);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
+  PG_RETURN_FLOAT8(result);
 }
 
 PGDLLEXPORT Datum Nsegment_end_position(PG_FUNCTION_ARGS);
@@ -607,7 +615,10 @@ Datum
 Nsegment_end_position(PG_FUNCTION_ARGS)
 {
   Nsegment *ns = PG_GETARG_NSEGMENT_P(0);
-  PG_RETURN_FLOAT8(nsegment_end_position(ns));
+  double result = nsegment_end_position(ns);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
+  PG_RETURN_FLOAT8(result);
 }
 
 /*****************************************************************************

--- a/mobilitydb/src/npoint/tnpoint_spatialfuncs.c
+++ b/mobilitydb/src/npoint/tnpoint_spatialfuncs.c
@@ -33,6 +33,9 @@
  */
 
 /* PostgreSQL */
+/* C */
+#include <float.h>
+/* PostgreSQL */
 #include <postgres.h>
 /* MEOS */
 #include <meos.h>
@@ -82,6 +85,8 @@ Tnpoint_length(PG_FUNCTION_ARGS)
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   double result = tnpoint_length(temp);
   PG_FREE_IF_COPY(temp, 0);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 

--- a/mobilitydb/src/rgeo/trgeo_spatialfuncs.c
+++ b/mobilitydb/src/rgeo/trgeo_spatialfuncs.c
@@ -422,6 +422,8 @@ Trgeometry_length(PG_FUNCTION_ARGS)
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   double result = trgeometry_length(temp);
   PG_FREE_IF_COPY(temp, 0);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 

--- a/mobilitydb/src/temporal/temporal.c
+++ b/mobilitydb/src/temporal/temporal.c
@@ -36,6 +36,7 @@
 
 /* C */
 #include <assert.h>
+#include <float.h>
 /* PostgreSQL */
 #include <postgres.h>
 #include <pgtypes.h>
@@ -2870,6 +2871,8 @@ Tnumber_integral(PG_FUNCTION_ARGS)
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   double result = tnumber_integral(temp);
   PG_FREE_IF_COPY(temp, 0);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 

--- a/mobilitydb/src/temporal/temporal_analytics.c
+++ b/mobilitydb/src/temporal/temporal_analytics.c
@@ -36,6 +36,7 @@
 
 /* C */
 #include <assert.h>
+#include <float.h>
 /* PostgreSQL */
 #include <postgres.h>
 #include <funcapi.h>
@@ -196,6 +197,8 @@ Temporal_similarity(FunctionCallInfo fcinfo, SimFunc simfunc)
   }
   PG_FREE_IF_COPY(temp1, 0);
   PG_FREE_IF_COPY(temp2, 1);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 

--- a/mobilitydb/test/geo/expected/067_tpoint_similarity_lcss_hausdorff.test.out
+++ b/mobilitydb/test/geo/expected/067_tpoint_similarity_lcss_hausdorff.test.out
@@ -76,7 +76,7 @@ SELECT lcssDistance(
   -1.0);
  lcssdistance 
 --------------
-           -1
+             
 (1 row)
 
 SELECT round(averageHausdorffDistance(

--- a/mobilitydb/test/geo/queries/067_tpoint_similarity_lcss_hausdorff.test.sql
+++ b/mobilitydb/test/geo/queries/067_tpoint_similarity_lcss_hausdorff.test.sql
@@ -90,7 +90,7 @@ SELECT round(lcssDistance(
 -- LCSS distance — error paths (defensive validation)
 -------------------------------------------------------------------------------
 
--- Negative epsilon → returns -1.0
+-- Negative epsilon → returns NULL
 SELECT lcssDistance(
   tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',
   tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02]',


### PR DESCRIPTION
A double-returning MEOS function signals failure with a value outside its
result domain, and the codebase uses two of them.

`temporal_analytics.c` returns `DBL_MAX` from `temporal_hausdorff_distance` and
`temporal_frechet_distance` and `-1.0` from
`temporal_average_hausdorff_distance` and `temporal_lcss_distance`.
`temporal.c` returns `DBL_MAX` from `tnumber_twavg` and `-1.0` from
`tnumber_integral` twelve lines above it. `postgis_funcs.c` returns `DBL_MAX`
from `geom_length` and `geom_perimeter` while `tpoint_length` and
`stbox_perimeter` return `-1.0`.

`DBL_MAX` is the sentinel of the double-returning accessors — `floatspan_lower`,
`floatset_start_value`, `tfloat_min_value`, `float_get_bin`, `tnumber_twavg`,
`geom_length` — so the `-1.0` functions adopt it: the base-type distances of
cbuffer and pose, the set, span and spanset distances, the two similarity
distances, the box area, volume and perimeter, the temporal point, network
point and rigid geometry lengths, the network point and segment positions, the
float span and span set widths, the integral, and the two internal distance
helpers.

Four of them — `nsegment_start_position`, `nsegment_end_position`,
`tnpoint_length`, `trgeometry_length` — state no `@return` at all and carry the
sentinel only in their `VALIDATE_*` argument; they now document it like their
siblings. `tpoint_speed` returns `Temporal *` and documents `NULL`.

**Why the direction matters**

* For `tnumber_integral` a negative sentinel is ambiguous, not merely divergent:
  `tnumberseq_integral` accumulates `(max + min) * duration / 2`, so the
  integral of a temporal number with negative values is negative and `-1.0` is
  a value the function can legitimately return.
* A negative sentinel sorts BEFORE every real distance. Under a GiST/SPGiST
  KNN scan an error bound then wins the `ORDER BY ... LIMIT`, so the scan
  answers with the entries it could not compute. `DBL_MAX` sorts last.
* A binding derives its null condition from the wrapper return block, where
  `result < 0` is the guard of the three-valued integer predicates. `-1.0` on a
  double collides with it; uniform `DBL_MAX` makes the guard a function of the
  C return type alone.

**SQL**

The wrappers that surface those doubles map the sentinel to `NULL`, in the
shape `NAD_tgeo_tgeo` has. `Stbox_area`, `Stbox_volume` and `Stbox_perimeter`
already test `DBL_MAX`, so their guard is unreachable while MEOS answers
`-1.0`; it becomes live.

`lcssDistance` with a negative epsilon returns `NULL` rather than `-1`, and
`067_tpoint_similarity_lcss_hausdorff` records that.

The fraction-returning locators `cbuffersegm_locate`, `posesegm_locate` and
`line_locate_point` keep `-1.0`, where it means not located rather than failed,
and the integer and Datum distances keep `-1`, having no `DBL_MAX` to return.
