### PR TITLE
Create the ways table of the npoint data generator only when absent

### DIFF
--- a/mobilitydb/datagen/npoint/create_test_tables_tnpoint.sql
+++ b/mobilitydb/datagen/npoint/create_test_tables_tnpoint.sql
@@ -34,26 +34,29 @@
  * These functions use the random generator for these types that are in the
  * file random_tnpoint.sql. Refer to that file for the meaning of the
  * parameters used in the function calls of this file.
+ *
+ * The road network is materialized on demand by ensure_random_ways() in
+ * random_tnpoint.sql. The identifiers of the generated network points are
+ * taken from the routes of the resulting ways table.
  */
 
 DROP FUNCTION IF EXISTS create_test_tables_npoint();
 CREATE OR REPLACE FUNCTION create_test_tables_npoint(size int DEFAULT 1000)
 RETURNS text AS $$
+DECLARE
+  perc int := size / 4;
+  lown int;
+  highn int;
 BEGIN
 
 -------------------------------------------------------------------------------
 
-DROP TABLE IF EXISTS ways;
-CREATE TABLE ways (
-  gid bigint PRIMARY KEY,
-  the_geom geometry,
-  length float
-);
-INSERT INTO ways(gid, the_geom)
-SELECT k, random_geomlinestring(0, size, 0, size,10)
-FROM generate_series (0, size) AS k;
-UPDATE ways
-SET length = st_length(the_geom);
+/* Materialize the synthetic road network read by every random function below.
+   Creates the table ways only when it is absent — a road network already
+   loaded in the database is left untouched and its routes are used instead. */
+PERFORM ensure_random_ways();
+SELECT min(gid), max(gid) INTO lown, highn FROM ways;
+RAISE NOTICE 'Generating network points on the routes of the table ways with identifiers in [%, %]', lown, highn;
 
 /*
 SELECT gid, st_astext(the_geom)
@@ -67,12 +70,12 @@ LIMIT 2;
 
 DROP TABLE IF EXISTS tbl_npoint;
 CREATE TABLE tbl_npoint AS
-SELECT k, random_npoint(0, size) AS np
+SELECT k, random_npoint(lown, highn) AS np
 FROM generate_series(1, size) k;
 
 DROP TABLE IF EXISTS tbl_nsegment;
 CREATE TABLE tbl_nsegment AS
-SELECT k, random_nsegment(0, size) AS ns
+SELECT k, random_nsegment(lown, highn) AS ns
 FROM generate_series(1, size) k;
 
 DROP TABLE IF EXISTS tbl_npointset;
@@ -80,7 +83,7 @@ CREATE TABLE tbl_npointset AS
 /* Add perc NULL values */
 SELECT k, NULL AS n
 FROM generate_series(1, perc) AS k UNION
-SELECT k, random_npoint_set(1, 100, 5, 10)
+SELECT k, random_npoint_set(lown, highn, 5, 10)
 FROM generate_series(perc+1, size) AS k;
 
 ------------------------------------------------------------------------------
@@ -89,22 +92,22 @@ FROM generate_series(perc+1, size) AS k;
 
 DROP TABLE IF EXISTS tbl_tnpoint_inst;
 CREATE TABLE tbl_tnpoint_inst AS
-SELECT k, random_tnpoint_inst(0, size, '2001-01-01', '2001-12-31') AS inst
+SELECT k, random_tnpoint_inst(lown, highn, '2001-01-01', '2001-12-31') AS inst
 FROM generate_series(1, size) k;
 
 DROP TABLE IF EXISTS tbl_tnpoint_discseq;
 CREATE TABLE tbl_tnpoint_discseq AS
-SELECT k, random_tnpoint_discseq(0, size, '2001-01-01', '2001-12-31', 10, 1, 10) AS seq
+SELECT k, random_tnpoint_discseq(lown, highn, '2001-01-01', '2001-12-31', 10, 1, 10) AS seq
 FROM generate_series(1, size) k;
 
 DROP TABLE IF EXISTS tbl_tnpoint_seq;
 CREATE TABLE tbl_tnpoint_seq AS
-SELECT k, random_tnpoint_seq(0, size, '2001-01-01', '2001-12-31', 10, 1, 10) AS seq
+SELECT k, random_tnpoint_contseq(lown, highn, '2001-01-01', '2001-12-31', 10, 1, 10) AS seq
 FROM generate_series(1, size) k;
 
 DROP TABLE IF EXISTS tbl_tnpoint_seqset;
 CREATE TABLE tbl_tnpoint_seqset AS
-SELECT k, random_tnpoint_seqset(0, size, '2001-01-01', '2001-12-31', 10, 1, 10, 1, 10) AS ss
+SELECT k, random_tnpoint_seqset(lown, highn, '2001-01-01', '2001-12-31', 10, 1, 10, 1, 10) AS ss
 FROM generate_series(1, size) AS k;
 
 DROP TABLE IF EXISTS tbl_tnpoint;

--- a/mobilitydb/datagen/npoint/random_tnpoint.sql
+++ b/mobilitydb/datagen/npoint/random_tnpoint.sql
@@ -31,22 +31,49 @@
  * random_tnpoint.sql
  * Basic synthetic data generator functions FOR network point types
  * and temporal network point types.
+ *
+ * All randomly generated values reference the routes of the table ways.
+ * The synthetic road network (100 random linestring routes with identifiers
+ * 1 to 100) is materialized on demand via @ref ensure_random_ways().
  */
 
 ------------------------------------------------------------------------------
 -- Ways table
 ------------------------------------------------------------------------------
 
-DROP TABLE IF EXISTS ways;
-CREATE TABLE ways(
-  gid bigint PRIMARY KEY,
-  the_geom geometry,
-  length float);
-INSERT INTO ways
-SELECT k, random_geom_linestring(0, 100, 0, 100, 10, 2, 10, 0)
-FROM generate_series(1, 100) AS k;
-UPDATE ways
-SET length = ST_Length(the_geom);
+/**
+ * @brief Ensure that the road network table ways exists
+ * @details Creates the table ways with 100 random linestring routes if no
+ *   such table is found in the search path. Idempotent — a real road network,
+ *   such as the one loaded by osm2pgrouting, is left in place. All random
+ *   functions in this file reference the routes of that table.
+ * @return Number of routes of the table ways
+ */
+DROP FUNCTION IF EXISTS ensure_random_ways();
+CREATE FUNCTION ensure_random_ways()
+RETURNS integer AS $$
+DECLARE
+  result integer;
+BEGIN
+  IF to_regclass('ways') IS NULL THEN
+    CREATE TABLE ways(
+      gid bigint PRIMARY KEY,
+      the_geom geometry,
+      length float);
+    INSERT INTO ways
+    SELECT k, random_geom_linestring(0, 100, 0, 100, 10, 2, 10, 0)
+    FROM generate_series(1, 100) AS k;
+    UPDATE ways
+    SET length = ST_Length(the_geom);
+  END IF;
+  SELECT count(*) INTO result FROM ways;
+  RETURN result;
+END;
+$$ LANGUAGE PLPGSQL;
+
+/*
+SELECT ensure_random_ways();
+*/
 
 ------------------------------------------------------------------------------
 -- Static Network Types
@@ -77,6 +104,7 @@ DROP FUNCTION IF EXISTS random_npoint;
 CREATE FUNCTION random_npoint(lown integer, highn integer)
   RETURNS npoint AS $$
 BEGIN
+  PERFORM ensure_random_ways();
   RETURN npoint(random_int(lown, highn), random_fraction());
 END;
 $$ LANGUAGE PLPGSQL STRICT;
@@ -99,6 +127,7 @@ DECLARE
   random2 float;
   tmp float;
 BEGIN
+  PERFORM ensure_random_ways();
   random1 = random_fraction();
   random2 = random_fraction();
   IF random1 > random2 THEN


### PR DESCRIPTION
The road network of a temporal network point deployment lives in the table `ways`. That table is not created by the `mobilitydb` extension: it holds the routes loaded from OpenStreetMap or pgRouting, every `npoint` value references its route identifiers, and `npoint_srid` derives the SRID of the whole network point family from it.

`ensure_random_ways()` bootstraps the network for the data generator. It creates `ways` with 100 random linestring routes only when no such table is found in the search path, and returns the number of routes of the resulting table. A road network that is already present is left untouched, so the generator never replaces a table it did not create, whether it is called once or repeatedly.

The network is materialized on demand from `random_npoint` and `random_nsegment`, following the shape of `random_tpcpoint.sql`, where `ensure_random_pcid()` materializes the pgpointcloud schema from the random generators that need it. A network is therefore available to any caller of the random functions, while the extension script itself creates no table, so `ways` is not a member of the extension.

`create_test_tables_npoint` calls the bootstrap and takes the bounds of the route identifiers from the resulting table, so the generated fixtures reference routes that exist in the network of the database, whether that network is the synthetic one or one that is already loaded. The function reports the identifier range it generates on.

The npoint regression suites build their tables from `test/npoint/data/load_npoint.sql.xz`, which creates and populates its own `public.ways` and does not install the datagen extension, so they are independent of this bootstrap.
