### PR TITLE
Give the box3d text representation the format PostGIS uses

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -200,6 +200,13 @@ box3d_make(double xmin, double xmax, double ymin, double ymax, double zmin,
  * @brief Return the string representation of a PostGIS BOX3D
  * @param[in] box Box
  * @param[in] maxdd Maximum number of decimal digits
+ * @details The format is `BOX3D(xmin ymin zmin,xmax ymax zmax)`, the one
+ * PostGIS gives the @p box3d type it declares, so that a value printed here
+ * is read back by a PostgreSQL session and the other way round. As PostGIS
+ * does, the Z ordinates are always printed and the SRID never is. PostGIS
+ * prints the ordinates with at most #OUT_DEFAULT_DECIMAL_DIGITS decimal
+ * digits, which is thus the value of @p maxdd that reproduces its output
+ * character for character
  */
 char *
 box3d_out(const BOX3D *box, int maxdd)
@@ -209,30 +216,25 @@ box3d_out(const BOX3D *box, int maxdd)
   if (! ensure_not_negative(maxdd))
     return NULL;
 
-  static size_t size = MAX_LEN_BOX3D + 1;
+  /* Six ordinates of at most #OUT_MAX_BYTES_DOUBLE characters each, the
+   * `BOX3D(` prefix, the five separators, the closing parenthesis and the
+   * terminating null all fit in #MAX_LEN_BOX3D + 1 characters */
   char buf[MAX_LEN_BOX3D + 1];
-  char *xmin = NULL, *xmax = NULL, *ymin = NULL, *ymax = NULL, *zmin = NULL,
-    *zmax = NULL;
-
-  char srid[18];
-  if (box->srid > 0)
-    /* SRID_MAXIMUM is defined by PostGIS as 999999 */
-    snprintf(srid, sizeof(srid), "SRID=%d;", box->srid);
-  else
-    srid[0] = '\0';
-
-  xmin = float8_out(box->xmin, maxdd);
-  xmax = float8_out(box->xmax, maxdd);
-  ymin = float8_out(box->ymin, maxdd);
-  ymax = float8_out(box->ymax, maxdd);
-  zmin = float8_out(box->zmin, maxdd);
-  zmax = float8_out(box->zmax, maxdd);
-  snprintf(buf, size, "%sBOX3D((%s,%s,%s),(%s,%s,%s))",
-      srid, xmin, ymin, zmin, xmax, ymax, zmax);
-
-  pfree(xmin); pfree(xmax);
-  pfree(ymin); pfree(ymax);
-  pfree(zmin); pfree(zmax);
+  int len = 6;
+  memcpy(buf, "BOX3D(", 6);
+  len += lwprint_double(box->xmin, maxdd, buf + len);
+  buf[len++] = ' ';
+  len += lwprint_double(box->ymin, maxdd, buf + len);
+  buf[len++] = ' ';
+  len += lwprint_double(box->zmin, maxdd, buf + len);
+  buf[len++] = ',';
+  len += lwprint_double(box->xmax, maxdd, buf + len);
+  buf[len++] = ' ';
+  len += lwprint_double(box->ymax, maxdd, buf + len);
+  buf[len++] = ' ';
+  len += lwprint_double(box->zmax, maxdd, buf + len);
+  buf[len++] = ')';
+  buf[len] = '\0';
   return strdup(buf);
 }
 
@@ -240,8 +242,15 @@ box3d_out(const BOX3D *box, int maxdd)
  * @ingroup meos_geo_base_inout
  * @brief Return a PostGIS BOX3D from its string representation
  * @param[in] str String
- * @details The format is `[SRID=#;]BOX3D((xmin,ymin,zmin),(xmax,ymax,zmax))`,
- * the inverse of #box3d_out
+ * @details The format is `BOX3D(xmin ymin zmin,xmax ymax zmax)`, the inverse
+ * of #box3d_out and the one PostGIS gives the @p box3d type it declares. As
+ * PostGIS does, the Z ordinates may be left out, as in
+ * `BOX3D(xmin ymin,xmax ymax)`, in which case they are zero, and the SRID of
+ * the result is always unknown
+ * @note The format `[SRID=#;]BOX3D((xmin,ymin,zmin),(xmax,ymax,zmax))` written
+ * by previous versions of #box3d_out is still accepted, so that a value stored
+ * by them can still be read. The two formats are told apart by the character
+ * following `BOX3D(`, which is an opening parenthesis in the latter only
  */
 BOX3D *
 box3d_in(const char *str)
@@ -249,6 +258,15 @@ box3d_in(const char *str)
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(str, NULL);
 
+  double xmin, ymin, zmin, xmax, ymax, zmax;
+  /* Format written by PostGIS, with the Z ordinates omitted or not */
+  if (sscanf(str, " BOX3D(%lf %lf %lf ,%lf %lf %lf)",
+      &xmin, &ymin, &zmin, &xmax, &ymax, &zmax) == 6)
+    return box3d_make(xmin, xmax, ymin, ymax, zmin, zmax, SRID_UNKNOWN);
+  if (sscanf(str, " BOX3D(%lf %lf ,%lf %lf)", &xmin, &ymin, &xmax, &ymax) == 4)
+    return box3d_make(xmin, xmax, ymin, ymax, 0.0, 0.0, SRID_UNKNOWN);
+
+  /* Format written by previous versions of #box3d_out */
   int32_t srid = SRID_UNKNOWN;
   const char *ptr = str;
   /* Optional "SRID=#;" prefix */
@@ -264,8 +282,6 @@ box3d_in(const char *str)
     }
     ptr = end + 1;
   }
-
-  double xmin, ymin, zmin, xmax, ymax, zmax;
   if (sscanf(ptr, " BOX3D((%lf,%lf,%lf),(%lf,%lf,%lf))",
       &xmin, &ymin, &zmin, &xmax, &ymax, &zmax) != 6)
   {

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -30,7 +30,7 @@
 /**
  * @file
  * @brief A program that tests the WKT input functions of the geo API on
- * malformed input.
+ * malformed input, and the text representation of the PostGIS @p box3d type.
  *
  * A parse failure is only observable once
  * #meos_initialize_noexit_error_handler is installed — the handler every
@@ -50,6 +50,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <meos.h>
 #include <meos_geo.h>
 
@@ -87,6 +88,61 @@ int main(void)
   assert(good != NULL);
   assert(meos_errno() == 0);
   free(good);
+
+  /* The text representation of a box3d is the one PostGIS gives the type it
+   * declares, so that the value crosses between a PostgreSQL session and any
+   * other binding. PostGIS prints the ordinates with at most 15 decimal
+   * digits, the value of maxdd that reproduces its output */
+  const char *box3d_strs[][2] = {
+    /* Three dimensions, the form a PostgreSQL session prints for
+     * stbox 'STBOX Z((1,1,1),(5,5,5))'::box3d */
+    {"BOX3D(1 1 1,5 5 5)", "BOX3D(1 1 1,5 5 5)"},
+    /* The Z ordinates may be left out on input and are then zero, and they
+     * are printed back, as PostGIS does */
+    {"BOX3D(1 2,3 4)", "BOX3D(1 2 0,3 4 0)"},
+    /* Negative and fractional ordinates */
+    {"BOX3D(-1.5 -2.25 -3.125,5 5 5)", "BOX3D(-1.5 -2.25 -3.125,5 5 5)"},
+    /* The bounds are ordered on input */
+    {"BOX3D(5 5 5,1 1 1)", "BOX3D(1 1 1,5 5 5)"},
+    /* The format written by previous versions is still read, and the SRID it
+     * carries is not printed back, as PostGIS never prints one */
+    {"BOX3D((1,2,3),(4,5,6))", "BOX3D(1 2 3,4 5 6)"},
+    {"SRID=4326;BOX3D((1,2,3),(4,5,6))", "BOX3D(1 2 3,4 5 6)"}
+  };
+  for (size_t i = 0; i < sizeof(box3d_strs) / sizeof(box3d_strs[0]); i++)
+  {
+    meos_errno_reset();
+    BOX3D *box = box3d_in(box3d_strs[i][0]);
+    assert(box != NULL);
+    assert(meos_errno() == 0);
+    char *str = box3d_out(box, 15);
+    printf("box3d_in(\"%s\") -> \"%s\"\n", box3d_strs[i][0], str);
+    assert(strcmp(str, box3d_strs[i][1]) == 0);
+    /* The output of box3d_out is read back by box3d_in */
+    BOX3D *box1 = box3d_in(str);
+    assert(box1 != NULL);
+    char *str1 = box3d_out(box1, 15);
+    assert(strcmp(str, str1) == 0);
+    free(str); free(str1); free(box); free(box1);
+  }
+
+  /* A box3d whose SRID is set still prints without one, as PostGIS does */
+  meos_errno_reset();
+  BOX3D *box_srid = box3d_make(1, 5, 1, 5, 1, 5, 4326);
+  assert(box_srid != NULL);
+  char *str_srid = box3d_out(box_srid, 15);
+  printf("box3d_out(box3d_make(..., 4326)): \"%s\"\n", str_srid);
+  assert(strcmp(str_srid, "BOX3D(1 1 1,5 5 5)") == 0);
+  free(str_srid); free(box_srid);
+
+  /* A malformed box3d returns NULL and sets the error status */
+  meos_errno_reset();
+  BOX3D *bad_box3d = box3d_in("BOX3D(1 2 3)");
+  printf("box3d_in(\"BOX3D(1 2 3)\"): %s, errno %d\n",
+    bad_box3d ? "non-NULL" : "NULL", meos_errno());
+  assert(bad_box3d == NULL);
+  assert(meos_errno() != 0);
+  meos_errno_reset();
 
   /* Finalize MEOS */
   meos_finalize();


### PR DESCRIPTION
PostGIS declares the `box3d` type and MobilityDB uses it in SQL, casting an `stbox` to and from it. liblwgeom does not provide the type's input and output functions — the real ones live in the PostGIS extension layer, and the vendored library carries only `printBOX3D`, a debug printer to stdout — so MEOS implements its own. The two do not write the same text.

MEOS writes

    [SRID=#;]BOX3D((xmin,ymin,zmin),(xmax,ymax,zmax))

while PostGIS writes

    BOX3D(xmin ymin zmin,xmax ymax zmax)

with the ordinates separated by spaces, the corners by a comma, and never an SRID. The same value therefore reads differently depending on the binding, and neither parser accepts the other's output: a `box3d` written by MEOS is rejected by a PostgreSQL session, and a `box3d` printed by a PostgreSQL session is rejected by MEOS. Nothing interoperates, so aligning MEOS to PostGIS can only add compatibility.

Write the format PostGIS writes, and read it. The ordinates go through `lwprint_double`, the printer PostGIS itself uses, so `maxdd` keeps its documented meaning as the maximum number of decimal digits and the value 15 that PostGIS passes reproduces its output character for character. As PostGIS does, the Z ordinates are always printed, they may be left out on input and are then zero, and the SRID is never printed.

The format previous versions wrote is still accepted on input, so a value stored by them can still be parsed. The two grammars are told apart by the character following `BOX3D(`, an opening parenthesis in the old format only, so no string is ambiguous.

The PostgreSQL rendering of `stbox::box3d` comes from PostGIS's own output function, not from MEOS, so no expected output under `mobilitydb/test` moves. `meos/test/geo_test.c` gains coverage of the round trip and of the shapes PostGIS accepts: three dimensions, the two-dimensional input form, negative and fractional ordinates, unordered bounds, a value whose SRID is set, the old format, and a malformed value.