### PR TITLE
Free the reference geometry parsed for a temporal rigid geometry

### DIFF
--- a/meos/src/rgeo/trgeo_parser.c
+++ b/meos/src/rgeo/trgeo_parser.c
@@ -336,20 +336,11 @@ trgeo_parse(const char **str, MeosType temptype)
   /* Determine the subtype of the temporal rigid geometry and call the
    * function corresponding to the subtype passing the SRID */
   if (**str != '{' && **str != '[' && **str != '(')
-  {
-    TInstant *inst = trgeoinst_parse(str, temptype, true, &temp_srid, geom);
-    if (! inst)
-      return NULL;
-    result = (Temporal *) inst;
-  }
+    result = (Temporal *) trgeoinst_parse(str, temptype, true, &temp_srid,
+      geom);
   else if (**str == '[' || **str == '(')
-  {
-    TSequence *seq = trgeoseq_cont_parse(str, temptype, interp, true,
+    result = (Temporal *) trgeoseq_cont_parse(str, temptype, interp, true,
       &temp_srid, geom);
-    if (! seq)
-      return NULL;
-    result = (Temporal *) seq;
-  }
   else if (**str == '{')
   {
     bak = *str;
@@ -368,6 +359,9 @@ trgeo_parse(const char **str, MeosType temptype)
         geom);
     }
   }
+  /* The reference geometry is copied into the result */
+  if (geom)
+    pfree(geom);
   return result;
 }
 


### PR DESCRIPTION
The parser of a temporal rigid geometry reads the reference geometry that precedes the temporal part and hands it to the constructor of the subtype it then parses. Every one of those constructors copies the geometry into the value it builds, as the parser of an instant does for the pose it reads, so the parsed geometry belongs to the parser. Freeing it removes a leak of one geometry per parsed value.

The geometry is freed once the value is built, on every path. The two subtypes that return as soon as their parse fails share the single exit of the other two, since a failed parse leaves the result null.

A valgrind run over seven parsed values reports the leak as `728 bytes in 7 blocks are definitely lost`, allocated in `gserialized2_from_lwgeom` under `trgeo_parse_geom`, and reports no loss with the fix. The instant, discrete sequence, continuous sequence and sequence set subtypes each round-trip through `trgeometry_in` and `trgeometry_out` to the same text.