### PR TITLE
Return NULL from the SQL functions that surface a distance sentinel

### DIFF
--- a/mobilitydb/src/cbuffer/cbuffer.c
+++ b/mobilitydb/src/cbuffer/cbuffer.c
@@ -32,6 +32,8 @@
  * @brief Static circular buffer type
  */
 
+/* C */
+#include <float.h>
 /* PostgreSQL */
 #include <postgres.h>
 #include <pgtypes.h>
@@ -393,7 +395,10 @@ Datum
 Cbuffer_radius(PG_FUNCTION_ARGS)
 {
   Cbuffer *cb = PG_GETARG_CBUFFER_P(0);
-  PG_RETURN_FLOAT8(cbuffer_radius(cb));
+  double result = cbuffer_radius(cb);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
+  PG_RETURN_FLOAT8(result);
 }
 
 /*****************************************************************************

--- a/mobilitydb/src/cbuffer/tcbuffer_distance.c
+++ b/mobilitydb/src/cbuffer/tcbuffer_distance.c
@@ -384,6 +384,8 @@ NAD_cbuffer_stbox(PG_FUNCTION_ARGS)
   Cbuffer *cb = PG_GETARG_CBUFFER_P(0);
   STBox *box = PG_GETARG_STBOX_P(1);
   double result = nad_cbuffer_stbox(cb, box);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 

--- a/mobilitydb/src/npoint/tnpoint_distance.c
+++ b/mobilitydb/src/npoint/tnpoint_distance.c
@@ -319,6 +319,8 @@ NAD_stbox_tnpoint(PG_FUNCTION_ARGS)
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
   double result = nad_tnpoint_stbox(temp, box);
   PG_FREE_IF_COPY(temp, 1);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 
@@ -338,6 +340,8 @@ NAD_tnpoint_stbox(PG_FUNCTION_ARGS)
   STBox *box = PG_GETARG_STBOX_P(1);
   double result = nad_tnpoint_stbox(temp, box);
   PG_FREE_IF_COPY(temp, 0);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 
@@ -357,6 +361,8 @@ NAD_npoint_tnpoint(PG_FUNCTION_ARGS)
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
   double result = nad_tnpoint_npoint(temp, np);
   PG_FREE_IF_COPY(temp, 1);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 
@@ -376,6 +382,8 @@ NAD_tnpoint_npoint(PG_FUNCTION_ARGS)
   Npoint *np = PG_GETARG_NPOINT_P(1);
   double result = nad_tnpoint_npoint(temp, np);
   PG_FREE_IF_COPY(temp, 0);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 

--- a/mobilitydb/src/pointcloud/tpc_boxops.c
+++ b/mobilitydb/src/pointcloud/tpc_boxops.c
@@ -47,6 +47,8 @@
  * directly.
  */
 
+/* C */
+#include <float.h>
 /* PostgreSQL */
 #include <postgres.h>
 #include <fmgr.h>
@@ -427,7 +429,10 @@ NAD_tpcbox_tpcbox(PG_FUNCTION_ARGS)
 {
   TPCBox *box1 = PG_GETARG_TPCBOX_P(0);
   TPCBox *box2 = PG_GETARG_TPCBOX_P(1);
-  PG_RETURN_FLOAT8(nad_tpcbox_tpcbox(box1, box2));
+  double result = nad_tpcbox_tpcbox(box1, box2);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
+  PG_RETURN_FLOAT8(result);
 }
 
 PGDLLEXPORT Datum NAD_tpointcloud_tpcbox(PG_FUNCTION_ARGS);
@@ -445,6 +450,8 @@ NAD_tpointcloud_tpcbox(PG_FUNCTION_ARGS)
   TPCBox *box = PG_GETARG_TPCBOX_P(1);
   double result = nad_tpointcloud_tpcbox(temp, box);
   PG_FREE_IF_COPY(temp, 0);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 
@@ -463,6 +470,8 @@ NAD_tpcbox_tpointcloud(PG_FUNCTION_ARGS)
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
   double result = nad_tpointcloud_tpcbox(temp, box);
   PG_FREE_IF_COPY(temp, 1);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 
@@ -482,6 +491,8 @@ NAD_tpointcloud_tpointcloud(PG_FUNCTION_ARGS)
   double result = nad_tpointcloud_tpointcloud(temp1, temp2);
   PG_FREE_IF_COPY(temp1, 0);
   PG_FREE_IF_COPY(temp2, 1);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 

--- a/mobilitydb/src/pose/pose.c
+++ b/mobilitydb/src/pose/pose.c
@@ -34,6 +34,7 @@
 
 /* C */
 #include <assert.h>
+#include <float.h>
 #include <math.h>
 /* PostgreSQL */
 #include <postgres.h>
@@ -529,7 +530,10 @@ Datum
 Pose_rotation(PG_FUNCTION_ARGS)
 {
   Pose *pose = PG_GETARG_POSE_P(0);
-  PG_RETURN_FLOAT8(pose_rotation(pose));
+  double result = pose_rotation(pose);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
+  PG_RETURN_FLOAT8(result);
 }
 
 PGDLLEXPORT Datum Pose_orientation(PG_FUNCTION_ARGS);
@@ -583,6 +587,8 @@ Pose_yaw(PG_FUNCTION_ARGS)
   Pose *pose = PG_GETARG_POSE_P(0);
   double result = pose_yaw(pose);
   PG_FREE_IF_COPY(pose, 0);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 
@@ -599,6 +605,8 @@ Pose_pitch(PG_FUNCTION_ARGS)
   Pose *pose = PG_GETARG_POSE_P(0);
   double result = pose_pitch(pose);
   PG_FREE_IF_COPY(pose, 0);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 
@@ -615,6 +623,8 @@ Pose_roll(PG_FUNCTION_ARGS)
   Pose *pose = PG_GETARG_POSE_P(0);
   double result = pose_roll(pose);
   PG_FREE_IF_COPY(pose, 0);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 

--- a/mobilitydb/src/pose/tpose_distance.c
+++ b/mobilitydb/src/pose/tpose_distance.c
@@ -360,6 +360,8 @@ NAD_pose_tpose(PG_FUNCTION_ARGS)
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
   double result = nad_tpose_pose(temp, pose);
   PG_FREE_IF_COPY(temp, 1);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 
@@ -379,6 +381,8 @@ NAD_tpose_pose(PG_FUNCTION_ARGS)
   Pose *pose = PG_GETARG_POSE_P(1);
   double result = nad_tpose_pose(temp, pose);
   PG_FREE_IF_COPY(temp, 0);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 

--- a/mobilitydb/src/temporal/temporal.c
+++ b/mobilitydb/src/temporal/temporal.c
@@ -2889,6 +2889,8 @@ Tnumber_twavg(PG_FUNCTION_ARGS)
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   double result = tnumber_twavg(temp);
   PG_FREE_IF_COPY(temp, 0);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 

--- a/mobilitydb/src/temporal/tnumber_distance.c
+++ b/mobilitydb/src/temporal/tnumber_distance.c
@@ -127,6 +127,8 @@ NAD_number_tnumber(PG_FUNCTION_ARGS)
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
   double result = nad_tnumber_number(temp, value);
   PG_FREE_IF_COPY(temp, 1);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 
@@ -146,6 +148,8 @@ NAD_tnumber_number(PG_FUNCTION_ARGS)
   Datum value = PG_GETARG_DATUM(1);
   double result = nad_tnumber_number(temp, value);
   PG_FREE_IF_COPY(temp, 0);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
   PG_RETURN_FLOAT8(result);
 }
 

--- a/mobilitydb/test/pointcloud/expected/440_tpc_distance.test.out
+++ b/mobilitydb/test/pointcloud/expected/440_tpc_distance.test.out
@@ -31,7 +31,7 @@ SELECT (tpcpoint(PC_MakePoint(1, ARRAY[0.0, 0.0, 0.0]::float[]), '2024-01-01'::t
 SELECT (tpcpoint(PC_MakePoint(1, ARRAY[0.0, 0.0, 0.0]::float[]),
                  '2024-01-01'::timestamptz)) |=|
        (tpcbox_zt(0, 0, 0, 0, 0, 0,
-                  tstzspan '[2099-01-01, 2099-01-02]', 1, 0)) > 1e10;
+                  tstzspan '[2099-01-01, 2099-01-02]', 1, 0)) IS NULL;
  ?column? 
 ----------
  t

--- a/mobilitydb/test/pointcloud/queries/440_tpc_distance.test.sql
+++ b/mobilitydb/test/pointcloud/queries/440_tpc_distance.test.sql
@@ -35,11 +35,11 @@ SELECT (:box_at_origin) |=| (:box_at_origin);
 -- Distance from a point to a box at the same location is zero.
 SELECT (:p1) |=| (:box_at_origin);
 
--- Disjoint time spans yield infinity.
+-- Disjoint time spans yield NULL, as the temporal geo nearest approach does.
 SELECT (tpcpoint(PC_MakePoint(1, ARRAY[0.0, 0.0, 0.0]::float[]),
                  '2024-01-01'::timestamptz)) |=|
        (tpcbox_zt(0, 0, 0, 0, 0, 0,
-                  tstzspan '[2099-01-01, 2099-01-02]', 1, 0)) > 1e10;
+                  tstzspan '[2099-01-01, 2099-01-02]', 1, 0)) IS NULL;
 
 -- Pcid mismatch is an error: values of two schemas cannot be compared.
 SELECT (:p1) |=| (tpcbox_zt(0, 0, 0, 0, 0, 0,


### PR DESCRIPTION
A double-returning MEOS function signals failure with `DBL_MAX`, and the SQL
wrapper turns that into a NULL. `NAD_tgeo_tgeo`, `Stbox_area` and the temporal
circular buffer distances all end with

```c
  if (result == DBL_MAX)
    PG_RETURN_NULL();
  PG_RETURN_FLOAT8(result);
```

Nineteen wrappers hand the sentinel to SQL instead, so a call that cannot answer
reads as a distance of `1.7976931348623157e+308`: the nearest-approach distances
of the temporal network point, pose, pointcloud, circular buffer and number
families, the pose rotation, yaw, pitch and roll angles, the circular buffer
radius, and the time-weighted average. They now carry the same guard.

This is also what the generated bindings read: a binding derives its SQL-NULL
condition from the wrapper's return block, so a wrapper without the guard
teaches every binding that the sentinel is a value.

**Tests**

`440_tpc_distance` covers a temporal pointcloud value and a TPCBox whose time
frames do not intersect. `nad_tpcbox_tpcbox` returns infinity there, and the SQL
surface now answers NULL, as `nearestApproachDistance` does for temporal geos —
`064_tpoint_distance_tbl` already relies on that with `WHERE t1.temp |=| t2.temp
IS NOT NULL`. The case asserts `IS NULL` rather than comparing the sentinel
against `1e10`, so it states the contract instead of evaluating to NULL.
