### PR TITLE
Validate h3index values where they enter MobilityDB

### DIFF
--- a/doc/es/temporal_h3_index.xml
+++ b/doc/es/temporal_h3_index.xml
@@ -20,7 +20,7 @@
 
 	<sect1 xml:id="th3_inout">
 		<title>Entrada y Salida</title>
-		<para>Un valor <varname>th3index</varname> se introduce utilizando la sintaxis temporal estándar con el identificador de celda H3 de 64 bits subyacente. El analizador acepta la forma hexadecimal canónica (la que produce la CLI de H3 y <varname>h3_cell_to_string</varname> en el proyecto original), con un prefijo <varname>0x</varname> opcional y como máximo 16 dígitos significativos. El hexadecimal es idiomático en el ecosistema H3 y es lo que emite la función de salida, todos los ejemplos siguientes lo usan.</para>
+		<para>Un valor <varname>th3index</varname> se introduce utilizando la sintaxis temporal estándar con el identificador de celda H3 de 64 bits subyacente. El analizador acepta la forma hexadecimal canónica (la que produce la CLI de H3 y <varname>h3_cell_to_string</varname> en el proyecto original), con un prefijo <varname>0x</varname> opcional y como máximo 16 dígitos significativos. El valor debe además denotar algo del sistema de indexación H3, es decir, una celda, una arista dirigida o un vértice, de modo que un literal hexadecimal bien formado como <varname>12345</varname>, que no es ninguno de los tres, se rechaza en lugar de almacenarse como un valor sin ubicación. El hexadecimal es idiomático en el ecosistema H3 y es lo que emite la función de salida, todos los ejemplos siguientes lo usan.</para>
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3index '831c02fffffffff@2001-01-01';
 SELECT th3index '{831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02}';

--- a/doc/temporal_h3_index.xml
+++ b/doc/temporal_h3_index.xml
@@ -20,7 +20,7 @@
 
 	<sect1 xml:id="th3_inout">
 		<title>Input and Output</title>
-		<para>A <varname>th3index</varname> value is entered using the standard temporal syntax with the underlying 64-bit H3 cell identifier. The input parser accepts the canonical hexadecimal form (as produced by the H3 CLI and by <varname>h3_cell_to_string</varname> upstream), with an optional <varname>0x</varname> prefix and at most 16 significant digits. Hexadecimal is idiomatic in the H3 ecosystem and is what the output function emits, all examples below use it.</para>
+		<para>A <varname>th3index</varname> value is entered using the standard temporal syntax with the underlying 64-bit H3 cell identifier. The input parser accepts the canonical hexadecimal form (as produced by the H3 CLI and by <varname>h3_cell_to_string</varname> upstream), with an optional <varname>0x</varname> prefix and at most 16 significant digits. The value must also denote something in the H3 indexing system, that is, a cell, a directed edge or a vertex, so that a well-formed hexadecimal literal such as <varname>12345</varname>, which is none of the three, is rejected rather than stored as a value with no location. Hexadecimal is idiomatic in the H3 ecosystem and is what the output function emits, all examples below use it.</para>
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3index '831c02fffffffff@2001-01-01';
 SELECT th3index '{831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02}';

--- a/meos/include/h3/h3index.h
+++ b/meos/include/h3/h3index.h
@@ -38,7 +38,8 @@
  * the helpers here are minimal:
  *
  *   * an input parser that reads the canonical hexadecimal cell literal,
- *     with an optional "0x" prefix and at most 16 significant digits,
+ *     with an optional "0x" prefix and at most 16 significant digits, and
+ *     that requires the value to denote a cell, a directed edge or a vertex,
  *   * an output formatter (canonical form is hex, matching h3-pg),
  *   * comparison / ordering / hashing helpers — exposed at the MEOS
  *     layer so MobilityDuck and other consumers can reuse them
@@ -53,7 +54,8 @@
 /* PostgreSQL — for Datum / Int64GetDatum / DatumGetInt64 */
 #include <postgres.h>
 #include <h3api.h>
-/* MEOS — public h3index declarations (I/O, comparison, hashing) */
+/* MEOS — public h3index declarations (I/O, comparison, hashing) and the
+ * `VALIDATE_H3INDEX_*` macros */
 #include <meos_h3.h>
 
 /*****************************************************************************
@@ -75,6 +77,19 @@ extern bool meos_h3index_gt(H3Index a, H3Index b);
 extern bool meos_h3index_ge(H3Index a, H3Index b);
 extern int meos_h3index_cmp(H3Index a, H3Index b);
 extern uint32 meos_h3index_hash(H3Index cell);
+
+/*****************************************************************************
+ * Validators (bodies in h3index.c)
+ *
+ * The per-mode checks behind the `VALIDATE_H3INDEX_*` macros of the public
+ * `meos_h3.h`. Each reports the offending value with the mode the operation
+ * required, since the three modes share the same 64-bit representation and
+ * the error is otherwise indistinguishable from a plain typo.
+ *****************************************************************************/
+
+extern bool ensure_h3index_cell(H3Index cell);
+extern bool ensure_h3index_directed_edge(H3Index edge);
+extern bool ensure_h3index_vertex(H3Index vertex);
 
 /*****************************************************************************
  * Datum packing

--- a/meos/include/h3_ext_defs.in.h
+++ b/meos/include/h3_ext_defs.in.h
@@ -6,13 +6,27 @@
  * binding surface); the MobilityDB PostgreSQL extension does not, so that
  * both the h3 and mobilitydb extensions can be loaded in the same server.
  * Input reads, and output prints, the canonical hexadecimal cell literal
- * with an optional "0x" prefix and at most 16 significant digits, with no
- * cell-validity check. Comparison / ordering / hashing operate on the
- * uint64 cell identifier; they carry no geographic meaning but are
- * required for ordering, grouping, and hashing. */
+ * with an optional "0x" prefix and at most 16 significant digits. Input
+ * additionally requires the value to denote a cell, a directed edge or a
+ * vertex, the zero sentinel aside, so that no value without a location
+ * enters the type. Comparison / ordering / hashing operate on the uint64
+ * cell identifier; they carry no geographic meaning but are required for
+ * ordering, grouping, and hashing, and so apply to any of the modes. */
 
 extern H3Index h3index_in(const char *str);
 extern char *h3index_out(H3Index cell);
+
+/* Validity predicates. An h3index is a mode-tagged 64-bit identifier: the
+ * same bit pattern is a cell, a directed edge, or a vertex according to its
+ * mode bits, and the three predicates below are the only way to tell which.
+ * They are total functions on the uint64 domain — they answer false rather
+ * than raising, so they accept any bit pattern, including the invalid
+ * sentinel 0. They are what the input function and the per-operation
+ * validators are written in terms of. */
+
+extern bool h3_is_valid_cell(H3Index cell);
+extern bool h3_is_valid_directed_edge(H3Index edge);
+extern bool h3_is_valid_vertex(H3Index vertex);
 extern bool h3index_eq(H3Index a, H3Index b);
 extern bool h3index_ne(H3Index a, H3Index b);
 extern bool h3index_lt(H3Index a, H3Index b);

--- a/meos/include/meos_h3.h
+++ b/meos/include/meos_h3.h
@@ -64,6 +64,49 @@
     } while (0)
 #endif /* MEOS */
 
+/**
+ * @brief Ensure that an h3index is a valid H3 cell.
+ * @details An h3index is a mode-tagged identifier, so the operation decides
+ * which of the three predicates applies: a cell operation requires a cell, a
+ * directed-edge operation a directed edge, a vertex operation a vertex. The
+ * validity predicates themselves, and the mode-agnostic surfaces (input and
+ * output, comparison, ordering, hashing) take any bit pattern by design and
+ * must not use these macros.
+ * @note Unlike the type-validation macros above, these validate in both
+ * builds rather than asserting in the extension build. A temporal value's
+ * type is settled by the SQL type system before a function sees it, so there
+ * the assertion states a proven invariant, whereas the validity of an
+ * h3index is settled by nothing: the type is provided by the h3 extension,
+ * whose input function and bigint cast admit any 64-bit pattern. The value
+ * is therefore user input at every call, and asserting on user input aborts
+ * the backend instead of reporting the error.
+ */
+#define VALIDATE_H3INDEX_CELL(cell, ret) \
+  do { \
+    if (! ensure_h3index_cell(cell) ) \
+      return (ret); \
+  } while (0)
+
+/**
+ * @brief Ensure that an h3index is a valid H3 directed edge.
+ * Matches the pattern of `VALIDATE_H3INDEX_CELL` above.
+ */
+#define VALIDATE_H3INDEX_DIRECTED_EDGE(edge, ret) \
+  do { \
+    if (! ensure_h3index_directed_edge(edge) ) \
+      return (ret); \
+  } while (0)
+
+/**
+ * @brief Ensure that an h3index is a valid H3 vertex.
+ * Matches the pattern of `VALIDATE_H3INDEX_CELL` above.
+ */
+#define VALIDATE_H3INDEX_VERTEX(vertex, ret) \
+  do { \
+    if (! ensure_h3index_vertex(vertex) ) \
+      return (ret); \
+  } while (0)
+
 /*****************************************************************************
  * Static h3index SQL type — analogue of meos_cbuffer.h's
  * static-cbuffer section.

--- a/meos/src/h3/h3index.c
+++ b/meos/src/h3/h3index.c
@@ -72,11 +72,113 @@
 #include "h3/th3index_internal.h"
 
 /*****************************************************************************
+ * Validity predicates
+ *
+ * An h3index is a mode-tagged 64-bit identifier: the mode bits say whether
+ * the value denotes a cell, a directed edge, or a vertex, and the three
+ * predicates below are the only way to tell the modes apart. They are total
+ * functions on the uint64 domain — they answer false rather than raising,
+ * so they accept the invalid sentinel 0 and any other bit pattern, and are
+ * therefore the primitives the input function and the per-mode validators
+ * are written in terms of.
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_h3_base_accessor
+ * @brief Return true if an h3index is a valid H3 cell
+ * @param[in] cell H3 index
+ * @csqlfn #H3index_is_valid_cell()
+ */
+#if MEOS
+bool
+h3_is_valid_cell(H3Index cell)
+{
+  return h3_is_valid_cell_meos(cell);
+}
+#endif
+
+/**
+ * @ingroup meos_h3_base_accessor
+ * @brief Return true if an h3index is a valid H3 directed edge
+ * @param[in] edge H3 index
+ * @csqlfn #H3index_is_valid_directed_edge()
+ */
+#if MEOS
+bool
+h3_is_valid_directed_edge(H3Index edge)
+{
+  return h3_is_valid_directed_edge_meos(edge);
+}
+#endif
+
+/**
+ * @ingroup meos_h3_base_accessor
+ * @brief Return true if an h3index is a valid H3 vertex
+ * @param[in] vertex H3 index
+ * @csqlfn #H3index_is_valid_vertex()
+ */
+#if MEOS
+bool
+h3_is_valid_vertex(H3Index vertex)
+{
+  return h3_is_valid_vertex_meos(vertex);
+}
+#endif
+
+/*****************************************************************************
+ * Validators
+ *
+ * The per-mode checks behind the `VALIDATE_H3INDEX_*` macros. The three
+ * modes share the same 64-bit representation, so the message names the mode
+ * the operation required: without it a mode mismatch is indistinguishable
+ * from a plain typo.
+ *****************************************************************************/
+
+/**
+ * @brief Ensure that an h3index is a valid H3 cell
+ */
+bool
+ensure_h3index_cell(H3Index cell)
+{
+  if (h3_is_valid_cell_meos(cell))
+    return true;
+  meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+    "h3index %" PRIx64 " is not a valid H3 cell", (uint64_t) cell);
+  return false;
+}
+
+/**
+ * @brief Ensure that an h3index is a valid H3 directed edge
+ */
+bool
+ensure_h3index_directed_edge(H3Index edge)
+{
+  if (h3_is_valid_directed_edge_meos(edge))
+    return true;
+  meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+    "h3index %" PRIx64 " is not a valid H3 directed edge", (uint64_t) edge);
+  return false;
+}
+
+/**
+ * @brief Ensure that an h3index is a valid H3 vertex
+ */
+bool
+ensure_h3index_vertex(H3Index vertex)
+{
+  if (h3_is_valid_vertex_meos(vertex))
+    return true;
+  meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+    "h3index %" PRIx64 " is not a valid H3 vertex", (uint64_t) vertex);
+  return false;
+}
+
+/*****************************************************************************
  * Datum wrappers for inspection
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief
  */
 Datum
 datum_h3_get_resolution(Datum d)
@@ -108,6 +210,8 @@ datum_h3_is_valid_cell(Datum d)
 Datum
 datum_h3_is_res_class_iii(Datum d)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_CELL(DatumGetH3Index(d), (Datum) 0);
   return BoolGetDatum(h3_is_res_class_iii_meos(DatumGetH3Index(d)));
 }
 
@@ -117,6 +221,8 @@ datum_h3_is_res_class_iii(Datum d)
 Datum
 datum_h3_is_pentagon(Datum d)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_CELL(DatumGetH3Index(d), (Datum) 0);
   return BoolGetDatum(h3_is_pentagon_meos(DatumGetH3Index(d)));
 }
 
@@ -133,6 +239,8 @@ datum_h3_is_pentagon(Datum d)
 Datum
 datum_h3_cell_to_parent(Datum cell_d, Datum res_d)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_CELL(DatumGetH3Index(cell_d), (Datum) 0);
   return H3IndexGetDatum(h3_cell_to_parent_meos(DatumGetH3Index(cell_d),
     DatumGetInt32(res_d)));
 }
@@ -143,6 +251,8 @@ datum_h3_cell_to_parent(Datum cell_d, Datum res_d)
 Datum
 datum_h3_cell_to_parent_next(Datum cell_d)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_CELL(DatumGetH3Index(cell_d), (Datum) 0);
   return H3IndexGetDatum(h3_cell_to_parent_next_meos(DatumGetH3Index(cell_d)));
 }
 
@@ -152,6 +262,8 @@ datum_h3_cell_to_parent_next(Datum cell_d)
 Datum
 datum_h3_cell_to_center_child(Datum cell_d, Datum res_d)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_CELL(DatumGetH3Index(cell_d), (Datum) 0);
   return H3IndexGetDatum(h3_cell_to_center_child_meos(DatumGetH3Index(cell_d),
     DatumGetInt32(res_d)));
 }
@@ -162,6 +274,8 @@ datum_h3_cell_to_center_child(Datum cell_d, Datum res_d)
 Datum
 datum_h3_cell_to_center_child_next(Datum cell_d)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_CELL(DatumGetH3Index(cell_d), (Datum) 0);
   return H3IndexGetDatum(h3_cell_to_center_child_next_meos(
     DatumGetH3Index(cell_d)));
 }
@@ -172,6 +286,8 @@ datum_h3_cell_to_center_child_next(Datum cell_d)
 Datum
 datum_h3_cell_to_child_pos(Datum cell_d, Datum parent_res_d)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_CELL(DatumGetH3Index(cell_d), (Datum) 0);
   /* Return is a position index (int64), not a cell — plain
    * Int64GetDatum is correct here. */
   return Int64GetDatum(h3_cell_to_child_pos_meos(DatumGetH3Index(cell_d),
@@ -184,6 +300,8 @@ datum_h3_cell_to_child_pos(Datum cell_d, Datum parent_res_d)
 Datum
 datum_h3_child_pos_to_cell(Datum pos_d, Datum parent_d, Datum child_res_d)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_CELL(DatumGetH3Index(parent_d), (Datum) 0);
   /* pos_d carries a plain int64 child position. */
   return H3IndexGetDatum(h3_child_pos_to_cell_meos(DatumGetInt64(pos_d),
     DatumGetH3Index(parent_d), DatumGetInt32(child_res_d)));
@@ -199,6 +317,9 @@ datum_h3_child_pos_to_cell(Datum pos_d, Datum parent_d, Datum child_res_d)
 Datum
 datum_h3_are_neighbor_cells(Datum origin_d, Datum dest_d)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_CELL(DatumGetH3Index(origin_d), (Datum) 0);
+  VALIDATE_H3INDEX_CELL(DatumGetH3Index(dest_d), (Datum) 0);
   return BoolGetDatum(h3_are_neighbor_cells_meos(DatumGetH3Index(origin_d),
     DatumGetH3Index(dest_d)));
 }
@@ -209,6 +330,9 @@ datum_h3_are_neighbor_cells(Datum origin_d, Datum dest_d)
 Datum
 datum_h3_cells_to_directed_edge(Datum origin_d, Datum dest_d)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_CELL(DatumGetH3Index(origin_d), (Datum) 0);
+  VALIDATE_H3INDEX_CELL(DatumGetH3Index(dest_d), (Datum) 0);
   return H3IndexGetDatum(h3_cells_to_directed_edge_meos(
     DatumGetH3Index(origin_d), DatumGetH3Index(dest_d)));
 }
@@ -228,6 +352,8 @@ datum_h3_is_valid_directed_edge(Datum d)
 Datum
 datum_h3_get_directed_edge_origin(Datum d)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_DIRECTED_EDGE(DatumGetH3Index(d), (Datum) 0);
   return H3IndexGetDatum(h3_get_directed_edge_origin_meos(DatumGetH3Index(d)));
 }
 
@@ -237,6 +363,8 @@ datum_h3_get_directed_edge_origin(Datum d)
 Datum
 datum_h3_get_directed_edge_destination(Datum d)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_DIRECTED_EDGE(DatumGetH3Index(d), (Datum) 0);
   return H3IndexGetDatum(h3_get_directed_edge_destination_meos(
     DatumGetH3Index(d)));
 }
@@ -247,6 +375,8 @@ datum_h3_get_directed_edge_destination(Datum d)
 Datum
 datum_h3_directed_edge_to_boundary(Datum d)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_DIRECTED_EDGE(DatumGetH3Index(d), (Datum) 0);
   GSERIALIZED *gs = h3_directed_edge_to_gs_boundary(DatumGetH3Index(d));
   return PointerGetDatum(gs);
 }
@@ -261,6 +391,8 @@ datum_h3_directed_edge_to_boundary(Datum d)
 Datum
 datum_h3_cell_to_vertex(Datum cell_d, Datum vnum_d)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_CELL(DatumGetH3Index(cell_d), (Datum) 0);
   return H3IndexGetDatum(h3_cell_to_vertex_meos(DatumGetH3Index(cell_d),
     DatumGetInt32(vnum_d)));
 }
@@ -271,6 +403,8 @@ datum_h3_cell_to_vertex(Datum cell_d, Datum vnum_d)
 Datum
 datum_h3_vertex_to_latlng(Datum d)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_VERTEX(DatumGetH3Index(d), (Datum) 0);
   GSERIALIZED *gs = h3_vertex_to_gs_point(DatumGetH3Index(d));
   return PointerGetDatum(gs);
 }
@@ -294,6 +428,9 @@ datum_h3_is_valid_vertex(Datum d)
 Datum
 datum_h3_grid_distance(Datum origin_d, Datum dest_d)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_CELL(DatumGetH3Index(origin_d), (Datum) 0);
+  VALIDATE_H3INDEX_CELL(DatumGetH3Index(dest_d), (Datum) 0);
   /* Return is a hop count (int64), not a cell. */
   return Int64GetDatum(h3_grid_distance_meos(DatumGetH3Index(origin_d),
     DatumGetH3Index(dest_d)));
@@ -305,6 +442,9 @@ datum_h3_grid_distance(Datum origin_d, Datum dest_d)
 Datum
 datum_h3_cell_to_local_ij(Datum origin_d, Datum cell_d)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_CELL(DatumGetH3Index(origin_d), (Datum) 0);
+  VALIDATE_H3INDEX_CELL(DatumGetH3Index(cell_d), (Datum) 0);
   GSERIALIZED *gs = h3_cell_to_local_ij_meos(DatumGetH3Index(origin_d),
     DatumGetH3Index(cell_d));
   return PointerGetDatum(gs);
@@ -316,6 +456,8 @@ datum_h3_cell_to_local_ij(Datum origin_d, Datum cell_d)
 Datum
 datum_h3_local_ij_to_cell(Datum origin_d, Datum coord_d)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_CELL(DatumGetH3Index(origin_d), (Datum) 0);
   const GSERIALIZED *coord = (GSERIALIZED *) DatumGetPointer(coord_d);
   return H3IndexGetDatum(h3_local_ij_to_cell_meos(
     DatumGetH3Index(origin_d), coord));
@@ -342,6 +484,8 @@ datum_h3_latlng_to_cell(Datum point_d, Datum res_d)
 Datum
 datum_h3_cell_to_latlng(Datum d)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_CELL(DatumGetH3Index(d), (Datum) 0);
   GSERIALIZED *gs = h3_cell_to_geompoint(DatumGetH3Index(d));
   return PointerGetDatum(gs);
 }
@@ -352,6 +496,8 @@ datum_h3_cell_to_latlng(Datum d)
 Datum
 datum_h3_cell_to_boundary(Datum d)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_CELL(DatumGetH3Index(d), (Datum) 0);
   GSERIALIZED *gs = h3_cell_to_geom(DatumGetH3Index(d));
   return PointerGetDatum(gs);
 }
@@ -369,6 +515,8 @@ datum_h3_cell_to_boundary(Datum d)
 Datum
 datum_h3_cell_area(Datum cell_d, Datum unit_d)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_CELL(DatumGetH3Index(cell_d), (Datum) 0);
   return Float8GetDatum(h3_cell_area_meos(DatumGetH3Index(cell_d),
     (H3Unit) DatumGetInt32(unit_d)));
 }
@@ -379,6 +527,8 @@ datum_h3_cell_area(Datum cell_d, Datum unit_d)
 Datum
 datum_h3_edge_length(Datum edge_d, Datum unit_d)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_DIRECTED_EDGE(DatumGetH3Index(edge_d), (Datum) 0);
   return Float8GetDatum(h3_edge_length_meos(DatumGetH3Index(edge_d),
     (H3Unit) DatumGetInt32(unit_d)));
 }
@@ -458,6 +608,24 @@ meos_h3index_in(const char *str)
   {
     meos_error(ERROR, MEOS_ERR_TEXT_INPUT,
       "invalid h3index input \"%s\": h3 error code %u", str, (unsigned) err);
+    return (H3Index) 0;
+  }
+
+  /* The value must denote something in the H3 indexing system. A well-formed
+   * hexadecimal literal is not by itself an h3index: the mode bits and the
+   * digit sequence encode a cell, a directed edge or a vertex, and a literal
+   * such as "abc" or "12345" is none of the three. Accepting it would let a
+   * value with no location enter a spatiotemporal type, where it compares,
+   * groups and indexes as if it were a place. The zero sentinel is admitted
+   * because h3 reserves it as the conventional "no index" marker, which the
+   * validity predicates report as false and which callers test for */
+  if (cell != (H3Index) 0 && ! h3_is_valid_cell_meos(cell) &&
+      ! h3_is_valid_directed_edge_meos(cell) &&
+      ! h3_is_valid_vertex_meos(cell))
+  {
+    meos_error(ERROR, MEOS_ERR_TEXT_INPUT,
+      "invalid h3index input \"%s\": not a valid H3 cell, directed edge or "
+      "vertex", str);
     return (H3Index) 0;
   }
   return cell;

--- a/meos/src/h3/h3index_sets.c
+++ b/meos/src/h3/h3index_sets.c
@@ -118,6 +118,8 @@ h3_grid_disk(H3Index origin, int k)
 Set *
 meos_h3_grid_disk(H3Index origin, int k)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_CELL(origin, NULL);
   if (k < 0)
   {
     meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
@@ -158,6 +160,8 @@ h3_grid_ring(H3Index origin, int k)
 Set *
 meos_h3_grid_ring(H3Index origin, int k)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_CELL(origin, NULL);
   if (k < 0)
   {
     meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
@@ -204,6 +208,9 @@ h3_grid_path_cells(H3Index start, H3Index end)
 Set *
 meos_h3_grid_path_cells(H3Index start, H3Index end)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_CELL(start, NULL);
+  VALIDATE_H3INDEX_CELL(end, NULL);
   int64_t size;
   if (gridPathCellsSize(start, end, &size) != E_SUCCESS)
   {
@@ -242,6 +249,8 @@ h3_cell_to_children(H3Index origin, int childRes)
 Set *
 meos_h3_cell_to_children(H3Index origin, int childRes)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_CELL(origin, NULL);
   int64_t max;
   if (cellToChildrenSize(origin, childRes, &max) != E_SUCCESS)
   {
@@ -363,6 +372,8 @@ h3_origin_to_directed_edges(H3Index origin)
 Set *
 meos_h3_origin_to_directed_edges(H3Index origin)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_CELL(origin, NULL);
   /* Always 6 slots; pentagons fill only 5 (one slot is 0). */
   H3Index *edges = palloc0(6 * sizeof(H3Index));
   if (originToDirectedEdges(origin, edges) != E_SUCCESS)
@@ -390,6 +401,8 @@ h3_cell_to_vertexes(H3Index cell)
 Set *
 meos_h3_cell_to_vertexes(H3Index cell)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_CELL(cell, NULL);
   /* Always 6 slots; pentagons fill only 5 (one slot is 0). */
   H3Index *vertexes = palloc0(6 * sizeof(H3Index));
   if (cellToVertexes(cell, vertexes) != E_SUCCESS)
@@ -421,6 +434,8 @@ h3_get_icosahedron_faces(H3Index cell)
 Set *
 meos_h3_get_icosahedron_faces(H3Index cell)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_CELL(cell, NULL);
   int maxFaces;
   if (maxFaceCount(cell, &maxFaces) != E_SUCCESS)
   {

--- a/meos/src/h3/th3index_boxops.c
+++ b/meos/src/h3/th3index_boxops.c
@@ -117,6 +117,15 @@ th3index_cell_set_stbox(H3Index cell, STBox *box)
  * @param[out] box Spatiotemporal box
  * @note Mirrors `cbuffer_set_stbox` / `quadbin_set_stbox`; the helper the
  *   central `spatial_set_stbox` dispatch calls for an h3index value.
+ * @note This helper does not require its argument to be a cell, unlike the
+ *   conversions below. It is the bounding-box hook for every h3index-valued
+ *   set and temporal value, and those legitimately carry directed edges and
+ *   vertices: `h3_origin_to_directed_edges` and `h3_cell_to_vertexes` both
+ *   return sets whose elements are not cells. Bounding such a value still
+ *   reaches `cellToBoundary`, which is the wrong primitive for those two
+ *   modes and yields a box that does not describe the value — a defect that
+ *   predates the per-mode validators and needs a mode-aware box, not a
+ *   rejection here, since rejecting would break both operations outright.
  */
 bool
 h3index_set_stbox(H3Index cell, STBox *box)
@@ -137,6 +146,8 @@ h3index_set_stbox(H3Index cell, STBox *box)
 STBox *
 h3index_to_stbox(H3Index cell)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_CELL(cell, NULL);
   STBox box;
   if (! h3index_set_stbox(cell, &box))
     return NULL;
@@ -153,6 +164,8 @@ h3index_to_stbox(H3Index cell)
 STBox *
 h3index_timestamptz_to_stbox(H3Index cell, TimestampTz t)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_H3INDEX_CELL(cell, NULL);
   STBox box;
   if (! h3index_set_stbox(cell, &box))
     return NULL;
@@ -173,6 +186,7 @@ h3index_tstzspan_to_stbox(H3Index cell, const Span *s)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(s, NULL);
+  VALIDATE_H3INDEX_CELL(cell, NULL);
   STBox box;
   if (! h3index_set_stbox(cell, &box))
     return NULL;

--- a/mobilitydb/test/h3/expected/250_h3index.test.out
+++ b/mobilitydb/test/h3/expected/250_h3index.test.out
@@ -40,6 +40,83 @@ SELECT h3index '12345';
  12345
 (1 row)
 
+SELECT isValidCell(h3index '622236750694711295');
+ isvalidcell 
+-------------
+ f
+(1 row)
+
+SELECT isValidDirectedEdge(h3index '622236750694711295');
+ isvaliddirectededge 
+---------------------
+ f
+(1 row)
+
+SELECT isValidVertex(h3index '622236750694711295');
+ isvalidvertex 
+---------------
+ f
+(1 row)
+
+SELECT isValidCell(h3index '12345');
+ isvalidcell 
+-------------
+ f
+(1 row)
+
+SELECT isValidCell(h3index '0xabc');
+ isvalidcell 
+-------------
+ f
+(1 row)
+
+/* Errors */
+SELECT h3GridDisk(h3index '622236750694711295', 1);
+ERROR:  h3index ffffffffffffffff is not a valid H3 cell
+SELECT h3GridDisk(h3index '12345', 1);
+ERROR:  h3index 12345 is not a valid H3 cell
+SELECT h3CellToChildren(h3index '0xabc', 6);
+ERROR:  h3index abc is not a valid H3 cell
+SELECT h3GetIcosahedronFaces(h3index '622236750694711295');
+ERROR:  h3index ffffffffffffffff is not a valid H3 cell
+SELECT h3OriginToDirectedEdges(h3index '12345');
+ERROR:  h3index 12345 is not a valid H3 cell
+SELECT numValues(h3GridDisk(h3index '831c02fffffffff', 1));
+ numvalues 
+-----------
+         7
+(1 row)
+
+SELECT numValues(h3GridDisk(h3index '880326b885fffff', 1));
+ numvalues 
+-----------
+         7
+(1 row)
+
+SELECT numValues(h3GridDisk(h3index '8a2a1072b59ffff', 1));
+ numvalues 
+-----------
+         7
+(1 row)
+
+SELECT numValues(h3CellToChildren(h3index '831c02fffffffff', 4));
+ numvalues 
+-----------
+         7
+(1 row)
+
+SELECT numValues(h3CellToVertexes(h3index '880326b885fffff'));
+ numvalues 
+-----------
+         6
+(1 row)
+
+SELECT numValues(h3OriginToDirectedEdges(h3index '8a2a1072b59ffff'));
+ numvalues 
+-----------
+         6
+(1 row)
+
 SELECT h3index '622236750694711295' = h3index '8a2a1072b59ffff';
  ?column? 
 ----------

--- a/mobilitydb/test/h3/expected/251_h3indexset.test.out
+++ b/mobilitydb/test/h3/expected/251_h3indexset.test.out
@@ -55,6 +55,18 @@ SELECT h3indexset '{8928308280fffffZZ}';
 ERROR:  invalid h3index input "8928308280fffffZZ": expected hexadecimal digits with an optional "0x" prefix
 LINE 1: SELECT h3indexset '{8928308280fffffZZ}';
                           ^
+SELECT h3indexset '{abc}';
+ERROR:  invalid h3index input "abc": not a valid H3 cell, directed edge or vertex
+LINE 1: SELECT h3indexset '{abc}';
+                          ^
+SELECT h3indexset '{0xabc}';
+ERROR:  invalid h3index input "0xabc": not a valid H3 cell, directed edge or vertex
+LINE 1: SELECT h3indexset '{0xabc}';
+                          ^
+SELECT h3indexset '{12345}';
+ERROR:  invalid h3index input "12345": not a valid H3 cell, directed edge or vertex
+LINE 1: SELECT h3indexset '{12345}';
+                          ^
 SELECT set(h3index '8a2a1072b59ffff');
          set         
 ---------------------

--- a/mobilitydb/test/h3/expected/270_th3index.test.out
+++ b/mobilitydb/test/h3/expected/270_th3index.test.out
@@ -6,11 +6,9 @@ SELECT th3index '8a2a100d645ffff@2012-01-01 08:00:00';
 
 /* Errors */
 SELECT th3index 'ABC@2012-01-01 08:00:00';
-             th3index             
-----------------------------------
- abc@Sun Jan 01 08:00:00 2012 PST
-(1 row)
-
+ERROR:  invalid h3index input "ABC": not a valid H3 cell, directed edge or vertex
+LINE 2: SELECT th3index 'ABC@2012-01-01 08:00:00';
+                        ^
 SELECT th3index '8a2a100d645ffff@2012-01-01 08:00:00,';
 ERROR:  Could not parse th3index value: Extraneous characters at the end
 LINE 1: SELECT th3index '8a2a100d645ffff@2012-01-01 08:00:00,';
@@ -23,55 +21,67 @@ SELECT th3index '8a2a100d645fffZZ@2012-01-01 08:00:00';
 ERROR:  invalid h3index input "8a2a100d645fffZZ": expected hexadecimal digits with an optional "0x" prefix
 LINE 1: SELECT th3index '8a2a100d645fffZZ@2012-01-01 08:00:00';
                         ^
-SELECT th3index ' { 8a2a100d645ffff@2001-01-01 08:00:00 , 8a2a100d6460000@2001-01-01 08:05:00 , 8a2a100d6460001@2001-01-01 08:06:00 } ';
+SELECT th3index '12345@2012-01-01 08:00:00';
+ERROR:  invalid h3index input "12345": not a valid H3 cell, directed edge or vertex
+LINE 1: SELECT th3index '12345@2012-01-01 08:00:00';
+                        ^
+SELECT th3index '0xabc@2012-01-01 08:00:00';
+ERROR:  invalid h3index input "0xabc": not a valid H3 cell, directed edge or vertex
+LINE 1: SELECT th3index '0xabc@2012-01-01 08:00:00';
+                        ^
+SELECT th3index 'ffffffffffffffff@2012-01-01 08:00:00';
+ERROR:  invalid h3index input "ffffffffffffffff": not a valid H3 cell, directed edge or vertex
+LINE 1: SELECT th3index 'ffffffffffffffff@2012-01-01 08:00:00';
+                        ^
+SELECT th3index ' { 8a2a100d645ffff@2001-01-01 08:00:00 , 8a2a100d6457fff@2001-01-01 08:05:00 , 8a2a100d64effff@2001-01-01 08:06:00 } ';
                                                                   th3index                                                                  
 --------------------------------------------------------------------------------------------------------------------------------------------
- {8a2a100d645ffff@Mon Jan 01 08:00:00 2001 PST, 8a2a100d6460000@Mon Jan 01 08:05:00 2001 PST, 8a2a100d6460001@Mon Jan 01 08:06:00 2001 PST}
+ {8a2a100d645ffff@Mon Jan 01 08:00:00 2001 PST, 8a2a100d6457fff@Mon Jan 01 08:05:00 2001 PST, 8a2a100d64effff@Mon Jan 01 08:06:00 2001 PST}
 (1 row)
 
-SELECT th3index '{8a2a100d645ffff@2001-01-01 08:00:00,8a2a100d6460000@2001-01-01 08:05:00,8a2a100d6460001@2001-01-01 08:06:00}';
+SELECT th3index '{8a2a100d645ffff@2001-01-01 08:00:00,8a2a100d6457fff@2001-01-01 08:05:00,8a2a100d64effff@2001-01-01 08:06:00}';
                                                                   th3index                                                                  
 --------------------------------------------------------------------------------------------------------------------------------------------
- {8a2a100d645ffff@Mon Jan 01 08:00:00 2001 PST, 8a2a100d6460000@Mon Jan 01 08:05:00 2001 PST, 8a2a100d6460001@Mon Jan 01 08:06:00 2001 PST}
+ {8a2a100d645ffff@Mon Jan 01 08:00:00 2001 PST, 8a2a100d6457fff@Mon Jan 01 08:05:00 2001 PST, 8a2a100d64effff@Mon Jan 01 08:06:00 2001 PST}
 (1 row)
 
 /* Errors */
-SELECT th3index '{8a2a100d645ffff@2001-01-01, 8a2a100d6460000@2001-01-02, 8a2a100d6460001@2001-01-03';
+SELECT th3index '{8a2a100d645ffff@2001-01-01, 8a2a100d6457fff@2001-01-02, 8a2a100d64effff@2001-01-03';
 ERROR:  Could not parse th3index value: Missing closing brace
-LINE 2: SELECT th3index '{8a2a100d645ffff@2001-01-01, 8a2a100d646000...
+LINE 2: SELECT th3index '{8a2a100d645ffff@2001-01-01, 8a2a100d6457ff...
                         ^
-SELECT th3index '{8a2a100d645ffff@2001-01-01, 8a2a100d6460000@2001-01-02, 8a2a100d6460001@2001-01-03},';
+SELECT th3index '{8a2a100d645ffff@2001-01-01, 8a2a100d6457fff@2001-01-02, 8a2a100d64effff@2001-01-03},';
 ERROR:  Could not parse th3index value: Extraneous characters at the end
-LINE 1: SELECT th3index '{8a2a100d645ffff@2001-01-01, 8a2a100d646000...
+LINE 1: SELECT th3index '{8a2a100d645ffff@2001-01-01, 8a2a100d6457ff...
                         ^
-SELECT th3index ' [ 8a2a100d645ffff@2001-01-01 08:00:00 , 8a2a100d6460000@2001-01-01 08:05:00 , 8a2a100d6460001@2001-01-01 08:06:00 ] ';
+SELECT th3index ' [ 8a2a100d645ffff@2001-01-01 08:00:00 , 8a2a100d6457fff@2001-01-01 08:05:00 , 8a2a100d64effff@2001-01-01 08:06:00 ] ';
                                                                   th3index                                                                  
 --------------------------------------------------------------------------------------------------------------------------------------------
- [8a2a100d645ffff@Mon Jan 01 08:00:00 2001 PST, 8a2a100d6460000@Mon Jan 01 08:05:00 2001 PST, 8a2a100d6460001@Mon Jan 01 08:06:00 2001 PST]
+ [8a2a100d645ffff@Mon Jan 01 08:00:00 2001 PST, 8a2a100d6457fff@Mon Jan 01 08:05:00 2001 PST, 8a2a100d64effff@Mon Jan 01 08:06:00 2001 PST]
 (1 row)
 
-SELECT th3index '[8a2a100d645ffff@2001-01-01 08:00:00,8a2a100d6460000@2001-01-01 08:05:00,8a2a100d6460001@2001-01-01 08:06:00]';
+SELECT th3index '[8a2a100d645ffff@2001-01-01 08:00:00,8a2a100d6457fff@2001-01-01 08:05:00,8a2a100d64effff@2001-01-01 08:06:00]';
                                                                   th3index                                                                  
 --------------------------------------------------------------------------------------------------------------------------------------------
- [8a2a100d645ffff@Mon Jan 01 08:00:00 2001 PST, 8a2a100d6460000@Mon Jan 01 08:05:00 2001 PST, 8a2a100d6460001@Mon Jan 01 08:06:00 2001 PST]
+ [8a2a100d645ffff@Mon Jan 01 08:00:00 2001 PST, 8a2a100d6457fff@Mon Jan 01 08:05:00 2001 PST, 8a2a100d64effff@Mon Jan 01 08:06:00 2001 PST]
 (1 row)
 
-SELECT th3index 'Interp=Step;[8a2a100d645ffff@2001-01-01 08:00:00,8a2a100d6460000@2001-01-01 08:05:00,8a2a100d6460001@2001-01-01 08:06:00]';
+SELECT th3index 'Interp=Step;[8a2a100d645ffff@2001-01-01 08:00:00,8a2a100d6457fff@2001-01-01 08:05:00,8a2a100d64effff@2001-01-01 08:06:00]';
                                                                   th3index                                                                  
 --------------------------------------------------------------------------------------------------------------------------------------------
- [8a2a100d645ffff@Mon Jan 01 08:00:00 2001 PST, 8a2a100d6460000@Mon Jan 01 08:05:00 2001 PST, 8a2a100d6460001@Mon Jan 01 08:06:00 2001 PST]
+ [8a2a100d645ffff@Mon Jan 01 08:00:00 2001 PST, 8a2a100d6457fff@Mon Jan 01 08:05:00 2001 PST, 8a2a100d64effff@Mon Jan 01 08:06:00 2001 PST]
 (1 row)
 
-SELECT th3index ' { [ 8a2a100d645ffff@2001-01-01 08:00:00 , 8a2a100d6460000@2001-01-01 08:05:00 ] , [ 8a2a100d6460001@2001-01-01 08:10:00 , 8a2a100d6460002@2001-01-01 08:15:00 ] } ';
+SELECT th3index ' { [ 8a2a100d645ffff@2001-01-01 08:00:00 , 8a2a100d6457fff@2001-01-01 08:05:00 ] , [ 8a2a100d64effff@2001-01-01 08:10:00 , 8a2a100d67b7fff@2001-01-01 08:15:00 ] } ';
                                                                                            th3index                                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[8a2a100d645ffff@Mon Jan 01 08:00:00 2001 PST, 8a2a100d6460000@Mon Jan 01 08:05:00 2001 PST], [8a2a100d6460001@Mon Jan 01 08:10:00 2001 PST, 8a2a100d6460002@Mon Jan 01 08:15:00 2001 PST]}
+ {[8a2a100d645ffff@Mon Jan 01 08:00:00 2001 PST, 8a2a100d6457fff@Mon Jan 01 08:05:00 2001 PST], [8a2a100d64effff@Mon Jan 01 08:10:00 2001 PST, 8a2a100d67b7fff@Mon Jan 01 08:15:00 2001 PST]}
 (1 row)
 
-SELECT th3index '{[8a2a100d645ffff@2001-01-01 08:00:00,8a2a100d6460000@2001-01-01 08:05:00],[8a2a100d6460001@2001-01-01 08:10:00,8a2a100d6460002@2001-01-01 08:15:00]}';
+SELECT th3index '{[8a2a100d645ffff@2001-01-01 08:00:00,8a2a100d6457fff@2001-01-01 08:05:00],[8a2a100d64effff@2001-01-01 08:10:00,8a2a100d67b7fff@2001-01-01 08:15:00]}';
                                                                                            th3index                                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[8a2a100d645ffff@Mon Jan 01 08:00:00 2001 PST, 8a2a100d6460000@Mon Jan 01 08:05:00 2001 PST], [8a2a100d6460001@Mon Jan 01 08:10:00 2001 PST, 8a2a100d6460002@Mon Jan 01 08:15:00 2001 PST]}
+ {[8a2a100d645ffff@Mon Jan 01 08:00:00 2001 PST, 8a2a100d6457fff@Mon Jan 01 08:05:00 2001 PST], [8a2a100d64effff@Mon Jan 01 08:10:00 2001 PST, 8a2a100d67b7fff@Mon Jan 01 08:15:00 2001 PST]}
 (1 row)
 
 SELECT asMFJSON(th3index '880326b885fffff@2012-01-01 08:00:00');
@@ -159,26 +169,26 @@ SELECT th3index(Instant) '8a2a100d645ffff@2012-01-01 08:00:00';
  8a2a100d645ffff@Sun Jan 01 08:00:00 2012 PST
 (1 row)
 
-SELECT th3index(Sequence) '{8a2a100d645ffff@2001-01-01, 8a2a100d6460000@2001-01-02}';
+SELECT th3index(Sequence) '{8a2a100d645ffff@2001-01-01, 8a2a100d6457fff@2001-01-02}';
                                            th3index                                           
 ----------------------------------------------------------------------------------------------
- {8a2a100d645ffff@Mon Jan 01 00:00:00 2001 PST, 8a2a100d6460000@Tue Jan 02 00:00:00 2001 PST}
+ {8a2a100d645ffff@Mon Jan 01 00:00:00 2001 PST, 8a2a100d6457fff@Tue Jan 02 00:00:00 2001 PST}
 (1 row)
 
-SELECT th3index(Sequence) '[8a2a100d645ffff@2001-01-01, 8a2a100d6460000@2001-01-02]';
+SELECT th3index(Sequence) '[8a2a100d645ffff@2001-01-01, 8a2a100d6457fff@2001-01-02]';
                                            th3index                                           
 ----------------------------------------------------------------------------------------------
- [8a2a100d645ffff@Mon Jan 01 00:00:00 2001 PST, 8a2a100d6460000@Tue Jan 02 00:00:00 2001 PST]
+ [8a2a100d645ffff@Mon Jan 01 00:00:00 2001 PST, 8a2a100d6457fff@Tue Jan 02 00:00:00 2001 PST]
 (1 row)
 
-SELECT th3index(SequenceSet) '{[8a2a100d645ffff@2001-01-01, 8a2a100d6460000@2001-01-02]}';
+SELECT th3index(SequenceSet) '{[8a2a100d645ffff@2001-01-01, 8a2a100d6457fff@2001-01-02]}';
                                             th3index                                            
 ------------------------------------------------------------------------------------------------
- {[8a2a100d645ffff@Mon Jan 01 00:00:00 2001 PST, 8a2a100d6460000@Tue Jan 02 00:00:00 2001 PST]}
+ {[8a2a100d645ffff@Mon Jan 01 00:00:00 2001 PST, 8a2a100d6457fff@Tue Jan 02 00:00:00 2001 PST]}
 (1 row)
 
 /* Errors */
-SELECT th3index(Instant) '{8a2a100d645ffff@2001-01-01, 8a2a100d6460000@2001-01-02}';
+SELECT th3index(Instant) '{8a2a100d645ffff@2001-01-01, 8a2a100d6457fff@2001-01-02}';
 ERROR:  Temporal type (Sequence) does not match column type (Instant)
 SELECT th3index(Sequence) '8a2a100d645ffff@2012-01-01 08:00:00';
 ERROR:  Temporal type (Instant) does not match column type (Sequence)
@@ -246,16 +256,16 @@ SELECT (th3index '8a2a100d645ffff@2012-01-01 08:00:00')::tbigint;
  622236723497533439@Sun Jan 01 08:00:00 2012 PST
 (1 row)
 
-SELECT (th3index '{8a2a100d645ffff@2001-01-01, 8a2a100d6460000@2001-01-02}')::tbigint;
+SELECT (th3index '{8a2a100d645ffff@2001-01-01, 8a2a100d6457fff@2001-01-02}')::tbigint;
                                               tbigint                                               
 ----------------------------------------------------------------------------------------------------
- {622236723497533439@Mon Jan 01 00:00:00 2001 PST, 622236723497533440@Tue Jan 02 00:00:00 2001 PST}
+ {622236723497533439@Mon Jan 01 00:00:00 2001 PST, 622236723497500671@Tue Jan 02 00:00:00 2001 PST}
 (1 row)
 
-SELECT (th3index '[8a2a100d645ffff@2001-01-01, 8a2a100d6460000@2001-01-02]')::tbigint;
+SELECT (th3index '[8a2a100d645ffff@2001-01-01, 8a2a100d6457fff@2001-01-02]')::tbigint;
                                               tbigint                                               
 ----------------------------------------------------------------------------------------------------
- [622236723497533439@Mon Jan 01 00:00:00 2001 PST, 622236723497533440@Tue Jan 02 00:00:00 2001 PST]
+ [622236723497533439@Mon Jan 01 00:00:00 2001 PST, 622236723497500671@Tue Jan 02 00:00:00 2001 PST]
 (1 row)
 
 SELECT ((tbigint '622236723497533439@2012-01-01 08:00:00')::th3index)::tbigint
@@ -297,8 +307,8 @@ CREATE TABLE tbl_th3index_binio(k int, temp th3index);
 CREATE TABLE
 INSERT INTO tbl_th3index_binio VALUES
   (1, th3index '8a2a100d645ffff@2012-01-01 08:00:00'),
-  (2, th3index '{8a2a100d645ffff@2001-01-01, 8a2a100d6460000@2001-01-02}'),
-  (3, th3index '[8a2a100d645ffff@2001-01-01, 8a2a100d6460000@2001-01-02]');
+  (2, th3index '{8a2a100d645ffff@2001-01-01, 8a2a100d6457fff@2001-01-02}'),
+  (3, th3index '[8a2a100d645ffff@2001-01-01, 8a2a100d6457fff@2001-01-02]');
 INSERT 0 3
 COPY tbl_th3index_binio TO '/tmp/tbl_th3index_binio' (FORMAT BINARY);
 COPY 3

--- a/mobilitydb/test/h3/queries/250_h3index.test.sql
+++ b/mobilitydb/test/h3/queries/250_h3index.test.sql
@@ -33,6 +33,36 @@ SELECT h3index 'not-a-hex-cell';
 SELECT h3index '12345';   -- not a valid H3 cell
 
 -------------------------------------------------------------------------------
+-- Values the h3 extension's parser admits are rejected where they enter a
+-- MobilityDB operation. The operation decides which mode it requires: the
+-- saturated value and the short hexadecimal spellings denote neither a cell
+-- nor a directed edge nor a vertex, so no operation accepts them. The
+-- validity predicates answer false instead of raising, since reporting the
+-- mode of an arbitrary value is what they are for.
+-------------------------------------------------------------------------------
+
+SELECT isValidCell(h3index '622236750694711295');
+SELECT isValidDirectedEdge(h3index '622236750694711295');
+SELECT isValidVertex(h3index '622236750694711295');
+SELECT isValidCell(h3index '12345');
+SELECT isValidCell(h3index '0xabc');
+
+/* Errors */
+SELECT h3GridDisk(h3index '622236750694711295', 1);
+SELECT h3GridDisk(h3index '12345', 1);
+SELECT h3CellToChildren(h3index '0xabc', 6);
+SELECT h3GetIcosahedronFaces(h3index '622236750694711295');
+SELECT h3OriginToDirectedEdges(h3index '12345');
+
+-- Valid cells keep working, at every resolution
+SELECT numValues(h3GridDisk(h3index '831c02fffffffff', 1));
+SELECT numValues(h3GridDisk(h3index '880326b885fffff', 1));
+SELECT numValues(h3GridDisk(h3index '8a2a1072b59ffff', 1));
+SELECT numValues(h3CellToChildren(h3index '831c02fffffffff', 4));
+SELECT numValues(h3CellToVertexes(h3index '880326b885fffff'));
+SELECT numValues(h3OriginToDirectedEdges(h3index '8a2a1072b59ffff'));
+
+-------------------------------------------------------------------------------
 -- Output: canonical hex form (matches h3-pg)
 -------------------------------------------------------------------------------
 

--- a/mobilitydb/test/h3/queries/251_h3indexset.test.sql
+++ b/mobilitydb/test/h3/queries/251_h3indexset.test.sql
@@ -37,6 +37,11 @@ SELECT h3indexset '{0xffffffffffffffffffffffff}';
 -- Characters that are not hexadecimal digits are rejected instead of
 -- being silently ignored
 SELECT h3indexset '{8928308280fffffZZ}';
+-- Short hexadecimal is well formed but denotes no cell, directed edge or
+-- vertex, so it is rejected rather than stored as a value with no location
+SELECT h3indexset '{abc}';
+SELECT h3indexset '{0xabc}';
+SELECT h3indexset '{12345}';
 
 -------------------------------------------------------------------------------
 -- Conversions

--- a/mobilitydb/test/h3/queries/270_th3index.test.sql
+++ b/mobilitydb/test/h3/queries/270_th3index.test.sql
@@ -34,28 +34,32 @@ SELECT th3index 'ABC@2012-01-01 08:00:00';
 SELECT th3index '8a2a100d645ffff@2012-01-01 08:00:00,';
 SELECT th3index 'ffffffffffffffffff@2012-01-01 08:00:00';
 SELECT th3index '8a2a100d645fffZZ@2012-01-01 08:00:00';
+-- Well-formed hexadecimal that denotes no cell, directed edge or vertex
+SELECT th3index '12345@2012-01-01 08:00:00';
+SELECT th3index '0xabc@2012-01-01 08:00:00';
+SELECT th3index 'ffffffffffffffff@2012-01-01 08:00:00';
 
 -------------------------------------------------------------------------------
 -- Temporal discrete sequence
 
-SELECT th3index ' { 8a2a100d645ffff@2001-01-01 08:00:00 , 8a2a100d6460000@2001-01-01 08:05:00 , 8a2a100d6460001@2001-01-01 08:06:00 } ';
-SELECT th3index '{8a2a100d645ffff@2001-01-01 08:00:00,8a2a100d6460000@2001-01-01 08:05:00,8a2a100d6460001@2001-01-01 08:06:00}';
+SELECT th3index ' { 8a2a100d645ffff@2001-01-01 08:00:00 , 8a2a100d6457fff@2001-01-01 08:05:00 , 8a2a100d64effff@2001-01-01 08:06:00 } ';
+SELECT th3index '{8a2a100d645ffff@2001-01-01 08:00:00,8a2a100d6457fff@2001-01-01 08:05:00,8a2a100d64effff@2001-01-01 08:06:00}';
 /* Errors */
-SELECT th3index '{8a2a100d645ffff@2001-01-01, 8a2a100d6460000@2001-01-02, 8a2a100d6460001@2001-01-03';
-SELECT th3index '{8a2a100d645ffff@2001-01-01, 8a2a100d6460000@2001-01-02, 8a2a100d6460001@2001-01-03},';
+SELECT th3index '{8a2a100d645ffff@2001-01-01, 8a2a100d6457fff@2001-01-02, 8a2a100d64effff@2001-01-03';
+SELECT th3index '{8a2a100d645ffff@2001-01-01, 8a2a100d6457fff@2001-01-02, 8a2a100d64effff@2001-01-03},';
 
 -------------------------------------------------------------------------------
 -- Temporal continuous sequence (step interpolation is inherited from T_INT8)
 
-SELECT th3index ' [ 8a2a100d645ffff@2001-01-01 08:00:00 , 8a2a100d6460000@2001-01-01 08:05:00 , 8a2a100d6460001@2001-01-01 08:06:00 ] ';
-SELECT th3index '[8a2a100d645ffff@2001-01-01 08:00:00,8a2a100d6460000@2001-01-01 08:05:00,8a2a100d6460001@2001-01-01 08:06:00]';
-SELECT th3index 'Interp=Step;[8a2a100d645ffff@2001-01-01 08:00:00,8a2a100d6460000@2001-01-01 08:05:00,8a2a100d6460001@2001-01-01 08:06:00]';
+SELECT th3index ' [ 8a2a100d645ffff@2001-01-01 08:00:00 , 8a2a100d6457fff@2001-01-01 08:05:00 , 8a2a100d64effff@2001-01-01 08:06:00 ] ';
+SELECT th3index '[8a2a100d645ffff@2001-01-01 08:00:00,8a2a100d6457fff@2001-01-01 08:05:00,8a2a100d64effff@2001-01-01 08:06:00]';
+SELECT th3index 'Interp=Step;[8a2a100d645ffff@2001-01-01 08:00:00,8a2a100d6457fff@2001-01-01 08:05:00,8a2a100d64effff@2001-01-01 08:06:00]';
 
 -------------------------------------------------------------------------------
 -- Temporal sequence set
 
-SELECT th3index ' { [ 8a2a100d645ffff@2001-01-01 08:00:00 , 8a2a100d6460000@2001-01-01 08:05:00 ] , [ 8a2a100d6460001@2001-01-01 08:10:00 , 8a2a100d6460002@2001-01-01 08:15:00 ] } ';
-SELECT th3index '{[8a2a100d645ffff@2001-01-01 08:00:00,8a2a100d6460000@2001-01-01 08:05:00],[8a2a100d6460001@2001-01-01 08:10:00,8a2a100d6460002@2001-01-01 08:15:00]}';
+SELECT th3index ' { [ 8a2a100d645ffff@2001-01-01 08:00:00 , 8a2a100d6457fff@2001-01-01 08:05:00 ] , [ 8a2a100d64effff@2001-01-01 08:10:00 , 8a2a100d67b7fff@2001-01-01 08:15:00 ] } ';
+SELECT th3index '{[8a2a100d645ffff@2001-01-01 08:00:00,8a2a100d6457fff@2001-01-01 08:05:00],[8a2a100d64effff@2001-01-01 08:10:00,8a2a100d67b7fff@2001-01-01 08:15:00]}';
 
 -------------------------------------------------------------------------------
 -- MF-JSON input/output (h3index cell ids are serialized as their int8 value,
@@ -80,11 +84,11 @@ SELECT th3indexFromMFJSON(asMFJSON(th3index '{[880326b885fffff@2001-01-01, 88032
 -------------------------------------------------------------------------------
 
 SELECT th3index(Instant) '8a2a100d645ffff@2012-01-01 08:00:00';
-SELECT th3index(Sequence) '{8a2a100d645ffff@2001-01-01, 8a2a100d6460000@2001-01-02}';
-SELECT th3index(Sequence) '[8a2a100d645ffff@2001-01-01, 8a2a100d6460000@2001-01-02]';
-SELECT th3index(SequenceSet) '{[8a2a100d645ffff@2001-01-01, 8a2a100d6460000@2001-01-02]}';
+SELECT th3index(Sequence) '{8a2a100d645ffff@2001-01-01, 8a2a100d6457fff@2001-01-02}';
+SELECT th3index(Sequence) '[8a2a100d645ffff@2001-01-01, 8a2a100d6457fff@2001-01-02]';
+SELECT th3index(SequenceSet) '{[8a2a100d645ffff@2001-01-01, 8a2a100d6457fff@2001-01-02]}';
 /* Errors */
-SELECT th3index(Instant) '{8a2a100d645ffff@2001-01-01, 8a2a100d6460000@2001-01-02}';
+SELECT th3index(Instant) '{8a2a100d645ffff@2001-01-01, 8a2a100d6457fff@2001-01-02}';
 SELECT th3index(Sequence) '8a2a100d645ffff@2012-01-01 08:00:00';
 SELECT th3index(Garbage) '8a2a100d645ffff@2012-01-01 08:00:00';
 
@@ -114,8 +118,8 @@ SELECT (tbigint '[622236723497533439@2001-01-01, 622236723497533440@2001-01-02]'
 
 -- th3index -> tbigint (explicit via ::)
 SELECT (th3index '8a2a100d645ffff@2012-01-01 08:00:00')::tbigint;
-SELECT (th3index '{8a2a100d645ffff@2001-01-01, 8a2a100d6460000@2001-01-02}')::tbigint;
-SELECT (th3index '[8a2a100d645ffff@2001-01-01, 8a2a100d6460000@2001-01-02]')::tbigint;
+SELECT (th3index '{8a2a100d645ffff@2001-01-01, 8a2a100d6457fff@2001-01-02}')::tbigint;
+SELECT (th3index '[8a2a100d645ffff@2001-01-01, 8a2a100d6457fff@2001-01-02]')::tbigint;
 
 -- Round-trip preserves value
 SELECT ((tbigint '622236723497533439@2012-01-01 08:00:00')::th3index)::tbigint
@@ -146,8 +150,8 @@ DROP TABLE IF EXISTS tbl_th3index_binio;
 CREATE TABLE tbl_th3index_binio(k int, temp th3index);
 INSERT INTO tbl_th3index_binio VALUES
   (1, th3index '8a2a100d645ffff@2012-01-01 08:00:00'),
-  (2, th3index '{8a2a100d645ffff@2001-01-01, 8a2a100d6460000@2001-01-02}'),
-  (3, th3index '[8a2a100d645ffff@2001-01-01, 8a2a100d6460000@2001-01-02]');
+  (2, th3index '{8a2a100d645ffff@2001-01-01, 8a2a100d6457fff@2001-01-02}'),
+  (3, th3index '[8a2a100d645ffff@2001-01-01, 8a2a100d6457fff@2001-01-02]');
 
 COPY tbl_th3index_binio TO '/tmp/tbl_th3index_binio' (FORMAT BINARY);
 


### PR DESCRIPTION
The h3 extension provides the `h3index` type and its input function, which reads a hexadecimal literal without asking whether the value denotes anything in the H3 indexing system. A literal such as `12345` is well-formed hexadecimal and is none of a cell, a directed edge or a vertex, yet it reaches `h3indexset` elements, `th3index` values and every operation built on them, where it compares, groups and indexes as though it named a place.

The h3 extension keeps ownership of the type: MobilityDB declares no `h3index` type, and the two extensions load into the same server. MobilityDB validates the values entering its own surfaces, so every binding behaves the same way.

The MEOS parser that reads `h3indexset` elements and `th3index` values requires the value to denote a cell, a directed edge or a vertex. It admits the zero sentinel, which h3 reserves as the conventional "no index" marker, which the validity predicates report as false and which callers test for.

Each operation additionally requires the mode it is defined for: a cell operation a cell, a directed-edge operation a directed edge, a vertex operation a vertex. The three modes share one 64-bit representation, so the message names the mode the operation requires, which is otherwise indistinguishable from a plain typo.

The change publishes the validity predicates as `h3_is_valid_cell`, `h3_is_valid_directed_edge` and `h3_is_valid_vertex`, alongside the other bare names whose C symbols collide with the h3 extension, so bindings can reach them. They answer false rather than raising. The mode-agnostic surfaces — input and output, comparison, ordering, hashing — accept any bit pattern, as ordering and grouping require.

These validators check in both builds rather than asserting in the extension build. A temporal value's type is settled by the SQL type system before a function sees it, so the type-validation macros assert a proven invariant; the validity of an h3index is settled by nothing, since the type comes from the h3 extension, whose input function and `bigint` cast admit any 64-bit pattern. The value is user input at every call, and asserting on user input aborts the backend.

Two surfaces stay as they are. The bare `h3index` literal is parsed by the h3 extension, not by MobilityDB, so `h3index '622236750694711295'` still saturates to `ffffffffffffffff` in a PostgreSQL session; the binding I/O ownership lint already records that divergence. The bounding-box helper shared by h3index-valued sets and temporal values accepts any mode, because `h3OriginToDirectedEdges` and `h3CellToVertexes` return sets whose elements are not cells; bounding those reaches `cellToBoundary`, which is the wrong primitive for them and yields a box that does not describe the value. That is a separate defect needing a mode-aware box, and a rejection there breaks both operations outright, so a note in place records it.

Three literals in the `th3index` tests are not H3 indices at all — `8a2a100d6460000`, `8a2a100d6460001` and `8a2a100d6460002` are false on all three predicates. Cells of the same resolution replace them.