### PR TITLE
Free the compacted sequence of a splitting append

### DIFF
--- a/meos/src/temporal/temporal_modif.c
+++ b/meos/src/temporal/temporal_modif.c
@@ -1742,13 +1742,18 @@ tsequence_append_tinstant(TSequence *seq, const TInstant *inst, double maxdist,
     if (split)
     {
       TSequence *sequences[2];
-      sequences[0] = (seq->count < seq->maxcount) ?
-        tsequence_compact((TSequence *) seq) : seq;
+      /* The compacted sequence is a copy owned by this function, while the
+       * sequence itself belongs to the caller */
+      bool compacted = (seq->count < seq->maxcount);
+      sequences[0] = compacted ? tsequence_compact((TSequence *) seq) : seq;
       /* Arbitrary initialization to 64 elements if in expandable mode */
       sequences[1] = tsequence_make_exp((TInstant **) &inst, 1,
         expand ? 64 : 1, true, true, interp, NORMALIZE_NO);
       TSequenceSet *result = tsequenceset_make_exp(sequences, 2,
         expand ? 64 : 2, NORMALIZE_NO);
+      /* The composing sequences are copied into the result */
+      if (compacted)
+        pfree(sequences[0]);
       pfree(sequences[1]);
       return (Temporal *) result;
     }


### PR DESCRIPTION
Appending an instant that opens a gap in a temporal sequence builds a sequence set from the sequence and the instant. When the sequence has space left for further instants, the sequence composing the result is a compacted copy of it. The constructor copies the composing sequences into the result, as it does for the sequence built from the instant, so that copy belongs to the appending function. Freeing it removes a leak of one sequence per splitting append, in both the plain and the expandable mode.

The copy is freed only when it is allocated: when the sequence has no space left, the composing sequence is the argument itself, which belongs to the caller and is left alone.

A valgrind run over ten splitting appends reports the leak as `1,760 bytes in 10 blocks are definitely lost`, allocated in `tsequence_compact`, and reports no loss with the fix.