### PR TITLE
Expand a big integer span instead of shifting it

### DIFF
--- a/mobilitydb/sql/temporal/003_span.in.sql
+++ b/mobilitydb/sql/temporal/003_span.in.sql
@@ -625,7 +625,7 @@ CREATE FUNCTION expand(intspan, integer)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION expand(bigintspan, bigint)
   RETURNS bigintspan
-  AS 'MODULE_PATHNAME', 'Numspan_shift'
+  AS 'MODULE_PATHNAME', 'Numspan_expand'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION expand(floatspan, float)
   RETURNS floatspan

--- a/mobilitydb/test/temporal/expected/003_span.test.out
+++ b/mobilitydb/test/temporal/expected/003_span.test.out
@@ -460,6 +460,42 @@ SELECT datespan '(2000-01-01,2000-01-02]';
  [01-02-2000, 01-03-2000)
 (1 row)
 
+SELECT expand(intspan '[1,1]', 1);
+ expand 
+--------
+ [0, 3)
+(1 row)
+
+SELECT expand(intspan '[1,3]', -1);
+ expand 
+--------
+ [2, 3)
+(1 row)
+
+SELECT expand(bigintspan '[1,1]', 1);
+ expand 
+--------
+ [0, 3)
+(1 row)
+
+SELECT expand(bigintspan '[1,5]', 1);
+ expand 
+--------
+ [0, 7)
+(1 row)
+
+SELECT expand(bigintspan '[1,5]', -1);
+ expand 
+--------
+ [2, 5)
+(1 row)
+
+SELECT expand(datespan '[2000-01-01,2000-01-02]', 1);
+          expand          
+--------------------------
+ [12-31-1999, 01-04-2000)
+(1 row)
+
 SELECT expand(floatspan '[1,1]', 1);
  expand 
 --------

--- a/mobilitydb/test/temporal/queries/003_span.test.sql
+++ b/mobilitydb/test/temporal/queries/003_span.test.sql
@@ -159,6 +159,13 @@ SELECT datespan '(2000-01-01,2000-01-02]';
 -- Transformation functions
 -------------------------------------------------------------------------------
 
+SELECT expand(intspan '[1,1]', 1);
+SELECT expand(intspan '[1,3]', -1);
+SELECT expand(bigintspan '[1,1]', 1);
+SELECT expand(bigintspan '[1,5]', 1);
+SELECT expand(bigintspan '[1,5]', -1);
+SELECT expand(datespan '[2000-01-01,2000-01-02]', 1);
+
 SELECT expand(floatspan '[1,1]', 1);
 SELECT expand(floatspan '[1,2]', 1);
 SELECT expand(floatspan '(1,4]', -1);

--- a/tools/codegen/inherited/manifest.d/span_families.yaml
+++ b/tools/codegen/inherited/manifest.d/span_families.yaml
@@ -101,9 +101,7 @@ span_families:
   - {sig: "duration({sp})", ret: "interval", sym: Datespan_duration, only: [date]}
   - {sig: "duration({sp})", ret: "interval", sym: Tstzspan_duration, only: [tstz]}
   - lit: "\n/*****************************************************************************\n * Transformation functions\n *****************************************************************************/\n\n"
-  - {sig: "expand({sp}, {v})", ret: "{sp}", sym: Numspan_expand, only: [int]}
-  - {sig: "expand({sp}, {v})", ret: "{sp}", sym: Numspan_shift, only: [bigint]}
-  - {sig: "expand({sp}, {v})", ret: "{sp}", sym: Numspan_expand, only: [float]}
+  - {sig: "expand({sp}, {v})", ret: "{sp}", sym: Numspan_expand, only: [int, bigint, float]}
   - {sig: "expand(datespan, {v})", ret: "datespan", sym: Numspan_expand, only: [int]}
   - {sig: "expand({sp}, interval)", ret: "{sp}", sym: Tstzspan_expand, only: [tstz]}
   - lit: "\n"


### PR DESCRIPTION
`expand(bigintspan, bigint)` moves the span by the value instead of widening it
by it.

The span transformation declarations are generated, and the manifest gives the
big integer overload the shift symbol. In
`tools/codegen/inherited/manifest.d/span_families.yaml` the integer, float and
date entries carry `Numspan_expand` and the big integer one carries
`Numspan_shift`, and the two wrappers do different things:
`Numspan_expand` calls `numspan_expand(s, value)`, `Numspan_shift` calls
`numspan_shift_scale(s, shift, 0, true, false)`.

With the symbol corrected the three numeric entries differ only in their type,
so they collapse into one over `[int, bigint, float]` — the shape the `shift`
entry below them already has, and one a per-type divergence cannot reappear in.

**Tests**

The transformation tests cover `expand()` for `floatspan` and `tstzspan`, which
leaves the binding uncontradicted. They now also cover the integer, big integer
and date spans, where the big integer results match the integer ones:

```
expand(intspan    '[1,1]',  1)  ->  [0, 3)
expand(bigintspan '[1,1]',  1)  ->  [0, 3)
expand(bigintspan '[1,5]',  1)  ->  [0, 7)
expand(bigintspan '[1,5]', -1)  ->  [2, 5)
```

Every other `expand()` overload binds an expand wrapper, and comparing each SQL
function's overloads against the operation their wrappers implement finds no
second case of this shape anywhere in the SQL surface.
