### PR TITLE
Restrict a temporal rigid geometry to the set type of its base values

### DIFF
--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -1107,18 +1107,23 @@ trgeometry_minus_value(const Temporal *temp, const GSERIALIZED *gs)
 /**
  * @ingroup meos_internal_rgeo_restrict
  * @brief Restrict a temporal rigid geometry to (the complement of) a set of
- * geometries
+ * poses
  * @param[in] temp Temporal rigid geometry
- * @param[in] s Set of values
+ * @param[in] s Set of poses
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
+ * @note The base values of a temporal rigid geometry are poses. As the other
+ * restrictions do, the function strips the value to its temporal pose,
+ * restricts that, and puts the reference geometry back on the result
  * @csqlfn #Temporal_restrict_values()
  */
 Temporal *
 trgeometry_restrict_values(const Temporal *temp, const Set *s, bool atfunc)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TRGEOMETRY(temp, NULL); VALIDATE_GEOMSET(s, NULL); 
-  Temporal *res = temporal_restrict_values(temp, s, atfunc);
+  VALIDATE_TRGEOMETRY(temp, NULL); VALIDATE_POSESET(s, NULL);
+  Temporal *tpose = trgeometry_to_tpose(temp);
+  Temporal *res = temporal_restrict_values(tpose, s, atfunc);
+  pfree(tpose);
   if (! res)
     return NULL;
   Temporal *result = geometry_tpose_to_trgeometry(trgeo_geom_p(temp), res);
@@ -1128,9 +1133,9 @@ trgeometry_restrict_values(const Temporal *temp, const Set *s, bool atfunc)
 
 /**
  * @ingroup meos_rgeo_restrict
- * @brief Restrict a temporal rigid geometry to a set of geometries
+ * @brief Restrict a temporal rigid geometry to a set of poses
  * @param[in] temp Temporal rigid geometry
- * @param[in] s Set of values
+ * @param[in] s Set of poses
  * @csqlfn #Temporal_at_values()
  */
 Temporal *
@@ -1142,10 +1147,10 @@ trgeometry_at_values(const Temporal *temp, const Set *s)
 /**
  * @ingroup meos_rgeo_restrict
  * @brief Restrict a temporal rigid geometry to the complement of a set of
- * geometries
+ * poses
  * @param[in] temp Temporal rigid geometry
  * @csqlfn #Temporal_minus_values()
- * @param[in] s Set of values
+ * @param[in] s Set of poses
  */
 Temporal *
 trgeometry_minus_values(const Temporal *temp, const Set *s)

--- a/meos/test/trgeo_test.c
+++ b/meos/test/trgeo_test.c
@@ -35,7 +35,8 @@
  * A trgeometry value carries a leading reference geometry ahead of its
  * temporal (pose) part. This test exercises trgeometry_in() directly on a
  * well-formed value and checks that the result round-trips through
- * trgeometry_out().
+ * trgeometry_out(). It also exercises the restriction of a trgeometry to a
+ * set of base values, whose base values are poses.
  *
  * The program can be built as follows
  * @code
@@ -47,6 +48,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <meos.h>
+#include <meos_geo.h>
+#include <meos_pose.h>
 #include <meos_rgeo.h>
 
 /* Main program */
@@ -102,6 +105,85 @@ int main(void)
     }
     free(trgeo1); free(trgeo1_out);
   }
+
+  /* The base values of a trgeometry are poses, so it is restricted to a set
+   * of poses */
+  static const char *trgeo3_in =
+    "Polygon((0 0,1 0,1 1,0 1,0 0));"
+    "[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02, "
+    "Pose(Point(20 0),0)@2001-01-03]";
+  static const char *at_expected =
+    "POLYGON((0 0,1 0,1 1,0 1,0 0));"
+    "{[Pose(POINT(10 0),0)@2001-01-02 00:00:00+00]}";
+
+  Temporal *trgeo3 = trgeometry_in(trgeo3_in);
+  Set *poseset1 = poseset_in("{\"Pose(Point(10 0),0)\"}");
+  if (! trgeo3 || ! poseset1)
+  {
+    printf("FAILED: could not build the trgeometry and the poseset\n");
+    result = 1;
+  }
+  else
+  {
+    /* Restricting to a pose the value takes keeps the instant at which it
+     * takes it, with the reference geometry back on the result */
+    meos_errno_reset();
+    Temporal *at = trgeometry_at_values(trgeo3, poseset1);
+    if (! at)
+    {
+      printf("FAILED: trgeometry_at_values returned NULL, errno %d\n",
+        meos_errno());
+      result = 1;
+    }
+    else
+    {
+      char *at_out = trgeometry_as_text(at, 6);
+      if (strcmp(at_out, at_expected) != 0)
+      {
+        printf("FAILED: trgeometry_at_values: %s != %s\n", at_out,
+          at_expected);
+        result = 1;
+      }
+      else
+        printf("OK: trgeometry_at_values(trgeometry, poseset): %s\n", at_out);
+      free(at); free(at_out);
+    }
+
+    /* The complement keeps everything else, and the two together give back the
+     * time of the value */
+    meos_errno_reset();
+    Temporal *minus = trgeometry_minus_values(trgeo3, poseset1);
+    if (! minus)
+    {
+      printf("FAILED: trgeometry_minus_values returned NULL, errno %d\n",
+        meos_errno());
+      result = 1;
+    }
+    else
+    {
+      char *minus_out = trgeometry_as_text(minus, 6);
+      printf("OK: trgeometry_minus_values(trgeometry, poseset): %s\n",
+        minus_out);
+      free(minus); free(minus_out);
+    }
+
+    /* A set of another base type is rejected, rather than reaching the
+     * restriction and being rejected there */
+    Set *geomset1 = geomset_in("{\"Point(0 0)\", \"Point(1 1)\"}");
+    meos_errno_reset();
+    Temporal *bad = trgeometry_at_values(trgeo3, geomset1);
+    if (bad || meos_errno() == 0)
+    {
+      printf("FAILED: trgeometry_at_values accepted a geomset\n");
+      result = 1;
+    }
+    else
+      printf("OK: trgeometry_at_values(trgeometry, geomset) rejected, "
+        "errno %d\n", meos_errno());
+    free(bad); free(geomset1);
+    meos_errno_reset();
+  }
+  free(trgeo3); free(poseset1);
 
   /* Finalize MEOS */
   meos_finalize();


### PR DESCRIPTION
The base values of a temporal rigid geometry are poses, but `trgeometry_restrict_values` validates its set as a set of geometries. Neither kind of set reaches the restriction:

- a `geomset` passes the validation and is then rejected inside `temporal_restrict_values` with `Operation on mixed temporal and set types: trgeometry, geomset`, because the base type of a `trgeometry` is a pose and not a geometry;
- a `poseset`, the only set the restriction can work on, is rejected by the validation before it gets there.

`trgeometry_at_values` and `trgeometry_minus_values` are unreachable in both directions.

The fix validates the set as a set of poses, and restricts the temporal pose rather than the temporal rigid geometry itself, putting the reference geometry back on the result. This is what every other restriction of the family does, and it is what the body is written for: it re-wraps through `geometry_tpose_to_trgeometry`, which accepts a temporal pose. Passing the un-stripped value makes that re-wrap fail with `The temporal value must be of type tpose` even once a set of the right type gets through.

The doc comments name the poses the functions take.

This is the restriction to base values. Restricting a temporal rigid geometry by a geometry is a different operation, with its own surface and its own algorithm.

`meos/test/trgeo_test.c` covers the restriction: `atValues` to a pose the value takes keeps the instant at which it takes it with the reference geometry back on it, `minusValues` keeps the complement, and a set of another base type is rejected at the boundary instead of inside the restriction.
