### PR TITLE
Compare pose coordinates numerically instead of by raw bytes

### DIFF
--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -1960,10 +1960,15 @@ pose_cmp(const Pose *pose1, const Pose *pose2)
   else if (srid1 > srid2)
     return 1;
 
-  if (hasz1)
-    return memcmp(pose1->data, pose2->data, sizeof(double) * 7);
-  else
-    return memcmp(pose1->data, pose2->data, sizeof(double) * 3);
+  int count = hasz1 ? 7 : 3;
+  for (int i = 0; i < count; i++)
+  {
+    if (pose1->data[i] < pose2->data[i])
+      return -1;
+    if (pose1->data[i] > pose2->data[i])
+      return 1;
+  }
+  return 0;
 }
 
 /**

--- a/mobilitydb/test/pose/expected/100_pose.test.out
+++ b/mobilitydb/test/pose/expected/100_pose.test.out
@@ -245,7 +245,7 @@ SELECT pose 'Pose(Point(1 1),0.5)' < pose 'Pose(Point(1 1),0.7)';
 SELECT pose 'Pose(Point(1 1),0.5)' < pose 'Pose(Point(2 2),0.5)';
  ?column? 
 ----------
- f
+ t
 (1 row)
 
 SELECT pose 'Pose(Point(1 1),0.5)' <= pose 'Pose(Point(1 1),0.5)';
@@ -263,7 +263,7 @@ SELECT pose 'Pose(Point(1 1),0.5)' <= pose 'Pose(Point(1 1),0.7)';
 SELECT pose 'Pose(Point(1 1),0.5)' <= pose 'Pose(Point(2 2),0.5)';
  ?column? 
 ----------
- f
+ t
 (1 row)
 
 SELECT pose 'Pose(Point(1 1),0.5)' > pose 'Pose(Point(1 1),0.5)';
@@ -281,7 +281,7 @@ SELECT pose 'Pose(Point(1 1),0.5)' > pose 'Pose(Point(1 1),0.7)';
 SELECT pose 'Pose(Point(1 1),0.5)' > pose 'Pose(Point(2 2),0.5)';
  ?column? 
 ----------
- t
+ f
 (1 row)
 
 SELECT pose 'Pose(Point(1 1),0.5)' >= pose 'Pose(Point(1 1),0.5)';
@@ -299,7 +299,7 @@ SELECT pose 'Pose(Point(1 1),0.5)' >= pose 'Pose(Point(1 1),0.7)';
 SELECT pose 'Pose(Point(1 1),0.5)' >= pose 'Pose(Point(2 2),0.5)';
  ?column? 
 ----------
- t
+ f
 (1 row)
 
 SELECT asEWKT(round(transform(transform(pose 'SRID=4326;Pose(Point(8 47 0), 1, 0, 0, 0)', 4978), 4326), 6));

--- a/mobilitydb/test/pose/expected/101_poseset_tbl.test.out
+++ b/mobilitydb/test/pose/expected/101_poseset_tbl.test.out
@@ -60,19 +60,19 @@ SELECT MIN(numValues(s)) FROM tbl_poseset2d;
 SELECT round(MIN(rotation(startValue(s))), 6) FROM tbl_poseset2d;
    round   
 -----------
- -0.054275
+ -0.054279
 (1 row)
 
 SELECT round(MIN(rotation(endValue(s))), 6) FROM tbl_poseset2d;
    round   
 -----------
- -0.054279
+ -0.054648
 (1 row)
 
 SELECT round(MIN(rotation(valueN(s, 1))), 6) FROM tbl_poseset2d;
    round   
 -----------
- -0.054275
+ -0.054279
 (1 row)
 
 SELECT MIN(array_length(getValues(s), 1)) FROM tbl_poseset2d;
@@ -100,7 +100,7 @@ SELECT COUNT(*) FROM test2 t1, tbl_poseset2d t2 WHERE t1.k = t2.k AND t1.s <> t2
 SELECT COUNT(*) FROM tbl_poseset2d t1, tbl_poseset2d t2 WHERE cmp(t1.s, t2.s) = -1;
  count 
 -------
-    24
+  4851
 (1 row)
 
 SELECT COUNT(*) FROM tbl_poseset2d t1, tbl_poseset2d t2 WHERE t1.s = t2.s;
@@ -142,7 +142,7 @@ SELECT COUNT(*) FROM tbl_poseset2d t1, tbl_poseset2d t2 WHERE t1.s >= t2.s;
 SELECT MAX(hash(s)) FROM tbl_poseset2d;
     max     
 ------------
- 2141422679
+ 2081505284
 (1 row)
 
 SELECT numValues(setUnion(pose)) FROM tbl_pose2d;

--- a/mobilitydb/test/pose/expected/102_tpose.test.out
+++ b/mobilitydb/test/pose/expected/102_tpose.test.out
@@ -605,19 +605,19 @@ SELECT asText(getValues(tpose 'Pose(Point(1 1), 0.5)@2000-01-01'));
 SELECT asText(getValues(tpose '{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}'));
                       astext                      
 --------------------------------------------------
- {"Pose(POINT(1 1),0.5)", "Pose(POINT(1 1),0.3)"}
+ {"Pose(POINT(1 1),0.3)", "Pose(POINT(1 1),0.5)"}
 (1 row)
 
 SELECT asText(getValues(tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]'));
                                   astext                                  
 --------------------------------------------------------------------------
- {"Pose(POINT(1 1),0.5)", "Pose(POINT(1 1),0.2)", "Pose(POINT(1 1),0.4)"}
+ {"Pose(POINT(1 1),0.2)", "Pose(POINT(1 1),0.4)", "Pose(POINT(1 1),0.5)"}
 (1 row)
 
 SELECT asText(getValues(tpose '{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}'));
                                               astext                                              
 --------------------------------------------------------------------------------------------------
- {"Pose(POINT(2 2),0.6)", "Pose(POINT(1 1),0.5)", "Pose(POINT(1 1),0.2)", "Pose(POINT(1 1),0.4)"}
+ {"Pose(POINT(1 1),0.2)", "Pose(POINT(1 1),0.4)", "Pose(POINT(1 1),0.5)", "Pose(POINT(2 2),0.6)"}
 (1 row)
 
 SELECT getTime(tpose 'Pose(Point(1 1), 0.5)@2000-01-01');
@@ -2028,7 +2028,7 @@ SELECT tpose '{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-0
 SELECT tpose '{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}' < tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]';
  ?column? 
 ----------
- t
+ f
 (1 row)
 
 SELECT tpose '{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}' < tpose '{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}';
@@ -2046,7 +2046,7 @@ SELECT tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-0
 SELECT tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]' < tpose '{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}';
  ?column? 
 ----------
- f
+ t
 (1 row)
 
 SELECT tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]' < tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]';
@@ -2124,7 +2124,7 @@ SELECT tpose '{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-0
 SELECT tpose '{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}' <= tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]';
  ?column? 
 ----------
- t
+ f
 (1 row)
 
 SELECT tpose '{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}' <= tpose '{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}';
@@ -2142,7 +2142,7 @@ SELECT tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-0
 SELECT tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]' <= tpose '{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}';
  ?column? 
 ----------
- f
+ t
 (1 row)
 
 SELECT tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]' <= tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]';
@@ -2220,7 +2220,7 @@ SELECT tpose '{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-0
 SELECT tpose '{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}' > tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]';
  ?column? 
 ----------
- f
+ t
 (1 row)
 
 SELECT tpose '{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}' > tpose '{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}';
@@ -2238,7 +2238,7 @@ SELECT tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-0
 SELECT tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]' > tpose '{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}';
  ?column? 
 ----------
- t
+ f
 (1 row)
 
 SELECT tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]' > tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]';
@@ -2316,7 +2316,7 @@ SELECT tpose '{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-0
 SELECT tpose '{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}' >= tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]';
  ?column? 
 ----------
- f
+ t
 (1 row)
 
 SELECT tpose '{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}' >= tpose '{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}';
@@ -2334,7 +2334,7 @@ SELECT tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-0
 SELECT tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]' >= tpose '{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}';
  ?column? 
 ----------
- t
+ f
 (1 row)
 
 SELECT tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]' >= tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]';

--- a/mobilitydb/test/rgeo/expected/150_trgeo.test.out
+++ b/mobilitydb/test/rgeo/expected/150_trgeo.test.out
@@ -748,19 +748,19 @@ SELECT asText(getValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 
 SELECT asText(getValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}'));
                       astext                      
 --------------------------------------------------
- {"Pose(POINT(1 1),0.5)", "Pose(POINT(1 1),0.3)"}
+ {"Pose(POINT(1 1),0.3)", "Pose(POINT(1 1),0.5)"}
 (1 row)
 
 SELECT asText(getValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]'));
                                   astext                                  
 --------------------------------------------------------------------------
- {"Pose(POINT(1 1),0.5)", "Pose(POINT(1 1),0.2)", "Pose(POINT(1 1),0.4)"}
+ {"Pose(POINT(1 1),0.2)", "Pose(POINT(1 1),0.4)", "Pose(POINT(1 1),0.5)"}
 (1 row)
 
 SELECT asText(getValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}'));
                                               astext                                              
 --------------------------------------------------------------------------------------------------
- {"Pose(POINT(2 2),0.6)", "Pose(POINT(1 1),0.5)", "Pose(POINT(1 1),0.2)", "Pose(POINT(1 1),0.4)"}
+ {"Pose(POINT(1 1),0.2)", "Pose(POINT(1 1),0.4)", "Pose(POINT(1 1),0.5)", "Pose(POINT(2 2),0.6)"}
 (1 row)
 
 SELECT getTime(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01');


### PR DESCRIPTION
pose_cmp() used memcmp() on the double arrays, which orders by byte layout rather than value and mishandles negative numbers. Switch to component-wise numeric comparison and update the expected output of tests whose results depended on the old order.