### PR TITLE
Add the distance surface for the pose base type

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1580,6 +1580,15 @@
 			</sect3>
 
 			<sect3>
+				<title>Operaciones de distancia</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="pose_distance_op"><varname>&lt;-&gt;</varname></link>: Devuelve la distancia</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
 				<title>Comparaciones</title>
 				<itemizedlist>
 					<listitem>

--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -333,6 +333,34 @@ FROM test;
 			</itemizedlist>
 		</sect2>
 
+		<sect2 xml:id="pose_distance">
+			<title>Operaciones de distancia</title>
+
+			<itemizedlist>
+				<listitem xml:id="pose_distance_op">
+					<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
+					<para>Devuelve la distancia</para>
+					<para><varname>distance({geo,stbox,pose},pose) → float</varname></para>
+					<para><varname>distance(pose,{geo,stbox,pose}) → float</varname></para>
+					<para><varname>{geo,stbox,pose} &lt;-&gt; pose → float</varname></para>
+					<para>Solo se tiene en cuenta el componente de punto de la pose, la orientación se ignora. La distancia se calcula en dos dimensiones, incluso cuando los argumentos son tridimensionales. El resultado es <varname>NULL</varname> cuando la geometría está vacía.</para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT round(distance(geometry 'Point(1 0)', pose 'Pose(Point(4 0),0)'), 6);
+-- 3
+SELECT round(distance(stbox 'STBOX X((1,-1),(3,1))', pose 'Pose(Point(4 0),0)'), 6);
+-- 1
+SELECT round(pose 'Pose(Point(0 0),0)' &lt;-&gt; pose 'Pose(Point(3 4),0)', 6);
+-- 5
+SELECT round(pose 'Pose(Point(0 0 0), 1, 0, 0, 0)' &lt;-&gt;
+  pose 'Pose(Point(3 4 12), 1, 0, 0, 0)', 6);
+-- 5
+SELECT round(geometry 'Point empty' &lt;-&gt; pose 'Pose(Point(4 0),0)', 6);
+-- NULL
+</programlisting>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
 		<sect2 xml:id="pose_comparison">
 			<title>Comparaciones</title>
 

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1562,6 +1562,15 @@
 			</sect3>
 
 			<sect3>
+				<title>Distance Operations</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="pose_distance_op"><varname>&lt;-&gt;</varname></link>: Return the distance</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+
+			<sect3>
 				<title>Comparisons</title>
 				<itemizedlist>
 					<listitem>

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -340,6 +340,34 @@ FROM test;
 			</itemizedlist>
 		</sect2>
 
+		<sect2 xml:id="pose_distance">
+			<title>Distance Operations</title>
+
+			<itemizedlist>
+				<listitem xml:id="pose_distance_op">
+					<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
+					<para>Return the distance</para>
+					<para><varname>distance({geo,stbox,pose},pose) → float</varname></para>
+					<para><varname>distance(pose,{geo,stbox,pose}) → float</varname></para>
+					<para><varname>{geo,stbox,pose} &lt;-&gt; pose → float</varname></para>
+					<para>Only the point component of the pose is taken into account, the orientation is ignored. The distance is computed in two dimensions, even when the arguments are three-dimensional. The result is <varname>NULL</varname> when the geometry is empty.</para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT round(distance(geometry 'Point(1 0)', pose 'Pose(Point(4 0),0)'), 6);
+-- 3
+SELECT round(distance(stbox 'STBOX X((1,-1),(3,1))', pose 'Pose(Point(4 0),0)'), 6);
+-- 1
+SELECT round(pose 'Pose(Point(0 0),0)' &lt;-&gt; pose 'Pose(Point(3 4),0)', 6);
+-- 5
+SELECT round(pose 'Pose(Point(0 0 0), 1, 0, 0, 0)' &lt;-&gt;
+  pose 'Pose(Point(3 4 12), 1, 0, 0, 0)', 6);
+-- 5
+SELECT round(geometry 'Point empty' &lt;-&gt; pose 'Pose(Point(4 0),0)', 6);
+-- NULL
+</programlisting>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
 		<sect2 xml:id="pose_comparison">
 			<title>Comparisons</title>
 

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -1781,7 +1781,7 @@ pose_distance(Datum pose1, Datum pose2)
  * @ingroup meos_pose_base_dist
  * @brief Return the distance between two poses
  * @return On error return @p DBL_MAX
- * @csqlfn Distance_pose_pose()
+ * @csqlfn #Distance_pose_pose()
  */
 double
 distance_pose_pose(const Pose *pose1, const Pose *pose2)
@@ -1790,7 +1790,8 @@ distance_pose_pose(const Pose *pose1, const Pose *pose2)
   if (! ensure_valid_pose_pose(pose1, pose2))
     return DBL_MAX;
   /* The following function assumes that all validity tests have been done */
-  return pose_distance(PointerGetDatum(pose1), PointerGetDatum(pose2));
+  return DatumGetFloat8(pose_distance(PointerGetDatum(pose1),
+    PointerGetDatum(pose2)));
 }
 
 /**
@@ -1811,7 +1812,7 @@ datum_pose_distance(Datum pose1, Datum pose2)
  * @ingroup meos_pose_base_dist
  * @brief Return the distance between a pose and a geometry
  * @return On error return @p DBL_MAX
- * @csqlfn Distance_pose_geo()
+ * @csqlfn #Distance_pose_geo()
  */
 double
 distance_pose_geo(const Pose *pose, const GSERIALIZED *gs)
@@ -1830,7 +1831,7 @@ distance_pose_geo(const Pose *pose, const GSERIALIZED *gs)
  * @ingroup meos_pose_base_dist
  * @brief Return the distance between a pose and a spatiotemporal box
  * @return On error return @p DBL_MAX
- * @csqlfn Distance_pose_stbox()
+ * @csqlfn #Distance_pose_stbox()
  */
 double
 distance_pose_stbox(const Pose *pose, const STBox *box)

--- a/mobilitydb/sql/pose/110_tpose_distance.in.sql
+++ b/mobilitydb/sql/pose/110_tpose_distance.in.sql
@@ -32,6 +32,66 @@
  * @brief Temporal distance for temporal poses
  */
 
+/*****************************************************************************
+ * Distance functions
+ *****************************************************************************/
+
+CREATE FUNCTION distance(geometry, pose)
+  RETURNS float
+  AS 'MODULE_PATHNAME', 'Distance_geo_pose'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION distance(stbox, pose)
+  RETURNS float
+  AS 'MODULE_PATHNAME', 'Distance_stbox_pose'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION distance(pose, geometry)
+  RETURNS float
+  AS 'MODULE_PATHNAME', 'Distance_pose_geo'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION distance(pose, stbox)
+  RETURNS float
+  AS 'MODULE_PATHNAME', 'Distance_pose_stbox'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION distance(pose, pose)
+  RETURNS float
+  AS 'MODULE_PATHNAME', 'Distance_pose_pose'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OPERATOR <-> (
+  PROCEDURE = distance,
+  LEFTARG = geometry,
+  RIGHTARG = pose,
+  COMMUTATOR = <->
+);
+CREATE OPERATOR <-> (
+  PROCEDURE = distance,
+  LEFTARG = stbox,
+  RIGHTARG = pose,
+  COMMUTATOR = <->
+);
+CREATE OPERATOR <-> (
+  PROCEDURE = distance,
+  LEFTARG = pose,
+  RIGHTARG = geometry,
+  COMMUTATOR = <->
+);
+CREATE OPERATOR <-> (
+  PROCEDURE = distance,
+  LEFTARG = pose,
+  RIGHTARG = stbox,
+  COMMUTATOR = <->
+);
+CREATE OPERATOR <-> (
+  PROCEDURE = distance,
+  LEFTARG = pose,
+  RIGHTARG = pose,
+  COMMUTATOR = <->
+);
+
+/*****************************************************************************
+ * Temporal distance functions
+ *****************************************************************************/
+
 CREATE FUNCTION tDistance(geometry(Point), tpose)
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tdistance_point_tpose'

--- a/mobilitydb/src/pose/tpose_distance.c
+++ b/mobilitydb/src/pose/tpose_distance.c
@@ -44,6 +44,109 @@
 #include "pg_geo/postgis.h"
 
 /*****************************************************************************
+ * Distance
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Distance_pose_geo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Distance_pose_geo);
+/**
+ * @ingroup mobilitydb_pose_dist
+ * @brief Return the distance between a pose and a geometry
+ * @sqlfn distance()
+ * @sqlop @p <->
+ */
+Datum
+Distance_pose_geo(PG_FUNCTION_ARGS)
+{
+  Pose *pose = PG_GETARG_POSE_P(0);
+  GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(1);
+  double result = distance_pose_geo(pose, gs);
+  PG_FREE_IF_COPY(gs, 1);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
+  PG_RETURN_FLOAT8(result);
+}
+
+PGDLLEXPORT Datum Distance_geo_pose(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Distance_geo_pose);
+/**
+ * @ingroup mobilitydb_pose_dist
+ * @brief Return the distance between a geometry and a pose
+ * @sqlfn distance()
+ * @sqlop @p <->
+ */
+Datum
+Distance_geo_pose(PG_FUNCTION_ARGS)
+{
+  GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(0);
+  Pose *pose = PG_GETARG_POSE_P(1);
+  double result = distance_pose_geo(pose, gs);
+  PG_FREE_IF_COPY(gs, 0);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
+  PG_RETURN_FLOAT8(result);
+}
+
+/*****************************************************************************/
+
+PGDLLEXPORT Datum Distance_pose_stbox(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Distance_pose_stbox);
+/**
+ * @ingroup mobilitydb_pose_dist
+ * @brief Return the distance between a pose and a spatiotemporal box
+ * @sqlfn distance()
+ * @sqlop @p <->
+ */
+Datum
+Distance_pose_stbox(PG_FUNCTION_ARGS)
+{
+  Pose *pose = PG_GETARG_POSE_P(0);
+  STBox *box = PG_GETARG_STBOX_P(1);
+  double result = distance_pose_stbox(pose, box);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
+  PG_RETURN_FLOAT8(result);
+}
+
+PGDLLEXPORT Datum Distance_stbox_pose(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Distance_stbox_pose);
+/**
+ * @ingroup mobilitydb_pose_dist
+ * @brief Return the distance between a spatiotemporal box and a pose
+ * @sqlfn distance()
+ * @sqlop @p <->
+ */
+Datum
+Distance_stbox_pose(PG_FUNCTION_ARGS)
+{
+  STBox *box = PG_GETARG_STBOX_P(0);
+  Pose *pose = PG_GETARG_POSE_P(1);
+  double result = distance_pose_stbox(pose, box);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
+  PG_RETURN_FLOAT8(result);
+}
+
+PGDLLEXPORT Datum Distance_pose_pose(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Distance_pose_pose);
+/**
+ * @ingroup mobilitydb_pose_dist
+ * @brief Return the distance between two poses
+ * @sqlfn distance()
+ * @sqlop @p <->
+ */
+Datum
+Distance_pose_pose(PG_FUNCTION_ARGS)
+{
+  Pose *pose1 = PG_GETARG_POSE_P(0);
+  Pose *pose2 = PG_GETARG_POSE_P(1);
+  double result = distance_pose_pose(pose1, pose2);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
+  PG_RETURN_FLOAT8(result);
+}
+
+/*****************************************************************************
  * Temporal distance
  *****************************************************************************/
 

--- a/mobilitydb/test/pose/expected/113_tpose_distance.test.out
+++ b/mobilitydb/test/pose/expected/113_tpose_distance.test.out
@@ -1,3 +1,121 @@
+SELECT round(distance(geometry 'Point(1 0)', pose 'Pose(Point(4 0),0)'), 6);
+ round 
+-------
+     3
+(1 row)
+
+SELECT round(distance(stbox 'STBOX X((1,-1),(3,1))', pose 'Pose(Point(4 0),0)'), 6);
+ round 
+-------
+     1
+(1 row)
+
+SELECT round(distance(pose 'Pose(Point(4 0),0)', geometry 'Point(1 0)'), 6);
+ round 
+-------
+     3
+(1 row)
+
+SELECT round(distance(pose 'Pose(Point(4 0),0)', stbox 'STBOX X((1,-1),(3,1))'), 6);
+ round 
+-------
+     1
+(1 row)
+
+SELECT round(distance(pose 'Pose(Point(0 0),0)', pose 'Pose(Point(3 4),0)'), 6);
+ round 
+-------
+     5
+(1 row)
+
+SELECT round(geometry 'Point(1 0)' <-> pose 'Pose(Point(4 0),0)', 6);
+ round 
+-------
+     3
+(1 row)
+
+SELECT round(stbox 'STBOX X((1,-1),(3,1))' <-> pose 'Pose(Point(4 0),0)', 6);
+ round 
+-------
+     1
+(1 row)
+
+SELECT round(pose 'Pose(Point(4 0),0)' <-> geometry 'Point(1 0)', 6);
+ round 
+-------
+     3
+(1 row)
+
+SELECT round(pose 'Pose(Point(4 0),0)' <-> stbox 'STBOX X((1,-1),(3,1))', 6);
+ round 
+-------
+     1
+(1 row)
+
+SELECT round(pose 'Pose(Point(0 0),0)' <-> pose 'Pose(Point(3 4),0)', 6);
+ round 
+-------
+     5
+(1 row)
+
+SELECT round(pose 'Pose(Point(0 0),0)' <-> pose 'Pose(Point(0 0),0)', 6);
+ round 
+-------
+     0
+(1 row)
+
+SELECT round(pose 'Pose(Point(0 0),0.5)' <-> pose 'Pose(Point(3 4),1.5)', 6);
+ round 
+-------
+     5
+(1 row)
+
+SELECT round(pose 'SRID=5676;Pose(Point(0 0),0)' <-> pose 'SRID=5676;Pose(Point(3 4),0)', 6);
+ round 
+-------
+     5
+(1 row)
+
+SELECT round(pose 'Pose(Point(0 0 0), 1, 0, 0, 0)' <-> pose 'Pose(Point(3 4 12), 1, 0, 0, 0)', 6);
+ round 
+-------
+     5
+(1 row)
+
+SELECT round(geometry 'Point empty' <-> pose 'Pose(Point(4 0),0)', 6);
+ round 
+-------
+      
+(1 row)
+
+SELECT round(pose 'Pose(Point(4 0),0)' <-> geometry 'Point empty', 6);
+ round 
+-------
+      
+(1 row)
+
+SELECT NULL::geometry <-> pose 'Pose(Point(4 0),0)';
+ ?column? 
+----------
+         
+(1 row)
+
+SELECT pose 'Pose(Point(4 0),0)' <-> NULL::stbox;
+ ?column? 
+----------
+         
+(1 row)
+
+SELECT NULL::pose <-> pose 'Pose(Point(4 0),0)';
+ ?column? 
+----------
+         
+(1 row)
+
+SELECT pose 'SRID=5676;Pose(Point(0 0),0)' <-> pose 'Pose(Point(3 4),0)';
+ERROR:  Operation on mixed SRID
+SELECT geometry 'SRID=5676;Point(1 0)' <-> pose 'Pose(Point(4 0),0)';
+ERROR:  Operation on mixed SRID
 SELECT round(tDistance(geometry 'Point(1 0)', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'), 6);
                                               round                                               
 --------------------------------------------------------------------------------------------------

--- a/mobilitydb/test/pose/queries/113_tpose_distance.test.sql
+++ b/mobilitydb/test/pose/queries/113_tpose_distance.test.sql
@@ -28,6 +28,38 @@
 -------------------------------------------------------------------------------
 
 -------------------------------------------------------------------------------
+-- distance
+-------------------------------------------------------------------------------
+
+SELECT round(distance(geometry 'Point(1 0)', pose 'Pose(Point(4 0),0)'), 6);
+SELECT round(distance(stbox 'STBOX X((1,-1),(3,1))', pose 'Pose(Point(4 0),0)'), 6);
+SELECT round(distance(pose 'Pose(Point(4 0),0)', geometry 'Point(1 0)'), 6);
+SELECT round(distance(pose 'Pose(Point(4 0),0)', stbox 'STBOX X((1,-1),(3,1))'), 6);
+SELECT round(distance(pose 'Pose(Point(0 0),0)', pose 'Pose(Point(3 4),0)'), 6);
+
+SELECT round(geometry 'Point(1 0)' <-> pose 'Pose(Point(4 0),0)', 6);
+SELECT round(stbox 'STBOX X((1,-1),(3,1))' <-> pose 'Pose(Point(4 0),0)', 6);
+SELECT round(pose 'Pose(Point(4 0),0)' <-> geometry 'Point(1 0)', 6);
+SELECT round(pose 'Pose(Point(4 0),0)' <-> stbox 'STBOX X((1,-1),(3,1))', 6);
+SELECT round(pose 'Pose(Point(0 0),0)' <-> pose 'Pose(Point(3 4),0)', 6);
+
+SELECT round(pose 'Pose(Point(0 0),0)' <-> pose 'Pose(Point(0 0),0)', 6);
+SELECT round(pose 'Pose(Point(0 0),0.5)' <-> pose 'Pose(Point(3 4),1.5)', 6);
+SELECT round(pose 'SRID=5676;Pose(Point(0 0),0)' <-> pose 'SRID=5676;Pose(Point(3 4),0)', 6);
+SELECT round(pose 'Pose(Point(0 0 0), 1, 0, 0, 0)' <-> pose 'Pose(Point(3 4 12), 1, 0, 0, 0)', 6);
+
+-- Empty geometry and NULL arguments
+SELECT round(geometry 'Point empty' <-> pose 'Pose(Point(4 0),0)', 6);
+SELECT round(pose 'Pose(Point(4 0),0)' <-> geometry 'Point empty', 6);
+SELECT NULL::geometry <-> pose 'Pose(Point(4 0),0)';
+SELECT pose 'Pose(Point(4 0),0)' <-> NULL::stbox;
+SELECT NULL::pose <-> pose 'Pose(Point(4 0),0)';
+
+-- Errors
+SELECT pose 'SRID=5676;Pose(Point(0 0),0)' <-> pose 'Pose(Point(3 4),0)';
+SELECT geometry 'SRID=5676;Point(1 0)' <-> pose 'Pose(Point(4 0),0)';
+
+-------------------------------------------------------------------------------
 -- tDistance
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR gives the `pose` base type the distance surface that its
sibling `cbuffer` already has in `210_tcbuffer_distance.in.sql`. The
MEOS functions `distance_pose_pose`, `distance_pose_geo` and
`distance_pose_stbox` exist and their documentation names the
PostgreSQL wrappers `Distance_pose_pose`, `Distance_pose_geo` and
`Distance_pose_stbox`, but those wrappers have no implementation, so
the distance between two poses, between a pose and a geometry, and
between a pose and a spatiotemporal box is unreachable from SQL.

The PR adds

* the five wrappers `Distance_pose_pose`, `Distance_pose_geo`,
  `Distance_geo_pose`, `Distance_pose_stbox` and `Distance_stbox_pose`
  in `mobilitydb/src/pose/tpose_distance.c`, next to the existing
  `NAD_*`, `NAI_*`, `Shortestline_*` and `Tdistance_*` pose wrappers,
* the corresponding `distance` functions and `<->` operators in
  `mobilitydb/sql/pose/110_tpose_distance.in.sql`, in both argument
  orders and with the commutators declared,
* regression tests covering the five bindings, the operator forms, the
  empty-geometry and `NULL` results and the mixed SRID errors,
* the `Distance Operations` section of the pose base type in the user
  manual and its entry in the reference chapter, in English and Spanish.

Only the point component of the pose participates in the distance and
the computation is planar, matching what the MEOS functions do.

The PR also repairs two defects that the new surface reaches.
`distance_pose_pose` returns the `Datum` produced by the internal
`pose_distance` function without unpacking it, so the value crossing
its `double` return type is the bit pattern of the distance instead of
the distance: the distance between `Pose(Point(0 0),0)` and
`Pose(Point(3 4),0)` comes out as `4.617315517961601e+18` instead of
`5`. A `DatumGetFloat8` call fixes it, and the defect is invisible
today only because the function has no caller. The `@csqlfn` tags of
the three functions also lack the `#` reference prefix that the sibling
`cbuffer` functions use, which keeps them from resolving to a wrapper.

The `<->` operators added here are defined on `pose <-> pose`,
`geometry <-> pose` and `stbox <-> pose`. None of these types is one of
the types for which `btree_gist` defines `<->`, so the two extensions
load together in either order.