### PR TITLE
Make the doxygen SQL function tags use a consistent link prefix

### DIFF
--- a/meos/src/geo/tgeo_boxops.c
+++ b/meos/src/geo/tgeo_boxops.c
@@ -1609,7 +1609,7 @@ geo_split_each_n_gboxes(const GSERIALIZED *gs, int elems_per_box, int *count)
  * @param[in] gs (Multi)line
  * @param[in] elems_per_box Number of input segments merged into an output box
  * @param[out] count Number of elements in the output array
- * @csqlfn Geo_split_each_n_stboxes()
+ * @csqlfn #Geo_split_each_n_stboxes()
  */
 STBox *
 geo_split_each_n_stboxes(const GSERIALIZED *gs, int elems_per_box, int *count)

--- a/meos/src/geo/tgeo_tile.c
+++ b/meos/src/geo/tgeo_tile.c
@@ -888,7 +888,7 @@ stbox_space_time_tile(const GSERIALIZED *point, TimestampTz t,
  * @param[in] duration Size of the time dimension as an interval
  * @param[in] sorigin Origin for the space dimension
  * @param[in] torigin Origin for the time dimension
- * @csqlfn Stbox_get_space_time_tile()
+ * @csqlfn #Stbox_get_space_time_tile()
  */
 STBox *
 stbox_get_space_time_tile(const GSERIALIZED *point, TimestampTz t,
@@ -905,7 +905,7 @@ stbox_get_space_time_tile(const GSERIALIZED *point, TimestampTz t,
  * @param[in] point Point
  * @param[in] xsize,ysize,zsize Size of the corresponding dimension
  * @param[in] sorigin Origin for the space dimension
- * @csqlfn Stbox_get_space_tile()
+ * @csqlfn #Stbox_get_space_tile()
  */
 STBox *
 stbox_get_space_tile(const GSERIALIZED *point, double xsize, double ysize,
@@ -921,7 +921,7 @@ stbox_get_space_tile(const GSERIALIZED *point, double xsize, double ysize,
  * @param[in] t Timestamp
  * @param[in] duration Size of the time dimension as an interval
  * @param[in] torigin Origin for the time dimension
- * @csqlfn Stbox_get_time_tile()
+ * @csqlfn #Stbox_get_time_tile()
  */
 STBox *
 stbox_get_time_tile(TimestampTz t, const Interval *duration,

--- a/mobilitydb/src/raster/temporal_raster.c
+++ b/mobilitydb/src/raster/temporal_raster.c
@@ -195,7 +195,7 @@ PG_FUNCTION_INFO_V1(Raster_value);
  * @param[in] rast Raster
  * @param[in] traj Trajectory
  * @param[in] band Band number (1-based, default 1)
- * @sqlfn #rasterValue()
+ * @sqlfn rasterValue()
  */
 Datum
 Raster_value(PG_FUNCTION_ARGS)
@@ -231,7 +231,7 @@ PG_FUNCTION_INFO_V1(Raster_at_value);
  * @param[in] rast Raster
  * @param[in] vspan Float value range (inclusive bounds)
  * @param[in] band Band number (1-based, default 1)
- * @sqlfn #atRasterValue()
+ * @sqlfn atRasterValue()
  */
 Datum
 Raster_at_value(PG_FUNCTION_ARGS)
@@ -264,7 +264,7 @@ PG_FUNCTION_INFO_V1(Raster_minus_value);
  * @param[in] rast Raster
  * @param[in] vspan Float value range to exclude
  * @param[in] band Band number (1-based, default 1)
- * @sqlfn #minusRasterValue()
+ * @sqlfn minusRasterValue()
  */
 Datum
 Raster_minus_value(PG_FUNCTION_ARGS)
@@ -297,7 +297,7 @@ PG_FUNCTION_INFO_V1(Eraster_value);
  * @param[in] traj Trajectory (SRID matching the raster)
  * @param[in] vspan Float value range
  * @param[in] band Band number (1-based, default 1)
- * @sqlfn #eRasterValue()
+ * @sqlfn eRasterValue()
  */
 Datum
 Eraster_value(PG_FUNCTION_ARGS)
@@ -330,7 +330,7 @@ PG_FUNCTION_INFO_V1(Araster_value);
  * @param[in] traj Trajectory (SRID matching the raster)
  * @param[in] vspan Float value range
  * @param[in] band Band number (1-based, default 1)
- * @sqlfn #aRasterValue()
+ * @sqlfn aRasterValue()
  */
 Datum
 Araster_value(PG_FUNCTION_ARGS)
@@ -626,7 +626,7 @@ PG_FUNCTION_INFO_V1(Trajectory_quadbins);
  * trajectory, for use as a WHERE-clause join key against a Raquet table
  * @param[in] traj  Trajectory (tgeompoint, SRID 4326)
  * @param[in] zoom  QUADBIN zoom level (0–15)
- * @sqlfn #quadbins()
+ * @sqlfn quadbins()
  */
 Datum
 Trajectory_quadbins(PG_FUNCTION_ARGS)


### PR DESCRIPTION
The `@csqlfn` tag names a PostgreSQL C wrapper function, which is a symbol known to doxygen and therefore takes the `#` link prefix, while the `@sqlfn` tag names a SQL-level function, which is not a doxygen symbol and takes no prefix. A handful of comments do not follow this distinction.

This removes the prefix from six `@sqlfn` tags in the raster module:

- `rasterValue()`, `atRasterValue()`, `minusRasterValue()`, `eRasterValue()`, `aRasterValue()`, `quadbins()`

and adds it to four `@csqlfn` tags in the geo module:

- `Geo_split_each_n_stboxes()`, `Stbox_get_space_time_tile()`, `Stbox_get_space_tile()`, `Stbox_get_time_tile()`

Each of the four wrapper names resolves to an actual `PG_FUNCTION_INFO_V1` function, and each of the six SQL names to an actual `CREATE FUNCTION` in `mobilitydb/sql`, so this introduces no dangling link.

Three `@csqlfn` tags in `meos/src/pose/pose.c` stay as they are on purpose: `Distance_pose_pose()`, `Distance_pose_geo()` and `Distance_pose_stbox()` name wrappers that exist nowhere in the tree, unlike the circular buffer equivalents, so a prefix there would create a broken link. That gap belongs to a separate change.

Comment-only, no behaviour change.