### PR TITLE
Hold the format picture caches where their references live

### DIFF
--- a/mobilitydb/test/json/expected/451_jsonbset_jsonfuncs.test.out
+++ b/mobilitydb/test/json/expected/451_jsonbset_jsonfuncs.test.out
@@ -421,6 +421,19 @@ SELECT jsonbsetPathMatch(jsonbset '{"{\"d\": \"2001-01-01\"}", "{\"d\": \"1999-0
  {t,f}
 (1 row)
 
+/* Every datetime comparison in a session parses its format afresh */
+SELECT jsonbsetPathMatchTz(jsonbset '{"{\"d\": \"2001-01-01\"}", "{\"d\": \"1999-01-01\"}"}', '$.d.datetime() > "2000-06-01".datetime()');
+ jsonbsetpathmatchtz 
+---------------------
+ {t,f}
+(1 row)
+
+SELECT jsonbsetPathExists(jsonbset '{"{\"d\": \"2001-01-01\"}"}', '$.d.datetime() > "2000-06-01".datetime()');
+ jsonbsetpathexists 
+--------------------
+ {t}
+(1 row)
+
 /* A path matching nothing is unknown, that is, false, for every element */
 SELECT jsonbsetPathMatch(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.xxx > 15', '{}', false);
  jsonbsetpathmatch 

--- a/mobilitydb/test/json/queries/451_jsonbset_jsonfuncs.test.sql
+++ b/mobilitydb/test/json/queries/451_jsonbset_jsonfuncs.test.sql
@@ -162,6 +162,9 @@ SELECT jsonbsetPathMatchTz(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"unit
 
 /* .datetime() casts a JSON string to a date/time value for comparison */
 SELECT jsonbsetPathMatch(jsonbset '{"{\"d\": \"2001-01-01\"}", "{\"d\": \"1999-01-01\"}"}', '$.d.datetime() > "2000-06-01".datetime()');
+/* Every datetime comparison in a session parses its format afresh */
+SELECT jsonbsetPathMatchTz(jsonbset '{"{\"d\": \"2001-01-01\"}", "{\"d\": \"1999-01-01\"}"}', '$.d.datetime() > "2000-06-01".datetime()');
+SELECT jsonbsetPathExists(jsonbset '{"{\"d\": \"2001-01-01\"}"}', '$.d.datetime() > "2000-06-01".datetime()');
 
 /* A path matching nothing is unknown, that is, false, for every element */
 SELECT jsonbsetPathMatch(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.xxx > 15', '{}', false);

--- a/pgtypes/utils/formatting.c
+++ b/pgtypes/utils/formatting.c
@@ -78,7 +78,13 @@
 #include "utils/numeric.h"
 #include "utils/pg_locale.h"
 #include "utils/timestamp.h"
+#include "utils/palloc.h"  /* MEOS: MemoryContext + MemoryContextAllocZero (backend build) */
 // #include "varatt.h"
+
+/* MEOS: the vendored memutils.h omits this backend global; declare it locally,
+ * as dynahash.c, pg_locale.c and jsonpath_exec.c do, so the extension can hold
+ * the format picture caches in a persistent context (see DCH_cache_getnew). */
+extern PGDLLIMPORT MemoryContext TopMemoryContext;
 
 #include "pgtypes.h"
 #include "../../meos/include/meos_error.h"
@@ -3744,8 +3750,20 @@ DCH_cache_getnew(const char *str, bool std)
   else
   {
     Assert(DCHCache[n_DCHCache] == NULL);
+    /*
+     * The entry outlives the call: DCHCache and n_DCHCache keep referring to
+     * it so a later parse of the same format picture reuses the parsed nodes.
+     * In the PostgreSQL extension the first parse typically runs in a
+     * per-tuple context, which resets while the entry stays counted, leaving
+     * the pointer dangling and the parsed format garbage. Allocate where the
+     * entry lives as long as the reference does.
+     */
     DCHCache[n_DCHCache] = ent = (DCHCacheEntry *)
+#if MEOS
       palloc0(sizeof(DCHCacheEntry));
+#else
+      MemoryContextAllocZero(TopMemoryContext, sizeof(DCHCacheEntry));
+#endif /* MEOS */
     ent->valid = false;
     strlcpy(ent->str, str, DCH_CACHE_SIZE + 1);
     ent->std = std;
@@ -4756,8 +4774,13 @@ NUM_cache_getnew(const char *str)
   else
   {
     Assert(NUMCache[n_NUMCache] == NULL);
+    /* The entry outlives the call, as for the date/time cache above */
     NUMCache[n_NUMCache] = ent = (NUMCacheEntry *)
+#if MEOS
       palloc0(sizeof(NUMCacheEntry));
+#else
+      MemoryContextAllocZero(TopMemoryContext, sizeof(NUMCacheEntry));
+#endif /* MEOS */
     ent->valid = false;
     strlcpy(ent->str, str, NUM_CACHE_SIZE + 1);
     ent->age = (++NUMCounter);


### PR DESCRIPTION
The first datetime comparison of a session answers correctly and every later one fails. In a fresh session,

```
SELECT jsonbsetPathMatch(jsonbset '{"{\"d\": \"2001-01-01\"}"}',
  '$.d.datetime() > "2000-06-01".datetime()');
 {t}
```

while the same comparison issued second — under any of `jsonbsetPathMatch`, `jsonbsetPathMatchTz`, `jsonbsetPathExists` or `jsonbsetPathExistsTz` — raises `trailing characters remain in input string after datetime format`, or `input string is too short for datetime format`. The function is immaterial: what matters is whether a format picture has been parsed earlier in the session.

`DCH_cache_getnew` and `NUM_cache_getnew` allocate their entry with `palloc`, so the entry belongs to the current memory context, while `DCHCache` and `NUMCache` keep pointing at it and `n_DCHCache` and `n_NUMCache` keep counting it. In the extension the first parse of a picture typically runs in a per-tuple context; once that context resets, the cache search walks a freed entry, matches its format string, and returns parsed nodes that no longer describe the picture — so the next parse of the very same picture reports the input as malformed. The standalone library never resets a context under the caches.

The entries are now allocated where they live as long as the reference does. The local declaration of `TopMemoryContext` follows `dynahash.c`, `pg_locale.c` and `jsonpath_exec.c`, which state the same reason for the same backend global; the last of those pins the format *text* cache of the same code, and this pins the *parsed* format cache one level down.

The regression queries cover a second and a third datetime comparison in the session, which this surface could not reach before: `jsonbsetPathMatchTz` returns `{t,f}`, matching PostgreSQL's own `jsonb_path_match_tz` on the same data, and `to_char` over both the datetime and the numeric cache is unchanged.

Receipt: strict-ci green on the committed tree — both targets clean, zero warnings, `pg_regress` all tests passed.
