### PR TITLE
Answer the ever spatial relationships of a temporal point from the box

### DIFF
--- a/doc/contributing/distance_design_notes.md
+++ b/doc/contributing/distance_design_notes.md
@@ -132,6 +132,24 @@ uses. Computing them by materialising the full temporal Boolean and projecting
 The running reduction answers the same question and stops as soon as it is
 decided.
 
+**The reduction earns its keep from the early exit, so it needs a threshold to
+exit on.** `eDwithin(d)` has one in `d` and reduces to the nearest approach
+profitably. `eIntersects` has the threshold `0`, but the nearest approach is
+computed exactly, and an exact minimum cannot stop at the first zero — it walks
+every segment to prove no smaller value exists. So `nad ≤ 0` is not the early
+exit the table describes; it is the same full walk wearing a threshold.
+
+The scan that stops at the first crossing is the target shape and no primitive
+implements it for this pair. Until one does, the ever intersects of a temporal
+point resolves through the clip engine and projects, which is the expensive
+form this section warns about and is still the cheapest available: measured on
+the tcbuffer join, the projection runs at 1.16× of the trajectory path it
+replaces and `aDisjoint`, which derives from it, at 2.01×, while the `nad`
+reduction runs at 0.95× and 1.70×. Neither number licenses the projection as
+the design: they measure two ways of walking every segment against each other.
+A scan that stops at the first crossing beats both, and remains the shape this
+relationship wants.
+
 **`disjoint` is the complement of `intersects` with the quantifier swapped:**
 `eDisjoint = ¬aIntersects`, `aDisjoint = ¬eIntersects`,
 `tDisjoint = ¬tIntersects`. A `disjoint` path that does not reduce to a negated
@@ -178,10 +196,31 @@ unknown, which here means no shared instant.
 | --- | --- | --- |
 | fixed-threshold `dwithin(d)`, `intersects` | yes | box distance > `d` ⟹ every point pair is farther than `d` |
 | ordering key for a pair loop | yes | the box distance is a valid lower bound to sort on |
-| `disjoint` prefilter | **no** | a box miss would prove disjointness and prune true rows |
+| `disjoint` as an index condition | **no** | a box miss proves disjointness, so `&&` prunes exactly the true rows |
+| `disjoint` as an early answer inside the function | **yes** | the same box miss that makes it unusable as a prefilter answers the relationship outright |
 | exact `nad`, `minDistance`, `\|=\|` — whole-pair box | **no** | no external threshold exists; the nearest pair can sit just outside the box |
 | exact `nad` — per-segment lower bound vs the running min | **yes** (planar) | the running minimum is a live threshold; a segment whose centre-box-minus-radius lower bound ≥ the running min cannot lower it |
 | `touches` prefilter via exact `nad` | **yes** | contact needs the gap `= 0` exactly; a strictly positive `nad` proves disjoint, so the pair can neither ever nor always touch |
+
+The two `disjoint` rows are the same fact read in opposite directions, and the
+direction is what decides soundness. A box miss proves that the values never
+meet. Fed to an index as `col && stbox(arg)`, that turns into a filter which
+keeps only the pairs whose boxes overlap and therefore drops every pair the
+miss has just proved disjoint — the rows the query wants. Read inside the
+relationship instead, the same miss is a complete answer: ever disjoint is
+true, ever intersects is false, and neither needs the trajectory the paths
+below would build. So the box belongs in the ever intersects and ever disjoint
+branches as an early answer, and never in their `SUPPORT` clause.
+
+A box test compares every dimension the two boxes share, so it answers in the
+dimensionality of the operands rather than of the relationship. That matters
+wherever the two differ: the ever disjoint of a temporal point resolves through
+a 2D covers, so a 3D pair separated in Z alone is *not* disjoint, while their
+boxes do not overlap. An early answer taken from `overlaps_stbox_stbox` would
+contradict the relationship there. Either restrict the early answer to planar
+2D operands, or take the box miss in 2D — the `gserialized_get_gbox_p` plus
+`gbox_overlaps_2d` reject that `geom_spatialrel` and `geo_covers2d` apply — but
+never clear the Z flag by hand.
 
 Soundness of the threshold prune depends on the box enclosing the whole value.
 For `tcbuffer` this holds because the box is **radius-aware** — the extent is

--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -1008,6 +1008,25 @@ ea_disjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 
   /* EVER */
 
+  /* A temporal geo whose bounding box does not overlap that of the geometry
+   * never meets it, so it is ever disjoint with it. Answering that from the
+   * boxes keeps the pairs the boxes separate off the paths below, which is
+   * what a join over a geometry column pays on most of its pairs, and is the
+   * prefilter #ea_dwithin_tgeo_geo carries before its own native path.
+   * Restricted to planar 2D operands on both sides: this relationship is 2D
+   * for a temporal point, which resolves it through a 2D covers, whereas the
+   * box comparison runs on every dimension the two boxes share and would
+   * answer on a Z separation the relationship ignores. */
+  if (! MEOS_FLAGS_GET_GEODETIC(temp->flags) &&
+      ! MEOS_FLAGS_GET_Z(temp->flags) && ! FLAGS_GET_Z(gs->gflags))
+  {
+    STBox box_temp, box_geom;
+    tspatial_set_stbox(temp, &box_temp);
+    geo_set_stbox(gs, &box_geom);
+    if (! overlaps_stbox_stbox(&box_geom, &box_temp))
+      return 1;
+  }
+
   /* Temporal point case: "ever disjoint" reduces to "not always covered". */
   if (tpoint_type(temp->temptype))
   {
@@ -1189,6 +1208,52 @@ ea_intersects_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
     return INVERT_RESULT(ea_disjoint_tgeo_geo(temp, gs, EVER));
 
   /* EVER */
+
+  /* A temporal geo whose bounding box does not overlap that of the geometry
+   * never meets it. Answering that from the boxes keeps the pairs the boxes
+   * separate off the paths below, which is what a join over a geometry column
+   * pays on most of its pairs, and is the prefilter #ea_dwithin_tgeo_geo
+   * carries before its own native path. Restricted to planar 2D operands on
+   * both sides, as the box comparison runs on every dimension the two boxes
+   * share while the relationship below resolves a 3D pair in 3D. */
+  if (! MEOS_FLAGS_GET_GEODETIC(temp->flags) &&
+      ! MEOS_FLAGS_GET_Z(temp->flags) && ! FLAGS_GET_Z(gs->gflags))
+  {
+    STBox box_temp, box_geom;
+    tspatial_set_stbox(temp, &box_temp);
+    geo_set_stbox(gs, &box_geom);
+    if (! overlaps_stbox_stbox(&box_geom, &box_temp))
+      return 0;
+  }
+
+  /* Native fast path for a temporal geometry point with linear interpolation
+   * against a 2D geometry the clip engine supports. The path below builds the
+   * trajectory of the whole temporal point and hands that geometry to GEOS,
+   * which costs more than the clip engine spends on the temporal Boolean this
+   * projects: the same #tpoint_linear_inter_geom serves #tinterrel_tgeo_geo,
+   * so the projection agrees with the temporal result by construction.
+   * Reducing to the nearest approach instead, as #ea_dwithin_tgeo_geo does for
+   * a strictly positive distance, measures slower here: that reduction earns
+   * its keep from an early exit at the first instant within the distance, and
+   * #nad_tgeo_geo resolves the exact minimum, so at a zero distance it walks
+   * every segment the clip engine walks once. A geometry with a Z dimension
+   * keeps the path below, whose relationship is the 3D one. */
+  if (temp->temptype == T_TGEOMPOINT && temp->subtype != TINSTANT &&
+      MEOS_FLAGS_GET_INTERP(temp->flags) == LINEAR &&
+      ! FLAGS_GET_Z(gs->gflags))
+  {
+    LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
+    bool supported = geom_clip_supported(lwgeom);
+    lwgeom_free(lwgeom);
+    if (supported)
+    {
+      Temporal *inter = tpoint_linear_inter_geom(temp, gs, false);
+      int result = ever_eq_temporal_base(inter, BoolGetDatum(true));
+      pfree(inter);
+      return result;
+    }
+  }
+
   datum_func2 func = geo_intersects_fn_geo(temp->flags, gs->gflags);
   return spatialrel_tgeo_geo(temp, gs, (Datum) NULL, (varfunc) func, 2,
     INVERT_NO, EVER);


### PR DESCRIPTION
The ever and always intersects and disjoint relationships of a temporal geometry point with a geometry resolve every pair through the trajectory of the whole temporal point, which they build and hand to GEOS. A join over a geometry column separates most of its pairs by their bounding boxes alone, and a temporal geo whose box does not overlap the geometry's never meets it.

Both ever branches answer that case from the boxes, the prefilter `ea_dwithin_tgeo_geo` already carries, and the ever intersects branch resolves the rest through the clip engine, projecting the temporal Boolean that the same `tpoint_linear_inter_geom` computes for `tinterrel_tgeo_geo`, so the answer agrees with the temporal result by construction. The always forms are the inversions of these two branches and follow from them.

The box prefilter is restricted to planar 2D operands on both sides. The box comparison runs on every dimension the two boxes share, whereas the ever disjoint of a temporal point resolves through a 2D covers, so a 3D pair would otherwise be answered on a Z separation that the relationship ignores.

Measured on the tcbuffer benchmark join (`VesselTrip100 × NaturalAreas100`), medians of three interleaved reps against the parent commit, each side bound to its own staged build, with `eDwithin` and `tIntersects` as untouched controls:

| query | before | after | ratio |
|---|---:|---:|---:|
| `aDisjoint(geom, Trip)` | 6264 ms | 3113 ms | 2.01x |
| `eDisjoint(geom, Trip)` | 3645 ms | 2095 ms | 1.74x |
| `eIntersects(geom, Trip)` | 1336 ms | 1155 ms | 1.16x |
| `aIntersects(geom, Trip)` | 1072 ms | 1080 ms | 0.99x |
| control `eDwithin(geom, Trip, 100)` | 1411 ms | 1430 ms | 1.01x |
| control `tIntersects(geom, Trip)` | 2468 ms | 2477 ms | 1.00x |

Every query returns the same row count on both sides, and no expected output changes.

The design notes gain what the measurement settles: the box belongs in these relationships as an early answer rather than as an index prefilter, which is the direction that makes it sound, and the reduction to the nearest approach does not serve a zero distance, because an exact minimum walks every segment where the reduction is meant to stop at the first crossing.

Not wired: the scan that stops at the first crossing. No primitive implements it for this pair, and it is the shape both the projection here and the nearest approach reduction approximate.
