### PR TITLE
Name the SQL function the span bound and geo instant accessors correspond to

### DIFF
--- a/meos/src/geo/tgeo.c
+++ b/meos/src/geo/tgeo.c
@@ -50,7 +50,7 @@
  * @brief Return a temporal point instant from a point and a timestamptz
  * @param[in] gs Value
  * @param[in] t Timestamp
- * @csqlfn #Tinstant_constructor()
+ * @csqlfn #Tpointinst_constructor()
  */
 TInstant *
 tpointinst_make(const GSERIALIZED *gs, TimestampTz t)
@@ -70,7 +70,7 @@ tpointinst_make(const GSERIALIZED *gs, TimestampTz t)
  * @brief Return a temporal instant geo from a geometry and a timestamptz
  * @param[in] gs Value
  * @param[in] t Timestamp
- * @csqlfn #Tinstant_constructor()
+ * @csqlfn #Tgeoinst_constructor()
  */
 TInstant *
 tgeoinst_make(const GSERIALIZED *gs, TimestampTz t)

--- a/meos/src/temporal/span_meos.c
+++ b/meos/src/temporal/span_meos.c
@@ -554,7 +554,7 @@ span_lower_inc(const Span *s)
  * @ingroup meos_setspan_accessor
  * @brief Return true if the upper bound of a span is inclusive
  * @param[in] s Span
- * @csqlfn #Span_lower_inc()
+ * @csqlfn #Span_upper_inc()
  */
 bool
 span_upper_inc(const Span *s)

--- a/mobilitydb/src/temporal/span.c
+++ b/mobilitydb/src/temporal/span.c
@@ -519,7 +519,7 @@ PG_FUNCTION_INFO_V1(Span_lower_inc);
 /**
  * @ingroup mobilitydb_setspan_accessor
  * @brief Return true if the lower bound of a span is inclusive
- * @sqlfn lower_inc()
+ * @sqlfn lowerInc()
  */
 Datum
 Span_lower_inc(PG_FUNCTION_ARGS)


### PR DESCRIPTION
Four documentation tags name a function other than the one they serve, so the catalog that derives each MEOS function's SQL name from them records the wrong name, or none at all.

`span_upper_inc` names the wrapper of its sibling:

```
meos/src/temporal/span_meos.c   span_upper_inc   @csqlfn #Span_lower_inc()   ->  #Span_upper_inc()
```

so the catalog gives the upper bound accessor the SQL name of the lower one. The wrapper `Span_lower_inc` in turn carries a name the SQL does not declare:

```
mobilitydb/src/temporal/span.c   Span_lower_inc   @sqlfn lower_inc()   ->  lowerInc()
```

with `003_span.in.sql:554` declaring `lowerInc(intspan)` and its four siblings. A signature is kept only when its SQL name matches the tag, so between the two the pair of accessors ends up with no signature at all and reaches no binding. The sibling wrapper `Span_upper_inc` already reads `upperInc()`.

`tpointinst_make` and `tgeoinst_make` both name the generic `#Tinstant_constructor()`, whose overloads cover the alphanumeric and the derived types and include no geometry or geography. Each corresponds to its own wrapper:

```
meos/src/geo/tgeo.c   tpointinst_make   ->  #Tpointinst_constructor()
                      tgeoinst_make     ->  #Tgeoinst_constructor()
```

as the SQL binds `tgeompoint(geometry(Point), timestamptz)` to `Tpointinst_constructor` (`052_tpoint.in.sql:133`) and `tgeometry(geometry, timestamptz)` to `Tgeoinst_constructor` (`052_tgeo.in.sql:141`).

Comment text only, so the extension behaves as before; the catalog is what reads these tags.
