### PR TITLE
Write temporal poses in their OGC GeoPose conformance class

### DIFF
--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -2682,7 +2682,7 @@
 				<title>Temporal JSON I/O</title>
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="pose_geopose_funcs"><varname>asGeoPose</varname>, <varname>tposeFromGeoPose</varname></link>: Convert a temporal pose to or from a TemporalGeoPose JSON envelope</para>
+						<para><link linkend="pose_geopose_funcs"><varname>asGeoPose</varname>, <varname>tposeFromGeoPose</varname></link>: Convert a temporal pose to or from its OGC GeoPose v1.0 encoding: a Basic document for an instant, a Composite Sequence Series for a sequence</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -1397,11 +1397,65 @@ SELECT asText(applyPose(ST_Point(1,0), tpose '[Pose(Point(0 0), 0)@2026-01-01,
 				<listitem xml:id="tpose_geopose_funcs">
 					<indexterm significance="normal"><primary><varname>asGeoPose</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tposeFromGeoPose</varname></primary></indexterm>
-					<para>Convert a temporal pose to or from a TemporalGeoPose JSON envelope</para>
+					<para>Convert a temporal pose to or from its OGC GeoPose v1.0 encoding</para>
 					<para><varname>asGeoPose(tpose,conformance int4=0,maxdecimaldigits int4=-1) → text</varname></para>
 					<para><varname>tposeFromGeoPose(text) → tpose</varname></para>
-					<para>Each per-instant payload is a strictly OGC-valid Basic-class GeoPose document plus a <varname>validTime</varname> member; the envelope records the conformance class, the interpolation, and (for sequences and sequence sets) the period bounds inclusion. A non-MEOS GeoPose consumer can iterate <varname>instants[]</varname> (or each <varname>sequences[].instants[]</varname>) and consume each element as a static GeoPose document.</para>
-					<para>The envelope shape is</para>
+					<para>The conformance class follows from the value. A single instant is a Basic document carrying its <varname>validTime</varname>; a sequence or sequence set is a Composite Sequence Series, of the Regular class when the instants are equally spaced by a whole number of milliseconds and of the Irregular class otherwise. The <varname>conformance</varname> argument chooses the orientation encoding of a Basic document, as it does for a <varname>pose</varname>, and has no effect on a Series, whose inner frames carry a quaternion and offer no such choice.</para>
+					<para>A Series states its outer frame once, as the local tangent plane East-North-Up frame at the position of the first pose, and gives each pose as an inner frame holding its translation from that tangent point, in metres, and its rotation relative to that frame's basis. Times are <varname>GeoPose_Instant</varname> values, that is Unix time in integer milliseconds, which is what the standard requires of every time position it defines. Sub-millisecond sampling is therefore not carried; the MF-JSON encoding, which the standard behind it types as a datetime string, does carry it.</para>
+					<para>The transition model reports the interpolation. Linear interpolation is the standard's <varname>interpolate</varname> model and step and discrete interpolation are its <varname>none</varname> model; since those two identifiers cannot tell step from discrete apart, the model's <varname>parameters</varname> name the interpolation with the same words the MF-JSON encoding uses.</para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asGeoPose(tpose '[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02,
+  Pose(Point(0 0 300), 0.5, 0.5, 0.5, 0.5)@2026-01-05]', 0, 6);
+-- {
+--  "header": {
+--   "poseCount": 3,
+--   "startInstant": 1767254400000,
+--   "stopInstant": 1767600000000,
+--   "transitionModel": {
+--    "authority": "/geopose/1.0",
+--    "id": "interpolate",
+--    "parameters": "interpolation=Linear"
+--   }
+--  },
+--  "outerFrame": {
+--   "authority": "/geopose/1.0",
+--   "id": "LTP-ENU",
+--   "parameters": "longitude=0&amp;latitude=0&amp;height=0&amp;crs=EPSG:4979"
+--  },
+--  "innerFrameAndTimeSeries": [
+--   {
+--    "frame": {
+--     "authority": "/geopose/1.0",
+--     "id": "RotateTranslate",
+--     "parameters": "translation=[0, 0, 0]&amp;rotation=[0.5, 0.5, 0.5, 0.5]"
+--    },
+--    "validTime": 1767254400000
+--   },
+--   {
+--    "frame": {
+--     "authority": "/geopose/1.0",
+--     "id": "RotateTranslate",
+--     "parameters": "translation=[0, 0, 100]&amp;rotation=[0.5, 0.5, 0.5, 0.5]"
+--    },
+--    "validTime": 1767340800000
+--   },
+--   {
+--    "frame": {
+--     "authority": "/geopose/1.0",
+--     "id": "RotateTranslate",
+--     "parameters": "translation=[0, 0, 300]&amp;rotation=[0.5, 0.5, 0.5, 0.5]"
+--    },
+--    "validTime": 1767600000000
+--   }
+--  ],
+--  "trailer": {
+--   "poseCount": 3
+--  }
+-- }
+</programlisting>
+					<para>A Series has neither gaps nor open bounds, so a sequence set is flattened into a single closed sequence and the bounds inclusion of a sequence is not preserved. Reading also accepts the <varname>TemporalGeoPose</varname> envelope that earlier releases wrote, an array of Basic-class objects each with an added <varname>validTime</varname>, so that data already stored in that form still loads.</para>
+					<para>That envelope's shape is</para>
 					<programlisting xml:space="preserve" format="linespecific">
 {
   "type":          "TemporalGeoPose",

--- a/meos/include/pose/pose.h
+++ b/meos/include/pose/pose.h
@@ -106,6 +106,11 @@ extern Datum datum_pose_apply_geo(Datum pose, Datum body);
 /* Transformation functions */
 
 extern Datum datum_pose_round(Datum pose, Datum size);
+extern void pose_quaternion_mul(double aw, double ax, double ay, double az,
+  double bw, double bx, double by, double bz,
+  double *ow, double *ox, double *oy, double *oz);
+extern void pose_enu_to_ecef_quaternion(double lat_rad, double lon_rad,
+  double *W, double *X, double *Y, double *Z);
 extern Pose *pose_transf_pj(const Pose *pose, int32_t srid_to,
   const LWPROJ *pj);
 

--- a/meos/include/pose/pose_geopose.h
+++ b/meos/include/pose/pose_geopose.h
@@ -45,9 +45,15 @@
  *****************************************************************************/
 
 /**
- * @brief OGC GeoPose conformance classes implemented for the JSON I/O.
- * @details The Advanced class (frame stacks, covariance) is not implemented
- * in this version.
+ * @brief Orientation encodings of an OGC GeoPose Basic document.
+ * @details The two Basic conformance classes differ only in how they carry
+ * the orientation, so one value chooses between them. It is orthogonal to
+ * the target conformance class, which follows from the value being written:
+ * a pose and a single temporal instant are Basic documents, a temporal
+ * sequence is a Composite Sequence Series. A Series carries a quaternion in
+ * every inner frame and offers no such choice.
+ *
+ * The Advanced, Chain, Graph and Stream classes are not implemented.
  */
 typedef enum
 {

--- a/meos/include/temporal/temporal.h
+++ b/meos/include/temporal/temporal.h
@@ -342,6 +342,12 @@ typedef int (*tpfunc_temp)(Datum, Datum, Datum, Datum, Datum, TimestampTz,
   #define DatumGetTSequenceSetP(X)   ((TSequenceSet *) PG_DETOAST_DATUM(X))
 #endif /* MEOS */
 
+/* Seconds separating the Unix epoch from the PostgreSQL epoch that a
+ * TimestampTz counts microseconds from. Every conversion between a
+ * TimestampTz and Unix time goes through this one constant, whatever
+ * resolution the target encoding asks for. */
+#define DELTA_UNIX_POSTGRES_EPOCH 946684800
+
 #define PG_GETARG_TEMPORAL_P(X)      ((Temporal *) PG_GETARG_VARLENA_P(X))
 #define PG_GETARG_TINSTANT_P(X)      ((TInstant *) PG_GETARG_VARLENA_P(X))
 #define PG_GETARG_TSEQUENCE_P(X)     ((TSequence *) PG_GETARG_VARLENA_P(X))

--- a/meos/src/geo/tpoint_spatialfuncs.c
+++ b/meos/src/geo/tpoint_spatialfuncs.c
@@ -69,13 +69,6 @@
 #include <utils/numeric.h>
 #include <pgtypes.h>
 
-/* Timestamps in PostgreSQL are encoded as MICROseconds since '2000-01-01'
- * while Unix epoch are encoded as MILLIseconds since '1970-01-01'.
- * Therefore the value used for conversions is computed as follows
- * select date_part('epoch', timestamp '2000-01-01' - timestamp '1970-01-01')
- * which results in 946684800 */
-#define DELTA_UNIX_POSTGRES_EPOCH 946684800
-
 /*****************************************************************************
  * Validity functions
  *****************************************************************************/

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -1506,8 +1506,8 @@ pose_set_srid(const Pose *pose, int32_t srid)
 /**
  * @brief Compose two unit quaternions: out = a * b (Hamilton convention).
  */
-static void
-quaternion_mul(double aw, double ax, double ay, double az,
+void
+pose_quaternion_mul(double aw, double ax, double ay, double az,
                double bw, double bx, double by, double bz,
                double *ow, double *ox, double *oy, double *oz)
 {
@@ -1527,7 +1527,7 @@ quaternion_mul(double aw, double ax, double ay, double az,
  * Converted to a quaternion via Shepperd's algorithm with the
  * largest-trace branch for numerical stability.
  */
-static void
+void
 pose_enu_to_ecef_quaternion(double lat_rad, double lon_rad,
   double *W, double *X, double *Y, double *Z)
 {
@@ -1600,7 +1600,7 @@ pose_orientation_apply_frame_change(int32_t srid_from, int32_t srid_to,
   {
     double Rw, Rx, Ry, Rz;
     pose_enu_to_ecef_quaternion(lat_rad, lon_rad, &Rw, &Rx, &Ry, &Rz);
-    quaternion_mul(Rw, Rx, Ry, Rz, Win, Xin, Yin, Zin, Wout, Xout, Yout, Zout);
+    pose_quaternion_mul(Rw, Rx, Ry, Rz, Win, Xin, Yin, Zin, Wout, Xout, Yout, Zout);
     return;
   }
 
@@ -1612,7 +1612,7 @@ pose_orientation_apply_frame_change(int32_t srid_from, int32_t srid_to,
     double Rw, Rx, Ry, Rz;
     pose_enu_to_ecef_quaternion(lat_rad, lon_rad, &Rw, &Rx, &Ry, &Rz);
     /* Conjugate of unit quaternion */
-    quaternion_mul(Rw, -Rx, -Ry, -Rz, Win, Xin, Yin, Zin,
+    pose_quaternion_mul(Rw, -Rx, -Ry, -Rz, Win, Xin, Yin, Zin,
       Wout, Xout, Yout, Zout);
     return;
   }

--- a/meos/src/pose/pose_geopose.c
+++ b/meos/src/pose/pose_geopose.c
@@ -60,7 +60,16 @@
  * `pitch: 0`, `roll: 0`, and yaw = theta. `theta` is stored in radians
  * internally; the JSON form uses degrees, per the standard.
  *
- * The Advanced GeoPose class (frame stacks, covariance) is not implemented.
+ * A temporal pose is written as an OGC Composite Sequence Series, either
+ * Regular or Irregular. Those classes encode each pose as an inner
+ * `FrameSpecification` holding a translation and a rotation relative to a
+ * single outer LTP-ENU frame, rather than as a Basic pose object, so the
+ * series encoding carries its own geographic-to-topocentric conversion.
+ * The MobilityDB `TemporalGeoPose` envelope, an array of Basic-class
+ * objects each carrying a `validTime`, remains available for reading and
+ * writing but is not an OGC conformance class.
+ *
+ * The Advanced, Chain, Graph and Stream classes are not implemented.
  */
 
 /* C */
@@ -84,10 +93,31 @@
  * Helpers
  *****************************************************************************/
 
-/* OGC GeoPose Basic conformance classes assume a geographic outer frame.
- * SRID 4326 (WGS-84) is the only one we currently expose; SRID 0 is
- * accepted on input and treated as geographic. */
-#define GEOPOSE_GEOGRAPHIC_SRID 4326
+/* Every GeoPose class fixes the outer frame to WGS-84 geographic. Two EPSG
+ * codes name that frame: 4326, which is two-dimensional, and 4979, which is
+ * three-dimensional. Their proj4 definitions are identical
+ * (`+proj=longlat +datum=WGS84 +no_defs`), the codes differing only in a
+ * declared dimensionality that proj4 does not express, so both are accepted
+ * and neither moves a coordinate. SRID 0 is accepted and treated as
+ * geographic.
+ *
+ * A GeoPose position is `{lat, lon, h}`, so 4979 is the code that describes
+ * it, and it is the one the composite outer frame declares. Values keep the
+ * SRID 4326 that the rest of the pose surface uses. */
+#define GEOPOSE_SRID_WGS84_2D 4326
+#define GEOPOSE_SRID_WGS84_3D 4979
+#define GEOPOSE_GEOGRAPHIC_SRID GEOPOSE_SRID_WGS84_2D
+
+/**
+ * @brief Return true if @p srid names the WGS-84 geographic frame the
+ * GeoPose classes require, or is unknown.
+ */
+static bool
+geopose_srid_is_geographic(int32_t srid)
+{
+  return srid == 0 || srid == GEOPOSE_SRID_WGS84_2D ||
+    srid == GEOPOSE_SRID_WGS84_3D;
+}
 
 /**
  * @brief Look up a JSON object member case-insensitively.
@@ -179,8 +209,139 @@ geopose_quaternion_to_ypr(double W, double X, double Y, double Z,
                      1.0 - 2.0 * (Y * Y + Z * Z));
 }
 
+/* Serialization flags: compact, and with '/' left unescaped so that the
+ * emitted authority strings read as the standard writes them. */
+#define GEOPOSE_JSON_FLAGS \
+  (JSON_C_TO_STRING_PLAIN | JSON_C_TO_STRING_NOSLASHESCAPE)
+
 #define GEOPOSE_DEG2RAD(d) ((d) * (M_PI / 180.0))
 #define GEOPOSE_RAD2DEG(r) ((r) * (180.0 / M_PI))
+
+/* String literals for the envelope's `interpolation` and `conformance` */
+static const char *
+geopose_interp_name(interpType interp)
+{
+  switch (interp)
+  {
+    case DISCRETE: return "Discrete";
+    case STEP:     return "Step";
+    case LINEAR:   return "Linear";
+    default:       return "None";
+  }
+}
+
+static interpType
+geopose_interp_from_string(const char *str)
+{
+  if (str == NULL) return INTERP_NONE;
+  if (strcmp(str, "Discrete") == 0) return DISCRETE;
+  if (strcmp(str, "Step")     == 0) return STEP;
+  if (strcmp(str, "Linear")   == 0) return LINEAR;
+  return INTERP_NONE;
+}
+
+/**
+ * @brief Return the value of @p key in a `key=value&key=value` parameter
+ * string, or @p NULL if the key is absent.
+ */
+static const char *
+geopose_param_find(const char *params, const char *key)
+{
+  size_t klen = strlen(key);
+  const char *p = params;
+  while (p != NULL && *p != '\0')
+  {
+    if (pg_strncasecmp(p, key, klen) == 0 && p[klen] == '=')
+      return p + klen + 1;
+    p = strchr(p, '&');
+    if (p != NULL)
+      p++;
+  }
+  return NULL;
+}
+
+/**
+ * @brief Read a bracketed list of @p n numbers, as emitted for the
+ * `translation` and `rotation` parameters.
+ */
+static bool
+geopose_param_list(const char *str, int n, double *out)
+{
+  char *end;
+  if (str == NULL)
+    return false;
+  while (*str == ' ')
+    str++;
+  if (*str != '[')
+    return false;
+  str++;
+  for (int i = 0; i < n; i++)
+  {
+    out[i] = strtod(str, &end);
+    if (end == str)
+      return false;
+    str = end;
+    while (*str == ' ')
+      str++;
+    if (i < n - 1)
+    {
+      if (*str != ',')
+        return false;
+      str++;
+    }
+  }
+  return (*str == ']');
+}
+
+/**
+ * @brief Read a single number parameter, as emitted for the outer frame's
+ * `longitude`, `latitude` and `height`.
+ */
+static bool
+geopose_param_number(const char *str, double *out)
+{
+  char *end;
+  if (str == NULL)
+    return false;
+  *out = strtod(str, &end);
+  return (end != str);
+}
+
+/**
+ * @brief Extract the position and orientation of a pose in the form every
+ * GeoPose encoding needs: longitude, latitude and height in degrees and
+ * metres, and a unit quaternion in Hamilton convention.
+ * @details Every class the standard defines fixes a WGS-84 outer frame, so
+ * this is also where the SRID is checked. A pose with SRID 0 is treated as
+ * geographic.
+ * @return On error return false
+ */
+static bool
+geopose_pose_components(const Pose *pose, double *lon, double *lat, double *h,
+  double *W, double *X, double *Y, double *Z)
+{
+  int32_t srid = pose_srid(pose);
+  if (! geopose_srid_is_geographic(srid))
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "GeoPose JSON requires a WGS-84 geographic SRID (4326 or 4979), "
+      "got %d", srid);
+    return false;
+  }
+  bool has_z = MEOS_FLAGS_GET_Z(pose->flags);
+  *lon = pose->data[0];
+  *lat = pose->data[1];
+  *h = has_z ? pose->data[2] : 0.0;
+  if (has_z)
+  {
+    *W = pose->data[3]; *X = pose->data[4];
+    *Y = pose->data[5]; *Z = pose->data[6];
+  }
+  else
+    /* 2D pose: pure yaw rotation about the local vertical. */
+    geopose_ypr_to_quaternion(pose->data[2], 0.0, 0.0, W, X, Y, Z);
+  return true;
+}
 
 /**
  * @brief Build a JSON double with a caller-controlled precision.
@@ -370,40 +531,19 @@ pose_to_geopose_object(const Pose *pose, int conformance, int precision)
       "(0 = Basic-Quaternion, 1 = Basic-YPR)", conformance);
     return NULL;
   }
-  int32_t srid = pose_srid(pose);
-  if (srid != 0 && srid != GEOPOSE_GEOGRAPHIC_SRID)
-  {
-    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
-      "GeoPose JSON requires SRID 4326 (WGS-84), got %d", srid);
+  /* Both classes start from a quaternion, and both place the position in
+   * the same geographic outer frame. */
+  double lon, lat, h, W, X, Y, Z;
+  if (! geopose_pose_components(pose, &lon, &lat, &h, &W, &X, &Y, &Z))
     return NULL;
-  }
-  bool has_z = MEOS_FLAGS_GET_Z(pose->flags);
-  /* Position: x is longitude, y is latitude, z (if present) is height. */
-  double lon = pose->data[0];
-  double lat = pose->data[1];
-  double h   = has_z ? pose->data[2] : 0.0;
-
-  /* Orientation. Both classes start from a quaternion: read it from a
-   * 3D pose, or build it from the 2D theta. */
-  double W, X, Y, Z;
-  if (has_z)
-  {
-    W = pose->data[3]; X = pose->data[4];
-    Y = pose->data[5]; Z = pose->data[6];
-  }
-  else
-  {
-    /* 2D pose: pure yaw rotation about Z. */
-    double theta_rad = pose->data[2];
-    geopose_ypr_to_quaternion(theta_rad, 0.0, 0.0, &W, &X, &Y, &Z);
-  }
 
   json_object *root = json_object_new_object();
   json_object *jpos = json_object_new_object();
   json_object_object_add(jpos, "lat", geopose_new_double(lat, precision));
   json_object_object_add(jpos, "lon", geopose_new_double(lon, precision));
-  /* Always emit `h` even for 2D poses so the JSON document is a
-   * complete Basic-class instance. */
+  /* `h` is required, so a 2D pose emits `h: 0`. GeoPose offers no way to
+   * say that a height is unknown, so zero is the convention for a
+   * height-free trajectory; it asserts more than the data holds. */
   json_object_object_add(jpos, "h",   geopose_new_double(h, precision));
   json_object_object_add(root, "position", jpos);
 
@@ -453,11 +593,718 @@ pose_as_geopose(const Pose *pose, int conformance, int precision)
   if (root == NULL)
     return NULL;
 
-  int flags = JSON_C_TO_STRING_PLAIN;
+  int flags = GEOPOSE_JSON_FLAGS;
   const char *raw = json_object_to_json_string_ext(root, flags);
   char *out = pstrdup(raw);
   json_object_put(root);
   return out;
+}
+
+/*****************************************************************************
+ * OGC GeoPose Composite Sequence classes — geodesy
+ *
+ * The Composite Sequence classes do not embed Basic pose objects. Every
+ * inner frame is a FrameSpecification whose `parameters` string carries a
+ * translation and a rotation relative to a single outer frame, which the
+ * standard's examples realize as an LTP-ENU frame anchored at an explicit
+ * tangent point. Emitting a conformant series therefore requires the
+ * geographic-to-topocentric conversion implemented here.
+ *****************************************************************************/
+
+/* WGS-84 defining parameters (EPSG::7030). The GeoPose Basic classes fix
+ * the outer frame to an implicit WGS-84 CRS (Requirements 12 and 14), so
+ * the topocentric conversion is against this ellipsoid. */
+#define GEOPOSE_WGS84_A   6378137.0
+#define GEOPOSE_WGS84_F   (1.0 / 298.257223563)
+#define GEOPOSE_WGS84_E2  (GEOPOSE_WGS84_F * (2.0 - GEOPOSE_WGS84_F))
+
+/**
+ * @brief Convert WGS-84 geographic coordinates to Earth-Centred
+ * Earth-Fixed Cartesian coordinates.
+ */
+static void
+geopose_geodetic_to_ecef(double lat_rad, double lon_rad, double h,
+  double *X, double *Y, double *Z)
+{
+  double s = sin(lat_rad), c = cos(lat_rad);
+  double N = GEOPOSE_WGS84_A / sqrt(1.0 - GEOPOSE_WGS84_E2 * s * s);
+  *X = (N + h) * c * cos(lon_rad);
+  *Y = (N + h) * c * sin(lon_rad);
+  *Z = (N * (1.0 - GEOPOSE_WGS84_E2) + h) * s;
+}
+
+/**
+ * @brief Recover the ellipsoidal height once the latitude is known.
+ * @details Uses whichever of the two equivalent expressions is better
+ * conditioned: @p p / cos φ degenerates at the poles, @p Z / sin φ at the
+ * equator. The switch is at |φ| = 45°, where both are equally conditioned.
+ */
+static double
+geopose_ecef_height(double p, double Z, double lat_rad, double N)
+{
+  double s = sin(lat_rad);
+  if (fabs(s) > M_SQRT1_2)
+    return Z / s - N * (1.0 - GEOPOSE_WGS84_E2);
+  return p / cos(lat_rad) - N;
+}
+
+/**
+ * @brief Convert Earth-Centred Earth-Fixed Cartesian coordinates to WGS-84
+ * geographic coordinates.
+ * @details Fixed-point iteration on (φ, h) seeded with the spherical
+ * approximation. The iteration count is fixed rather than
+ * convergence-tested so that every language binding computes exactly the
+ * same result from the same input, which this project requires of any
+ * value that reaches a serialization.
+ */
+static void
+geopose_ecef_to_geodetic(double X, double Y, double Z,
+  double *lat_rad, double *lon_rad, double *h)
+{
+  double p = sqrt(X * X + Y * Y);
+  if (p == 0.0)
+  {
+    /* On the polar axis the longitude is undefined; report it as zero. */
+    double b = GEOPOSE_WGS84_A * sqrt(1.0 - GEOPOSE_WGS84_E2);
+    *lon_rad = 0.0;
+    *lat_rad = (Z >= 0.0) ? M_PI_2 : -M_PI_2;
+    *h = fabs(Z) - b;
+    return;
+  }
+  *lon_rad = atan2(Y, X);
+  double lat = atan2(Z, p * (1.0 - GEOPOSE_WGS84_E2));
+  double N = GEOPOSE_WGS84_A;
+  for (int i = 0; i < 8; i++)
+  {
+    double s = sin(lat);
+    N = GEOPOSE_WGS84_A / sqrt(1.0 - GEOPOSE_WGS84_E2 * s * s);
+    double height = geopose_ecef_height(p, Z, lat, N);
+    lat = atan2(Z, p * (1.0 - GEOPOSE_WGS84_E2 * N / (N + height)));
+  }
+  double s = sin(lat);
+  N = GEOPOSE_WGS84_A / sqrt(1.0 - GEOPOSE_WGS84_E2 * s * s);
+  *lat_rad = lat;
+  *h = geopose_ecef_height(p, Z, lat, N);
+}
+
+/**
+ * @brief The outer frame of a Composite Sequence: an LTP-ENU frame
+ * anchored at a tangent point, cached with everything the per-instant
+ * conversions need.
+ */
+typedef struct
+{
+  double lat_rad;             /**< Tangent point latitude */
+  double lon_rad;             /**< Tangent point longitude */
+  double h;                   /**< Tangent point ellipsoidal height */
+  double X, Y, Z;             /**< Tangent point in ECEF */
+  double qw, qx, qy, qz;      /**< Rotation ECEF -> this frame's ENU basis */
+} GeoPoseAnchor;
+
+/**
+ * @brief Initialize the outer-frame anchor at a geographic tangent point.
+ * @details @p pose_enu_to_ecef_quaternion returns the quaternion of the
+ * matrix whose rows are the East, North and Up unit vectors expressed in
+ * ECEF, that is the rotation that takes ECEF components to ENU components
+ * at the tangent point. That is exactly what is needed here.
+ */
+static void
+geopose_anchor_set(GeoPoseAnchor *anchor, double lat_rad, double lon_rad,
+  double h)
+{
+  anchor->lat_rad = lat_rad;
+  anchor->lon_rad = lon_rad;
+  anchor->h = h;
+  geopose_geodetic_to_ecef(lat_rad, lon_rad, h, &anchor->X, &anchor->Y,
+    &anchor->Z);
+  pose_enu_to_ecef_quaternion(lat_rad, lon_rad, &anchor->qw, &anchor->qx,
+    &anchor->qy, &anchor->qz);
+}
+
+/**
+ * @brief Return the translation of a geographic point in the anchor's
+ * LTP-ENU frame, in metres.
+ */
+static void
+geopose_anchor_translation(const GeoPoseAnchor *anchor, double lat_rad,
+  double lon_rad, double h, double *e, double *n, double *u)
+{
+  double X, Y, Z;
+  geopose_geodetic_to_ecef(lat_rad, lon_rad, h, &X, &Y, &Z);
+  double dx = X - anchor->X, dy = Y - anchor->Y, dz = Z - anchor->Z;
+  double sl = sin(anchor->lon_rad), cl = cos(anchor->lon_rad);
+  double sp = sin(anchor->lat_rad), cp = cos(anchor->lat_rad);
+  *e = -sl * dx + cl * dy;
+  *n = -sp * cl * dx - sp * sl * dy + cp * dz;
+  *u =  cp * cl * dx + cp * sl * dy + sp * dz;
+}
+
+/**
+ * @brief Return the geographic coordinates of a translation expressed in
+ * the anchor's LTP-ENU frame. Inverse of @p geopose_anchor_translation.
+ */
+static void
+geopose_anchor_position(const GeoPoseAnchor *anchor, double e, double n,
+  double u, double *lat_rad, double *lon_rad, double *h)
+{
+  double sl = sin(anchor->lon_rad), cl = cos(anchor->lon_rad);
+  double sp = sin(anchor->lat_rad), cp = cos(anchor->lat_rad);
+  double X = anchor->X - sl * e - sp * cl * n + cp * cl * u;
+  double Y = anchor->Y + cl * e - sp * sl * n + cp * sl * u;
+  double Z = anchor->Z + cp * n + sp * u;
+  geopose_ecef_to_geodetic(X, Y, Z, lat_rad, lon_rad, h);
+}
+
+/**
+ * @brief Return the rotation that re-expresses an orientation given in the
+ * local ENU basis at (@p lat_rad, @p lon_rad) in the anchor's ENU basis.
+ * @details A Basic-class pose orients its body frame against the ENU basis
+ * at its *own* position, while a Composite Sequence inner frame orients it
+ * against the *outer* frame's basis. The two differ by the convergence of
+ * the two tangent planes, which is this rotation. Ignoring it would place
+ * every pose but the first at a subtly wrong attitude.
+ */
+static void
+geopose_anchor_rotation(const GeoPoseAnchor *anchor, double lat_rad,
+  double lon_rad, double *W, double *X, double *Y, double *Z)
+{
+  double lw, lx, ly, lz;
+  pose_enu_to_ecef_quaternion(lat_rad, lon_rad, &lw, &lx, &ly, &lz);
+  /* q(R_anchorENU<-ECEF) * q(R_ECEF<-localENU), the latter being the
+   * conjugate of the local ENU quaternion since both are unit. */
+  pose_quaternion_mul(anchor->qw, anchor->qx, anchor->qy, anchor->qz,
+    lw, -lx, -ly, -lz, W, X, Y, Z);
+}
+
+/*****************************************************************************
+ * OGC GeoPose Composite Sequence classes — JSON encoding
+ *****************************************************************************/
+
+/* Normative authority and identifier strings, as used by the encoding
+ * examples of OGC 21-056r11 Clause 9.2. */
+#define GEOPOSE_AUTHORITY       "/geopose/1.0"
+#define GEOPOSE_ID_OUTER_FRAME  "LTP-ENU"
+#define GEOPOSE_ID_INNER_FRAME  "RotateTranslate"
+#define GEOPOSE_ID_TM_NONE      "none"
+#define GEOPOSE_ID_TM_INTERP    "interpolate"
+/* Requirement 9 places the content of `parameters` outside the scope of
+ * GeoPose, so the transition model carries the interpolation there, spelled
+ * with the same words the MF-JSON encoding uses in
+ * `meos/src/temporal/type_out.c`. One vocabulary serves both of this
+ * implementation's OGC encodings, and the round trip stays lossless where
+ * the two attested enumeration literals alone would not distinguish step
+ * from discrete interpolation. */
+#define GEOPOSE_TM_PARAM_KEY    "interpolation"
+
+/* A GeoPose_Instant is Unix time in milliseconds: Requirement 10 states it
+ * "shall express Unix Time in seconds multiplied by 1,000, with the unit of
+ * measure in milliseconds", and Annex C.2 that time values are encoded as
+ * integers needing 64 bits. The offset comes from the one epoch constant the
+ * codebase keeps, scaled from its seconds to those milliseconds. */
+#define GEOPOSE_UNIX_EPOCH_OFFSET_MS \
+  (((int64) DELTA_UNIX_POSTGRES_EPOCH) * 1000)
+
+/**
+ * @brief Convert a timestamp to a GeoPose_Instant (Unix milliseconds).
+ * @details Rounds towards negative infinity so that the sub-millisecond
+ * remainder of a pre-2000 timestamp is dropped the same way as that of a
+ * post-2000 one, keeping the mapping monotonic.
+ */
+static int64
+geopose_instant_out(TimestampTz t)
+{
+  int64 us = (int64) t;
+  int64 ms = us / 1000;
+  if (us % 1000 != 0 && us < 0)
+    ms -= 1;
+  return ms + GEOPOSE_UNIX_EPOCH_OFFSET_MS;
+}
+
+/**
+ * @brief Convert a GeoPose_Instant (Unix milliseconds) to a timestamp.
+ */
+static TimestampTz
+geopose_instant_in(int64 instant)
+{
+  return (TimestampTz) ((instant - GEOPOSE_UNIX_EPOCH_OFFSET_MS) * 1000);
+}
+
+/**
+ * @brief Format a double into @p buf with the module's precision
+ * convention: @p precision significant digits, or lossless if negative.
+ */
+static void
+geopose_str_double(char *buf, size_t size, double v, int precision)
+{
+  snprintf(buf, size, "%.*g", (precision < 0) ? 17 : precision, v);
+}
+
+/**
+ * @brief Build a FrameSpecification object. All three members are required
+ * by the schema, so @p parameters is emitted even when empty.
+ */
+static json_object *
+geopose_frame_spec(const char *id, const char *parameters)
+{
+  json_object *res = json_object_new_object();
+  json_object_object_add(res, "authority",
+    json_object_new_string(GEOPOSE_AUTHORITY));
+  json_object_object_add(res, "id", json_object_new_string(id));
+  json_object_object_add(res, "parameters",
+    json_object_new_string(parameters));
+  return res;
+}
+
+/**
+ * @brief Build the TransitionModel for a MobilityDB interpolation.
+ * @details Requirement 35 asks for an instance of the TransitionModel
+ * enumeration, whose literals `interpolate` and `none` are the ones the
+ * encoding examples of the standard attest. Linear interpolation is
+ * `interpolate`; step and discrete interpolation both estimate nothing
+ * between poses and are `none`. The `parameters` string then names the
+ * interpolation exactly, which is what tells those two apart on the way
+ * back in.
+ */
+static json_object *
+geopose_transition_model(interpType interp)
+{
+  char params[64];
+  snprintf(params, sizeof(params), "%s=%s", GEOPOSE_TM_PARAM_KEY,
+    geopose_interp_name(interp));
+  json_object *res = json_object_new_object();
+  json_object_object_add(res, "authority",
+    json_object_new_string(GEOPOSE_AUTHORITY));
+  json_object_object_add(res, "id", json_object_new_string(
+    (interp == LINEAR) ? GEOPOSE_ID_TM_INTERP : GEOPOSE_ID_TM_NONE));
+  json_object_object_add(res, "parameters", json_object_new_string(params));
+  return res;
+}
+
+/**
+ * @brief Recover a MobilityDB interpolation from a TransitionModel object.
+ * @details The `parameters` string is authoritative when it names an
+ * interpolation, since the two enumeration literals cannot distinguish step
+ * from discrete interpolation on their own. A document from another
+ * implementation carries no such name, and then `interpolate` reads as
+ * linear and anything else as discrete.
+ */
+static interpType
+geopose_transition_model_interp(json_object *tm)
+{
+  json_object *jpar = geopose_find_member(tm, "parameters");
+  if (jpar != NULL && json_object_is_type(jpar, json_type_string))
+  {
+    const char *val = geopose_param_find(json_object_get_string(jpar),
+      GEOPOSE_TM_PARAM_KEY);
+    if (val != NULL)
+    {
+      interpType interp = geopose_interp_from_string(val);
+      if (interp != INTERP_NONE)
+        return interp;
+    }
+  }
+  json_object *jid = geopose_find_member(tm, "id");
+  if (jid == NULL || ! json_object_is_type(jid, json_type_string))
+    return LINEAR;
+  return (pg_strcasecmp(json_object_get_string(jid),
+    GEOPOSE_ID_TM_INTERP) == 0) ? LINEAR : DISCRETE;
+}
+
+/**
+ * @brief Build the inner FrameSpecification of a pose relative to the
+ * outer frame, in the `translation=[…]&rotation=[…]` form used by the
+ * encoding examples of the standard.
+ * @details The rotation list is ordered w, x, y, z, the order in which
+ * Requirement 15 lists the components of a GeoPose quaternion.
+ * @return On error return @p NULL
+ */
+static json_object *
+geopose_inner_frame(const GeoPoseAnchor *anchor, const Pose *pose,
+  int precision)
+{
+  double lon, lat, h, W, X, Y, Z;
+  if (! geopose_pose_components(pose, &lon, &lat, &h, &W, &X, &Y, &Z))
+    return NULL;
+  double lat_rad = GEOPOSE_DEG2RAD(lat), lon_rad = GEOPOSE_DEG2RAD(lon);
+
+  double e, n, u;
+  geopose_anchor_translation(anchor, lat_rad, lon_rad, h, &e, &n, &u);
+
+  double rw, rx, ry, rz, qw, qx, qy, qz;
+  geopose_anchor_rotation(anchor, lat_rad, lon_rad, &rw, &rx, &ry, &rz);
+  pose_quaternion_mul(rw, rx, ry, rz, W, X, Y, Z, &qw, &qx, &qy, &qz);
+
+  char be[64], bn[64], bu[64], bw[64], bx[64], by[64], bz[64];
+  geopose_str_double(be, sizeof(be), e, precision);
+  geopose_str_double(bn, sizeof(bn), n, precision);
+  geopose_str_double(bu, sizeof(bu), u, precision);
+  geopose_str_double(bw, sizeof(bw), qw, precision);
+  geopose_str_double(bx, sizeof(bx), qx, precision);
+  geopose_str_double(by, sizeof(by), qy, precision);
+  geopose_str_double(bz, sizeof(bz), qz, precision);
+
+  char params[512];
+  snprintf(params, sizeof(params),
+    "translation=[%s, %s, %s]&rotation=[%s, %s, %s, %s]",
+    be, bn, bu, bw, bx, by, bz);
+  return geopose_frame_spec(GEOPOSE_ID_INNER_FRAME, params);
+}
+
+/**
+ * @brief Build the outer FrameSpecification: the LTP-ENU frame at the
+ * anchor's tangent point.
+ */
+static json_object *
+geopose_outer_frame(const GeoPoseAnchor *anchor, int precision)
+{
+  char blon[64], blat[64], bh[64];
+  geopose_str_double(blon, sizeof(blon), GEOPOSE_RAD2DEG(anchor->lon_rad),
+    precision);
+  geopose_str_double(blat, sizeof(blat), GEOPOSE_RAD2DEG(anchor->lat_rad),
+    precision);
+  geopose_str_double(bh, sizeof(bh), anchor->h, precision);
+  /* The three tangent-point parameters are the ones the encoding examples
+   * of the standard use. `crs` names the geographic CRS they are given in,
+   * which the examples leave implicit: EPSG:4979, the three-dimensional
+   * WGS-84 code, since the tangent point carries a height. */
+  char params[256];
+  snprintf(params, sizeof(params),
+    "longitude=%s&latitude=%s&height=%s&crs=EPSG:%d",
+    blon, blat, bh, GEOPOSE_SRID_WGS84_3D);
+  return geopose_frame_spec(GEOPOSE_ID_OUTER_FRAME, params);
+}
+
+/**
+ * @brief Build a SeriesHeader or SeriesTrailer `poseCount` bearing object.
+ * @details `integrityCheck` is optional in both and is not emitted: the
+ * standard leaves the digest input undefined, so any value this
+ * implementation chose would not be checkable by another one.
+ */
+static json_object *
+geopose_series_trailer(int count)
+{
+  json_object *res = json_object_new_object();
+  json_object_object_add(res, "poseCount", json_object_new_int(count));
+  return res;
+}
+
+static json_object *
+geopose_series_header(int count, TimestampTz start, TimestampTz stop,
+  interpType interp)
+{
+  json_object *res = json_object_new_object();
+  json_object_object_add(res, "poseCount", json_object_new_int(count));
+  json_object_object_add(res, "startInstant",
+    json_object_new_int64(geopose_instant_out(start)));
+  json_object_object_add(res, "stopInstant",
+    json_object_new_int64(geopose_instant_out(stop)));
+  json_object_object_add(res, "transitionModel",
+    geopose_transition_model(interp));
+  return res;
+}
+
+/**
+ * @brief Return the constant inter-pose duration of @p instants in
+ * milliseconds, or -1 if the instants are not equally spaced by a whole
+ * number of milliseconds.
+ * @details A Regular Series states the spacing once, as an integer number
+ * of milliseconds (Requirement 25), and carries no per-pose time. It can
+ * therefore only represent instants that are equally spaced *and* whose
+ * spacing is a whole number of milliseconds; anything else must go out as
+ * an Irregular Series to stay lossless.
+ */
+static int64
+geopose_interpose_duration(const TInstant **instants, int count)
+{
+  if (count < 2)
+    return -1;
+  int64 delta = (int64) instants[1]->t - (int64) instants[0]->t;
+  if (delta <= 0 || delta % 1000 != 0)
+    return -1;
+  for (int i = 2; i < count; i++)
+  {
+    if ((int64) instants[i]->t - (int64) instants[i - 1]->t != delta)
+      return -1;
+  }
+  return delta / 1000;
+}
+
+/**
+ * @brief Build a Composite Sequence Series document for a temporal pose
+ * @param[in] temp Temporal pose
+ * @param[in] regular True to emit a Regular Series, false for an Irregular
+ * one
+ * @param[in] precision Significant digits in the emitted numbers
+ * @return On error return @p NULL
+ */
+static json_object *
+tpose_to_geopose_series(const Temporal *temp, bool regular, int precision)
+{
+  int count;
+  const TInstant **instants = temporal_insts_p(temp, &count);
+  if (instants == NULL)
+    return NULL;
+  int64 duration = geopose_interpose_duration(instants, count);
+  if (regular && duration < 0)
+  {
+    pfree(instants);
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "A GeoPose Regular Series requires at least two instants equally "
+      "spaced by a whole number of milliseconds");
+    return NULL;
+  }
+
+  /* Requirements 26 and 31 make the outer frame the first frame of the
+   * series, so the tangent point is the position of the first pose. */
+  double lon, lat, h, W, X, Y, Z;
+  if (! geopose_pose_components(DatumGetPoseP(tinstant_value_p(instants[0])),
+      &lon, &lat, &h, &W, &X, &Y, &Z))
+  {
+    pfree(instants);
+    return NULL;
+  }
+  GeoPoseAnchor anchor;
+  geopose_anchor_set(&anchor, GEOPOSE_DEG2RAD(lat), GEOPOSE_DEG2RAD(lon), h);
+
+  json_object *arr = json_object_new_array();
+  for (int i = 0; i < count; i++)
+  {
+    json_object *frame = geopose_inner_frame(&anchor,
+      DatumGetPoseP(tinstant_value_p(instants[i])), precision);
+    if (frame == NULL)
+    {
+      json_object_put(arr);
+      pfree(instants);
+      return NULL;
+    }
+    if (regular)
+      json_object_array_add(arr, frame);
+    else
+    {
+      json_object *elem = json_object_new_object();
+      json_object_object_add(elem, "frame", frame);
+      json_object_object_add(elem, "validTime",
+        json_object_new_int64(geopose_instant_out(instants[i]->t)));
+      json_object_array_add(arr, elem);
+    }
+  }
+
+  json_object *root = json_object_new_object();
+  json_object_object_add(root, "header", geopose_series_header(count,
+    instants[0]->t, instants[count - 1]->t,
+    MEOS_FLAGS_GET_INTERP(temp->flags)));
+  if (regular)
+    json_object_object_add(root, "interPoseDuration",
+      json_object_new_int64(duration));
+  json_object_object_add(root, "outerFrame",
+    geopose_outer_frame(&anchor, precision));
+  json_object_object_add(root, regular ? "innerFrameSeries" :
+    "innerFrameAndTimeSeries", arr);
+  json_object_object_add(root, "trailer", geopose_series_trailer(count));
+  pfree(instants);
+  return root;
+}
+
+/*****************************************************************************
+ * OGC GeoPose Composite Sequence classes — JSON decoding
+ *****************************************************************************/
+
+/**
+ * @brief Return the `parameters` string of a FrameSpecification object,
+ * checking that the object carries the three members the schema requires.
+ * @return On error return @p NULL
+ */
+static const char *
+geopose_frame_parameters(json_object *frame, const char *what)
+{
+  if (frame == NULL || ! json_object_is_type(frame, json_type_object))
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "GeoPose series %s must be a FrameSpecification object", what);
+    return NULL;
+  }
+  json_object *jpar = geopose_find_member(frame, "parameters");
+  if (jpar == NULL || ! json_object_is_type(jpar, json_type_string))
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "GeoPose series %s missing required 'parameters' string", what);
+    return NULL;
+  }
+  return json_object_get_string(jpar);
+}
+
+/**
+ * @brief Build the outer-frame anchor from a series' `outerFrame` member.
+ * @return On error return false
+ */
+static bool
+geopose_anchor_from_json(json_object *root, GeoPoseAnchor *anchor)
+{
+  const char *params = geopose_frame_parameters(
+    geopose_find_member(root, "outerFrame"), "'outerFrame'");
+  if (params == NULL)
+    return false;
+  double lon, lat, h;
+  if (! geopose_param_number(geopose_param_find(params, "longitude"), &lon) ||
+      ! geopose_param_number(geopose_param_find(params, "latitude"), &lat) ||
+      ! geopose_param_number(geopose_param_find(params, "height"), &h))
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "GeoPose series 'outerFrame' parameters must carry 'longitude', "
+      "'latitude' and 'height'");
+    return false;
+  }
+  geopose_anchor_set(anchor, GEOPOSE_DEG2RAD(lat), GEOPOSE_DEG2RAD(lon), h);
+  return true;
+}
+
+/**
+ * @brief Build the pose of an inner FrameSpecification of a series.
+ * @return On error return @p NULL
+ */
+static Pose *
+geopose_pose_from_inner_frame(const GeoPoseAnchor *anchor, json_object *frame)
+{
+  const char *params = geopose_frame_parameters(frame, "inner frame");
+  if (params == NULL)
+    return NULL;
+  double t[3], r[4];
+  if (! geopose_param_list(geopose_param_find(params, "translation"), 3, t) ||
+      ! geopose_param_list(geopose_param_find(params, "rotation"), 4, r))
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "GeoPose series inner frame parameters must carry a 3-element "
+      "'translation' and a 4-element 'rotation'");
+    return NULL;
+  }
+  double lat_rad, lon_rad, h;
+  geopose_anchor_position(anchor, t[0], t[1], t[2], &lat_rad, &lon_rad, &h);
+  /* Undo the tangent-plane convergence rotation applied on output. */
+  double rw, rx, ry, rz, W, X, Y, Z;
+  geopose_anchor_rotation(anchor, lat_rad, lon_rad, &rw, &rx, &ry, &rz);
+  pose_quaternion_mul(rw, -rx, -ry, -rz, r[0], r[1], r[2], r[3],
+    &W, &X, &Y, &Z);
+  return pose_make_3d(GEOPOSE_RAD2DEG(lon_rad), GEOPOSE_RAD2DEG(lat_rad), h,
+    W, X, Y, Z, true, GEOPOSE_GEOGRAPHIC_SRID);
+}
+
+/**
+ * @brief Build a temporal pose from a Composite Sequence Series document
+ * @details A series carries no bounds inclusivity and no gaps, so it always
+ * reads back as a single closed sequence, or as an instant when the series
+ * holds one pose and interpolates nothing.
+ * @return On error return @p NULL
+ */
+static Temporal *
+tpose_from_geopose_series(json_object *root, json_object *elements,
+  bool regular)
+{
+  GeoPoseAnchor anchor;
+  if (! geopose_anchor_from_json(root, &anchor))
+    return NULL;
+  if (! json_object_is_type(elements, json_type_array))
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "GeoPose series inner frame member must be a JSON array");
+    return NULL;
+  }
+  int count = (int) json_object_array_length(elements);
+  if (count == 0)
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "GeoPose series inner frame array must hold at least one element");
+    return NULL;
+  }
+
+  json_object *header = geopose_find_member(root, "header");
+  if (header == NULL || ! json_object_is_type(header, json_type_object))
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "GeoPose series missing required 'header' object");
+    return NULL;
+  }
+  json_object *jstart = geopose_find_member(header, "startInstant");
+  if (jstart == NULL || ! json_object_is_type(jstart, json_type_int))
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "GeoPose series header missing required integer 'startInstant'");
+    return NULL;
+  }
+  TimestampTz start = geopose_instant_in(json_object_get_int64(jstart));
+  interpType interp = geopose_transition_model_interp(
+    geopose_find_member(header, "transitionModel"));
+
+  /* A Regular Series states the spacing once instead of per pose. */
+  int64 duration = 0;
+  if (regular)
+  {
+    json_object *jdur = geopose_find_member(root, "interPoseDuration");
+    if (jdur == NULL || ! json_object_is_type(jdur, json_type_int))
+    {
+      meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+        "GeoPose Regular Series missing required integer "
+        "'interPoseDuration'");
+      return NULL;
+    }
+    duration = json_object_get_int64(jdur);
+  }
+
+  TInstant **instants = palloc(sizeof(TInstant *) * count);
+  int nfilled = 0;
+  for (int i = 0; i < count; i++)
+  {
+    json_object *elem = json_object_array_get_idx(elements, i);
+    json_object *frame;
+    TimestampTz t;
+    if (regular)
+    {
+      frame = elem;
+      t = start + (TimestampTz) (duration * i * 1000);
+    }
+    else
+    {
+      if (! json_object_is_type(elem, json_type_object))
+      {
+        meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+          "GeoPose Irregular Series element must be a FrameAndTime object");
+        break;
+      }
+      frame = geopose_find_member(elem, "frame");
+      json_object *jt = geopose_find_member(elem, "validTime");
+      if (jt == NULL || ! json_object_is_type(jt, json_type_int))
+      {
+        meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+          "GeoPose Irregular Series element missing required integer "
+          "'validTime'");
+        break;
+      }
+      t = geopose_instant_in(json_object_get_int64(jt));
+    }
+    Pose *pose = geopose_pose_from_inner_frame(&anchor, frame);
+    if (pose == NULL)
+      break;
+    instants[nfilled++] = tinstant_make(PointerGetDatum(pose), T_TPOSE, t);
+    pfree(pose);
+  }
+  if (nfilled < count)
+  {
+    pfree_array((void **) instants, nfilled);
+    return NULL;
+  }
+
+  Temporal *result;
+  if (count == 1 && interp != LINEAR && interp != STEP)
+  {
+    result = (Temporal *) instants[0];
+    pfree(instants);
+  }
+  else
+  {
+    result = (Temporal *) tsequence_make(instants, count, true, true, interp,
+      NORMALIZE);
+    pfree_array((void **) instants, count);
+  }
+  return result;
 }
 
 /*****************************************************************************
@@ -488,84 +1335,50 @@ pose_as_geopose(const Pose *pose, int conformance, int precision)
  *    "quaternion":{"x":0,"y":0,"z":0,"w":1}}
  *****************************************************************************/
 
-/* String literals for the envelope's `interpolation` and `conformance` */
-static const char *
-geopose_interp_name(interpType interp)
-{
-  switch (interp)
-  {
-    case DISCRETE: return "Discrete";
-    case STEP:     return "Step";
-    case LINEAR:   return "Linear";
-    default:       return "None";
-  }
-}
-
-static interpType
-geopose_interp_from_string(const char *str)
-{
-  if (str == NULL) return INTERP_NONE;
-  if (strcmp(str, "Discrete") == 0) return DISCRETE;
-  if (strcmp(str, "Step")     == 0) return STEP;
-  if (strcmp(str, "Linear")   == 0) return LINEAR;
-  return INTERP_NONE;
-}
-
-static const char *
-geopose_conformance_name(int conformance)
-{
-  return (conformance == GEOPOSE_BASIC_YPR) ? "Basic-YPR" : "Basic-Quaternion";
-}
 
 /**
- * @brief Append the per-instant Basic-class object (with `validTime`) to
- * @p instants_array. Returns false on error.
+ * @brief Build the Basic-class document of a single temporal instant.
+ * @details The Basic classes carry no time, so the instant's own is added
+ * under the name `validTime` that the Advanced, Chain, Graph, Series and
+ * Stream classes all use, and with the type they all give it: a
+ * GeoPose_Instant, that is Unix time in integer milliseconds. Every time
+ * this module writes is that same kind, whichever class the document
+ * belongs to.
+ * @return On error return @p NULL
  */
-static bool
-tposeinst_append_geopose(json_object *instants_array, const TInstant *inst,
-  int conformance, int precision)
+static char *
+tposeinst_as_geopose(const TInstant *inst, int conformance, int precision)
 {
   const Pose *pose = DatumGetPoseP(tinstant_value_p(inst));
-  json_object *obj = pose_to_geopose_object(pose, conformance, precision);
-  if (obj == NULL)
-    return false;
-  char *vt = pg_timestamptz_out(inst->t);
-  json_object_object_add(obj, "validTime", json_object_new_string(vt));
-  pfree(vt);
-  json_object_array_add(instants_array, obj);
-  return true;
-}
-
-/**
- * @brief Build the @p instants array for a TSequence.
- */
-static json_object *
-tposeseq_to_instants_array(const TSequence *seq, int conformance, int precision)
-{
-  json_object *arr = json_object_new_array();
-  for (int i = 0; i < seq->count; i++)
-  {
-    if (! tposeinst_append_geopose(arr, TSEQUENCE_INST_N(seq, i),
-        conformance, precision))
-    {
-      json_object_put(arr);
-      return NULL;
-    }
-  }
-  return arr;
+  json_object *root = pose_to_geopose_object(pose, conformance, precision);
+  if (root == NULL)
+    return NULL;
+  json_object_object_add(root, "validTime",
+    json_object_new_int64(geopose_instant_out(inst->t)));
+  char *res = pstrdup(json_object_to_json_string_ext(root,
+    GEOPOSE_JSON_FLAGS));
+  json_object_put(root);
+  return res;
 }
 
 /**
  * @ingroup meos_pose_geopose_accessor
  * @brief Return the OGC GeoPose JSON representation of a temporal pose
- * @details Each instant is emitted as a Basic-class GeoPose object with
- * an added @p validTime member (ISO-8601 timestamptz). The temporal
- * envelope carries the conformance class and interpolation. A
- * @p TSequenceSet emits a top-level @p sequences array; a @p TSequence
- * emits a single @p instants array; a @p TInstant emits an @p instants
- * array with one element.
+ * @details The class follows from the value, not from an argument. A
+ * @p TInstant is a Basic document carrying the instant's @p validTime; a
+ * @p TSequence or @p TSequenceSet is a Composite Sequence Series, the
+ * Regular one when its instants are equally spaced by a whole number of
+ * milliseconds and the Irregular one otherwise. The outer frame of a Series
+ * is the LTP-ENU frame at the first pose and each inner frame is that pose's
+ * translation and rotation relative to it.
+ *
+ * A Series flattens a @p TSequenceSet and drops bounds inclusivity, the
+ * standard's model having neither gaps nor open bounds. @p conformance
+ * chooses the orientation encoding of a Basic document and has no effect on
+ * a Series, whose inner frames carry a quaternion and offer no choice.
  * @param[in] temp Temporal pose
- * @param[in] conformance Conformance class (0 = Basic-Quaternion, 1 = Basic-YPR)
+ * @param[in] conformance Orientation encoding of a Basic document
+ * (0 = Basic-Quaternion, 1 = Basic-YPR)
  * @param[in] precision Significant digits in JSON numbers; -1 = lossless
  * @return On error return @p NULL
  * @csqlfn #Tpose_as_geopose()
@@ -575,74 +1388,27 @@ tpose_as_geopose(const Temporal *temp, int conformance, int precision)
 {
   VALIDATE_TPOSE(temp, NULL);
 
-  json_object *root = json_object_new_object();
-  json_object_object_add(root, "type",
-    json_object_new_string("TemporalGeoPose"));
-  json_object_object_add(root, "version", json_object_new_string("1.0"));
-  json_object_object_add(root, "conformance",
-    json_object_new_string(geopose_conformance_name(conformance)));
-  json_object_object_add(root, "interpolation",
-    json_object_new_string(geopose_interp_name(MEOS_FLAGS_GET_INTERP(temp->flags))));
+  /* The target class follows from the value. A single pose is a Basic
+   * document; a value that evolves over time is a Composite Sequence
+   * Series, Regular when its instants are equally spaced and Irregular
+   * otherwise. */
+  if (temp->subtype == TINSTANT)
+    return tposeinst_as_geopose((const TInstant *) temp, conformance,
+      precision);
 
-  switch (temp->subtype)
-  {
-    case TINSTANT:
-    {
-      json_object *arr = json_object_new_array();
-      if (! tposeinst_append_geopose(arr, (const TInstant *) temp,
-          conformance, precision))
-      {
-        json_object_put(arr);
-        json_object_put(root);
-        return NULL;
-      }
-      json_object_object_add(root, "instants", arr);
-      break;
-    }
-    case TSEQUENCE:
-    {
-      const TSequence *seq = (const TSequence *) temp;
-      json_object *arr = tposeseq_to_instants_array(seq, conformance, precision);
-      if (arr == NULL) { json_object_put(root); return NULL; }
-      json_object_object_add(root, "lower_inc",
-        json_object_new_boolean(seq->period.lower_inc));
-      json_object_object_add(root, "upper_inc",
-        json_object_new_boolean(seq->period.upper_inc));
-      json_object_object_add(root, "instants", arr);
-      break;
-    }
-    default: /* TSEQUENCESET */
-    {
-      const TSequenceSet *ss = (const TSequenceSet *) temp;
-      json_object *seqs = json_object_new_array();
-      for (int i = 0; i < ss->count; i++)
-      {
-        const TSequence *seq = TSEQUENCESET_SEQ_N(ss, i);
-        json_object *arr = tposeseq_to_instants_array(seq, conformance,
-          precision);
-        if (arr == NULL)
-        {
-          json_object_put(seqs);
-          json_object_put(root);
-          return NULL;
-        }
-        json_object *seqobj = json_object_new_object();
-        json_object_object_add(seqobj, "lower_inc",
-          json_object_new_boolean(seq->period.lower_inc));
-        json_object_object_add(seqobj, "upper_inc",
-          json_object_new_boolean(seq->period.upper_inc));
-        json_object_object_add(seqobj, "instants", arr);
-        json_object_array_add(seqs, seqobj);
-      }
-      json_object_object_add(root, "sequences", seqs);
-      break;
-    }
-  }
-
-  const char *raw = json_object_to_json_string_ext(root, JSON_C_TO_STRING_PLAIN);
-  char *out = pstrdup(raw);
-  json_object_put(root);
-  return out;
+  int count;
+  const TInstant **instants = temporal_insts_p(temp, &count);
+  if (instants == NULL)
+    return NULL;
+  bool regular = (geopose_interpose_duration(instants, count) >= 0);
+  pfree(instants);
+  json_object *series = tpose_to_geopose_series(temp, regular, precision);
+  if (series == NULL)
+    return NULL;
+  char *res = pstrdup(json_object_to_json_string_ext(series,
+    GEOPOSE_JSON_FLAGS));
+  json_object_put(series);
+  return res;
 }
 
 /**
@@ -658,15 +1424,21 @@ tposeinst_from_geopose_object(json_object *obj)
       "TemporalGeoPose 'instants' element must be an object");
     return NULL;
   }
+  /* `validTime` is a GeoPose_Instant, and a datetime string is taken as
+   * well since that is what the MobilityDB envelope holds. */
   json_object *jt = geopose_find_member(obj, "validTime");
-  if (jt == NULL || ! json_object_is_type(jt, json_type_string))
+  TimestampTz t;
+  if (jt != NULL && json_object_is_type(jt, json_type_int))
+    t = geopose_instant_in(json_object_get_int64(jt));
+  else if (jt != NULL && json_object_is_type(jt, json_type_string))
+    t = pg_timestamptz_in(json_object_get_string(jt), -1);
+  else
   {
     meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
-      "TemporalGeoPose instant missing required 'validTime' string");
+      "A GeoPose Basic document needs a 'validTime' to read as a temporal "
+      "pose");
     return NULL;
   }
-  const char *ts = json_object_get_string(jt);
-  TimestampTz t = pg_timestamptz_in(ts, -1);
   Pose *pose = pose_from_geopose_object(obj);
   if (! pose) return NULL;
   TInstant *inst = tinstant_make(PointerGetDatum(pose), T_TPOSE, t);
@@ -714,12 +1486,20 @@ tpose_parse_instants(json_object *instants_arr, TInstant ***out_instants)
 /**
  * @ingroup meos_pose_geopose_accessor
  * @brief Return a temporal pose from its OGC GeoPose JSON representation
- * @details Parses the @p TemporalGeoPose envelope (see @p tpose_as_geopose
- * for the shape). Each instant's payload is auto-detected as
- * Basic-Quaternion or Basic-YPR by the same rule as the static entry
- * point. The interpolation and bounds-inclusion flags come from the
- * envelope; the resulting tpose has SRID 4326.
- * @param[in] json TemporalGeoPose JSON string
+ * @details The document shape is auto-detected:
+ *
+ *   - An OGC Composite Sequence Series, recognized by its
+ *     @p innerFrameAndTimeSeries or @p innerFrameSeries member. The
+ *     interpolation comes from the header's transition model and the
+ *     result is one closed sequence, or an instant for a single
+ *     non-interpolated pose.
+ *   - The MobilityDB @p TemporalGeoPose envelope, whose per-instant
+ *     payload is auto-detected as Basic-Quaternion or Basic-YPR by the
+ *     same rule as the static entry point, and whose interpolation and
+ *     bounds-inclusion flags come from the envelope.
+ *
+ * The resulting temporal pose has SRID 4326.
+ * @param[in] json GeoPose JSON string
  * @return On error return @p NULL
  * @csqlfn #Tpose_from_geopose()
  */
@@ -746,6 +1526,27 @@ tpose_from_geopose(const char *json)
     return NULL;
   }
   json_tokener_free(tok);
+
+  /* A Basic document holds one pose. With a `validTime` it is a temporal
+   * instant, which is what a temporal pose of that subtype writes. */
+  if (geopose_find_member(root, "position") != NULL)
+  {
+    TInstant *inst = tposeinst_from_geopose_object(root);
+    json_object_put(root);
+    return (Temporal *) inst;
+  }
+
+  /* An OGC Composite Sequence Series is recognized by the inner frame
+   * member that its conformance class requires. */
+  json_object *jirr = geopose_find_member(root, "innerFrameAndTimeSeries");
+  json_object *jreg = geopose_find_member(root, "innerFrameSeries");
+  if (jirr != NULL || jreg != NULL)
+  {
+    Temporal *result = tpose_from_geopose_series(root,
+      (jirr != NULL) ? jirr : jreg, jirr == NULL);
+    json_object_put(root);
+    return result;
+  }
 
   /* Optional envelope sanity: known type. */
   json_object *jtype = geopose_find_member(root, "type");

--- a/mobilitydb/sql/pose/120_geopose_frames.in.sql
+++ b/mobilitydb/sql/pose/120_geopose_frames.in.sql
@@ -77,7 +77,11 @@ INSERT INTO geopose_frames(frame_id, authority, code, name, srid, is_geographic,
   (3, 'OGC',  'LTP',  'Local Tangent Plane (East-North-Up)', NULL, false,
      'Parameterised at runtime by an anchor (lat, lon, h). The outer-frame conversion to ECEF is the standard ENU rotation matrix at the anchor.'),
   (4, 'OGC',  'BODY', 'Right-handed body axes (default inner frame)', NULL, false,
-     'Conventional inner frame: X forward, Y left, Z up. The pose''s quaternion takes vectors from this body frame to the outer frame.');
+     'Conventional inner frame: X forward, Y left, Z up. The pose''s quaternion takes vectors from this body frame to the outer frame.'),
+  (5, '/geopose/1.0', 'LTP-ENU', 'GeoPose outer frame of a Composite Sequence Series', NULL, false,
+     'Authority and id emitted as the outerFrame of a Series. Parameterised by the tangent point of the first pose as ''longitude=<degrees>&latitude=<degrees>&height=<metres>''.'),
+  (6, '/geopose/1.0', 'RotateTranslate', 'GeoPose inner frame of a Composite Sequence Series', NULL, false,
+     'Authority and id emitted for each inner frame of a Series. Parameterised as ''translation=[e, n, u]&rotation=[w, x, y, z]'', the translation in metres in the outer frame and the rotation taking body axes to the outer frame.');
 
 /* Helper SQL functions to query the registry without exposing the schema. */
 

--- a/mobilitydb/test/pose/expected/103_pose_geopose.test.out
+++ b/mobilitydb/test/pose/expected/103_pose_geopose.test.out
@@ -152,11 +152,11 @@ ERROR:  GeoPose 'quaternion' must carry numeric 'w','x','y','z' members
 SELECT asGeoPose(pose 'Pose(Point(1 1),0.5)', 99, 6);
 ERROR:  Unknown GeoPose conformance class 99 (0 = Basic-Quaternion, 1 = Basic-YPR)
 SELECT asGeoPose(pose 'SRID=5676;Pose(Point(1 1),0.5)', 0, 6);
-ERROR:  GeoPose JSON requires SRID 4326 (WGS-84), got 5676
+ERROR:  GeoPose JSON requires a WGS-84 geographic SRID (4326 or 4979), got 5676
 SELECT asGeoPose(tpose 'Pose(Point(8 47), 0)@2026-01-01', 0, 6);
-                                                                                                                asgeopose                                                                                                                
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {"type":"TemporalGeoPose","version":"1.0","conformance":"Basic-Quaternion","interpolation":"None","instants":[{"position":{"lat":47,"lon":8,"h":0},"quaternion":{"x":0,"y":0,"z":0,"w":1},"validTime":"Thu Jan 01 00:00:00 2026 PST"}]}
+                                               asgeopose                                                
+--------------------------------------------------------------------------------------------------------
+ {"position":{"lat":47,"lon":8,"h":0},"quaternion":{"x":0,"y":0,"z":0,"w":1},"validTime":1767254400000}
 (1 row)
 
 SELECT asText(tposeFromGeoPose(asGeoPose(tpose 'Pose(Point(8 47), 0)@2026-01-01', 0, 6)));
@@ -165,28 +165,35 @@ SELECT asText(tposeFromGeoPose(asGeoPose(tpose 'Pose(Point(8 47), 0)@2026-01-01'
  GeodPose(POINT Z (8 47 0),1,0,0,0)@Thu Jan 01 00:00:00 2026 PST
 (1 row)
 
-SELECT asGeoPose(tpose '[Pose(Point(8 47), 0)@2026-01-01, Pose(Point(9 48), 0.5)@2026-01-02]', 0, 6);
-                                                                                                                                                                                                     asgeopose                                                                                                                                                                                                     
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {"type":"TemporalGeoPose","version":"1.0","conformance":"Basic-Quaternion","interpolation":"Linear","lower_inc":true,"upper_inc":true,"instants":[{"position":{"lat":47,"lon":8,"h":0},"quaternion":{"x":0,"y":0,"z":0,"w":1},"validTime":"Thu Jan 01 00:00:00 2026 PST"},{"position":{"lat":48,"lon":9,"h":0},"quaternion":{"x":0,"y":0,"z":0.247404,"w":0.968912},"validTime":"Fri Jan 02 00:00:00 2026 PST"}]}
+SELECT asGeoPose(tpose '[Pose(Point(0 0), 0)@2026-01-01, Pose(Point(0 0), 0.5)@2026-01-02]', 0, 6);
+                                                                                                                                                                                                                                                                                                                asgeopose                                                                                                                                                                                                                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"header":{"poseCount":2,"startInstant":1767254400000,"stopInstant":1767340800000,"transitionModel":{"authority":"/geopose/1.0","id":"interpolate","parameters":"interpolation=Linear"}},"interPoseDuration":86400000,"outerFrame":{"authority":"/geopose/1.0","id":"LTP-ENU","parameters":"longitude=0&latitude=0&height=0&crs=EPSG:4979"},"innerFrameSeries":[{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 0]&rotation=[1, 0, 0, 0]"},{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 0]&rotation=[0.968912, 0, 0, 0.247404]"}],"trailer":{"poseCount":2}}
 (1 row)
 
-SELECT asText(tposeFromGeoPose(asGeoPose(tpose '[Pose(Point(8 47), 0)@2026-01-01, Pose(Point(9 48), 0.5)@2026-01-02]', 0, 6)));
-                                                                               astext                                                                               
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
- [GeodPose(POINT Z (8 47 0),1,0,0,0)@Thu Jan 01 00:00:00 2026 PST, GeodPose(POINT Z (9 48 0),0.968912386131041,0,0,0.247404098595501)@Fri Jan 02 00:00:00 2026 PST]
+SELECT asText(round(tposeFromGeoPose(asGeoPose(tpose '[Pose(Point(0 0), 0)@2026-01-01, Pose(Point(0 1), 0)@2026-01-02]', 0, 15)), 6));
+                                                              astext                                                              
+----------------------------------------------------------------------------------------------------------------------------------
+ [GeodPose(POINT Z (0 0 0),1,0,0,0)@Thu Jan 01 00:00:00 2026 PST, GeodPose(POINT Z (0 1 0),1,0,0,0)@Fri Jan 02 00:00:00 2026 PST]
 (1 row)
 
-SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01, Pose(Point(8 47 1500), 0.7071067811865476, 0, 0, 0.7071067811865475)@2026-01-02]', 1, 6);
-                                                                                                                                                                                             asgeopose                                                                                                                                                                                             
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {"type":"TemporalGeoPose","version":"1.0","conformance":"Basic-YPR","interpolation":"Linear","lower_inc":true,"upper_inc":true,"instants":[{"position":{"lat":47,"lon":8,"h":1500},"angles":{"yaw":0,"pitch":0,"roll":0},"validTime":"Thu Jan 01 00:00:00 2026 PST"},{"position":{"lat":47,"lon":8,"h":1500},"angles":{"yaw":90,"pitch":0,"roll":0},"validTime":"Fri Jan 02 00:00:00 2026 PST"}]}
+SELECT asGeoPose(tpose '[Pose(Point(0 0 0), 1, 0, 0, 0)@2026-01-01, Pose(Point(0 0 0), 0.707107, 0, 0, 0.707107)@2026-01-02]', 1, 6);
+                                                                                                                                                                                                                                                                                                                asgeopose                                                                                                                                                                                                                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"header":{"poseCount":2,"startInstant":1767254400000,"stopInstant":1767340800000,"transitionModel":{"authority":"/geopose/1.0","id":"interpolate","parameters":"interpolation=Linear"}},"interPoseDuration":86400000,"outerFrame":{"authority":"/geopose/1.0","id":"LTP-ENU","parameters":"longitude=0&latitude=0&height=0&crs=EPSG:4979"},"innerFrameSeries":[{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 0]&rotation=[1, 0, 0, 0]"},{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 0]&rotation=[0.707107, 0, 0, 0.707107]"}],"trailer":{"poseCount":2}}
 (1 row)
 
-SELECT asGeoPose(tpose '{[Pose(Point(8 47), 0)@2026-01-01, Pose(Point(9 48), 0.5)@2026-01-02], [Pose(Point(10 50), 1)@2026-01-04, Pose(Point(11 51), 1.5)@2026-01-05]}', 1, 4);
-                                                                                                                                                                                                                                                                                                                                                       asgeopose                                                                                                                                                                                                                                                                                                                                                        
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {"type":"TemporalGeoPose","version":"1.0","conformance":"Basic-YPR","interpolation":"Linear","sequences":[{"lower_inc":true,"upper_inc":true,"instants":[{"position":{"lat":47,"lon":8,"h":0},"angles":{"yaw":0,"pitch":0,"roll":0},"validTime":"Thu Jan 01 00:00:00 2026 PST"},{"position":{"lat":48,"lon":9,"h":0},"angles":{"yaw":28.65,"pitch":0,"roll":0},"validTime":"Fri Jan 02 00:00:00 2026 PST"}]},{"lower_inc":true,"upper_inc":true,"instants":[{"position":{"lat":50,"lon":10,"h":0},"angles":{"yaw":57.3,"pitch":0,"roll":0},"validTime":"Sun Jan 04 00:00:00 2026 PST"},{"position":{"lat":51,"lon":11,"h":0},"angles":{"yaw":85.94,"pitch":0,"roll":0},"validTime":"Mon Jan 05 00:00:00 2026 PST"}]}]}
+SELECT asGeoPose(tpose '{[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01, Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02], [Pose(Point(0 0 300), 0.5, 0.5, 0.5, 0.5)@2026-01-04, Pose(Point(0 0 600), 0.5, 0.5, 0.5, 0.5)@2026-01-05]}', 1, 4);
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        asgeopose                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"header":{"poseCount":4,"startInstant":1767254400000,"stopInstant":1767600000000,"transitionModel":{"authority":"/geopose/1.0","id":"interpolate","parameters":"interpolation=Linear"}},"outerFrame":{"authority":"/geopose/1.0","id":"LTP-ENU","parameters":"longitude=0&latitude=0&height=0&crs=EPSG:4979"},"innerFrameAndTimeSeries":[{"frame":{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 0]&rotation=[0.5, 0.5, 0.5, 0.5]"},"validTime":1767254400000},{"frame":{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 100]&rotation=[0.5, 0.5, 0.5, 0.5]"},"validTime":1767340800000},{"frame":{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 300]&rotation=[0.5, 0.5, 0.5, 0.5]"},"validTime":1767513600000},{"frame":{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 600]&rotation=[0.5, 0.5, 0.5, 0.5]"},"validTime":1767600000000}],"trailer":{"poseCount":4}}
+(1 row)
+
+SELECT tposeFromGeoPose(asGeoPose(tpose '[Pose(Point(0 0), 0)@2026-01-01, Pose(Point(0 1), 0)@2026-01-02]', 0, 15)) =
+  tposeFromGeoPose(asGeoPose(tpose '[Pose(Point(0 0), 0)@2026-01-01, Pose(Point(0 1), 0)@2026-01-02]', 0, 6)) AS same;
+ same 
+------
+ f
 (1 row)
 
 SELECT pose '{"position":{"lat":1.0,"lon":1.0,"h":1.0},"quaternion":{"x":0.5,"y":0.5,"z":0.5,"w":0.5}}';
@@ -226,3 +233,321 @@ SELECT asText(tpose '{[Pose(Point(8 47), 0)@2026-01-01, Pose(Point(9 48), 0.5)@2
  {[Pose(POINT(8 47),0)@Thu Jan 01 00:00:00 2026 PST, Pose(POINT(9 48),0.5)@Fri Jan 02 00:00:00 2026 PST], [Pose(POINT(10 50),1)@Sun Jan 04 00:00:00 2026 PST]}
 (1 row)
 
+SELECT asGeoPose(pose 'SRID=4979;Pose(Point(8 47 1500), 1, 0, 0, 0)', 0, 6);
+                                    asgeopose                                    
+---------------------------------------------------------------------------------
+ {"position":{"lat":47,"lon":8,"h":1500},"quaternion":{"x":0,"y":0,"z":0,"w":1}}
+(1 row)
+
+SELECT asGeoPose(pose 'SRID=4979;Pose(Point(8 47 1500), 1, 0, 0, 0)', 0, 6) =
+  asGeoPose(pose 'SRID=4326;Pose(Point(8 47 1500), 1, 0, 0, 0)', 0, 6) AS same;
+ same 
+------
+ t
+(1 row)
+
+SELECT poseFromGeoPose(asGeoPose(
+  pose 'SRID=4979;Pose(Point(8 47 1500), 1, 0, 0, 0)', 0, 15)) =
+  poseFromGeoPose(asGeoPose(
+  pose 'SRID=4326;Pose(Point(8 47 1500), 1, 0, 0, 0)', 0, 15)) AS same;
+ same 
+------
+ t
+(1 row)
+
+SELECT asGeoPose(tpose 'SRID=4979;[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02]', 0, 6) =
+  asGeoPose(tpose 'SRID=4326;[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02]', 0, 6) AS same;
+ same 
+------
+ t
+(1 row)
+
+/* Errors */
+-- A projected SRID is not a GeoPose outer frame.
+SELECT asGeoPose(pose 'SRID=5676;Pose(Point(1 1),0.5)', 0, 6);
+ERROR:  GeoPose JSON requires a WGS-84 geographic SRID (4326 or 4979), got 5676
+SELECT asGeoPose(tpose 'SRID=5676;[Pose(Point(1 1),0.5)@2026-01-01,
+  Pose(Point(2 2),0.5)@2026-01-02]', 0, 6);
+ERROR:  GeoPose JSON requires a WGS-84 geographic SRID (4326 or 4979), got 5676
+SELECT asGeoPose(tpose 'Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01', 0, 6);
+                                                 asgeopose                                                 
+-----------------------------------------------------------------------------------------------------------
+ {"position":{"lat":47,"lon":8,"h":1500},"quaternion":{"x":0,"y":0,"z":0,"w":1},"validTime":1767254400000}
+(1 row)
+
+SELECT asGeoPose(tpose 'Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01', 1, 6);
+                                                asgeopose                                                 
+----------------------------------------------------------------------------------------------------------
+ {"position":{"lat":47,"lon":8,"h":1500},"angles":{"yaw":0,"pitch":0,"roll":0},"validTime":1767254400000}
+(1 row)
+
+SELECT asGeoPose(tpose '[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02,
+  Pose(Point(0 0 300), 0.5, 0.5, 0.5, 0.5)@2026-01-03]', 0, 6);
+                                                                                                                                                                                                                                                                                                                                                                              asgeopose                                                                                                                                                                                                                                                                                                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"header":{"poseCount":3,"startInstant":1767254400000,"stopInstant":1767427200000,"transitionModel":{"authority":"/geopose/1.0","id":"interpolate","parameters":"interpolation=Linear"}},"interPoseDuration":86400000,"outerFrame":{"authority":"/geopose/1.0","id":"LTP-ENU","parameters":"longitude=0&latitude=0&height=0&crs=EPSG:4979"},"innerFrameSeries":[{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 0]&rotation=[0.5, 0.5, 0.5, 0.5]"},{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 100]&rotation=[0.5, 0.5, 0.5, 0.5]"},{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 300]&rotation=[0.5, 0.5, 0.5, 0.5]"}],"trailer":{"poseCount":3}}
+(1 row)
+
+SELECT asGeoPose(tpose '[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02,
+  Pose(Point(0 0 300), 0.5, 0.5, 0.5, 0.5)@2026-01-05]', 0, 6);
+                                                                                                                                                                                                                                                                                                                                                                                                                         asgeopose                                                                                                                                                                                                                                                                                                                                                                                                                          
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"header":{"poseCount":3,"startInstant":1767254400000,"stopInstant":1767600000000,"transitionModel":{"authority":"/geopose/1.0","id":"interpolate","parameters":"interpolation=Linear"}},"outerFrame":{"authority":"/geopose/1.0","id":"LTP-ENU","parameters":"longitude=0&latitude=0&height=0&crs=EPSG:4979"},"innerFrameAndTimeSeries":[{"frame":{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 0]&rotation=[0.5, 0.5, 0.5, 0.5]"},"validTime":1767254400000},{"frame":{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 100]&rotation=[0.5, 0.5, 0.5, 0.5]"},"validTime":1767340800000},{"frame":{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 300]&rotation=[0.5, 0.5, 0.5, 0.5]"},"validTime":1767600000000}],"trailer":{"poseCount":3}}
+(1 row)
+
+SELECT asGeoPose(tpose '[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02]', 0, 6) =
+  asGeoPose(tpose '[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02]', 1, 6) AS same;
+ same 
+------
+ t
+(1 row)
+
+SELECT asGeoPose(tpose '{[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02],
+  [Pose(Point(0 0 300), 0.5, 0.5, 0.5, 0.5)@2026-01-04]}', 0, 6);
+                                                                                                                                                                                                                                                                                                                                                                                                                         asgeopose                                                                                                                                                                                                                                                                                                                                                                                                                          
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"header":{"poseCount":3,"startInstant":1767254400000,"stopInstant":1767513600000,"transitionModel":{"authority":"/geopose/1.0","id":"interpolate","parameters":"interpolation=Linear"}},"outerFrame":{"authority":"/geopose/1.0","id":"LTP-ENU","parameters":"longitude=0&latitude=0&height=0&crs=EPSG:4979"},"innerFrameAndTimeSeries":[{"frame":{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 0]&rotation=[0.5, 0.5, 0.5, 0.5]"},"validTime":1767254400000},{"frame":{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 100]&rotation=[0.5, 0.5, 0.5, 0.5]"},"validTime":1767340800000},{"frame":{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 300]&rotation=[0.5, 0.5, 0.5, 0.5]"},"validTime":1767513600000}],"trailer":{"poseCount":3}}
+(1 row)
+
+WITH j AS (SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02,
+  Pose(Point(10 49 1700), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb AS d)
+SELECT (d->'header'->>'poseCount')::int = jsonb_array_length(d->'innerFrameAndTimeSeries')
+  AND (d->'trailer'->>'poseCount')::int = jsonb_array_length(d->'innerFrameAndTimeSeries')
+FROM j;
+ ?column? 
+----------
+ t
+(1 row)
+
+WITH j AS (SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb AS d)
+SELECT to_timestamp((d->'header'->>'startInstant')::bigint / 1000) AT TIME ZONE 'UTC',
+       to_timestamp((d->'header'->>'stopInstant')::bigint / 1000) AT TIME ZONE 'UTC'
+FROM j;
+         timezone         |         timezone         
+--------------------------+--------------------------
+ Thu Jan 01 08:00:00 2026 | Mon Jan 05 08:00:00 2026
+(1 row)
+
+WITH j AS (SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb AS d)
+SELECT to_timestamp((e->>'validTime')::bigint / 1000) AT TIME ZONE 'UTC'
+FROM j, jsonb_array_elements(d->'innerFrameAndTimeSeries') AS e;
+ timezone 
+----------
+(0 rows)
+
+WITH j AS (SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01 00:00:00.123456,
+  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb AS d)
+SELECT (d->'header'->>'startInstant')::bigint % 1000 AS millisecond_kept FROM j;
+ millisecond_kept 
+------------------
+              123
+(1 row)
+
+SELECT (asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 6)::jsonb->>'interPoseDuration')::bigint;
+   int8   
+----------
+ 86400000
+(1 row)
+
+WITH j(interp, d) AS (VALUES
+  ('linear', asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+     Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb),
+  ('step', asGeoPose(tpose 'Interp=Step;[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+     Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb),
+  ('discrete', asGeoPose(tpose '{Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+     Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05}', 0, 6)::jsonb))
+SELECT interp,
+  d->'header'->'transitionModel'->>'authority',
+  d->'header'->'transitionModel'->>'id',
+  d->'header'->'transitionModel'->>'parameters'
+FROM j;
+  interp  |   ?column?   |  ?column?   |        ?column?        
+----------+--------------+-------------+------------------------
+ linear   | /geopose/1.0 | interpolate | interpolation=Linear
+ step     | /geopose/1.0 | none        | interpolation=Step
+ discrete | /geopose/1.0 | none        | interpolation=Discrete
+(3 rows)
+
+WITH j AS (SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 6)::jsonb AS d)
+SELECT d->'outerFrame'->>'authority', d->'outerFrame'->>'id',
+  d->'outerFrame'->>'parameters'
+FROM j;
+   ?column?   | ?column? |                     ?column?                      
+--------------+----------+---------------------------------------------------
+ /geopose/1.0 | LTP-ENU  | longitude=8&latitude=47&height=1500&crs=EPSG:4979
+(1 row)
+
+WITH j AS (SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 6)::jsonb AS d)
+SELECT d->'innerFrameSeries'->0->>'authority', d->'innerFrameSeries'->0->>'id',
+  split_part(d->'innerFrameSeries'->0->>'parameters', '&', 1)
+FROM j;
+   ?column?   |    ?column?     |      split_part       
+--------------+-----------------+-----------------------
+ /geopose/1.0 | RotateTranslate | translation=[0, 0, 0]
+(1 row)
+
+SELECT authority, code FROM geopose_frames WHERE authority = '/geopose/1.0'
+ORDER BY code;
+  authority   |      code       
+--------------+-----------------
+ /geopose/1.0 | LTP-ENU
+ /geopose/1.0 | RotateTranslate
+(2 rows)
+
+SELECT asText(round(tposeFromGeoPose(asGeoPose(
+  tpose 'Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01', 0, 15)), 6));
+                               astext                               
+--------------------------------------------------------------------
+ GeodPose(POINT Z (8 47 1500),1,0,0,0)@Thu Jan 01 00:00:00 2026 PST
+(1 row)
+
+SELECT asText(round(tposeFromGeoPose(asGeoPose(
+  tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+    Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02,
+    Pose(Point(10 47 1700), 1, 0, 0, 0)@2026-01-03]', 0, 15)), 6));
+                                                                                                    astext                                                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [GeodPose(POINT Z (8 47 1500),1,0,0,0)@Thu Jan 01 00:00:00 2026 PST, GeodPose(POINT Z (9 48 1600),1,0,0,0)@Fri Jan 02 00:00:00 2026 PST, GeodPose(POINT Z (10 47 1700),1,0,0,0)@Sat Jan 03 00:00:00 2026 PST]
+(1 row)
+
+SELECT asText(round(tposeFromGeoPose(asGeoPose(
+  tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+    Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 15)), 6));
+                                                                  astext                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------
+ [GeodPose(POINT Z (8 47 1500),1,0,0,0)@Thu Jan 01 00:00:00 2026 PST, GeodPose(POINT Z (9 48 1600),1,0,0,0)@Mon Jan 05 00:00:00 2026 PST]
+(1 row)
+
+SELECT interp(tposeFromGeoPose(asGeoPose(
+  tpose 'Interp=Step;[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+    Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 15)));
+ interp 
+--------
+ Step
+(1 row)
+
+SELECT interp(tposeFromGeoPose(asGeoPose(
+  tpose '{Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+    Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02}', 0, 15)));
+  interp  
+----------
+ Discrete
+(1 row)
+
+SELECT asText(round(tposeFromGeoPose(asGeoPose(
+  tpose '{[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+    Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02],
+   [Pose(Point(10 50 1700), 1, 0, 0, 0)@2026-01-04]}', 0, 15)), 6));
+                                                                                                    astext                                                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [GeodPose(POINT Z (8 47 1500),1,0,0,0)@Thu Jan 01 00:00:00 2026 PST, GeodPose(POINT Z (9 48 1600),1,0,0,0)@Fri Jan 02 00:00:00 2026 PST, GeodPose(POINT Z (10 50 1700),1,0,0,0)@Sun Jan 04 00:00:00 2026 PST]
+(1 row)
+
+SELECT asText(round(tposeFromGeoPose('{
+  "header": {"poseCount": 3, "startInstant": 1630560671429,
+    "stopInstant": 1630560716429,
+    "transitionModel": {"authority": "/geopose/1.0", "id": "none",
+      "parameters": ""}},
+  "outerFrame": {"authority": "/geopose/1.0", "id": "LTP-ENU",
+    "parameters": "longitude=-122.3000000&latitude=47.7000000&height=11.000"},
+  "innerFrameAndTimeSeries": [
+    {"frame": {"authority": "/geopose/1.0", "id": "RotateTranslate",
+      "parameters": "translation=[0.0, 0.0, 0.0]&rotation=[1.0, 0.0, 0.0, 0.0]"},
+     "validTime": 1630560671429},
+    {"frame": {"authority": "/geopose/1.0", "id": "RotateTranslate",
+      "parameters": "translation=[10.0, 20.0, 5.0]&rotation=[1.0, 0.0, 0.0, 0.0]"},
+     "validTime": 1630560693929},
+    {"frame": {"authority": "/geopose/1.0", "id": "RotateTranslate",
+      "parameters": "translation=[20.0, 40.0, 10.0]&rotation=[1.0, 0.0, 0.0, 0.0]"},
+     "validTime": 1630560716429}],
+  "trailer": {"poseCount": 3}}'), 4));
+                                                                                                                          astext                                                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {GeodPose(POINT Z (-122.3 47.7 11),1,0,0,0)@Wed Sep 01 22:31:11.429 2021 PDT, GeodPose(POINT Z (-122.2999 47.7002 16),1,0,0,0)@Wed Sep 01 22:31:33.929 2021 PDT, GeodPose(POINT Z (-122.2997 47.7004 21.0002),1,0,0,0)@Wed Sep 01 22:31:56.429 2021 PDT}
+(1 row)
+
+SELECT asText(round(tposeFromGeoPose('{
+  "header": {"poseCount": 3, "startInstant": 1630560671367,
+    "stopInstant": 1630560673367,
+    "transitionModel": {"authority": "/geopose/1.0", "id": "interpolate",
+      "parameters": ""}},
+  "interPoseDuration": 1000,
+  "outerFrame": {"authority": "/geopose/1.0", "id": "LTP-ENU",
+    "parameters": "longitude=-122.3000000&latitude=47.7000000&height=11.000"},
+  "innerFrameSeries": [
+    {"authority": "/geopose/1.0", "id": "RotateTranslate",
+     "parameters": "translation=[0.0, 0.0, 0.0]&rotation=[1.0, 0.0, 0.0, 0.0]"},
+    {"authority": "/geopose/1.0", "id": "RotateTranslate",
+     "parameters": "translation=[0.5, 0.0, 0.0]&rotation=[1.0, 0.0, 0.0, 0.0]"},
+    {"authority": "/geopose/1.0", "id": "RotateTranslate",
+     "parameters": "translation=[1.0, 0.0, 0.0]&rotation=[1.0, 0.0, 0.0, 0.0]"}],
+  "trailer": {"poseCount": 3}}'), 6));
+                                                                             astext                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [GeodPose(POINT Z (-122.3 47.7 11),1,0,0,0)@Wed Sep 01 22:31:11.367 2021 PDT, GeodPose(POINT Z (-122.299987 47.7 11),1,0,0,0)@Wed Sep 01 22:31:13.367 2021 PDT]
+(1 row)
+
+SELECT asText(tposeFromGeoPose('{"type":"TemporalGeoPose","version":"1.0",
+  "conformance":"Basic-Quaternion","interpolation":"Linear",
+  "lower_inc":true,"upper_inc":true,"instants":[
+    {"position":{"lat":47,"lon":8,"h":0},"quaternion":{"x":0,"y":0,"z":0,"w":1},
+     "validTime":"2026-01-01 00:00:00+01"},
+    {"position":{"lat":48,"lon":9,"h":0},"quaternion":{"x":0,"y":0,"z":0,"w":1},
+     "validTime":"2026-01-02 00:00:00+01"}]}'));
+                                                               astext                                                               
+------------------------------------------------------------------------------------------------------------------------------------
+ [GeodPose(POINT Z (8 47 0),1,0,0,0)@Wed Dec 31 15:00:00 2025 PST, GeodPose(POINT Z (9 48 0),1,0,0,0)@Thu Jan 01 15:00:00 2026 PST]
+(1 row)
+
+/* Errors */
+-- A Basic document without a validTime is a pose, not a temporal pose.
+SELECT tposeFromGeoPose(
+  '{"position":{"lat":47,"lon":8,"h":0},"quaternion":{"x":0,"y":0,"z":0,"w":1}}');
+ERROR:  A GeoPose Basic document needs a 'validTime' to read as a temporal pose
+SELECT tposeFromGeoPose('{"header": {"poseCount": 1, "startInstant": 0,
+  "stopInstant": 0, "transitionModel": {"authority": "/geopose/1.0",
+  "id": "none", "parameters": ""}},
+  "innerFrameAndTimeSeries": [{"frame": {"authority": "/geopose/1.0",
+    "id": "RotateTranslate", "parameters": "translation=[0, 0, 0]&rotation=[1, 0, 0, 0]"},
+   "validTime": 0}], "trailer": {"poseCount": 1}}');
+ERROR:  GeoPose series 'outerFrame' must be a FrameSpecification object
+SELECT tposeFromGeoPose('{"header": {"poseCount": 1, "startInstant": 0,
+  "stopInstant": 0, "transitionModel": {"authority": "/geopose/1.0",
+  "id": "none", "parameters": ""}},
+  "outerFrame": {"authority": "/geopose/1.0", "id": "LTP-ENU",
+    "parameters": "longitude=0&latitude=0&height=0"},
+  "innerFrameAndTimeSeries": [{"frame": {"authority": "/geopose/1.0",
+    "id": "RotateTranslate", "parameters": "translation=[0, 0, 0]"},
+   "validTime": 0}], "trailer": {"poseCount": 1}}');
+ERROR:  GeoPose series inner frame parameters must carry a 3-element 'translation' and a 4-element 'rotation'
+SELECT tposeFromGeoPose('{"header": {"poseCount": 1, "startInstant": 0,
+  "stopInstant": 0, "transitionModel": {"authority": "/geopose/1.0",
+  "id": "none", "parameters": ""}},
+  "outerFrame": {"authority": "/geopose/1.0", "id": "LTP-ENU",
+    "parameters": "longitude=0&latitude=0&height=0"},
+  "innerFrameAndTimeSeries": [{"frame": {"authority": "/geopose/1.0",
+    "id": "RotateTranslate", "parameters": "translation=[0, 0, 0]&rotation=[1, 0, 0, 0]"}}],
+  "trailer": {"poseCount": 1}}');
+ERROR:  GeoPose Irregular Series element missing required integer 'validTime'
+SELECT tposeFromGeoPose('{"header": {"poseCount": 1, "startInstant": 0,
+  "stopInstant": 0, "transitionModel": {"authority": "/geopose/1.0",
+  "id": "none", "parameters": ""}},
+  "outerFrame": {"authority": "/geopose/1.0", "id": "LTP-ENU",
+    "parameters": "longitude=0&latitude=0&height=0"},
+  "innerFrameSeries": [{"authority": "/geopose/1.0",
+    "id": "RotateTranslate", "parameters": "translation=[0, 0, 0]&rotation=[1, 0, 0, 0]"}],
+  "trailer": {"poseCount": 1}}');
+ERROR:  GeoPose Regular Series missing required integer 'interPoseDuration'

--- a/mobilitydb/test/pose/expected/107_geopose_frames.test.out
+++ b/mobilitydb/test/pose/expected/107_geopose_frames.test.out
@@ -1,7 +1,7 @@
 SELECT count(*) FROM geopose_frames;
  count 
 -------
-     4
+     6
 (1 row)
 
 SELECT geoPoseFrameSRID(1), geoPoseFrameIsGeographic(1);
@@ -44,6 +44,6 @@ DELETE 1
 SELECT count(*) FROM geopose_frames;
  count 
 -------
-     4
+     6
 (1 row)
 

--- a/mobilitydb/test/pose/queries/103_pose_geopose.test.sql
+++ b/mobilitydb/test/pose/queries/103_pose_geopose.test.sql
@@ -169,21 +169,30 @@ SELECT asGeoPose(pose 'SRID=5676;Pose(Point(1 1),0.5)', 0, 6);
 -- valid OGC GeoPose document; the envelope adds the temporal framing.
 -------------------------------------------------------------------------------
 
--- TInstant tpose -> envelope with interpolation "None" and a single instants[].
+-- TInstant tpose -> a Basic document carrying its validTime.
 SELECT asGeoPose(tpose 'Pose(Point(8 47), 0)@2026-01-01', 0, 6);
 -- Round-trip preserves subtype.
 SELECT asText(tposeFromGeoPose(asGeoPose(tpose 'Pose(Point(8 47), 0)@2026-01-01', 0, 6)));
 
--- 2D linear-interp TSequence -> envelope with instants[].
-SELECT asGeoPose(tpose '[Pose(Point(8 47), 0)@2026-01-01, Pose(Point(9 48), 0.5)@2026-01-02]', 0, 6);
--- Round-trip preserves the underlying pose values to 6 digits.
-SELECT asText(tposeFromGeoPose(asGeoPose(tpose '[Pose(Point(8 47), 0)@2026-01-01, Pose(Point(9 48), 0.5)@2026-01-02]', 0, 6)));
+-- 2D linear-interp TSequence -> a Series. Its inner frames hold a rotation
+-- against the outer frame, so a 2D pose comes back three-dimensional.
+SELECT asGeoPose(tpose '[Pose(Point(0 0), 0)@2026-01-01, Pose(Point(0 0), 0.5)@2026-01-02]', 0, 6);
+-- Round-trip preserves the underlying pose values.
+SELECT asText(round(tposeFromGeoPose(asGeoPose(tpose '[Pose(Point(0 0), 0)@2026-01-01, Pose(Point(0 1), 0)@2026-01-02]', 0, 15)), 6));
 
--- Basic-YPR output of a 3D yaw-only TSequence.
-SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01, Pose(Point(8 47 1500), 0.7071067811865476, 0, 0, 0.7071067811865475)@2026-01-02]', 1, 6);
+-- A 3D yaw-only TSequence. A Series carries a quaternion whichever
+-- orientation encoding is asked for.
+SELECT asGeoPose(tpose '[Pose(Point(0 0 0), 1, 0, 0, 0)@2026-01-01, Pose(Point(0 0 0), 0.707107, 0, 0, 0.707107)@2026-01-02]', 1, 6);
 
--- TSequenceSet -> top-level sequences[].
-SELECT asGeoPose(tpose '{[Pose(Point(8 47), 0)@2026-01-01, Pose(Point(9 48), 0.5)@2026-01-02], [Pose(Point(10 50), 1)@2026-01-04, Pose(Point(11 51), 1.5)@2026-01-05]}', 1, 4);
+-- TSequenceSet -> one flattened Series.
+SELECT asGeoPose(tpose '{[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01, Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02], [Pose(Point(0 0 300), 0.5, 0.5, 0.5, 0.5)@2026-01-04, Pose(Point(0 0 600), 0.5, 0.5, 0.5, 0.5)@2026-01-05]}', 1, 4);
+
+-- A Series spends its digits on metres from the tangent point rather than on
+-- degrees, so the precision it is written at bounds how well a position far
+-- from that point survives: fifteen digits carry a degree of latitude back
+-- exactly, six do not.
+SELECT tposeFromGeoPose(asGeoPose(tpose '[Pose(Point(0 0), 0)@2026-01-01, Pose(Point(0 1), 0)@2026-01-02]', 0, 15)) =
+  tposeFromGeoPose(asGeoPose(tpose '[Pose(Point(0 0), 0)@2026-01-01, Pose(Point(0 1), 0)@2026-01-02]', 0, 6)) AS same;
 
 -------------------------------------------------------------------------------
 -- Reading a GeoPose document as a value of the type
@@ -204,3 +213,280 @@ SELECT asText(tpose (asGeoPose(tpose 'Pose(Point(8 47), 0)@2026-01-01', 0, 6)));
 -- set of instants nor a set of sequences is a GeoPose document.
 SELECT asText(tpose '{Pose(Point(8 47), 0)@2026-01-01, Pose(Point(9 48), 0.5)@2026-01-02}');
 SELECT asText(tpose '{[Pose(Point(8 47), 0)@2026-01-01, Pose(Point(9 48), 0.5)@2026-01-02], [Pose(Point(10 50), 1)@2026-01-04]}');
+
+-------------------------------------------------------------------------------
+-- Geographic SRIDs accepted at the GeoPose boundary
+--
+-- A Basic document carries no CRS member: the conformance class fixes the
+-- outer frame. EPSG:4326 and EPSG:4979 name the same WGS-84 geographic frame
+-- and share a proj4 definition, so both are accepted and both give the same
+-- bytes.
+-------------------------------------------------------------------------------
+
+SELECT asGeoPose(pose 'SRID=4979;Pose(Point(8 47 1500), 1, 0, 0, 0)', 0, 6);
+
+SELECT asGeoPose(pose 'SRID=4979;Pose(Point(8 47 1500), 1, 0, 0, 0)', 0, 6) =
+  asGeoPose(pose 'SRID=4326;Pose(Point(8 47 1500), 1, 0, 0, 0)', 0, 6) AS same;
+
+SELECT poseFromGeoPose(asGeoPose(
+  pose 'SRID=4979;Pose(Point(8 47 1500), 1, 0, 0, 0)', 0, 15)) =
+  poseFromGeoPose(asGeoPose(
+  pose 'SRID=4326;Pose(Point(8 47 1500), 1, 0, 0, 0)', 0, 15)) AS same;
+
+SELECT asGeoPose(tpose 'SRID=4979;[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02]', 0, 6) =
+  asGeoPose(tpose 'SRID=4326;[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02]', 0, 6) AS same;
+
+/* Errors */
+
+-- A projected SRID is not a GeoPose outer frame.
+SELECT asGeoPose(pose 'SRID=5676;Pose(Point(1 1),0.5)', 0, 6);
+SELECT asGeoPose(tpose 'SRID=5676;[Pose(Point(1 1),0.5)@2026-01-01,
+  Pose(Point(2 2),0.5)@2026-01-02]', 0, 6);
+
+-------------------------------------------------------------------------------
+-- The conformance class follows from the value
+--
+-- A single instant is a Basic document carrying its validTime. A sequence is
+-- an OGC Composite Sequence Series: the Regular class when the instants are
+-- equally spaced by a whole number of milliseconds, the Irregular class
+-- otherwise. The equator-meridian anchor used below keeps the ENU basis
+-- exactly representable, so the emitted numbers are stable.
+-------------------------------------------------------------------------------
+
+-- A temporal instant is a Basic document plus validTime.
+SELECT asGeoPose(tpose 'Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01', 0, 6);
+SELECT asGeoPose(tpose 'Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01', 1, 6);
+
+-- Equally spaced instants give a Regular Series: the spacing is stated once
+-- as interPoseDuration and the inner frames carry no time.
+SELECT asGeoPose(tpose '[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02,
+  Pose(Point(0 0 300), 0.5, 0.5, 0.5, 0.5)@2026-01-03]', 0, 6);
+
+-- Unequally spaced instants give an Irregular Series: every inner frame
+-- carries its own validTime.
+SELECT asGeoPose(tpose '[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02,
+  Pose(Point(0 0 300), 0.5, 0.5, 0.5, 0.5)@2026-01-05]', 0, 6);
+
+-- A Series carries a quaternion in every inner frame, so the orientation
+-- encoding argument makes no difference to it.
+SELECT asGeoPose(tpose '[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02]', 0, 6) =
+  asGeoPose(tpose '[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02]', 1, 6) AS same;
+
+-- A sequence set is a Series too, flattened.
+SELECT asGeoPose(tpose '{[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02],
+  [Pose(Point(0 0 300), 0.5, 0.5, 0.5, 0.5)@2026-01-04]}', 0, 6);
+
+-------------------------------------------------------------------------------
+-- Series header and trailer
+-------------------------------------------------------------------------------
+
+-- poseCount agrees with the length of the inner frame array in both.
+WITH j AS (SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02,
+  Pose(Point(10 49 1700), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb AS d)
+SELECT (d->'header'->>'poseCount')::int = jsonb_array_length(d->'innerFrameAndTimeSeries')
+  AND (d->'trailer'->>'poseCount')::int = jsonb_array_length(d->'innerFrameAndTimeSeries')
+FROM j;
+
+-- startInstant and stopInstant are the temporal extent, in Unix milliseconds.
+WITH j AS (SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb AS d)
+SELECT to_timestamp((d->'header'->>'startInstant')::bigint / 1000) AT TIME ZONE 'UTC',
+       to_timestamp((d->'header'->>'stopInstant')::bigint / 1000) AT TIME ZONE 'UTC'
+FROM j;
+
+-- Each validTime is the instant's Unix time in milliseconds.
+WITH j AS (SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb AS d)
+SELECT to_timestamp((e->>'validTime')::bigint / 1000) AT TIME ZONE 'UTC'
+FROM j, jsonb_array_elements(d->'innerFrameAndTimeSeries') AS e;
+
+-- A millisecond of the extent survives; a microsecond does not.
+WITH j AS (SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01 00:00:00.123456,
+  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb AS d)
+SELECT (d->'header'->>'startInstant')::bigint % 1000 AS millisecond_kept FROM j;
+
+-- interPoseDuration is the spacing in milliseconds.
+SELECT (asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 6)::jsonb->>'interPoseDuration')::bigint;
+
+-------------------------------------------------------------------------------
+-- Transition model: the interpolation of the temporal value
+-------------------------------------------------------------------------------
+
+WITH j(interp, d) AS (VALUES
+  ('linear', asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+     Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb),
+  ('step', asGeoPose(tpose 'Interp=Step;[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+     Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb),
+  ('discrete', asGeoPose(tpose '{Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+     Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05}', 0, 6)::jsonb))
+SELECT interp,
+  d->'header'->'transitionModel'->>'authority',
+  d->'header'->'transitionModel'->>'id',
+  d->'header'->'transitionModel'->>'parameters'
+FROM j;
+
+-------------------------------------------------------------------------------
+-- Outer and inner frame specifications
+-------------------------------------------------------------------------------
+
+-- The outer frame is the LTP-ENU frame at the tangent point of the first pose.
+WITH j AS (SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 6)::jsonb AS d)
+SELECT d->'outerFrame'->>'authority', d->'outerFrame'->>'id',
+  d->'outerFrame'->>'parameters'
+FROM j;
+
+-- The first inner frame sits at the origin of the outer frame.
+WITH j AS (SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 6)::jsonb AS d)
+SELECT d->'innerFrameSeries'->0->>'authority', d->'innerFrameSeries'->0->>'id',
+  split_part(d->'innerFrameSeries'->0->>'parameters', '&', 1)
+FROM j;
+
+-- The registry documents the authority and id pairs the encoder emits.
+SELECT authority, code FROM geopose_frames WHERE authority = '/geopose/1.0'
+ORDER BY code;
+
+-------------------------------------------------------------------------------
+-- Round-trip through the conformant form
+-------------------------------------------------------------------------------
+
+-- A temporal instant round-trips through its Basic document.
+SELECT asText(round(tposeFromGeoPose(asGeoPose(
+  tpose 'Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01', 0, 15)), 6));
+
+-- A Regular Series round-trips to the same value, to the emitted precision.
+SELECT asText(round(tposeFromGeoPose(asGeoPose(
+  tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+    Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02,
+    Pose(Point(10 47 1700), 1, 0, 0, 0)@2026-01-03]', 0, 15)), 6));
+
+-- An Irregular Series round-trips its uneven spacing too.
+SELECT asText(round(tposeFromGeoPose(asGeoPose(
+  tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+    Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 15)), 6));
+
+-- Step interpolation survives the transition model.
+SELECT interp(tposeFromGeoPose(asGeoPose(
+  tpose 'Interp=Step;[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+    Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 15)));
+
+-- Discrete interpolation does too.
+SELECT interp(tposeFromGeoPose(asGeoPose(
+  tpose '{Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+    Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02}', 0, 15)));
+
+-- A Series has neither gaps nor open bounds, so a sequence set flattens into
+-- one closed sequence.
+SELECT asText(round(tposeFromGeoPose(asGeoPose(
+  tpose '{[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+    Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02],
+   [Pose(Point(10 50 1700), 1, 0, 0, 0)@2026-01-04]}', 0, 15)), 6));
+
+-- A document written by another implementation reads as well. This is the
+-- Irregular Series example of the standard; its poseCount states the length
+-- of its own inner frame array.
+SELECT asText(round(tposeFromGeoPose('{
+  "header": {"poseCount": 3, "startInstant": 1630560671429,
+    "stopInstant": 1630560716429,
+    "transitionModel": {"authority": "/geopose/1.0", "id": "none",
+      "parameters": ""}},
+  "outerFrame": {"authority": "/geopose/1.0", "id": "LTP-ENU",
+    "parameters": "longitude=-122.3000000&latitude=47.7000000&height=11.000"},
+  "innerFrameAndTimeSeries": [
+    {"frame": {"authority": "/geopose/1.0", "id": "RotateTranslate",
+      "parameters": "translation=[0.0, 0.0, 0.0]&rotation=[1.0, 0.0, 0.0, 0.0]"},
+     "validTime": 1630560671429},
+    {"frame": {"authority": "/geopose/1.0", "id": "RotateTranslate",
+      "parameters": "translation=[10.0, 20.0, 5.0]&rotation=[1.0, 0.0, 0.0, 0.0]"},
+     "validTime": 1630560693929},
+    {"frame": {"authority": "/geopose/1.0", "id": "RotateTranslate",
+      "parameters": "translation=[20.0, 40.0, 10.0]&rotation=[1.0, 0.0, 0.0, 0.0]"},
+     "validTime": 1630560716429}],
+  "trailer": {"poseCount": 3}}'), 4));
+
+-- The Regular Series example reads from its interPoseDuration alone.
+SELECT asText(round(tposeFromGeoPose('{
+  "header": {"poseCount": 3, "startInstant": 1630560671367,
+    "stopInstant": 1630560673367,
+    "transitionModel": {"authority": "/geopose/1.0", "id": "interpolate",
+      "parameters": ""}},
+  "interPoseDuration": 1000,
+  "outerFrame": {"authority": "/geopose/1.0", "id": "LTP-ENU",
+    "parameters": "longitude=-122.3000000&latitude=47.7000000&height=11.000"},
+  "innerFrameSeries": [
+    {"authority": "/geopose/1.0", "id": "RotateTranslate",
+     "parameters": "translation=[0.0, 0.0, 0.0]&rotation=[1.0, 0.0, 0.0, 0.0]"},
+    {"authority": "/geopose/1.0", "id": "RotateTranslate",
+     "parameters": "translation=[0.5, 0.0, 0.0]&rotation=[1.0, 0.0, 0.0, 0.0]"},
+    {"authority": "/geopose/1.0", "id": "RotateTranslate",
+     "parameters": "translation=[1.0, 0.0, 0.0]&rotation=[1.0, 0.0, 0.0, 0.0]"}],
+  "trailer": {"poseCount": 3}}'), 6));
+
+-- A TemporalGeoPose envelope written by an earlier release still reads.
+SELECT asText(tposeFromGeoPose('{"type":"TemporalGeoPose","version":"1.0",
+  "conformance":"Basic-Quaternion","interpolation":"Linear",
+  "lower_inc":true,"upper_inc":true,"instants":[
+    {"position":{"lat":47,"lon":8,"h":0},"quaternion":{"x":0,"y":0,"z":0,"w":1},
+     "validTime":"2026-01-01 00:00:00+01"},
+    {"position":{"lat":48,"lon":9,"h":0},"quaternion":{"x":0,"y":0,"z":0,"w":1},
+     "validTime":"2026-01-02 00:00:00+01"}]}'));
+
+-------------------------------------------------------------------------------
+-- Errors
+-------------------------------------------------------------------------------
+
+/* Errors */
+
+-- A Basic document without a validTime is a pose, not a temporal pose.
+SELECT tposeFromGeoPose(
+  '{"position":{"lat":47,"lon":8,"h":0},"quaternion":{"x":0,"y":0,"z":0,"w":1}}');
+
+-- A series without an outer frame.
+SELECT tposeFromGeoPose('{"header": {"poseCount": 1, "startInstant": 0,
+  "stopInstant": 0, "transitionModel": {"authority": "/geopose/1.0",
+  "id": "none", "parameters": ""}},
+  "innerFrameAndTimeSeries": [{"frame": {"authority": "/geopose/1.0",
+    "id": "RotateTranslate", "parameters": "translation=[0, 0, 0]&rotation=[1, 0, 0, 0]"},
+   "validTime": 0}], "trailer": {"poseCount": 1}}');
+
+-- An inner frame without a rotation.
+SELECT tposeFromGeoPose('{"header": {"poseCount": 1, "startInstant": 0,
+  "stopInstant": 0, "transitionModel": {"authority": "/geopose/1.0",
+  "id": "none", "parameters": ""}},
+  "outerFrame": {"authority": "/geopose/1.0", "id": "LTP-ENU",
+    "parameters": "longitude=0&latitude=0&height=0"},
+  "innerFrameAndTimeSeries": [{"frame": {"authority": "/geopose/1.0",
+    "id": "RotateTranslate", "parameters": "translation=[0, 0, 0]"},
+   "validTime": 0}], "trailer": {"poseCount": 1}}');
+
+-- An Irregular Series element without a validTime.
+SELECT tposeFromGeoPose('{"header": {"poseCount": 1, "startInstant": 0,
+  "stopInstant": 0, "transitionModel": {"authority": "/geopose/1.0",
+  "id": "none", "parameters": ""}},
+  "outerFrame": {"authority": "/geopose/1.0", "id": "LTP-ENU",
+    "parameters": "longitude=0&latitude=0&height=0"},
+  "innerFrameAndTimeSeries": [{"frame": {"authority": "/geopose/1.0",
+    "id": "RotateTranslate", "parameters": "translation=[0, 0, 0]&rotation=[1, 0, 0, 0]"}}],
+  "trailer": {"poseCount": 1}}');
+
+-- A Regular Series without an interPoseDuration.
+SELECT tposeFromGeoPose('{"header": {"poseCount": 1, "startInstant": 0,
+  "stopInstant": 0, "transitionModel": {"authority": "/geopose/1.0",
+  "id": "none", "parameters": ""}},
+  "outerFrame": {"authority": "/geopose/1.0", "id": "LTP-ENU",
+    "parameters": "longitude=0&latitude=0&height=0"},
+  "innerFrameSeries": [{"authority": "/geopose/1.0",
+    "id": "RotateTranslate", "parameters": "translation=[0, 0, 0]&rotation=[1, 0, 0, 0]"}],
+  "trailer": {"poseCount": 1}}');
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
Writes a temporal pose in the OGC GeoPose v1.0 conformance class its own subtype determines, and reads all of them back.

## What the conformance classes are here

**Basic-YPR and Basic-Quaternion — conformant, unqualified.** A `pose`, and a temporal pose of one instant, are Basic documents. The standard specifies these classes completely and the encoding already matched them; this change leaves the member names and types alone. Every Basic document the regression suite emits validates against the normative schema, and the Basic-Quaternion ones validate against `GeoPose.Basic.Strict_Quaternion.Schema.json`, which forbids additional properties.

**Composite Sequence Regular and Irregular Series — conformant in structure, with a qualification.** A temporal sequence or sequence set is a Series: the Regular class when its instants are equally spaced by a whole number of milliseconds, the Irregular class otherwise. `header`, `outerFrame`, `innerFrameSeries` or `innerFrameAndTimeSeries`, `interPoseDuration` and `trailer` are all present with the members and types the schemas require, `poseCount` agrees with the array length in both header and trailer, and the extent comes from the value. Every Series the suite emits validates against its normative schema.

The qualification is that the standard leaves two things to the frame authority. A composite document carries no position and no quaternion: each pose is a `FrameSpecification{authority, id, parameters}` whose `parameters` is an opaque string the schemas do not constrain, and `TransitionModel` is the same triple with no enumerated identifiers in the normative text. This implementation follows the encoding examples of Clause 9.2 rather than inventing a shape: `translation=[e, n, u]&rotation=[w, x, y, z]` for an inner frame, `longitude=…&latitude=…&height=…` for the outer one. Two implementations that both validate can still disagree on what those strings mean.

**Not implemented:** Advanced, Chain, Graph, Stream.

## What the encoding does

The outer frame is the local tangent plane East-North-Up frame at the first pose, as Requirements 26 and 31 ask. Each inner frame therefore holds a translation in metres from that tangent point and a rotation against that frame's basis, which means the encoding converts every position to topocentric coordinates and composes each pose's own quaternion with the convergence between its tangent plane and the outer one. Without that composition every pose but the first would sit at a subtly wrong attitude. The geodetic conversion round-trips to about 1e-15 degrees, so the precision the document is written at is what bounds fidelity, not the arithmetic.

Times are `GeoPose_Instant` values. Requirement 10 states that one "shall express Unix Time in seconds multiplied by 1,000, with the unit of measure in milliseconds", and Annex C.2 that time values are integers needing 64 bits, so they are signed integer milliseconds. Conversions between a `TimestampTz` and Unix time share one epoch constant.

The transition model reports the interpolation. Linear interpolation is the standard's `interpolate` model, step and discrete interpolation its `none` model. Those two identifiers cannot tell step from discrete apart, so the model's `parameters` names the interpolation with the same words the MF-JSON encoding uses, keeping one interpolation vocabulary across both of this implementation's OGC encodings.

## Geographic SRIDs

Both EPSG:4326 and EPSG:4979 are accepted at the conversion boundary. They name the same WGS-84 geographic frame and share a proj4 definition, so accepting 4979 moves no coordinate; a Basic document carries no CRS member at all, and a pose declared either way produces identical bytes. EPSG:4979 is the code the outer frame declares, since a GeoPose position carries a height. Projected SRIDs are still refused.

A pose without a height emits `h` as zero. The standard requires the member and offers no way to say that a height is unknown, so zero is the documented convention for a height-free trajectory, and it asserts more than the data holds.

## Consequences worth knowing

A Series has neither gaps nor open bounds, so a sequence set is flattened into one closed sequence and the bounds inclusion of a sequence is not preserved. A Series also returns three-dimensional poses, its inner frames carrying a full quaternion. And because a Series spends its digits on metres from the tangent point rather than on degrees, the precision it is written at bounds how well a position far from that point survives: fifteen digits carry a degree of latitude back exactly, six do not.

Reading accepts the Basic document, both Series classes, and the `TemporalGeoPose` envelope earlier releases wrote, so data already stored in that form loads unchanged.

## Surface

Unchanged. No new function, no new argument, no new default. The class is derived from the value; `conformance` keeps its meaning of choosing the orientation encoding of a Basic document and has no effect on a Series. The frame registry lists the authority and identifier pairs the encoder emits, giving the seeded catalog a reader.
