### PR TITLE
Store a k-d box under the dimension the search narrows

### DIFF
--- a/meos/include/temporal/temporal_sptree.h
+++ b/meos/include/temporal/temporal_sptree.h
@@ -78,6 +78,12 @@ struct SPTree
   size_t nodeboxsize;   /**< Size of an inner node region */
   int dims;             /**< Number of dimensions of the box */
   int nchild;           /**< Number of children per node */
+  const uint8 *kd_bits; /**< For a k-d tree, the quadrant bit carrying each
+                             dimension, in the order @p kdtree_next narrows
+                             them. A level must store a box under the bit of
+                             the dimension its region is then narrowed on, or
+                             the search prunes the subtrees holding the
+                             matches. */
   SPTreeKind kind;      /**< Quad-tree or k-d tree */
   SPNode *root;         /**< Root node, or @p NULL when empty */
   int (*box_dims)(const void *box);  /**< Dimensions of a box, or @p NULL when

--- a/meos/src/temporal/temporal_sptree.c
+++ b/meos/src/temporal/temporal_sptree.c
@@ -56,6 +56,31 @@
 #include "temporal/temporal_sptree.h"
 
 /*****************************************************************************
+ * k-d split dimensions
+ *
+ * A k-d level stores a box under one bit of its quadrant code, and the search
+ * then narrows the node region on one dimension. The two must be the same
+ * dimension: the tables below give, for each family, the quadrant bit carrying
+ * the dimension that `*node_kdtree_next` narrows at that level.
+ *
+ * The bits are those the matching getQuadrant assigns, and the order is the one
+ * the matching *node_kdtree_next walks, so the two orders being different — as
+ * they are for the spatiotemporal box, whose bits run Z, Y, X, period while its
+ * search narrows X, Y, Z, period — is carried by the table rather than by a
+ * rule. `*node_kdtree_next` is shared with the SP-GiST operator classes, whose
+ * descent is PostgreSQL's, so the order it walks is fixed and this side adapts.
+ *****************************************************************************/
+
+/* lower, upper */
+static const uint8 SPAN_KD_BITS[2] = {1, 0};
+/* span.lower, span.upper, period.lower, period.upper */
+static const uint8 TBOX_KD_BITS[4] = {3, 2, 1, 0};
+/* xmin, xmax, ymin, ymax, zmin, zmax, period.lower, period.upper */
+static const uint8 STBOX_KD_BITS_Z[8] = {3, 2, 5, 4, 7, 6, 1, 0};
+/* xmin, xmax, ymin, ymax, period.lower, period.upper */
+static const uint8 STBOX_KD_BITS[6] = {3, 2, 5, 4, 1, 0};
+
+/*****************************************************************************
  * Family-specific adapters (Span)
  *****************************************************************************/
 
@@ -279,6 +304,7 @@ sptree_create(MeosType bboxtype, SPTreeKind kind)
     sptree->spantype = bboxtype;
     sptree->basetype = spantype_basetype(bboxtype);
     sptree->dims = 2;
+    sptree->kd_bits = SPAN_KD_BITS;
     sptree->nodeboxsize = sizeof(SpanNode);
     sptree->get_quadrant = &span_get_quadrant;
     sptree->nodebox_init = &span_nodebox_init;
@@ -290,6 +316,7 @@ sptree_create(MeosType bboxtype, SPTreeKind kind)
   else if (bboxtype == T_TBOX)
   {
     sptree->dims = 4;
+    sptree->kd_bits = TBOX_KD_BITS;
     sptree->nodeboxsize = sizeof(TboxNode);
     sptree->get_quadrant = &tbox_get_quadrant;
     sptree->nodebox_init = &tbox_nodebox_init;
@@ -482,6 +509,7 @@ sptree_insert(SPTree *sptree, void *box, int id)
   if (sptree->dims < 0)
   {
     sptree->dims = sptree->box_dims(box);
+    sptree->kd_bits = (sptree->dims == 8) ? STBOX_KD_BITS_Z : STBOX_KD_BITS;
     sptree->nchild = (sptree->kind == SPTREE_QUADTREE) ?
       (1 << sptree->dims) : 2;
   }
@@ -490,8 +518,11 @@ sptree_insert(SPTree *sptree, void *box, int id)
   while (*slot != NULL)
   {
     uint8 quadrant = sptree->get_quadrant((*slot)->centroid, box);
+    /* Store the box under the bit of the dimension the search narrows at this
+     * level, so that the region a search descends into is the region the box
+     * was partitioned by */
     int child = (sptree->kind == SPTREE_QUADTREE) ? (int) quadrant :
-      (int) ((quadrant >> (level % sptree->dims)) & 1);
+      (int) ((quadrant >> sptree->kd_bits[level % sptree->dims]) & 1);
     slot = &(*slot)->children[child];
     level++;
   }

--- a/meos/test/sptree_test.c
+++ b/meos/test/sptree_test.c
@@ -859,6 +859,124 @@ test_nn_stbox(void)
   sptree_free(sptree);
 }
 
+
+/*****************************************************************************
+ * Selective windows
+ *
+ * A query covering the whole space is accepted by every inner node, so it
+ * never prunes and never exercises the dimension a k-d level splits on. Only a
+ * window narrower than the data does. These cases are deterministic and assert
+ * a non-empty answer, so they cannot pass by matching nothing.
+ *****************************************************************************/
+
+#define SEL_BOXES 200
+
+static void
+selective(const char *label, const SPTree *sptree, const void *query,
+  const bool *truth, int ntruth)
+{
+  MeosArray *result = meos_array_create(sizeof(int));
+  int count = sptree_search(sptree, RTREE_OVERLAPS, query, result);
+  bool *in_index = calloc(SEL_BOXES, sizeof(bool));
+  for (int i = 0; i < count; i++)
+    in_index[*(int *) meos_array_get(result, i)] = true;
+  int missed = 0;
+  for (int i = 0; i < SEL_BOXES; i++)
+    if (truth[i] && ! in_index[i])
+      missed++;
+  char name[128];
+  snprintf(name, sizeof(name), "%s window matches %d, none missed", label,
+    ntruth);
+  check(name, ntruth > 0 && missed == 0);
+  free(in_index);
+  meos_array_destroy(result);
+}
+
+static void
+test_selective_intspan(SPTreeKind kind, const char *kindname)
+{
+  Span *boxes[SEL_BOXES];
+  SPTree *sptree = sptree_create_intspan(kind);
+  for (int i = 0; i < SEL_BOXES; i++)
+  {
+    boxes[i] = intspan_make(i, i + 2, true, false);
+    sptree_insert(sptree, boxes[i], i);
+  }
+  Span *query = intspan_make(10, 40, true, false);
+  bool truth[SEL_BOXES];
+  int n = 0;
+  for (int i = 0; i < SEL_BOXES; i++)
+    if ((truth[i] = overlaps_span_span(boxes[i], query)))
+      n++;
+  char label[64];
+  snprintf(label, sizeof(label), "Integer span %s selective", kindname);
+  selective(label, sptree, query, truth, n);
+  for (int i = 0; i < SEL_BOXES; i++)
+    free(boxes[i]);
+  free(query);
+  sptree_free(sptree);
+}
+
+static void
+test_selective_tbox(SPTreeKind kind, const char *kindname)
+{
+  TBox *boxes[SEL_BOXES];
+  SPTree *sptree = sptree_create_tbox(kind);
+  for (int i = 0; i < SEL_BOXES; i++)
+  {
+    /* One dimension is held constant on purpose: splitting on it separates
+     * nothing, so a level that splits the wrong dimension loses the rows. */
+    Span *t = tstzspan_make(0, 86400000000, true, false);
+    Span *v = floatspan_make(i, i + 2, true, false);
+    boxes[i] = tbox_make(v, t);
+    free(t); free(v);
+    sptree_insert(sptree, boxes[i], i);
+  }
+  Span *qt = tstzspan_make(0, 2 * 86400000000, true, false);
+  Span *qv = floatspan_make(10, 40, true, false);
+  TBox *query = tbox_make(qv, qt);
+  free(qt); free(qv);
+  bool truth[SEL_BOXES];
+  int n = 0;
+  for (int i = 0; i < SEL_BOXES; i++)
+    if ((truth[i] = overlaps_tbox_tbox(boxes[i], query)))
+      n++;
+  char label[64];
+  snprintf(label, sizeof(label), "Temporal box %s selective", kindname);
+  selective(label, sptree, query, truth, n);
+  for (int i = 0; i < SEL_BOXES; i++)
+    free(boxes[i]);
+  free(query);
+  sptree_free(sptree);
+}
+
+static void
+test_selective_stbox(SPTreeKind kind, const char *kindname)
+{
+  STBox *boxes[SEL_BOXES];
+  SPTree *sptree = sptree_create_stbox(kind);
+  Span *t = tstzspan_make(0, 86400000000, true, false);
+  for (int i = 0; i < SEL_BOXES; i++)
+  {
+    boxes[i] = stbox_make(true, false, false, 0, i, i + 1, i, i + 1, 0, 0, t);
+    sptree_insert(sptree, boxes[i], i);
+  }
+  STBox *query = stbox_make(true, false, false, 0, 10, 40, 10, 40, 0, 0, t);
+  free(t);
+  bool truth[SEL_BOXES];
+  int n = 0;
+  for (int i = 0; i < SEL_BOXES; i++)
+    if ((truth[i] = overlaps_stbox_stbox(boxes[i], query)))
+      n++;
+  char label[64];
+  snprintf(label, sizeof(label), "Spatiotemporal box %s selective", kindname);
+  selective(label, sptree, query, truth, n);
+  for (int i = 0; i < SEL_BOXES; i++)
+    free(boxes[i]);
+  free(query);
+  sptree_free(sptree);
+}
+
 int
 main(void)
 {
@@ -878,6 +996,12 @@ main(void)
   test_tpcbox(SPTREE_QUADTREE, "quad-tree");
   test_tpcbox(SPTREE_KDTREE, "k-d tree");
 #endif
+  test_selective_intspan(SPTREE_QUADTREE, "quad-tree");
+  test_selective_intspan(SPTREE_KDTREE, "k-d tree");
+  test_selective_tbox(SPTREE_QUADTREE, "quad-tree");
+  test_selective_tbox(SPTREE_KDTREE, "k-d tree");
+  test_selective_stbox(SPTREE_QUADTREE, "quad-tree");
+  test_selective_stbox(SPTREE_KDTREE, "k-d tree");
   test_mest();
   test_stbox_mest();
   test_nn_floatspan();


### PR DESCRIPTION
A k-d level stores a box under one bit of its quadrant code, and a search narrows the node region on one dimension. The two must name the same dimension. The descent takes bit `level % dims`, counting from the least significant end, while each `*node_kdtree_next` narrows its dimensions in its own order, so the region is narrowed on a dimension the data is not partitioned by: the consistency test prunes the subtrees holding the matches, and a bounded query returns nothing at all for a temporal box or a spatiotemporal box.

The tree carries the quadrant bit of each dimension in the order its `*node_kdtree_next` narrows them, and the descent stores a box under that bit. The orders differ per family — the spatiotemporal box assigns its bits Z, Y, X, period while its search narrows X, Y, Z, period — so the mapping is a table per family rather than an arithmetic rule.

`*node_kdtree_next` is shared with the SP-GiST operator classes, whose descent is PostgreSQL's, so the order it narrows in is fixed and the tree adapts to it.

An index whose query covers the whole space accepts every node and prunes nothing, so it cannot notice which dimension a level splits on: the existing cases query a window fifteen times the size of the data. The added cases query a window on the scale of the data, over boxes holding one dimension constant so that splitting the wrong one loses the rows, and assert the answer is not empty.
