### PR TITLE
Restrict a temporal rigid geometry to the type of its base values

### DIFF
--- a/meos/include/meos_rgeo.h
+++ b/meos/include/meos_rgeo.h
@@ -172,8 +172,8 @@ extern Temporal *trgeometry_at_geom(const Temporal *temp, const GSERIALIZED *gs)
 extern Temporal *trgeometry_minus_geom(const Temporal *temp, const GSERIALIZED *gs);
 extern Temporal *trgeometry_at_stbox(const Temporal *temp, const STBox *box, bool border_inc);
 extern Temporal *trgeometry_minus_stbox(const Temporal *temp, const STBox *box, bool border_inc);
-extern Temporal *trgeometry_at_value(const Temporal *temp, const GSERIALIZED *gs);
-extern Temporal *trgeometry_minus_value(const Temporal *temp, const GSERIALIZED *gs);
+extern Temporal *trgeometry_at_value(const Temporal *temp, const Pose *pose);
+extern Temporal *trgeometry_minus_value(const Temporal *temp, const Pose *pose);
 extern Temporal *trgeometry_at_values(const Temporal *temp, const Set *s);
 extern Temporal *trgeometry_minus_values(const Temporal *temp, const Set *s);
 extern Temporal *trgeometry_at_timestamptz(const Temporal *temp, TimestampTz t);

--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -1053,10 +1053,13 @@ trgeometry_set_interp(const Temporal *temp, interpType interp)
 
 /**
  * @ingroup meos_internal_rgeo_restrict
- * @brief Restrict a temporal rigid geometry to (the complement of) a geometry
+ * @brief Restrict a temporal rigid geometry to (the complement of) a pose
  * @param[in] temp Temporal rigid geometry
  * @param[in] value Value
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
+ * @note The base values of a temporal rigid geometry are poses. As the other
+ * restrictions do, the function strips the value to its temporal pose,
+ * restricts that, and puts the reference geometry back on the result
  * @note This function does a bounding box test for the temporal types
  * different from instant. The singleton tests are done in the functions for
  * the specific temporal types.
@@ -1067,8 +1070,9 @@ trgeometry_restrict_value(const Temporal *temp, Datum value, bool atfunc)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
-
-  Temporal *res = temporal_restrict_value(temp, value, atfunc);
+  Temporal *tpose = trgeometry_to_tpose(temp);
+  Temporal *res = temporal_restrict_value(tpose, value, atfunc);
+  pfree(tpose);
   if (! res)
     return NULL;
   Temporal *result = geometry_tpose_to_trgeometry(trgeo_geom_p(temp), res);
@@ -1078,28 +1082,32 @@ trgeometry_restrict_value(const Temporal *temp, Datum value, bool atfunc)
 
 /**
  * @ingroup meos_rgeo_restrict
- * @brief Restrict a temporal rigid geometry to a geometry
+ * @brief Restrict a temporal rigid geometry to a pose
  * @param[in] temp Temporal rigid geometry
- * @param[in] gs Geometry
+ * @param[in] pose Pose
  * @csqlfn #Temporal_at_value()
  */
 Temporal *
-trgeometry_at_value(const Temporal *temp, const GSERIALIZED *gs)
+trgeometry_at_value(const Temporal *temp, const Pose *pose)
 {
-  return trgeometry_restrict_value(temp, PointerGetDatum(gs), REST_AT);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pose, NULL);
+  return trgeometry_restrict_value(temp, PointerGetDatum(pose), REST_AT);
 }
 
 /**
  * @ingroup meos_rgeo_restrict
- * @brief Restrict a temporal rigid geometry to the complement of a geometry
+ * @brief Restrict a temporal rigid geometry to the complement of a pose
  * @param[in] temp Temporal rigid geometry
- * @param[in] gs Geometry
+ * @param[in] pose Pose
  * @csqlfn #Temporal_minus_value()
  */
 Temporal *
-trgeometry_minus_value(const Temporal *temp, const GSERIALIZED *gs)
+trgeometry_minus_value(const Temporal *temp, const Pose *pose)
 {
-  return trgeometry_restrict_value(temp, PointerGetDatum(gs), REST_MINUS);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pose, NULL);
+  return trgeometry_restrict_value(temp, PointerGetDatum(pose), REST_MINUS);
 }
 
 /*****************************************************************************/

--- a/meos/test/trgeo_test.c
+++ b/meos/test/trgeo_test.c
@@ -36,7 +36,7 @@
  * temporal (pose) part. This test exercises trgeometry_in() directly on a
  * well-formed value and checks that the result round-trips through
  * trgeometry_out(). It also exercises the restriction of a trgeometry to a
- * set of base values, whose base values are poses.
+ * base value and to a set of base values, whose base values are poses.
  *
  * The program can be built as follows
  * @code
@@ -181,6 +181,63 @@ int main(void)
       printf("OK: trgeometry_at_values(trgeometry, geomset) rejected, "
         "errno %d\n", meos_errno());
     free(bad); free(geomset1);
+    meos_errno_reset();
+
+    /* The singular restrictions take a base value, that is, a pose */
+    Pose *pose1 = pose_in("Pose(Point(10 0),0)");
+    meos_errno_reset();
+    Temporal *at_value = trgeometry_at_value(trgeo3, pose1);
+    if (! at_value)
+    {
+      printf("FAILED: trgeometry_at_value returned NULL, errno %d\n",
+        meos_errno());
+      result = 1;
+    }
+    else
+    {
+      char *at_value_out = trgeometry_as_text(at_value, 6);
+      if (strcmp(at_value_out, at_expected) != 0)
+      {
+        printf("FAILED: trgeometry_at_value: %s != %s\n", at_value_out,
+          at_expected);
+        result = 1;
+      }
+      else
+        printf("OK: trgeometry_at_value(trgeometry, pose): %s\n",
+          at_value_out);
+      free(at_value); free(at_value_out);
+    }
+
+    /* The complement keeps everything else */
+    meos_errno_reset();
+    Temporal *minus_value = trgeometry_minus_value(trgeo3, pose1);
+    if (! minus_value)
+    {
+      printf("FAILED: trgeometry_minus_value returned NULL, errno %d\n",
+        meos_errno());
+      result = 1;
+    }
+    else
+    {
+      char *minus_value_out = trgeometry_as_text(minus_value, 6);
+      printf("OK: trgeometry_minus_value(trgeometry, pose): %s\n",
+        minus_value_out);
+      free(minus_value); free(minus_value_out);
+    }
+
+    /* A temporal value of another type is rejected */
+    Temporal *tpose1 = trgeometry_to_tpose(trgeo3);
+    meos_errno_reset();
+    Temporal *bad_value = trgeometry_at_value(tpose1, pose1);
+    if (bad_value || meos_errno() == 0)
+    {
+      printf("FAILED: trgeometry_at_value accepted a temporal pose\n");
+      result = 1;
+    }
+    else
+      printf("OK: trgeometry_at_value(tpose, pose) rejected, errno %d\n",
+        meos_errno());
+    free(bad_value); free(tpose1); free(pose1);
     meos_errno_reset();
   }
   free(trgeo3); free(poseset1);


### PR DESCRIPTION
The base values of a temporal rigid geometry are poses: the catalog defines
the base type of `trgeometry` as `pose`. `trgeometry_at_value` and
`trgeometry_minus_value` take a pose, and restrict the temporal pose rather
than the temporal rigid geometry itself, putting the reference geometry back
on the result. This is what every other restriction of the family does, and
it is the singular counterpart of the set-based change that makes
`trgeometry_at_values` and `trgeometry_minus_values` take a set of poses.

A geometry argument does not match the base type of the value, so it is
rejected before the restriction happens; and a value that is not stripped to
its temporal pose makes the re-wrap through `geometry_tpose_to_trgeometry`
fail with "The temporal value must be of type tpose". Both directions of the
restriction are therefore unreachable without the change.

The internal `trgeometry_restrict_value` keeps its `Datum` parameter, as the
other internal restrictions do. The doc comments name the poses the
functions take.

The functions have no SQL surface and no callers, so the change is confined
to the MEOS public header and the family source. `meos/test/trgeo_test.c`
gains the singular counterpart of the set-based checks, including the
control that the result is a temporal rigid geometry carrying its reference
geometry.