### PR TITLE
Report a temporal point that meets a polygon boundary as intersecting it

### DIFF
--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -746,6 +746,34 @@ float8_qsort_cmp(const void *a1, const void *a2)
 }
 
 /**
+ * @brief Return true if a point lies on the boundary of a polygonal component
+ * @details Only the polygon boundary edges are considered, straight
+ * (#EDGE_POLY) and circular (#EDGE_POLYARC). The candidate array filtered by
+ * the box of a segment suffices for a point lying on that segment: a boundary
+ * edge through such a point has a box meeting the segment box, so it is in the
+ * candidates
+ */
+static bool
+point_on_poly_boundary(double px, double py, Edge **edges, int nedges)
+{
+  for (int i = 0; i < nedges; i++)
+  {
+    const Edge *e = edges[i];
+    if (e->etype == EDGE_POLY)
+    {
+      if (point_on_segment(px, py, e->x1, e->y1, e->x2, e->y2))
+        return true;
+    }
+    else if (e->etype == EDGE_POLYARC)
+    {
+      if (point_on_arc(px, py, e))
+        return true;
+    }
+  }
+  return false;
+}
+
+/**
  * @brief Compute the intersection intervals of a trajectory segment with an
  * array of polygon edges
  * @details The ray-casting cannot use the edges filtered by the segment box,
@@ -854,8 +882,11 @@ intervals_from_polygons(const POINT2D *a, const POINT2D *b, Edge **edges,
   }
   events->count = newcount;
 
-  /* Build intervals using midpoint test */
-  for (int i = 0; i < (int) events->count - 1; i++)
+  /* Build intervals using midpoint test, recording for each event whether it
+   * bounds an interval the point spends in the polygon interior */
+  int nevents = (int) events->count;
+  bool *bounded = palloc0(sizeof(bool) * (nevents > 0 ? nevents : 1));
+  for (int i = 0; i < nevents - 1; i++)
   {
     double ta = evtarr[i];
     double tb = evtarr[i + 1];
@@ -872,8 +903,32 @@ intervals_from_polygons(const POINT2D *a, const POINT2D *b, Edge **edges,
       span_set(Float8GetDatum(ta), Float8GetDatum(tb), true, true,
         T_FLOAT8, T_FLOATSPAN, &in);
       meos_array_add(intervals, &in);
+      bounded[i] = bounded[i + 1] = true;
     }
   }
+
+  /* A segment that meets the boundary without entering the interior is in the
+   * closure of the polygon at that instant alone. Such a contact bounds no
+   * interval, so it is emitted as the instantaneous interval that it is */
+  for (int i = 0; i < nevents; i++)
+  {
+    if (bounded[i])
+      continue;
+    double t = evtarr[i];
+    if (t < 0.0)
+      t = 0.0;
+    else if (t > 1.0)
+      t = 1.0;
+    double x = ax + t * rx;
+    double y = ay + t * ry;
+    if (! point_on_poly_boundary(x, y, edges, nedges))
+      continue;
+    Span in;
+    span_set(Float8GetDatum(t), Float8GetDatum(t), true, true,
+      T_FLOAT8, T_FLOATSPAN, &in);
+    meos_array_add(intervals, &in);
+  }
+  pfree(bounded);
   return;
 }
 

--- a/mobilitydb/test/geo/expected/070_tpoint_spatialrels.test.out
+++ b/mobilitydb/test/geo/expected/070_tpoint_spatialrels.test.out
@@ -2208,3 +2208,46 @@ SELECT eIntersects(
  t
 (1 row)
 
+SELECT eIntersects(geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))',
+  tgeompoint '[Point(-3 -3)@2000-01-01, Point(-1 -1)@2000-01-02]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))',
+  tgeompoint '[Point(-1 -1)@2000-01-01, Point(-3 -3)@2000-01-02]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))',
+  tgeompoint '[Point(-3 0)@2000-01-01, Point(-1 0)@2000-01-02]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))',
+  tgeompoint '[Point(-3 -1)@2000-01-01, Point(-1 -1)@2000-01-02, Point(-3 -1)@2000-01-03]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT tIntersects(geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))',
+  tgeompoint '[Point(-3 -1)@2000-01-01, Point(-1 -1)@2000-01-02, Point(-3 -1)@2000-01-03]');
+                                                             tintersects                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST], (f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT atGeometry(
+  tgeompoint '[Point(-3 -1)@2000-01-01, Point(-1 -1)@2000-01-02, Point(-3 -1)@2000-01-03]',
+  geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
+                                 atgeometry                                  
+-----------------------------------------------------------------------------
+ {[0101000000000000000000F0BF000000000000F0BF@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+

--- a/mobilitydb/test/geo/queries/070_tpoint_spatialrels.test.sql
+++ b/mobilitydb/test/geo/queries/070_tpoint_spatialrels.test.sql
@@ -583,4 +583,20 @@ SELECT eIntersects(
   tgeompoint '[Point(5 5)@2000-01-01, Point(5 5)@2000-01-02]',
   tgeompoint '[Point(0 0)@2000-01-01, Point(10 10)@2000-01-03]');
 
+-- A trajectory that reaches the boundary of a polygon without entering its
+-- interior meets it at that instant alone
+SELECT eIntersects(geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))',
+  tgeompoint '[Point(-3 -3)@2000-01-01, Point(-1 -1)@2000-01-02]');
+SELECT eIntersects(geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))',
+  tgeompoint '[Point(-1 -1)@2000-01-01, Point(-3 -3)@2000-01-02]');
+SELECT eIntersects(geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))',
+  tgeompoint '[Point(-3 0)@2000-01-01, Point(-1 0)@2000-01-02]');
+SELECT eIntersects(geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))',
+  tgeompoint '[Point(-3 -1)@2000-01-01, Point(-1 -1)@2000-01-02, Point(-3 -1)@2000-01-03]');
+SELECT tIntersects(geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))',
+  tgeompoint '[Point(-3 -1)@2000-01-01, Point(-1 -1)@2000-01-02, Point(-3 -1)@2000-01-03]');
+SELECT atGeometry(
+  tgeompoint '[Point(-3 -1)@2000-01-01, Point(-1 -1)@2000-01-02, Point(-3 -1)@2000-01-03]',
+  geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
+
 -------------------------------------------------------------------------------


### PR DESCRIPTION
The polygon path of the clip engine collects the parameters at which a
trajectory segment meets a boundary edge, then keeps the sub-interval between
two consecutive parameters when its midpoint lies in the interior. A segment
that reaches the boundary without entering the interior bounds no such
sub-interval, since the midpoints on both sides are outside, so the contact is
dropped. Polygon boundary edges travel only this path — `intervals_from_lines`
filters on `EDGE_LINE` and `intervals_from_points` on `EDGE_POINT` — so nothing
else reports the contact.

This emits the contact as the instantaneous interval that it is: an event that
bounds no interior interval and whose position lies on a boundary edge becomes
the closed interval at that parameter. The boundary test uses the candidates
already filtered by the box of the segment, which suffices because a boundary
edge through a point on the segment has a box meeting the segment box.

## Evidence

Against the relationship on the trajectory, over a square and the trajectories
that reach it without entering:

| case | without the contact | with it | trajectory |
| --- | --- | --- | --- |
| end on a vertex | 0 | 1 | 1 |
| start on a vertex | 0 | 1 | 1 |
| end on an edge | 0 | 1 | 1 |
| start on an edge | 0 | 1 | 1 |
| graze a vertex and leave | 0 | 1 | 1 |
| through a vertex into the interior | 1 | 1 | 1 |
| across the interior | 1 | 1 | 1 |

The temporal relationship and the restriction carry the contact as a single
instant:

    tIntersects -> {[f@Jan 01, t@Jan 02], (f@Jan 02, f@Jan 03]}
    atGeometry  -> {[POINT(-1 -1)@Jan 02]}

This is what the engine states about itself: the zero-distance comment on
`tpoint_linear_dwithin_geom` describes `tDwithin(., ., 0)` as agreeing with
tIntersects including isolated contact instants.

The six queries join `070_tpoint_spatialrels`, whose expected output grows by
43 lines with no deletion: every case the suite covers already keeps its value,
and the contact cases are new coverage.