### PR TITLE
Restore the licence wording in the JSON regression queries

### DIFF
--- a/mobilitydb/test/json/queries/450_jsonbset_tbl.test.sql
+++ b/mobilitydb/test/json/queries/450_jsonbset_tbl.test.sql
@@ -9,7 +9,7 @@
 -- Copyright (c) 2001-2025, PostGIS contributors
 --
 -- Permission to use, copy, modify, and distribute this software and its
--- documentation for any purjsonb, without fee, and without a written
+-- documentation for any purpose, without fee, and without a written
 -- agreement is hereby granted, provided that the above copyright notice and
 -- this paragraph and the following two paragraphs appear in all copies.
 --

--- a/mobilitydb/test/json/queries/451_jsonbset_jsonfuncs.test.sql
+++ b/mobilitydb/test/json/queries/451_jsonbset_jsonfuncs.test.sql
@@ -9,7 +9,7 @@
 -- Copyright (c) 2001-2025, PostGIS contributors
 --
 -- Permission to use, copy, modify, and distribute this software and its
--- documentation for any purjsonb, without fee, and without a written
+-- documentation for any purpose, without fee, and without a written
 -- agreement is hereby granted, provided that the above copyright notice and
 -- this paragraph and the following two paragraphs appear in all copies.
 --
@@ -21,7 +21,7 @@
 --
 -- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
 -- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
--- AND FITNESS FOR A PARTICULAR PURjsonb. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
 -- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
 -- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 --

--- a/mobilitydb/test/json/queries/452_tjsonb.test.sql
+++ b/mobilitydb/test/json/queries/452_tjsonb.test.sql
@@ -9,7 +9,7 @@
 -- Copyright (c) 2001-2025, PostGIS contributors
 --
 -- Permission to use, copy, modify, and distribute this software and its
--- documentation for any purjsonb, without fee, and without a written
+-- documentation for any purpose, without fee, and without a written
 -- agreement is hereby granted, provided that the above copyright notice and
 -- this paragraph and the following two paragraphs appear in all copies.
 --
@@ -21,7 +21,7 @@
 --
 -- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
 -- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
--- AND FITNESS FOR A PARTICULAR PURjsonb. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
 -- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
 -- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 --

--- a/mobilitydb/test/json/queries/454_tjsonb_jsonfuncs.test.sql
+++ b/mobilitydb/test/json/queries/454_tjsonb_jsonfuncs.test.sql
@@ -9,7 +9,7 @@
 -- Copyright (c) 2001-2025, PostGIS contributors
 --
 -- Permission to use, copy, modify, and distribute this software and its
--- documentation for any purjsonb, without fee, and without a written
+-- documentation for any purpose, without fee, and without a written
 -- agreement is hereby granted, provided that the above copyright notice and
 -- this paragraph and the following two paragraphs appear in all copies.
 --
@@ -21,7 +21,7 @@
 --
 -- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
 -- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
--- AND FITNESS FOR A PARTICULAR PURjsonb. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
 -- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
 -- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 --

--- a/mobilitydb/test/json/queries/456_tjsonb_op.test.sql
+++ b/mobilitydb/test/json/queries/456_tjsonb_op.test.sql
@@ -9,7 +9,7 @@
 -- Copyright (c) 2001-2025, PostGIS contributors
 --
 -- Permission to use, copy, modify, and distribute this software and its
--- documentation for any purjsonb, without fee, and without a written
+-- documentation for any purpose, without fee, and without a written
 -- agreement is hereby granted, provided that the above copyright notice and
 -- this paragraph and the following two paragraphs appear in all copies.
 --
@@ -21,7 +21,7 @@
 --
 -- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
 -- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
--- AND FITNESS FOR A PARTICULAR PURjsonb. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
 -- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
 -- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 --

--- a/mobilitydb/test/json/queries/460_tjsonb_topops_tbl.test.sql
+++ b/mobilitydb/test/json/queries/460_tjsonb_topops_tbl.test.sql
@@ -9,7 +9,7 @@
 -- Copyright (c) 2001-2025, PostGIS contributors
 --
 -- Permission to use, copy, modify, and distribute this software and its
--- documentation for any purjsonb, without fee, and without a written
+-- documentation for any purpose, without fee, and without a written
 -- agreement is hereby granted, provided that the above copyright notice and
 -- this paragraph and the following two paragraphs appear in all copies.
 --

--- a/mobilitydb/test/json/queries/462_tjsonb_posops_tbl.test.sql
+++ b/mobilitydb/test/json/queries/462_tjsonb_posops_tbl.test.sql
@@ -9,7 +9,7 @@
 -- Copyright (c) 2001-2025, PostGIS contributors
 --
 -- Permission to use, copy, modify, and distribute this software and its
--- documentation for any purjsonb, without fee, and without a written
+-- documentation for any purpose, without fee, and without a written
 -- agreement is hereby granted, provided that the above copyright notice and
 -- this paragraph and the following two paragraphs appear in all copies.
 --


### PR DESCRIPTION
Seven JSON test files read `for any purjsonb` and `FITNESS FOR A PARTICULAR PURjsonb` — eleven occurrences where a search and replace of `pose` by `jsonb`, from the time the family was derived, reached the word `purpose` inside the licence header the whole tree shares:

```
mobilitydb/test/json/queries/450_jsonbset_tbl.test.sql
mobilitydb/test/json/queries/451_jsonbset_jsonfuncs.test.sql
mobilitydb/test/json/queries/452_tjsonb.test.sql
mobilitydb/test/json/queries/454_tjsonb_jsonfuncs.test.sql
mobilitydb/test/json/queries/456_tjsonb_op.test.sql
mobilitydb/test/json/queries/460_tjsonb_topops_tbl.test.sql
mobilitydb/test/json/queries/462_tjsonb_posops_tbl.test.sql
```

They read `purpose` and `PURPOSE` again, matching every other test file.

`pg_regress` does not echo the header, so no expected output changes: the wording appears zero times under `mobilitydb/test/json/expected/`. Nothing outside those seven headers is touched, and no other occurrence of the pattern remains in the tree.

The `license_check` job passes either way, since `licensecheck` identifies which licence a header carries rather than comparing its text, so a mangled word inside the paragraph does not register.
