### PR TITLE
Describe the native paths by what they do rather than what they avoid

### DIFF
--- a/meos/include/cbuffer/tcbuffer.h
+++ b/meos/include/cbuffer/tcbuffer.h
@@ -75,7 +75,7 @@ extern int tcbuffersegm_distance_turnpt(Datum start1, Datum end1, Datum start2,
   Datum end2, Datum dist UNUSED, TimestampTz lower, TimestampTz upper,
   TimestampTz *t1, TimestampTz *t2);
 
-/* Native (GEOS-free) temporal within relationship helpers */
+/* Native temporal within relationship helpers */
 
 extern void *tcbuffer_geo_ctx_make(const GSERIALIZED *gs);
 extern void tcbuffer_geo_ctx_free(void *ctx);

--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -860,7 +860,7 @@ nai_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
  * Shortest line: same closed-form minimisation, but tracking the witness
  * (the parameter on the swept-capsule segment that attains the minimum and
  * the nearest point on the geometry edge), so the connecting line can be
- * built without GEOS. The nearest-approach value path above is left
+ * built natively. The nearest-approach value path above is left
  * untouched.
  *****************************************************************************/
 

--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -88,7 +88,7 @@ datum_geom_covers(Datum geom1, Datum geom2)
 
 /**
  * @brief Return a Datum true if the first geometry covers the second one,
- * computed natively without GEOS
+ * computed natively
  */
 Datum
 datum_geo_covers2d(Datum geom1, Datum geom2)
@@ -109,7 +109,7 @@ datum_geom_disjoint2d(Datum geom1, Datum geom2)
 
 /**
  * @brief Return a Datum true if two geometries are disjoint in 2D, computed
- * natively without GEOS
+ * natively
  */
 Datum
 datum_geo_disjoint2d(Datum geom1, Datum geom2)
@@ -156,7 +156,7 @@ datum_geom_intersects2d(Datum geom1, Datum geom2)
 
 /**
  * @brief Return a Datum true if two geometries intersect in 2D, computed
- * natively without GEOS
+ * natively
  */
 Datum
 datum_geo_intersects2d(Datum geom1, Datum geom2)
@@ -1760,7 +1760,7 @@ ea_dwithin_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist,
    * native path below, which resolves every within-distance sub-period of every
    * segment only for the projection to discard all but their existence. The
    * nearest approach is a single running minimum, and
-   * #nad_tpoint_geo_analytic computes it with the same GEOS-free analytic
+   * #nad_tpoint_geo_analytic computes it with the same native analytic
    * engine, so the reduction is cheaper without giving up the native path. A
    * zero distance is left on the paths below, where the ever/always intersects
    * and disjoint relationships are defined in terms of ea_dwithin(., ., 0.0),

--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -32,7 +32,7 @@
  * @brief Fast 2D/3D temporal point clipping against 2D geometries
  * @details Support (multi)point, (multi)line, triangle, (multi)polygons with
  * holes and islands inside holes (recursively), and collection of the above
- * @note Avoid processing in GEOS to improve performance
+ * @note Processing is done natively to improve performance
  */
 
 /* C */
@@ -1601,9 +1601,9 @@ edges_have_area(Edge **edges, int nedges)
 
 /**
  * @brief Return true if two 2D geometries intersect, computed natively
- * @details The portable, GEOS-free counterpart of PostGIS `ST_Intersects` for
- * the geometry types the clip engine extracts into edges: two geometries meet
- * when a boundary edge of one crosses a boundary edge of the other, or when a
+ * @details Native counterpart of PostGIS `ST_Intersects` for the geometry
+ * types the clip engine extracts into edges: two geometries meet when a
+ * boundary edge of one crosses a boundary edge of the other, or when a
  * vertex of one lies inside the polygonal interior of the other. Points,
  * (multi)lines, (multi)polygons with holes, triangles, circular strings,
  * curve polygons, and collections of these are supported. The candidate edge
@@ -1706,7 +1706,7 @@ geo_intersects2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 }
 
 /*****************************************************************************
- * Native GEOS-free planar covers predicate
+ * Native planar covers predicate
  *****************************************************************************/
 
 /**
@@ -1846,7 +1846,7 @@ geo_is_poly(const GSERIALIZED *gs)
 
 /**
  * @brief Return true if the first 2D geometry covers the second, computed
- * natively without GEOS
+ * natively
  * @details Geometry A covers geometry B when every point of B lies in the
  * closure of A, that is, B has no point in A's exterior (the DE-9IM
  * `T*****FF*` family). Every vertex of B, and the midpoint of every
@@ -1948,8 +1948,8 @@ geo_covers2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
  * point with linear interpolation and a 2D geometry
  * @details The temporal geometric point may be in 2D or 3D and the Z dimension 
  * is also computed
- * @note For performance reasons we avoid the call to ST_Intersection
- * which delegates the computation to GEOS
+ * @note For performance reasons the intersection is computed natively
+ * instead of through ST_Intersection
  * @pre The arguments have the same SRID, the geometry is 2D and is not empty.
  * This is verified in #tgeo_restrict_geom
  */
@@ -2570,7 +2570,7 @@ next_segment:
  * @ingroup meos_internal_geo
  * @brief Return a temporal Boolean that states whether a temporal geometric
  * point with linear interpolation is within a distance of a 2D geometry
- * @details Native GEOS-free counterpart of the polygonal-buffer approximation:
+ * @details Native counterpart of the polygonal-buffer approximation:
  * for a zero distance it is exactly #tpoint_linear_inter_geom (tIntersects),
  * otherwise it solves the per-segment within-distance sub-intervals in closed
  * form. The result is a temporal Boolean defined over the whole time of the
@@ -2924,7 +2924,7 @@ tpointseq_distance_geom(const TSequence *seq, Edge **edges, int nedges)
  * @ingroup meos_internal_geo
  * @brief Return the temporal float distance between a temporal geometric point
  * with linear interpolation and a 2D geometry
- * @details Native GEOS-free counterpart of the generic distance lifting for a
+ * @details Native counterpart of the generic distance lifting for a
  * non-point geometry operand: the distance to a multi-edge or curved target
  * has an arbitrary number of turning points per segment which the point-only
  * base turning-point function cannot represent. The result is a temporal float


### PR DESCRIPTION
The comments on the native geometry kernels qualified them as GEOS-free.
That names the library the code does not call instead of naming the
implementation, and it reads as a comparison with PostGIS rather than as a
description of MobilityDB — an odd thing to say about work that is built on
PostGIS and links its geometry library.

Say native instead, which is the term already used elsewhere in these files
and carries the same information.

Comment-only: four files, sixteen lines, no code change.