### PR TITLE
Name the SQL function each temporal comparison and restriction corresponds to

### DIFF
--- a/meos/src/cbuffer/tcbuffer.c
+++ b/meos/src/cbuffer/tcbuffer.c
@@ -1449,7 +1449,7 @@ tcbuffer_restrict_cbuffer(const Temporal *temp, const Cbuffer *cb, bool atfunc)
  * @brief Return a temporal circular buffer restricted to a circular buffer
  * @param[in] temp Temporal value
  * @param[in] cb Value
- * @csqlfn #Temporal_at_value()
+ * @csqlfn #Tcbuffer_at_cbuffer()
  */
 Temporal *
 tcbuffer_at_cbuffer(const Temporal *temp, const Cbuffer *cb)
@@ -1463,7 +1463,7 @@ tcbuffer_at_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * circular buffer
  * @param[in] temp Temporal value
  * @param[in] cb Value
- * @csqlfn #Temporal_minus_value()
+ * @csqlfn #Tcbuffer_minus_cbuffer()
  */
 Temporal *
 tcbuffer_minus_cbuffer(const Temporal *temp, const Cbuffer *cb)

--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -1788,7 +1788,7 @@ nad_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
  * and a spatiotemporal box
  * @param[in] temp Temporal circular buffer
  * @param[in] box Spatiotemporal box
- * @csqlfn #NAD_tcbuffer_geo()
+ * @csqlfn #NAD_tcbuffer_stbox()
  */
 double
 nad_tcbuffer_stbox(const Temporal *temp, const STBox *box)

--- a/meos/src/json/tjsonb_compops.c
+++ b/meos/src/json/tjsonb_compops.c
@@ -53,7 +53,7 @@
  * @brief Return true if a JSONB is ever equal to a temporal JSONB
  * @param[in] jb JSONB value
  * @param[in] temp Temporal JSONB
- * @csqlfn #Ever_eq_base_temporal()
+ * @csqlfn #Ever_eq_jsonb_tjsonb()
  */
 int
 ever_eq_jsonb_tjsonb(const Jsonb *jb, const Temporal *temp)
@@ -68,7 +68,7 @@ ever_eq_jsonb_tjsonb(const Jsonb *jb, const Temporal *temp)
  * @brief Return true if a temporal JSONB is ever equal to a JSONB
  * @param[in] temp Temporal JSONB
  * @param[in] jb JSONB value
- * @csqlfn #Ever_eq_temporal_base()
+ * @csqlfn #Ever_eq_tjsonb_jsonb()
  */
 int
 ever_eq_tjsonb_jsonb(const Temporal *temp, const Jsonb *jb)
@@ -83,7 +83,7 @@ ever_eq_tjsonb_jsonb(const Temporal *temp, const Jsonb *jb)
  * @brief Return true if a JSONB is always equal to a temporal JSONB
  * @param[in] jb JSONB
  * @param[in] temp Temporal JSONB
- * @csqlfn #Always_eq_base_temporal()
+ * @csqlfn #Always_eq_jsonb_tjsonb()
  */
 int
 always_eq_jsonb_tjsonb(const Jsonb *jb, const Temporal *temp)
@@ -98,7 +98,7 @@ always_eq_jsonb_tjsonb(const Jsonb *jb, const Temporal *temp)
  * @brief Return true if a temporal JSONB is always equal to a JSONB
  * @param[in] temp Temporal JSONB
  * @param[in] jb JSONB
- * @csqlfn #Always_eq_temporal_base()
+ * @csqlfn #Always_eq_tjsonb_jsonb()
  */
 int
 always_eq_tjsonb_jsonb(const Temporal *temp, const Jsonb *jb)
@@ -165,7 +165,7 @@ always_ne_tjsonb_tjsonb(const Temporal *temp1, const Temporal *temp2)
  * @brief Return true if a JSONB is ever different from a temporal JSONB
  * @param[in] jb JSONB
  * @param[in] temp Temporal JSONB
- * @csqlfn #Ever_ne_base_temporal()
+ * @csqlfn #Ever_ne_jsonb_tjsonb()
  */
 int
 ever_ne_jsonb_tjsonb(const Jsonb *jb, const Temporal *temp)
@@ -180,7 +180,7 @@ ever_ne_jsonb_tjsonb(const Jsonb *jb, const Temporal *temp)
  * @brief Return true if a temporal JSONB is ever different from a JSONB
  * @param[in] temp Temporal JSONB
  * @param[in] jb JSONB
- * @csqlfn #Ever_ne_temporal_base()
+ * @csqlfn #Ever_ne_tjsonb_jsonb()
  */
 int
 ever_ne_tjsonb_jsonb(const Temporal *temp, const Jsonb *jb)
@@ -195,7 +195,7 @@ ever_ne_tjsonb_jsonb(const Temporal *temp, const Jsonb *jb)
  * @brief Return true if a JSONB is always different from a temporal JSONB
  * @param[in] jb JSONB
  * @param[in] temp Temporal JSONB
- * @csqlfn #Always_ne_base_temporal()
+ * @csqlfn #Always_ne_jsonb_tjsonb()
  */
 int
 always_ne_jsonb_tjsonb(const Jsonb *jb, const Temporal *temp)
@@ -210,7 +210,7 @@ always_ne_jsonb_tjsonb(const Jsonb *jb, const Temporal *temp)
  * @brief Return true if a temporal JSONB is always different from a JSONB
  * @param[in] temp Temporal JSONB
  * @param[in] jb JSONB
- * @csqlfn #Always_ne_temporal_base()
+ * @csqlfn #Always_ne_tjsonb_jsonb()
  */
 int
 always_ne_tjsonb_jsonb(const Temporal *temp, const Jsonb *jb)
@@ -229,7 +229,7 @@ always_ne_tjsonb_jsonb(const Temporal *temp, const Jsonb *jb)
  * @brief Return the temporal equality of a JSONB and a temporal JSONB
  * @param[in] jb JSONB
  * @param[in] temp Temporal JSONB
- * @csqlfn #Teq_base_temporal()
+ * @csqlfn #Teq_jsonb_tjsonb()
  */
 Temporal *
 teq_jsonb_tjsonb(const Jsonb *jb, const Temporal *temp)
@@ -244,7 +244,7 @@ teq_jsonb_tjsonb(const Jsonb *jb, const Temporal *temp)
  * @brief Return the temporal equality of a temporal JSONB and a JSONB
  * @param[in] temp Temporal JSONB
  * @param[in] jb JSONB
- * @csqlfn #Teq_temporal_base()
+ * @csqlfn #Teq_tjsonb_jsonb()
  */
 Temporal *
 teq_tjsonb_jsonb(const Temporal *temp, const Jsonb *jb)
@@ -259,7 +259,7 @@ teq_tjsonb_jsonb(const Temporal *temp, const Jsonb *jb)
  * @brief Return the temporal difference of a JSONB and a temporal JSONB
  * @param[in] jb JSONB
  * @param[in] temp Temporal JSONB
- * @csqlfn #Tne_base_temporal()
+ * @csqlfn #Tne_jsonb_tjsonb()
  */
 Temporal *
 tne_jsonb_tjsonb(const Jsonb *jb, const Temporal *temp)
@@ -274,7 +274,7 @@ tne_jsonb_tjsonb(const Jsonb *jb, const Temporal *temp)
  * @brief Return the temporal difference of a temporal JSONB and a JSONB
  * @param[in] temp Temporal JSONB
  * @param[in] jb JSONB
- * @csqlfn #Tne_temporal_base()
+ * @csqlfn #Tne_tjsonb_jsonb()
  */
 Temporal *
 tne_tjsonb_jsonb(const Temporal *temp, const Jsonb *jb)

--- a/meos/src/temporal/span_ops.c
+++ b/meos/src/temporal/span_ops.c
@@ -187,7 +187,7 @@ contained_value_span(Datum value, const Span *s)
  * @ingroup meos_setspan_topo
  * @brief Return true if the first span is contained in the second one
  * @param[in] s1,s2 Spans
- * @csqlfn #Contained_value_span()
+ * @csqlfn #Contained_span_span()
  */
 bool
 contained_span_span(const Span *s1, const Span *s2)

--- a/meos/src/temporal/spanset.c
+++ b/meos/src/temporal/spanset.c
@@ -424,7 +424,7 @@ set_to_spanset(const Set *s)
  * @ingroup meos_setspan_conversion
  * @brief Convert a span into a span set
  * @param[in] s Span
- * @csqlfn #Spanset_to_span()
+ * @csqlfn #Span_to_spanset()
  */
 SpanSet *
 span_to_spanset(const Span *s)
@@ -1218,7 +1218,7 @@ numspanset_shift_scale(const SpanSet *ss, Datum shift, Datum width,
  * @param[in] ss Span set
  * @param[in] shift Interval to shift the span set, may be NULL
  * @param[in] duration Interval for the duration of the result, may be NULL
- * @csqlfn #Numspanset_shift(), #Numspanset_scale(), #Numspanset_shift_scale()
+ * @csqlfn #Tstzspanset_shift(), #Tstzspanset_scale(), #Tstzspanset_shift_scale()
  */
 SpanSet *
 tstzspanset_shift_scale(const SpanSet *ss, const Interval *shift,

--- a/mobilitydb/src/temporal/spanset.c
+++ b/mobilitydb/src/temporal/spanset.c
@@ -291,7 +291,7 @@ PG_FUNCTION_INFO_V1(Span_to_spanset);
 /**
  * @ingroup mobilitydb_setspan_conversion
  * @brief Convert a span into a span set
- * @sqlfn instspanset(), floatspanset(), ...
+ * @sqlfn spanset()
  */
 Datum
 Span_to_spanset(PG_FUNCTION_ARGS)


### PR DESCRIPTION
The `@csqlfn` tag names the PG wrapper a MEOS function is exposed through, and
the catalog derives that function's SQL name from it, so a tag naming the
family's generic wrapper attributes the function to the wrong SQL name in every
generated binding.

Eighteen functions name a generic wrapper while their own exists:

* the twelve temporal JSONB comparisons name `Ever_eq_base_temporal` and its
  siblings rather than `Ever_eq_jsonb_tjsonb` and theirs,
* `tcbuffer_at_cbuffer` and `tcbuffer_minus_cbuffer` name `Temporal_at_value`
  and `Temporal_minus_value` rather than `Tcbuffer_at_cbuffer` and
  `Tcbuffer_minus_cbuffer`,
* `nad_tcbuffer_stbox` names `NAD_tcbuffer_geo`,
* `tstzspanset_shift_scale` names the `Numspanset` trio,
* `span_to_spanset` names `Spanset_to_span`, the inverse conversion,
* `contained_span_span` names `Contained_value_span`, the value-in-span
  variant.

Each tag now names the wrapper whose SQL function the MEOS function backs, so
the extractor keeps reading the tag rather than deriving anything from it.

`Span_to_spanset` states `@sqlfn spanset()`: the five declarations that bind it
are `spanset(intspan)`, `spanset(bigintspan)`, `spanset(floatspan)`,
`spanset(datespan)` and `spanset(tstzspan)`, so the name it carried resolved to
a SQL function that does not exist.

Regenerating the catalog from this tree resolves each function to its own
wrapper: `ever_eq_jsonb_tjsonb` to `Ever_eq_jsonb_tjsonb` (`eEq`),
`tcbuffer_at_cbuffer` to `Tcbuffer_at_cbuffer` (`atValue`), `span_to_spanset` to
`Span_to_spanset` (`spanset`), `nad_tcbuffer_stbox` to `NAD_tcbuffer_stbox`
(`nearestApproachDistance`).

Comment-only: no line outside a doxygen block changes.
