### PR TITLE
Compute the segment distance lower bound through the named box distance

### DIFF
--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -1862,11 +1862,11 @@ tcbufferseg_distance_lb(Datum start1, Datum end1, Datum start2, Datum end2)
   const POINT2D *e2 = cbuffer_point2d_p(ce2);
   double r1 = fmax(cs1->radius, ce1->radius);
   double r2 = fmax(cs2->radius, ce2->radius);
-  double dx = fmax(fmax(fmin(s1->x, e1->x) - fmax(s2->x, e2->x),
-    fmin(s2->x, e2->x) - fmax(s1->x, e1->x)), 0.0);
-  double dy = fmax(fmax(fmin(s1->y, e1->y) - fmax(s2->y, e2->y),
-    fmin(s2->y, e2->y) - fmax(s1->y, e1->y)), 0.0);
-  return sqrt(dx * dx + dy * dy) - r1 - r2;
+  return sqrt(box2d_distance_sqr(
+    fmin(s1->x, e1->x), fmin(s1->y, e1->y),
+    fmax(s1->x, e1->x), fmax(s1->y, e1->y),
+    fmin(s2->x, e2->x), fmin(s2->y, e2->y),
+    fmax(s2->x, e2->x), fmax(s2->y, e2->y))) - r1 - r2;
 }
 
 /**

--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -1831,11 +1831,11 @@ tpointseg_distance_lb(Datum start1, Datum end1, Datum start2, Datum end2)
   const POINT2D *e1 = DATUM_POINT2D_P(end1);
   const POINT2D *s2 = DATUM_POINT2D_P(start2);
   const POINT2D *e2 = DATUM_POINT2D_P(end2);
-  double dx = fmax(fmax(fmin(s1->x, e1->x) - fmax(s2->x, e2->x),
-    fmin(s2->x, e2->x) - fmax(s1->x, e1->x)), 0.0);
-  double dy = fmax(fmax(fmin(s1->y, e1->y) - fmax(s2->y, e2->y),
-    fmin(s2->y, e2->y) - fmax(s1->y, e1->y)), 0.0);
-  return sqrt(dx * dx + dy * dy);
+  return sqrt(box2d_distance_sqr(
+    fmin(s1->x, e1->x), fmin(s1->y, e1->y),
+    fmax(s1->x, e1->x), fmax(s1->y, e1->y),
+    fmin(s2->x, e2->x), fmin(s2->y, e2->y),
+    fmax(s2->x, e2->x), fmax(s2->y, e2->y)));
 }
 
 /**


### PR DESCRIPTION
The synchronized nearest-approach pass prunes a segment pair with a lower bound on their distance: a moving point stays inside the bounding box of its two endpoints, so the gap between the two endpoint boxes bounds the synchronized distance from below, and for discs the same gap minus the larger endpoint radius of each bounds the signed gap.

That gap is the axis-aligned box distance each file already names `box2d_distance_sqr` — `meos/src/geo/tgeo_distance.c` and `meos/src/cbuffer/tcbuffer_distance.c`, where the three prune levels of the swept-capsule kernels call it. The two lower bounds `tpointseg_distance_lb` and `tcbufferseg_distance_lb` spell the same arithmetic out a second time, with the box corners folded into the expression.

Both build their boxes from the endpoint extrema and call the named function, so the file states the gap formula once and the lower bound reads as what it is: a box distance over two endpoint boxes, with the radii subtracted in the circular buffer case.

The distance suites `064_tgeo_distance`, `064_tpoint_distance` and `210_tcbuffer_distance`, with their table-driven variants, exercise both lower bounds through the nearest-approach entry points.
