### PR TITLE
Derive string ownership in the smoke tests from the declared return type

### DIFF
--- a/tools/codegen/gen_smoketest/gen_smoketest.py
+++ b/tools/codegen/gen_smoketest/gen_smoketest.py
@@ -149,6 +149,17 @@ def emit_call(fname, ret, args, arg_map, skip_map, override_args,
     ret = cleanup_type(ret)
     decl_ret = ("const " + ret) if is_const_ret else ret
     if ret == "char *":
+        # A string return declared `const char *` is a BORROWED string: MEOS
+        # returns a pointer into static storage (e.g. the geometry type-name
+        # table behind geo_typename, or a catalog enum-name array) or into a
+        # long-lived cache, never a fresh copy the caller owns. A fresh string
+        # is declared `char *`. The declared return type is therefore the
+        # ownership signal, and it is read straight off the header — no
+        # per-function list to maintain as the API grows.
+        if is_const_ret or fname in no_free:
+            return (f"  {{ {decl_ret} r = {call};\n"
+                    f"    printf(\"{fname}: %s\\n\", r ? r : \"NULL\");\n"
+                    f"    /* {fname} returns a borrowed string; do NOT free */ }}\n")
         return (f"  {{ char *r = {call};\n"
                 f"    printf(\"{fname}: %s\\n\", r ? r : \"NULL\");\n"
                 f"    if (r) free(r); }}\n")
@@ -866,8 +877,6 @@ TGEOMETRY_CONFIG = dict(
         "re:_to_geography$": "needs spatial_ref_sys CSV",
         # Out-params with non-uniform shape (e.g. GSERIALIZED ***).
         "re:^geo_array_": "out-param triple-pointer not in canned set",
-        # Returns a static string literal — free()ing it crashes.
-        "geo_typename":   "returns static string; free() is invalid",
         # Constructors that crash on LINEAR interp default for a span/spanset
         # input — the canned tstzspanset has gaps which the kernel rejects.
         # Refining requires per-function interp arg overrides.


### PR DESCRIPTION
A MEOS function declared `const char *` returns a borrowed string: a pointer
into static storage, such as the geometry type-name table behind
`geo_typename` or a catalog enum-name array, or into a long-lived cache. Only
a `char *` return is a fresh copy the caller owns. Freeing a borrowed string
aborts with `free(): invalid pointer`.

The declared return qualifier is therefore the ownership signal, and the
generator already computes it. This makes the `char *` branch honour it, so
the rule comes straight off the header and covers every present and future
borrow-returning accessor without a hand-maintained list: `geo_typename`,
`temporal_subtype`, `temporal_interp`, `temporal_basetype_name`,
`meos_pc_schema_xml`, and the catalog `tempsubtype_name` / `meostype_name` /
`interptype_name` / `meosoper_name` family. The same branch also honours
`no_free` for string results, which the `char *` case shadows by returning
ahead of it.

With the rule in place `geo_typename` needs no skip and is exercised for
real, emitting

    { const char * r = geo_typename(1);
      printf("geo_typename: %s\n", r ? r : "NULL");
      /* geo_typename returns a borrowed string; do NOT free */ }

which prints `geo_typename: Point`.

`geo_typename` keeps its signature and its borrow semantics, matching every
other `const char *` accessor in the public API, so no MEOS source changes.

All six generated suites emit exactly the same `free()` calls as before
(163 / 84 / 77 / 43 / 126 / 64), the only diff in any generated file is the
`geo_typename` call site in place of its skip comment, and valgrind reports
an identical error profile with zero invalid frees.