### PR TITLE
Call the library input functions from the type input wrappers

### DIFF
--- a/mobilitydb/src/cbuffer/cbuffer.c
+++ b/mobilitydb/src/cbuffer/cbuffer.c
@@ -75,7 +75,7 @@ Datum
 Cbuffer_in(PG_FUNCTION_ARGS)
 {
   const char *str = PG_GETARG_CSTRING(0);
-  PG_RETURN_CBUFFER_P(cbuffer_parse(&str, true));
+  PG_RETURN_CBUFFER_P(cbuffer_in(str));
 }
 
 PGDLLEXPORT Datum Cbuffer_out(PG_FUNCTION_ARGS);

--- a/mobilitydb/src/cbuffer/tcbuffer.c
+++ b/mobilitydb/src/cbuffer/tcbuffer.c
@@ -102,7 +102,7 @@ Datum
 Tcbuffer_in(PG_FUNCTION_ARGS)
 {
   const char *input = PG_GETARG_CSTRING(0);
-  Temporal *result = tspatial_parse(&input, T_TCBUFFER);
+  Temporal *result = tcbuffer_in(input);
   PG_RETURN_TEMPORAL_P(result);
 }
 

--- a/mobilitydb/src/geo/stbox.c
+++ b/mobilitydb/src/geo/stbox.c
@@ -43,6 +43,7 @@
 #include <lib/stringinfo.h>
 /* MEOS */
 #include <meos.h>
+#include <meos_geo.h>
 #include <meos_internal.h>
 #include <meos_internal_geo.h>
 #include "temporal/set.h"
@@ -74,7 +75,7 @@ Datum
 Stbox_in(PG_FUNCTION_ARGS)
 {
   const char *str = PG_GETARG_CSTRING(0);
-  PG_RETURN_STBOX_P(stbox_parse(&str));
+  PG_RETURN_STBOX_P(stbox_in(str));
 }
 
 PGDLLEXPORT Datum Stbox_out(PG_FUNCTION_ARGS);

--- a/mobilitydb/src/npoint/npoint.c
+++ b/mobilitydb/src/npoint/npoint.c
@@ -48,6 +48,7 @@
 #include <liblwgeom.h>
 /* MEOS */
 #include <meos.h>
+#include <meos_npoint.h>
 #include <meos_internal.h>
 #include "temporal/set.h"
 #include "temporal/span.h"
@@ -140,7 +141,7 @@ Datum
 Npoint_in(PG_FUNCTION_ARGS)
 {
   const char *str = PG_GETARG_CSTRING(0);
-  PG_RETURN_NPOINT_P(npoint_parse(&str, true));
+  PG_RETURN_NPOINT_P(npoint_in(str));
 }
 
 PGDLLEXPORT Datum Npoint_out(PG_FUNCTION_ARGS);


### PR DESCRIPTION
The input wrappers of four types (`Cbuffer_in`, `Tcbuffer_in`, `Stbox_in`, `Npoint_in`) re-call the parser that the corresponding library function already wraps. Calling the library function instead keeps the reading identical and adds the null check it performs. The wrappers of the other types already read their values this way, so this makes the four match them. Reading these types then lives in the library, where the other bindings reach it.

`stbox.c` and `npoint.c` needed an added include for the umbrella header declaring the library function (`meos_geo.h` and `meos_npoint.h` respectively); `cbuffer.c` and `tcbuffer.c` already included the header they needed.
