### PR TITLE
Bound the accepted input of the h3index parser

### DIFF
--- a/doc/es/temporal_h3_index.xml
+++ b/doc/es/temporal_h3_index.xml
@@ -20,7 +20,7 @@
 
 	<sect1 xml:id="th3_inout">
 		<title>Entrada y Salida</title>
-		<para>Un valor <varname>th3index</varname> se introduce utilizando la sintaxis temporal estándar con el identificador de celda H3 de 64 bits subyacente. El analizador acepta la forma hexadecimal canónica (la que produce la CLI de H3 y <varname>h3_cell_to_string</varname> en el proyecto original), con un prefijo <varname>0x</varname> opcional, tal como la lee la propia biblioteca H3. El hexadecimal es idiomático en el ecosistema H3 y es lo que emite la función de salida, todos los ejemplos siguientes lo usan.</para>
+		<para>Un valor <varname>th3index</varname> se introduce utilizando la sintaxis temporal estándar con el identificador de celda H3 de 64 bits subyacente. El analizador acepta la forma hexadecimal canónica (la que produce la CLI de H3 y <varname>h3_cell_to_string</varname> en el proyecto original), con un prefijo <varname>0x</varname> opcional y como máximo 16 dígitos significativos. El hexadecimal es idiomático en el ecosistema H3 y es lo que emite la función de salida, todos los ejemplos siguientes lo usan.</para>
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3index '831c02fffffffff@2001-01-01';
 SELECT th3index '{831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02}';

--- a/doc/temporal_h3_index.xml
+++ b/doc/temporal_h3_index.xml
@@ -20,7 +20,7 @@
 
 	<sect1 xml:id="th3_inout">
 		<title>Input and Output</title>
-		<para>A <varname>th3index</varname> value is entered using the standard temporal syntax with the underlying 64-bit H3 cell identifier. The input parser accepts the canonical hexadecimal form (as produced by the H3 CLI and by <varname>h3_cell_to_string</varname> upstream), with an optional <varname>0x</varname> prefix, as the H3 library itself reads it. Hexadecimal is idiomatic in the H3 ecosystem and is what the output function emits, all examples below use it.</para>
+		<para>A <varname>th3index</varname> value is entered using the standard temporal syntax with the underlying 64-bit H3 cell identifier. The input parser accepts the canonical hexadecimal form (as produced by the H3 CLI and by <varname>h3_cell_to_string</varname> upstream), with an optional <varname>0x</varname> prefix and at most 16 significant digits. Hexadecimal is idiomatic in the H3 ecosystem and is what the output function emits, all examples below use it.</para>
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3index '831c02fffffffff@2001-01-01';
 SELECT th3index '{831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02}';

--- a/meos/include/h3/h3index.h
+++ b/meos/include/h3/h3index.h
@@ -37,8 +37,8 @@
  * compound payload (it is a 64-bit integer cell identifier), so
  * the helpers here are minimal:
  *
- *   * an input parser that delegates to the h3 library, which reads the
- *     canonical hexadecimal cell literal with an optional "0x" prefix,
+ *   * an input parser that reads the canonical hexadecimal cell literal,
+ *     with an optional "0x" prefix and at most 16 significant digits,
  *   * an output formatter (canonical form is hex, matching h3-pg),
  *   * comparison / ordering / hashing helpers — exposed at the MEOS
  *     layer so MobilityDuck and other consumers can reuse them

--- a/meos/include/h3_ext_defs.in.h
+++ b/meos/include/h3_ext_defs.in.h
@@ -5,9 +5,9 @@
  * PostgreSQL extension. The MEOS library defines them (they are the public
  * binding surface); the MobilityDB PostgreSQL extension does not, so that
  * both the h3 and mobilitydb extensions can be loaded in the same server.
- * Input parses and output prints with libh3's stringToH3 / h3ToString —
- * hexadecimal with an optional "0x" prefix, no cell-validity check —
- * exactly as h3-pg does. Comparison / ordering / hashing operate on the
+ * Input reads, and output prints, the canonical hexadecimal cell literal
+ * with an optional "0x" prefix and at most 16 significant digits, with no
+ * cell-validity check. Comparison / ordering / hashing operate on the
  * uint64 cell identifier; they carry no geographic meaning but are
  * required for ordering, grouping, and hashing. */
 

--- a/meos/src/h3/h3index.c
+++ b/meos/src/h3/h3index.c
@@ -418,9 +418,40 @@ meos_h3index_in(const char *str)
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(str, (H3Index) 0);
 
-  /* Delegate to libh3, exactly as the h3-pg extension's input function
-   * does, so both extensions parse the same representation (hexadecimal,
-   * with an optional "0x" prefix, no cell-validity check) */
+  /* The accepted input is an optional "0x" or "0X" prefix followed by at
+   * least one and at most 16 significant hexadecimal digits, leading zeros
+   * being insignificant, and nothing else. There is no cell-validity check.
+   * The domain is bounded here rather than inherited from libh3, which
+   * saturates a value wider than 64 bits and stops at the first character it
+   * cannot read: both map strings that differ onto the value of an unrelated
+   * cell, so distinct inputs would compare equal and corrupt joins, grouping
+   * and deduplication. MobilityDB must yield identical results in every
+   * binding, whichever version of libh3 the binding links, hence the check
+   * precedes the delegation. The parsing itself is left to libh3 */
+  const char *p = str;
+  if (p[0] == '0' && (p[1] == 'x' || p[1] == 'X'))
+    p += 2;
+  const char *start = p;
+  while (*p == '0')
+    p++;
+  const char *significant = p;
+  while (isxdigit((unsigned char) *p))
+    p++;
+  if (*p != '\0' || p == start)
+  {
+    meos_error(ERROR, MEOS_ERR_TEXT_INPUT,
+      "invalid h3index input \"%s\": expected hexadecimal digits with an "
+      "optional \"0x\" prefix", str);
+    return (H3Index) 0;
+  }
+  if (p - significant > 16)
+  {
+    meos_error(ERROR, MEOS_ERR_TEXT_INPUT,
+      "invalid h3index input \"%s\": at most 16 hexadecimal digits are "
+      "allowed", str);
+    return (H3Index) 0;
+  }
+
   H3Index cell;
   H3Error err;
   if ((err = stringToH3(str, &cell)) != E_SUCCESS)

--- a/mobilitydb/test/h3/expected/251_h3indexset.test.out
+++ b/mobilitydb/test/h3/expected/251_h3indexset.test.out
@@ -10,10 +10,24 @@ SELECT h3indexset '{8a2a1072b59ffff}';
  {"8a2a1072b59ffff"}
 (1 row)
 
-SELECT h3indexset '{622236750694711295}';
-ERROR:  H3 cellToBoundary failed for cell ffffffffffffffff
-LINE 1: SELECT h3indexset '{622236750694711295}';
-                          ^
+SELECT h3indexset '{0x8a2a1072b59ffff}';
+     h3indexset      
+---------------------
+ {"8a2a1072b59ffff"}
+(1 row)
+
+SELECT h3indexset '{0x0000000008a2a1072b59ffff}';
+     h3indexset      
+---------------------
+ {"8a2a1072b59ffff"}
+(1 row)
+
+SELECT h3indexset '{00000008a2a1072b59ffff}';
+     h3indexset      
+---------------------
+ {"8a2a1072b59ffff"}
+(1 row)
+
 /* Errors */
 SELECT h3indexset '{0}';
  h3indexset 
@@ -22,8 +36,24 @@ SELECT h3indexset '{0}';
 (1 row)
 
 SELECT h3indexset '{not-a-cell}';
-ERROR:  invalid h3index input "not-a-cell": h3 error code 1
+ERROR:  invalid h3index input "not-a-cell": expected hexadecimal digits with an optional "0x" prefix
 LINE 1: SELECT h3indexset '{not-a-cell}';
+                          ^
+SELECT h3indexset '{622236750694711295}';
+ERROR:  invalid h3index input "622236750694711295": at most 16 hexadecimal digits are allowed
+LINE 1: SELECT h3indexset '{622236750694711295}';
+                          ^
+SELECT h3indexset '{ffffffffffffffffff}';
+ERROR:  invalid h3index input "ffffffffffffffffff": at most 16 hexadecimal digits are allowed
+LINE 1: SELECT h3indexset '{ffffffffffffffffff}';
+                          ^
+SELECT h3indexset '{0xffffffffffffffffffffffff}';
+ERROR:  invalid h3index input "0xffffffffffffffffffffffff": at most 16 hexadecimal digits are allowed
+LINE 1: SELECT h3indexset '{0xffffffffffffffffffffffff}';
+                          ^
+SELECT h3indexset '{8928308280fffffZZ}';
+ERROR:  invalid h3index input "8928308280fffffZZ": expected hexadecimal digits with an optional "0x" prefix
+LINE 1: SELECT h3indexset '{8928308280fffffZZ}';
                           ^
 SELECT set(h3index '8a2a1072b59ffff');
          set         

--- a/mobilitydb/test/h3/expected/270_th3index.test.out
+++ b/mobilitydb/test/h3/expected/270_th3index.test.out
@@ -15,6 +15,14 @@ SELECT th3index '8a2a100d645ffff@2012-01-01 08:00:00,';
 ERROR:  Could not parse th3index value: Extraneous characters at the end
 LINE 1: SELECT th3index '8a2a100d645ffff@2012-01-01 08:00:00,';
                         ^
+SELECT th3index 'ffffffffffffffffff@2012-01-01 08:00:00';
+ERROR:  invalid h3index input "ffffffffffffffffff": at most 16 hexadecimal digits are allowed
+LINE 1: SELECT th3index 'ffffffffffffffffff@2012-01-01 08:00:00';
+                        ^
+SELECT th3index '8a2a100d645fffZZ@2012-01-01 08:00:00';
+ERROR:  invalid h3index input "8a2a100d645fffZZ": expected hexadecimal digits with an optional "0x" prefix
+LINE 1: SELECT th3index '8a2a100d645fffZZ@2012-01-01 08:00:00';
+                        ^
 SELECT th3index ' { 8a2a100d645ffff@2001-01-01 08:00:00 , 8a2a100d6460000@2001-01-01 08:05:00 , 8a2a100d6460001@2001-01-01 08:06:00 } ';
                                                                   th3index                                                                  
 --------------------------------------------------------------------------------------------------------------------------------------------

--- a/mobilitydb/test/h3/queries/250_h3index.test.sql
+++ b/mobilitydb/test/h3/queries/250_h3index.test.sql
@@ -10,7 +10,14 @@
 -- operators, btree + hash opclasses, ASSIGNMENT casts to/from bigint.
 
 -------------------------------------------------------------------------------
--- Input parser: hex (canonical) and decimal both accepted
+-- Input parser
+--
+-- The h3index literal is parsed by the input function of the h3 extension,
+-- which provides the type. It reads hexadecimal, saturates a value wider
+-- than 64 bits, and stops at the first character it cannot read, so the
+-- decimal spelling of a cell yields an unrelated cell. The MobilityDB
+-- parser, which reads the elements of an h3indexset and the values of a
+-- th3index, rejects those spellings instead (see 251 and 270).
 -------------------------------------------------------------------------------
 
 SELECT h3index '8a2a1072b59ffff';

--- a/mobilitydb/test/h3/queries/251_h3indexset.test.sql
+++ b/mobilitydb/test/h3/queries/251_h3indexset.test.sql
@@ -20,14 +20,23 @@ SELECT h3indexset '{8a2a1072b59ffff, 831c02fffffffff, 880326b885fffff}';
 -- Singleton
 SELECT h3indexset '{8a2a1072b59ffff}';
 
--- The h3 library reads a cell literal as hexadecimal, so the decimal
--- spelling of a cell is read as hex, exceeds 64 bits, and reaches the
--- cell lookup as the saturated value
-SELECT h3indexset '{622236750694711295}';
+-- An optional "0x" prefix and insignificant leading zeros are accepted
+SELECT h3indexset '{0x8a2a1072b59ffff}';
+SELECT h3indexset '{0x0000000008a2a1072b59ffff}';
+SELECT h3indexset '{00000008a2a1072b59ffff}';
 
 /* Errors */
 SELECT h3indexset '{0}';                     -- the 0 sentinel is rejected
 SELECT h3indexset '{not-a-cell}';
+-- A cell literal is read as hexadecimal, so the decimal spelling of a cell
+-- has more than 16 significant hexadecimal digits and is rejected instead
+-- of being silently narrowed to another cell
+SELECT h3indexset '{622236750694711295}';
+SELECT h3indexset '{ffffffffffffffffff}';
+SELECT h3indexset '{0xffffffffffffffffffffffff}';
+-- Characters that are not hexadecimal digits are rejected instead of
+-- being silently ignored
+SELECT h3indexset '{8928308280fffffZZ}';
 
 -------------------------------------------------------------------------------
 -- Conversions

--- a/mobilitydb/test/h3/queries/270_th3index.test.sql
+++ b/mobilitydb/test/h3/queries/270_th3index.test.sql
@@ -32,6 +32,8 @@ SELECT th3index '8a2a100d645ffff@2012-01-01 08:00:00';
 /* Errors */
 SELECT th3index 'ABC@2012-01-01 08:00:00';
 SELECT th3index '8a2a100d645ffff@2012-01-01 08:00:00,';
+SELECT th3index 'ffffffffffffffffff@2012-01-01 08:00:00';
+SELECT th3index '8a2a100d645fffZZ@2012-01-01 08:00:00';
 
 -------------------------------------------------------------------------------
 -- Temporal discrete sequence


### PR DESCRIPTION
The h3index input function delegates the whole parse to the h3 library, which saturates a value that does not fit in 64 bits and stops at the first character it cannot read. Strings that differ therefore yield the same cell: `ffffffffffffffffff` and `0xffffffffffffffffffffffff` both give `ffffffffffffffff`, and `8928308280fffffZZ` gives `8928308280fffff`. Distinct inputs that collapse onto one value compare equal, which silently corrupts joins, `GROUP BY`, `DISTINCT` and deduplication, and the decimal spelling of a cell reaches the cell lookup as an unrelated cell.

This bounds the accepted input before the delegation. The parser accepts an optional `0x` or `0X` prefix followed by at least one and at most 16 significant hexadecimal digits, leading zeros being insignificant, and nothing else; there is still no cell-validity check. Anything longer, or holding a character that is not a hexadecimal digit, raises an error. The parsing itself remains libh3's.

Defining the domain here rather than inheriting it keeps the result identical in every binding, whichever version of the h3 library the binding links.

The h3indexset element parser and the th3index value parser both route through this function and are bounded with it. The `h3index` literal in the PostgreSQL extension is parsed by the h3 extension, which provides the type, and is unaffected.
