### PR TITLE
Validate that a tiling dimension is given for temporal box tiles

### DIFF
--- a/meos/src/temporal/temporal_tile_meos.c
+++ b/meos/src/temporal/temporal_tile_meos.c
@@ -106,6 +106,19 @@ tbox_value_time_tiles(const TBox *box, Datum vsize, const Interval *duration,
 }
 
 /**
+ * @brief Ensure that at least one dimension is given for tiling a temporal box
+ */
+static bool
+ensure_one_tile_dimension(double vsize, const Interval *duration)
+{
+  if (vsize > 0 || duration)
+    return true;
+  meos_error(ERROR, MEOS_ERR_INVALID_ARG,
+    "At least one of the arguments vsize or duration must be given");
+  return false;
+}
+
+/**
  * @ingroup meos_temporal_analytics_tile
  * @brief Return the tiles of a temporal integer box
  * @param[in] box Input box to split
@@ -122,6 +135,8 @@ tintbox_value_time_tiles(const TBox *box, int vsize, const Interval *duration,
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(box, NULL); VALIDATE_NOT_NULL(count, NULL);
+  if (! ensure_one_tile_dimension((double) vsize, duration))
+    return NULL;
   return tbox_value_time_tiles(box, Int32GetDatum(vsize), duration,
     Int32GetDatum(vorigin), torigin, count);
 }
@@ -143,6 +158,8 @@ tfloatbox_value_time_tiles(const TBox *box, double vsize,
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(box, NULL); VALIDATE_NOT_NULL(count, NULL);
+  if (! ensure_one_tile_dimension(vsize, duration))
+    return NULL;
   return tbox_value_time_tiles(box, Float8GetDatum(vsize), duration,
     Float8GetDatum(vorigin), torigin, count);
 }
@@ -159,8 +176,7 @@ tfloatbox_value_time_tiles(const TBox *box, double vsize,
 TBox *
 tintbox_value_tiles(const TBox *box, int vsize, int vorigin, int *count)
 {
-  return tbox_value_time_tiles(box, Int32GetDatum(vsize), NULL,
-    Int32GetDatum(vorigin), 0, count);
+  return tintbox_value_time_tiles(box, vsize, NULL, vorigin, 0, count);
 }
 
 /**
@@ -176,8 +192,23 @@ TBox *
 tfloatbox_value_tiles(const TBox *box, double vsize, double vorigin,
   int *count)
 {
-  return tbox_value_time_tiles(box, Float8GetDatum(vsize), NULL,
-    Float8GetDatum(vorigin), 0, count);
+  return tfloatbox_value_time_tiles(box, vsize, NULL, vorigin, 0, count);
+}
+
+/**
+ * @ingroup meos_temporal_analytics_tile
+ * @brief Return the time tiles of a temporal integer box
+ * @param[in] box Input box to split
+ * @param[in] duration Interval defining the size of the bins
+ * @param[in] torigin Time origin of the tiles
+ * @param[out] count Number of elements in the output array
+ * @csqlfn #Tbox_time_tiles()
+ */
+TBox *
+tintbox_time_tiles(const TBox *box, const Interval *duration,
+  TimestampTz torigin, int *count)
+{
+  return tintbox_value_time_tiles(box, 0, duration, 0, torigin, count);
 }
 
 /**
@@ -190,28 +221,10 @@ tfloatbox_value_tiles(const TBox *box, double vsize, double vorigin,
  * @csqlfn #Tbox_time_tiles()
  */
 TBox *
-tintbox_time_tiles(const TBox *box, const Interval *duration, 
+tfloatbox_time_tiles(const TBox *box, const Interval *duration,
   TimestampTz torigin, int *count)
 {
-  return tbox_value_time_tiles(box, Int32GetDatum(0), duration,
-    Int32GetDatum(0), torigin, count);
-}
-
-/**
- * @ingroup meos_temporal_analytics_tile
- * @brief Return the time tiles of a temporal float box
- * @param[in] box Input box to split
- * @param[in] duration Interval defining the size of the bins
- * @param[in] torigin Time origin of the tiles
- * @param[out] count Number of elements in the output array
- * @csqlfn #Tbox_time_tiles()
- */
-TBox *
-tfloatbox_time_tiles(const TBox *box, const Interval *duration, 
-  TimestampTz torigin, int *count)
-{
-  return tbox_value_time_tiles(box, Float8GetDatum(0.0), duration,
-    Float8GetDatum(0.0), torigin, count);
+  return tfloatbox_value_time_tiles(box, 0.0, duration, 0.0, torigin, count);
 }
 
 /*****************************************************************************


### PR DESCRIPTION
The functions computing the tiles of a temporal box accept a value size that may be zero and a duration that may be `NULL`, but nothing rejects the combination of both. With no dimension left to tile on, the call reaches `tbox_tile_state_make`, which is guarded there only by `assert(duration || datum_gt(vsize, 0, box->span.basetype))`. In a release build the assertion is compiled out and the caller silently obtains a grid state with no dimensions instead of an error; in a debug build the process aborts.

Observed with a debug build of MEOS, one process per call, all with `duration` `NULL`:

* `tintbox_value_time_tiles(box, 0, NULL, 0, torigin, &count)` aborts with `Assertion 'duration || datum_gt(vsize, 0, box->span.basetype)' failed`
* `tfloatbox_value_time_tiles(box, 0.0, NULL, 0.0, torigin, &count)` aborts with the same assertion
* `tintbox_value_tiles(box, 0, 0, &count)` and `tfloatbox_value_tiles(box, 0.0, 0.0, &count)` reach the same path, since they pass `NULL` as duration by construction
* `tintbox_time_tiles(box, NULL, torigin, &count)` and `tfloatbox_time_tiles(box, NULL, torigin, &count)` reach it as well, since they pass a zero value size by construction

This PR adds the check to the two functions that accept both arguments, so that the case raises an error and returns `NULL` as the remaining invalid inputs do, and makes the value-only and time-only functions delegate to them instead of to the internal function, mirroring the way `stbox_space_tiles` and `stbox_time_tiles` delegate to `stbox_space_time_tiles`. The internal `tbox_value_time_tiles` keeps its assertions.

The check is the temporal box counterpart of the spatiotemporal box one in `stbox_space_time_tiles`, and is a parallel `ensure_one_tile_dimension` local to `temporal_tile_meos.c`; each family file keeps its own helper.
