### PR TITLE
Build the clip context only for a geometry the clip engine decomposes

### DIFF
--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -1049,7 +1049,17 @@ ea_disjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
   void *ctx = NULL;
   if (! MEOS_FLAGS_GET_GEODETIC(temp->flags) &&
       ! (MEOS_FLAGS_GET_Z(temp->flags) && FLAGS_GET_Z(gs->gflags)))
-    ctx = geo_clip_ctx_make(gs);
+  {
+    /* Only a geometry the clip engine decomposes into edges gets a context.
+     * A context for another type reports the type as unsupported for the
+     * whole relationship, while resolving the composing values one by one
+     * reaches the decomposition only for a value whose box meets the
+     * geometry, and answers from the boxes alone for the values that do not */
+    LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
+    if (geom_clip_supported(lwgeom))
+      ctx = geo_clip_ctx_make(gs);
+    lwgeom_free(lwgeom);
+  }
   datum_func2 func = geo_disjoint_fn_geo(temp->flags, gs->gflags);
   for (int i = 0; i < count; i++)
   {


### PR DESCRIPTION
The ever-disjoint relationship of a temporal geometry builds a clip context
for the geometry and then walks the composing values against it. Building the
context extracts the edges of the geometry, and the extraction reports an
unsupported type for a geometry the clip engine does not decompose, such as a
polyhedral surface or a TIN.

Resolving the composing values one by one reaches that extraction only for a
value whose bounding box meets the geometry, and answers from the boxes alone
for the values that do not. A geometry of an unsupported type whose box meets
the temporal value as a whole but none of its composing values is therefore
answered, not rejected.

This builds the context only when `geom_clip_supported` accepts the geometry —
the guard `tinterrel_tgeo_geo` already applies before its own native path — and
resolves the values through the relationship otherwise.

## Evidence

Probe over a temporal geometry of two point values and a polyhedral surface
lying between them, inside the bounding box of the temporal value and outside
the box of each of its values, under the noexit error handler:

| build | result |
| --- | --- |
| `cc1f4fb108` | `edisjoint_tgeo_geo -> 1  (meos_errno=0)` |
| `e21e5178e0` | `edisjoint_tgeo_geo -> 1  (meos_errno=13)` |
| this branch | `edisjoint_tgeo_geo -> 1  (meos_errno=0)` |

The return value is the same in all three; the error status is not. The default
error handler exits and the extension raises, so the condition surfaces as an
error there and as a set errno under the noexit handler the bindings install,
which is why the regression tests do not reach it.

One file, +11/-1, with no expected-output change.