### PR TITLE
Validate that at least one tiling dimension is given for stbox tiles

### DIFF
--- a/meos/src/geo/tgeo_tile.c
+++ b/meos/src/geo/tgeo_tile.c
@@ -645,6 +645,20 @@ stbox_tile_state_get(STboxGridState *state, STBox *box)
 }
 
 /**
+ * @brief Ensure that at least one dimension is given for tiling a
+ * spatiotemporal box
+ */
+static bool
+ensure_one_tile_dimension(double xsize, const Interval *duration)
+{
+  if (xsize > 0 || duration)
+    return true;
+  meos_error(ERROR, MEOS_ERR_INVALID_ARG,
+    "At least one of the arguments xsize or duration must be given");
+  return false;
+}
+
+/**
  * @ingroup meos_geo_tile
  * @brief Return the spatiotemporal grid of a spatiotemporal box
  * @param[in] bounds Bounds
@@ -669,7 +683,8 @@ stbox_space_time_tiles(const STBox *bounds, double xsize, double ysize,
    * Since we pass by default Point(0 0 0) as origin independently of the input
    * STBox, we test the same spatial dimensionality only for STBox Z */
   VALIDATE_NOT_NULL(count, NULL); VALIDATE_NOT_NULL(bounds, NULL);
-  if (! ensure_has_X(T_STBOX, bounds->flags) ||
+  if (! ensure_one_tile_dimension(xsize, duration) ||
+      ! ensure_has_X(T_STBOX, bounds->flags) ||
       ! ensure_not_geodetic(bounds->flags) ||
       ! ensure_not_negative_datum(Float8GetDatum(xsize), T_FLOAT8) ||
       ! ensure_not_negative_datum(Float8GetDatum(ysize), T_FLOAT8) ||

--- a/tools/codegen/gen_smoketest/gen_smoketest.py
+++ b/tools/codegen/gen_smoketest/gen_smoketest.py
@@ -883,13 +883,6 @@ TGEOMETRY_CONFIG = dict(
         "re:^tgeoseqset_from_base":  "needs STEP interp on multi-span input",
         "re:^tgeoseq_from_base":     "needs STEP interp on multi-span input",
         "re:^tpoint_from_base":      "needs hand-constructed Temporal input",
-        # Time-tiling functions take an Interval* duration; the canned
-        # interv1 is NULL, which trips assert(xsize > 0 || duration) in
-        # stbox_tile_state_make. They need a real duration to exercise.
-        "stbox_get_space_time_tile": "interv1=NULL triggers assert(xsize>0||duration)",
-        "stbox_get_time_tile":       "interv1=NULL triggers assert(xsize>0||duration)",
-        "stbox_space_time_tiles":    "interv1=NULL triggers assert(xsize>0||duration)",
-        "stbox_time_tiles":          "interv1=NULL triggers assert(xsize>0||duration)",
     },
     common_inputs="""\
   TimestampTz tstz1 = timestamptz_in("2001-01-02", -1);


### PR DESCRIPTION
The functions computing the tiles of a spatiotemporal box accept a spatial tile size that may be zero and a duration that may be NULL, but nothing rejects the combination of both. With `xsize <= 0` and `duration` NULL the call reaches `stbox_tile_state_make` with no dimension to tile on, which is guarded there only by `assert(xsize > 0 || duration)`. In a release build the assertion is compiled out and the caller silently obtains a grid state with no dimensions instead of an error; in a debug build the process aborts.

Observed with a debug build of MEOS:

* `stbox_space_time_tiles(bounds, 0, 0, 0, NULL, NULL, 0, true, &count)` aborts with `Assertion 'xsize > 0 || duration' failed`
* `stbox_time_tiles(bounds, NULL, 0, true, &count)` aborts with the same assertion
* `stbox_space_tiles` reaches the same path, since it also delegates to `stbox_space_time_tiles`

`stbox_get_space_time_tile` and `stbox_get_time_tile` are not affected: they go through `stbox_space_time_tile`, which already validates the duration and returns NULL.

This PR adds the check to `stbox_space_time_tiles`, so that the case raises an error and returns NULL as the remaining invalid inputs do. It also removes the corresponding entries from the smoke-test generator, so that the four functions are exercised by the smoke suites.