### PR TITLE
Declare the temporal intersects lifting entry once

### DIFF
--- a/meos/include/geo/tgeo_tempspatialrels.h
+++ b/meos/include/geo/tgeo_tempspatialrels.h
@@ -55,9 +55,6 @@ extern Temporal *tinterrel_tgeo_geo(const Temporal *temp,
   const GSERIALIZED *gs, bool tinter);
 extern Temporal *tinterrel_tspatial_base(const Temporal *temp, Datum base,
   bool tinter, datum_func2 func);
-
-extern Temporal *tinterrel_tspatial_base(const Temporal *temp,
-  Datum base, bool tinter, datum_func2 func);
 extern Temporal *tinterrel_tspatial_tspatial(const Temporal *temp1,
   const Temporal *temp2, bool tinter);
 


### PR DESCRIPTION
The header declares `tinterrel_tspatial_base` twice with the same signature,
the two differing only in where the line wraps, and a blank line separates the
second from the `tinterrel_tgeo_geo` above it.

This keeps one declaration, which places the three `tinterrel` entries in a
single block like the `tspatialrel` pair above them.

Header only, three lines removed, with no expected-output change.