### PR TITLE
Read a GeoPose document as a pose and as a temporal pose

### DIFF
--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -514,6 +514,11 @@ pose_in(const char *str)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(str, NULL);
+  /* A leading brace marks a GeoPose document: the text form of a pose starts
+   * with POSE or GEODPOSE, so no pose text begins with one. The geometry input
+   * reads GeoJSON the same way */
+  if (str[0] == '{')
+    return pose_from_geopose(str);
   return pose_parse(&str, true);
 }
 

--- a/meos/src/pose/tpose.c
+++ b/meos/src/pose/tpose.c
@@ -179,6 +179,21 @@ Temporal *
 tpose_in(const char *str)
 {
   VALIDATE_NOT_NULL(str, NULL);
+  /* A brace opens a GeoPose document and also a sequence set, so unlike a pose
+   * the brace alone does not tell them apart. What follows it does: a JSON
+   * member name is quoted, whereas after the brace the temporal form holds a
+   * sequence or a pose, and a pose reads Pose(...), never quoted.
+   * This rests on the values of this type being unquoted. A type whose values
+   * are text carries a quote after the brace in its temporal form too, so the
+   * test does not carry over to one */
+  if (str[0] == '{')
+  {
+    const char *p = str + 1;
+    while (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r')
+      p++;
+    if (*p == '"')
+      return tpose_from_geopose(str);
+  }
   return tspatial_parse(&str, T_TPOSE);
 }
 

--- a/mobilitydb/src/pose/pose.c
+++ b/mobilitydb/src/pose/pose.c
@@ -77,7 +77,7 @@ Datum
 Pose_in(PG_FUNCTION_ARGS)
 {
   const char *str = PG_GETARG_CSTRING(0);
-  PG_RETURN_POINTER(pose_parse(&str, true));
+  PG_RETURN_POINTER(pose_in(str));
 }
 
 PGDLLEXPORT Datum Pose_out(PG_FUNCTION_ARGS);

--- a/mobilitydb/src/pose/tpose.c
+++ b/mobilitydb/src/pose/tpose.c
@@ -38,6 +38,7 @@
 #include <pgtypes.h>                  /* text_to_cstring / cstring_to_text */
 /* MEOS */
 #include <meos.h>
+#include <meos_pose.h>
 #include "temporal/set.h"
 #include "geo/tspatial_parser.h"
 #include "pose/pose.h"
@@ -78,7 +79,7 @@ Datum
 Tpose_in(PG_FUNCTION_ARGS)
 {
   const char *input = PG_GETARG_CSTRING(0);
-  Temporal *result = tspatial_parse(&input, T_TPOSE);
+  Temporal *result = tpose_in(input);
   PG_RETURN_POINTER(result);
 }
 

--- a/mobilitydb/test/pose/expected/103_pose_geopose.test.out
+++ b/mobilitydb/test/pose/expected/103_pose_geopose.test.out
@@ -189,3 +189,40 @@ SELECT asGeoPose(tpose '{[Pose(Point(8 47), 0)@2026-01-01, Pose(Point(9 48), 0.5
  {"type":"TemporalGeoPose","version":"1.0","conformance":"Basic-YPR","interpolation":"Linear","sequences":[{"lower_inc":true,"upper_inc":true,"instants":[{"position":{"lat":47,"lon":8,"h":0},"angles":{"yaw":0,"pitch":0,"roll":0},"validTime":"Thu Jan 01 00:00:00 2026 PST"},{"position":{"lat":48,"lon":9,"h":0},"angles":{"yaw":28.65,"pitch":0,"roll":0},"validTime":"Fri Jan 02 00:00:00 2026 PST"}]},{"lower_inc":true,"upper_inc":true,"instants":[{"position":{"lat":50,"lon":10,"h":0},"angles":{"yaw":57.3,"pitch":0,"roll":0},"validTime":"Sun Jan 04 00:00:00 2026 PST"},{"position":{"lat":51,"lon":11,"h":0},"angles":{"yaw":85.94,"pitch":0,"roll":0},"validTime":"Mon Jan 05 00:00:00 2026 PST"}]}]}
 (1 row)
 
+SELECT pose '{"position":{"lat":1.0,"lon":1.0,"h":1.0},"quaternion":{"x":0.5,"y":0.5,"z":0.5,"w":0.5}}';
+                                               pose                                               
+--------------------------------------------------------------------------------------------------
+ GEODPOSE(01010000A0E6100000000000000000F03F000000000000F03F000000000000F03F, 0.5, 0.5, 0.5, 0.5)
+(1 row)
+
+SELECT pose '{"position":{"lat":1.0,"lon":1.0,"h":1.0},"quaternion":{"x":0.5,"y":0.5,"z":0.5,"w":0.5}}' =
+  poseFromGeoPose('{"position":{"lat":1.0,"lon":1.0,"h":1.0},"quaternion":{"x":0.5,"y":0.5,"z":0.5,"w":0.5}}') AS same;
+ same 
+------
+ t
+(1 row)
+
+SELECT pose 'Pose(Point(8 47), 0)';
+                         pose                         
+------------------------------------------------------
+ POSE (010100000000000000000020400000000000804740, 0)
+(1 row)
+
+SELECT asText(tpose (asGeoPose(tpose 'Pose(Point(8 47), 0)@2026-01-01', 0, 6)));
+                             astext                              
+-----------------------------------------------------------------
+ GeodPose(POINT Z (8 47 0),1,0,0,0)@Thu Jan 01 00:00:00 2026 PST
+(1 row)
+
+SELECT asText(tpose '{Pose(Point(8 47), 0)@2026-01-01, Pose(Point(9 48), 0.5)@2026-01-02}');
+                                                 astext                                                 
+--------------------------------------------------------------------------------------------------------
+ {Pose(POINT(8 47),0)@Thu Jan 01 00:00:00 2026 PST, Pose(POINT(9 48),0.5)@Fri Jan 02 00:00:00 2026 PST}
+(1 row)
+
+SELECT asText(tpose '{[Pose(Point(8 47), 0)@2026-01-01, Pose(Point(9 48), 0.5)@2026-01-02], [Pose(Point(10 50), 1)@2026-01-04]}');
+                                                                            astext                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[Pose(POINT(8 47),0)@Thu Jan 01 00:00:00 2026 PST, Pose(POINT(9 48),0.5)@Fri Jan 02 00:00:00 2026 PST], [Pose(POINT(10 50),1)@Sun Jan 04 00:00:00 2026 PST]}
+(1 row)
+

--- a/mobilitydb/test/pose/queries/103_pose_geopose.test.sql
+++ b/mobilitydb/test/pose/queries/103_pose_geopose.test.sql
@@ -184,3 +184,23 @@ SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01, Pose(Poi
 
 -- TSequenceSet -> top-level sequences[].
 SELECT asGeoPose(tpose '{[Pose(Point(8 47), 0)@2026-01-01, Pose(Point(9 48), 0.5)@2026-01-02], [Pose(Point(10 50), 1)@2026-01-04, Pose(Point(11 51), 1.5)@2026-01-05]}', 1, 4);
+
+-------------------------------------------------------------------------------
+-- Reading a GeoPose document as a value of the type
+-------------------------------------------------------------------------------
+
+-- A pose reads a GeoPose document, giving what the explicit conversion gives.
+SELECT pose '{"position":{"lat":1.0,"lon":1.0,"h":1.0},"quaternion":{"x":0.5,"y":0.5,"z":0.5,"w":0.5}}';
+SELECT pose '{"position":{"lat":1.0,"lon":1.0,"h":1.0},"quaternion":{"x":0.5,"y":0.5,"z":0.5,"w":0.5}}' =
+  poseFromGeoPose('{"position":{"lat":1.0,"lon":1.0,"h":1.0},"quaternion":{"x":0.5,"y":0.5,"z":0.5,"w":0.5}}') AS same;
+
+-- The text form of a pose reads as before.
+SELECT pose 'Pose(Point(8 47), 0)';
+
+-- A temporal pose reads a GeoPose document too.
+SELECT asText(tpose (asGeoPose(tpose 'Pose(Point(8 47), 0)@2026-01-01', 0, 6)));
+
+-- A brace opens a sequence set as well, and one still reads as such: neither a
+-- set of instants nor a set of sequences is a GeoPose document.
+SELECT asText(tpose '{Pose(Point(8 47), 0)@2026-01-01, Pose(Point(9 48), 0.5)@2026-01-02}');
+SELECT asText(tpose '{[Pose(Point(8 47), 0)@2026-01-01, Pose(Point(9 48), 0.5)@2026-01-02], [Pose(Point(10 50), 1)@2026-01-04]}');


### PR DESCRIPTION
A GeoPose document reaches a pose only through `poseFromGeoPose`, and written as a value of
the type it fails.

The geometry input reads GeoJSON from a leading brace, and the pose input reads a GeoPose
document the same way, since the text form of a pose starts with `POSE` or `GEODPOSE` and so
never begins with a brace.

A temporal pose needs more than the brace, which also opens a sequence set: a JSON member name
is quoted, whereas after the brace the temporal form holds a sequence or a pose, and a pose
reads `Pose(...)`, never quoted.

This rests on the values of the type being unquoted, and does not carry over to a type whose
values are text.

The input functions of the extension call the MEOS entry points, so the behaviour is the
library's and every binding has it.
