### PR TITLE
Reject a negative tile size in the temporal box tiling functions

### DIFF
--- a/meos/include/meos_internal.h
+++ b/meos/include/meos_internal.h
@@ -1414,6 +1414,7 @@ extern Span *tnumber_value_bins(const Temporal *temp, Datum size, Datum origin, 
 extern TBox *tnumber_value_time_boxes(const Temporal *temp, Datum vsize, const Interval *duration, Datum vorigin, TimestampTz torigin, int *count);
 extern Temporal **tnumber_value_split(const Temporal *temp, Datum vsize, Datum vorigin, Datum **bins, int *count);
 extern TBox *tbox_get_value_time_tile(Datum value, TimestampTz t, Datum vsize, const Interval *duration, Datum vorigin, TimestampTz torigin, MeosType basetype, MeosType spantype);
+extern TBox *tbox_value_time_tiles(const TBox *box, Datum vsize, const Interval *duration, Datum vorigin, TimestampTz torigin, int *count);
 extern Temporal **tnumber_value_time_split(const Temporal *temp, Datum size, const Interval *duration, Datum vorigin, TimestampTz torigin, Datum **value_bins, TimestampTz **time_bins, int *count);
 
 /*****************************************************************************/

--- a/meos/src/temporal/temporal_tile_meos.c
+++ b/meos/src/temporal/temporal_tile_meos.c
@@ -135,7 +135,8 @@ tintbox_value_time_tiles(const TBox *box, int vsize, const Interval *duration,
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(box, NULL); VALIDATE_NOT_NULL(count, NULL);
-  if (! ensure_one_tile_dimension((double) vsize, duration))
+  if (! ensure_not_negative_datum(Int32GetDatum(vsize), T_INT4) ||
+      ! ensure_one_tile_dimension((double) vsize, duration))
     return NULL;
   return tbox_value_time_tiles(box, Int32GetDatum(vsize), duration,
     Int32GetDatum(vorigin), torigin, count);
@@ -158,7 +159,8 @@ tfloatbox_value_time_tiles(const TBox *box, double vsize,
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(box, NULL); VALIDATE_NOT_NULL(count, NULL);
-  if (! ensure_one_tile_dimension(vsize, duration))
+  if (! ensure_not_negative_datum(Float8GetDatum(vsize), T_FLOAT8) ||
+      ! ensure_one_tile_dimension(vsize, duration))
     return NULL;
   return tbox_value_time_tiles(box, Float8GetDatum(vsize), duration,
     Float8GetDatum(vorigin), torigin, count);


### PR DESCRIPTION
The public temporal box tiling functions pass their value size straight to the
internal `tbox_value_time_tiles`, whose precondition that the size is not
negative is stated by an assertion. A negative size aborts a build that checks
the assertions and is undefined behaviour in a build that compiles them out:

```
tintbox_value_tiles(box, -5, 0, &count)
probe: meos/src/temporal/temporal_tile_meos.c:77: tbox_value_time_tiles:
  Assertion `not_negative_datum(vsize, box->span.basetype)' failed.
```

`tintbox_value_time_tiles` and `tfloatbox_value_time_tiles` validate the size
with `ensure_not_negative_datum` ahead of the check that at least one tiling
dimension is given. The four public functions that take a size, that is the two
above and the `tintbox_value_tiles` and `tfloatbox_value_tiles` wrappers that
delegate to them, return `NULL` and raise an invalid-argument-value error. This
completes the validation parity with the spatiotemporal box tiles, where
`stbox_space_time_tiles` validates its sizes the same way.

A size of zero stays valid when a duration is given, which is the case that
tiles on the time dimension alone.

`tbox_value_time_tiles` is declared in `meos_internal.h`, next to the other
internal tile functions. The function belongs to the internal API and is
exported by the library, and no header declares it.
