### PR TITLE
Clarify the interpolation validators

### DIFF
--- a/doc/es/temporal_types_p1.xml
+++ b/doc/es/temporal_types_p1.xml
@@ -1264,7 +1264,7 @@ FROM (SELECT unnest(tint '[1@2001-01-01, 2@2001-01-02, 1@2001-01-03]') AS un) t;
 -- 2 | {[2001-01-02, 2001-01-03)}
 SELECT (un).value, (un).time
 FROM (SELECT unnest(tfloat '[1@2001-01-01, 2@2001-01-02, 1@2001-01-03]') AS un) t;
--- ERROR:  The temporal value cannot have linear interpolation
+-- ERROR:  Operation not supported for temporal values with linear interpolation
 SELECT ST_AsText((un).value), (un).time
 FROM (SELECT unnest(tgeompoint 'Interp=Step;[Point(1 1)@2001-01-01,
   Point(2 2)@2001-01-02, Point(1 1)@2001-01-03]') AS un) t;

--- a/doc/temporal_types_p1.xml
+++ b/doc/temporal_types_p1.xml
@@ -1258,7 +1258,7 @@ FROM (SELECT unnest(tint '[1@2001-01-01, 2@2001-01-02, 1@2001-01-03]') AS un) t;
 -- 2 | {[2001-01-02, 2001-01-03)}
 SELECT (un).value, (un).time
 FROM (SELECT unnest(tfloat '[1@2001-01-01, 2@2001-01-02, 1@2001-01-03]') AS un) t;
--- ERROR:  The temporal value cannot have linear interpolation
+-- ERROR:  Operation not supported for temporal values with linear interpolation
 SELECT ST_AsText((un).value), (un).time
 FROM (SELECT unnest(tgeompoint 'Interp=Step;[Point(1 1)@2001-01-01,
   Point(2 2)@2001-01-02, Point(1 1)@2001-01-03]') AS un) t;

--- a/meos/include/temporal/temporal.h
+++ b/meos/include/temporal/temporal.h
@@ -397,7 +397,7 @@ extern bool ensure_not_null(void *ptr);
 extern bool ensure_one_not_null(void *ptr1, void *ptr2);
 extern bool ensure_one_true(bool hasshift, bool haswidth);
 extern bool ensure_valid_interp(MeosType temptype, interpType interp);
-extern bool ensure_continuous(const Temporal *temp);
+extern bool ensure_continuous_interp(const Temporal *temp);
 extern bool ensure_same_interp(const Temporal *temp1, const Temporal *temp2);
 extern bool ensure_same_continuous_interp(int16 flags1, int16 flags2);
 extern bool ensure_linear_interp(int16 flags);

--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -729,7 +729,7 @@ trgeometry_start_sequence(const Temporal *temp)
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
   /* Ensure the validity of the arguments */
-  if (! ensure_continuous(temp))
+  if (! ensure_continuous_interp(temp))
     return NULL;
 
   const TSequence *res_pose = (temp->subtype == TSEQUENCE) ?
@@ -752,7 +752,7 @@ trgeometry_end_sequence(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
-  if (! ensure_continuous(temp))
+  if (! ensure_continuous_interp(temp))
     return NULL;
 
   const TSequence *res_pose = (temp->subtype == TSEQUENCE) ?
@@ -777,7 +777,7 @@ trgeometry_sequence_n(const Temporal *temp, int n)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
-  if (! ensure_continuous(temp) || ! ensure_positive(n))
+  if (! ensure_continuous_interp(temp) || ! ensure_positive(n))
     return NULL;
 
   const TSequence *res_pose;
@@ -814,7 +814,7 @@ trgeometry_sequences(const Temporal *temp, int *count)
   *count = 0;
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
-  if (! ensure_continuous(temp))
+  if (! ensure_continuous_interp(temp))
     return NULL;
 
   const GSERIALIZED *geo = trgeo_geom_p(temp);
@@ -887,7 +887,7 @@ trgeometry_segments(const Temporal *temp, int *count)
   *count = 0;
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
-  if (! ensure_continuous(temp))
+  if (! ensure_continuous_interp(temp))
     return NULL;
 
   const GSERIALIZED *geo = trgeo_geom_p(temp);

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -183,10 +183,17 @@ ensure_valid_interp(MeosType temptype, interpType interp)
 }
 
 /**
- * @brief Ensure that the subtype of temporal type is a sequence (set)
+ * @brief Ensure that a temporal value has continuous, that is, step or linear,
+ * interpolation
+ * @details The test excludes temporal instants, which carry no interpolation,
+ * and values with discrete interpolation. Therefore, the value is necessarily
+ * a temporal sequence (set) whose interpolation is either step or linear.
+ * @note This tests the interpolation of the value. Whether the temporal type
+ * is able to carry linear interpolation is a distinct question, tested by
+ * #ensure_valid_interp()
  */
 bool
-ensure_continuous(const Temporal *temp)
+ensure_continuous_interp(const Temporal *temp)
 {
   assert(temptype_subtype(temp->subtype));
   if (temp->subtype != TINSTANT && ! MEOS_FLAGS_DISCRETE_INTERP(temp->flags))
@@ -244,6 +251,11 @@ ensure_linear_interp(int16 flags)
 
 /**
  * @brief Ensure that a temporal value does not have linear interpolation
+ * @details This is a precondition of the calling operation, which enumerates
+ * the discrete values of the temporal value and thus cannot account for the
+ * values taken between two consecutive instants. It does not state that the
+ * temporal type is unable to carry linear interpolation, which is tested by
+ * #ensure_valid_interp()
  */
 bool
 ensure_nonlinear_interp(int16 flags)
@@ -251,7 +263,7 @@ ensure_nonlinear_interp(int16 flags)
   if (! MEOS_FLAGS_LINEAR_INTERP(flags))
     return true;
   meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
-    "The temporal value cannot have linear interpolation");
+    "Operation not supported for temporal values with linear interpolation");
   return false;
 }
 
@@ -2431,7 +2443,7 @@ temporal_num_sequences(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(temp, -1);
-  if (! ensure_continuous(temp))
+  if (! ensure_continuous_interp(temp))
     return -1;
   return (temp->subtype == TSEQUENCE) ? 1 : ((TSequenceSet *) temp)->count;
 }
@@ -2449,7 +2461,7 @@ temporal_start_sequence(const Temporal *temp)
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(temp, NULL);
   /* Ensure the validity of the arguments */
-  if (! ensure_continuous(temp))
+  if (! ensure_continuous_interp(temp))
     return NULL;
 
   if (temp->subtype == TSEQUENCE)
@@ -2473,7 +2485,7 @@ temporal_end_sequence(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(temp, NULL);
-  if (! ensure_continuous(temp))
+  if (! ensure_continuous_interp(temp))
     return NULL;
 
   if (temp->subtype == TSEQUENCE)
@@ -2498,7 +2510,7 @@ temporal_sequence_n(const Temporal *temp, int n)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(temp, NULL);
-  if (! ensure_continuous(temp))
+  if (! ensure_continuous_interp(temp))
     return NULL;
 
   if (temp->subtype == TSEQUENCE)
@@ -2529,7 +2541,7 @@ temporal_sequences_p(const Temporal *temp, int *count)
 {
   /* Ensure the validity of the arguments */
   assert(temp); assert(count);
-  if (! ensure_continuous(temp))
+  if (! ensure_continuous_interp(temp))
     return NULL;
 
   if (temp->subtype == TSEQUENCE)

--- a/meos/src/temporal/tsequence.c
+++ b/meos/src/temporal/tsequence.c
@@ -1438,6 +1438,7 @@ tcontseq_to_step(const TSequence *seq)
 int
 tstepseq_to_linear_iter(const TSequence *seq, TSequence **result)
 {
+  assert(temptype_supports_linear(seq->temptype));
   if (seq->count == 1)
   {
     result[0] = tsequence_copy(seq);

--- a/mobilitydb/test/temporal/expected/022_temporal_tbl.test.out
+++ b/mobilitydb/test/temporal/expected/022_temporal_tbl.test.out
@@ -1641,7 +1641,7 @@ SELECT COUNT(*) FROM tbl_ttext t1, test2 t2 WHERE t1.k = t2.k AND t1.temp <> t2.
 (1 row)
 
 SELECT COUNT(*) FROM (SELECT k, unnest(temp) AS rec FROM tbl_tfloat) AS T;
-ERROR:  The temporal value cannot have linear interpolation
+ERROR:  Operation not supported for temporal values with linear interpolation
 SELECT COUNT(shiftValue(temp, i)) FROM tbl_tint, tbl_int;
  count 
 -------


### PR DESCRIPTION
The interpolation rules enforced by MEOS live at two distinct levels, but the validators do not read that way. This PR makes their names, doc comments and error messages say what they actually enforce. Behaviour is unchanged.

### `ensure_continuous` renamed to `ensure_continuous_interp`

The function does not test continuity. It tests that a temporal value has continuous, that is, step or linear, interpolation, thereby excluding temporal instants, which carry no interpolation, and values with discrete interpolation. Its doc comment describes it as testing the subtype, which is only part of what it does.

The old name also clashes with a meaning that "continuous" already carries in the codebase: the CONTINUOUS flag records whether the temporal *type* supports linear interpolation. The new name follows the sibling `ensure_same_continuous_interp`, which uses the same notion of continuous interpolation and the same `MEOS_FLAGS_STEP_LINEAR_INTERP` test. The doc comment now describes the test performed and points at the distinct rule tested by `ensure_valid_interp`.

The function is internal, declared only in the internal header, so the public API surface is untouched. All twelve occurrences are updated.

### Error message of `ensure_nonlinear_interp` reworded

The message differs from the message of `ensure_valid_interp` by a single word, so a user cannot tell the two failures apart. The two are unrelated:

- `ensure_valid_interp` states the catalog rule on which temporal types may carry linear interpolation.
- `ensure_nonlinear_interp` is a precondition of the calling operation, which enumerates the discrete values of a temporal value and thus cannot account for the values taken between two consecutive instants.

The message now states that operation-level reason, following the wording already used elsewhere for operations that are not supported for a given kind of input. The doc comment records the distinction. The function name stays, since it is the exact complement of the adjacent `ensure_linear_interp` and shares its signature.

### Assertion added to `tstepseq_to_linear_iter`

This internal iterator sets linear interpolation on its result without consulting the catalog. Its callers reach it only through `temporal_set_interp`, which validates the temporal type, so it is unreachable with an unsupported type. The assertion states that guarantee where it is relied upon, following the idiom that public functions validate and internal functions assert.

### Behaviour

The set of accepted inputs is identical, in both directions. No signature changes, no validation added or removed. The only expected output that differs is the single line quoting the reworded message, harvested from the test run rather than hand-edited; the two manual examples showing that message match it.
