### PR TITLE
Reject a temporal point that never reaches a geometry from touching it

### DIFF
--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -1415,6 +1415,21 @@ ea_touches_tpoint_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
   if (! overlaps_stbox_stbox(&box1, &box2))
     return 0;
 
+  /* Touching requires the two to reach a distance of exactly zero, so a
+   * strictly positive exact nearest approach proves them disjoint and neither
+   * quantifier can hold. The paths below build the trajectory of the whole
+   * temporal point and the boundary of the geometry once per pair, and resolve
+   * the intersection natively, which indexes the boundary edges: a profile of
+   * this join spends about three quarters of its samples building that index,
+   * in node_insert and get_axis_stbox. The nearest approach reaches the same
+   * rejection without the boundary and its index. The box test above leaves
+   * the pairs that share an extent, which is where a spatial join spends its
+   * time, and this rejects those among them that never make contact. #ea_touches_tcbuffer_geo carries the same reject with the
+   * same tolerance, and the guards above have already restricted this to
+   * planar 2D operands, which is what the nearest approach requires. */
+  if (nad_tgeo_geo(temp, gs) > 1e-6)
+    return 0;
+
   /* EVER */
   if (ever)
   {


### PR DESCRIPTION
Touching requires the temporal point and the geometry to reach a distance of exactly zero, so a strictly positive exact nearest approach proves them disjoint and neither the ever nor the always quantifier can hold.

A pair that clears the bounding box test builds the trajectory of the whole temporal point and the boundary of the geometry, then resolves the intersection natively over an index of the boundary edges. That index is where the relationship spends its time. A profile of the benchmark join on the parent commit, sampling the backend at 499 Hz:

```
28.93%  node_insert.constprop.0
20.02%  get_axis_stbox
12.83%  topo_stbox_stbox_init
 4.33%  stbox_expand
 3.74%  stbox_srid
 2.86%  contains_stbox_stbox
 0.96%  bbox_expand_stbox
```

About three quarters of the samples build that index, once per pair. The nearest approach reaches the same rejection without the boundary and without the index.

`ea_touches_tcbuffer_geo` carries this reject with the same tolerance, which is why the relationship costs a temporal circular buffer less than the temporal point it derives from. The guards above the reject restrict the function to planar 2D operands, which is what the nearest approach requires.

Measured on the tcbuffer benchmark join (`VesselTrip100 × NaturalAreas100`), medians of three interleaved reps against the parent commit, each side bound to its own staged build:

| query | before | after | ratio |
|---|---:|---:|---:|
| `eTouches(geom, Trip)` | 8954 ms | 1798 ms | 4.98x |
| `aTouches(geom, Trip)` | 1556 ms | 1526 ms | 1.02x |
| control `eDwithin(geom, Trip, 100)` | 1483 ms | 1470 ms | 1.01x |
| control `tIntersects(geom, Trip)` | 2770 ms | 2722 ms | 1.02x |
| control `eIntersects(geom, Trip)` | 1352 ms | 1285 ms | 1.05x |

The before column is the more variable side, spanning 8206 to 15708 ms across its reps against 1627 to 1822 ms after, so the median understates the gap. Every query returns the same row count on both sides, and no expected output changes.

Not addressed: the index is still built once per pair for the pairs that do make contact. Building it once per distinct geometry would serve every relationship that resolves against a geometry's edges, not only this one.
